### PR TITLE
feat(tab-tear-off): Phase 4 — WH_MOUSE_LL hook + cross-window merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.411"
+version = "0.33.412"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.411"
+version = "0.33.412"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.411"
+version = "0.33.412"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.411"
+version = "0.33.412"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.410"
+version = "0.33.411"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.410"
+version = "0.33.411"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.410"
+version = "0.33.411"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.410"
+version = "0.33.411"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.411"
+version = "0.33.412"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.410"
+version = "0.33.411"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -391,6 +391,26 @@ pub fn tear_off_sc_move_handshake(
         .and_then(|v| v.as_f64())
         .ok_or_else(|| "missing or invalid cursorY".to_string())? as i32;
 
+    // Phase 4 args — drive the WH_MOUSE_LL hook + finalize event.
+    // Optional in case a future call site doesn't need merge detection;
+    // if any are missing/empty, we skip the hook install and the
+    // dragged window simply ends as a standalone after mouseup.
+    let tab_id = args
+        .get("tabId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let source_ws_id = args
+        .get("sourceWsId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let dest_ws_id = args
+        .get("destWsId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
     // Win32-only path. The HWND poll, ReleaseCapture, and the SC_MOVE
     // post all live inside the cfg block — on macOS / Linux the
     // function returns Ok(null) immediately (Phase 7 adds platform
@@ -407,6 +427,22 @@ pub fn tear_off_sc_move_handshake(
         // this to <16 ms.
         let dest_hwnd = wait_for_browser_hwnd(state, &dest_label, std::time::Duration::from_millis(2000))
             .ok_or_else(|| format!("dest window not registered within 2s: {}", dest_label))?;
+
+        // Phase 4 — install the WH_MOUSE_LL hook on a dedicated thread
+        // BEFORE PostMessageW(SC_MOVE) so the hook is armed when the
+        // user starts moving. Otherwise the first cursor positions of
+        // the move-loop would be missed. Skip if any merge-related
+        // arg is empty (Phase 2 callers).
+        if !tab_id.is_empty() && !source_ws_id.is_empty() && !dest_ws_id.is_empty() {
+            crate::commands::tear_off_hook::start_tear_off_tracking(
+                state.clone(),
+                source_label.clone(),
+                dest_label.clone(),
+                tab_id.clone(),
+                source_ws_id.clone(),
+                dest_ws_id.clone(),
+            )?;
+        }
 
         let t_handshake = std::time::Instant::now();
 

--- a/agentmux-cef/src/commands/mod.rs
+++ b/agentmux-cef/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod window;
 pub mod backend;
 pub mod providers;
 pub mod drag;
+pub mod tear_off_hook;
 pub mod clipboard;
 pub mod stubs;
 pub mod palette;

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -1,0 +1,372 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Tear-off Phase 4 — WH_MOUSE_LL low-level mouse hook for cross-window
+// merge detection during the SC_MOVE modal move-loop.
+//
+// Background: while Windows runs the modal SC_MOVE loop (entered via
+// `commands/drag.rs::tear_off_sc_move_handshake`), AgentMux's normal
+// renderer message handlers DON'T fire — Windows owns the cursor
+// until mouseup. To detect "is the cursor over another AgentMux
+// window's tab strip?" we install a global low-level mouse hook on a
+// dedicated thread with its own GetMessage loop.
+//
+// The hook callback runs on the install thread (not arbitrary
+// threads). It uses thread-local storage to access the hook context
+// (Arc<AppState>, source/dest labels, tab id, etc.) without risking
+// re-entrant locking issues that a global Mutex would have.
+//
+// Architecture:
+//   * `start_tear_off_tracking()` is called from the IPC handler
+//     BEFORE the SC_MOVE post. Spawns a thread, installs the hook,
+//     returns a `TrackingHandle` that's dropped when the user releases
+//     the mouse (the thread's GetMessage loop sees WM_LBUTTONUP and
+//     calls PostQuitMessage).
+//   * On every WM_MOUSEMOVE, the callback does WindowFromPoint →
+//     GetAncestor(GA_ROOT) and looks the HWND up in `state.browsers`
+//     (skipping the dragged window itself). If the candidate target
+//     changed, emits `tearoff:hover-changed` IPC events to the new
+//     and old candidate's renderers.
+//   * On WM_LBUTTONUP, emits `tearoff:finalize` to the source window's
+//     renderer with the final candidate label + cursor position. The
+//     source-side frontend handles the merge (calls
+//     MoveTabToWorkspace + closes the dragged window).
+//
+// Spec: docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26 §4.3-§4.4
+// Phase 5 (cancel-back-to-source) reuses the same finalize event
+// with a different source-side handler.
+
+#[cfg(target_os = "windows")]
+use std::cell::RefCell;
+#[cfg(target_os = "windows")]
+use std::sync::Arc;
+
+#[cfg(target_os = "windows")]
+use crate::state::AppState;
+
+#[cfg(target_os = "windows")]
+struct HookContext {
+    state: Arc<AppState>,
+    /// Label of the source window (the one the tab originated from).
+    /// Used to skip self-detection during cursor tracking, and as the
+    /// destination for the `tearoff:finalize` event.
+    source_label: String,
+    /// Label of the dragged-window-now-following-the-cursor. Also
+    /// excluded from candidate detection — landing on the dragged
+    /// window's own strip would be a no-op.
+    dragged_label: String,
+    /// The tab being torn off. Echoed back in the finalize payload so
+    /// the source frontend doesn't have to track per-drag state.
+    tab_id: String,
+    /// Source workspace ID. Echoed back so the frontend can call
+    /// `MoveTabToWorkspace` from a different window context if needed.
+    source_ws_id: String,
+    /// Destination workspace ID (the new workspace TearOffTab created).
+    /// Used by the source-side cancel-back path in Phase 5.
+    dest_ws_id: String,
+    /// Last-known candidate target label, or None when over a non-
+    /// AgentMux window or the desktop. Used to emit hover-clear events
+    /// when the cursor leaves a candidate.
+    current_target: RefCell<Option<String>>,
+}
+
+#[cfg(target_os = "windows")]
+thread_local! {
+    static HOOK_CTX: RefCell<Option<HookContext>> = const { RefCell::new(None) };
+}
+
+/// Spawn a hook thread for the duration of a tear-off gesture.
+/// Returns Ok once the hook is installed; the thread runs in the
+/// background until WM_LBUTTONUP arrives or `stop_tear_off_tracking`
+/// is called.
+///
+/// Safe to call from a Tokio worker thread — the hook thread is
+/// independent and runs its own message loop.
+#[cfg(target_os = "windows")]
+pub fn start_tear_off_tracking(
+    state: Arc<AppState>,
+    source_label: String,
+    dragged_label: String,
+    tab_id: String,
+    source_ws_id: String,
+    dest_ws_id: String,
+) -> Result<(), String> {
+    use std::sync::mpsc;
+
+    // Use a oneshot channel so the spawn returns only after the hook
+    // is fully installed. Otherwise PostMessageW(SC_MOVE) could fire
+    // before the hook is ready and we'd miss the first few mouse
+    // events of the move-loop.
+    let (ready_tx, ready_rx) = mpsc::channel::<Result<(), String>>();
+
+    std::thread::Builder::new()
+        .name("tear-off-hook".to_string())
+        .spawn(move || {
+            let ctx = HookContext {
+                state,
+                source_label,
+                dragged_label,
+                tab_id,
+                source_ws_id,
+                dest_ws_id,
+                current_target: RefCell::new(None),
+            };
+            HOOK_CTX.with(|cell| *cell.borrow_mut() = Some(ctx));
+
+            unsafe {
+                use windows_sys::Win32::UI::WindowsAndMessaging::{
+                    DispatchMessageW, GetMessageW, SetWindowsHookExW,
+                    TranslateMessage, UnhookWindowsHookEx, MSG, WH_MOUSE_LL,
+                };
+
+                let hook = SetWindowsHookExW(
+                    WH_MOUSE_LL,
+                    Some(low_level_mouse_proc),
+                    std::ptr::null_mut(),
+                    0,
+                );
+                if hook.is_null() {
+                    let err = windows_sys::Win32::Foundation::GetLastError();
+                    HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
+                    let _ = ready_tx.send(Err(format!(
+                        "SetWindowsHookExW failed: GetLastError={}",
+                        err
+                    )));
+                    return;
+                }
+
+                let _ = ready_tx.send(Ok(()));
+
+                tracing::info!(
+                    target: "dnd:tearoff",
+                    "[dnd:tearoff] hook installed, entering message loop"
+                );
+
+                // Standard GetMessage pump. The loop exits when the
+                // hook callback posts WM_QUIT after WM_LBUTTONUP.
+                let mut msg: MSG = std::mem::zeroed();
+                loop {
+                    let r = GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0);
+                    if r <= 0 {
+                        break; // 0 = WM_QUIT, -1 = error
+                    }
+                    let _ = TranslateMessage(&msg);
+                    DispatchMessageW(&msg);
+                }
+
+                UnhookWindowsHookEx(hook);
+                HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
+
+                tracing::info!(
+                    target: "dnd:tearoff",
+                    "[dnd:tearoff] hook uninstalled, thread exiting"
+                );
+            }
+        })
+        .map_err(|e| format!("failed to spawn hook thread: {}", e))?;
+
+    // Block until the hook thread either installs the hook or fails.
+    // ~milliseconds latency on success.
+    ready_rx
+        .recv()
+        .map_err(|e| format!("hook ready channel closed: {}", e))?
+}
+
+/// No-op stub for non-Windows builds. Phase 7 adds platform
+/// equivalents (CGEventTap on macOS, polled XQueryPointer on X11).
+#[cfg(not(target_os = "windows"))]
+pub fn start_tear_off_tracking(
+    _state: std::sync::Arc<crate::state::AppState>,
+    _source_label: String,
+    _dragged_label: String,
+    _tab_id: String,
+    _source_ws_id: String,
+    _dest_ws_id: String,
+) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn low_level_mouse_proc(
+    n_code: i32,
+    w_param: windows_sys::Win32::Foundation::WPARAM,
+    l_param: windows_sys::Win32::Foundation::LPARAM,
+) -> windows_sys::Win32::Foundation::LRESULT {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CallNextHookEx, MSLLHOOKSTRUCT, WM_LBUTTONUP, WM_MOUSEMOVE,
+    };
+
+    if n_code < 0 {
+        return CallNextHookEx(std::ptr::null_mut(), n_code, w_param, l_param);
+    }
+
+    let msg_id = w_param as u32;
+    let hook_struct = &*(l_param as *const MSLLHOOKSTRUCT);
+    let cursor_x = hook_struct.pt.x;
+    let cursor_y = hook_struct.pt.y;
+
+    match msg_id {
+        WM_MOUSEMOVE => {
+            handle_mouse_move(cursor_x, cursor_y);
+        }
+        WM_LBUTTONUP => {
+            handle_button_up(cursor_x, cursor_y);
+            // Tell our message loop to exit — the move-loop is over.
+            use windows_sys::Win32::UI::WindowsAndMessaging::PostQuitMessage;
+            PostQuitMessage(0);
+        }
+        _ => {}
+    }
+
+    CallNextHookEx(std::ptr::null_mut(), n_code, w_param, l_param)
+}
+
+#[cfg(target_os = "windows")]
+fn handle_mouse_move(cursor_x: i32, cursor_y: i32) {
+    HOOK_CTX.with(|cell| {
+        let ctx_ref = cell.borrow();
+        let Some(ctx) = ctx_ref.as_ref() else {
+            return;
+        };
+
+        let candidate = candidate_label_under_cursor(ctx, cursor_x, cursor_y);
+        let mut current = ctx.current_target.borrow_mut();
+        if *current == candidate {
+            return; // no change
+        }
+
+        // Hover left the previous candidate.
+        if let Some(prev) = current.as_ref() {
+            crate::events::emit_event_to_window(
+                &ctx.state,
+                prev,
+                "tearoff:hover-cleared",
+                &serde_json::json!({}),
+            );
+        }
+        // Hover entered the new candidate.
+        if let Some(next) = candidate.as_ref() {
+            crate::events::emit_event_to_window(
+                &ctx.state,
+                next,
+                "tearoff:hover-changed",
+                &serde_json::json!({
+                    "cursorX": cursor_x,
+                    "cursorY": cursor_y,
+                    "tabId": ctx.tab_id,
+                }),
+            );
+        }
+        *current = candidate;
+    });
+}
+
+#[cfg(target_os = "windows")]
+fn handle_button_up(cursor_x: i32, cursor_y: i32) {
+    HOOK_CTX.with(|cell| {
+        let ctx_ref = cell.borrow();
+        let Some(ctx) = ctx_ref.as_ref() else {
+            return;
+        };
+
+        let candidate = candidate_label_under_cursor(ctx, cursor_x, cursor_y);
+
+        tracing::info!(
+            target: "dnd:tearoff",
+            tab_id = %ctx.tab_id,
+            cursor_x = %cursor_x,
+            cursor_y = %cursor_y,
+            target = ?candidate,
+            "[dnd:tearoff] mouseup — finalize"
+        );
+
+        match &candidate {
+            Some(target_label) => {
+                // Merge path. Tell the candidate's renderer to pull the
+                // tab in from `dest_ws_id` (the temporary workspace the
+                // dragged window owns). The candidate has its own
+                // workspace ID locally and can compute the insertion
+                // index from `cursorX` against its tab strip geometry.
+                // After the merge the candidate calls closeWindowByLabel
+                // on the dragged window to clean up.
+                crate::events::emit_event_to_window(
+                    &ctx.state,
+                    target_label,
+                    "tearoff:merge",
+                    &serde_json::json!({
+                        "tabId": ctx.tab_id,
+                        "fromWsId": ctx.dest_ws_id,
+                        "draggedWindowLabel": ctx.dragged_label,
+                        "cursorX": cursor_x,
+                        "cursorY": cursor_y,
+                    }),
+                );
+            }
+            None => {
+                // Standalone path. The dragged window simply stays
+                // where the user released. Inform the source renderer
+                // (Phase 5 will use this to update any cancel-back UI
+                // state on the source side).
+                crate::events::emit_event_to_window(
+                    &ctx.state,
+                    &ctx.source_label,
+                    "tearoff:standalone",
+                    &serde_json::json!({
+                        "tabId": ctx.tab_id,
+                        "draggedWindowLabel": ctx.dragged_label,
+                    }),
+                );
+            }
+        }
+    });
+}
+
+/// Find the AgentMux window label whose top-level HWND contains the
+/// cursor position. Returns None if the cursor is over the desktop or
+/// a non-AgentMux window. Excludes the dragged window itself
+/// (landing on the dragged window's strip would be a no-op merge).
+#[cfg(target_os = "windows")]
+fn candidate_label_under_cursor(ctx: &HookContext, x: i32, y: i32) -> Option<String> {
+    use windows_sys::Win32::Foundation::POINT;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        GetAncestor, WindowFromPoint, GA_ROOT,
+    };
+
+    let pt = POINT { x, y };
+    let hwnd = unsafe { WindowFromPoint(pt) };
+    if hwnd.is_null() {
+        return None;
+    }
+    let root = unsafe { GetAncestor(hwnd, GA_ROOT) };
+    let root = if root.is_null() { hwnd } else { root };
+
+    // Reverse-lookup label by walking state.browsers. The map is
+    // small (typically 1-3 entries during a tear-off) so linear scan
+    // is fine — and we hold the mutex only for the duration of the
+    // walk, never spanning emit_event calls.
+    let browsers = ctx.state.browsers.lock();
+    for (label, browser) in browsers.iter() {
+        // Skip the dragged window itself.
+        if label == &ctx.dragged_label {
+            continue;
+        }
+        // Only consider top-level instance windows; pane child
+        // browsers etc. don't have tab strips.
+        if !is_instance_label(label) {
+            continue;
+        }
+        use cef::{ImplBrowser, ImplBrowserHost};
+        if let Some(host) = browser.host() {
+            let h = host.window_handle();
+            if !h.0.is_null() && h.0 as *mut std::ffi::c_void == root {
+                return Some(label.clone());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn is_instance_label(label: &str) -> bool {
+    label == "main" || label.starts_with("window-")
+}

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -116,20 +116,55 @@ pub fn start_tear_off_tracking(
             unsafe {
                 use windows_sys::Win32::UI::WindowsAndMessaging::{
                     DispatchMessageW, GetMessageW, SetWindowsHookExW,
-                    TranslateMessage, UnhookWindowsHookEx, MSG, WH_MOUSE_LL,
+                    TranslateMessage, UnhookWindowsHookEx, MSG,
+                    WH_KEYBOARD_LL, WH_MOUSE_LL,
                 };
 
-                let hook = SetWindowsHookExW(
+                // hMod: pass our own module handle (defensive — the
+                // OS accepts NULL for WH_MOUSE_LL/WH_KEYBOARD_LL but
+                // the contract technically requires the module
+                // containing the hook proc).
+                let h_module = windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(
+                    std::ptr::null(),
+                );
+
+                let mouse_hook = SetWindowsHookExW(
                     WH_MOUSE_LL,
                     Some(low_level_mouse_proc),
-                    std::ptr::null_mut(),
+                    h_module,
                     0,
                 );
-                if hook.is_null() {
+                if mouse_hook.is_null() {
                     let err = windows_sys::Win32::Foundation::GetLastError();
                     HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
                     let _ = ready_tx.send(Err(format!(
-                        "SetWindowsHookExW failed: GetLastError={}",
+                        "SetWindowsHookExW(WH_MOUSE_LL) failed: GetLastError={}",
+                        err
+                    )));
+                    return;
+                }
+
+                // ESC during the SC_MOVE modal loop cancels the move
+                // but Windows sends no WM_LBUTTONUP — without a
+                // keyboard hook the mouse hook would survive forever
+                // (and worse, the next unrelated WM_LBUTTONUP anywhere
+                // on the desktop would fire handle_button_up with
+                // stale tear-off context, silently merging the wrong
+                // tab into the wrong window). The keyboard hook
+                // catches VK_ESCAPE and treats it as a standalone
+                // finalisation. (reagent PR #565 P1)
+                let kb_hook = SetWindowsHookExW(
+                    WH_KEYBOARD_LL,
+                    Some(low_level_keyboard_proc),
+                    h_module,
+                    0,
+                );
+                if kb_hook.is_null() {
+                    let err = windows_sys::Win32::Foundation::GetLastError();
+                    UnhookWindowsHookEx(mouse_hook);
+                    HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
+                    let _ = ready_tx.send(Err(format!(
+                        "SetWindowsHookExW(WH_KEYBOARD_LL) failed: GetLastError={}",
                         err
                     )));
                     return;
@@ -139,11 +174,12 @@ pub fn start_tear_off_tracking(
 
                 tracing::info!(
                     target: "dnd:tearoff",
-                    "[dnd:tearoff] hook installed, entering message loop"
+                    "[dnd:tearoff] hooks installed (mouse + keyboard), entering message loop"
                 );
 
-                // Standard GetMessage pump. The loop exits when the
-                // hook callback posts WM_QUIT after WM_LBUTTONUP.
+                // Standard GetMessage pump. The loop exits when a
+                // hook callback posts WM_QUIT after WM_LBUTTONUP or
+                // VK_ESCAPE.
                 let mut msg: MSG = std::mem::zeroed();
                 loop {
                     let r = GetMessageW(&mut msg, std::ptr::null_mut(), 0, 0);
@@ -154,12 +190,13 @@ pub fn start_tear_off_tracking(
                     DispatchMessageW(&msg);
                 }
 
-                UnhookWindowsHookEx(hook);
+                UnhookWindowsHookEx(kb_hook);
+                UnhookWindowsHookEx(mouse_hook);
                 HOOK_CTX.with(|cell| *cell.borrow_mut() = None);
 
                 tracing::info!(
                     target: "dnd:tearoff",
-                    "[dnd:tearoff] hook uninstalled, thread exiting"
+                    "[dnd:tearoff] hooks uninstalled, thread exiting"
                 );
             }
         })
@@ -184,6 +221,56 @@ pub fn start_tear_off_tracking(
     _dest_ws_id: String,
 ) -> Result<(), String> {
     Ok(())
+}
+
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn low_level_keyboard_proc(
+    n_code: i32,
+    w_param: windows_sys::Win32::Foundation::WPARAM,
+    l_param: windows_sys::Win32::Foundation::LPARAM,
+) -> windows_sys::Win32::Foundation::LRESULT {
+    use windows_sys::Win32::UI::Input::KeyboardAndMouse::VK_ESCAPE;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CallNextHookEx, KBDLLHOOKSTRUCT, PostQuitMessage, WM_KEYDOWN, WM_SYSKEYDOWN,
+    };
+
+    if n_code < 0 {
+        return CallNextHookEx(std::ptr::null_mut(), n_code, w_param, l_param);
+    }
+
+    let msg_id = w_param as u32;
+    if msg_id == WM_KEYDOWN || msg_id == WM_SYSKEYDOWN {
+        let kb = &*(l_param as *const KBDLLHOOKSTRUCT);
+        if kb.vkCode == VK_ESCAPE as u32 {
+            // Treat as a standalone finalisation — the dragged
+            // window stays where the user had it. Phase 5 will
+            // upgrade this to a cancel-back when the spec lands
+            // the original-index restoration.
+            HOOK_CTX.with(|cell| {
+                let ctx_ref = cell.borrow();
+                if let Some(ctx) = ctx_ref.as_ref() {
+                    tracing::info!(
+                        target: "dnd:tearoff",
+                        tab_id = %ctx.tab_id,
+                        "[dnd:tearoff] ESC pressed — standalone finalize"
+                    );
+                    crate::events::emit_event_to_window(
+                        &ctx.state,
+                        &ctx.source_label,
+                        "tearoff:standalone",
+                        &serde_json::json!({
+                            "tabId": ctx.tab_id,
+                            "draggedWindowLabel": ctx.dragged_label,
+                            "reason": "esc",
+                        }),
+                    );
+                }
+            });
+            PostQuitMessage(0);
+        }
+    }
+
+    CallNextHookEx(std::ptr::null_mut(), n_code, w_param, l_param)
 }
 
 #[cfg(target_os = "windows")]
@@ -229,26 +316,40 @@ fn handle_mouse_move(cursor_x: i32, cursor_y: i32) {
             return;
         };
 
-        let candidate = candidate_label_under_cursor(ctx, cursor_x, cursor_y);
-        let mut current = ctx.current_target.borrow_mut();
-        if *current == candidate {
-            return; // no change
-        }
+        // Single browsers-lock acquisition: detect candidate AND
+        // pre-clone the browser handles for prev/next targets in
+        // one critical section. Lock held only here, never spanning
+        // emit_event calls below.
+        let (candidate, prev_browser, next_browser, candidate_changed) = {
+            use cef::Browser;
+            let browsers = ctx.state.browsers.lock();
+            let candidate = candidate_label_under_cursor_locked(ctx, &browsers, cursor_x, cursor_y);
+            let prev_label = ctx.current_target.borrow().clone();
+            let candidate_changed = prev_label != candidate;
+            let prev_browser: Option<Browser> = if candidate_changed {
+                prev_label.as_ref().and_then(|l| browsers.get(l).cloned())
+            } else {
+                None
+            };
+            let next_browser: Option<Browser> = candidate
+                .as_ref()
+                .and_then(|l| browsers.get(l).cloned());
+            (candidate, prev_browser, next_browser, candidate_changed)
+        };
 
-        // Hover left the previous candidate.
-        if let Some(prev) = current.as_ref() {
-            crate::events::emit_event_to_window(
-                &ctx.state,
-                prev,
-                "tearoff:hover-cleared",
-                &serde_json::json!({}),
-            );
+        // Lock released — emit events without re-locking.
+        if let Some(b) = prev_browser.as_ref() {
+            crate::events::emit_event(b, "tearoff:hover-cleared", &serde_json::json!({}));
         }
-        // Hover entered the new candidate.
-        if let Some(next) = candidate.as_ref() {
-            crate::events::emit_event_to_window(
-                &ctx.state,
-                next,
+        // Always emit hover-changed when over a candidate, not just on
+        // candidate-change. The destination's insertion indicator
+        // tracks the cursor X within the strip — without per-move
+        // updates the indicator would lock to wherever the cursor
+        // entered and never slide as the user traverses the strip.
+        // (reagent PR #565 P1)
+        if let Some(b) = next_browser.as_ref() {
+            crate::events::emit_event(
+                b,
                 "tearoff:hover-changed",
                 &serde_json::json!({
                     "cursorX": cursor_x,
@@ -257,7 +358,9 @@ fn handle_mouse_move(cursor_x: i32, cursor_y: i32) {
                 }),
             );
         }
-        *current = candidate;
+        if candidate_changed {
+            *ctx.current_target.borrow_mut() = candidate;
+        }
     });
 }
 
@@ -269,7 +372,10 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
             return;
         };
 
-        let candidate = candidate_label_under_cursor(ctx, cursor_x, cursor_y);
+        let candidate = {
+            let browsers = ctx.state.browsers.lock();
+            candidate_label_under_cursor_locked(ctx, &browsers, cursor_x, cursor_y)
+        };
 
         tracing::info!(
             target: "dnd:tearoff",
@@ -322,11 +428,17 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
 }
 
 /// Find the AgentMux window label whose top-level HWND contains the
-/// cursor position. Returns None if the cursor is over the desktop or
-/// a non-AgentMux window. Excludes the dragged window itself
-/// (landing on the dragged window's strip would be a no-op merge).
+/// cursor position. Excludes the dragged window itself (landing on
+/// the dragged window's strip would be a no-op merge). Takes the
+/// browsers lock guard from the caller so we don't re-acquire on
+/// the WM_MOUSEMOVE hot path.
 #[cfg(target_os = "windows")]
-fn candidate_label_under_cursor(ctx: &HookContext, x: i32, y: i32) -> Option<String> {
+fn candidate_label_under_cursor_locked(
+    ctx: &HookContext,
+    browsers: &std::collections::HashMap<String, cef::Browser>,
+    x: i32,
+    y: i32,
+) -> Option<String> {
     use windows_sys::Win32::Foundation::POINT;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         GetAncestor, WindowFromPoint, GA_ROOT,
@@ -340,18 +452,10 @@ fn candidate_label_under_cursor(ctx: &HookContext, x: i32, y: i32) -> Option<Str
     let root = unsafe { GetAncestor(hwnd, GA_ROOT) };
     let root = if root.is_null() { hwnd } else { root };
 
-    // Reverse-lookup label by walking state.browsers. The map is
-    // small (typically 1-3 entries during a tear-off) so linear scan
-    // is fine — and we hold the mutex only for the duration of the
-    // walk, never spanning emit_event calls.
-    let browsers = ctx.state.browsers.lock();
     for (label, browser) in browsers.iter() {
-        // Skip the dragged window itself.
         if label == &ctx.dragged_label {
             continue;
         }
-        // Only consider top-level instance windows; pane child
-        // browsers etc. don't have tab strips.
         if !is_instance_label(label) {
             continue;
         }

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -62,6 +62,45 @@ pub fn close_window(state: &Arc<AppState>) -> Result<serde_json::Value, String> 
     Ok(serde_json::Value::Null)
 }
 
+/// Close a specific window by label. Used by the tear-off Phase 4
+/// merge path: after the candidate window pulls the dragged tab into
+/// its own workspace via MoveTabToWorkspace, the dragged window is
+/// empty and should be destroyed. Posts WM_CLOSE on Win32; uses the
+/// existing UI-thread close task on other platforms.
+pub fn close_window_by_label(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "missing label".to_string())?
+        .to_string();
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use cef::{ImplBrowser, ImplBrowserHost};
+        use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+        let browsers = state.browsers.lock();
+        if let Some(browser) = browsers.get(&label) {
+            if let Some(host) = browser.host() {
+                let hwnd = host.window_handle();
+                if !hwnd.0.is_null() {
+                    PostMessageW(hwnd.0 as *mut std::ffi::c_void, WM_CLOSE, 0, 0);
+                    return Ok(serde_json::Value::Null);
+                }
+            }
+        }
+        return Err(format!("no top-level HWND for label {}", label));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        crate::ui_tasks::post_close_window(state, &label);
+        Ok(serde_json::Value::Null)
+    }
+}
+
 /// Minimize the window.
 pub fn minimize_window(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
     #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/events.rs
+++ b/agentmux-cef/src/events.rs
@@ -55,3 +55,29 @@ pub fn emit_event_all_windows(state: &crate::state::AppState, event: &str, paylo
         emit_event(browser, event, payload);
     }
 }
+
+/// Emit an event to a specific browser window by label.
+/// Used by the tear-off Phase 4 hook to push merge-candidate
+/// changes to the destination renderer.
+pub fn emit_event_to_window(
+    state: &crate::state::AppState,
+    label: &str,
+    event: &str,
+    payload: &serde_json::Value,
+) -> bool {
+    let browsers = state.browsers.lock();
+    match browsers.get(label) {
+        Some(browser) => {
+            emit_event(browser, event, payload);
+            true
+        }
+        None => {
+            tracing::warn!(
+                "Cannot emit event '{}' to label '{}': no such browser",
+                event,
+                label
+            );
+            false
+        }
+    }
+}

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -274,6 +274,7 @@ async fn route_command(
         }
         "list_windows" => Ok(commands::window::list_windows(state)),
         "focus_window" => commands::window::focus_window(state, args),
+        "close_window_by_label" => commands::window::close_window_by_label(state, args),
 
         // ---- Clipboard (CEF can't use navigator.clipboard without permission policy) ----
         "read_clipboard" => commands::clipboard::read_clipboard(),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.411"
+version = "0.33.412"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.410"
+version = "0.33.411"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.410"
+version = "0.33.411"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.411"
+version = "0.33.412"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.410"
+version = "0.33.411"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.411"
+version = "0.33.412"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -248,27 +248,56 @@ function TabBar(props: TabBarProps): JSX.Element {
     //    releases over no AgentMux window. Currently informational only;
     //    Phase 5 will use this to update cancel-back UI state.
     onMount(() => {
+        // `mounted` flag protects against the race where the component
+        // unmounts (e.g. tab change, HMR) while the dynamic import or
+        // listenEvent calls are still in flight. Without this, listeners
+        // registered after onCleanup ran would leak forever — they're
+        // not in `unsubs` yet when onCleanup fires, so the cleanup pass
+        // misses them. (gemini PR #565 HIGH)
+        let mounted = true;
         let unsubs: Array<() => void> = [];
+        const trackOrDispose = (unsub: () => void) => {
+            if (mounted) {
+                unsubs.push(unsub);
+            } else {
+                unsub();
+            }
+        };
         fireAndForget(async () => {
             const { listenEvent } = await import("@/app/platform/ipc");
+            if (!mounted) return;
 
-            unsubs.push(
+            trackOrDispose(
                 await listenEvent<{ cursorX: number; cursorY: number }>(
                     "tearoff:hover-changed",
                     (payload) => {
+                        // Host emits hover-changed when cursor is over
+                        // ANY part of this window's HWND; check Y against
+                        // the strip rect so dropping on the content area
+                        // doesn't trigger a merge. (codex PR #565 P1)
+                        const stripRect = tabBarScrollRef?.getBoundingClientRect();
+                        if (!stripRect) {
+                            setInsertionPoint(null);
+                            return;
+                        }
                         const clientX = payload.cursorX - window.screenX;
+                        const clientY = payload.cursorY - window.screenY;
+                        if (clientY < stripRect.top || clientY > stripRect.bottom) {
+                            setInsertionPoint(null);
+                            return;
+                        }
                         setInsertionPoint(computeInsertionPoint(clientX));
                     },
                 ),
             );
 
-            unsubs.push(
+            trackOrDispose(
                 await listenEvent("tearoff:hover-cleared", () => {
                     setInsertionPoint(null);
                 }),
             );
 
-            unsubs.push(
+            trackOrDispose(
                 await listenEvent<{
                     tabId: string;
                     fromWsId: string;
@@ -284,7 +313,24 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 Logger.warn("dnd", "tearoff:merge — no own workspace, skipping", payload);
                                 return;
                             }
+                            // Strip-area hit test: only merge when the
+                            // cursor is actually over the tab strip,
+                            // not the content area below. Otherwise an
+                            // accidental release while passing over a
+                            // window's body would silently relocate
+                            // the tab. (codex PR #565 P1)
+                            const stripRect = tabBarScrollRef?.getBoundingClientRect();
                             const clientX = payload.cursorX - window.screenX;
+                            const clientY = payload.cursorY - window.screenY;
+                            if (
+                                !stripRect ||
+                                clientY < stripRect.top ||
+                                clientY > stripRect.bottom
+                            ) {
+                                Logger.info("dnd", "tearoff:merge — cursor not over strip, leaving as standalone", payload);
+                                setInsertionPoint(null);
+                                return;
+                            }
                             const ip = computeInsertionPoint(clientX);
                             const tabs = tabIds();
                             // Convert insertion point to numeric index. The
@@ -325,13 +371,14 @@ function TabBar(props: TabBarProps): JSX.Element {
                 }),
             );
 
-            unsubs.push(
+            trackOrDispose(
                 await listenEvent("tearoff:standalone", (payload) => {
                     Logger.info("dnd", "tearoff:standalone", payload);
                 }),
             );
         });
         onCleanup(() => {
+            mounted = false;
             for (const u of unsubs) u();
             unsubs = [];
         });

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -231,6 +231,112 @@ function TabBar(props: TabBarProps): JSX.Element {
         onCleanup(cleanup);
     });
 
+    // Phase 4 — listen for the host's tear-off events. Each AgentMux
+    // window subscribes; the host targets the right window via
+    // emit_event_to_window so other windows see nothing.
+    //
+    //  tearoff:hover-changed — cursor entered this window's strip area
+    //    while another window's tab is mid-tear-off. Show the standard
+    //    insertion-point indicator so the user can see where the merge
+    //    will land.
+    //  tearoff:hover-cleared — cursor left this window's strip. Drop
+    //    the indicator.
+    //  tearoff:merge — mouseup over this window. Pull the dragged
+    //    tab into our workspace at the cursor's X position, then close
+    //    the (now empty) dragged window.
+    //  tearoff:standalone — emitted to the source window when the user
+    //    releases over no AgentMux window. Currently informational only;
+    //    Phase 5 will use this to update cancel-back UI state.
+    onMount(() => {
+        let unsubs: Array<() => void> = [];
+        fireAndForget(async () => {
+            const { listenEvent } = await import("@/app/platform/ipc");
+
+            unsubs.push(
+                await listenEvent<{ cursorX: number; cursorY: number }>(
+                    "tearoff:hover-changed",
+                    (payload) => {
+                        const clientX = payload.cursorX - window.screenX;
+                        setInsertionPoint(computeInsertionPoint(clientX));
+                    },
+                ),
+            );
+
+            unsubs.push(
+                await listenEvent("tearoff:hover-cleared", () => {
+                    setInsertionPoint(null);
+                }),
+            );
+
+            unsubs.push(
+                await listenEvent<{
+                    tabId: string;
+                    fromWsId: string;
+                    draggedWindowLabel: string;
+                    cursorX: number;
+                    cursorY: number;
+                }>("tearoff:merge", (payload) => {
+                    setInsertionPoint(null);
+                    fireAndForget(async () => {
+                        try {
+                            const ownWsId = props.workspace?.oid;
+                            if (!ownWsId) {
+                                Logger.warn("dnd", "tearoff:merge — no own workspace, skipping", payload);
+                                return;
+                            }
+                            const clientX = payload.cursorX - window.screenX;
+                            const ip = computeInsertionPoint(clientX);
+                            const tabs = tabIds();
+                            // Convert insertion point to numeric index. The
+                            // dragged tab isn't in `tabs` (different workspace),
+                            // so no removal-shift adjustment needed (unlike
+                            // executeReorder above).
+                            let insertIdx: number;
+                            if (!ip) {
+                                insertIdx = tabs.length;
+                            } else if (ip.beforeTabId === null) {
+                                insertIdx = 0;
+                            } else if (ip.afterTabId === null) {
+                                insertIdx = tabs.length;
+                            } else {
+                                insertIdx = tabs.indexOf(ip.afterTabId);
+                                if (insertIdx < 0) insertIdx = tabs.length;
+                            }
+                            await WorkspaceService.MoveTabToWorkspace(
+                                payload.tabId,
+                                payload.fromWsId,
+                                ownWsId,
+                                insertIdx,
+                            );
+                            await getApi().closeWindowByLabel(payload.draggedWindowLabel);
+                            Logger.info("dnd", "tearoff:merge complete", {
+                                tabId: payload.tabId,
+                                fromWsId: payload.fromWsId,
+                                ownWsId,
+                                insertIdx,
+                            });
+                        } catch (e) {
+                            Logger.error("dnd", "tearoff:merge failed", {
+                                error: String(e),
+                                payload,
+                            });
+                        }
+                    });
+                }),
+            );
+
+            unsubs.push(
+                await listenEvent("tearoff:standalone", (payload) => {
+                    Logger.info("dnd", "tearoff:standalone", payload);
+                }),
+            );
+        });
+        onCleanup(() => {
+            for (const u of unsubs) u();
+            unsubs = [];
+        });
+    });
+
     // Mouse-wheel hover over the strip → horizontal scroll. Ctrl+wheel
     // is reserved for the app-wide zoom (see AppZoomHandler in app.tsx),
     // so this only kicks in for unmodified scrolls. We forward whichever
@@ -355,6 +461,12 @@ async function requestTearOff(
             destWindowLabel,
             cursorX,
             cursorY,
+            // Phase 4 — fields the host hook needs to drive the merge
+            // event on mouseup. Without these the hook is skipped and
+            // the dragged window simply ends as a standalone.
+            tabId,
+            sourceWsId: workspaceId,
+            destWsId: newWsId,
         });
         // Handshake succeeded — Windows now owns the move loop. Clear
         // the cross-window drag payload so the legacy dragend pipeline

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -184,7 +184,19 @@ declare global {
             destWindowLabel: string;
             cursorX: number;
             cursorY: number;
+            /** Phase 4 — drives the WH_MOUSE_LL hook for cross-window
+             *  merge detection. When all three are non-empty, the host
+             *  arms the hook before posting SC_MOVE; on mouseup the
+             *  candidate window receives `tearoff:merge` (or the source
+             *  receives `tearoff:standalone` if no candidate). */
+            tabId?: string;
+            sourceWsId?: string;
+            destWsId?: string;
         }) => Promise<{ handshakeMs: number; totalMs: number }>;
+        /** Close a specific AgentMux window by label. Used by Phase 4
+         *  merge to clean up the dragged window after its tab is moved
+         *  into the destination workspace. */
+        closeWindowByLabel: (label: string) => Promise<void>;
         setDragCursor: () => Promise<void>;
         restoreDragCursor: () => Promise<void>;
         releaseDragCapture: () => Promise<void>;

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -582,6 +582,9 @@ export function buildCefApi(): AppApi {
                 args,
             );
         },
+        closeWindowByLabel: async (label: string) => {
+            await invokeCommand("close_window_by_label", { label });
+        },
 
         // --- Drag cursor & helpers ---
         setDragCursor: async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.410",
+  "version": "0.33.411",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.410",
+      "version": "0.33.411",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.411",
+  "version": "0.33.412",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.411",
+      "version": "0.33.412",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.410",
+  "version": "0.33.411",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.411",
+  "version": "0.33.412",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 4 of the tear-off spec at \`docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md\`. Closes the killer Chrome feature: **dropping a torn-off tab onto another AgentMux window's strip merges the tab into that window's workspace**. Drop on empty desktop or non-AgentMux app → tab stays as a standalone window (existing Phase 2 behaviour preserved).

## Architecture

### Backend (Win32)

\`agentmux-cef/src/commands/tear_off_hook.rs\` (new, ~290 lines):

- \`start_tear_off_tracking()\` spawns a dedicated thread, installs \`WH_MOUSE_LL\` via \`SetWindowsHookExW(thread_id=0)\`, runs its own \`GetMessage\` loop. Hook context lives in thread-local \`RefCell\` since the low-level mouse callback signature has no user-data slot.
- On every \`WM_MOUSEMOVE\`: \`WindowFromPoint\` → \`GetAncestor(GA_ROOT)\` → look up in \`state.browsers\`, skipping the dragged window itself. Candidate-change → emit \`tearoff:hover-changed\` / \`-cleared\` to the affected windows.
- On \`WM_LBUTTONUP\`: emit \`tearoff:merge\` to the candidate (or \`tearoff:standalone\` to source if no candidate). \`PostQuitMessage\` breaks the loop, hook uninstalls, thread exits.
- Hook is armed BEFORE \`PostMessageW(SC_MOVE)\` in \`tear_off_sc_move_handshake\` so the first cursor positions of the move-loop aren't missed. Uses an \`mpsc\` oneshot to block until the hook is fully installed.

### Frontend

\`tabbar.tsx\` \`requestTearOff\` payload extended with \`tabId / sourceWsId / destWsId\`. New \`onMount\` block subscribes to the four \`tearoff:*\` events:

- **hover-changed/-cleared** → drives the existing \`setInsertionPoint\` signal. The gap-glide animation already in place renders the indicator unchanged.
- **merge** → computes insertion index from cursor X (screen→client via \`window.screenX\`) using the existing \`computeInsertionPoint\`. Calls \`MoveTabToWorkspace(tabId, fromWsId, ownWsId, idx)\` then \`closeWindowByLabel(draggedWindowLabel)\`.
- **standalone** → currently informational only (Phase 5 will use this for cancel-back UI updates).

### New plumbing

- \`emit_event_to_window\` in \`events.rs\` — targets a specific browser by label.
- \`close_window_by_label\` IPC — posts \`WM_CLOSE\` to a specific HWND (used by the candidate after merging).

## Per-spec quality bar

- ✅ **Pixel-accurate merge insertion (G6)** — uses \`computeInsertionPoint\` on the candidate's strip geometry, same code path as in-window reorder.
- ⏭ **Cancel-back-to-source (G7)** deferred to Phase 5. When candidate == source label, the merge currently treats it as a regular same-workspace move (degenerate but harmless — the tab moves back to source's workspace at the cursor's X, just not at the original index).
- ⏭ **ESC during move-loop** deferred to Phase 5. Windows cancels \`SC_MOVE\` on ESC and the hook never sees \`WM_LBUTTONUP\`, so we currently leak the hook thread (sits in \`GetMessage\` forever). Phase 5 adds a \`WM_QUIT\` path.

## Test plan

- [ ] Open AgentMux. Drag a tab past the strip's bottom → new window appears + follows cursor (Phase 2 behaviour unchanged).
- [ ] **NEW**: drag the moving window over another AgentMux window's tab strip → strip should show the standard insertion-point indicator at the cursor X. Move along the strip → indicator moves between gaps.
- [ ] **NEW**: release the mouse over the candidate's strip → tab should merge into that workspace at the indicated position; the dragged window should close.
- [ ] Drop over the desktop / non-AgentMux app → existing standalone behaviour, no merge.
- [ ] Multi-window scenario: open 3 windows. Tear from window A, drop over window B → tab in B; A and B's other tabs unchanged; the temporary window destroyed.
- [ ] Look for \`[dnd:tearoff] mouseup — finalize\` log line with \`target=Some(\"window-...\")\` on merge or \`target=None\` on standalone.

## Notes for reviewers

- The hook thread is named \`tear-off-hook\` for tracing visibility.
- Per \`reference_pr_review_bots.md\` codex doesn't auto-fire on push; will trigger \`@codex review\` as a5af after open.
- \`unsafe\` blocks are kept tight (just the Win32 calls); all the bookkeeping is safe Rust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)