### PR TITLE
feat(launch-modal): plain-language UX rewrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.384"
+version = "0.33.385"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.384"
+version = "0.33.385"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.384"
+version = "0.33.385"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.384"
+version = "0.33.385"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.384"
+version = "0.33.385"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.384"
+version = "0.33.385"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.384"
+version = "0.33.385"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.384"
+version = "0.33.385"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_LAUNCH_MODAL_PLAIN_LANGUAGE_2026_04_24.md
+++ b/docs/specs/SPEC_LAUNCH_MODAL_PLAIN_LANGUAGE_2026_04_24.md
@@ -1,0 +1,231 @@
+# Spec: Launch Modal Plain-Language Rewrite
+
+**Date:** 2026-04-24
+**Status:** Draft, ready to implement
+**Owner:** AgentA
+**Supersedes UX of:** `docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md` §6
+**Touches:** `frontend/app/view/agent/components/AgentLaunchModal.tsx`,
+             `frontend/app/view/agent/styles/_launch-modal-body.scss`
+
+---
+
+## 1. Problem
+
+The launch modal today mixes a clean primary task ("name this new
+agent and start it") with devops/CLI terminology that bleeds in
+from the backend layer:
+
+| What the UI says | What the user has to decode |
+|---|---|
+| "Runtime: Host / Container" | "Is this an OS runtime thing? What's the difference for *me*?" |
+| "Runs on your machine with your shell" | "I don't know what a shell is" |
+| "Runs inside Docker/Podman — sandboxed" | "I don't know what Docker or Podman is; what's sandboxed mean?" |
+| "Image: (placeholder `python:3.11-slim`)" | "What's an image? Do I need to pick one?" |
+| "Working dir: `data/agents/my-agent-20260424-143220/`" | "Why am I seeing a filesystem path? Can I change it? Should I?" |
+| "1–64 characters. Becomes part of the working directory." | "Working directory, again — *why am I being told this?*" |
+
+These aren't factually wrong, but they push the user down a stack
+they didn't come here to think about. A user wants to name a helper
+and start it. They should not need to understand Docker, shells,
+filesystem slugification rules, or working-directory lifecycles to
+finish the task.
+
+## 2. Goals
+
+- **G1.** No devops jargon (`shell`, `Docker`, `Podman`, `image`,
+  `working directory`, `sandboxed`, `runtime`) in the default view.
+- **G2.** Each field answers a plain-English "what does this do?" in
+  one sentence. No filesystem paths visible by default.
+- **G3.** Power users can still override the container image and
+  see the generated directory name, but it moves under an
+  **Advanced** disclosure that stays closed by default.
+- **G4.** No change to `LaunchOverrides` / backend contract. Pure
+  UX-layer rewrite.
+- **G5.** Stylelint-clean, zero visual regression for users who
+  don't open Advanced, tsc clean, same `.agent-launch-modal-*`
+  BEM prefix (SCSS partial already exists at
+  `frontend/app/view/agent/styles/_launch-modal-body.scss`).
+
+## 3. Non-goals
+
+- No new backend fields, no new RPC, no new props.
+- No change to the agent-definition picker (#524, #525), the
+  import modal, or the delete-confirm modal.
+- No translation / i18n — copy is English only for now.
+- No addition of new icons or illustrations (keep the visual weight
+  unchanged).
+
+---
+
+## 4. Design
+
+### 4.1 Field-by-field copy rewrite
+
+| Field | Today's label + hint | New label + hint |
+|---|---|---|
+| Name | **Name** — *1–64 characters. Becomes part of the working directory.* | **Give this agent a name** — *So you can tell it apart from others. 1–64 characters.* |
+| Runtime option A | **Host** — *Runs on your machine with your shell.* | **On this computer** — *Fastest. The agent can read and change files on your machine.* |
+| Runtime option B | **Container** — *Runs inside Docker/Podman — sandboxed.* | **In a safe sandbox** — *Slower to start, but the agent can't touch files outside its own workspace. Recommended for untrusted tasks.* |
+| Runtime legend | **Runtime** | **Where should it run?** |
+| Image (Advanced only) | **Image** — *Leave blank to use the default image.* | **Override sandbox base** — *Leave blank unless you know exactly which base image you need.* |
+| Working-dir preview | Shown by default under "Working dir: &lt;path&gt;" | **Removed from default view.** Shown inside Advanced as "Its files will live in &lt;name&gt;" — just the directory name, no `data/agents/` prefix. |
+
+### 4.2 Progressive disclosure — "Advanced" section
+
+A collapsed `<details>` element (or custom disclosure) at the
+bottom of the body, labelled **"Advanced options"**. When closed
+(default), it adds zero visual noise. When open, it reveals:
+
+- The container-image override input (only relevant when "In a
+  safe sandbox" is selected — otherwise the field is hidden inside
+  the expanded panel with a greyed-out "only applies to sandbox
+  runtime" note).
+- The directory-name preview, phrased as a plain English
+  sentence, not as a file path.
+
+Rationale: the two technical things a power user might legitimately
+care about (image override + name-to-directory mapping) stay
+accessible, but they no longer define the modal's first impression.
+
+### 4.3 Copy on the launch button
+
+Today: `"Launching…"` while pending. **No change** — already plain
+language.
+
+### 4.4 Catalog blurb (`catalog()?.popoverMarkdown`)
+
+Line 107-110 of the current modal renders the catalog entry's
+`popoverMarkdown` above the form. This copy lives in
+`frontend/app/view/agent/defaults/cli-catalog.ts` and often
+contains CLI-specific phrasing ("Anthropic's Claude Code CLI",
+"Codex — OpenAI's CLI", etc.).
+
+**Decision:** leave the catalog copy alone. It describes the
+*product* the user chose (e.g. "Claude Code"), not a UI control
+they need to understand to finish the task. It also serves as the
+user's "am I launching the right thing?" confirmation and removing
+it would hurt more than help.
+
+If catalog copy mentions implementation details ("runs
+`claude --verbose …`"), that's a cli-catalog.ts content bug, fixed
+separately — not a launch-modal concern.
+
+### 4.5 Visual structure
+
+```
+┌── Launch Claude Code ──────────────────┐
+│  <catalog blurb>                       │
+│                                        │
+│  Give this agent a name                │
+│  [___________________________]         │
+│  So you can tell it apart. 1–64 chars. │
+│                                        │
+│  Where should it run?                  │
+│  ( ) On this computer                  │
+│      Fastest. Can read+change files.   │
+│  ( ) In a safe sandbox                 │
+│      Slower. Can't touch your files.   │
+│                                        │
+│  ▸ Advanced options                    │
+│                                        │
+│  [Cancel]                [Launch]      │
+└────────────────────────────────────────┘
+```
+
+Opened Advanced:
+
+```
+│  ▾ Advanced options                    │
+│    Override sandbox base               │
+│    [_____________________]             │
+│    Leave blank unless you know         │
+│    exactly which base image you need.  │
+│                                        │
+│    Its files will live in              │
+│    `my-helper-20260424-143220`         │
+```
+
+## 5. Implementation
+
+### 5.1 TSX changes (`AgentLaunchModal.tsx`)
+
+1. Rename user-facing strings per §4.1. Keep the `LaunchOverrides`
+   interface and backend-facing property names unchanged.
+2. Add a local `showAdvanced = createSignal(false)` and wrap the
+   image input + directory preview in a `<details>` /
+   custom-toggled block. A native `<details>` is fine — modal-v2
+   handles focus trap correctly for any focusable descendants.
+3. Move the `<Show when={previewDir()}>` block into Advanced.
+   Change its render from `Working dir: data/agents/<slug>/` to
+   `Its files will live in <slug>` (no filesystem path).
+4. When Advanced is collapsed and runtime === "container", the
+   container image still uses the catalog default — behaviour is
+   identical to today for the 99% path.
+5. Hide the container-image input when runtime === "host" (as
+   today) but also when Advanced is closed; when Advanced is open
+   and runtime is "host", render the input **disabled** with a
+   one-line hint "Only applies to the sandbox runtime" so power
+   users switching runtimes understand the relationship.
+
+### 5.2 SCSS changes (`_launch-modal-body.scss`)
+
+1. Add `.agent-launch-modal-advanced` styles for the `<details>`:
+   collapsed header row, subtle chevron, body padding matching
+   the other fields. Use existing spacing tokens — no new values.
+2. Remove (or relax) any CSS that assumed the preview is always
+   visible — the preview is now inside Advanced.
+3. No token churn, no color changes; keep the visual weight
+   identical at first glance.
+
+### 5.3 Tests
+
+No unit tests in scope for the modal today. Add none (keeps this
+PR focused). Validation is manual + the automated build.
+
+### 5.4 Validation checklist
+
+- ✅ `task build:frontend` succeeds
+- ✅ `npx tsc --noEmit` clean
+- ✅ `npm run lint:scss` green
+- ✅ Manual smoke (`task dev`):
+  - Open a definition card → modal opens
+  - Enter a name, Enter → submits (backend unchanged, no
+    regression)
+  - Toggle "Advanced" → reveals image override + directory
+    preview
+  - Switch runtime to "host" while Advanced is open → image
+    field greys out with the "Only applies to sandbox" note
+  - Resize window while modal open → backdrop still clips panes
+    (PR #544 behaviour unchanged)
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Users who were relying on seeing the working directory at a glance now need to click Advanced | Plain-English sentence replaces path; if anyone complains, we can surface the slug inline under the name field — cheap to reverse. |
+| "On this computer" / "In a safe sandbox" reads marketing-y | Tested internally with CLAUDE.md guidance ("explain fields in general easy-to-understand terms"). If a power-user cohort prefers the technical labels, a future "advanced labels" setting could flip them globally. Not in scope. |
+| Native `<details>` may not style consistently across CEF versions | Fallback: a `createSignal`-driven button + conditional render. Either is trivial; pick whichever styles cleanest. |
+| Users confused about what "sandbox" means if they've never heard it | The hint says what it *does* ("can't touch files outside its own workspace") — no need to define the word. |
+
+## 7. Non-goals (re-stated)
+
+- No content-model overhaul. `LaunchOverrides`, the launch RPC,
+  the working-dir resolution logic, and the catalog config all
+  stay identical.
+- No new popovers or tooltips (the spec-quoted §6.3 popover
+  plan from `SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md` is a
+  separate expansion — this PR is strictly copy + disclosure).
+
+## 8. Cross-references
+
+- `docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md` §6 —
+  original spec this refines.
+- `frontend/app/view/agent/components/AgentLaunchModal.tsx` —
+  target component.
+- `frontend/app/view/agent/styles/_launch-modal-body.scss` —
+  target SCSS partial.
+- `frontend/app/view/agent/defaults/cli-catalog.ts` — the catalog
+  entries whose copy is out of scope for this spec but could
+  benefit from a similar plain-language pass.

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -44,15 +44,13 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
     const [image, setImage] = createSignal<string>("");
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
+    const [showAdvanced, setShowAdvanced] = createSignal(false);
 
-    // Live preview — the backend computes the real stamp on submit,
-    // but showing something now reassures the user that their name
-    // will become a directory.
-    const previewDir = createMemo(() => {
-        const trimmed = name().trim();
-        if (!trimmed) return "";
-        return `data/agents/${buildInstanceSlug(trimmed)}/`;
-    });
+    // Live preview of the instance slug — shown inside Advanced as
+    // "Its files will live in <slug>" so power users can see what
+    // their name will become. The backend stamps the real slug on
+    // submit, but this is close enough for the user to recognise it.
+    const hasName = () => name().trim().length > 0;
 
     const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
 
@@ -110,7 +108,7 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                     </Show>
 
                     <label class="agent-launch-modal-field">
-                        <span class="agent-launch-modal-label">Name</span>
+                        <span class="agent-launch-modal-label">Give this agent a name</span>
                         <input
                             class="agent-launch-modal-input"
                             type="text"
@@ -119,15 +117,15 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                             value={name()}
                             onInput={(e) => setName(e.currentTarget.value)}
                             disabled={submitting()}
-                            aria-label="Instance name"
+                            aria-label="Agent name"
                         />
                         <span class="agent-launch-modal-hint">
-                            1–64 characters. Becomes part of the working directory.
+                            So you can tell it apart from other agents. 1–64 characters.
                         </span>
                     </label>
 
                     <fieldset class="agent-launch-modal-field agent-launch-modal-runtime">
-                        <legend class="agent-launch-modal-label">Runtime</legend>
+                        <legend class="agent-launch-modal-label">Where should it run?</legend>
                         <label class="agent-launch-modal-radio">
                             <input
                                 type="radio"
@@ -137,9 +135,9 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                                 disabled={submitting()}
                             />
                             <span>
-                                <strong>Host</strong>
+                                <strong>On this computer</strong>
                                 <span class="agent-launch-modal-hint">
-                                    Runs on your machine with your shell.
+                                    Fastest. The agent can read and change files on your machine.
                                 </span>
                             </span>
                         </label>
@@ -155,44 +153,58 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                                 disabled={submitting() || !containerSupported()}
                             />
                             <span>
-                                <strong>Container</strong>
+                                <strong>In a safe sandbox</strong>
                                 <span class="agent-launch-modal-hint">
                                     {containerSupported()
-                                        ? "Runs inside Docker/Podman — sandboxed."
-                                        : "Not supported for this CLI."}
+                                        ? "Slower to start, but the agent can't touch files outside its own workspace. Recommended for untrusted tasks."
+                                        : "Not available for this agent."}
                                 </span>
                             </span>
                         </label>
                     </fieldset>
 
-                    <Show when={runtime() === "container" && containerSupported()}>
-                        <label class="agent-launch-modal-field">
-                            <span class="agent-launch-modal-label">Image</span>
-                            <input
-                                class="agent-launch-modal-input"
-                                type="text"
-                                placeholder={catalog()?.containerImage ?? ""}
-                                value={image()}
-                                onInput={(e) => setImage(e.currentTarget.value)}
-                                disabled={submitting()}
-                                aria-label="Container image"
-                            />
-                            <span class="agent-launch-modal-hint">
-                                Leave blank to use the default image.
-                            </span>
-                        </label>
-                    </Show>
-
-                    <Show when={previewDir()}>
-                        <div class="agent-launch-modal-preview">
-                            <span class="agent-launch-modal-preview-label">Working dir:</span>
-                            <code>{previewDir()}</code>
-                        </div>
-                    </Show>
-
                     <Show when={error()}>
                         <div class="agent-launch-modal-error">{error()}</div>
                     </Show>
+
+                    <details
+                        class="agent-launch-modal-advanced"
+                        open={showAdvanced()}
+                        onToggle={(e) => setShowAdvanced(e.currentTarget.open)}
+                    >
+                        <summary class="agent-launch-modal-advanced-summary">
+                            Advanced options
+                        </summary>
+                        <div class="agent-launch-modal-advanced-body">
+                            <label
+                                class="agent-launch-modal-field"
+                                classList={{ "agent-launch-modal-field--disabled": runtime() !== "container" }}
+                            >
+                                <span class="agent-launch-modal-label">Override sandbox base</span>
+                                <input
+                                    class="agent-launch-modal-input"
+                                    type="text"
+                                    placeholder={catalog()?.containerImage ?? ""}
+                                    value={image()}
+                                    onInput={(e) => setImage(e.currentTarget.value)}
+                                    disabled={submitting() || runtime() !== "container" || !containerSupported()}
+                                    aria-label="Sandbox base image"
+                                />
+                                <span class="agent-launch-modal-hint">
+                                    {runtime() === "container"
+                                        ? "Leave blank unless you know exactly which base image you need."
+                                        : "Only applies to the sandbox runtime."}
+                                </span>
+                            </label>
+
+                            <Show when={hasName()}>
+                                <div class="agent-launch-modal-preview">
+                                    <span class="agent-launch-modal-preview-label">Its files will live in</span>
+                                    <code>{buildInstanceSlug(name().trim())}</code>
+                                </div>
+                            </Show>
+                        </div>
+                    </details>
                 </div>
             </ModalBody>
             <ModalFooter>

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -138,3 +138,55 @@
     border-radius: 3px;
 }
 
+// Advanced disclosure — collapsed by default. Reveals the container-image
+// override + the "files will live in <slug>" preview. Hidden by default so
+// first-time users aren't confronted with container base images and
+// filesystem slugs. See SPEC_LAUNCH_MODAL_PLAIN_LANGUAGE_2026_04_24.md.
+
+.agent-launch-modal-advanced {
+    border-top: 1px dashed var(--border-color);
+    padding-top: var(--space-2);
+}
+
+.agent-launch-modal-advanced-summary {
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--secondary-text-color);
+    user-select: none;
+    list-style: none;         // hide default triangle marker in webkit
+    padding: var(--space-1) 0;
+
+    // Render our own chevron so it matches the design system look and
+    // doesn't inherit Chromium's default triangle.
+    &::before {
+        content: "▸";
+        display: inline-block;
+        width: 1em;
+        margin-right: var(--space-1);
+        transition: transform 0.1s ease;
+    }
+
+    &:hover {
+        color: var(--main-text-color);
+    }
+}
+
+.agent-launch-modal-advanced[open] .agent-launch-modal-advanced-summary::before {
+    transform: rotate(90deg);
+}
+
+.agent-launch-modal-advanced-body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    padding-top: var(--space-2);
+}
+
+// When Advanced is open but runtime is "host", the image field is shown
+// but disabled with a note explaining when it applies. Visual hint that
+// this input is inactive in the current context.
+.agent-launch-modal-field--disabled {
+    opacity: 0.6;
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.384",
+  "version": "0.33.385",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.384",
+      "version": "0.33.385",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.384",
+  "version": "0.33.385",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The launch modal today leaks devops terminology (`Host / Container`, `shell`, `Docker/Podman`, `Image`, `Working dir: data/agents/<slug>/`) to end-users who just want to name an agent and start it. This PR rewrites the user-facing copy into plain English and moves the two technical fields a power user might legitimately want (container image override, instance-slug preview) under a collapsed **"Advanced options"** disclosure.

## Copy changes

| Element | Today | This PR |
|---|---|---|
| Name label | **Name** / *1–64 characters. Becomes part of the working directory.* | **Give this agent a name** / *So you can tell it apart from other agents. 1–64 characters.* |
| Runtime fieldset | **Runtime** | **Where should it run?** |
| Option A | **Host** / *Runs on your machine with your shell.* | **On this computer** / *Fastest. The agent can read and change files on your machine.* |
| Option B | **Container** / *Runs inside Docker/Podman — sandboxed.* | **In a safe sandbox** / *Slower to start, but the agent can't touch files outside its own workspace. Recommended for untrusted tasks.* |
| Image field | Always visible when Container selected; labelled **Image** | **Hidden by default.** Lives inside Advanced as **Override sandbox base**. Greys out with "Only applies to the sandbox runtime" when the user switches back to "On this computer". |
| Preview | Always visible: `Working dir: data/agents/<slug>/` | **Hidden by default.** Lives inside Advanced as "Its files will live in `<slug>`" — just the slug, no filesystem path. |

## No backend change

`LaunchOverrides` interface, the launch RPC, the working-directory resolution, and the catalog config are all untouched. This PR is strictly copy + disclosure.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `task build:frontend` | succeeds |
| `npm run lint:scss` | green |

Spec: `docs/specs/SPEC_LAUNCH_MODAL_PLAIN_LANGUAGE_2026_04_24.md`

## Test plan

- [ ] Click an agent definition card → modal opens with plain-language copy
- [ ] Type a name, hit Enter → submits (identical to before)
- [ ] Toggle **Advanced options** → reveals the image override + slug preview
- [ ] Select "In a safe sandbox" → image override enables. Switch back to "On this computer" with Advanced open → image field greys out with "Only applies to the sandbox runtime" hint
- [ ] Resize window with modal open → backdrop still clips panes (PR #544 behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)