### PR TITLE
fix(tab-tear-off): Phase 2 codex follow-ups (PostMessage error + payload-clear timing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.409"
+version = "0.33.410"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.409"
+version = "0.33.410"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.409"
+version = "0.33.410"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.409"
+version = "0.33.410"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.409"
+version = "0.33.410"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -433,12 +433,24 @@ pub fn tear_off_sc_move_handshake(
             SetForegroundWindow(dest_hwnd);
 
             let lparam = ((cursor_y as i32 as u32) << 16) | (cursor_x as i32 as u32 & 0xFFFF);
-            PostMessageW(
+            // PostMessageW returns BOOL — 0 means the post failed (e.g.
+            // dest HWND went invalid between wait_for_browser_hwnd and
+            // here, or the message queue rejected the post). Return an
+            // error so the frontend doesn't silently treat tear-off as
+            // complete; the UI can fall back / log.
+            let post_ok = PostMessageW(
                 dest_hwnd,
                 WM_SYSCOMMAND,
                 (SC_MOVE as usize) | (HTCAPTION as usize),
                 lparam as isize,
             );
+            if post_ok == 0 {
+                let last_err = windows_sys::Win32::Foundation::GetLastError();
+                return Err(format!(
+                    "PostMessageW(SC_MOVE) failed: GetLastError={}",
+                    last_err
+                ));
+            }
         }
 
         t_handshake.elapsed().as_micros() as f64 / 1000.0

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.409"
+version = "0.33.410"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.409"
+version = "0.33.410"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.409"
+version = "0.33.410"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -134,19 +134,10 @@ function TabBar(props: TabBarProps): JSX.Element {
                     const draggedTabId = source.data.tabId as string;
                     const wsId = props.workspace?.oid;
                     if (wsId) {
-                        // Clear the cross-window drag payload IMMEDIATELY
-                        // so CrossWindowDragMonitor's dragend handler
-                        // doesn't also run the legacy dragend tear-off
-                        // pipeline against the same gesture. Without
-                        // this, both paths fire TearOffTab on the same
-                        // tab — the second one fails (tab already moved)
-                        // and emits noisy errors.
-                        setCurrentDragPayload(null);
                         // openWindowAtPosition + SC_MOVE expect SCREEN
                         // coordinates, but `input.clientX/Y` are
                         // viewport-relative. Convert via window.screenX/Y
-                        // (works across multi-monitor setups; getBoundingClientRect
-                        // would only handle within-window offsets).
+                        // (works across multi-monitor setups).
                         const screenX = window.screenX + input.clientX;
                         const screenY = window.screenY + input.clientY;
                         // Phase 2: real tear-off (sidecar TearOffTab +
@@ -154,7 +145,14 @@ function TabBar(props: TabBarProps): JSX.Element {
                         // Fire-and-forget — the user is mid-drag and the
                         // host's SC_MOVE handshake will take over the
                         // cursor synchronously from Windows' point of view.
-                        // (See requestTearOff below.)
+                        //
+                        // The cross-window drag payload is cleared INSIDE
+                        // requestTearOff after the SC_MOVE handshake
+                        // returns successfully — clearing it here would
+                        // strand the legacy dragend fallback if any step
+                        // (TearOffTab, openWindowAtPosition, handshake)
+                        // failed mid-flight, leaving the gesture as a
+                        // silent no-op.
                         fireAndForget(() =>
                             requestTearOff(draggedTabId, wsId, screenX, screenY),
                         );
@@ -358,6 +356,13 @@ async function requestTearOff(
             cursorX,
             cursorY,
         });
+        // Handshake succeeded — Windows now owns the move loop. Clear
+        // the cross-window drag payload so the legacy dragend pipeline
+        // (CrossWindowDragMonitor) doesn't double-process this gesture
+        // when its dragend fires. Cleared HERE rather than in onDrag so
+        // a failure mid-pipeline (TearOffTab, openWindowAtPosition, or
+        // the handshake itself) leaves the legacy fallback intact.
+        setCurrentDragPayload(null);
         Logger.info("dnd", "tab tear-off complete", {
             tabId,
             destWindowLabel,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.409",
+  "version": "0.33.410",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.409",
+      "version": "0.33.410",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.409",
+  "version": "0.33.410",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to **#563** (Phase 2 SC_MOVE handshake) addressing two post-merge codex flags. Both are reliability fixes — no functional change on the happy path.

### P1 — Surface PostMessageW(SC_MOVE) failure (\`drag.rs:431\`)

The previous handler ignored \`PostMessageW\`'s BOOL return. If Windows rejected the post (dest HWND went invalid during the HWND-wait window, message queue full, etc.) no modal move-loop starts but the handler returned the metrics struct as if everything succeeded — the frontend treated tear-off as complete and the legacy dragend fallback never fired. Now we check the return and surface \`GetLastError\` so the frontend can fall back / log diagnostically.

### P2 — Defer drag-payload clear until handshake succeeds (\`tabbar.tsx:144\`)

\`setCurrentDragPayload(null)\` was firing in \`onDrag\` BEFORE the async tear-off pipeline started, so any failure mid-pipeline (\`TearOffTab\`, \`openWindowAtPosition\`, or the handshake itself) stranded \`CrossWindowDragMonitor\`'s \`dragend\` fallback with no payload — turning the gesture into a silent no-op. Moved the clear to fire AFTER \`tearOffSCMoveHandshake\` returns successfully (inside \`requestTearOff\`). The legacy dragend fallback now reliably picks up partial-failure cases.

## Test plan

- [ ] Happy path: drag past threshold → new window appears + follows cursor → SC_MOVE log fires with handshakeMs (unchanged behaviour from #563).
- [ ] Force a failure path (e.g. invalid workspaceId on TearOffTab) → no silent loss; legacy dragend fallback should fire on mouse release and the user still gets a tear-off (or a clear error).
- [ ] No regressions: existing \`dragend\` tear-off (drop outside the window without crossing strip-bottom) still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)