### PR TITLE
fix(overlay): scope pane clip to the requesting window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.379"
+version = "0.33.380"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.379"
+version = "0.33.380"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.379"
+version = "0.33.380"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.379"
+version = "0.33.380"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.379"
+version = "0.33.380"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -340,13 +340,48 @@ impl BrowserPaneManager {
     ///
     /// No-op on non-Windows: other platforms don't use native child HWNDs
     /// for panes, so there's no airspace to work around.
+    ///
+    /// `window_label` scopes the clip to panes whose top-level ancestor
+    /// matches the requesting window. Without it, a modal opened in
+    /// window B would clip panes in window A (see Codex P1 on PR #544).
+    /// Empty string matches today's legacy callers that don't know their
+    /// window label — falls through to the no-filter behaviour for
+    /// back-compat until every caller is updated.
     #[cfg(target_os = "windows")]
-    pub fn set_pane_overlay_clip(&self, state: &Arc<AppState>, overlay_rects: &[(i32, i32, i32, i32)]) {
+    pub fn set_pane_overlay_clip(
+        &self,
+        state: &Arc<AppState>,
+        window_label: &str,
+        overlay_rects: &[(i32, i32, i32, i32)],
+    ) {
         use windows_sys::Win32::Foundation::{POINT, RECT};
         use windows_sys::Win32::Graphics::Gdi::{
             CombineRgn, CreateRectRgn, DeleteObject, MapWindowPoints, SetWindowRgn, RGN_DIFF,
         };
-        use windows_sys::Win32::UI::WindowsAndMessaging::{GetParent, GetWindowRect};
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            GetAncestor, GetParent, GetWindowRect, GA_ROOT,
+        };
+
+        // Resolve the requesting window's top-level HWND so we can filter
+        // panes by ownership. If the label is unknown we fall through with
+        // no filter — matches pre-scoping behaviour rather than silently
+        // doing nothing.
+        let requesting_top_level: *mut std::ffi::c_void = if window_label.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let browsers = state.browsers.lock();
+            match browsers.get(window_label).and_then(|b| b.host()) {
+                Some(host) => {
+                    let h = host.window_handle();
+                    if h.0.is_null() {
+                        std::ptr::null_mut()
+                    } else {
+                        unsafe { GetAncestor(h.0 as _, GA_ROOT) as *mut std::ffi::c_void }
+                    }
+                }
+                None => std::ptr::null_mut(),
+            }
+        };
 
         let labels = self.lifecycle.live_labels();
         let browsers = state.browsers.lock();
@@ -364,6 +399,16 @@ impl BrowserPaneManager {
                 continue;
             }
             let pane_hwnd = hwnd_raw.0 as *mut std::ffi::c_void;
+
+            // Window-scope filter. Skip panes whose top-level HWND differs
+            // from the requesting window's. `null` requesting = legacy
+            // caller / no-op filter (applies to all panes).
+            if !requesting_top_level.is_null() {
+                let pane_top = unsafe { GetAncestor(pane_hwnd as _, GA_ROOT) as *mut std::ffi::c_void };
+                if pane_top != requesting_top_level {
+                    continue;
+                }
+            }
 
             unsafe {
                 // Empty overlay list = restore full visibility (region=NULL).
@@ -431,7 +476,13 @@ impl BrowserPaneManager {
         );
     }
     #[cfg(not(target_os = "windows"))]
-    pub fn set_pane_overlay_clip(&self, _state: &Arc<AppState>, _overlay_rects: &[(i32, i32, i32, i32)]) {}
+    pub fn set_pane_overlay_clip(
+        &self,
+        _state: &Arc<AppState>,
+        _window_label: &str,
+        _overlay_rects: &[(i32, i32, i32, i32)],
+    ) {
+    }
 
     /// Give keyboard focus to the pane's child HWND so keystrokes reach the
     /// embedded page. Called by the frontend's ViewModel.giveFocus() when the

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -351,7 +351,17 @@ async fn route_command(
             // Empty list restores full visibility. See
             // BROWSER_PANE_Z_ORDER_FOCUS_REPORT.md Issue 1.
             //
+            // `window_label` scopes the clip to panes owned by the
+            // requesting window so a modal in window B doesn't also
+            // hide panes in window A (Codex P1 on PR #544). Defaults to
+            // "main" for back-compat with older frontends that omit it.
+            //
             // Each rect: { x, y, w, h } in main-window client pixel coords.
+            let window_label = args
+                .get("window_label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("main")
+                .to_string();
             let rects: Vec<(i32, i32, i32, i32)> = args
                 .get("rects")
                 .and_then(|v| v.as_array())
@@ -367,7 +377,9 @@ async fn route_command(
                         .collect()
                 })
                 .unwrap_or_default();
-            state.browser_panes.set_pane_overlay_clip(state, &rects);
+            state
+                .browser_panes
+                .set_pane_overlay_clip(state, &window_label, &rects);
             Ok(serde_json::json!(true))
         }
         "main_window_focus" => {

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.379"
+version = "0.33.380"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.379"
+version = "0.33.380"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.379"
+version = "0.33.380"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/platform/pane-overlay.ts
+++ b/frontend/app/platform/pane-overlay.ts
@@ -28,9 +28,26 @@ interface OverlayRect {
 const overlayRects = new Map<number, OverlayRect>();
 let nextOverlayId = 1;
 
+/**
+ * Window label of the host window this frontend instance belongs to.
+ * Set by the CEF launcher on each window's startup URL via `?windowLabel=`.
+ * Defaults to `"main"` so single-window builds work unchanged. Backend
+ * uses this to scope the overlay clip to panes owned by THIS window
+ * (fixes Codex P1 on PR #544: without scoping, a modal in window B
+ * would clip panes in window A).
+ */
+function currentWindowLabel(): string {
+    try {
+        return new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+    } catch {
+        return "main";
+    }
+}
+
 function sendClip(): void {
     const rects = Array.from(overlayRects.values());
-    invokeCommand("browser_panes_set_overlay_clip", { rects }).catch(() => {});
+    const window_label = currentWindowLabel();
+    invokeCommand("browser_panes_set_overlay_clip", { rects, window_label }).catch(() => {});
 }
 
 function rectFromElement(el: HTMLElement): OverlayRect {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.379",
+  "version": "0.33.380",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.379",
+      "version": "0.33.380",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.379",
+  "version": "0.33.380",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #544 — addresses the Codex P1 ("Scope modal pane clip to owning window").

`browser_panes_set_overlay_clip` applied its rects to every live pane globally, so opening a modal in one CEF window would also clip panes in other windows. The bug exists for any consumer of `usePaneOverlay` — MoreDropdown is affected too — but modal-v2 amplifies it (persistent full-viewport clip vs. a transient small rect). This PR fixes both at once by scoping at the primitive level.

## Changes

Same pattern as the existing `main_window_focus` handler.

**Backend** (`agentmux-cef/src/browser_panes.rs`, `ipc.rs`):
- `set_pane_overlay_clip` takes a `window_label: &str`.
- IPC handler extracts `window_label` from args (defaults to `"main"` for back-compat if an older frontend omits it).
- Filter: resolve the requesting window's top-level HWND via `state.browsers[window_label] → host → GetAncestor(GA_ROOT)`, then skip any pane whose own top-level differs.
- Empty label string falls through with no filter — matches pre-scoping behaviour for callers that don't know their window.

**Frontend** (`frontend/app/platform/pane-overlay.ts`):
- `sendClip()` reads `?windowLabel=` from `window.location.search` (set by the CEF launcher on each secondary window's startup URL; falls back to `"main"`).
- Every overlay registration — modal backdrop, MoreDropdown, any future consumer — now publishes the label it belongs to.

## Why this PR is small

No new IPC surface, no new frontend API. The existing URL-query `windowLabel` plumbing is already consumed by `toggle_devtools`, `main_window_focus`, and `getWindowLabel()` in `frontend/util/cef-api.ts:407-410` — I'm just following the same path.

## Behaviour matrix

| Caller | Today (without fix) | With fix |
|---|---|---|
| Single-window (all users today) | Clips apply to every pane | Clips apply to every pane (identical — the one main HWND matches itself) |
| Multi-window, modal in window A | Clips panes in B + C too (bug) | Clips only panes in A |
| Legacy caller omitting `window_label` | N/A (all callers were legacy) | Defaults to `"main"` on backend, filter still works |

## Test plan

- [ ] Single-window: modal opens, backdrop paints over pane (same as #544 post-merge)
- [ ] Single-window: MoreDropdown opens, pane clips under it
- [ ] Multi-window (if reachable): open pane in window A + window B; open modal in A → only A's pane clipped, B stays live
- [ ] `cargo check -p agentmux-cef` green (includes non-Windows stub signature update)

## Related

- #544 — modal-v2 wired into the airspace clip (where this bug was surfaced)
- Codex review comment on #544 `frontend/app/element/modal-v2.tsx:343`

🤖 Generated with [Claude Code](https://claude.com/claude-code)