### PR TITLE
feat(statusbar): version-click instance panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.402"
+version = "0.33.403"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.402"
+version = "0.33.403"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.402"
+version = "0.33.403"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.402"
+version = "0.33.403"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.399"
+version = "0.33.400"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.399"
+version = "0.33.400"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.399"
+version = "0.33.400"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.399"
+version = "0.33.400"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.401"
+version = "0.33.402"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.401"
+version = "0.33.402"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.401"
+version = "0.33.402"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.401"
+version = "0.33.402"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.400"
+version = "0.33.401"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.400"
+version = "0.33.401"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.400"
+version = "0.33.401"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.400"
+version = "0.33.401"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.401"
+version = "0.33.402"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.399"
+version = "0.33.400"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.402"
+version = "0.33.403"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.400"
+version = "0.33.401"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.401"
+version = "0.33.402"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.399"
+version = "0.33.400"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.402"
+version = "0.33.403"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.400"
+version = "0.33.401"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.399"
+version = "0.33.400"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.400"
+version = "0.33.401"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.402"
+version = "0.33.403"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.401"
+version = "0.33.402"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.402"
+version = "0.33.403"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.399"
+version = "0.33.400"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.400"
+version = "0.33.401"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.401"
+version = "0.33.402"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md
+++ b/docs/specs/SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md
@@ -1,0 +1,291 @@
+# Spec: Version-Click Instance Panel
+
+**Date:** 2026-04-25 (revised 2026-04-26 to reflect arch drift)
+**Status:** Draft, ready to implement (V1 — per-window tokens deferred)
+**Owner:** AgentA
+
+## Drift since 2026-04-25 (verified 2026-04-26)
+
+Three items the original draft assumed don't match the current
+codebase. Two are fortunate (less work), one is scope-trimming:
+
+1. **`getApi().focusWindow(label)` already exists** at
+   `agentmux-cef/src/commands/window.rs:324-348`, complete with
+   `SetForegroundWindow` already imported. §5.1 is no-op.
+2. **`token-usage` store is global / session-scoped, NOT
+   per-window** (`frontend/app/store/token-usage.ts:14`). The V1
+   ships **without** per-window token totals in the window list
+   to avoid blocking on a token-usage refactor. The row format
+   simplifies to `Window N · focused-agent · started-at`. A
+   follow-up can extend token-usage per-window and add the totals.
+3. ~~**`window-instances-changed` event does not exist**~~ —
+   correction on second look: it DOES exist. Emitted at
+   `agentmux-cef/src/commands/window.rs:514` on window create with
+   the new count as payload. (May need a second emit on destroy
+   if not already present — verify before adding.)
+
+**V1 scope adjustment** — LAN peers section dropped from this
+panel. `HostPopover` already shows LAN with hover-rich detail;
+duplicating it here would be confusing UX. The version panel V1
+is: **about-info + this-process windows + actions**. LAN stays in
+HostPopover.
+
+**V1 scope adjustment** — per-window data simplified to
+`{ label, instanceNum, isCurrent }` (drop `focusedAgent*`,
+`startedAt`, `tokens` from the row). `getApi().listWindows()`
+already returns the labels we need; richer per-window data is a
+follow-up that requires extending the host registry.
+
+Bonus: `AboutModalDetails` TS type at `frontend/types/custom.d.ts`
+has `buildTime: number` but the Rust handler at
+`agentmux-cef/src/commands/platform.rs:127-140` returns string,
+plus `platform`, `arch`, `backendEndpoints` fields the TS type
+omits. V1 fixes the type.
+**Touches:** `frontend/app/statusbar/StatusBar.tsx`,
+             new `frontend/app/statusbar/InstancePanel.tsx`,
+             new `frontend/app/statusbar/_instance-panel.scss`,
+             `frontend/app/store/global.ts` (read-only —
+             consumes existing window/LAN atoms)
+
+---
+
+## 1. Problem
+
+Clicking `vX.X.X` in the bottom-right of the status bar today
+opens a new AgentMux window via `getApi().openNewWindow()`.
+That's a useful action but it's the *only* thing the user can
+do, and it gives up the version chip's natural role as an
+"about / status" affordance:
+
+- No way to see what other windows are open in this AgentMux
+  process, or what's running in them.
+- LAN peer instances exist (`lanInstancesAtom`) but only
+  surface in the separate `HostPopover` widget that most
+  users don't notice.
+- There's no consolidated "About this app" panel — the
+  version number lives next to a click handler that has
+  nothing to do with the version itself.
+
+## 2. Goals
+
+- **G1.** Clicking the version chip opens a popover anchored
+  to it.
+- **G2.** The popover shows the open windows in this
+  AgentMux process: window index, focused agent (if any),
+  started-at, link to focus.
+- **G3.** Surfaces LAN-discovered peer instances (consume
+  `lanInstancesAtom` directly — no duplicate plumbing).
+- **G4.** "Open another window" button stays prominent
+  (preserves today's primary action).
+- **G5.** Includes "About" metadata: full version, commit
+  short-sha when known, build date, runtime (Windows /
+  macOS / Linux), and a copy-to-clipboard affordance for
+  bug-report convenience.
+- **G6.** Reuses the airspace primitive (`usePaneOverlay`)
+  so the popover paints over any browser pane HWND — same
+  as MoreDropdown, modal-v2, TokenBreakdownPopover.
+- **G7.** Edge-anchored so it doesn't overflow the right
+  edge of the window. Same pattern as the status-bar
+  tooltips from PR #553.
+
+## 3. Non-goals
+
+- **No remote control** of LAN peers from this panel. They
+  are read-only listings; existing host-popover logic stays.
+- **No per-window kill / close**. Clicking a window switches
+  focus to it; that's all.
+- **No history of *closed* windows.** Snapshot of the live
+  process state.
+- **No theme picker, settings shortcut, or telemetry
+  toggle.** Those belong in settings — out of scope.
+
+---
+
+## 4. Design
+
+### 4.1 Anchor + open
+
+The version chip becomes a button (`<button>` not `<span>`)
+with `aria-haspopup="dialog"` and `aria-expanded`. Click
+toggles the popover open/closed. Esc closes when open.
+Click-outside closes (same handler pattern as
+TokenBreakdownPopover).
+
+The previous primary action — "open new window" — is now
+the panel's confirm button instead of a side-effect of the
+chip click. New users discover it; existing users get one
+extra click but a much richer affordance.
+
+### 4.2 Layout
+
+```
+┌ AgentMux ──────────────────────────────────────┐
+│ Version  v0.33.392  [📋 copy]                  │
+│ Build    2026-04-25 · windows-x86_64           │
+│ Commit   bd7d90a (click to copy)               │
+├────────────────────────────────────────────────┤
+│ This process — 2 windows                        │
+│ ● Window 1 (focused)    Claude — feat/auth     │
+│   started 14:02 · 18 turns · ↑42k ↓12k         │
+│ ○ Window 2              Codex — bugfix/queue   │
+│   started 14:31 · 4 turns · ↑8k ↓2k            │
+├────────────────────────────────────────────────┤
+│ LAN peers — 1 visible                           │
+│ ◇ kona.local (asaf)    v0.33.388 · 5 panes     │
+├────────────────────────────────────────────────┤
+│ [+ Open another window]              [Close]   │
+└────────────────────────────────────────────────┘
+```
+
+### 4.3 Sections, top to bottom
+
+**Header — App identity (G5).**
+- Full version (`vX.Y.Z`).
+- Build date + platform string.
+- Commit short-sha (when present in the build artifact).
+- Each row has a small copy icon that copies the value to
+  the clipboard for bug-report convenience.
+
+**This process — open windows (G2).**
+- Header row: `"This process — N windows"` where N is
+  `windowCountAtom`.
+- One row per window. Today's data we already have:
+  - Window instance number (`windowInstanceNumAtom` is
+    *this* window — others come from a sidecar registry).
+  - Focused / not-focused indicator (●/○).
+- New data we should expose so the rows are useful:
+  - Currently-focused agent slug + name (if any).
+  - Started-at timestamp.
+  - Per-window token totals (from the
+    `token-usage` store, scoped per window).
+- Click a row → focus that window via a new
+  `getApi().focusWindow(label)` call. Behaviour parity
+  with how the OS taskbar would handle a click.
+
+**LAN peers — discovered instances (G3).**
+- Reads `lanInstancesAtom` directly.
+- Displays the same compact rows that today's
+  `HostPopover` shows. If the LAN list is empty, hide the
+  whole section (don't render an empty "no peers" line —
+  most users never have peers; an empty section adds
+  visual debt).
+- Read-only: no click action on peers (G3 / non-goal).
+
+**Footer — actions.**
+- Primary button: **`+ Open another window`** — calls the
+  existing `getApi().openNewWindow()`. Same effect as
+  today's chip click, just one click later.
+- Secondary button: **Close** — dismisses the panel
+  without action. Esc and click-outside do the same.
+
+### 4.4 Empty / degraded states
+
+- **Single-window process (the common case):** the "This
+  process" section shows just one row. Still rendered, so
+  users learn the section exists for when they do open a
+  second.
+- **Backend offline (`backendStatusAtom === "crashed"`):**
+  some live data (per-window token totals, focus indicator)
+  may be stale. Render last-known values with a small
+  "(backend offline)" caption above the section. Don't
+  block the popover from opening.
+- **Build metadata missing:** if the host couldn't supply
+  commit / build-date, render `"unknown"` rather than
+  hiding the row — empty rows look like a UI bug.
+
+## 5. Plumbing required
+
+### 5.1 New host API
+
+**(Already exists — no work)** `getApi().focusWindow(label)` is
+implemented at `agentmux-cef/src/commands/window.rs:324-348` with
+`SetForegroundWindow` already imported. Wire the panel's
+"click row to focus" handler to it directly.
+
+### 5.2 New frontend atom (V1 — token totals deferred)
+
+`openWindowsAtom: Accessor<WindowInstance[]>` in
+`frontend/app/store/global.ts`. Each `WindowInstance`:
+
+```ts
+interface WindowInstance {
+    label: string;             // "main", "window-2", …
+    instanceNum: number;
+    focusedAgentId?: string;   // current pane's agent slug, if any
+    focusedAgentName?: string;
+    startedAt: number;         // epoch ms
+    isFocused: boolean;        // distinct from "this window"
+    // tokens: deferred — needs token-usage per-window refactor.
+}
+```
+
+Source of truth: a new host event `window-instances-changed`
+(emitted from the create / destroy paths in
+`agentmux-cef/src/commands/window.rs`). Frontend listens via
+the existing event-bus pattern, builds the array.
+
+### 5.3 New build-info API
+
+`getApi().getBuildInfo(): Promise<{ version: string;
+commit?: string; buildDate?: string; platform: string }>`.
+Reads from the existing about-modal-details surface so
+this is mostly a re-shape, not new plumbing.
+
+## 6. Interaction model
+
+**Click version chip:** open / close popover (toggle).
+**Esc / click-outside:** close (per
+TokenBreakdownPopover precedent).
+**Click a window row:** focus that window. Popover stays
+open so the user can see the change reflected (focus
+indicator updates).
+**Click "Open another window":** call
+`getApi().openNewWindow()`. Popover closes.
+**Click copy icon next to version / commit / build:**
+write the value to clipboard, briefly flash the icon as
+"copied" (reuse the existing `CopyButton` element).
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Per-window data dependency on a new host event | If the event isn't shipping yet, fall back to showing only the local window's data and a "(other windows offline)" caption. Not a blocker. |
+| Popover overflow off the right edge of the window | Anchor with `right: 0; left: auto` — same pattern PR #553's status-bar tooltips use. |
+| Clicking a *focused* window does nothing visibly — looks broken | Disable that row's click handler; render the focus indicator more prominently so it's clear it's already focused. |
+| Cross-window state desync (per-instance DOM IDs) | Apply the rule from `SPEC_DECISION_PROMPT_DESIGN_2026_04_25 §8`: any DOM `id`/radio `name` is per-instance via `createUniqueId()`. |
+| Single-window users see an "extra" button click for what used to be one click | Match the chip itself as the explicit "open" target via Shift+Click for power users (same fast-path), with the panel as the new default. |
+
+## 8. Validation
+
+- ✅ `task build:frontend` succeeds
+- ✅ `tsc --noEmit` clean
+- ✅ Stylelint green
+- ✅ Manual smoke (`task dev`):
+  - Single window → popover lists 1 window, "Open another
+    window" works
+  - After opening, popover shows 2 windows
+  - Click the non-focused window → focus moves there
+  - Esc / click-outside closes
+  - With a browser pane visible behind the popover →
+    popover paints cleanly (airspace works)
+- ✅ Bug-report copy: clicking copy on each header row
+  writes the right value to clipboard
+
+## 9. Cross-references
+
+- `frontend/app/statusbar/StatusBar.tsx` — version-chip
+  current click handler
+- `frontend/app/statusbar/HostPopover.tsx` — reference
+  popover anchored from the status bar; LAN list source
+- `frontend/app/statusbar/TokenBreakdownPopover.tsx` — the
+  closest sibling; airspace + outside-click handling to
+  copy
+- `frontend/app/store/token-usage.ts` — per-window token
+  scoping (extend if needed)
+- `agentmux-cef/src/commands/window.rs` — where
+  `focusWindow` would land
+- `SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.3-4.4` —
+  always-visible widget + edge-anchor patterns this panel
+  inherits
+- `SPEC_DECISION_PROMPT_DESIGN_2026_04_25 §8` —
+  per-instance ID rule that applies here too

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -80,22 +80,38 @@ async function initInstanceTracking(): Promise<void> {
     const isInstanceLabel = (l: string): boolean =>
         l === "main" || /^window-/.test(l);
 
+    // Stable ordering: "main" pinned first, others alphabetical. Without
+    // this the panel rows can shuffle between refreshes (state.browsers
+    // is a Rust HashMap with non-deterministic iteration), and two
+    // windows could both display as "Window 1" because InstancePanel
+    // uses the array index for naming and special-cases "main".
+    const sortInstanceLabels = (labels: string[]): string[] =>
+        [...labels].sort((a, b) => {
+            if (a === "main") return -1;
+            if (b === "main") return 1;
+            return a.localeCompare(b);
+        });
+
     // The host emits `window-instances-changed` *before* the new browser
     // is registered in state.browsers (the emit fires from window.rs:514
     // while registration happens later via on_after_created in client.rs).
-    // listWindows() called immediately after the event can still return
-    // the OLD set. Retry up to a few times until the count matches the
-    // event payload, then settle.
-    const refreshLabels = async (expectedCount?: number, retriesLeft = 4): Promise<void> => {
+    // The previous fix compared count against the event payload, but the
+    // event count comes from window_instance_registry (different data
+    // structure than state.browsers) so a count match is not reliable.
+    // Robust fix: poll until the listWindows() result actually CHANGES
+    // from the previously-seen set. Up to 6×50ms (~300ms total) covers
+    // the empirical CEF on_after_created delay with margin.
+    let lastLabelsKey = "";
+    const refreshLabels = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
         try {
             const all = await getApi().listWindows();
-            const labels = (Array.isArray(all) ? all : []).filter(isInstanceLabel);
-            if (expectedCount != null && labels.length !== expectedCount && retriesLeft > 0) {
-                // Race: event arrived before registration completed.
-                // Back off and try again.
-                setTimeout(() => refreshLabels(expectedCount, retriesLeft - 1), 50);
+            const labels = sortInstanceLabels((Array.isArray(all) ? all : []).filter(isInstanceLabel));
+            const key = labels.join("|");
+            if (waitForChange && key === lastLabelsKey && retriesLeft > 0) {
+                setTimeout(() => refreshLabels(true, retriesLeft - 1), 50);
                 return;
             }
+            lastLabelsKey = key;
             setOpenWindowLabelsAtom(labels);
         } catch {
             setOpenWindowLabelsAtom([]);
@@ -112,13 +128,14 @@ async function initInstanceTracking(): Promise<void> {
         setWindowCountAtom(windowCount);
 
         // Keep count + label list in sync whenever any window opens or
-        // closes. Pass the count from the event payload so refreshLabels
-        // can retry through the registration race (see comment above).
+        // closes. Pass `waitForChange=true` so refreshLabels polls until
+        // listWindows() reports a different label set than last time —
+        // robust against the event-vs-registration race documented above.
         await getApi().listen("window-instances-changed", (event: any) => {
             const payload = event?.payload ?? event;
             const count = typeof payload === "number" ? payload : 0;
             setWindowCountAtom(count);
-            refreshLabels(count);
+            refreshLabels(true);
         });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -72,10 +72,31 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
  * Called once per window after the wave UI is fully initialized.
  */
 async function initInstanceTracking(): Promise<void> {
-    const refreshLabels = async () => {
+    // listWindows() returns ALL keys in state.browsers, which includes
+    // browser-pane child browsers (`browser-pane-*`) and other internal
+    // labels — not just top-level app windows. The instance panel only
+    // wants the labels it can sensibly focus, so filter here. Top-level
+    // window labels are either "main" or "window-<uuid>".
+    const isInstanceLabel = (l: string): boolean =>
+        l === "main" || /^window-/.test(l);
+
+    // The host emits `window-instances-changed` *before* the new browser
+    // is registered in state.browsers (the emit fires from window.rs:514
+    // while registration happens later via on_after_created in client.rs).
+    // listWindows() called immediately after the event can still return
+    // the OLD set. Retry up to a few times until the count matches the
+    // event payload, then settle.
+    const refreshLabels = async (expectedCount?: number, retriesLeft = 4): Promise<void> => {
         try {
-            const labels = await getApi().listWindows();
-            setOpenWindowLabelsAtom(Array.isArray(labels) ? labels : []);
+            const all = await getApi().listWindows();
+            const labels = (Array.isArray(all) ? all : []).filter(isInstanceLabel);
+            if (expectedCount != null && labels.length !== expectedCount && retriesLeft > 0) {
+                // Race: event arrived before registration completed.
+                // Back off and try again.
+                setTimeout(() => refreshLabels(expectedCount, retriesLeft - 1), 50);
+                return;
+            }
+            setOpenWindowLabelsAtom(labels);
         } catch {
             setOpenWindowLabelsAtom([]);
         }
@@ -91,13 +112,13 @@ async function initInstanceTracking(): Promise<void> {
         setWindowCountAtom(windowCount);
 
         // Keep count + label list in sync whenever any window opens or
-        // closes. The host emits this with the new count as payload (see
-        // agentmux-cef/src/commands/window.rs:514) but doesn't include
-        // the label list, so we re-fetch via listWindows() each time.
+        // closes. Pass the count from the event payload so refreshLabels
+        // can retry through the registration race (see comment above).
         await getApi().listen("window-instances-changed", (event: any) => {
             const payload = event?.payload ?? event;
-            setWindowCountAtom(typeof payload === "number" ? payload : 0);
-            refreshLabels();
+            const count = typeof payload === "number" ? payload : 0;
+            setWindowCountAtom(count);
+            refreshLabels(count);
         });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -28,6 +28,7 @@ import {
     windowInstanceNumAtom,
     setWindowInstanceNumAtom,
     setWindowCountAtom,
+    setOpenWindowLabelsAtom,
     setReinitVersion,
     setUpdaterStatusAtom,
     setUpdaterVersionAtom,
@@ -71,19 +72,32 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
  * Called once per window after the wave UI is fully initialized.
  */
 async function initInstanceTracking(): Promise<void> {
+    const refreshLabels = async () => {
+        try {
+            const labels = await getApi().listWindows();
+            setOpenWindowLabelsAtom(Array.isArray(labels) ? labels : []);
+        } catch {
+            setOpenWindowLabelsAtom([]);
+        }
+    };
+
     try {
         const [instanceNum, windowCount] = await Promise.all([
             getApi().getInstanceNumber(),
             getApi().getWindowCount(),
+            refreshLabels(),
         ]);
         setWindowInstanceNumAtom(instanceNum);
         setWindowCountAtom(windowCount);
 
-        // Keep count in sync whenever any window opens or closes.
-        // Uses the platform-agnostic listen from AppApi.
+        // Keep count + label list in sync whenever any window opens or
+        // closes. The host emits this with the new count as payload (see
+        // agentmux-cef/src/commands/window.rs:514) but doesn't include
+        // the label list, so we re-fetch via listWindows() each time.
         await getApi().listen("window-instances-changed", (event: any) => {
             const payload = event?.payload ?? event;
             setWindowCountAtom(typeof payload === "number" ? payload : 0);
+            refreshLabels();
         });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -1,0 +1,184 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * InstancePanel — popover anchored under the version chip in the status
+ * bar's bottom-right. Surfaces "About" metadata + a list of open windows
+ * in this AgentMux process, with actions to focus a window or open a
+ * new one. Replaces the version chip's old "click → openNewWindow"
+ * behaviour with a richer affordance.
+ *
+ * Spec: SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md
+ *
+ * V1 scope: about-info + windows + actions. LAN peers stay in
+ * HostPopover (they already have a richer hover-rich detail view).
+ * Per-window token totals deferred until token-usage is per-window.
+ */
+
+import { atoms, getApi, openWindowLabelsAtom, windowInstanceNumAtom } from "@/store/global";
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+
+interface InstancePanelProps {
+    anchorRect: DOMRect | null;
+    onClose: () => void;
+}
+
+const POPOVER_WIDTH = 320;
+const GUTTER = 8;
+
+export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
+    let rootRef: HTMLDivElement | undefined;
+
+    // Airspace cut so the popover paints over any browser pane HWND that
+    // the status bar overlaps. Same primitive as TokenBreakdownPopover,
+    // MoreDropdown, modal-v2.
+    usePaneOverlay(() => rootRef);
+
+    const about = createMemo(() => {
+        const d = getApi().getAboutModalDetails();
+        return {
+            version: d?.version ?? "unknown",
+            buildTime: d?.buildTime ? String(d.buildTime) : null,
+            platform: (d as any)?.platform ?? null,
+            arch: (d as any)?.arch ?? null,
+        };
+    });
+
+    const labels = openWindowLabelsAtom;
+    const myInstanceNum = windowInstanceNumAtom;
+    const [myLabel, setMyLabel] = createSignal<string | null>(null);
+    getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
+
+    const positioning = createMemo(() => {
+        const r = props.anchorRect;
+        if (!r) return { bottom: GUTTER, right: GUTTER };
+        const rightFromViewport = Math.max(GUTTER, window.innerWidth - r.right);
+        const bottomFromViewport = Math.max(GUTTER, window.innerHeight - r.top);
+        return { bottom: bottomFromViewport, right: rightFromViewport };
+    });
+
+    const handleFocusWindow = async (label: string) => {
+        if (label === myLabel()) return; // already focused
+        try {
+            await getApi().focusWindow(label);
+        } catch (e) {
+            console.error("[InstancePanel] focusWindow failed:", e);
+        }
+    };
+
+    const handleOpenNewWindow = async () => {
+        try {
+            await getApi().openNewWindow();
+        } catch (e) {
+            console.error("[InstancePanel] openNewWindow failed:", e);
+        }
+        props.onClose();
+    };
+
+    const handleCopy = (label: string, value: string) => {
+        clipboardWriteText(`${label}: ${value}`);
+    };
+
+    // Display label: "main" → "Window 1", "window-<uuid>" → use the
+    // hex prefix as a stable short name. The host doesn't track human-
+    // readable per-window names today; the user sees the index +
+    // short-id which is enough to disambiguate.
+    const displayLabel = (label: string, idx: number): string => {
+        if (label === "main") return "Window 1";
+        const m = /^window-([0-9a-f]{8})/i.exec(label);
+        if (m) return `Window ${idx + 1} · ${m[1]}`;
+        return `Window ${idx + 1}`;
+    };
+
+    return (
+        <div
+            ref={(el) => (rootRef = el)}
+            class="instance-panel"
+            role="dialog"
+            aria-label="AgentMux instance panel"
+            style={{
+                position: "fixed",
+                bottom: `${positioning().bottom}px`,
+                right: `${positioning().right}px`,
+                width: `${POPOVER_WIDTH}px`,
+            }}
+        >
+            <div class="instance-panel-header">
+                <div class="instance-panel-row instance-panel-row-meta">
+                    <span class="instance-panel-label">Version</span>
+                    <span class="instance-panel-value">v{about().version}</span>
+                    <button
+                        type="button"
+                        class="instance-panel-copy"
+                        title="Copy version"
+                        onClick={() => handleCopy("version", `v${about().version}`)}
+                    >
+                        ⧉
+                    </button>
+                </div>
+                <Show when={about().buildTime}>
+                    <div class="instance-panel-row instance-panel-row-meta">
+                        <span class="instance-panel-label">Build</span>
+                        <span class="instance-panel-value instance-panel-mono">{about().buildTime}</span>
+                    </div>
+                </Show>
+                <Show when={about().platform || about().arch}>
+                    <div class="instance-panel-row instance-panel-row-meta">
+                        <span class="instance-panel-label">Runtime</span>
+                        <span class="instance-panel-value instance-panel-mono">
+                            {[about().platform, about().arch].filter(Boolean).join(" · ")}
+                        </span>
+                    </div>
+                </Show>
+            </div>
+            <div class="instance-panel-divider" />
+            <div class="instance-panel-section">
+                <div class="instance-panel-section-title">
+                    This process — {labels().length} window{labels().length !== 1 ? "s" : ""}
+                </div>
+                <For each={labels()}>
+                    {(label, i) => {
+                        const isCurrent = () => label === myLabel();
+                        return (
+                            <button
+                                type="button"
+                                class="instance-panel-window-row"
+                                classList={{ "instance-panel-window-row-current": isCurrent() }}
+                                onClick={() => handleFocusWindow(label)}
+                                disabled={isCurrent()}
+                                title={isCurrent() ? "This window" : `Focus ${label}`}
+                            >
+                                <span class="instance-panel-window-dot">{isCurrent() ? "●" : "○"}</span>
+                                <span class="instance-panel-window-name">{displayLabel(label, i())}</span>
+                                <Show when={isCurrent()}>
+                                    <span class="instance-panel-window-badge">this</span>
+                                </Show>
+                            </button>
+                        );
+                    }}
+                </For>
+            </div>
+            <div class="instance-panel-divider" />
+            <div class="instance-panel-footer">
+                <button
+                    type="button"
+                    class="instance-panel-btn instance-panel-btn-primary"
+                    onClick={handleOpenNewWindow}
+                >
+                    + Open another window
+                </button>
+                <button
+                    type="button"
+                    class="instance-panel-btn"
+                    onClick={props.onClose}
+                >
+                    Close
+                </button>
+            </div>
+        </div>
+    );
+};
+
+InstancePanel.displayName = "InstancePanel";

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -15,7 +15,7 @@
  * Per-window token totals deferred until token-usage is per-window.
  */
 
-import { atoms, getApi, openWindowLabelsAtom, windowInstanceNumAtom } from "@/store/global";
+import { getApi, openWindowLabelsAtom } from "@/store/global";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
@@ -47,7 +47,6 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     });
 
     const labels = openWindowLabelsAtom;
-    const myInstanceNum = windowInstanceNumAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
 

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 @use "./token-usage";
+@use "./instance-panel";
 
 .status-bar {
     // Responsive 2-row wrap (§4.4 of SPEC_STATUSBAR_TOKEN_USAGE).
@@ -217,6 +218,13 @@
         font-size: 10px;
         padding: 0 5px;
         border-radius: 2px;
+        // Button reset so the chip looks identical whether it's a
+        // <span> (offline) or a <button> (clickable instance panel).
+        background: transparent;
+        border: none;
+        color: inherit;
+        font-family: inherit;
+        line-height: inherit;
 
         &.clickable {
             cursor: pointer;

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -1,11 +1,12 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, getApi, windowInstanceNumAtom, windowCountAtom, backendStatusAtom } from "@/store/global";
-import { Show, type JSX } from "solid-js";
+import { getApi, windowInstanceNumAtom, windowCountAtom, backendStatusAtom } from "@/store/global";
+import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
 import { HostPopover } from "./HostPopover";
+import { InstancePanel } from "./InstancePanel";
 import { SystemStats } from "./SystemStats";
 import { TokenUsageIndicator } from "./TokenUsageIndicator";
 import { UpdateStatus } from "./UpdateStatus";
@@ -16,13 +17,39 @@ const StatusBar = (): JSX.Element => {
     const instanceNum = windowInstanceNumAtom;
     const windowCount = windowCountAtom;
 
-    const handleNewWindow = async () => {
-        try {
-            await getApi().openNewWindow();
-        } catch (error) {
-            console.error("[StatusBar] Failed to open new window:", error);
+    let versionRef!: HTMLButtonElement;
+    const [panelOpen, setPanelOpen] = createSignal(false);
+    const [anchorRect, setAnchorRect] = createSignal<DOMRect | null>(null);
+
+    const handleVersionClick = () => {
+        if (panelOpen()) {
+            setPanelOpen(false);
+            return;
         }
+        setAnchorRect(versionRef?.getBoundingClientRect() ?? null);
+        setPanelOpen(true);
     };
+
+    // Esc + click-outside close. Mirrors TokenBreakdownPopover precedent.
+    createEffect(() => {
+        if (!panelOpen()) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setPanelOpen(false);
+        };
+        const onClick = (e: MouseEvent) => {
+            const t = e.target as Node;
+            if (versionRef?.contains(t)) return;
+            const panelEl = document.querySelector(".instance-panel");
+            if (panelEl?.contains(t)) return;
+            setPanelOpen(false);
+        };
+        document.addEventListener("keydown", onKey);
+        document.addEventListener("mousedown", onClick);
+        onCleanup(() => {
+            document.removeEventListener("keydown", onKey);
+            document.removeEventListener("mousedown", onClick);
+        });
+    });
 
     return (
         <div class="status-bar">
@@ -50,20 +77,27 @@ const StatusBar = (): JSX.Element => {
                             </span>
                         }
                     >
-                        <span
+                        <button
+                            ref={versionRef!}
+                            type="button"
                             class="status-version clickable"
-                            onClick={handleNewWindow}
-                            data-tip="Click to open new window"
-                            aria-label="AgentMux version"
+                            onClick={handleVersionClick}
+                            data-tip="Click for instance panel"
+                            aria-label="AgentMux version — open instance panel"
+                            aria-haspopup="dialog"
+                            aria-expanded={panelOpen()}
                         >
                             v{version}
                             <Show when={windowCount() > 1}>
                                 <span class="instance-num"> ({instanceNum()})</span>
                             </Show>
-                        </span>
+                        </button>
                     </Show>
                 </Show>
             </div>
+            <Show when={panelOpen()}>
+                <InstancePanel anchorRect={anchorRect()} onClose={() => setPanelOpen(false)} />
+            </Show>
         </div>
     );
 };

--- a/frontend/app/statusbar/_instance-panel.scss
+++ b/frontend/app/statusbar/_instance-panel.scss
@@ -1,0 +1,164 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// InstancePanel — popover anchored to the version chip.
+// Spec: SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md.
+
+.instance-panel {
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md, 6px);
+    box-shadow: var(--shadow-modal, 0 24px 48px rgba(0, 0, 0, 0.45));
+    padding: var(--space-2);
+    color: var(--main-text-color);
+    font-size: 12px;
+    user-select: none;
+    z-index: var(--z-popover, 8500);
+}
+
+.instance-panel-header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+}
+
+.instance-panel-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    line-height: 1.4;
+}
+
+.instance-panel-row-meta {
+    .instance-panel-label {
+        flex: 0 0 64px;
+        color: var(--secondary-text-color);
+        font-size: 11px;
+    }
+    .instance-panel-value {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+}
+
+.instance-panel-mono {
+    font-family: var(--font-mono, "Hack", monospace);
+    font-size: 11px;
+}
+
+.instance-panel-copy {
+    flex: 0 0 auto;
+    background: transparent;
+    border: 1px solid transparent;
+    color: var(--secondary-text-color);
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-size: 12px;
+    line-height: 1;
+
+    &:hover {
+        border-color: var(--border-color);
+        color: var(--main-text-color);
+    }
+}
+
+.instance-panel-divider {
+    height: 1px;
+    background: var(--border-color);
+    margin: var(--space-2) calc(var(--space-2) * -1);
+}
+
+.instance-panel-section-title {
+    font-size: 11px;
+    color: var(--secondary-text-color);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: var(--space-1);
+}
+
+.instance-panel-window-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: var(--space-1) var(--space-1-5);
+    color: var(--main-text-color);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+    line-height: 1.3;
+
+    &:hover:not(:disabled) {
+        background: var(--hover-bg-color);
+        border-color: var(--border-color);
+    }
+    &:disabled {
+        cursor: default;
+    }
+
+    .instance-panel-window-dot {
+        flex: 0 0 auto;
+        color: var(--accent-color);
+        font-size: 10px;
+        width: 10px;
+        text-align: center;
+    }
+    .instance-panel-window-name {
+        flex: 1 1 auto;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .instance-panel-window-badge {
+        flex: 0 0 auto;
+        font-size: 10px;
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: var(--accent-color);
+        color: var(--button-text-color);
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+    }
+}
+
+.instance-panel-window-row-current {
+    background: rgb(from var(--accent-color) r g b / 0.08);
+}
+
+.instance-panel-footer {
+    display: flex;
+    gap: var(--space-1-5);
+    margin-top: var(--space-1);
+}
+
+.instance-panel-btn {
+    flex: 1 1 auto;
+    background: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--main-text-color);
+    padding: var(--space-1) var(--space-2);
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+
+    &:hover {
+        background: var(--hover-bg-color);
+    }
+}
+
+.instance-panel-btn-primary {
+    background: var(--accent-color);
+    border-color: var(--accent-color);
+    color: var(--button-text-color);
+    font-weight: 600;
+
+    &:hover {
+        filter: brightness(1.1);
+    }
+}

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -131,6 +131,12 @@ export const [windowInstanceNumAtom, setWindowInstanceNumAtom] = createSignal(0)
 export const [windowCountAtom, setWindowCountAtom] = createSignal(1);
 export const [lanInstancesAtom, setLanInstancesAtom] = createSignal<LanInstance[]>([]);
 
+// List of all open AgentMux window labels in this process. Updated by
+// app-init's window-instances-changed listener whenever a window opens
+// or closes. Consumed by the version-click instance panel.
+// See SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md.
+export const [openWindowLabelsAtom, setOpenWindowLabelsAtom] = createSignal<string[]>([]);
+
 // ---------------------------------------------------------------------------
 // GlobalAtomsType-compatible export (used in wos.ts callBackendService)
 // ---------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.400",
+  "version": "0.33.401",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.400",
+      "version": "0.33.401",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.401",
+  "version": "0.33.402",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.401",
+      "version": "0.33.402",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.402",
+  "version": "0.33.403",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.402",
+      "version": "0.33.403",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.399",
+  "version": "0.33.400",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.399",
+      "version": "0.33.400",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.400",
+  "version": "0.33.401",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.399",
+  "version": "0.33.400",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.402",
+  "version": "0.33.403",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.401",
+  "version": "0.33.402",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Replaces the version chip's old \"click → openNewWindow\" side-effect with an anchored popover surfacing about-info + open-windows in this AgentMux process + actions. Chrome-style multi-window awareness from a chip that was previously a one-trick affordance.

**What's in the panel:**
- **About:** version, build time, runtime (\`platform · arch\`) with a copy-to-clipboard for bug-report convenience.
- **This process — N windows:** one row per open window. Current window shows a \"this\" badge and is non-clickable; other rows are click-to-focus via the existing \`getApi().focusWindow(label)\` RPC.
- **Footer:** \`+ Open another window\` (the old primary action, now accent-coloured) and \`Close\`.

**Plumbing reuse (no new RPCs needed):**
- \`getApi().focusWindow(label)\` already exists at \`agentmux-cef/src/commands/window.rs:324-348\`.
- \`window-instances-changed\` event already emits at \`window.rs:514\`; new \`openWindowLabelsAtom\` subscribes via the existing app-init listener and re-fetches \`getApi().listWindows()\` on every event.
- \`usePaneOverlay\` primitive paints over any browser pane HWND (same airspace pattern as TokenBreakdownPopover, MoreDropdown, modal-v2).
- Esc + click-outside close handler mirrors HostPopover / TokenBreakdownPopover precedent.

**V1 deferrals (called out in the spec):**
- LAN peers — \`HostPopover\` already shows them with hover-rich detail; duplicating here would be confusing UX.
- Per-window token totals — needs a token-usage refactor (currently global / session-scoped). Separate PR.

Spec: \`docs/specs/SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md\` (now committed, with revision notes on three drift items).

## Test plan

- [ ] Single-window: click \`vX.Y.Z\` in the status bar → panel opens with about-info + 1 row \"Window 1\" (badged \"this\", disabled). Footer button \"+ Open another window\".
- [ ] Click \"+ Open another window\" → spawns a second AgentMux window. Re-open panel → now shows 2 rows.
- [ ] Click the non-current row → that window focuses.
- [ ] Esc closes the panel. Click-outside closes the panel. Re-clicking the chip toggles open/closed.
- [ ] Open a browser pane behind the status bar, then open the panel → panel paints cleanly over it (airspace works).
- [ ] Click each copy icon → clipboard receives \`version: v0.33.400\` etc.
- [ ] Backend offline state: chip shows v with strikethrough opacity; click does nothing (existing fallback path preserved).

## Notes for reviewers

- Chip element changed from \`<span>\` to \`<button>\` to satisfy \`aria-haspopup=\"dialog\"\` semantics. The \`.status-version\` SCSS got a button-reset block so the visual is identical in both states.
- \`atoms\` removed from StatusBar imports — wasn't used after the refactor.
- The new \`openWindowLabelsAtom\` is intentionally just \`string[]\` for V1; richer per-window data (started-at, focused agent, tokens) would need backend registry extension and is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)