### PR TITLE
fix(linux): apply GTK opacity + scope stale backend cleanup by data dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux"
-version = "0.32.82"
+version = "0.32.84"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -46,7 +46,7 @@ dependencies = [
 
 [[package]]
 name = "agentmuxsrv-rs"
-version = "0.32.82"
+version = "0.32.84"
 dependencies = [
  "async-stream",
  "axum",
@@ -7174,7 +7174,7 @@ dependencies = [
 
 [[package]]
 name = "wsh-rs"
-version = "0.32.82"
+version = "0.32.84"
 dependencies = [
  "base64 0.22.1",
  "clap",

--- a/agentmuxsrv-rs/Cargo.toml
+++ b/agentmuxsrv-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmuxsrv-rs"
-version = "0.32.83"
+version = "0.32.84"
 edition = "2021"
 description = "AgentMux Rust backend (drop-in replacement for Go agentmuxsrv)"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.32.83",
+  "version": "0.32.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.32.83",
+      "version": "0.32.84",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.32.83",
+  "version": "0.32.84",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux"
-version = "0.32.83"
+version = "0.32.84"
 description = "AgentMux - AI-Native Terminal"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -317,10 +317,27 @@ pub fn set_window_transparency(
     }
 
     #[cfg(target_os = "linux")]
-    if blur {
-        // Linux blur is compositor-dependent; CSS backdrop-filter is the primary fallback.
-        // No reliable cross-compositor API exists.
-        tracing::info!("Linux blur requested — using CSS fallback (no native API)");
+    {
+        if blur {
+            // Linux blur is compositor-dependent; CSS backdrop-filter is the primary fallback.
+            // No reliable cross-compositor API exists.
+            tracing::info!("Linux blur requested — using CSS fallback (no native API)");
+        }
+
+        // Apply window-level opacity via GTK so the compositor composites the window
+        // at the requested transparency level. Without this the opacity value is ignored
+        // and the window renders fully opaque regardless of the CSS setting.
+        use gtk::prelude::*;
+        window.with_webview(move |webview| {
+            let gtk_win = webview.inner()
+                .parent()
+                .and_then(|p| p.parent())
+                .and_then(|w| w.dynamic_cast::<gtk::Window>().ok());
+            if let Some(win) = gtk_win {
+                win.set_opacity(opacity);
+                tracing::info!("Linux: set GTK window opacity={}", opacity);
+            }
+        }).ok();
     }
 
     Ok(())

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -172,7 +172,7 @@ pub async fn spawn_backend(app: &tauri::AppHandle) -> Result<BackendSpawnResult,
 
     // 2. Cleanup stale processes/files ------------------------------------
     #[cfg(unix)]
-    cleanup_stale_backends(current_version);
+    cleanup_stale_backends(current_version, &data_dir);
     cleanup_stale_endpoints(&config_dir);
 
     // 3. Ensure directory tree --------------------------------------------
@@ -261,10 +261,15 @@ pub async fn spawn_backend(app: &tauri::AppHandle) -> Result<BackendSpawnResult,
 ///
 /// When the frontend crashes or is force-killed, the backend process may survive.
 /// On the next launch we find all running agentmuxsrv-rs processes, inspect their
-/// `--instance` argument, and kill any whose version differs from `current_version`.
+/// `--instance` and `--wavedata` arguments, and kill any whose version differs from
+/// `current_version` AND whose wavedata path is under our `data_dir`.
+///
+/// Scoping by `data_dir` prevents dev instances from killing production instances
+/// (and vice versa) — each app identifier has its own isolated data directory.
 #[cfg(unix)]
-fn cleanup_stale_backends(current_version: &str) {
+fn cleanup_stale_backends(current_version: &str, data_dir: &std::path::Path) {
     let current_instance = format!("v{}", current_version);
+    let data_dir_str = data_dir.to_string_lossy().to_string();
     let my_pid = std::process::id();
 
     tracing::info!(
@@ -368,7 +373,40 @@ fn cleanup_stale_backends(current_version: &str) {
             }
         };
 
-        // Step 4: Compare versions — skip if it matches the current version
+        // Step 4a: Check --wavedata — only kill backends sharing our data dir.
+        // Dev instances use ai.agentmux.app.dev/..., production uses ai.agentmux.app.vX-Y-Z/...
+        // We must not kill backends belonging to a different app identifier.
+        let wavedata_path = cmdline
+            .split_whitespace()
+            .collect::<Vec<&str>>()
+            .windows(2)
+            .find_map(|pair| {
+                if pair[0] == "--wavedata" {
+                    Some(pair[1].to_string())
+                } else {
+                    None
+                }
+            });
+
+        match &wavedata_path {
+            Some(wavedata) if !wavedata.starts_with(&data_dir_str) => {
+                tracing::info!(
+                    "cleanup_stale_backends: PID {} has different data dir (wavedata={}), skipping",
+                    pid, wavedata
+                );
+                continue;
+            }
+            None => {
+                tracing::info!(
+                    "cleanup_stale_backends: PID {} has no --wavedata arg, skipping",
+                    pid
+                );
+                continue;
+            }
+            _ => {}
+        }
+
+        // Step 4b: Compare versions — skip if it matches the current version
         if instance_version == current_instance {
             tracing::info!(
                 "cleanup_stale_backends: PID {} is current version ({}), keeping",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "AgentMux",
-  "version": "0.32.83",
-  "identifier": "ai.agentmux.app.v0-32-83",
+  "version": "0.32.84",
+  "identifier": "ai.agentmux.app.v0-32-84",
   "build": {
     "devUrl": "http://localhost:5173",
     "frontendDist": "../dist/frontend",

--- a/wsh-rs/Cargo.toml
+++ b/wsh-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wsh-rs"
-version = "0.32.83"
+version = "0.32.84"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 


### PR DESCRIPTION
## Summary

- **Opacity not working on Linux**: `set_window_transparency` received `opacity=0.75` but the transparent+no-blur path on Linux fell through returning `Ok(())` with no side effects. Fix: call `gtk::Window::set_opacity()` so the compositor composites the window at the correct transparency level.

- **Stale backend cleanup killing wrong instances**: `cleanup_stale_backends` killed any `agentmuxsrv-rs` process whose `--instance` version differed from the current version, regardless of which app identifier owned it. This caused launching a dev build (`task dev`) to SIGKILL a running production AppImage's backend, making it go Offline. Fix: also parse `--wavedata` from the process cmdline and only kill backends whose wavedata path is under our own `data_dir`. Dev instances (`.app.dev/...`) and production instances (`.app.vX-Y-Z/...`) now have fully isolated cleanup.

## Test plan

- [ ] Set opacity slider — window should visually dim on Linux
- [ ] Run production AppImage, then launch `task dev` — AppImage should NOT go Offline
- [ ] Run `task dev`, close it, reopen — stale backend from same instance is still cleaned up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)