### PR TITLE
feat(decision-prompt): v1 PR-2 — decision panel UI (#551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.391"
+version = "0.33.392"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.391"
+version = "0.33.392"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.391"
+version = "0.33.392"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.391"
+version = "0.33.392"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.391"
+version = "0.33.392"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.391"
+version = "0.33.392"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.391"
+version = "0.33.392"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.391"
+version = "0.33.392"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md
+++ b/docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md
@@ -211,22 +211,51 @@ The parent must NOT:
 
 When changing the panel, verify each:
 
+**State**
+
 - [ ] All seven transient signals reset on a single
   `createEffect(request_id)` and nowhere else.
+- [ ] High-risk armed flag does not survive a request change.
+
+**Keyboard**
+
 - [ ] Exactly one keyboard handler exists; no `onKeyDown`
   attribute on any panel-owned element.
 - [ ] All key branches early-return on `!inOwnPane`.
 - [ ] All key branches respect the `!editable || inPanel`
   guard (Enter, Esc, scope letters).
+
+**Click handlers (parity with keyboard equivalents)**
+
+- [ ] Defer button click is symmetric with Esc — both call
+  `setMinimized(true)` and `props.onDefer?.()`. (Reagent
+  round-5 caught the click branch missing the minimize call.)
+- [ ] Allow button click is symmetric with Enter — both honour
+  the high-risk gate (shift modifier or armed-state).
+- [ ] Deny button click is symmetric with Shift+Enter and
+  the deny-mode Enter dispatch.
+
+**Lifecycle**
+
 - [ ] `usePaneOverlay` is called from a child mounted INSIDE
   the `<Show>`, not from the outer component.
-- [ ] High-risk armed flag does not survive a request change.
 - [ ] Defer leaves the prompt reachable: minimized button
   still renders, click expands, new request auto-expands.
 - [ ] Empty deny + non-`once` scope shows a visible error,
   doesn't silently no-op.
+
+**Multi-pane / multi-instance**
+
 - [ ] Two open panels (different panes) do not cross-trigger
   on a single keystroke.
+- [ ] DOM identifiers that natively imply mutual exclusion
+  (radio `name`, `<datalist>` ids, etc.) are per-instance via
+  `createUniqueId()`. (Reagent round-5: shared
+  `name="agent-decision-scope"` caused multi-pane scope
+  selection to desync.)
+- [ ] Two panels with different head requests show
+  independent state — selecting scope in one does NOT change
+  the rendered selection in the other.
 
 ## 9. Rollback path
 

--- a/docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md
+++ b/docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md
@@ -1,0 +1,248 @@
+# Decision Prompt — Cohesive Design (Step-Back Doc)
+
+**Date:** 2026-04-25
+**Status:** Living design doc, sits next to
+            `SPEC_DECISION_PROMPT_2026_04_24.md`
+**Why this exists:** PR #556 surfaced 7+ P1 issues across four
+            review rounds — each individual fix was correct in
+            isolation but the component grew without a coherent
+            keyboard / state model. This doc enumerates the full
+            interaction matrix so the next implementation pass
+            (or refactor) has a single ground-truth to check
+            against.
+
+---
+
+## 1. Why so many bugs
+
+The decision panel is doing five fundamentally interlocking jobs:
+
+1. **Cross-context keyboard input** — handle Enter / Esc /
+   Shift+Enter / scope-letters that may originate from the panel
+   itself, the composer textarea, or any other element in the pane.
+2. **Per-pane scoping** — multiple agent panes can each have
+   their own pending prompt; one pane's keystroke must not
+   activate another pane's panel.
+3. **Per-request transient state** — high-risk armed flag, deny
+   mode, scope selection, feedback text, deny error message — all
+   need to reset when the head request changes.
+4. **Lifecycle-driven rendering** — the panel mounts only when
+   there's a pending request; some hooks (`usePaneOverlay`)
+   capture state at mount time and don't reactively refresh.
+5. **No-dead-end UX** — every action the user can take has to
+   leave a path back to deciding the prompt, including Defer.
+
+Each PR-556 review round caught one slice of one of these and we
+patched in isolation. The patch added a new interaction the next
+round caught. Hence the cascade.
+
+This doc fixes the underlying problem: decide ONCE what the model
+is, write it down, and check every change against it.
+
+---
+
+## 2. State model
+
+The panel owns these reactive signals:
+
+| Signal | Source | Reset when |
+|---|---|---|
+| `pending: ToolNode[]` | Parent prop (read from documentAtom) | Parent atom updates |
+| `head: ToolNode \| null` | `pending[0]` | Auto via memo |
+| `request: PermissionRequestEvent \| null` | `head?.pendingPermission` | Auto via memo |
+| `scope` | Local `createSignal` | **Reset on `request.request_id` change** (via createEffect) |
+| `denyMode: boolean` | Local | Reset on request change AND on successful dispatch |
+| `feedback: string` | Local | Reset on request change AND on successful dispatch |
+| `denyError: string \| null` | Local | Reset on textarea input AND on request change |
+| `highRiskArmed: boolean` | Local + 500ms timer | Reset on request change AND on successful Allow AND on timer fire |
+| `minimized: boolean` | Local | **Reset on request change** so a fresh prompt always re-expands |
+
+**Invariant**: every per-request transient signal MUST reset when
+`request.request_id` changes. There's exactly one place to do
+this — a single `createEffect` reading `request_id` and clearing
+all of: `scope`, `denyMode`, `feedback`, `denyError`,
+`highRiskArmed`, `minimized`. Do NOT spread the resets across
+multiple effects.
+
+## 3. Keyboard model
+
+### 3.1 Listener
+
+ONE global capture-phase `keydown` listener installed via
+`createEffect` while `request()` is non-null. Cleaned up on
+request becoming null and on component unmount.
+
+There is no `onKeyDown` on any DOM element rendered by this
+panel. Mixing the two duplicated handling and broke the high-risk
+gate (PR #556 round 2). Single source of truth.
+
+### 3.2 Routing predicates
+
+| Predicate | Definition |
+|---|---|
+| `inOwnPane` | `paneRoot.contains(target)` where `paneRoot = rootRef.closest('.agent-view')` |
+| `inPanel` | `rootRef.contains(target)` |
+| `editable` | target is `INPUT` / `TEXTAREA` / `[contenteditable]` |
+| `inFeedback` | `inPanel && target.tagName === "TEXTAREA"` |
+
+**Hard gate (early-return):** if `!inOwnPane`, ignore the event
+entirely. This blocks cross-pane leakage.
+
+### 3.3 Per-key behaviour
+
+Within `inOwnPane`, each key maps as follows. The same `editable`
+guard applies symmetrically to Enter, Esc, and the scope letters
+— they all defer to the composer when the user is typing.
+
+| Key | When `inFeedback` | When `inPanel && !inFeedback` | When `inOwnPane && !editable` | When `inOwnPane && editable && !inPanel` |
+|---|---|---|---|---|
+| `Enter` | newline (default) | Allow / arm / deny | Allow / arm | (no-op — composer handles) |
+| `Shift+Enter` | dispatch deny | enter deny mode | enter deny mode | (no-op — composer handles) |
+| `Esc` | minimize | minimize | minimize | (no-op — composer handles) |
+| `o` / `s` / `p` / `g` | typed into textarea | set scope | set scope | (no-op — composer handles) |
+| any other | typed into textarea | (default) | (default) | (default) |
+
+`inFeedback` rule for Enter is the one exception that diverges
+from `inPanel` general behaviour: Enter inside the feedback
+textarea inserts a newline (browser default) so users can write
+multi-line denials.
+
+## 4. Lifecycle
+
+### 4.1 Mounting
+
+The panel root (or its minimized variant) is wrapped in
+`<Show when={request()}>`. The hook `usePaneOverlay` MUST be
+called from a child component mounted inside that `<Show>`, not
+from the outer component. Otherwise `onMount` runs before
+`rootRef` is attached and the airspace clip never registers.
+
+Pattern: a tiny null-rendering `DecisionPanelClip` child that
+calls `usePaneOverlay(p.getEl)` and is mounted inside the
+`<Show>`. Same pattern as modal-v2's `ModalPaneOverlayClip`.
+
+### 4.2 Request transitions
+
+| Transition | Effect |
+|---|---|
+| `null → R1` | All transient state resets (already at defaults). Panel mounts. Airspace clip registers. |
+| `R1 → R2` (head changes) | `createEffect` on `request_id` resets all transient state. Panel re-renders with R2's data. Airspace re-evaluates on next resize (acceptable — same screen rect). |
+| `R1 → null` (resolved) | Panel unmounts via `<Show>`. Airspace clip cleaned up by `usePaneOverlay`'s `onCleanup`. All listeners detach. |
+| Defer | Sets `minimized = true` (local). Parent is informed via `onDefer` prop for logging only — parent does NOT remove the request from `pending`. |
+| Allow / Deny | Panel calls `onDecide`. Parent is responsible for transitioning the ToolNode out of `pending_approval`. New `request()` is null (or next pending), `<Show>` reacts. |
+
+### 4.3 Minimized state
+
+Defer / Esc collapses the panel into a compact button anchored at
+the same location: `Decision pending — <tool> [click to decide]`.
+- The minimized button still calls `usePaneOverlay` so its
+  smaller rect is the airspace cut while collapsed.
+- Clicking expands.
+- A new request (request_id change) auto-expands via the §2
+  reset rule.
+- The keyboard listener stays armed while minimized — Enter from
+  outside any editable still acts on the (minimized) head request.
+  This is intentional: "decision is still pending" is the user's
+  responsibility, and the state is visible.
+
+## 5. High-risk Allow
+
+### 5.1 Two-step gate
+
+When `risk === "high"`, the first Allow trigger only **arms**
+the gate (sets `highRiskArmed = true`) for 500ms. Within that
+window, a second Allow trigger commits the decision.
+
+### 5.2 What counts as "Allow trigger"
+
+- Click the Allow button (without Shift)
+- Press Enter when `inPanel || (inOwnPane && !editable)`
+
+### 5.3 Bypass paths
+
+A single keystroke commits when:
+- `risk !== "high"` (no gate to begin with)
+- The trigger event has `shiftKey === true` (deliberate shift-click)
+
+### 5.4 Reset rules
+
+`highRiskArmed` resets to false:
+- On request change (§2 — common reset)
+- On the 500ms timer firing
+- On any successful Allow dispatch
+
+The §2 reset closes the cross-request armed leak: arming
+prompt A then advancing to prompt B within 500ms cannot
+auto-commit B.
+
+## 6. Multi-pane
+
+Each `AgentDecisionPanel` instance:
+- Has its own `rootRef` and own `paneRoot` (resolved via
+  `closest('.agent-view')`)
+- Has its own keyboard listener
+- Hard-gates by `paneRoot.contains(target)`
+
+When two panes both have pending prompts:
+- Each panel's listener only fires for keystrokes in its own pane
+- The user must click into a pane (or have focus there from
+  composer) to operate that pane's prompt
+- Two prompts = two visible panels (or minimized buttons), each
+  scoped to its own pane
+
+## 7. Parent contract (`agent-view.tsx`)
+
+The parent must:
+- Pass `pending: () => ToolNode[]` — the live array of pending
+  ToolNodes from `documentAtom`, oldest first.
+- Pass `onDecide(decision)` — handle the side effect of resolving
+  the ToolNode (set status, write to backend in PR-3).
+- Pass `onDefer()` — optional. Used for logging / audit only.
+  The parent must NOT filter out deferred requests — the panel
+  manages its own minimized state.
+
+The parent must NOT:
+- Maintain a "deferred" set. (PR #556 round 4 P1 — the panel owns
+  this now.)
+- Mount more than one `AgentDecisionPanel` per pane.
+- Pass a custom keyboard handler. The panel installs its own.
+
+## 8. Validation checklist
+
+When changing the panel, verify each:
+
+- [ ] All seven transient signals reset on a single
+  `createEffect(request_id)` and nowhere else.
+- [ ] Exactly one keyboard handler exists; no `onKeyDown`
+  attribute on any panel-owned element.
+- [ ] All key branches early-return on `!inOwnPane`.
+- [ ] All key branches respect the `!editable || inPanel`
+  guard (Enter, Esc, scope letters).
+- [ ] `usePaneOverlay` is called from a child mounted INSIDE
+  the `<Show>`, not from the outer component.
+- [ ] High-risk armed flag does not survive a request change.
+- [ ] Defer leaves the prompt reachable: minimized button
+  still renders, click expands, new request auto-expands.
+- [ ] Empty deny + non-`once` scope shows a visible error,
+  doesn't silently no-op.
+- [ ] Two open panels (different panes) do not cross-trigger
+  on a single keystroke.
+
+## 9. Rollback path
+
+If the cohesive refactor doesn't land cleanly, the safest
+rollback for PR-556 is: revert the panel JSX/SCSS/agent-view
+wiring; keep the type plumbing from PR #555 in main. PR-3
+implementation can then build the panel from scratch against
+this doc rather than against the patched-PR-556 history.
+
+## 10. Cross-references
+
+- `docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md` — feature spec
+- `docs/specs/SPEC_MODAL_PANE_CLIP_2026_04_24.md` —
+  `usePaneOverlay` pattern
+- `frontend/app/element/modal-v2.tsx` — `ModalPaneOverlayClip`
+  reference implementation of the §4.1 mounting pattern
+- agentmuxai/agentmux#551 — issue this implements
+- agentmuxai/agentmux#556 — the PR whose review history
+  motivated this doc

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -27,6 +27,7 @@
 @use "styles/action-bar";
 @use "styles/auth-overlay";
 @use "styles/responsive";
+@use "styles/decision-panel";
 
 .agent-view {
     container-type: inline-size;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -23,6 +23,7 @@ import { useControllerStatusEvents } from "./hooks/useControllerStatusEvents";
 import { useAgentCommands } from "./hooks/useAgentCommands";
 import { AgentControlBar } from "./components/AgentControlBar";
 import { ActivityLogPanel } from "./components/ActivityLogPanel";
+import { AgentDecisionPanel } from "./components/AgentDecisionPanel";
 import { AgentDocumentView } from "./components/AgentDocumentView";
 import { AgentFooter, AgentStatusLine } from "./components/AgentFooter";
 import { PendingMessagesPanel } from "./components/PendingMessagesPanel";
@@ -116,7 +117,40 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Auth + launch flow state and the onCleanup that kills the CLI
     // if the pane closes mid-login.
-    const [, setDocument] = agentAtoms().documentAtom;
+    const [getDocument, setDocument] = agentAtoms().documentAtom;
+
+    // Pending decision queue — every ToolNode whose `status === "pending_approval"`,
+    // oldest first. The decision panel renders the head; clicking
+    // Allow / Deny clears that node from the queue. The actual `tool:decision`
+    // IPC + sidecar stdin write lands in PR-3; today the panel just transitions
+    // the node to running/denied locally so the UI loop closes.
+    // Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5.
+    const pendingDecisions = (): import("./types").ToolNode[] => {
+        const docs = getDocument();
+        const out: import("./types").ToolNode[] = [];
+        for (const n of docs) {
+            if (n.type === "tool" && n.status === "pending_approval") out.push(n);
+        }
+        return out;
+    };
+
+    const handleDecide = (decision: import("./components/AgentDecisionPanel").DecisionOutcome) => {
+        // Local-only resolution for v1 PR-2. The IPC call to the sidecar
+        // (which writes y/n to the subprocess's stdin and registers any
+        // session/project/global rule) is added in PR-3; for now this
+        // just clears the pending state so the UI flow can be exercised.
+        setDocument((prev) =>
+            prev.map((n) => {
+                if (n.type !== "tool" || n.status !== "pending_approval") return n;
+                if (n.pendingPermission?.request_id !== decision.request_id) return n;
+                return {
+                    ...n,
+                    status: decision.outcome === "allow" ? "running" : "denied",
+                    pendingPermission: undefined,
+                };
+            }),
+        );
+    };
     const status = useAgentControllerStatus({
         blockId: model.blockId,
         provider,
@@ -533,6 +567,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     </button>
                 </div>
             </Show>
+
+            {/* Permission decision panel — surfaced when one or more
+                tool calls are gated by the CLI awaiting user approval.
+                Sits above the queue so it can't be missed. The panel
+                renders nothing when no ToolNode is in pending_approval.
+                v1 PR-2 wires the UI; PR-3 adds the IPC + sidecar stdin
+                write so decisions actually reach the subprocess.
+                Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5. */}
+            <AgentDecisionPanel
+                pending={pendingDecisions}
+                onDecide={handleDecide}
+            />
 
             {/* Queue sits directly below the feed so the user's newly-
                 typed message lands next to the live conversation it's

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -119,26 +119,19 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // if the pane closes mid-login.
     const [getDocument, setDocument] = agentAtoms().documentAtom;
 
-    // Pending decision queue — every ToolNode whose `status === "pending_approval"`,
-    // oldest first, minus any whose request the user has deferred. The
-    // decision panel renders the head; clicking Allow / Deny clears
-    // the node from the queue (transitions status). Defer adds the
-    // request_id to the deferred set so the panel hides without
-    // resolving — a later pending node (or the same one if its
-    // request_id changes) brings the panel back. The actual
+    // Pending decision queue — every ToolNode whose
+    // `status === "pending_approval"`, oldest first. The decision
+    // panel renders the head; Allow / Deny clears the node by
+    // transitioning its status. Defer is HANDLED INSIDE THE PANEL
+    // (it minimizes locally) — per
+    // docs/specs/SPEC_DECISION_PROMPT_DESIGN_2026_04_25.md §7,
+    // the parent must NOT filter pending. The actual
     // `tool:decision` IPC + sidecar stdin write lands in PR-3.
-    // Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5.
-    const [deferredIds, setDeferredIds] = createSignal<Set<string>>(new Set());
-
     const pendingDecisions = (): import("./types").ToolNode[] => {
         const docs = getDocument();
-        const deferred = deferredIds();
         const out: import("./types").ToolNode[] = [];
         for (const n of docs) {
-            if (n.type !== "tool" || n.status !== "pending_approval") continue;
-            const reqId = n.pendingPermission?.request_id;
-            if (reqId && deferred.has(reqId)) continue;
-            out.push(n);
+            if (n.type === "tool" && n.status === "pending_approval") out.push(n);
         }
         return out;
     };
@@ -588,20 +581,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 pending={pendingDecisions}
                 onDecide={handleDecide}
                 onDefer={() => {
-                    // Defer keeps the ToolNode in pending_approval but
-                    // hides the panel by adding the head's request_id
-                    // to the deferred set. A new pending request brings
-                    // the panel back. Codex P2 on PR #556 — previously
-                    // `onDefer` was unset.
-                    const head = pendingDecisions()[0];
-                    const reqId = head?.pendingPermission?.request_id;
-                    if (!reqId) return;
-                    setDeferredIds((prev) => {
-                        const next = new Set(prev);
-                        next.add(reqId);
-                        return next;
-                    });
-                    log("agent", "Decision deferred");
+                    // Logging only — the panel itself manages the
+                    // minimized state (per doc §7 + §4.3) so the
+                    // prompt remains reachable.
+                    log("agent", "Decision minimized");
                 }}
             />
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -120,16 +120,25 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     const [getDocument, setDocument] = agentAtoms().documentAtom;
 
     // Pending decision queue — every ToolNode whose `status === "pending_approval"`,
-    // oldest first. The decision panel renders the head; clicking
-    // Allow / Deny clears that node from the queue. The actual `tool:decision`
-    // IPC + sidecar stdin write lands in PR-3; today the panel just transitions
-    // the node to running/denied locally so the UI loop closes.
+    // oldest first, minus any whose request the user has deferred. The
+    // decision panel renders the head; clicking Allow / Deny clears
+    // the node from the queue (transitions status). Defer adds the
+    // request_id to the deferred set so the panel hides without
+    // resolving — a later pending node (or the same one if its
+    // request_id changes) brings the panel back. The actual
+    // `tool:decision` IPC + sidecar stdin write lands in PR-3.
     // Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5.
+    const [deferredIds, setDeferredIds] = createSignal<Set<string>>(new Set());
+
     const pendingDecisions = (): import("./types").ToolNode[] => {
         const docs = getDocument();
+        const deferred = deferredIds();
         const out: import("./types").ToolNode[] = [];
         for (const n of docs) {
-            if (n.type === "tool" && n.status === "pending_approval") out.push(n);
+            if (n.type !== "tool" || n.status !== "pending_approval") continue;
+            const reqId = n.pendingPermission?.request_id;
+            if (reqId && deferred.has(reqId)) continue;
+            out.push(n);
         }
         return out;
     };
@@ -578,6 +587,22 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             <AgentDecisionPanel
                 pending={pendingDecisions}
                 onDecide={handleDecide}
+                onDefer={() => {
+                    // Defer keeps the ToolNode in pending_approval but
+                    // hides the panel by adding the head's request_id
+                    // to the deferred set. A new pending request brings
+                    // the panel back. Codex P2 on PR #556 — previously
+                    // `onDefer` was unset.
+                    const head = pendingDecisions()[0];
+                    const reqId = head?.pendingPermission?.request_id;
+                    if (!reqId) return;
+                    setDeferredIds((prev) => {
+                        const next = new Set(prev);
+                        next.add(reqId);
+                        return next;
+                    });
+                    log("agent", "Decision deferred");
+                }}
             />
 
             {/* Queue sits directly below the feed so the user's newly-

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -168,11 +168,17 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
         const inFeedback = inPanel && target?.tagName === "TEXTAREA";
 
         if (e.key === "Escape") {
-            // Esc defers when focus is in this pane (already gated above).
-            // Outside this pane: not our event.
-            e.preventDefault();
-            e.stopPropagation();
-            props.onDefer?.();
+            // Esc defers ONLY when focus is non-editable or in the
+            // panel itself. Reagent P1 round-3: Esc in the composer
+            // textarea (or any editable in the pane) needs to keep its
+            // normal meaning — dismiss autocomplete, cancel slash
+            // picker, etc. Symmetric with the Enter / scope-letter
+            // guards below.
+            if (!editable || inPanel) {
+                e.preventDefault();
+                e.stopPropagation();
+                props.onDefer?.();
+            }
             return;
         }
         // Letter-keyed scope: only when not typing into any editable

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -73,12 +73,14 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
     // depending on which branch is mounted; widened to HTMLElement
     // so both ref assignments type-check.
     let rootRef: HTMLElement | undefined;
-    // Per-instance scope-radio group name. Hardcoding the same name
-    // across panels caused multi-pane scope desync (reagent P2 round-5):
-    // picking scope in pane A's panel cleared pane B's radio via
-    // native radio-group rules, even though both Solid signals were
-    // correct.
-    const scopeGroupName = `agent-decision-scope-${createUniqueId()}`;
+    // Per-instance unique IDs. Anything that's `name=` on a radio,
+    // `id=` on an element targeted by aria-describedby/-labelledby,
+    // or otherwise globally addressable in the DOM must be scoped
+    // per-instance. Hardcoding caused multi-pane desync — reagent
+    // P2 round-5 (radio name) + round-6 (deny-error id).
+    const uid = createUniqueId();
+    const scopeGroupName = `agent-decision-scope-${uid}`;
+    const denyErrorId = `agent-decision-deny-error-${uid}`;
 
     const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
     const queueDepth = () => props.pending().length;
@@ -391,11 +393,11 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                             rows={3}
                             autofocus
                             aria-invalid={denyError() != null}
-                            aria-describedby={denyError() ? "agent-decision-deny-error" : undefined}
+                            aria-describedby={denyError() ? denyErrorId : undefined}
                         />
                         <Show when={denyError()}>
                             <span
-                                id="agent-decision-deny-error"
+                                id={denyErrorId}
                                 class="agent-decision-panel-feedback-error"
                                 role="alert"
                             >

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -17,7 +17,7 @@
  * downstream of "user clicked Allow / Deny" can be exercised.
  */
 
-import { createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import type { PermissionRequestEvent, ToolNode } from "../types";
 
@@ -109,6 +109,12 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
         }
     };
 
+    // Visible validation message when Send-denial is pressed without
+    // the required feedback. Cleared on next keystroke in the textarea.
+    // Reagent P1: previously the deny silently no-op'd, leaving the user
+    // stuck with no indication why nothing happened.
+    const [denyError, setDenyError] = createSignal<string | null>(null);
+
     const dispatchDeny = () => {
         const r = request();
         if (!r) return;
@@ -116,7 +122,7 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
         // §10 open question: empty deny scopes only allowed for "once".
         // Pragmatic default: empty allowed for once, required for others.
         if (scope() !== "once" && text.length === 0) {
-            // Keep deny mode open; rely on the textarea's required cue.
+            setDenyError("Feedback is required when the denial applies beyond just this call.");
             return;
         }
         void props.onDecide({
@@ -127,18 +133,36 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
         });
         setDenyMode(false);
         setFeedback("");
+        setDenyError(null);
+    };
+
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+        const el = target as HTMLElement | null;
+        if (!el) return false;
+        const tag = el.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA") return true;
+        if (el.isContentEditable) return true;
+        return false;
     };
 
     const handleKey = (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement | null;
+        const inPanel = !!rootRef && !!target && rootRef.contains(target);
+        const editable = isEditableTarget(target);
+        const inFeedback = inPanel && target?.tagName === "TEXTAREA";
+
         if (e.key === "Escape") {
+            // Esc always defers, no matter where focus is — the user
+            // is signalling "not now".
             e.preventDefault();
+            e.stopPropagation();
             props.onDefer?.();
             return;
         }
-        // Letter-keyed scope only when not typing into the feedback textarea.
-        const target = e.target as HTMLElement | null;
-        const inFeedback = target?.tagName === "TEXTAREA";
-        if (!inFeedback && e.key.length === 1) {
+        // Letter-keyed scope: only when not typing into any editable
+        // (composer, feedback textarea, etc.). Composer keystrokes
+        // would otherwise be hijacked.
+        if (!editable && e.key.length === 1) {
             const map: Record<string, DecisionOutcome["scope"]> = {
                 o: "once", s: "session", p: "project", g: "global",
             };
@@ -150,20 +174,46 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
             }
         }
         if (e.key === "Enter") {
-            if (denyMode()) {
-                if (e.shiftKey || (target?.tagName !== "TEXTAREA")) {
+            // Inside the deny feedback textarea: Enter inserts a newline
+            // (default browser behaviour); Shift+Enter sends the denial.
+            if (inFeedback) {
+                if (e.shiftKey) {
                     e.preventDefault();
                     dispatchDeny();
                 }
-            } else if (e.shiftKey) {
-                e.preventDefault();
-                setDenyMode(true);
-            } else {
-                e.preventDefault();
-                dispatchAllow(e);
+                return;
             }
+            // Outside any editable element OR inside the panel itself:
+            // Enter = Allow (or arm high-risk), Shift+Enter = enter deny mode.
+            if (!editable || inPanel) {
+                if (denyMode()) {
+                    e.preventDefault();
+                    dispatchDeny();
+                } else if (e.shiftKey) {
+                    e.preventDefault();
+                    setDenyMode(true);
+                } else {
+                    e.preventDefault();
+                    dispatchAllow(e);
+                }
+            }
+            // If editable and not in panel (composer): let the composer
+            // handle Enter. The user must click the panel to act on it.
         }
     };
+
+    // Install a global capture-phase keydown listener while the panel
+    // is open so decision shortcuts work even when focus is elsewhere
+    // (e.g. the composer textarea). Codex P1 on PR #556: previously the
+    // panel's `onKeyDown` only fired when the panel itself was focused,
+    // but the panel has tabIndex=-1 and never auto-focuses, so keys
+    // never reached the handler in practice.
+    createEffect(() => {
+        if (!request()) return;
+        const onWindowKey = (e: KeyboardEvent) => handleKey(e);
+        window.addEventListener("keydown", onWindowKey, true);
+        onCleanup(() => window.removeEventListener("keydown", onWindowKey, true));
+    });
 
     const previewText = (): string | null => {
         const p = request()?.preview;
@@ -248,12 +298,27 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                         <span>Tell the agent why (sent verbatim on the next turn)</span>
                         <textarea
                             class="agent-decision-panel-feedback-input"
+                            classList={{ "agent-decision-panel-feedback-input--error": denyError() != null }}
                             value={feedback()}
                             placeholder="e.g. don't delete my node_modules; run npm ci"
-                            onInput={(e) => setFeedback(e.currentTarget.value)}
+                            onInput={(e) => {
+                                setFeedback(e.currentTarget.value);
+                                if (denyError()) setDenyError(null);
+                            }}
                             rows={3}
                             autofocus
+                            aria-invalid={denyError() != null}
+                            aria-describedby={denyError() ? "agent-decision-deny-error" : undefined}
                         />
+                        <Show when={denyError()}>
+                            <span
+                                id="agent-decision-deny-error"
+                                class="agent-decision-panel-feedback-error"
+                                role="alert"
+                            >
+                                {denyError()}
+                            </span>
+                        </Show>
                     </label>
                 </Show>
 

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -17,7 +17,7 @@
  * downstream of "user clicked Allow / Deny" can be exercised.
  */
 
-import { createEffect, createMemo, createSignal, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, createUniqueId, For, onCleanup, Show, type Accessor, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import type { PermissionRequestEvent, ToolNode } from "../types";
 
@@ -73,6 +73,12 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
     // depending on which branch is mounted; widened to HTMLElement
     // so both ref assignments type-check.
     let rootRef: HTMLElement | undefined;
+    // Per-instance scope-radio group name. Hardcoding the same name
+    // across panels caused multi-pane scope desync (reagent P2 round-5):
+    // picking scope in pane A's panel cleared pane B's radio via
+    // native radio-group rules, even though both Solid signals were
+    // correct.
+    const scopeGroupName = `agent-decision-scope-${createUniqueId()}`;
 
     const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
     const queueDepth = () => props.pending().length;
@@ -359,7 +365,7 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                             >
                                 <input
                                     type="radio"
-                                    name="agent-decision-scope"
+                                    name={scopeGroupName}
                                     checked={scope() === s}
                                     onChange={() => setScope(s)}
                                 />
@@ -442,7 +448,15 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                             <button
                                 type="button"
                                 class="agent-decision-panel-btn agent-decision-panel-btn--cancel"
-                                onClick={() => props.onDefer?.()}
+                                onClick={() => {
+                                    // Symmetric with Esc handler: minimize the
+                                    // panel into the compact "Decision pending"
+                                    // bar, then notify parent (logging only).
+                                    // Reagent P1 round-5 — without setMinimized,
+                                    // the click was a visible no-op.
+                                    setMinimized(true);
+                                    props.onDefer?.();
+                                }}
                             >
                                 Defer
                             </button>

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -155,13 +155,21 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
 
     const handleKey = (e: KeyboardEvent) => {
         const target = e.target as HTMLElement | null;
+        // Scope every shortcut to events originating inside this
+        // panel's own pane. Without this check, a pending prompt in
+        // pane A would react to keys from pane B (Esc, Enter, etc.)
+        // and multiple open prompts in different panes would all
+        // dispatch on the same keystroke. Codex P1 on PR #556.
+        const paneRoot = rootRef?.closest(".agent-view") as HTMLElement | null;
+        if (paneRoot && target && !paneRoot.contains(target)) return;
+
         const inPanel = !!rootRef && !!target && rootRef.contains(target);
         const editable = isEditableTarget(target);
         const inFeedback = inPanel && target?.tagName === "TEXTAREA";
 
         if (e.key === "Escape") {
-            // Esc always defers, no matter where focus is — the user
-            // is signalling "not now".
+            // Esc defers when focus is in this pane (already gated above).
+            // Outside this pane: not our event.
             e.preventDefault();
             e.stopPropagation();
             props.onDefer?.();

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -56,12 +56,20 @@ const SCOPE_HINT: Record<DecisionOutcome["scope"], string> = {
 
 const SCOPE_ORDER: DecisionOutcome["scope"][] = ["once", "session", "project", "global"];
 
+// Tiny child that calls usePaneOverlay against the panel root ref.
+// Same pattern as modal-v2's `ModalPaneOverlayClip` — mounted only
+// when the panel is visible, so `onMount` runs while `rootRef` is
+// already attached to the live DOM element. Calling usePaneOverlay
+// from the outer component would register undefined on first mount
+// (the `<Show>` hasn't materialised yet) and never refresh on
+// reveal — codex P1 on PR #556.
+const DecisionPanelClip = (p: { getEl: Accessor<HTMLElement | null | undefined> }): JSX.Element => {
+    usePaneOverlay(p.getEl);
+    return null;
+};
+
 export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element => {
     let rootRef: HTMLDivElement | undefined;
-    // Win32 airspace cut so the panel paints over any browser pane
-    // HWND in the same window. Same primitive used by modal-v2 and
-    // MoreDropdown — see frontend/app/platform/pane-overlay.ts.
-    usePaneOverlay(() => rootRef);
 
     const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
     const queueDepth = () => props.pending().length;
@@ -237,9 +245,9 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                 }}
                 role="dialog"
                 aria-label="Permission decision required"
-                onKeyDown={handleKey}
                 tabIndex={-1}
             >
+                <DecisionPanelClip getEl={() => rootRef} />
                 <div class="agent-decision-panel-header">
                     <span class="agent-decision-panel-icon" aria-hidden="true">⚠</span>
                     <span class="agent-decision-panel-title">

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -69,10 +69,22 @@ const DecisionPanelClip = (p: { getEl: Accessor<HTMLElement | null | undefined> 
 };
 
 export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element => {
-    let rootRef: HTMLDivElement | undefined;
+    // Holds either the expanded panel div or the minimized button
+    // depending on which branch is mounted; widened to HTMLElement
+    // so both ref assignments type-check.
+    let rootRef: HTMLElement | undefined;
 
     const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
     const queueDepth = () => props.pending().length;
+
+    // Minimized state — Defer / Esc collapses the panel into a
+    // compact "Decision pending" bar instead of removing it from
+    // the UI. Codex P1 round-4: previously the parent maintained a
+    // deferredIds set that it never cleared, leaving deferred
+    // prompts permanently unreachable. Single per-request reset
+    // effect below clears this and every other transient signal
+    // when the head changes — see SPEC_DECISION_PROMPT_DESIGN §2.
+    const [minimized, setMinimized] = createSignal(false);
 
     const request = (): PermissionRequestEvent | null => head()?.pendingPermission ?? null;
     const risk = (): "low" | "medium" | "high" => request()?.risk ?? "medium";
@@ -86,6 +98,11 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
     const [highRiskArmed, setHighRiskArmed] = createSignal(false);
     let highRiskTimer: number | null = null;
 
+    // Visible validation message when Send-denial is pressed without
+    // the required feedback. Cleared on next keystroke in the textarea
+    // (and on per-request reset below).
+    const [denyError, setDenyError] = createSignal<string | null>(null);
+
     const armHighRisk = () => {
         setHighRiskArmed(true);
         if (highRiskTimer != null) window.clearTimeout(highRiskTimer);
@@ -94,6 +111,29 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
             highRiskTimer = null;
         }, 500);
     };
+
+    // SINGLE per-request reset for every transient panel signal. Per
+    // SPEC_DECISION_PROMPT_DESIGN §2 invariant: when the head request
+    // changes (defer advances queue, deny resolves, new prompt
+    // arrives), every per-prompt UI flag must clear so we never
+    // accidentally inherit state from the previous request — most
+    // importantly the high-risk armed flag (otherwise arming prompt
+    // A and advancing to B within 500ms auto-commits B).
+    createEffect(() => {
+        const id = request()?.request_id ?? null;
+        // touch id so the effect re-runs on every change
+        void id;
+        setMinimized(false);
+        setScope("once");
+        setDenyMode(false);
+        setFeedback("");
+        setDenyError(null);
+        setHighRiskArmed(false);
+        if (highRiskTimer != null) {
+            window.clearTimeout(highRiskTimer);
+            highRiskTimer = null;
+        }
+    });
 
     const dispatchAllow = (e?: KeyboardEvent | MouseEvent) => {
         const r = request();
@@ -116,12 +156,6 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
             highRiskTimer = null;
         }
     };
-
-    // Visible validation message when Send-denial is pressed without
-    // the required feedback. Cleared on next keystroke in the textarea.
-    // Reagent P1: previously the deny silently no-op'd, leaving the user
-    // stuck with no indication why nothing happened.
-    const [denyError, setDenyError] = createSignal<string | null>(null);
 
     const dispatchDeny = () => {
         const r = request();
@@ -168,15 +202,15 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
         const inFeedback = inPanel && target?.tagName === "TEXTAREA";
 
         if (e.key === "Escape") {
-            // Esc defers ONLY when focus is non-editable or in the
+            // Esc minimizes ONLY when focus is non-editable or in the
             // panel itself. Reagent P1 round-3: Esc in the composer
             // textarea (or any editable in the pane) needs to keep its
             // normal meaning — dismiss autocomplete, cancel slash
-            // picker, etc. Symmetric with the Enter / scope-letter
-            // guards below.
+            // picker, etc.
             if (!editable || inPanel) {
                 e.preventDefault();
                 e.stopPropagation();
+                setMinimized(true);
                 props.onDefer?.();
             }
             return;
@@ -250,8 +284,29 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
 
     return (
         <Show when={request()}>
+            <Show
+                when={!minimized()}
+                fallback={
+                    <button
+                        type="button"
+                        ref={(el) => { rootRef = el; }}
+                        class="agent-decision-panel-minimized"
+                        classList={{ "agent-decision-panel-minimized--high-risk": risk() === "high" }}
+                        onClick={() => setMinimized(false)}
+                        aria-label="Re-open decision prompt"
+                    >
+                        <DecisionPanelClip getEl={() => rootRef} />
+                        <span class="agent-decision-panel-icon" aria-hidden="true">⚠</span>
+                        <span>
+                            Decision pending — {request()!.tool}
+                            <Show when={queueDepth() > 1}> ({queueDepth()} total)</Show>
+                        </span>
+                        <span class="agent-decision-panel-minimized-cta">click to decide</span>
+                    </button>
+                }
+            >
             <div
-                ref={rootRef}
+                ref={(el) => { rootRef = el; }}
                 class="agent-decision-panel"
                 classList={{
                     "agent-decision-panel--high-risk": risk() === "high",
@@ -395,6 +450,7 @@ export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element 
                     </Show>
                 </div>
             </div>
+            </Show>
         </Show>
     );
 };

--- a/frontend/app/view/agent/components/AgentDecisionPanel.tsx
+++ b/frontend/app/view/agent/components/AgentDecisionPanel.tsx
@@ -1,0 +1,315 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentDecisionPanel — surfaced when one or more `ToolNode`s in the
+ * pane have `status === "pending_approval"`. Lets the user allow or
+ * deny a per-tool-call permission gate.
+ *
+ * Implements docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5.
+ *
+ * **v1 PR-2 scope (this PR):** panel UI + decision callback
+ * contract. The actual `tool:decision` IPC + sidecar stdin write
+ * lands in PR-3; today the panel just calls
+ * `props.onDecide(decision)` and the caller is responsible for
+ * removing the pending node. Without a real-detection path
+ * (PR-4), the panel never appears in production — but everything
+ * downstream of "user clicked Allow / Deny" can be exercised.
+ */
+
+import { createMemo, createSignal, For, Show, type Accessor, type JSX } from "solid-js";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import type { PermissionRequestEvent, ToolNode } from "../types";
+
+export interface DecisionOutcome {
+    request_id: string;
+    outcome: "allow" | "deny";
+    scope: "once" | "session" | "project" | "global";
+    feedback?: string;
+}
+
+interface AgentDecisionPanelProps {
+    /** Pending decisions, oldest first. The panel shows the head; a
+     *  chevron indicates how many more are queued. */
+    pending: Accessor<ToolNode[]>;
+    /** User decision. Caller is responsible for advancing the queue
+     *  by removing the corresponding node from `pending`. */
+    onDecide: (decision: DecisionOutcome) => void | Promise<void>;
+    /** Defer — leave the prompt in pending state. Closes the panel
+     *  without making a decision. */
+    onDefer?: () => void;
+}
+
+const SCOPE_LABEL: Record<DecisionOutcome["scope"], string> = {
+    once: "Once",
+    session: "Session",
+    project: "Project",
+    global: "Global",
+};
+
+const SCOPE_HINT: Record<DecisionOutcome["scope"], string> = {
+    once: "Just this one call",
+    session: "Until this pane closes",
+    project: "This repo, future runs",
+    global: "Everywhere, future runs",
+};
+
+const SCOPE_ORDER: DecisionOutcome["scope"][] = ["once", "session", "project", "global"];
+
+export const AgentDecisionPanel = (props: AgentDecisionPanelProps): JSX.Element => {
+    let rootRef: HTMLDivElement | undefined;
+    // Win32 airspace cut so the panel paints over any browser pane
+    // HWND in the same window. Same primitive used by modal-v2 and
+    // MoreDropdown — see frontend/app/platform/pane-overlay.ts.
+    usePaneOverlay(() => rootRef);
+
+    const head = createMemo<ToolNode | null>(() => props.pending()[0] ?? null);
+    const queueDepth = () => props.pending().length;
+
+    const request = (): PermissionRequestEvent | null => head()?.pendingPermission ?? null;
+    const risk = (): "low" | "medium" | "high" => request()?.risk ?? "medium";
+
+    const [scope, setScope] = createSignal<DecisionOutcome["scope"]>("once");
+    const [feedback, setFeedback] = createSignal("");
+    const [denyMode, setDenyMode] = createSignal(false);
+    // High-risk Allow needs a second action (double-Enter or shift-click).
+    // Tracked via a transient flag set on first activate; cleared after
+    // 500ms so the user can't approve in their sleep.
+    const [highRiskArmed, setHighRiskArmed] = createSignal(false);
+    let highRiskTimer: number | null = null;
+
+    const armHighRisk = () => {
+        setHighRiskArmed(true);
+        if (highRiskTimer != null) window.clearTimeout(highRiskTimer);
+        highRiskTimer = window.setTimeout(() => {
+            setHighRiskArmed(false);
+            highRiskTimer = null;
+        }, 500);
+    };
+
+    const dispatchAllow = (e?: KeyboardEvent | MouseEvent) => {
+        const r = request();
+        if (!r) return;
+        if (risk() === "high") {
+            const shiftHeld = e && "shiftKey" in e && e.shiftKey;
+            if (!shiftHeld && !highRiskArmed()) {
+                armHighRisk();
+                return;
+            }
+        }
+        void props.onDecide({
+            request_id: r.request_id,
+            outcome: "allow",
+            scope: scope(),
+        });
+        setHighRiskArmed(false);
+        if (highRiskTimer != null) {
+            window.clearTimeout(highRiskTimer);
+            highRiskTimer = null;
+        }
+    };
+
+    const dispatchDeny = () => {
+        const r = request();
+        if (!r) return;
+        const text = feedback().trim();
+        // §10 open question: empty deny scopes only allowed for "once".
+        // Pragmatic default: empty allowed for once, required for others.
+        if (scope() !== "once" && text.length === 0) {
+            // Keep deny mode open; rely on the textarea's required cue.
+            return;
+        }
+        void props.onDecide({
+            request_id: r.request_id,
+            outcome: "deny",
+            scope: scope(),
+            feedback: text || undefined,
+        });
+        setDenyMode(false);
+        setFeedback("");
+    };
+
+    const handleKey = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
+            e.preventDefault();
+            props.onDefer?.();
+            return;
+        }
+        // Letter-keyed scope only when not typing into the feedback textarea.
+        const target = e.target as HTMLElement | null;
+        const inFeedback = target?.tagName === "TEXTAREA";
+        if (!inFeedback && e.key.length === 1) {
+            const map: Record<string, DecisionOutcome["scope"]> = {
+                o: "once", s: "session", p: "project", g: "global",
+            };
+            const sc = map[e.key.toLowerCase()];
+            if (sc) {
+                e.preventDefault();
+                setScope(sc);
+                return;
+            }
+        }
+        if (e.key === "Enter") {
+            if (denyMode()) {
+                if (e.shiftKey || (target?.tagName !== "TEXTAREA")) {
+                    e.preventDefault();
+                    dispatchDeny();
+                }
+            } else if (e.shiftKey) {
+                e.preventDefault();
+                setDenyMode(true);
+            } else {
+                e.preventDefault();
+                dispatchAllow(e);
+            }
+        }
+    };
+
+    const previewText = (): string | null => {
+        const p = request()?.preview;
+        if (!p) return null;
+        switch (p.kind) {
+            case "diff": return p.content;
+            case "bash": return `$ ${p.command}`;
+            case "text": return p.content;
+            case "none": return null;
+        }
+    };
+
+    return (
+        <Show when={request()}>
+            <div
+                ref={rootRef}
+                class="agent-decision-panel"
+                classList={{
+                    "agent-decision-panel--high-risk": risk() === "high",
+                    "agent-decision-panel--armed": highRiskArmed(),
+                }}
+                role="dialog"
+                aria-label="Permission decision required"
+                onKeyDown={handleKey}
+                tabIndex={-1}
+            >
+                <div class="agent-decision-panel-header">
+                    <span class="agent-decision-panel-icon" aria-hidden="true">⚠</span>
+                    <span class="agent-decision-panel-title">
+                        Decision required
+                    </span>
+                    <Show when={queueDepth() > 1}>
+                        <span class="agent-decision-panel-queue">
+                            {queueDepth() - 1} more queued
+                        </span>
+                    </Show>
+                    <Show when={risk() === "high"}>
+                        <span class="agent-decision-panel-risk">high-risk</span>
+                    </Show>
+                </div>
+
+                <dl class="agent-decision-panel-meta">
+                    <dt>Tool</dt>
+                    <dd>{request()!.tool}</dd>
+                    <Show when={request()!.target}>
+                        <dt>Target</dt>
+                        <dd><code>{request()!.target}</code></dd>
+                    </Show>
+                    <Show when={request()!.reason}>
+                        <dt>Why</dt>
+                        <dd>{request()!.reason}</dd>
+                    </Show>
+                </dl>
+
+                <Show when={previewText()}>
+                    <pre class="agent-decision-panel-preview"><code>{previewText()}</code></pre>
+                </Show>
+
+                <fieldset class="agent-decision-panel-scope">
+                    <legend>Scope</legend>
+                    <For each={SCOPE_ORDER}>
+                        {(s) => (
+                            <label
+                                class="agent-decision-panel-scope-option"
+                                classList={{ "agent-decision-panel-scope-option--active": scope() === s }}
+                            >
+                                <input
+                                    type="radio"
+                                    name="agent-decision-scope"
+                                    checked={scope() === s}
+                                    onChange={() => setScope(s)}
+                                />
+                                <span class="agent-decision-panel-scope-label">{SCOPE_LABEL[s]}</span>
+                                <span class="agent-decision-panel-scope-hint">{SCOPE_HINT[s]}</span>
+                            </label>
+                        )}
+                    </For>
+                </fieldset>
+
+                <Show when={denyMode()}>
+                    <label class="agent-decision-panel-feedback">
+                        <span>Tell the agent why (sent verbatim on the next turn)</span>
+                        <textarea
+                            class="agent-decision-panel-feedback-input"
+                            value={feedback()}
+                            placeholder="e.g. don't delete my node_modules; run npm ci"
+                            onInput={(e) => setFeedback(e.currentTarget.value)}
+                            rows={3}
+                            autofocus
+                        />
+                    </label>
+                </Show>
+
+                <div class="agent-decision-panel-actions">
+                    <Show when={!denyMode()} fallback={
+                        <>
+                            <button
+                                type="button"
+                                class="agent-decision-panel-btn agent-decision-panel-btn--cancel"
+                                onClick={() => { setDenyMode(false); setFeedback(""); }}
+                            >
+                                Back
+                            </button>
+                            <button
+                                type="button"
+                                class="agent-decision-panel-btn agent-decision-panel-btn--deny"
+                                onClick={dispatchDeny}
+                            >
+                                Send denial
+                            </button>
+                        </>
+                    }>
+                        <button
+                            type="button"
+                            class="agent-decision-panel-btn agent-decision-panel-btn--allow"
+                            classList={{ "agent-decision-panel-btn--armed": risk() === "high" && highRiskArmed() }}
+                            onClick={(e) => dispatchAllow(e)}
+                            title={
+                                risk() === "high"
+                                    ? "Hold Shift while clicking, or press Enter twice (high-risk confirm)"
+                                    : "Allow this tool call"
+                            }
+                        >
+                            {risk() === "high" && highRiskArmed() ? "Press again to allow" : "Allow"}
+                        </button>
+                        <button
+                            type="button"
+                            class="agent-decision-panel-btn agent-decision-panel-btn--deny"
+                            onClick={() => setDenyMode(true)}
+                        >
+                            Deny + feedback
+                        </button>
+                        <Show when={props.onDefer}>
+                            <button
+                                type="button"
+                                class="agent-decision-panel-btn agent-decision-panel-btn--cancel"
+                                onClick={() => props.onDefer?.()}
+                            >
+                                Defer
+                            </button>
+                        </Show>
+                    </Show>
+                </div>
+            </div>
+        </Show>
+    );
+};
+
+AgentDecisionPanel.displayName = "AgentDecisionPanel";

--- a/frontend/app/view/agent/styles/_decision-panel.scss
+++ b/frontend/app/view/agent/styles/_decision-panel.scss
@@ -198,6 +198,16 @@
     &:focus {
         border-color: var(--accent-color);
     }
+
+    &--error {
+        border-color: var(--error-color);
+    }
+}
+
+.agent-decision-panel-feedback-error {
+    font-size: 11px;
+    color: var(--error-color);
+    margin-top: var(--space-0-5);
 }
 
 .agent-decision-panel-actions {
@@ -224,12 +234,16 @@
         &:hover {
             background: color-mix(in srgb, var(--success-color) 35%, transparent);
         }
+    }
 
-        &--armed {
-            background: color-mix(in srgb, var(--accent-color) 30%, transparent);
-            border-color: var(--accent-color);
-            color: var(--accent-color);
-        }
+    // High-risk Allow's armed state — JSX applies the standalone
+    // `agent-decision-panel-btn--armed` class. Previously nested under
+    // `--allow`, which compiled to `--allow--armed` and never matched.
+    // Codex/reagent P1 on PR #556.
+    &--armed {
+        background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+        border-color: var(--accent-color);
+        color: var(--accent-color);
     }
 
     &--deny {

--- a/frontend/app/view/agent/styles/_decision-panel.scss
+++ b/frontend/app/view/agent/styles/_decision-panel.scss
@@ -30,6 +30,49 @@
     }
 }
 
+// Minimized variant — shown after Defer / Esc. Compact, single-row
+// affordance that keeps the prompt reachable. Click expands. Per
+// SPEC_DECISION_PROMPT_DESIGN §4.3.
+.agent-decision-panel-minimized {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin: 0 var(--space-1-5);
+    padding: var(--space-1) var(--space-3);
+    background: color-mix(in srgb, var(--warning-color) 6%, var(--main-bg-color));
+    border: 1px solid color-mix(in srgb, var(--warning-color) 40%, transparent);
+    border-radius: 4px;
+    color: var(--warning-color);
+    font-family: inherit;
+    font-size: 11px;
+    cursor: pointer;
+    text-align: left;
+    transition: background 80ms ease, border-color 80ms ease;
+    flex-shrink: 0;
+
+    &:hover {
+        background: color-mix(in srgb, var(--warning-color) 12%, var(--main-bg-color));
+        border-color: var(--warning-color);
+    }
+
+    &--high-risk {
+        background: color-mix(in srgb, var(--error-color) 8%, var(--main-bg-color));
+        border-color: color-mix(in srgb, var(--error-color) 50%, transparent);
+        color: var(--error-color);
+
+        &:hover {
+            background: color-mix(in srgb, var(--error-color) 14%, var(--main-bg-color));
+            border-color: var(--error-color);
+        }
+    }
+}
+
+.agent-decision-panel-minimized-cta {
+    margin-left: auto;
+    color: var(--secondary-text-color);
+    font-size: 10px;
+}
+
 @keyframes agent-decision-panel-armed {
     0%   { background: color-mix(in srgb, var(--accent-color) 30%, var(--main-bg-color)); }
     100% { background: color-mix(in srgb, var(--error-color) 10%, var(--main-bg-color)); }

--- a/frontend/app/view/agent/styles/_decision-panel.scss
+++ b/frontend/app/view/agent/styles/_decision-panel.scss
@@ -1,0 +1,255 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// AgentDecisionPanel — surfaced for per-tool-call permission gates.
+// Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §5.
+
+.agent-decision-panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    margin: 0 var(--space-1-5);
+    background: color-mix(in srgb, var(--warning-color) 8%, var(--main-bg-color));
+    border: 1px solid color-mix(in srgb, var(--warning-color) 50%, transparent);
+    border-radius: 4px;
+    font-size: 12px;
+    flex-shrink: 0;
+
+    // Visual escalation when the gated tool is high-risk. Reads as
+    // "stop and look" rather than "answer this when convenient".
+    &--high-risk {
+        background: color-mix(in srgb, var(--error-color) 10%, var(--main-bg-color));
+        border-color: color-mix(in srgb, var(--error-color) 60%, transparent);
+    }
+
+    // Brief flash after the first Enter on a high-risk Allow — tells
+    // the user "we received the keystroke, hit it again to commit".
+    &--armed {
+        animation: agent-decision-panel-armed 0.5s ease-out;
+    }
+}
+
+@keyframes agent-decision-panel-armed {
+    0%   { background: color-mix(in srgb, var(--accent-color) 30%, var(--main-bg-color)); }
+    100% { background: color-mix(in srgb, var(--error-color) 10%, var(--main-bg-color)); }
+}
+
+.agent-decision-panel-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    font-weight: 600;
+    color: var(--warning-color);
+
+    .agent-decision-panel--high-risk & {
+        color: var(--error-color);
+    }
+}
+
+.agent-decision-panel-icon {
+    font-size: 14px;
+    line-height: 1;
+}
+
+.agent-decision-panel-title {
+    flex: 1;
+    min-width: 0;
+}
+
+.agent-decision-panel-queue,
+.agent-decision-panel-risk {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px 5px;
+    border-radius: 2px;
+    background: color-mix(in srgb, var(--main-text-color) 10%, transparent);
+    color: var(--secondary-text-color);
+    font-weight: 500;
+}
+
+.agent-decision-panel-risk {
+    background: color-mix(in srgb, var(--error-color) 25%, transparent);
+    color: var(--error-color);
+}
+
+.agent-decision-panel-meta {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 2px var(--space-2);
+    margin: 0;
+
+    dt {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+        align-self: baseline;
+    }
+
+    dd {
+        margin: 0;
+        color: var(--main-text-color);
+        overflow-wrap: anywhere;
+
+        code {
+            font-family: var(--fixed-font, monospace);
+            font-size: 11px;
+            color: var(--accent-color);
+            background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+            padding: 1px 4px;
+            border-radius: 2px;
+        }
+    }
+}
+
+.agent-decision-panel-preview {
+    margin: 0;
+    padding: var(--space-1-5) var(--space-2);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    max-height: 160px;
+    overflow-y: auto;
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+    line-height: 1.4;
+
+    code {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+        color: var(--main-text-color);
+    }
+}
+
+.agent-decision-panel-scope {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+    border: none;
+    padding: 0;
+    margin: 0;
+
+    legend {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+        padding: 0;
+        margin-bottom: var(--space-0-5);
+    }
+}
+
+.agent-decision-panel-scope-option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    padding: var(--space-0-5) var(--space-1);
+    border-radius: 2px;
+    cursor: pointer;
+    transition: background 80ms ease;
+
+    &:hover {
+        background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+    }
+
+    &--active {
+        background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+    }
+}
+
+.agent-decision-panel-scope-label {
+    flex: 0 0 5em;
+    font-weight: 500;
+    color: var(--main-text-color);
+}
+
+.agent-decision-panel-scope-hint {
+    color: var(--secondary-text-color);
+    font-size: 11px;
+}
+
+.agent-decision-panel-feedback {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+
+    span {
+        font-size: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--secondary-text-color);
+    }
+}
+
+.agent-decision-panel-feedback-input {
+    font-family: inherit;
+    font-size: 12px;
+    line-height: 1.4;
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 3px;
+    padding: var(--space-1) var(--space-2);
+    resize: vertical;
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+    }
+}
+
+.agent-decision-panel-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-1-5);
+}
+
+.agent-decision-panel-btn {
+    padding: var(--space-1) var(--space-3);
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: 3px;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: background 80ms ease, border-color 80ms ease;
+
+    &--allow {
+        background: color-mix(in srgb, var(--success-color) 22%, transparent);
+        border-color: color-mix(in srgb, var(--success-color) 50%, transparent);
+        color: var(--success-color);
+
+        &:hover {
+            background: color-mix(in srgb, var(--success-color) 35%, transparent);
+        }
+
+        &--armed {
+            background: color-mix(in srgb, var(--accent-color) 30%, transparent);
+            border-color: var(--accent-color);
+            color: var(--accent-color);
+        }
+    }
+
+    &--deny {
+        background: color-mix(in srgb, var(--error-color) 18%, transparent);
+        border-color: color-mix(in srgb, var(--error-color) 50%, transparent);
+        color: var(--error-color);
+
+        &:hover {
+            background: color-mix(in srgb, var(--error-color) 30%, transparent);
+        }
+    }
+
+    &--cancel {
+        background: transparent;
+        border-color: var(--border-color);
+        color: var(--secondary-text-color);
+
+        &:hover {
+            background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+            color: var(--main-text-color);
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.391",
+  "version": "0.33.392",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.391",
+      "version": "0.33.392",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.391",
+  "version": "0.33.392",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Second implementation chunk of `docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md` (issue #551). Builds on the type plumbing from #555.

This PR adds the **decision panel UI** — the thing the user actually interacts with. It surfaces whenever a `ToolNode` has `status === "pending_approval"`. Today no production code-path produces that state (detection lands in PR-4), so the panel never appears yet — but every downstream consumer can be wired against a stable contract.

## New surface

- **`AgentDecisionPanel.tsx`** — renders Tool / Target / optional Reason + Preview, a 4-way scope picker (Once / Session / Project / Global), and Allow / Deny + feedback / Defer actions. Multi-call queue indicator in the header (`"N more queued"`). High-risk variant requires a second action (hold Shift or press Enter twice).
- **`_decision-panel.scss`** — amber for medium-risk, red for high-risk, brief armed-state flash on the first Enter for high-risk Allow.
- **`agent-view.tsx`** — derives the pending queue from `documentAtom` by filtering `type === "tool" && status === "pending_approval"`. Renders the panel above the message queue zone (most prominent slot while waiting on the user).

## Keyboard

| Key | Action |
|---|---|
| `Enter` | Allow (or arm high-risk for double-confirm) |
| `Shift-Enter` | Switch to deny + feedback mode |
| `o` / `s` / `p` / `g` | Set scope |
| `Esc` | Defer (panel closes, prompt stays pending) |

## Airspace

Panel calls `usePaneOverlay` so it paints cleanly over any browser pane HWND in the same window — same primitive as modal-v2 (#544) and MoreDropdown.

## What's NOT in this PR

- No `tool:decision` websocket RPC. Today `onDecide` resolves the node locally (status → `"running"` for allow, `"denied"` for deny; `pendingPermission` cleared) so the UI loop closes. Real sidecar stdin write lands in **PR-3**.
- No rules persistence (`.agentmux/permissions.json`). **PR-3**.
- No memory store (`decision-memory.json`). **PR-3**.
- No detection — `ClaudeTranslator.parsePermissionRequest` still returns `null`. **PR-4**.

## Validation

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `task build:frontend` | succeeds |
| `npm run lint:scss` (this file) | clean. 239 pre-existing errors in PR #554's new theme files are unrelated to this PR. |
| User-visible behaviour | none — no code-path emits `pending_approval` yet. Panel can be exercised manually by stuffing the status into a ToolNode via dev tools. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)