### PR TITLE
feat(agent-pane): zone reorder + enriched Worked footer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.385"
+version = "0.33.386"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.385"
+version = "0.33.386"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.385"
+version = "0.33.386"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.385"
+version = "0.33.386"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.385"
+version = "0.33.386"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.385"
+version = "0.33.386"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.385"
+version = "0.33.386"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.385"
+version = "0.33.386"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md
+++ b/docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md
@@ -1,0 +1,243 @@
+# Spec: Agent Pane Zone Reorder + Enriched "Worked" Footer
+
+**Date:** 2026-04-24
+**Status:** Draft, ready to implement
+**Owner:** AgentA
+**Touches:** `frontend/app/view/agent/agent-view.tsx`,
+             `frontend/app/view/agent/components/AgentFooter.tsx`,
+             `frontend/app/view/agent/styles/_pending-footer.scss`
+
+---
+
+## 1. Problem
+
+Two related UX gaps in the agent pane:
+
+### 1.1 Queue sits in the wrong zone
+When the user types a new message while the agent is still working,
+the typed text lands in a **pending queue** (amber banner) that
+renders *below* the status line and activity log:
+
+```
+┌ feed ──────────────────────────────────┐
+│ …conversation transcript…              │
+│                                        │
+├ status line ──────────────────────────┤
+│ ⠋ Working…                             │
+├ activity log ──────────────────────────┤
+│ (events)                               │
+├ pending queue ────────────────────── ← │
+│ “fix the thing”                        │
+│ “then run tests”                       │
+├ composer ──────────────────────────────┤
+│ [type here…]                           │
+└────────────────────────────────────────┘
+```
+
+Problem: the queue feels visually divorced from the feed it's queued
+against. The user types, their message disappears into the composer,
+and then reappears on the other side of two unrelated zones
+(status + activity). The "pending" concept reads more clearly when
+the queued items sit **directly under the live feed**, next to the
+newest assistant message, with the "Working…" indicator right below
+them — because the queue is what the agent will work on *next* after
+the current turn.
+
+### 1.2 "Worked" label lacks the numbers users want at a glance
+
+At the end of a turn, the status line collapses from
+`"Working… · ↑12k  ↓3k · 42s"` to `"Worked · $0.018 · 42s · 4 turns"`.
+Tokens disappear from the completed-turn summary, even though they're
+still the most-asked-about number during a post-mortem ("how much did
+that cost us in tokens?"). The cost value is useful too but subservient
+to tokens — tokens are what users budget against and what carry over
+into the next turn's context window.
+
+## 2. Goals
+
+- **G1.** Move the pending queue directly below the feed and above
+  the "Working…" status line in the pane's DOM order.
+- **G2.** Enrich the "Worked" terminal-state label so it always
+  shows **duration + total tokens** (input + output), with cost and
+  turn count as secondary metadata (smaller type, same row).
+- **G3.** No visual regression for running turns (the "Working…"
+  animation + live token counters stay as-is).
+- **G4.** Tokens-over-duration ordering matches the composer's
+  live readout for continuity — the same glyphs (`↑`/`↓`), the same
+  number formatting.
+
+## 3. Non-goals
+
+- No change to the pending-queue colour transition (amber → blue on
+  accept) — that's governed by
+  `AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md` and stays intact.
+- No change to the activity log panel, retry bar, or auth overlay
+  positions — only the queue moves.
+- No new metadata fields. Tokens + duration + cost + turn count are
+  all already available in `SessionStats` and `TurnTokens`; this is
+  a rendering change.
+- No change to `AgentFooter`'s text input or slash picker.
+
+---
+
+## 4. Design
+
+### 4.1 New DOM order
+
+```
+.agent-view
+├── BookmarksPanel
+├── AgentSearchBar
+├── SessionDigestBanner
+├── AgentFocusedPanel (overlay)
+├── AgentDocumentView       ← the feed (unchanged)
+├── AgentRetryBar           (unchanged; shows only on auth failure)
+├── PendingMessagesPanel    ← MOVED HERE (was below activity log)
+├── AgentStatusLine         ← "Working…" / "Worked …"
+├── ActivityLogPanel        (unchanged position)
+└── .agent-composer-region  (unchanged)
+    └── …
+```
+
+Rationale: queue-then-status reads top-to-bottom as *"here's what
+you've told the agent next → here's what it's currently doing"*.
+
+### 4.2 Worked-footer layout
+
+**Running turn (unchanged):**
+```
+⠋ Working…                     ↑12k ↓3k · 42s
+```
+
+**Completed turn (today):**
+```
+✓ Worked          $0.018 · 42s · 4 turns
+```
+
+**Completed turn (this spec):**
+```
+✓ Worked · 42s · ↑12k ↓3k            $0.018 · 4 turns
+```
+
+- Primary line (left group): state label, duration, total tokens
+  with up/down glyphs. Same font size as the running-turn
+  display so nothing jumps on transition.
+- Secondary line (right group): cost + turn count, rendered in
+  `--secondary-text-color` at the existing smaller size.
+- If `TurnTokens` is unavailable for a completed turn (older CLI
+  stream, missing `usage` field), fall back gracefully to
+  `Worked · 42s · $0.018 · 4 turns` — identical to today.
+
+### 4.3 Copy + formatting rules
+
+- Duration: `XXs` when under a minute, `X.Xm` for 60-599s,
+  `Xm Xs` for 10 minutes and above. Matches existing
+  `statsText()` logic — reuse, don't duplicate.
+- Tokens: reuse `tokenText()` in `AgentFooter.tsx:107`, which
+  already emits `↑NNNk  ↓NNNk` with the same k-rounding we use in
+  the running-turn readout.
+- Cost: `$0.0XX` keep the 3-decimal precision that
+  `statsText()` uses today.
+- Turn count: `N turns` (pluralise — `1 turn` / `N turns`).
+- Separator: middle dot `·` with `0.5ch` horizontal margins, same
+  as today.
+
+---
+
+## 5. Implementation
+
+### 5.1 `agent-view.tsx`
+
+Move the `<PendingMessagesPanel>` JSX node from its current
+position (between `<AgentStatusLine>` and composer) to sit
+**immediately after `<AgentRetryBar>` and before
+`<AgentStatusLine>`**. Line numbers per Explorer report: today the
+panel lives around line 590; target position is just before the
+status-line block near line 539. No prop changes, no new atoms.
+
+### 5.2 `AgentFooter.tsx` → `AgentStatusLine`
+
+Rewrite the fallback/"Worked" branch (today at lines 138-142) so it
+pulls both `statsText()` and `tokenText()` and composes them into
+left- and right-group spans matching §4.2. Concretely:
+
+```tsx
+// Existing:
+<span class="agent-status-line-text">
+    Worked {statsText()}
+</span>
+
+// New:
+<span class="agent-status-line-text">
+    <span class="agent-status-line-primary">
+        Worked · {formatDuration(stats().duration_ms)} · {tokenText()}
+    </span>
+    <Show when={stats().cost_usd || stats().num_turns}>
+        <span class="agent-status-line-secondary">
+            {formatCostAndTurns(stats())}
+        </span>
+    </Show>
+</span>
+```
+
+Extract `formatDuration()` / `formatCostAndTurns()` helpers from
+the existing `statsText()` so the Working branch keeps using the
+same formatters (no drift).
+
+### 5.3 `_pending-footer.scss`
+
+The moved position may need a tweak to the spacing/border: when
+the queue sits *above* the status line, its visual weight should
+be a bit lower than today's bottom-of-stack placement. Concretely:
+
+- Change the queue's top border from solid to a 1px dashed
+  border-top and a 1px solid border-bottom — visually "pinned to
+  the feed above it" rather than "floating above the footer".
+- Reduce its vertical padding by one `--space` token to tighten
+  it against the feed.
+
+No color changes. Existing amber-→-blue transition stays.
+
+### 5.4 Status-line two-group flex
+
+Update the status-line container so it's a `display: flex;
+justify-content: space-between;` row with primary + secondary
+groups as children. The current layout is already left-right-split
+for tokens-right but the new Worked state uses the same pattern on
+the completed branch too.
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Users relying on muscle memory ("queue is the amber thing above the input") | The queue is still amber and still visible. Its position change should be *more* intuitive (closer to the feed it queues against). If needed, a one-time "New layout" tooltip can be added later. |
+| Token data missing for older stream replays | Fallback path in §4.2 keeps parity with today when `TurnTokens` is null. |
+| Status-line width overflows on narrow panes | The `.agent-status-line` already has container queries (`@container`) in the responsive partial — if the combined primary+secondary string overflows, we can collapse to just primary. Spec-level placeholder; actual threshold determined empirically in review. |
+| Two-row vs. one-row completed footer | The spec is one row. If the pane width can't hold both groups, wrap to two rows via `flex-wrap` — cheaper than hiding information. |
+
+## 7. Validation
+
+- ✅ `task build:frontend` succeeds
+- ✅ `tsc --noEmit` clean
+- ✅ Stylelint green
+- ✅ Manual smoke (`task dev`):
+  - Send a message, start a second one while first runs → queue
+    appears **between** feed and status line
+  - Let a turn complete → footer shows
+    `Worked · 42s · ↑12k ↓3k` with `$0.018 · 4 turns` on the right
+  - Start a new turn → live `Working…` shows tokens on the right
+    as today
+  - Resize pane narrow → cost+turns gracefully drop or wrap
+
+## 8. Cross-references
+
+- `frontend/app/view/agent/agent-view.tsx` — JSX order
+- `frontend/app/view/agent/components/AgentFooter.tsx` —
+  `AgentStatusLine` + `statsText()` + `tokenText()`
+- `frontend/app/view/agent/components/PendingMessagesPanel.tsx` —
+  moved component
+- `frontend/app/view/agent/styles/_pending-footer.scss` — queue CSS
+- `AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md` — governs the queue's
+  colour transitions (not changed here)

--- a/docs/specs/SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md
+++ b/docs/specs/SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md
@@ -1,0 +1,265 @@
+# Spec: Status-Bar Token Usage Indicator + Per-Service Breakdown
+
+**Date:** 2026-04-24
+**Status:** Draft, ready to implement
+**Owner:** AgentA
+**Touches:** `frontend/app/statusbar/StatusBar.tsx` (+ SCSS),
+             new `frontend/app/statusbar/TokenUsageIndicator.tsx`,
+             new `frontend/app/statusbar/TokenBreakdownPopover.tsx`,
+             a new token-aggregation store (see §5.1 — location TBD
+             during impl, proposal: `frontend/app/store/token-usage.ts`)
+
+---
+
+## 1. Problem
+
+AgentMux runs multiple agent CLIs concurrently (Claude Code, Codex,
+Gemini, Copilot, …) and every turn consumes tokens, but today the
+user has no single place to see *"how many tokens have I burned
+today across everything?"* The per-turn readout in the agent pane's
+status line (`↑12k ↓3k`) answers a local question; it doesn't
+answer the budget question.
+
+Users want:
+
+1. A small at-a-glance total in the **bottom status bar** that
+   increments as sessions run.
+2. Clicking that total opens a **breakdown popover** that splits
+   the total by service (Claude / Codex / Gemini / Copilot / …) so
+   they can see where the spend is concentrated.
+
+## 2. Goals
+
+- **G1.** Persistent running total on the status bar, updated live
+  as stream-json events arrive.
+- **G2.** Popover (click to open, click-outside / Esc to close)
+  showing per-service input + output token counts plus a total row.
+- **G3.** Totals aggregate across all live agent panes + historical
+  turns persisted since AgentMux started this session. A "Reset"
+  option in the popover clears the running total to zero.
+- **G4.** Zero backend work — per-turn `TurnTokens` and
+  `SessionStats` are already parsed from stream-json; this spec
+  aggregates existing data client-side.
+- **G5.** Popover uses the existing `usePaneOverlay` primitive so
+  it renders correctly over a browser pane (modal-v2 already does).
+
+## 3. Non-goals
+
+- No cost display on the status-bar total. Cost belongs in the
+  per-turn footer (see
+  `SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md`). Tokens
+  are the budget unit here.
+- No persistence across AgentMux restarts. Session-local only.
+  (Stretch goal noted in §7.)
+- No per-model breakdown (Opus vs. Sonnet vs. Haiku). Service-level
+  only. Could extend later if demand surfaces.
+- No rate-limit / remaining-budget integration. Those numbers live
+  in a different realm (provider headers, subscription tiers) and
+  belong in a separate spec.
+
+---
+
+## 4. Design
+
+### 4.1 Status-bar indicator
+
+Placement: the indicator sits in the status bar's **right group**,
+alongside other passive readouts (backend status, connection
+status). Compact form by default:
+
+```
+┌ status bar ───────────────────────────────────────────────────┐
+│ …left-group things…          🪙 42k ↑ / 12k ↓   v0.33.385     │
+└───────────────────────────────────────────────────────────────┘
+```
+
+- 🪙 icon (`fa-coins` from the font-awesome set AgentMux already
+  bundles — same glyph family as other status icons).
+- Numbers use the same `k` rounding as `tokenText()` in
+  `AgentFooter.tsx` (`formatTokenCount(n)`: <1000 → raw, ≥1000 →
+  `Xk` with one decimal when under 10k).
+- On hover: subtle background highlight so it reads as clickable.
+- Tab-index + `role="button"` + keyboard activation (Enter/Space).
+
+When total is zero (no turns completed yet this session), the
+indicator shows `🪙 0` — visible but muted. The zero state doubles
+as a "I exist; click me to see the breakdown" affordance.
+
+### 4.2 Breakdown popover
+
+Opens on click below the indicator (popover anchor = indicator
+bounding rect). Uses the existing modal-v2-adjacent overlay
+primitive (`usePaneOverlay` for the Win32 airspace cut; same
+pattern as MoreDropdown — see PR #544 / #545). If native
+`<dialog>` positioning is painful, render via Solid's `<Portal>`
+like MoreDropdown does.
+
+Layout:
+
+```
+┌────────────────────────────┐
+│ Token Usage · this session │
+├────────────────────────────┤
+│ Claude Code      ↑28k ↓ 8k │
+│ Codex            ↑10k ↓ 3k │
+│ Gemini           ↑ 4k ↓ 1k │
+│ Copilot          ↑ 0  ↓ 0  │
+├────────────────────────────┤
+│ Total            ↑42k ↓12k │
+├────────────────────────────┤
+│ [Reset counter]            │
+└────────────────────────────┘
+```
+
+- Header: `"Token Usage · this session"` + smaller subheader with
+  the session start time (so the user knows what "this session"
+  means — e.g. `"since 9:12 AM"`).
+- One row per service that has contributed tokens this session.
+  Services with zero so far are hidden (reduce noise) unless
+  `debug` flag is on. Exception: always show all four services
+  the user currently has registered agent definitions for, even if
+  zero, so the popover looks complete.
+- Services ordered by total tokens descending (biggest consumer
+  first). Stable secondary sort = service name alphabetical.
+- Total row is bold, same row layout, divider above it.
+- "Reset counter" button at the bottom. Confirms via
+  `ConfirmModal` (reuses modal-v2's preset) with destructive
+  styling, since resetting loses the running total.
+
+### 4.3 Interaction model
+
+- Click indicator → popover opens.
+- Click outside / Esc → closes.
+- Click another DOM element → closes.
+- Popover is **modal-equivalent for Win32 airspace** (calls
+  `usePaneOverlay` on its root so pane HWNDs clip where it paints)
+  but is not a true modal (no backdrop, doesn't block page
+  interaction). Same pattern the MoreDropdown uses today.
+- Keyboard: Enter on indicator opens; Esc closes; Tab cycles
+  through "Reset counter" back to indicator trigger.
+
+---
+
+## 5. Implementation
+
+### 5.1 Client-side aggregation store
+
+Create `frontend/app/store/token-usage.ts` (or equivalent). It
+exports a Solid store shaped roughly:
+
+```ts
+type ServiceId = "claude" | "codex" | "gemini" | "copilot" | string;
+
+interface ServiceUsage {
+    input: number;
+    output: number;
+}
+
+interface TokenUsageState {
+    sessionStartAt: number;     // epoch ms of first observation
+    byService: Record<ServiceId, ServiceUsage>;
+}
+```
+
+Exported methods:
+
+- `recordTurn(serviceId, tokens: TurnTokens)` — called from the
+  existing per-turn completion path (where `SessionEndEvent`
+  fires). Increments the running totals.
+- `getTotal()` — computed sum across all services.
+- `resetSession()` — clears `byService` and bumps
+  `sessionStartAt` to `Date.now()`.
+
+**Plumbing:** find the location where `TurnTokens` becomes final
+per turn (likely `useAgentStream.ts` where `SessionEndEvent` is
+emitted — per the Explorer report). Call `recordTurn(provider,
+tokens)` there. The `provider` string already lives on the agent
+definition / catalog entry.
+
+### 5.2 `TokenUsageIndicator.tsx`
+
+New component rendered inside `StatusBar.tsx`. Reads the store's
+total. Renders the compact `🪙 42k ↑ / 12k ↓` label. On activate,
+toggles a `createSignal` flag that mounts the
+`TokenBreakdownPopover`.
+
+### 5.3 `TokenBreakdownPopover.tsx`
+
+New component. Renders the breakdown layout in §4.2. Uses
+`usePaneOverlay(() => rootRef)` for airspace. Anchors its
+positioning to the indicator element's bounding rect (reuse or
+generalise MoreDropdown's anchoring math).
+
+### 5.4 Integration into `StatusBar.tsx`
+
+Add the `<TokenUsageIndicator />` to the right-group children.
+Ordering to be finalised in review — proposal: just left of the
+version-number readout.
+
+### 5.5 Styling
+
+New SCSS partial `frontend/app/statusbar/_token-usage.scss`
+(follows the Phase 5 split pattern). BEM classes:
+`.token-usage-indicator`, `.token-usage-breakdown`,
+`.token-usage-breakdown-row`, `.token-usage-breakdown-total`,
+`.token-usage-breakdown-reset`. All colours via tokens
+(`--secondary-text-color` for numbers, `--accent-color` for
+hover/focus, `--error-color` for destructive-reset button).
+
+### 5.6 Test plan
+
+- [ ] `task build:frontend` succeeds
+- [ ] `tsc --noEmit` clean
+- [ ] Stylelint green
+- [ ] Manual (`task dev`):
+  - Launch an agent, run a turn → indicator updates as the turn
+    completes
+  - Launch a second agent of a different service, run a turn →
+    both services appear in the popover breakdown
+  - Click indicator → popover opens below it, over a browser pane
+    if present (airspace works)
+  - Reset counter → popover confirms → total returns to 0
+  - Esc / click-outside closes popover
+  - Open dev tools, inspect: token-usage store state matches
+    what's visible in the UI
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Double-counting a turn if the stream-json replays on reconnect | Key turns by `(sessionId, turnIndex)` in the store and ignore duplicates. |
+| Service IDs inconsistent between the catalog and the stream event | Centralise the normalisation in the store's `recordTurn` — map any recognised provider alias to the canonical id set. Unknown ids pass through as-is and get their own row. |
+| Popover layout breaks on very narrow pane widths | The popover is fixed-width (320px). Status bar itself stays compact. If the pane is narrower than the popover, it anchors to the right edge of the viewport and clips gracefully (same pattern as MoreDropdown). |
+| Reset button accidentally hit | Destructive `ConfirmModal` gate — matches the pattern used for delete-definition. |
+| No persistence → restart wipes the counter | Spec limits scope to session-local. A follow-up could persist to `localStorage` keyed by date; not in scope here. |
+
+## 7. Stretch goals (not in this PR)
+
+1. **Daily/weekly cumulative totals** persisted to `localStorage`.
+   Would let the indicator show *"42k today / 310k this week"*.
+2. **Cost column** in the breakdown popover (not on the indicator
+   itself) — reuses per-turn `cost_usd` the same way tokens
+   aggregate. Needs a decision on whether to show estimated cost
+   when the provider doesn't emit one.
+3. **Rate-limit integration** — read provider headers the sidecar
+   already captures and surface remaining quota next to the
+   indicator. Separate spec.
+4. **Per-model breakdown** (Opus vs. Sonnet). Indicator stays
+   service-level; popover gains an expand-row per service.
+
+## 8. Cross-references
+
+- `frontend/app/statusbar/StatusBar.tsx` + `StatusBar.scss` —
+  target for the new indicator.
+- `frontend/app/view/agent/hooks/useAgentStream.ts` (per Explorer
+  report) — where `TurnTokens` becomes final per turn; hook the
+  store's `recordTurn` here.
+- `frontend/app/view/agent/components/AgentFooter.tsx` —
+  `formatTokenCount` / `tokenText` — reuse for consistent glyph
+  style across the per-pane and global indicators.
+- `frontend/app/platform/pane-overlay.ts` — `usePaneOverlay` for
+  airspace (same pattern as modal-v2, MoreDropdown).
+- `SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md` —
+  companion spec for per-pane token rendering.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -531,11 +531,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 </div>
             </Show>
 
-            {/* Working…/Stopping… status — deliberately rendered ABOVE
-                the activity log so the user's eye lands on live state
-                before diagnostics. Used to live inside the composer
-                region right above the input; moved here so the activity
-                log doesn't push it off-screen during long agent output. */}
+            {/* Queue sits directly below the feed so the user's newly-
+                typed message lands next to the live conversation it's
+                queued against. Previously lived below the activity log;
+                repositioning per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24. */}
+            <PendingMessagesPanel pendingMessages={pendingMessagesAtom[0]} />
+
+            {/* Working…/Stopping… status — reads as "what the agent is
+                doing about the queue above". Used to live inside the
+                composer region right above the input; moved here so the
+                activity log doesn't push it off-screen during long
+                agent output. */}
             <AgentStatusLine
                 loading={status.isLoading() || agentAtoms().turnActiveAtom[0]() || stoppingAtom[0]()}
                 stopping={stoppingAtom[0]()}
@@ -555,7 +561,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             />
 
             <ActivityLogPanel entries={logLines} />
-            <PendingMessagesPanel pendingMessages={pendingMessagesAtom[0]} />
 
             <div class="agent-composer-region">
                 <Show when={commands.helpVisible()}>

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -534,8 +534,19 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             {/* Queue sits directly below the feed so the user's newly-
                 typed message lands next to the live conversation it's
                 queued against. Previously lived below the activity log;
-                repositioning per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24. */}
-            <PendingMessagesPanel pendingMessages={pendingMessagesAtom[0]} />
+                repositioning per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.
+                "Send now" lives inside the queue header (right side)
+                so it sits adjacent to the messages it accelerates. */}
+            <PendingMessagesPanel
+                pendingMessages={pendingMessagesAtom[0]}
+                showSendNow={() =>
+                    agentAtoms().turnActiveAtom[0]() &&
+                    pendingMessagesAtom[0]().length > 0
+                }
+                onSendImmediately={() => {
+                    commands.stopAgent();
+                }}
+            />
 
             {/* Working…/Stopping… status — reads as "what the agent is
                 doing about the queue above". Used to live inside the
@@ -593,18 +604,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}
                     getCompletions={commands.completions}
-                    // Show "Send now" while a turn is running and there's
-                    // something to accelerate — pending queue items or
-                    // text waiting in the composer. On click: SIGINT +
-                    // submit the composer text (which tails the queue;
-                    // process_waiter drains it right after the kill).
-                    showSendNow={() =>
-                        agentAtoms().turnActiveAtom[0]() &&
-                        pendingMessagesAtom[0]().length > 0
-                    }
-                    onSendImmediately={() => {
-                        commands.stopAgent();
-                    }}
                 />
             </div>
             {/* AgentActionBar (Add / Import / Export) lives in the

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -87,8 +87,11 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
 
     // Completed-turn summary split into two groups so tokens + duration
     // (the numbers users ask about most) sit on the primary line and
-    // cost + turn count take the secondary role. Per
-    // docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md §4.2.
+    // cost + turn count take the secondary role. Tokens read from
+    // sessionStats rather than turnTokens because finalizeTurn nulls
+    // the live turnTokens signal on session_end — the snapshot lives
+    // in sessionStats.input_tokens / output_tokens. Per PR #549 review.
+    // Spec: docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md §4.2.
     const workedPrimary = createMemo((): string | null => {
         const stats = props.sessionStats;
         if (!stats) return null;
@@ -97,7 +100,9 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
             const s = Math.round(stats.duration_ms / 1000);
             parts.push(s < 60 ? `${Math.max(1, s)}s` : `${Math.floor(s / 60)}m ${s % 60}s`);
         }
-        if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
+        if (stats.input_tokens != null || stats.output_tokens != null) {
+            parts.push(fmtTokens({ input: stats.input_tokens ?? 0, output: stats.output_tokens ?? 0 }));
+        }
         return parts.join("  \u00b7  ");
     });
 

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -203,19 +203,6 @@ interface AgentFooterProps {
      * If absent, autocomplete is disabled.
      */
     getCompletions?: (prefix: string) => SlashCommand[];
-    /**
-     * Show the "Send now" button above the composer. Caller typically
-     * passes `turnActive() && (hasText || pendingCount > 0)` so the
-     * button appears only when there's something to force through and
-     * the agent is currently busy.
-     */
-    showSendNow?: () => boolean;
-    /**
-     * Fires when the user clicks "Send now". Caller is expected to
-     * `stopAgent()` (SIGINT) and then — if the composer has text —
-     * call `onSendMessage` with it. See AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md.
-     */
-    onSendImmediately?: () => void;
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -375,17 +362,9 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
 
     return (
         <div class="agent-footer">
-            <Show when={props.showSendNow?.()}>
-                <button
-                    type="button"
-                    class="agent-send-immediately-btn"
-                    onClick={() => props.onSendImmediately?.()}
-                    title="Stop the current turn and process the queue now"
-                >
-                    <span class="agent-send-immediately-icon">⏭</span>
-                    <span>Send now</span>
-                </button>
-            </Show>
+            {/* "Send now" now renders inside PendingMessagesPanel (right
+                of the queue header) so it sits next to the messages it
+                accelerates, not above the composer. */}
             <div class="agent-input-container">
                 <Show when={autocompletePrefix() !== null && completions().length > 0}>
                     <SlashAutocomplete

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -85,21 +85,31 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
         if (props.loading && !props.currentTool) setLastPhrase(phrase());
     });
 
-    // Reactive derived values used in both branches.
-    const statsText = createMemo((): string | null => {
+    // Completed-turn summary split into two groups so tokens + duration
+    // (the numbers users ask about most) sit on the primary line and
+    // cost + turn count take the secondary role. Per
+    // docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md §4.2.
+    const workedPrimary = createMemo((): string | null => {
         const stats = props.sessionStats;
         if (!stats) return null;
-        const parts: string[] = [];
-        parts.push(ingToEd(lastPhrase()));
-        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
+        const parts: string[] = [ingToEd(lastPhrase())];
         if (stats.duration_ms != null) {
             const s = Math.round(stats.duration_ms / 1000);
             parts.push(s < 60 ? `${Math.max(1, s)}s` : `${Math.floor(s / 60)}m ${s % 60}s`);
         }
+        if (props.turnTokens) parts.push(fmtTokens(props.turnTokens));
+        return parts.join("  \u00b7  ");
+    });
+
+    const workedSecondary = createMemo((): string | null => {
+        const stats = props.sessionStats;
+        if (!stats) return null;
+        const parts: string[] = [];
+        if (stats.cost_usd != null) parts.push(`$${stats.cost_usd.toFixed(3)}`);
         if (stats.num_turns) {
             parts.push(`${stats.num_turns} ${stats.num_turns === 1 ? "turn" : "turns"}`);
         }
-        return parts.join("  \u00b7  ");
+        return parts.length ? parts.join("  \u00b7  ") : null;
     });
 
     const rightText = createMemo((): string => {
@@ -128,7 +138,7 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
             when={props.loading}
             fallback={
                 <Show
-                    when={statsText()}
+                    when={workedPrimary()}
                     fallback={
                         <span class="agent-status-line">
                             {processBadge()}
@@ -136,8 +146,15 @@ export const AgentStatusLine = (props: AgentStatusLineProps): JSX.Element => {
                     }
                 >
                     <span class="agent-status-line agent-status-line--stats">
-                        {statsText()}
-                        {processBadge()}
+                        <span class="agent-status-left">{workedPrimary()}</span>
+                        <span class="agent-status-right">
+                            <Show when={workedSecondary()}>
+                                <span class="agent-status-line-secondary">
+                                    {workedSecondary()}
+                                </span>
+                            </Show>
+                            {processBadge()}
+                        </span>
                     </span>
                 </Show>
             }

--- a/frontend/app/view/agent/components/PendingMessagesPanel.tsx
+++ b/frontend/app/view/agent/components/PendingMessagesPanel.tsx
@@ -20,6 +20,12 @@ import type { PendingMessage } from "../state";
 
 interface PendingMessagesPanelProps {
     pendingMessages: Accessor<PendingMessage[]>;
+    /** True when the user should be offered a "Send now" shortcut —
+     *  typically: a turn is running AND the queue is non-empty. */
+    showSendNow?: Accessor<boolean>;
+    /** Fires when the user clicks "Send now". Caller is expected to
+     *  SIGINT the running turn so the queued messages drain. */
+    onSendImmediately?: () => void;
 }
 
 export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Element => (
@@ -27,11 +33,22 @@ export const PendingMessagesPanel = (props: PendingMessagesPanelProps): JSX.Elem
         <div class="agent-pending-zone">
             <div class="agent-pending-header">
                 <span class="agent-spinner-dot" />
-                <span>
+                <span class="agent-pending-header-text">
                     Queued — will send when the agent is idle (
                     {props.pendingMessages().length}
                     {props.pendingMessages().length === 1 ? " message" : " messages"})
                 </span>
+                <Show when={props.showSendNow?.()}>
+                    <button
+                        type="button"
+                        class="agent-send-immediately-btn"
+                        onClick={() => props.onSendImmediately?.()}
+                        title="Stop the current turn and process the queue now"
+                    >
+                        <span class="agent-send-immediately-icon">⏭</span>
+                        <span>Send now</span>
+                    </button>
+                </Show>
             </div>
             <For each={props.pendingMessages()}>
                 {(msg) => (

--- a/frontend/app/view/agent/defaults/cli-catalog.ts
+++ b/frontend/app/view/agent/defaults/cli-catalog.ts
@@ -55,7 +55,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "CLAUDE.md",
         mcpSupport: "stdio+http",
         popoverMarkdown:
-            "Walks CWD → root loading CLAUDE.md + CLAUDE.local.md at each level. Merges ~/.claude/CLAUDE.md and org policy. Reads .claude/rules/**. MCP over stdio + HTTP. Auto-memory in ~/.claude/projects/<hash>/memory/. No size limit (guideline: keep CLAUDE.md under 200 lines).",
+            "Anthropic's coding agent. Strong at reasoning through long sessions and explaining its thinking as it works. Good when you want it to read widely across a codebase before changing anything. Best if you already use Claude.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/claude:latest",
@@ -68,7 +68,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "AGENTS.md",
         mcpSupport: "stdio+http+oauth",
         popoverMarkdown:
-            "Loads AGENTS.md: global → git root → CWD, concatenated (32KB limit). Config is TOML at ~/.codex/config.toml. 6 concurrent agent threads by default. MCP over stdio, HTTP, OAuth. Enterprise-enforced requirements.toml supported.",
+            "OpenAI's coding agent. Fast and focused — good at small, well-defined tasks and quick refactors. Can work on several files in parallel. Uses your OpenAI account.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/codex:latest",
@@ -81,7 +81,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "GEMINI.md",
         mcpSupport: "stdio+http",
         popoverMarkdown:
-            "Loads ~/.gemini/GEMINI.md + ./GEMINI.md (walks up to .git). Subdirectory GEMINI.md files load just-in-time (v0.34.0+). Plan Mode is default — read-only until user approves writes. GEMINI_SYSTEM_MD replaces the system prompt entirely.",
+            "Google's coding agent. Very large context window — it can look at a lot of code at once. Defaults to reading + planning before it writes anything, so it's a safer pick when you're still deciding what to change. Uses your Google account.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/gemini:latest",
@@ -94,7 +94,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "AGENTS.md",
         mcpSupport: "stdio+http",
         popoverMarkdown:
-            "Discovers AGENTS.md in project root (auto-generates via /init if absent). Config TOML at ~/.kimi/. MCP at ~/.kimi/mcp.json. Injects KIMI_* system-prompt vars (KIMI_NOW, KIMI_WORK_DIR, KIMI_AGENTS_MD, etc.). Context window: 262,144 tokens (K2.6).",
+            "An open-source coding agent from Moonshot with a huge memory — it can hold a lot of project history in mind at once. Good when you need it to remember a long conversation or read many files without losing track.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/kimi:latest",
@@ -107,7 +107,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "AGENTS.md or CLAUDE.md",
         mcpSupport: "stdio+http",
         popoverMarkdown:
-            "Reads ~/.pi/agent/AGENTS.md (or CLAUDE.md) globally plus .pi/AGENTS.md walked from CWD. 4 built-in tools (Read, Write, Edit, Bash) — everything else via extensions. 15+ model providers. Supports ACP so another agent can orchestrate it. Disable context with -nc.",
+            "A flexible agent that can run on your choice of model — Claude, OpenAI, Google, and more. Pick this if you want to try different models against the same task, or if you have API keys from several providers and want to switch easily.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/pi:latest",
@@ -120,7 +120,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "AGENTS.md + SOUL.md + …",
         mcpSupport: "none",
         popoverMarkdown:
-            "OpenClaw is an orchestrator, not a coding agent itself. Manages N child agents (Pi, Claude, Codex, Gemini) over ACP (JSON-RPC 2.0 / stdio). First-turn injects AGENTS.md + SOUL.md + TOOLS.md + IDENTITY.md + USER.md + HEARTBEAT.md + MEMORY.md + BOOTSTRAP.md. Single Gateway daemon with lane-aware FIFO queue.",
+            "Not a coding agent itself — it runs *other* agents for you and keeps them coordinated. Pick this when you want several agents working in parallel and handing tasks to each other, rather than doing the work directly.",
         hostSupported: true,
         containerSupported: false,
     },
@@ -132,7 +132,7 @@ export const CLI_CATALOG: CliCatalogEntry[] = [
         primaryContextFile: "AGENTS.md",
         mcpSupport: "stdio+http",
         popoverMarkdown:
-            "Reads AGENTS.md + .github/copilot-instructions.md + .github/instructions/**/*.instructions.md. Also reads CLAUDE.md and GEMINI.md at repo root as compat. Config JSONC at ~/.copilot/config.json. Shift+Tab cycles Interactive → Plan → Autopilot. Built-in subagents: Explore / Task / Plan / Code-review. MCP user-scope only today.",
+            "GitHub's coding agent. Integrates closely with GitHub repos and pull requests. Has a switch between Interactive, Plan, and Autopilot so you can choose how much freedom it gets. Best if you mostly work on GitHub and have a Copilot subscription.",
         hostSupported: true,
         containerSupported: true,
         containerImage: "agentmux/copilot:latest",

--- a/frontend/app/view/agent/styles/_control-bar.scss
+++ b/frontend/app/view/agent/styles/_control-bar.scss
@@ -150,6 +150,33 @@
         &.agent-status-line--stats {
             opacity: 0.5;
             gap: 0;
+
+            // Two-group layout: primary on the left (Worked · duration ·
+            // tokens), secondary on the right (cost · turn count + any
+            // process badge). Matches the running-turn layout so nothing
+            // jumps when the turn transitions from Working → Worked.
+            // Per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md §4.2.
+            justify-content: space-between;
+
+            .agent-status-left {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .agent-status-right {
+                flex-shrink: 0;
+                margin-left: var(--space-2);
+                display: inline-flex;
+                align-items: center;
+                gap: var(--space-1-5);
+            }
+
+            .agent-status-line-secondary {
+                color: var(--secondary-text-color);
+            }
         }
     }
 

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -39,6 +39,47 @@
             text-transform: uppercase;
             letter-spacing: 0.5px;
             opacity: 0.9;
+
+            // Let the text take the middle and the "Send now" button
+            // float flush right. Per user feedback: button lives inside
+            // the queue block, on the right of its header row.
+            .agent-pending-header-text {
+                flex: 1;
+                min-width: 0;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+        }
+
+        // "Send now" — sits on the right of the queue header. Appears
+        // only when a turn is running AND something is queued. Clicking
+        // fires SIGINT; the backend's queue drains the oldest pending
+        // message as soon as the killed process exits.
+        .agent-send-immediately-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--space-1);
+            padding: var(--space-0-5) var(--space-2);
+            background: color-mix(in srgb, var(--accent-color) 20%, transparent);
+            border: 1px solid var(--accent-color);
+            border-radius: 3px;
+            color: var(--accent-color);
+            font-family: inherit;
+            font-size: 10px;
+            font-weight: 500;
+            text-transform: none;
+            letter-spacing: 0;
+            cursor: pointer;
+            transition: background 80ms ease;
+            flex-shrink: 0;
+            &:hover {
+                background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+            }
+            .agent-send-immediately-icon {
+                font-size: 12px;
+                line-height: 1;
+            }
         }
 
         .agent-pending-item {
@@ -60,34 +101,6 @@
         border-top: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--main-text-color) 3%, transparent);
         padding: var(--space-0-5) var(--space-0-5);
-
-        // "Send now" — appears when there's something queued AND a turn
-        // is running. Clicking it fires SIGINT; the backend's queue
-        // drains the oldest pending message as soon as the killed
-        // process exits.
-        .agent-send-immediately-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: var(--space-1);
-            margin: var(--space-0-5) var(--space-0-5) var(--space-1);
-            padding: var(--space-0-5) var(--space-2);
-            background: color-mix(in srgb, var(--accent-color) 20%, transparent);
-            border: 1px solid var(--accent-color);
-            border-radius: 3px;
-            color: var(--accent-color);
-            font-family: inherit;
-            font-size: 11px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: background 80ms ease;
-            &:hover {
-                background: color-mix(in srgb, var(--accent-color) 30%, transparent);
-            }
-            .agent-send-immediately-icon {
-                font-size: 12px;
-                line-height: 1;
-            }
-        }
 
         .agent-input-container {
             display: flex;

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -14,9 +14,14 @@
     // blue (accepted), which is the user's visible "accepted" signal.
     // See AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md.
     .agent-pending-zone {
-        border-top: 1px solid var(--border-color);
+        // Queue sits directly below the feed (post-reorder PR). Dashed
+        // top border visually pins it to the feed above; solid bottom
+        // border separates it from the "Working…" status line below.
+        // Per SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md §5.3.
+        border-top: 1px dashed var(--border-color);
+        border-bottom: 1px solid var(--border-color);
         background: color-mix(in srgb, var(--warning-color) 6%, var(--main-bg-color));
-        padding: var(--space-1) var(--space-1-5);
+        padding: var(--space-0-5) var(--space-1-5);
         display: flex;
         flex-direction: column;
         gap: 3px;

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -219,6 +219,12 @@ export interface SessionStats {
     cost_usd?: number;    // from result.cost_usd
     duration_ms?: number; // from result.duration_ms
     num_turns?: number;   // from result.num_turns
+    /** Snapshot of TurnTokens.input at finalizeTurn — preserved here
+     *  because the live TurnTokens signal is nulled on session_end
+     *  before the Worked footer renders. See PR #549 reagent/codex P1. */
+    input_tokens?: number;
+    /** Snapshot of TurnTokens.output at finalizeTurn (see above). */
+    output_tokens?: number;
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -74,7 +74,7 @@ export function useAgentStream({
     const [, setSessionStats] = sessionStatsAtom;
     const [, setTurnActive] = turnActiveAtom;
     const [, setCurrentTool] = currentToolAtom;
-    const [, setTurnTokens] = turnTokensAtom;
+    const [getTurnTokens, setTurnTokens] = turnTokensAtom;
     const getStopping = stoppingAtom?.[0];
     const setStopping = stoppingAtom?.[1];
 
@@ -190,7 +190,18 @@ export function useAgentStream({
          */
         const finalizeTurn = (stats: SessionStats | null) => {
             parser.flushPending();
-            setSessionStats(stats);
+            // Snapshot live turn tokens into SessionStats before nulling
+            // the live signal. The Worked footer reads from sessionStats
+            // (since turnTokens is cleared on session_end); without this
+            // merge the headline tokens-in-Worked feature shows nothing.
+            // Per PR #549 reagent/codex P1.
+            const tokens = getTurnTokens();
+            const mergedStats: SessionStats | null = stats
+                ? { ...stats, input_tokens: tokens?.input, output_tokens: tokens?.output }
+                : tokens
+                    ? { input_tokens: tokens.input, output_tokens: tokens.output }
+                    : null;
+            setSessionStats(mergedStats);
             setCurrentTool(null);
             setTurnTokens(null);
             setTurnActive(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.385",
+  "version": "0.33.386",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.385",
+      "version": "0.33.386",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.385",
+  "version": "0.33.386",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two tweaks in the agent pane per `docs/specs/SPEC_AGENT_PANE_ZONE_ORDER_WORKED_FOOTER_2026_04_24.md`:

### 1. Queue moves directly below the feed

Today the pending queue renders *below* the "Working…" status line and activity log. When a user types while a turn is running, the typed text "disappears" into the composer and reappears on the far side of two unrelated zones.

New DOM order inside `.agent-view`:

```
- AgentDocumentView (feed)
- AgentRetryBar (conditional)
- PendingMessagesPanel      ← MOVED HERE (was below activity log)
- AgentStatusLine           ← "Working…" / "Worked · …"
- ActivityLogPanel
- composer-region
```

Queue gets a dashed top border + solid bottom border to visually pin it to the feed above.

### 2. Enriched "Worked" footer

| State | Today | This PR |
|---|---|---|
| Running | `⠋ Working…                  ↑12k ↓3k · 42s` | *(unchanged)* |
| Completed | `✓ Worked · $0.018 · 42s · 4 turns` | `✓ Worked · 42s · ↑12k ↓3k          $0.018 · 4 turns` |

Tokens are what users budget against and carry forward into the next turn's context window. Duration sits next to them as the paired metric. Cost + turn count move to a secondary group on the right (`--secondary-text-color`). Transition Working → Worked no longer jumps the layout — both branches use the same two-group flex.

## No backend change

Uses existing `SessionStats` (`cost_usd`, `duration_ms`, `num_turns`) and `TurnTokens` (`input`, `output`). Pure render-layer.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `task build:frontend` | succeeds |
| `npm run lint:scss` | green |

## Test plan

- [ ] Send a message, start a second while first runs → queue appears between feed and status line
- [ ] Turn completes → footer shows `Worked · 42s · ↑12k ↓3k` with `$0.018 · N turns` on the right
- [ ] Resize pane narrow → right group wraps or drops gracefully (no overflow)
- [ ] Tokens missing (older stream replay) → falls back to today's display

🤖 Generated with [Claude Code](https://claude.com/claude-code)