### PR TITLE
feat(decision-prompt): v1 PR-1 — type plumbing + adapter stub (#551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.390"
+version = "0.33.391"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.390"
+version = "0.33.391"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.390"
+version = "0.33.391"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.390"
+version = "0.33.391"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.390"
+version = "0.33.391"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.390"
+version = "0.33.391"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.390"
+version = "0.33.391"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.390"
+version = "0.33.391"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md
+++ b/docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md
@@ -358,7 +358,9 @@ New `decisionPrompt` block in `settings-template.jsonc`:
 ## 9. Provider adapters
 
 Today each provider has an adapter under
-`frontend/app/view/agent/translators/`. Add a
+`frontend/app/view/agent/providers/` (entries: `claude-translator.ts`,
+`codex-translator.ts`, `gemini-translator.ts`, `kimi-translator.ts`,
+`acp-translator.ts`, dispatched via `translator-factory.ts`). Add a
 `parsePermissionRequest(raw): PermissionRequestEvent | null` hook
 per adapter:
 
@@ -373,6 +375,30 @@ per adapter:
 
 Unsupported providers gate the prompt feature off in the agent
 card's UI so the user can't pick a mode the CLI can't honour.
+
+### 9.1 Detection strategy
+
+A spec-refresh ground-truth (2026-04-24): Claude Code CLI in
+non-bypass + non-interactive mode (`--print --output-format
+stream-json`) does not currently emit a structured
+`permission_request` JSON event when it gates a tool call. It
+prompts on the controlling tty for `y/n`, which is what causes
+the sidecar's stdin to hang (issue #551 §Problem). Two plausible
+paths forward:
+
+1. **Lobby Anthropic for a structured stream-json event.**
+   Cleanest. Out of our hands; treat as a stretch goal.
+2. **Synthesise a `PermissionRequestEvent` ourselves** by
+   detecting the y/n prompt pattern in the CLI's mixed-format
+   output: when the parser sees a recognisable
+   "Allow tool call to <X>? [y/n]" line, materialise the event,
+   suppress the raw line from the document, and stash the
+   prompt's tty descriptor so `tool:decision` can answer it.
+
+Path 2 ships in v1.x; path 1 is preferred if upstream cooperates.
+v1's first PR delivers the *type plumbing* and a stub adapter
+hook so the rest of the system can be built against the shape
+without committing to a specific detection strategy yet.
 
 ---
 

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -54,8 +54,10 @@ interface ToolBlockProps {
 
 const STATUS_ICON: Record<ToolNode["status"], string> = {
     running: "⏳",
+    pending_approval: "⚠",
     success: "✓",
     failed: "✗",
+    denied: "⊘",
 };
 
 // Walk upward from `el` to find the first ancestor with a non-1 CSS zoom.

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -1,7 +1,7 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { SessionStats, StreamEvent } from "../types";
+import type { PermissionRequestEvent, SessionStats, StreamEvent } from "../types";
 import type { OutputTranslator } from "./translator";
 
 /**
@@ -79,6 +79,20 @@ export class ClaudeTranslator implements OutputTranslator {
         this.currentToolName = null;
         this.toolInputBuffer = "";
         this.toolNameById.clear();
+    }
+
+    /**
+     * Stub. Claude Code CLI does not currently emit a structured
+     * `permission_request` stream event; in non-bypass + non-interactive
+     * mode it prompts y/n on the controlling tty. Detection strategy
+     * (line-pattern recognition vs. waiting for an upstream event) is
+     * decided in a later v1 PR — see
+     * docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §9.1. This hook is
+     * here so the rest of the system can wire to the right interface
+     * shape today.
+     */
+    parsePermissionRequest(_raw: unknown): PermissionRequestEvent | null {
+        return null;
     }
 
     private isStreamEvent(event: any): boolean {

--- a/frontend/app/view/agent/providers/translator.ts
+++ b/frontend/app/view/agent/providers/translator.ts
@@ -1,7 +1,7 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { StreamEvent } from "../types";
+import type { PermissionRequestEvent, StreamEvent } from "../types";
 
 /**
  * Translates raw CLI output events into the internal StreamEvent format.
@@ -18,4 +18,19 @@ export interface OutputTranslator {
      * Reset any internal state (e.g., between sessions).
      */
     reset(): void;
+
+    /**
+     * Detect a per-tool-call permission request in the CLI's output and
+     * synthesise a `PermissionRequestEvent`. Returns null if the input
+     * isn't a permission gate. Today every implementation returns null
+     * — the type hook lands in v1 PR-1; the actual detection arrives
+     * per-provider in later PRs.
+     *
+     * `raw` is whatever shape the provider's stdout produced — a
+     * stream-json event, a parsed Anthropic message, or a raw text
+     * line for CLIs that prompt on tty. The translator decides.
+     *
+     * Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §9.
+     */
+    parsePermissionRequest?(raw: unknown): PermissionRequestEvent | null;
 }

--- a/frontend/app/view/agent/types.ts
+++ b/frontend/app/view/agent/types.ts
@@ -160,12 +160,23 @@ export interface ToolNode {
     id: string;
     tool: "Read" | "Edit" | "Bash" | "Write" | "Grep" | "Glob" | "Task" | "Agent" | "Other";
     params: ToolParams;
-    status: "running" | "success" | "failed";
+    /** Lifecycle:
+     *  - `running`           — call dispatched, awaiting result
+     *  - `pending_approval`  — provider gated the call; user owes a decision
+     *  - `success`           — completed without error
+     *  - `failed`            — completed with error
+     *  - `denied`            — user denied the call via the decision panel
+     *  Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.2.
+     */
+    status: "running" | "pending_approval" | "success" | "failed" | "denied";
     duration?: number; // Seconds
     result?: ToolResult;
     collapsed: boolean;
     summary: string; // e.g., "📖 Read auth.ts (0.3s) ✓"
     timestamp?: number; // Unix ms — when this tool call was initiated
+    /** Set when status === "pending_approval". Carried into the
+     *  decision panel + echoed back through `tool:decision` IPC. */
+    pendingPermission?: PermissionRequestEvent;
 }
 
 /**
@@ -247,7 +258,8 @@ export type StreamEvent =
     | ToolResultEvent
     | AgentMessageEvent
     | UserMessageEvent
-    | SessionEndEvent;
+    | SessionEndEvent
+    | PermissionRequestEvent;
 
 export interface TextEvent {
     type: "text";
@@ -270,11 +282,49 @@ export interface ToolResultEvent {
     type: "tool_result";
     tool: string;
     id: string;
-    status: "success" | "failed";
+    status: "success" | "failed" | "denied";
     duration?: number;
     result?: any;
     exitCode?: number;
 }
+
+/**
+ * Per-tool-call permission gate. Emitted by the provider adapter
+ * when the CLI asks the user to allow / deny a specific tool call.
+ *
+ * Today's adapters return null from their `parsePermissionRequest`
+ * hook (no structured CLI event yet — see
+ * docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §9.1). The type is
+ * defined here so the rest of the system (UI panel, IPC handler,
+ * memory store) can be built against the shape while the
+ * detection strategy is still being chosen.
+ *
+ * Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.1.
+ */
+export interface PermissionRequestEvent {
+    type: "permission_request";
+    /** Opaque id; echoed back in the `tool:decision` IPC. */
+    request_id: string;
+    /** Tool the agent wants to invoke ("bash", "str_replace", …). */
+    tool: string;
+    /** Path / command / url the tool will act on. May be null when
+     *  the tool's args don't have a single canonical target. */
+    target: string | null;
+    /** Provider-supplied rationale. Optional. */
+    reason?: string;
+    /** Optional preview content (diff text, bash command, …). */
+    preview?: PermissionPreview;
+    /** Risk classification — drives whether single-keystroke
+     *  approval is allowed or a confirm step is required. Defaults
+     *  to "medium" when the adapter doesn't supply one. */
+    risk?: "low" | "medium" | "high";
+}
+
+export type PermissionPreview =
+    | { kind: "diff"; content: string }
+    | { kind: "bash"; command: string }
+    | { kind: "text"; content: string }
+    | { kind: "none" };
 
 export interface AgentMessageEvent {
     type: "agent_message";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.388",
+  "version": "0.33.391",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.388",
+      "version": "0.33.391",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.390",
+  "version": "0.33.391",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First implementation chunk of `docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md` (issue agentmuxai/agentmux#551).

This PR is **type plumbing only** — no UI, no IPC, no detection logic. It sets up the contract every later PR will build against, so subsequent work can land independently.

## Spec refresh (in this PR)

- §9 — corrected provider directory: `frontend/app/view/agent/providers/` (not `translators/`).
- New §9.1 — **Detection strategy.** Ground-truthed against current code: Claude Code CLI in non-bypass + non-interactive mode does *not* emit a structured `permission_request` JSON event; it prompts on the controlling tty for `y/n`. Two paths forward (upstream event vs. local synthesis); v1 PR-1 commits to neither, just the type shape.

## Code changes

- `frontend/app/view/agent/types.ts`
  - `StreamEvent` gains `PermissionRequestEvent` member with `request_id`, `tool`, `target`, optional `reason` / `preview` / `risk`
  - `PermissionPreview` discriminated union (`diff` / `bash` / `text` / `none`)
  - `ToolNode.status` extended with `pending_approval` and `denied`. New optional `pendingPermission` field
  - `ToolResultEvent.status` gains `denied`
- `frontend/app/view/agent/components/ToolBlock.tsx` — STATUS_ICON table covers the two new statuses (⚠, ⊘)
- `frontend/app/view/agent/providers/translator.ts` — `OutputTranslator` interface gains optional `parsePermissionRequest(raw): PermissionRequestEvent | null`
- `frontend/app/view/agent/providers/claude-translator.ts` — implements stub returning `null` with a TODO comment pointing at §9.1

## What's next (per spec §11 Rollout)

- **v1 PR-2** — Decision panel TSX + `tool:decision` IPC handler in `agentmux-srv/src/server/websocket.rs`. Wires the panel to `pending_approval` ToolNodes. No detection yet; can be exercised manually by stuffing a fake event through `useAgentStream`.
- **v1 PR-3** — Per-(tool, target) memory + project rules (`.agentmux/permissions.json`) + global rules.
- **v1 PR-4** — Real detection: ClaudeTranslator's `parsePermissionRequest` synthesises events from y/n line patterns; sidecar wires the decision back to the subprocess's stdin.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `task build:frontend` | succeeds |
| User-visible change | none (this PR only widens type unions; no runtime emits the new variants yet) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)