### PR TITLE
feat(backend): explicit tabId arg on CreateBlock — closes tab-presets TOCTOU

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.403"
+version = "0.33.404"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.403"
+version = "0.33.404"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.403"
+version = "0.33.404"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.403"
+version = "0.33.404"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.404"
+version = "0.33.405"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.404"
+version = "0.33.405"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.404"
+version = "0.33.405"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.404"
+version = "0.33.405"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.405"
+version = "0.33.406"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.405"
+version = "0.33.406"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.405"
+version = "0.33.406"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.405"
+version = "0.33.406"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.403"
+version = "0.33.404"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.405"
+version = "0.33.406"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.404"
+version = "0.33.405"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.405"
+version = "0.33.406"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.403"
+version = "0.33.404"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.404"
+version = "0.33.405"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.404"
+version = "0.33.405"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.403"
+version = "0.33.404"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.405"
+version = "0.33.406"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.404"
+version = "0.33.405"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.403"
+version = "0.33.404"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.405"
+version = "0.33.406"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/service.rs
+++ b/agentmux-srv/src/backend/service.rs
@@ -179,8 +179,14 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
         }),
         ("object", "CreateBlock") => Some(MethodMeta {
             desc: Some("create a new block".into()),
-            // Optional `tabId` (args[2]) overrides uicontext.active_tab_id —
-            // see SPEC_VERSION_INSTANCE_PANEL_2026_04_25 follow-up + the
+            // arg_names is documented as if `uiContext` were args[0], but
+            // uiContext actually rides in the call envelope (call.uicontext),
+            // not in the args array. So the handler reads positions
+            // shifted left by 1: blockDef = args[0], rtOpts = args[1],
+            // tabId = args[2]. (Same shift convention as every other
+            // CreateBlock-style handler in this file.) tabId overrides
+            // uicontext.active_tab_id when present — see
+            // SPEC_VERSION_INSTANCE_PANEL_2026_04_25 follow-up + the
             // tab-presets TOCTOU note in frontend/app/tab/tab-presets.ts.
             arg_names: vec![
                 "uiContext".into(),

--- a/agentmux-srv/src/backend/service.rs
+++ b/agentmux-srv/src/backend/service.rs
@@ -179,7 +179,15 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
         }),
         ("object", "CreateBlock") => Some(MethodMeta {
             desc: Some("create a new block".into()),
-            arg_names: vec!["uiContext".into(), "blockDef".into(), "rtOpts".into()],
+            // Optional `tabId` (args[2]) overrides uicontext.active_tab_id —
+            // see SPEC_VERSION_INSTANCE_PANEL_2026_04_25 follow-up + the
+            // tab-presets TOCTOU note in frontend/app/tab/tab-presets.ts.
+            arg_names: vec![
+                "uiContext".into(),
+                "blockDef".into(),
+                "rtOpts".into(),
+                "tabId".into(),
+            ],
             return_desc: Some("blockId".into()),
         }),
         ("object", "DeleteBlock") => Some(MethodMeta {

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -103,7 +103,7 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
             // wrong-tab routing hard to diagnose. Missing/null/empty
             // is fine: treat as "no override" and use uicontext.
             let explicit_tab_id: Option<String> = match service::get_optional_arg::<String>(args, 2) {
-                Ok(opt) => opt.filter(|s| !s.trim().is_empty()),
+                Ok(opt) => opt.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()),
                 Err(e) => return WebReturnType::error(format!("invalid tabId arg: {}", e)),
             };
             let tab_id = match explicit_tab_id {

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -96,10 +96,16 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
             // when the RPC's uicontext is serialised. Eliminates the
             // TOCTOU race where the user can switch tabs between the
             // call site and the server-side handler.
-            let explicit_tab_id: Option<String> = service::get_optional_arg::<String>(args, 2)
-                .ok()
-                .flatten()
-                .filter(|s| !s.is_empty());
+            //
+            // A *malformed* args[2] (e.g. non-string from a stale SDK)
+            // returns an error — silently falling back to uicontext
+            // would defeat the explicit-targeting contract and make
+            // wrong-tab routing hard to diagnose. Missing/null/empty
+            // is fine: treat as "no override" and use uicontext.
+            let explicit_tab_id: Option<String> = match service::get_optional_arg::<String>(args, 2) {
+                Ok(opt) => opt.filter(|s| !s.is_empty()),
+                Err(e) => return WebReturnType::error(format!("invalid tabId arg: {}", e)),
+            };
             let tab_id = match explicit_tab_id {
                 Some(id) => id,
                 None => match call

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -85,17 +85,31 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
             WebReturnType::success(serde_json::json!(results))
         }
         ("object", "CreateBlock") => {
-            let tab_id = match call
-                .uicontext
-                .as_ref()
-                .map(|ctx| ctx.active_tab_id.clone())
-            {
-                Some(id) if !id.is_empty() => id,
-                _ => return WebReturnType::error("missing uicontext.activetabid"),
-            };
             let block_def: BlockDef = match service::get_arg(args, 0) {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
+            };
+            // Optional explicit tab_id at args[2] (args[1] is rtOpts).
+            // When present, overrides uicontext.active_tab_id — lets
+            // callers like applyTabPreset (frontend) target a specific
+            // tab without depending on which tab happens to be active
+            // when the RPC's uicontext is serialised. Eliminates the
+            // TOCTOU race where the user can switch tabs between the
+            // call site and the server-side handler.
+            let explicit_tab_id: Option<String> = service::get_optional_arg::<String>(args, 2)
+                .ok()
+                .flatten()
+                .filter(|s| !s.is_empty());
+            let tab_id = match explicit_tab_id {
+                Some(id) => id,
+                None => match call
+                    .uicontext
+                    .as_ref()
+                    .map(|ctx| ctx.active_tab_id.clone())
+                {
+                    Some(id) if !id.is_empty() => id,
+                    _ => return WebReturnType::error("missing uicontext.activetabid"),
+                },
             };
             match wcore::create_block(store, &tab_id, block_def.meta) {
                 Ok(block) => {

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -103,7 +103,7 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
             // wrong-tab routing hard to diagnose. Missing/null/empty
             // is fine: treat as "no override" and use uicontext.
             let explicit_tab_id: Option<String> = match service::get_optional_arg::<String>(args, 2) {
-                Ok(opt) => opt.filter(|s| !s.is_empty()),
+                Ok(opt) => opt.filter(|s| !s.trim().is_empty()),
                 Err(e) => return WebReturnType::error(format!("invalid tabId arg: {}", e)),
             };
             let tab_id = match explicit_tab_id {

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -47,7 +47,12 @@ export const ClientService = new ClientServiceType();
 // objectservice.ObjectService (object)
 class ObjectServiceType {
     // @returns blockId (and object updates)
-    CreateBlock(blockDef: BlockDef, rtOpts: RuntimeOpts): Promise<string> {
+    // `tabId` (optional) overrides uicontext.active_tab_id on the
+    // server. Use it when the caller knows the target tab independent
+    // of the current active-tab atom — e.g. tab-presets applying a
+    // layout to a freshly-created tab without racing against the user
+    // switching tabs mid-flow.
+    CreateBlock(blockDef: BlockDef, rtOpts: RuntimeOpts, tabId?: string): Promise<string> {
         return WOS.callBackendService("object", "CreateBlock", Array.from(arguments))
     }
 

--- a/frontend/app/tab/tab-presets.ts
+++ b/frontend/app/tab/tab-presets.ts
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, fullConfigAtom, WOS } from "@/app/store/global";
+import { fullConfigAtom, WOS } from "@/app/store/global";
 import { ObjectService } from "@/app/store/services";
 import { getLayoutModelForTabById } from "@/layout/index";
 import {
@@ -109,24 +109,11 @@ export async function applyTabPreset(tabId: string, preset: PresetNode): Promise
     }
 }
 
-// ObjectService.CreateBlock is routed by uicontext.active_tab_id on the
-// server (see agentmux-srv/src/server/service.rs:88-95). Between awaits
-// the user could have clicked away to a different tab — abort cleanly
-// rather than silently land blocks in the wrong tab.
-//
-// CAVEAT (TOCTOU): the check sits one statement before the actual
-// `await CreateBlock` call, so a tab switch in the *sub-microsecond*
-// gap between check and invoke isn't caught — but realistically a
-// human can't click in that window. The realistic gap (the 50-200ms
-// network round-trip BETWEEN successive CreateBlock calls) IS caught
-// by re-checking at the start of every `createBlockOnModel` invocation.
-//
-// A complete fix requires the backend `CreateBlock` to accept an
-// explicit `tab_id` arg that overrides `uicontext.active_tab_id`.
-// Tracked as a follow-up to this PR.
-function activeTabStillTargets(expectedTabId: string): boolean {
-    return atoms.activeTabId() === expectedTabId;
-}
+// CreateBlock now takes an explicit `tabId` arg that overrides the
+// server-side uicontext.active_tab_id routing — closes the TOCTOU
+// race where the user could click away to another tab between the
+// frontend check and the server-side handler. See backend
+// agentmux-srv/src/server/service.rs `("object", "CreateBlock")`.
 
 // Recursive walk. Returns the blockId of the FIRST leaf in the subtree —
 // callers use that as the split target for subsequent sibling subtrees.
@@ -161,9 +148,10 @@ async function applyNode(
     return firstId!;
 }
 
-// Create a block via the layout model (NOT via the global createBlock —
-// that one targets the active tab via getLayoutModelForStaticTab, which
-// would race against the new-tab activation).
+// Create a block on the explicit target tab. We pass `expectedTabId`
+// to ObjectService.CreateBlock so the server routes it correctly
+// regardless of which tab is currently active (the user can click
+// freely during preset application without scrambling the layout).
 async function createBlockOnModel(
     expectedTabId: string,
     layoutModel: any,
@@ -171,25 +159,8 @@ async function createBlockOnModel(
     splitTargetId: string | null,
     splitDir: "horizontal" | "vertical" | null,
 ): Promise<string> {
-    // Guard: ObjectService.CreateBlock routes via uicontext.active_tab_id
-    // server-side. If the user switched tabs since we started, abort
-    // rather than dropping the new block into the wrong tab.
-    if (!activeTabStillTargets(expectedTabId)) {
-        throw new Error("active tab changed before block creation — aborting");
-    }
     const rtOpts: RuntimeOpts = { termsize: { rows: 25, cols: 80 } };
-    const blockId = await ObjectService.CreateBlock(blockDef, rtOpts);
-    // Post-await re-check: the await yields to the event loop, so a
-    // user click on another tab could have landed before the RPC's
-    // uicontext was serialised. If that happened, the block was
-    // created in the wrong tab — try to delete it and abort. Best-
-    // effort cleanup; worst case the orphan block lingers until tab
-    // close. The full structural fix is a tab_id arg on the backend
-    // CreateBlock RPC; tracked as a follow-up.
-    if (!activeTabStillTargets(expectedTabId)) {
-        await ObjectService.DeleteBlock(blockId).catch(() => {});
-        throw new Error("active tab changed during block creation — aborting");
-    }
+    const blockId = await ObjectService.CreateBlock(blockDef, rtOpts, expectedTabId);
 
     if (splitTargetId === null) {
         const action: LayoutTreeInsertNodeAction = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.403",
+  "version": "0.33.404",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.403",
+      "version": "0.33.404",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.405",
+  "version": "0.33.406",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.405",
+      "version": "0.33.406",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.404",
+  "version": "0.33.405",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.404",
+      "version": "0.33.405",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.404",
+  "version": "0.33.405",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.405",
+  "version": "0.33.406",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.403",
+  "version": "0.33.404",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to **#560** that closes the TOCTOU race the tab-presets module had to work around.

PR #560's \`tab-presets.ts\` calls \`ObjectService.CreateBlock\` to seed each block in a freshly-created tab. The server routes \`CreateBlock\` via \`uicontext.active_tab_id\` — which is captured at the moment the RPC envelope is built. If the user clicks another tab between the frontend's pre-call \`activeTabStillTargets\` check and the RPC arriving on the server, blocks land in the wrong tab. The frontend mitigations (check-before-await, post-await re-check + DeleteBlock cleanup) narrowed the window but couldn't close it structurally.

This PR closes it at the source: an optional \`tabId\` arg on \`CreateBlock\` (args[2]) overrides \`uicontext.active_tab_id\` when present.

## Changes

**Backend (Rust):**
- \`agentmux-srv/src/server/service.rs\` — handler reads \`get_optional_arg::<String>(args, 2)\`. When present and non-empty, that's the target tab; otherwise fall back to \`uicontext.active_tab_id\` (existing behaviour).
- \`agentmux-srv/src/backend/service.rs\` — arg_names metadata extended with \`\"tabId\"\`.

**Frontend (TS):**
- \`services.ts\` — \`CreateBlock(blockDef, rtOpts, tabId?)\` signature.
- \`tab-presets.ts\` — passes \`expectedTabId\` explicitly. Removes the \`activeTabStillTargets\` guard, the post-await re-check, and the \`DeleteBlock\` orphan-cleanup — none needed once the routing is deterministic.

**Backward-compatible.** Existing two-arg callers (every caller other than tab-presets) continue to route via \`uicontext\`.

## Stacked on #560

This PR's base is \`agenta/version-instance-panel\` so the diff is just the new work. After #560 merges, this PR's diff against main reduces to these 4 files.

## Test plan

- [ ] \`cargo check -p agentmux-srv\` — clean (verified locally).
- [ ] \`tsc --noEmit\` — clean.
- [ ] Open AgentMux, click \"+\" → tab gets agent + sysinfo + swarm preset (same as #560 behaviour).
- [ ] Repeat the test rapidly clicking between tabs during \"+\" press → preset blocks land in the new tab regardless of click timing (the previous TOCTOU window is gone).
- [ ] No regressions in widget-picker block creation (still routes via uicontext for back-compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)