### PR TITLE
feat(decision-prompt): v1 PR-3a — tool:decision IPC + stdin write (#551)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.392"
+version = "0.33.393"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.392"
+version = "0.33.393"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.392"
+version = "0.33.393"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.392"
+version = "0.33.393"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.392"
+version = "0.33.393"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.392"
+version = "0.33.393"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.392"
+version = "0.33.393"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.392"
+version = "0.33.393"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -149,6 +149,13 @@ pub const COMMAND_CONTROLLER_RESTART: &str = "controllerrestart";
 pub const COMMAND_CONTROLLER_STOP: &str = "controllerstop";
 pub const COMMAND_CONTROLLER_RESYNC: &str = "controllerresync";
 
+/// Per-tool-call permission decision RPC. Frontend sends after the
+/// user clicks Allow / Deny in `AgentDecisionPanel`. The handler
+/// writes `y\n` / `n\n` to the subprocess's stdin so the agent CLI
+/// receives the y/n it was waiting for. Spec:
+/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+pub const COMMAND_TOOL_DECISION: &str = "tooldecision";
+
 // Subprocess agent commands
 pub const COMMAND_SUBPROCESS_SPAWN: &str = "subprocessspawn";
 pub const COMMAND_AGENT_INPUT: &str = "agentinput";
@@ -475,6 +482,30 @@ pub struct CommandBlockInputData {
     pub signame: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub termsize: Option<serde_json::Value>,
+}
+
+/// Data for `tooldecision` — frontend's reply to a per-tool-call
+/// permission gate. Backend translates `outcome` to a y/n write on
+/// the subprocess's stdin. `request_id` and `feedback` are carried
+/// through for audit logging + future feedback-relay paths but are
+/// not consumed by the v1 stdin-write path. Spec:
+/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CommandToolDecisionData {
+    pub blockid: String,
+    /// Opaque id matched against a `PermissionRequestEvent`. Echoed
+    /// in the audit log; not needed for the stdin write itself.
+    pub request_id: String,
+    /// "allow" or "deny". Anything else returns an error.
+    pub outcome: String,
+    /// "once" / "session" / "project" / "global". Captured so the
+    /// rules-persistence layer (PR-3b) can write a matching rule
+    /// without re-asking the user.
+    pub scope: String,
+    /// User-typed denial reason. Optional. Future PR will relay
+    /// this verbatim into the agent's next prompt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback: Option<String>,
 }
 
 // ---- Subprocess agent command data types ----

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -150,10 +150,11 @@ pub const COMMAND_CONTROLLER_STOP: &str = "controllerstop";
 pub const COMMAND_CONTROLLER_RESYNC: &str = "controllerresync";
 
 /// Per-tool-call permission decision RPC. Frontend sends after the
-/// user clicks Allow / Deny in `AgentDecisionPanel`. The handler
-/// writes `y\n` / `n\n` to the subprocess's stdin so the agent CLI
-/// receives the y/n it was waiting for. Spec:
-/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+/// user clicks Allow / Deny in `AgentDecisionPanel`. Today the
+/// handler validates the payload and logs the decision (audit
+/// trail); actual delivery to the agent CLI — rules persistence
+/// vs. interactive subprocess — is deferred to PR-3b/PR-4 per
+/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
 pub const COMMAND_TOOL_DECISION: &str = "tooldecision";
 
 // Subprocess agent commands
@@ -485,16 +486,16 @@ pub struct CommandBlockInputData {
 }
 
 /// Data for `tooldecision` — frontend's reply to a per-tool-call
-/// permission gate. Backend translates `outcome` to a y/n write on
-/// the subprocess's stdin. `request_id` and `feedback` are carried
-/// through for audit logging + future feedback-relay paths but are
-/// not consumed by the v1 stdin-write path. Spec:
-/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+/// permission gate. Today the backend validates the outcome and
+/// logs the decision; actual delivery to the agent CLI is deferred
+/// to PR-3b/PR-4 (rules persistence vs. interactive subprocess
+/// path). Spec:
+/// docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CommandToolDecisionData {
     pub blockid: String,
     /// Opaque id matched against a `PermissionRequestEvent`. Echoed
-    /// in the audit log; not needed for the stdin write itself.
+    /// in the audit log so the audit trail can be cross-referenced.
     pub request_id: String,
     /// "allow" or "deny". Anything else returns an error.
     pub outcome: String,

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -690,6 +690,18 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                         ));
                     }
                 }
+                // Validate scope so PR-3b's rules-persistence layer
+                // can trust the value without re-checking. Reagent P1
+                // round-3 on PR #557.
+                match cmd.scope.as_str() {
+                    "once" | "session" | "project" | "global" => {}
+                    other => {
+                        return Err(format!(
+                            "tooldecision: invalid scope '{}' (expected 'once'/'session'/'project'/'global')",
+                            other
+                        ));
+                    }
+                }
                 tracing::info!(
                     block_id = %cmd.blockid,
                     request_id = %cmd.request_id,

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -656,38 +656,48 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
         }),
     );
 
-    // tooldecision → reply to a per-tool-call permission gate. Writes
-    // y\n / n\n to the subprocess's stdin so the agent CLI receives
-    // the y/n it was waiting for. v1 PR-3a: stdin write only — rules
-    // persistence (PR-3b) and feedback relay (later) are layered on
-    // top without changing this handler. Spec:
-    // docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+    // tooldecision → reply to a per-tool-call permission gate.
+    //
+    // The original PR-3a draft tried to write `y\n` / `n\n` to the
+    // subprocess's stdin via `blockcontroller::send_input`. Codex P1
+    // on PR #557 caught that this would fail: `SubprocessController::
+    // send_input` (and `PersistentSubprocessController::send_input`)
+    // both reject raw `input_data`, returning `Err("...use
+    // AgentInputCommand")`. The deeper truth is that AgentMux runs
+    // the agent CLI in non-interactive `--print` mode — the CLI
+    // never reads stdin and a y/n write would be a no-op even if
+    // the controller accepted it. See SPEC_DECISION_PROMPT
+    // _2026_04_24.md §9.1.
+    //
+    // For now this handler accepts the decision, validates the
+    // payload, logs it (audit trail via `~/.agentmux/logs/`), and
+    // returns Ok. The actual delivery mechanism (rule-persistence
+    // for next-turn application, or interactive-mode subprocess
+    // launch with stdin write) is decided in PR-3b / PR-4 once we
+    // pick a CLI integration strategy.
     engine.register_handler(
         COMMAND_TOOL_DECISION,
         Box::new(|data, _ctx| {
             Box::pin(async move {
                 let cmd: CommandToolDecisionData = serde_json::from_value(data)
                     .map_err(|e| format!("tooldecision: {e}"))?;
-                let stdin_payload: &[u8] = match cmd.outcome.as_str() {
-                    "allow" => b"y\n",
-                    "deny" => b"n\n",
+                match cmd.outcome.as_str() {
+                    "allow" | "deny" => {}
                     other => {
                         return Err(format!(
                             "tooldecision: invalid outcome '{}' (expected 'allow' or 'deny')",
                             other
                         ));
                     }
-                };
+                }
                 tracing::info!(
                     block_id = %cmd.blockid,
                     request_id = %cmd.request_id,
                     outcome = %cmd.outcome,
                     scope = %cmd.scope,
                     has_feedback = cmd.feedback.is_some(),
-                    "[tooldecision] writing y/n to subprocess stdin"
+                    "[tooldecision] received (delivery mechanism deferred to PR-3b/PR-4)"
                 );
-                let input = blockcontroller::BlockInputUnion::data(stdin_payload.to_vec());
-                blockcontroller::send_input(&cmd.blockid, input)?;
                 Ok(None)
             })
         }),

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -17,12 +17,14 @@ use crate::backend::blockcontroller;
 use crate::backend::rpc::engine::WshRpcEngine;
 use crate::backend::rpc_types::{
     CommandBlockInputData, CommandControllerResyncData, CommandEventReadHistoryData,
-    CommandGetMetaData, CommandSetMetaData, RpcMessage, COMMAND_CONTROLLER_INPUT,
+    CommandGetMetaData, CommandSetMetaData, CommandToolDecisionData,
+    RpcMessage, COMMAND_CONTROLLER_INPUT,
     COMMAND_CONTROLLER_RESYNC, COMMAND_EVENT_READ_HISTORY, COMMAND_EVENT_SUB, COMMAND_EVENT_UNSUB,
     COMMAND_EVENT_UNSUB_ALL, COMMAND_GET_FULL_CONFIG, COMMAND_GET_META,
     COMMAND_GET_AI_RATE_LIMIT, COMMAND_ROUTE_ANNOUNCE, COMMAND_ROUTE_UNANNOUNCE,
     COMMAND_SET_META, COMMAND_SET_CONFIG, COMMAND_APP_INFO,
-    COMMAND_SUBPROCESS_SPAWN, COMMAND_AGENT_INPUT, COMMAND_AGENT_STOP, COMMAND_WRITE_AGENT_CONFIG,
+    COMMAND_SUBPROCESS_SPAWN, COMMAND_AGENT_INPUT, COMMAND_AGENT_STOP, COMMAND_TOOL_DECISION,
+    COMMAND_WRITE_AGENT_CONFIG,
     CommandSubprocessSpawnData, CommandAgentInputData, CommandAgentStopData, CommandWriteAgentConfigData,
 };
 use crate::backend::obj::{Block, TermSize, WaveObjUpdate, wave_obj_to_value};
@@ -648,6 +650,43 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let cmd: CommandBlockInputData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerinput: {e}"))?;
                 let input = parse_block_input(&cmd)?;
+                blockcontroller::send_input(&cmd.blockid, input)?;
+                Ok(None)
+            })
+        }),
+    );
+
+    // tooldecision → reply to a per-tool-call permission gate. Writes
+    // y\n / n\n to the subprocess's stdin so the agent CLI receives
+    // the y/n it was waiting for. v1 PR-3a: stdin write only — rules
+    // persistence (PR-3b) and feedback relay (later) are layered on
+    // top without changing this handler. Spec:
+    // docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+    engine.register_handler(
+        COMMAND_TOOL_DECISION,
+        Box::new(|data, _ctx| {
+            Box::pin(async move {
+                let cmd: CommandToolDecisionData = serde_json::from_value(data)
+                    .map_err(|e| format!("tooldecision: {e}"))?;
+                let stdin_payload: &[u8] = match cmd.outcome.as_str() {
+                    "allow" => b"y\n",
+                    "deny" => b"n\n",
+                    other => {
+                        return Err(format!(
+                            "tooldecision: invalid outcome '{}' (expected 'allow' or 'deny')",
+                            other
+                        ));
+                    }
+                };
+                tracing::info!(
+                    block_id = %cmd.blockid,
+                    request_id = %cmd.request_id,
+                    outcome = %cmd.outcome,
+                    scope = %cmd.scope,
+                    has_feedback = cmd.feedback.is_some(),
+                    "[tooldecision] writing y/n to subprocess stdin"
+                );
+                let input = blockcontroller::BlockInputUnion::data(stdin_payload.to_vec());
                 blockcontroller::send_input(&cmd.blockid, input)?;
                 Ok(None)
             })

--- a/docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md
+++ b/docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md
@@ -376,29 +376,59 @@ per adapter:
 Unsupported providers gate the prompt feature off in the agent
 card's UI so the user can't pick a mode the CLI can't honour.
 
-### 9.1 Detection strategy
+### 9.1 Detection strategy + delivery mechanism
 
-A spec-refresh ground-truth (2026-04-24): Claude Code CLI in
-non-bypass + non-interactive mode (`--print --output-format
-stream-json`) does not currently emit a structured
-`permission_request` JSON event when it gates a tool call. It
-prompts on the controlling tty for `y/n`, which is what causes
-the sidecar's stdin to hang (issue #551 §Problem). Two plausible
-paths forward:
+Spec-refresh ground-truth (2026-04-24, updated 2026-04-25
+during PR #557 review):
 
-1. **Lobby Anthropic for a structured stream-json event.**
-   Cleanest. Out of our hands; treat as a stretch goal.
-2. **Synthesise a `PermissionRequestEvent` ourselves** by
-   detecting the y/n prompt pattern in the CLI's mixed-format
-   output: when the parser sees a recognisable
-   "Allow tool call to <X>? [y/n]" line, materialise the event,
-   suppress the raw line from the document, and stash the
-   prompt's tty descriptor so `tool:decision` can answer it.
+**Detection.** Claude Code CLI in non-bypass + non-interactive
+mode (`--print --output-format stream-json`) does not emit a
+structured `permission_request` JSON event. The original
+spec assumed the CLI would prompt y/n on stdin and we'd snoop
+the output for it. In fact, in `--print` mode the CLI does
+not read stdin at all — there's no interactive prompt to
+answer. Permission gating happens entirely via the
+`--permission-mode` flag set at spawn time.
 
-Path 2 ships in v1.x; path 1 is preferred if upstream cooperates.
-v1's first PR delivers the *type plumbing* and a stub adapter
-hook so the rest of the system can be built against the shape
-without committing to a specific detection strategy yet.
+**Delivery.** Because the running subprocess never asks the
+user mid-turn, there's nothing to "write y/n to." Codex's P1
+on PR #557 caught the matching issue at the controller layer:
+`SubprocessController::send_input` rejects raw `input_data`
+(returns `Err("...use AgentInputCommand")`). Even if it
+accepted bytes, the subprocess wouldn't read them.
+
+**This means the v1 design as originally drafted (mid-turn
+y/n write) cannot work against `--print` Claude.** Two viable
+paths forward; PR-3b / PR-4 picks one:
+
+1. **Rules-persistence-only model.** Each turn runs to
+   completion; the user's decision becomes a persisted rule
+   (`.agentmux/permissions.json`). The NEXT turn launches
+   with a tightened `--permission-mode` (or pre-allowed tool
+   list) reflecting accumulated rules. UI flow becomes
+   "after a turn lands with denied tool calls, the panel
+   asks 'remember this for next time?' rather than gating
+   the live turn." Smaller scope; matches today's
+   architecture; loses the "interrupt the agent" power-feature
+   from the original spec but ships v1 cleanly.
+
+2. **Interactive-mode subprocess launch.** Spawn Claude CLI
+   *without* `--print` so it prompts on a real tty; capture
+   stdout for the panel; write y/n to a controller that
+   actually pipes to stdin. Requires a new controller type
+   parallel to `SubprocessController`, a tty pump, and
+   parsing of mixed text-mode output. Larger scope; matches
+   the issue's original vision.
+
+PR-3a (the in-flight PR #557) lands the IPC contract +
+frontend wiring + audit logging. The handler **no-ops the
+delivery** (logs only) so it doesn't regress behaviour.
+PR-3b implements path 1 and revisits whether path 2 is
+worth a follow-up.
+
+PR-1's type plumbing + PR-2's panel UI still lay the right
+foundation either way — the open question is only where the
+decision *goes* once it's made.
 
 ---
 

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -82,6 +82,13 @@ class RpcApiType {
         return client.rpcCall("controllerinput", data, opts);
     }
 
+    // command "tooldecision" [call]
+    // Reply to a per-tool-call permission gate. Backend writes y\n / n\n
+    // to the subprocess stdin. See SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+    ToolDecisionCommand(client: RpcClient, data: CommandToolDecisionData, opts?: RpcOpts): Promise<void> {
+        return client.rpcCall("tooldecision", data, opts);
+    }
+
     // command "controllerresync" [call]
     ControllerResyncCommand(client: RpcClient, data: CommandControllerResyncData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("controllerresync", data, opts);

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -83,8 +83,10 @@ class RpcApiType {
     }
 
     // command "tooldecision" [call]
-    // Reply to a per-tool-call permission gate. Backend writes y\n / n\n
-    // to the subprocess stdin. See SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+    // Reply to a per-tool-call permission gate. Today the backend
+    // validates the payload and logs the decision (audit trail) —
+    // actual delivery to the agent CLI is deferred to PR-3b/PR-4
+    // per SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
     ToolDecisionCommand(client: RpcClient, data: CommandToolDecisionData, opts?: RpcOpts): Promise<void> {
         return client.rpcCall("tooldecision", data, opts);
     }

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -137,10 +137,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     };
 
     const handleDecide = (decision: import("./components/AgentDecisionPanel").DecisionOutcome) => {
-        // Local-only resolution for v1 PR-2. The IPC call to the sidecar
-        // (which writes y/n to the subprocess's stdin and registers any
-        // session/project/global rule) is added in PR-3; for now this
-        // just clears the pending state so the UI flow can be exercised.
+        // Optimistic UI update — flip the ToolNode out of
+        // pending_approval immediately so the panel disappears (or
+        // advances to the next pending request). The backend write
+        // happens in parallel; if it fails we log but don't try to
+        // roll back the visual transition.
         setDocument((prev) =>
             prev.map((n) => {
                 if (n.type !== "tool" || n.status !== "pending_approval") return n;
@@ -152,6 +153,18 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 };
             }),
         );
+        // Send the decision to the sidecar so it can write y/n to the
+        // subprocess's stdin (PR-3a). Rules persistence + memory store
+        // come in PR-3b. Spec: SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+        void RpcApi.ToolDecisionCommand(TabRpcClient, {
+            blockid: model.blockId,
+            request_id: decision.request_id,
+            outcome: decision.outcome,
+            scope: decision.scope,
+            feedback: decision.feedback,
+        }).catch((err: unknown) => {
+            log("error", `tool:decision failed: ${String(err)}`);
+        });
     };
     const status = useAgentControllerStatus({
         blockId: model.blockId,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -153,9 +153,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 };
             }),
         );
-        // Send the decision to the sidecar so it can write y/n to the
-        // subprocess's stdin (PR-3a). Rules persistence + memory store
-        // come in PR-3b. Spec: SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+        // Send the decision to the sidecar so it can record + audit
+        // it (PR-3a). Actual delivery to the agent CLI — rules
+        // persistence (path 1) or interactive subprocess stdin (path
+        // 2) — is deferred to PR-3b/PR-4 per
+        // SPEC_DECISION_PROMPT_2026_04_24.md §9.1.
         void RpcApi.ToolDecisionCommand(TabRpcClient, {
             blockid: model.blockId,
             request_id: decision.request_id,

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -152,6 +152,16 @@ declare global {
         termsize?: TermSize;
     };
 
+    // wshrpc.CommandToolDecisionData — per-tool-call permission reply.
+    // Spec: docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md §4.3.
+    type CommandToolDecisionData = {
+        blockid: string;
+        request_id: string;
+        outcome: "allow" | "deny";
+        scope: "once" | "session" | "project" | "global";
+        feedback?: string;
+    };
+
     // wshrpc.CommandBlockSetViewData
     type CommandBlockSetViewData = {
         blockid: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.392",
+  "version": "0.33.393",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.392",
+      "version": "0.33.393",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.392",
+  "version": "0.33.393",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third implementation chunk of `docs/specs/SPEC_DECISION_PROMPT_2026_04_24.md` (issue #551). Builds on:
- #555 — type plumbing
- #556 — decision panel UI (local-only resolution)

This PR closes the wire loop: when the user clicks Allow / Deny in `AgentDecisionPanel`, the decision is forwarded to the sidecar, which writes `y\n` / `n\n` to the agent CLI subprocess's stdin. PR-4 will land the detection that flips a `ToolNode` to `pending_approval` in the first place; until then production behaviour is unchanged.

## Backend (`agentmux-srv`)

- New `COMMAND_TOOL_DECISION = "tooldecision"` + matching `CommandToolDecisionData` struct in `rpc_types.rs`
- New websocket handler in `server/websocket.rs`:
  - Translates `outcome` → stdin bytes (`b"y\n"` / `b"n\n"`)
  - Rejects unknown outcomes with an error (no fuzz-write)
  - Forwards via the existing `blockcontroller::send_input` plumbing — same path as terminal input
  - Logs `(block_id, request_id, outcome, scope, has_feedback)` at INFO so the audit trail is on-disk via `~/.agentmux/logs/` before the explicit audit-log file (later PR) lands

## Frontend

- `RpcApi.ToolDecisionCommand` in `rpc-api.ts`
- `CommandToolDecisionData` type in `gotypes.d.ts`
- `agent-view.tsx`'s `handleDecide`: optimistic UI flip + parallel sidecar write. Failure logged in activity log; no UI rollback (backend is source-of-truth, failed writes are rare)

## What's NOT in this PR (per spec §11)

- No rules persistence (`.agentmux/permissions.json` + global) — **PR-3b**
- No per-(tool, target) memory store — **PR-3b**
- No feedback relay (denial feedback is carried over the wire + logged, but the agent doesn't yet receive it in its next turn — defer until upstream protocol picks a path)
- No detection — `ClaudeTranslator.parsePermissionRequest` still returns `null` — **PR-4**

## Validation

| Check | Result |
|---|---|
| `cargo check -p agentmux-srv` | clean (14 pre-existing warnings) |
| `tsc --noEmit` | clean |
| `task build:frontend` | succeeds |
| User-visible behaviour | unchanged today — no event emits `pending_approval` yet. End-to-end path can be exercised by stuffing the status manually via dev tools, with the new INFO log line appearing in the sidecar log. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)