### PR TITLE
fix: Win11 pane focus border invisible on normal terminals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.42"
+version = "0.33.43"
 dependencies = [
  "axum 0.8.8",
  "cef",
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.42"
+version = "0.33.43"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.42"
+version = "0.33.43"
 dependencies = [
  "async-stream",
  "axum 0.7.9",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-wsh"
-version = "0.33.42"
+version = "0.33.43"
 dependencies = [
  "base64",
  "clap",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.42"
+version = "0.33.43"
 description = "AgentMux CEF Host — Pinned Chromium renderer replacing system WebView2"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.42"
+version = "0.33.43"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.42"
+version = "0.33.43"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-wsh/Cargo.toml
+++ b/agentmux-wsh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-wsh"
-version = "0.33.42"
+version = "0.33.43"
 edition = "2021"
 description = "Shell integration CLI for AgentMux"
 

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -419,12 +419,14 @@
             pointer-events: none;
             border-radius: var(--block-border-radius);
             z-index: var(--zindex-block-mask-inner);
-            // backdrop-filter guarantees this element composites above all
-            // composited-scroll children (xterm-viewport with overflow-y:scroll).
-            // backdrop-filter elements MUST render above the layers they sample —
-            // unlike will-change:opacity/transform which Chromium may squash or
-            // reorder. 0.1px blur is imperceptible at any DPR.
+            // Force this element onto its own compositor layer so it renders
+            // above xterm's hardware-accelerated scroll/WebGL surfaces.
+            // Two independent hints — either alone may be optimized away by
+            // Chromium on certain DWM configurations (Win11 vs Win10):
+            //   1. backdrop-filter: spec-required to composite above sampled layers
+            //   2. will-change: transform: forces a dedicated GPU layer
             backdrop-filter: blur(0.1px);
+            will-change: transform;
 
             &.show-block-mask {
                 user-select: none;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.42",
+  "version": "0.33.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.42",
+      "version": "0.33.43",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.42",
+  "version": "0.33.43",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Problem
On Windows 11, normal terminal panes show no blue focus border when selected. Agent-loaded terminals show their colored border correctly. Works fine on Windows 10.

## Root cause
PR #267 fixed this with `backdrop-filter: blur(0.1px)` to force `.block-mask` onto its own compositor layer above xterm's GPU surface. On Win11's DWM compositor, Chromium optimizes away the 0.1px blur — the layer promotion doesn't happen. Agent terminals still work because the `has-agent-color` class change forces a style recalculation that accidentally promotes the layer.

## Fix
Add `will-change: transform` alongside `backdrop-filter` as belt-and-suspenders compositor layer promotion. Either hint alone may be optimized away on specific platforms, but together they reliably force layer promotion on both Win10 and Win11.

## Test plan
- [ ] **Win11**: Normal terminal focused → blue accent border visible on all 4 sides
- [ ] **Win11**: Agent terminal focused → agent color border visible
- [ ] **Win10**: No regression — both border types still work
- [ ] Terminal text/scrolling render correctly (WebGL not broken)
- [ ] Drag-and-drop pane rearrangement still works

@AgentX — can you verify on your Win11 machine? Portable build at v0.33.43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)