### PR TITLE
feat: add theme system with 8 named themes (window:theme)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.388"
+version = "0.33.389"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.388"
+version = "0.33.389"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.388"
+version = "0.33.389"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.388"
+version = "0.33.389"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.389"
+version = "0.33.390"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.389"
+version = "0.33.390"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.389"
+version = "0.33.390"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.389"
+version = "0.33.390"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.388"
+version = "0.33.389"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.389"
+version = "0.33.390"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.389"
+version = "0.33.390"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.388"
+version = "0.33.389"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.388"
+version = "0.33.389"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.389"
+version = "0.33.390"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.389"
+version = "0.33.390"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.388"
+version = "0.33.389"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/app.scss
+++ b/frontend/app/app.scss
@@ -3,6 +3,7 @@
 
 @use "reset.scss";
 @use "theme.scss";
+@use "themes/index";
 
 html {
     overflow: hidden;

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -139,6 +139,14 @@ function AppSettingsUpdater() {
         // Apply Tauri-level window transparency and platform blur effects
         const isBlur = windowSettings?.["window:blur"] ?? false;
         getApi().setWindowTransparency(isTransparentOrBlur, isBlur, opacity);
+
+        // Apply color theme
+        const theme = windowSettings?.["window:theme"];
+        if (theme && theme !== "default") {
+            document.documentElement.setAttribute("data-theme", theme);
+        } else {
+            document.documentElement.removeAttribute("data-theme");
+        }
     });
     return null;
 }

--- a/frontend/app/themes/catppuccin.scss
+++ b/frontend/app/themes/catppuccin.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #f5c2e7;
     --term-bright-cyan: #94e2d5;
     --term-bright-white: #a6adc8;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/catppuccin.scss
+++ b/frontend/app/themes/catppuccin.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Catppuccin Mocha — soft pastel dark, warm mauve accent
+
+[data-theme="catppuccin"] {
+    --main-bg-color: #1e1e2e;
+    --panel-bg-color: rgba(24, 24, 37, 0.6);
+    --block-bg-color: rgba(17, 17, 27, 0.7);
+    --block-bg-solid-color: #11111b;
+    --modal-bg-color: #24273a;
+
+    --main-text-color: #cdd6f4;
+    --secondary-text-color: #bac2de;
+    --grey-text-color: #585b70;
+
+    --accent-color: #cba6f7;
+    --link-color: #89dceb;
+
+    --border-color: rgba(203, 166, 247, 0.18);
+    --form-element-border-color: rgba(203, 166, 247, 0.15);
+    --keybinding-border-color: rgba(203, 166, 247, 0.28);
+
+    --hover-bg-color: rgba(203, 166, 247, 0.07);
+    --highlight-bg-color: rgba(203, 166, 247, 0.14);
+
+    --error-color: #f38ba8;
+    --warning-color: #fab387;
+    --success-color: #a6e3a1;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.04);
+    --button-grey-hover-bg: rgba(203, 166, 247, 0.09);
+    --button-grey-border-color: rgba(203, 166, 247, 0.18);
+    --button-green-bg: #a6e3a1;
+    --button-red-bg: #f38ba8;
+    --button-yellow-bg: #f9e2af;
+
+    --scrollbar-thumb-color: rgba(203, 166, 247, 0.18);
+    --scrollbar-thumb-hover-color: rgba(203, 166, 247, 0.4);
+
+    --term-background: #1e1e2e;
+    --term-foreground: #cdd6f4;
+    --term-black: #45475a;
+    --term-red: #f38ba8;
+    --term-green: #a6e3a1;
+    --term-yellow: #f9e2af;
+    --term-blue: #89b4fa;
+    --term-magenta: #f5c2e7;
+    --term-cyan: #94e2d5;
+    --term-white: #bac2de;
+    --term-bright-black: #585b70;
+    --term-bright-red: #f38ba8;
+    --term-bright-green: #a6e3a1;
+    --term-bright-yellow: #f9e2af;
+    --term-bright-blue: #89b4fa;
+    --term-bright-magenta: #f5c2e7;
+    --term-bright-cyan: #94e2d5;
+    --term-bright-white: #a6adc8;
+}

--- a/frontend/app/themes/dracula.scss
+++ b/frontend/app/themes/dracula.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Dracula — purple-forward dark, vibrant palette
+
+[data-theme="dracula"] {
+    --main-bg-color: #282a36;
+    --panel-bg-color: rgba(33, 34, 44, 0.6);
+    --block-bg-color: rgba(24, 25, 32, 0.7);
+    --block-bg-solid-color: #1e1f29;
+    --modal-bg-color: #2e303d;
+
+    --main-text-color: #f8f8f2;
+    --secondary-text-color: #c5c8d1;
+    --grey-text-color: #6272a4;
+
+    --accent-color: #bd93f9;
+    --link-color: #8be9fd;
+
+    --border-color: rgba(189, 147, 249, 0.2);
+    --form-element-border-color: rgba(189, 147, 249, 0.15);
+    --keybinding-border-color: rgba(189, 147, 249, 0.3);
+
+    --hover-bg-color: rgba(189, 147, 249, 0.08);
+    --highlight-bg-color: rgba(189, 147, 249, 0.16);
+
+    --error-color: #ff5555;
+    --warning-color: #ffb86c;
+    --success-color: #50fa7b;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.05);
+    --button-grey-hover-bg: rgba(189, 147, 249, 0.1);
+    --button-grey-border-color: rgba(189, 147, 249, 0.2);
+    --button-green-bg: #50fa7b;
+    --button-red-bg: #ff5555;
+    --button-yellow-bg: #f1fa8c;
+
+    --scrollbar-thumb-color: rgba(189, 147, 249, 0.2);
+    --scrollbar-thumb-hover-color: rgba(189, 147, 249, 0.45);
+
+    --term-background: #282a36;
+    --term-foreground: #f8f8f2;
+    --term-black: #21222c;
+    --term-red: #ff5555;
+    --term-green: #50fa7b;
+    --term-yellow: #f1fa8c;
+    --term-blue: #6272a4;
+    --term-magenta: #ff79c6;
+    --term-cyan: #8be9fd;
+    --term-white: #f8f8f2;
+    --term-bright-black: #6272a4;
+    --term-bright-red: #ff6e6e;
+    --term-bright-green: #69ff94;
+    --term-bright-yellow: #ffffa5;
+    --term-bright-blue: #d6acff;
+    --term-bright-magenta: #ff92df;
+    --term-bright-cyan: #a4ffff;
+    --term-bright-white: #ffffff;
+}

--- a/frontend/app/themes/dracula.scss
+++ b/frontend/app/themes/dracula.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #ff92df;
     --term-bright-cyan: #a4ffff;
     --term-bright-white: #ffffff;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/gruvbox.scss
+++ b/frontend/app/themes/gruvbox.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #d3869b;
     --term-bright-cyan: #8ec07c;
     --term-bright-white: #ebdbb2;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/gruvbox.scss
+++ b/frontend/app/themes/gruvbox.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Gruvbox Dark — retro warm dark, earthy yellows and greens
+
+[data-theme="gruvbox"] {
+    --main-bg-color: #282828;
+    --panel-bg-color: rgba(32, 32, 32, 0.6);
+    --block-bg-color: rgba(20, 20, 20, 0.7);
+    --block-bg-solid-color: #1d2021;
+    --modal-bg-color: #3c3836;
+
+    --main-text-color: #ebdbb2;
+    --secondary-text-color: #d5c4a1;
+    --grey-text-color: #7c6f64;
+
+    --accent-color: #d79921;
+    --link-color: #83a598;
+
+    --border-color: rgba(215, 153, 33, 0.2);
+    --form-element-border-color: rgba(215, 153, 33, 0.15);
+    --keybinding-border-color: rgba(215, 153, 33, 0.3);
+
+    --hover-bg-color: rgba(215, 153, 33, 0.08);
+    --highlight-bg-color: rgba(215, 153, 33, 0.16);
+
+    --error-color: #cc241d;
+    --warning-color: #d79921;
+    --success-color: #98971a;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.04);
+    --button-grey-hover-bg: rgba(215, 153, 33, 0.1);
+    --button-grey-border-color: rgba(215, 153, 33, 0.2);
+    --button-green-bg: #98971a;
+    --button-red-bg: #cc241d;
+    --button-yellow-bg: #d79921;
+
+    --scrollbar-thumb-color: rgba(215, 153, 33, 0.2);
+    --scrollbar-thumb-hover-color: rgba(215, 153, 33, 0.45);
+
+    --term-background: #282828;
+    --term-foreground: #ebdbb2;
+    --term-black: #282828;
+    --term-red: #cc241d;
+    --term-green: #98971a;
+    --term-yellow: #d79921;
+    --term-blue: #458588;
+    --term-magenta: #b16286;
+    --term-cyan: #689d6a;
+    --term-white: #a89984;
+    --term-bright-black: #928374;
+    --term-bright-red: #fb4934;
+    --term-bright-green: #b8bb26;
+    --term-bright-yellow: #fabd2f;
+    --term-bright-blue: #83a598;
+    --term-bright-magenta: #d3869b;
+    --term-bright-cyan: #8ec07c;
+    --term-bright-white: #ebdbb2;
+}

--- a/frontend/app/themes/high-contrast.scss
+++ b/frontend/app/themes/high-contrast.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #ff88ff;
     --term-bright-cyan: #88ffff;
     --term-bright-white: #ffffff;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/high-contrast.scss
+++ b/frontend/app/themes/high-contrast.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// High Contrast — pure black, white text, cyan accent. WCAG AA compliant.
+
+[data-theme="high-contrast"] {
+    --main-bg-color: #000000;
+    --panel-bg-color: rgba(0, 0, 0, 0.9);
+    --block-bg-color: #000000;
+    --block-bg-solid-color: #000000;
+    --modal-bg-color: #111111;
+
+    --main-text-color: #ffffff;
+    --secondary-text-color: #e0e0e0;
+    --grey-text-color: #a0a0a0;
+
+    --accent-color: rgb(0, 220, 255);
+    --link-color: #00dcff;
+
+    --border-color: rgba(255, 255, 255, 0.4);
+    --form-element-border-color: rgba(255, 255, 255, 0.35);
+    --keybinding-border-color: rgba(255, 255, 255, 0.5);
+
+    --hover-bg-color: rgba(255, 255, 255, 0.15);
+    --highlight-bg-color: rgba(255, 255, 255, 0.25);
+
+    --error-color: rgb(255, 80, 80);
+    --warning-color: rgb(255, 220, 0);
+    --success-color: rgb(0, 240, 100);
+
+    --button-grey-bg: rgba(255, 255, 255, 0.1);
+    --button-grey-hover-bg: rgba(255, 255, 255, 0.2);
+    --button-grey-border-color: rgba(255, 255, 255, 0.4);
+    --button-green-bg: rgb(0, 200, 80);
+    --button-red-bg: rgb(255, 60, 60);
+    --button-yellow-bg: rgb(255, 200, 0);
+
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.3);
+    --scrollbar-thumb-hover-color: rgba(255, 255, 255, 0.6);
+
+    --term-background: #000000;
+    --term-foreground: #ffffff;
+    --term-black: #000000;
+    --term-red: #ff5555;
+    --term-green: #55ff55;
+    --term-yellow: #ffff55;
+    --term-blue: #5555ff;
+    --term-magenta: #ff55ff;
+    --term-cyan: #55ffff;
+    --term-white: #ffffff;
+    --term-bright-black: #555555;
+    --term-bright-red: #ff8888;
+    --term-bright-green: #88ff88;
+    --term-bright-yellow: #ffff88;
+    --term-bright-blue: #8888ff;
+    --term-bright-magenta: #ff88ff;
+    --term-bright-cyan: #88ffff;
+    --term-bright-white: #ffffff;
+}

--- a/frontend/app/themes/index.scss
+++ b/frontend/app/themes/index.scss
@@ -1,0 +1,13 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Theme barrel — all named themes. Add new themes here.
+
+@use "midnight";
+@use "high-contrast";
+@use "monokai";
+@use "nord";
+@use "dracula";
+@use "catppuccin";
+@use "tokyo-night";
+@use "gruvbox";

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -1,0 +1,52 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Midnight — deep navy dark, electric blue accent
+
+[data-theme="midnight"] {
+    --main-bg-color: rgb(10, 12, 22);
+    --panel-bg-color: rgba(8, 10, 20, 0.6);
+    --block-bg-color: rgba(4, 6, 14, 0.7);
+    --block-bg-solid-color: rgb(4, 6, 14);
+    --modal-bg-color: rgb(14, 18, 32);
+
+    --main-text-color: #e8eaf6;
+    --secondary-text-color: rgb(160, 170, 200);
+    --grey-text-color: #5a6070;
+
+    --accent-color: rgb(100, 160, 255);
+    --link-color: #7ab4ff;
+
+    --border-color: rgba(100, 140, 255, 0.18);
+    --form-element-border-color: rgba(100, 140, 255, 0.15);
+    --keybinding-border-color: rgba(100, 140, 255, 0.25);
+
+    --hover-bg-color: rgba(100, 160, 255, 0.08);
+    --highlight-bg-color: rgba(100, 160, 255, 0.16);
+
+    --button-grey-bg: rgba(100, 160, 255, 0.06);
+    --button-grey-hover-bg: rgba(100, 160, 255, 0.12);
+    --button-grey-border-color: rgba(100, 140, 255, 0.18);
+
+    --scrollbar-thumb-color: rgba(100, 160, 255, 0.18);
+    --scrollbar-thumb-hover-color: rgba(100, 160, 255, 0.4);
+
+    --term-background: #060810;
+    --term-foreground: #c8d0e8;
+    --term-black: #0a0c16;
+    --term-red: #e06c75;
+    --term-green: #7ab4ff;
+    --term-yellow: #e5c07b;
+    --term-blue: #528bff;
+    --term-magenta: #c678dd;
+    --term-cyan: #56b6c2;
+    --term-white: #c8d0e8;
+    --term-bright-black: #3a4060;
+    --term-bright-red: #ef6b73;
+    --term-bright-green: #98c8ff;
+    --term-bright-yellow: #f0c97a;
+    --term-bright-blue: #7ab4ff;
+    --term-bright-magenta: #d898f0;
+    --term-bright-cyan: #7ee8f0;
+    --term-bright-white: #e8eaf6;
+}

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -35,7 +35,7 @@
     --term-foreground: #c8d0e8;
     --term-black: #0a0c16;
     --term-red: #e06c75;
-    --term-green: #7ab4ff;
+    --term-green: #57c7a0;
     --term-yellow: #e5c07b;
     --term-blue: #528bff;
     --term-magenta: #c678dd;
@@ -43,10 +43,26 @@
     --term-white: #c8d0e8;
     --term-bright-black: #3a4060;
     --term-bright-red: #ef6b73;
-    --term-bright-green: #98c8ff;
+    --term-bright-green: #7edebb;
     --term-bright-yellow: #f0c97a;
     --term-bright-blue: #7ab4ff;
     --term-bright-magenta: #d898f0;
     --term-bright-cyan: #7ee8f0;
     --term-bright-white: #e8eaf6;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/monokai.scss
+++ b/frontend/app/themes/monokai.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #ae81ff;
     --term-bright-cyan: #66d9ef;
     --term-bright-white: #f9f8f5;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/monokai.scss
+++ b/frontend/app/themes/monokai.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Monokai — warm dark, vivid pink/green/yellow palette
+
+[data-theme="monokai"] {
+    --main-bg-color: #272822;
+    --panel-bg-color: rgba(36, 37, 31, 0.6);
+    --block-bg-color: rgba(26, 27, 22, 0.7);
+    --block-bg-solid-color: #1a1b16;
+    --modal-bg-color: #2d2e27;
+
+    --main-text-color: #f8f8f2;
+    --secondary-text-color: #cfcfc2;
+    --grey-text-color: #75715e;
+
+    --accent-color: #a6e22e;
+    --link-color: #a6e22e;
+
+    --border-color: rgba(255, 255, 255, 0.12);
+    --form-element-border-color: rgba(255, 255, 255, 0.1);
+    --keybinding-border-color: rgba(248, 248, 242, 0.2);
+
+    --hover-bg-color: rgba(166, 226, 46, 0.08);
+    --highlight-bg-color: rgba(166, 226, 46, 0.16);
+
+    --error-color: #f92672;
+    --warning-color: #e6db74;
+    --success-color: #a6e22e;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.05);
+    --button-grey-hover-bg: rgba(255, 255, 255, 0.1);
+    --button-grey-border-color: rgba(255, 255, 255, 0.12);
+    --button-green-bg: #a6e22e;
+    --button-red-bg: #f92672;
+    --button-yellow-bg: #e6db74;
+
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.15);
+    --scrollbar-thumb-hover-color: rgba(166, 226, 46, 0.4);
+
+    --term-background: #272822;
+    --term-foreground: #f8f8f2;
+    --term-black: #272822;
+    --term-red: #f92672;
+    --term-green: #a6e22e;
+    --term-yellow: #e6db74;
+    --term-blue: #66d9ef;
+    --term-magenta: #ae81ff;
+    --term-cyan: #66d9ef;
+    --term-white: #f8f8f2;
+    --term-bright-black: #75715e;
+    --term-bright-red: #f92672;
+    --term-bright-green: #a6e22e;
+    --term-bright-yellow: #e6db74;
+    --term-bright-blue: #66d9ef;
+    --term-bright-magenta: #ae81ff;
+    --term-bright-cyan: #66d9ef;
+    --term-bright-white: #f9f8f5;
+}

--- a/frontend/app/themes/nord.scss
+++ b/frontend/app/themes/nord.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Nord — arctic blue-grey, calm and readable
+
+[data-theme="nord"] {
+    --main-bg-color: #2e3440;
+    --panel-bg-color: rgba(39, 44, 54, 0.6);
+    --block-bg-color: rgba(30, 34, 42, 0.7);
+    --block-bg-solid-color: #1e222a;
+    --modal-bg-color: #3b4252;
+
+    --main-text-color: #eceff4;
+    --secondary-text-color: #d8dee9;
+    --grey-text-color: #616e88;
+
+    --accent-color: #88c0d0;
+    --link-color: #81a1c1;
+
+    --border-color: rgba(136, 192, 208, 0.2);
+    --form-element-border-color: rgba(136, 192, 208, 0.15);
+    --keybinding-border-color: rgba(136, 192, 208, 0.3);
+
+    --hover-bg-color: rgba(136, 192, 208, 0.08);
+    --highlight-bg-color: rgba(136, 192, 208, 0.16);
+
+    --error-color: #bf616a;
+    --warning-color: #ebcb8b;
+    --success-color: #a3be8c;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.05);
+    --button-grey-hover-bg: rgba(136, 192, 208, 0.1);
+    --button-grey-border-color: rgba(136, 192, 208, 0.2);
+    --button-green-bg: #a3be8c;
+    --button-red-bg: #bf616a;
+    --button-yellow-bg: #ebcb8b;
+
+    --scrollbar-thumb-color: rgba(136, 192, 208, 0.2);
+    --scrollbar-thumb-hover-color: rgba(136, 192, 208, 0.45);
+
+    --term-background: #2e3440;
+    --term-foreground: #d8dee9;
+    --term-black: #3b4252;
+    --term-red: #bf616a;
+    --term-green: #a3be8c;
+    --term-yellow: #ebcb8b;
+    --term-blue: #81a1c1;
+    --term-magenta: #b48ead;
+    --term-cyan: #88c0d0;
+    --term-white: #e5e9f0;
+    --term-bright-black: #4c566a;
+    --term-bright-red: #bf616a;
+    --term-bright-green: #a3be8c;
+    --term-bright-yellow: #ebcb8b;
+    --term-bright-blue: #81a1c1;
+    --term-bright-magenta: #b48ead;
+    --term-bright-cyan: #8fbcbb;
+    --term-bright-white: #eceff4;
+}

--- a/frontend/app/themes/nord.scss
+++ b/frontend/app/themes/nord.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #b48ead;
     --term-bright-cyan: #8fbcbb;
     --term-bright-white: #eceff4;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/tokyo-night.scss
+++ b/frontend/app/themes/tokyo-night.scss
@@ -56,4 +56,20 @@
     --term-bright-magenta: #bb9af7;
     --term-bright-cyan: #7dcfff;
     --term-bright-white: #c0caf5;
+
+    // Tailwind @theme token sync — keeps utility classes (text-foreground, bg-accent-400, etc.) in theme
+    --color-background: var(--main-bg-color);
+    --color-foreground: var(--main-text-color);
+    --color-primary: var(--main-text-color);
+    --color-muted-foreground: var(--secondary-text-color);
+    --color-secondary: var(--secondary-text-color);
+    --color-muted: var(--grey-text-color);
+    --color-accent-400: var(--accent-color);
+    --color-error: var(--error-color);
+    --color-warning: var(--warning-color);
+    --color-success: var(--success-color);
+    --color-panel: var(--panel-bg-color);
+    --color-hover: var(--hover-bg-color);
+    --color-border: var(--border-color);
+    --color-modalbg: var(--modal-bg-color);
 }

--- a/frontend/app/themes/tokyo-night.scss
+++ b/frontend/app/themes/tokyo-night.scss
@@ -1,0 +1,59 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tokyo Night — deep blue-purple city aesthetic
+
+[data-theme="tokyo-night"] {
+    --main-bg-color: #1a1b2e;
+    --panel-bg-color: rgba(22, 23, 40, 0.6);
+    --block-bg-color: rgba(14, 15, 26, 0.7);
+    --block-bg-solid-color: #0e0f1a;
+    --modal-bg-color: #1f2035;
+
+    --main-text-color: #c0caf5;
+    --secondary-text-color: #9aa5ce;
+    --grey-text-color: #565f89;
+
+    --accent-color: #7aa2f7;
+    --link-color: #73daca;
+
+    --border-color: rgba(122, 162, 247, 0.18);
+    --form-element-border-color: rgba(122, 162, 247, 0.15);
+    --keybinding-border-color: rgba(122, 162, 247, 0.28);
+
+    --hover-bg-color: rgba(122, 162, 247, 0.07);
+    --highlight-bg-color: rgba(122, 162, 247, 0.14);
+
+    --error-color: #f7768e;
+    --warning-color: #e0af68;
+    --success-color: #9ece6a;
+
+    --button-grey-bg: rgba(255, 255, 255, 0.04);
+    --button-grey-hover-bg: rgba(122, 162, 247, 0.09);
+    --button-grey-border-color: rgba(122, 162, 247, 0.18);
+    --button-green-bg: #9ece6a;
+    --button-red-bg: #f7768e;
+    --button-yellow-bg: #e0af68;
+
+    --scrollbar-thumb-color: rgba(122, 162, 247, 0.18);
+    --scrollbar-thumb-hover-color: rgba(122, 162, 247, 0.4);
+
+    --term-background: #1a1b2e;
+    --term-foreground: #c0caf5;
+    --term-black: #15161e;
+    --term-red: #f7768e;
+    --term-green: #9ece6a;
+    --term-yellow: #e0af68;
+    --term-blue: #7aa2f7;
+    --term-magenta: #bb9af7;
+    --term-cyan: #7dcfff;
+    --term-white: #a9b1d6;
+    --term-bright-black: #414868;
+    --term-bright-red: #f7768e;
+    --term-bright-green: #9ece6a;
+    --term-bright-yellow: #e0af68;
+    --term-bright-blue: #7aa2f7;
+    --term-bright-magenta: #bb9af7;
+    --term-bright-cyan: #7dcfff;
+    --term-bright-white: #c0caf5;
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1118,6 +1118,7 @@ declare global {
         "window:savelastwindow"?: boolean;
         "window:dimensions"?: string;
         "window:zoom"?: number;
+        "window:theme"?: string;
         "telemetry:*"?: boolean;
         "telemetry:enabled"?: boolean;
         "telemetry:interval"?: number;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.389",
+  "version": "0.33.390",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.388",
+  "version": "0.33.389",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -218,6 +218,11 @@
         "window:zoom": {
           "type": "number"
         },
+        "window:theme": {
+          "type": "string",
+          "enum": ["default", "midnight", "high-contrast", "monokai", "nord", "dracula", "catppuccin", "tokyo-night", "gruvbox"],
+          "description": "UI color theme. Options: default (dark grey + blue), midnight (deep navy), high-contrast (black + cyan), monokai (warm dark + green), nord (arctic blue-grey), dracula (purple dark), catppuccin (pastel dark + mauve), tokyo-night (blue-purple), gruvbox (retro warm + yellow)"
+        },
         "telemetry:*": {
           "type": "boolean"
         },

--- a/specs/themes-spec.md
+++ b/specs/themes-spec.md
@@ -1,0 +1,390 @@
+# Spec: Theme System
+
+## Overview
+
+Introduce a runtime theme system for AgentMux. Users can switch themes without restarting. All themes are defined as SCSS files that override the existing CSS custom properties from `theme.scss`.
+
+## Architecture
+
+### Theme Files
+
+Each theme lives in `frontend/app/themes/<name>.scss` and overrides `:root` variables under a `[data-theme="<name>"]` selector:
+
+```scss
+// frontend/app/themes/midnight.scss
+[data-theme="midnight"] {
+  --main-bg-color: rgb(10, 12, 22);
+  --accent-color: rgb(100, 160, 255);
+  // ...
+}
+```
+
+The default theme (current) remains in `theme.scss` on `:root` — no selector needed. All named themes inherit from it and override only what differs.
+
+### Theme Application
+
+Set `data-theme` on `<html>` at runtime:
+
+```ts
+document.documentElement.setAttribute("data-theme", themeName);
+```
+
+CSS specificity: `[data-theme="x"] { ... }` (0,1,0) beats `:root { ... }` (0,0,1) — no `!important` needed.
+
+### State & Persistence
+
+Theme is set via `settings.json` — the same config file users already edit for all other preferences. The setting key is `window:theme`.
+
+**Example `settings.json`:**
+```json
+{
+  "window:theme": "midnight"
+}
+```
+
+Valid values (see **Themes** section below for full descriptions):
+
+| Value | Theme |
+|-------|-------|
+| `"default"` | Default — dark grey, blue accent (built-in baseline) |
+| `"midnight"` | Midnight — deep navy, electric blue |
+| `"high-contrast"` | High Contrast — pure black, white text, cyan accent |
+| `"monokai"` | Monokai — warm dark, pink/green palette |
+| `"nord"` | Nord — arctic blue-grey tones |
+| `"dracula"` | Dracula — purple-forward dark |
+| `"catppuccin"` | Catppuccin Mocha — soft pastel dark, mauve accent |
+| `"tokyo-night"` | Tokyo Night — deep blue-purple |
+| `"gruvbox"` | Gruvbox Dark — retro warm dark, earthy yellows |
+
+Omitting `window:theme` (or setting it to `"default"`) uses the built-in baseline.
+
+- **Jotai atom** `themeAtom` in `frontend/app/store/theme.ts` — reads from the settings store, not localStorage
+- Settings changes are watched live — theme applies without restart
+
+### Bundling
+
+All theme SCSS files are imported in `app.scss`:
+
+```scss
+// Themes
+@use './themes/midnight';
+@use './themes/high-contrast';
+@use './themes/monokai';
+// ...
+```
+
+### Theme Picker
+
+New `<ThemePicker />` component in Settings → Appearance. Displays theme name + a small color swatch preview (background + accent). Applies immediately on selection.
+
+---
+
+## Variables Each Theme Must Define
+
+A theme file only needs to override the variables that visually change. The minimum set:
+
+| Group | Variables |
+|-------|-----------|
+| **Backgrounds** | `--main-bg-color`, `--panel-bg-color`, `--block-bg-color`, `--block-bg-solid-color`, `--modal-bg-color` |
+| **Text** | `--main-text-color`, `--secondary-text-color`, `--grey-text-color` |
+| **Accent** | `--accent-color`, `--color-accent-400` (+ scale 50–900 in tailwindsetup if needed) |
+| **Borders** | `--border-color`, `--form-element-border-color` |
+| **Hover/Highlight** | `--hover-bg-color`, `--highlight-bg-color` |
+| **Status** | `--error-color`, `--warning-color`, `--success-color` |
+| **Terminal ANSI** | All 16 `--term-*` colors + `--term-foreground`, `--term-background` |
+| **Buttons** | `--button-green-bg`, `--button-red-bg`, `--button-yellow-bg` |
+| **Scrollbars** | `--scrollbar-thumb-color`, `--scrollbar-thumb-hover-color` |
+
+---
+
+## Themes
+
+### 1. Default (existing — no file needed)
+Current `theme.scss` — dark grey, blue accent. The baseline all others extend.
+
+---
+
+### 2. Midnight
+
+Deep navy dark — darker and more blue-shifted than Default. Good for late-night sessions.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `rgb(10, 12, 22)` |
+| `--panel-bg-color` | `rgba(8, 10, 20, 0.6)` |
+| `--block-bg-color` | `rgba(4, 6, 14, 0.7)` |
+| `--block-bg-solid-color` | `rgb(4, 6, 14)` |
+| `--modal-bg-color` | `rgb(14, 18, 32)` |
+| `--main-text-color` | `#e8eaf6` |
+| `--secondary-text-color` | `rgb(160, 170, 200)` |
+| `--accent-color` | `rgb(100, 160, 255)` |
+| `--border-color` | `rgba(100, 140, 255, 0.18)` |
+| `--hover-bg-color` | `rgba(100, 160, 255, 0.08)` |
+| Terminal bg | `#060810` |
+| Terminal fg | `#c8d0e8` |
+
+---
+
+### 3. High Contrast
+
+Maximum legibility — pure black background, white text, bright saturated accent. Accessibility-first.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#000000` |
+| `--panel-bg-color` | `rgba(0, 0, 0, 0.85)` |
+| `--block-bg-color` | `#000000` |
+| `--block-bg-solid-color` | `#000000` |
+| `--modal-bg-color` | `#111111` |
+| `--main-text-color` | `#ffffff` |
+| `--secondary-text-color` | `#e0e0e0` |
+| `--accent-color` | `rgb(0, 220, 255)` |
+| `--border-color` | `rgba(255, 255, 255, 0.4)` |
+| `--hover-bg-color` | `rgba(255, 255, 255, 0.15)` |
+| `--error-color` | `rgb(255, 80, 80)` |
+| `--warning-color` | `rgb(255, 220, 0)` |
+| `--success-color` | `rgb(0, 240, 100)` |
+| Terminal bg | `#000000` |
+| Terminal fg | `#ffffff` |
+| ANSI colors | Full bright palette — no muted/dark variants |
+
+---
+
+### 4. Monokai
+
+Classic editor theme. Warm dark background with vivid pink/green/orange syntax palette.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#272822` |
+| `--panel-bg-color` | `rgba(36, 37, 31, 0.6)` |
+| `--block-bg-color` | `rgba(26, 27, 22, 0.7)` |
+| `--block-bg-solid-color` | `#1a1b16` |
+| `--modal-bg-color` | `#2d2e27` |
+| `--main-text-color` | `#f8f8f2` |
+| `--secondary-text-color` | `#cfcfc2` |
+| `--accent-color` | `#a6e22e` |
+| `--border-color` | `rgba(255, 255, 255, 0.12)` |
+| `--hover-bg-color` | `rgba(166, 226, 46, 0.08)` |
+| `--error-color` | `#f92672` |
+| `--warning-color` | `#e6db74` |
+| `--success-color` | `#a6e22e` |
+| Terminal fg | `#f8f8f2` |
+| Terminal bg | `#272822` |
+| `--term-red` | `#f92672` |
+| `--term-green` | `#a6e22e` |
+| `--term-yellow` | `#e6db74` |
+| `--term-blue` | `#66d9ef` |
+| `--term-magenta` | `#ae81ff` |
+| `--term-cyan` | `#66d9ef` |
+
+---
+
+### 5. Nord
+
+Arctic color palette — cool blue-grey tones, calm and readable.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#2e3440` |
+| `--panel-bg-color` | `rgba(39, 44, 54, 0.6)` |
+| `--block-bg-color` | `rgba(30, 34, 42, 0.7)` |
+| `--block-bg-solid-color` | `#1e222a` |
+| `--modal-bg-color` | `#3b4252` |
+| `--main-text-color` | `#eceff4` |
+| `--secondary-text-color` | `#d8dee9` |
+| `--accent-color` | `#88c0d0` |
+| `--border-color` | `rgba(136, 192, 208, 0.2)` |
+| `--hover-bg-color` | `rgba(136, 192, 208, 0.08)` |
+| `--error-color` | `#bf616a` |
+| `--warning-color` | `#ebcb8b` |
+| `--success-color` | `#a3be8c` |
+| Terminal fg | `#d8dee9` |
+| Terminal bg | `#2e3440` |
+
+---
+
+### 6. Dracula
+
+High-contrast purple-forward dark theme — vibrant and widely loved.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#282a36` |
+| `--panel-bg-color` | `rgba(33, 34, 44, 0.6)` |
+| `--block-bg-color` | `rgba(24, 25, 32, 0.7)` |
+| `--block-bg-solid-color` | `#1e1f29` |
+| `--modal-bg-color` | `#2e303d` |
+| `--main-text-color` | `#f8f8f2` |
+| `--secondary-text-color` | `#c5c8d1` |
+| `--accent-color` | `#bd93f9` |
+| `--border-color` | `rgba(189, 147, 249, 0.2)` |
+| `--hover-bg-color` | `rgba(189, 147, 249, 0.08)` |
+| `--error-color` | `#ff5555` |
+| `--warning-color` | `#ffb86c` |
+| `--success-color` | `#50fa7b` |
+| `--link-color` | `#8be9fd` |
+| Terminal fg | `#f8f8f2` |
+| Terminal bg | `#282a36` |
+| `--term-red` | `#ff5555` |
+| `--term-green` | `#50fa7b` |
+| `--term-yellow` | `#f1fa8c` |
+| `--term-blue` | `#6272a4` |
+| `--term-magenta` | `#ff79c6` |
+| `--term-cyan` | `#8be9fd` |
+
+---
+
+### 7. Catppuccin Mocha
+
+Soft pastel dark — gentle on the eyes, warm mauve tones.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#1e1e2e` |
+| `--panel-bg-color` | `rgba(24, 24, 37, 0.6)` |
+| `--block-bg-color` | `rgba(17, 17, 27, 0.7)` |
+| `--block-bg-solid-color` | `#11111b` |
+| `--modal-bg-color` | `#24273a` |
+| `--main-text-color` | `#cdd6f4` |
+| `--secondary-text-color` | `#bac2de` |
+| `--accent-color` | `#cba6f7` |
+| `--border-color` | `rgba(203, 166, 247, 0.18)` |
+| `--hover-bg-color` | `rgba(203, 166, 247, 0.07)` |
+| `--error-color` | `#f38ba8` |
+| `--warning-color` | `#fab387` |
+| `--success-color` | `#a6e3a1` |
+| Terminal fg | `#cdd6f4` |
+| Terminal bg | `#1e1e2e` |
+
+---
+
+### 8. Tokyo Night
+
+Deep blue-purple city aesthetic — popular in VS Code community.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#1a1b2e` |
+| `--panel-bg-color` | `rgba(22, 23, 40, 0.6)` |
+| `--block-bg-color` | `rgba(14, 15, 26, 0.7)` |
+| `--block-bg-solid-color` | `#0e0f1a` |
+| `--modal-bg-color` | `#1f2035` |
+| `--main-text-color` | `#c0caf5` |
+| `--secondary-text-color` | `#9aa5ce` |
+| `--accent-color` | `#7aa2f7` |
+| `--border-color` | `rgba(122, 162, 247, 0.18)` |
+| `--hover-bg-color` | `rgba(122, 162, 247, 0.07)` |
+| `--error-color` | `#f7768e` |
+| `--warning-color` | `#e0af68` |
+| `--success-color` | `#9ece6a` |
+| `--link-color` | `#73daca` |
+| Terminal fg | `#c0caf5` |
+| Terminal bg | `#1a1b2e` |
+
+---
+
+### 9. Gruvbox Dark
+
+Retro warm dark — earthy yellows, oranges, and greens. Easy on the eyes for long sessions.
+
+| Token | Value |
+|-------|-------|
+| `--main-bg-color` | `#282828` |
+| `--panel-bg-color` | `rgba(32, 32, 32, 0.6)` |
+| `--block-bg-color` | `rgba(20, 20, 20, 0.7)` |
+| `--block-bg-solid-color` | `#1d2021` |
+| `--modal-bg-color` | `#3c3836` |
+| `--main-text-color` | `#ebdbb2` |
+| `--secondary-text-color` | `#d5c4a1` |
+| `--accent-color` | `#d79921` |
+| `--border-color` | `rgba(215, 153, 33, 0.2)` |
+| `--hover-bg-color` | `rgba(215, 153, 33, 0.08)` |
+| `--error-color` | `#cc241d` |
+| `--warning-color` | `#d79921` |
+| `--success-color` | `#98971a` |
+| Terminal fg | `#ebdbb2` |
+| Terminal bg | `#282828` |
+| `--term-red` | `#cc241d` |
+| `--term-green` | `#98971a` |
+| `--term-yellow` | `#d79921` |
+| `--term-blue` | `#458588` |
+| `--term-magenta` | `#b16286` |
+| `--term-cyan` | `#689d6a` |
+
+---
+
+## File Structure
+
+```
+frontend/app/
+├── theme.scss                  # Default theme (unchanged — :root)
+├── themes/
+│   ├── index.scss              # @use barrel: imports all themes
+│   ├── midnight.scss
+│   ├── high-contrast.scss
+│   ├── monokai.scss
+│   ├── nord.scss
+│   ├── dracula.scss
+│   ├── catppuccin.scss
+│   ├── tokyo-night.scss
+│   └── gruvbox.scss
+├── store/
+│   └── theme.ts                # Jotai atom + persistence helpers
+└── element/
+    └── themepicker.tsx/.scss   # Theme picker component
+```
+
+`app.scss` adds one line:
+```scss
+@use './themes/index';
+```
+
+---
+
+## Theme Picker UI (optional — settings.json is primary)
+
+Power users set `window:theme` directly in `settings.json`. The picker is a convenience UI:
+
+- Location: Settings → Appearance tab
+- Each option: theme name + horizontal color swatch (bg, accent, text, error chips)
+- Active theme highlighted
+- Selecting writes `window:theme` to settings store — applies instantly, persists across restarts
+
+---
+
+## Schema Update
+
+Add `window:theme` to `schema/settings.json` so the settings editor validates and autocompletes it:
+
+```json
+"window:theme": {
+  "type": "string",
+  "enum": ["default", "midnight", "high-contrast", "monokai", "nord", "dracula", "catppuccin", "tokyo-night", "gruvbox"],
+  "description": "UI color theme. Options: default, midnight, high-contrast, monokai, nord, dracula, catppuccin, tokyo-night, gruvbox"
+}
+```
+
+Add it alongside the other `window:*` entries.
+
+---
+
+## Implementation Order
+
+1. `schema/settings.json` — add `window:theme` with enum + description
+2. `frontend/app/themes/*.scss` — all theme files + barrel
+3. `frontend/app/app.scss` — add `@use './themes/index'`
+4. `frontend/app/store/theme.ts` — atom that reads from settings store, applies `data-theme` on `<html>`
+5. `frontend/app/element/themepicker.tsx` — optional UI picker in Settings → Appearance (writes to settings store)
+6. Verify each theme with a smoke test (set in settings.json, reopen app, confirm theme applies)
+
+## Verification Plan
+
+- [ ] Setting `window:theme` in `settings.json` applies the theme on next open
+- [ ] Changing the setting live (if settings are watched) applies without restart
+- [ ] Omitting `window:theme` renders the default theme correctly
+- [ ] All 9 themes render correctly — no invisible text, no broken contrast
+- [ ] Terminal ANSI colors apply correctly per theme
+- [ ] High Contrast theme meets WCAG AA (4.5:1 minimum contrast ratio)
+- [ ] Default theme is unchanged (`:root` values untouched)
+- [ ] `schema/settings.json` enum validates correctly (invalid theme name rejected)


### PR DESCRIPTION
## Summary

- Adds a CSS custom-property theme system to AgentMux
- Theme is set via `settings.json` — the existing config users already edit
- Applies instantly via `data-theme` attribute on `<html>`, no restart needed

## Usage

Add to your `settings.json`:
```json
{
  "window:theme": "midnight"
}
```

## Available Themes

| Value | Description |
|-------|-------------|
| `default` | Built-in dark grey + blue accent (unchanged baseline) |
| `midnight` | Deep navy dark, electric blue accent |
| `high-contrast` | Pure black, white text, cyan accent — WCAG AA |
| `monokai` | Warm dark, vivid pink/green/yellow palette |
| `nord` | Arctic blue-grey, calm and readable |
| `dracula` | Purple-forward dark, vibrant palette |
| `catppuccin` | Soft pastel dark, warm mauve accent |
| `tokyo-night` | Deep blue-purple city aesthetic |
| `gruvbox` | Retro warm dark, earthy yellows and greens |

## Implementation

- `frontend/app/themes/*.scss` — 8 theme files using `[data-theme="x"]` selector to override `:root` CSS variables (backgrounds, text, accent, borders, status, terminal ANSI palette)
- `frontend/app/themes/index.scss` — barrel import
- `frontend/app/app.scss` — imports themes barrel
- `frontend/app/app.tsx` — `AppSettingsUpdater` watches `window:theme` and sets/removes `data-theme` on `document.documentElement`
- `frontend/types/gotypes.d.ts` — adds `window:theme?: string` to `SettingsType`
- `schema/settings.json` — adds `window:theme` with enum of all valid values + descriptions

## Test plan

- [ ] Set each theme in `settings.json`, verify it applies on next open
- [ ] Change setting while app is running — verify instant apply
- [ ] Omit `window:theme` — verify default theme unchanged
- [ ] Verify terminal ANSI colors apply correctly per theme
- [ ] Verify no broken contrast / invisible text in any theme

🤖 Generated with [Claude Code](https://claude.ai/claude-code)