### PR TITLE
feat(tab-tear-off): Phase 5 — cancel-back-to-source (ESC + drop-on-source)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.419"
+version = "0.33.420"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.419"
+version = "0.33.420"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.419"
+version = "0.33.420"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.419"
+version = "0.33.420"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.428"
+version = "0.33.429"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.428"
+version = "0.33.429"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.428"
+version = "0.33.429"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.428"
+version = "0.33.429"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.426"
+version = "0.33.427"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.426"
+version = "0.33.427"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.426"
+version = "0.33.427"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.426"
+version = "0.33.427"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.422"
+version = "0.33.423"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.422"
+version = "0.33.423"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.422"
+version = "0.33.423"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.422"
+version = "0.33.423"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.425"
+version = "0.33.426"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.425"
+version = "0.33.426"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.425"
+version = "0.33.426"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.425"
+version = "0.33.426"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.427"
+version = "0.33.428"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.427"
+version = "0.33.428"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.427"
+version = "0.33.428"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.427"
+version = "0.33.428"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.420"
+version = "0.33.421"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.420"
+version = "0.33.421"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.420"
+version = "0.33.421"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.420"
+version = "0.33.421"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.423"
+version = "0.33.424"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.423"
+version = "0.33.424"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.423"
+version = "0.33.424"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.423"
+version = "0.33.424"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.424"
+version = "0.33.425"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.424"
+version = "0.33.425"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.424"
+version = "0.33.425"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.424"
+version = "0.33.425"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.421"
+version = "0.33.422"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.421"
+version = "0.33.422"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.421"
+version = "0.33.422"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.421"
+version = "0.33.422"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.419"
+version = "0.33.420"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.420"
+version = "0.33.421"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.421"
+version = "0.33.422"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.428"
+version = "0.33.429"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.426"
+version = "0.33.427"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.423"
+version = "0.33.424"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.427"
+version = "0.33.428"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.425"
+version = "0.33.426"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.424"
+version = "0.33.425"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.422"
+version = "0.33.423"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -473,6 +473,14 @@ pub fn tear_off_sc_move_handshake(
         .get("originalTabIndex")
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as usize;
+    // Phase 5 — was the tab pinned in its source workspace?
+    // Threaded into HookContext so the cancel-back payload can tell
+    // the backend to restore into pinnedtabids vs tabids. Defaults
+    // to false (regular tab). (gemini PR #567 round-6 MEDIUM)
+    let was_pinned = args
+        .get("wasPinned")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     // Win32-only path. The HWND poll, ReleaseCapture, and the SC_MOVE
     // post all live inside the cfg block — on macOS / Linux the
@@ -505,6 +513,7 @@ pub fn tear_off_sc_move_handshake(
                 source_ws_id.clone(),
                 dest_ws_id.clone(),
                 original_tab_index,
+                was_pinned,
             )?;
         }
 

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -465,6 +465,14 @@ pub fn tear_off_sc_move_handshake(
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    // Phase 5 — original tab index for cancel-back (ESC or drop on
+    // source strip). Defaults to 0 if missing — cancel-back will
+    // reinsert at start, which is best-effort if the caller didn't
+    // provide the real index.
+    let original_tab_index = args
+        .get("originalTabIndex")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
 
     // Win32-only path. The HWND poll, ReleaseCapture, and the SC_MOVE
     // post all live inside the cfg block — on macOS / Linux the
@@ -496,6 +504,7 @@ pub fn tear_off_sc_move_handshake(
                 tab_id.clone(),
                 source_ws_id.clone(),
                 dest_ws_id.clone(),
+                original_tab_index,
             )?;
         }
 

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -72,6 +72,11 @@ struct HookContext {
     /// AgentMux window or the desktop. Used to emit hover-clear events
     /// when the cursor leaves a candidate.
     current_target: RefCell<Option<String>>,
+    /// Set true the moment a finalisation event has been emitted
+    /// (cancel-back via ESC, merge, or standalone). Subsequent hook
+    /// callbacks bail without emitting — without this guard, a
+    /// post-ESC mouseup would fire a second redundant event.
+    finalized: RefCell<bool>,
 }
 
 #[cfg(target_os = "windows")]
@@ -116,6 +121,7 @@ pub fn start_tear_off_tracking(
                 dest_ws_id,
                 original_tab_index,
                 current_target: RefCell::new(None),
+                finalized: RefCell::new(false),
             };
             HOOK_CTX.with(|cell| *cell.borrow_mut() = Some(ctx));
 
@@ -255,6 +261,10 @@ unsafe extern "system" fn low_level_keyboard_proc(
             HOOK_CTX.with(|cell| {
                 let ctx_ref = cell.borrow();
                 if let Some(ctx) = ctx_ref.as_ref() {
+                    if *ctx.finalized.borrow() {
+                        return;
+                    }
+                    *ctx.finalized.borrow_mut() = true;
                     tracing::info!(
                         target: "dnd:tearoff",
                         tab_id = %ctx.tab_id,
@@ -380,6 +390,12 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
         let Some(ctx) = ctx_ref.as_ref() else {
             return;
         };
+        // If a previous handler already finalized (e.g. ESC fired and
+        // posted WM_QUIT, but this mouseup arrived first), bail.
+        if *ctx.finalized.borrow() {
+            return;
+        }
+        *ctx.finalized.borrow_mut() = true;
 
         let candidate = {
             let browsers = ctx.state.browsers.lock();
@@ -397,15 +413,19 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
 
         match &candidate {
             Some(target_label) if target_label == &ctx.source_label => {
-                // Phase 5 cancel-back: drop on the source window's own
-                // strip. Restore the tab at its original index — not
-                // wherever the cursor happens to land — so the user
-                // gets back the exact pre-tear state.
+                // Phase 5 cancel-back path. The cursor is over the
+                // source window — but candidate_label_under_cursor only
+                // identifies the top-level HWND, not which sub-region
+                // (strip vs content vs sidebar). The frontend's
+                // cancel-back handler does the same strip hit-test
+                // the merge handler does, and falls through to
+                // standalone behaviour if the cursor isn't on the
+                // strip. We pass cursorY so the frontend can decide.
                 tracing::info!(
                     target: "dnd:tearoff",
                     tab_id = %ctx.tab_id,
                     original_index = %ctx.original_tab_index,
-                    "[dnd:tearoff] drop on source strip — cancel-back"
+                    "[dnd:tearoff] drop on source window — cancel-back candidate"
                 );
                 crate::events::emit_event_to_window(
                     &ctx.state,
@@ -416,6 +436,8 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
                         "fromWsId": ctx.dest_ws_id,
                         "draggedWindowLabel": ctx.dragged_label,
                         "originalIndex": ctx.original_tab_index,
+                        "cursorX": cursor_x,
+                        "cursorY": cursor_y,
                         "reason": "drop-on-source",
                     }),
                 );

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -62,8 +62,12 @@ struct HookContext {
     /// `MoveTabToWorkspace` from a different window context if needed.
     source_ws_id: String,
     /// Destination workspace ID (the new workspace TearOffTab created).
-    /// Used by the source-side cancel-back path in Phase 5.
+    /// Cancel-back uses this as the `fromWsId` when restoring.
     dest_ws_id: String,
+    /// Phase 5 — tab's original index in the source workspace at the
+    /// moment of tear-off. Used by cancel-back (ESC or drop on source
+    /// strip) to reinsert the tab where it was, not at the end.
+    original_tab_index: usize,
     /// Last-known candidate target label, or None when over a non-
     /// AgentMux window or the desktop. Used to emit hover-clear events
     /// when the cursor leaves a candidate.
@@ -90,6 +94,7 @@ pub fn start_tear_off_tracking(
     tab_id: String,
     source_ws_id: String,
     dest_ws_id: String,
+    original_tab_index: usize,
 ) -> Result<(), String> {
     use std::sync::mpsc;
 
@@ -109,6 +114,7 @@ pub fn start_tear_off_tracking(
                 tab_id,
                 source_ws_id,
                 dest_ws_id,
+                original_tab_index,
                 current_target: RefCell::new(None),
             };
             HOOK_CTX.with(|cell| *cell.borrow_mut() = Some(ctx));
@@ -219,6 +225,7 @@ pub fn start_tear_off_tracking(
     _tab_id: String,
     _source_ws_id: String,
     _dest_ws_id: String,
+    _original_tab_index: usize,
 ) -> Result<(), String> {
     Ok(())
 }
@@ -242,25 +249,27 @@ unsafe extern "system" fn low_level_keyboard_proc(
     if msg_id == WM_KEYDOWN || msg_id == WM_SYSKEYDOWN {
         let kb = &*(l_param as *const KBDLLHOOKSTRUCT);
         if kb.vkCode == VK_ESCAPE as u32 {
-            // Treat as a standalone finalisation — the dragged
-            // window stays where the user had it. Phase 5 will
-            // upgrade this to a cancel-back when the spec lands
-            // the original-index restoration.
+            // Phase 5: ESC = cancel-back. The dragged window is
+            // destroyed and the tab reinserts at its original index
+            // in the source workspace.
             HOOK_CTX.with(|cell| {
                 let ctx_ref = cell.borrow();
                 if let Some(ctx) = ctx_ref.as_ref() {
                     tracing::info!(
                         target: "dnd:tearoff",
                         tab_id = %ctx.tab_id,
-                        "[dnd:tearoff] ESC pressed — standalone finalize"
+                        original_index = %ctx.original_tab_index,
+                        "[dnd:tearoff] ESC pressed — cancel-back to source"
                     );
                     crate::events::emit_event_to_window(
                         &ctx.state,
                         &ctx.source_label,
-                        "tearoff:standalone",
+                        "tearoff:cancel-back",
                         &serde_json::json!({
                             "tabId": ctx.tab_id,
+                            "fromWsId": ctx.dest_ws_id,
                             "draggedWindowLabel": ctx.dragged_label,
+                            "originalIndex": ctx.original_tab_index,
                             "reason": "esc",
                         }),
                     );
@@ -387,6 +396,30 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
         );
 
         match &candidate {
+            Some(target_label) if target_label == &ctx.source_label => {
+                // Phase 5 cancel-back: drop on the source window's own
+                // strip. Restore the tab at its original index — not
+                // wherever the cursor happens to land — so the user
+                // gets back the exact pre-tear state.
+                tracing::info!(
+                    target: "dnd:tearoff",
+                    tab_id = %ctx.tab_id,
+                    original_index = %ctx.original_tab_index,
+                    "[dnd:tearoff] drop on source strip — cancel-back"
+                );
+                crate::events::emit_event_to_window(
+                    &ctx.state,
+                    &ctx.source_label,
+                    "tearoff:cancel-back",
+                    &serde_json::json!({
+                        "tabId": ctx.tab_id,
+                        "fromWsId": ctx.dest_ws_id,
+                        "draggedWindowLabel": ctx.dragged_label,
+                        "originalIndex": ctx.original_tab_index,
+                        "reason": "drop-on-source",
+                    }),
+                );
+            }
             Some(target_label) => {
                 // Merge path. Tell the candidate's renderer to pull the
                 // tab in from `dest_ws_id` (the temporary workspace the
@@ -411,8 +444,8 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
             None => {
                 // Standalone path. The dragged window simply stays
                 // where the user released. Inform the source renderer
-                // (Phase 5 will use this to update any cancel-back UI
-                // state on the source side).
+                // (informational only — no UI state to update on the
+                // source side; the tab is already gone).
                 crate::events::emit_event_to_window(
                     &ctx.state,
                     &ctx.source_label,

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -67,7 +67,14 @@ struct HookContext {
     /// Phase 5 — tab's original index in the source workspace at the
     /// moment of tear-off. Used by cancel-back (ESC or drop on source
     /// strip) to reinsert the tab where it was, not at the end.
+    /// Index is into `pinnedtabids` if `was_pinned`, else into `tabids`.
     original_tab_index: usize,
+    /// Phase 5 — true if the tab was pinned in its source workspace.
+    /// Threaded through to the cancel-back payload so the backend can
+    /// restore into `pinnedtabids` and preserve pinned status. Without
+    /// this, a pinned tab torn off + cancel-backed would silently
+    /// come back unpinned. (gemini PR #567 round-6 MEDIUM)
+    was_pinned: bool,
     /// Last-known candidate target label, or None when over a non-
     /// AgentMux window or the desktop. Used to emit hover-clear events
     /// when the cursor leaves a candidate.
@@ -100,6 +107,7 @@ pub fn start_tear_off_tracking(
     source_ws_id: String,
     dest_ws_id: String,
     original_tab_index: usize,
+    was_pinned: bool,
 ) -> Result<(), String> {
     use std::sync::mpsc;
 
@@ -120,6 +128,7 @@ pub fn start_tear_off_tracking(
                 source_ws_id,
                 dest_ws_id,
                 original_tab_index,
+                was_pinned,
                 current_target: RefCell::new(None),
                 finalized: RefCell::new(false),
             };
@@ -232,6 +241,7 @@ pub fn start_tear_off_tracking(
     _source_ws_id: String,
     _dest_ws_id: String,
     _original_tab_index: usize,
+    _was_pinned: bool,
 ) -> Result<(), String> {
     Ok(())
 }
@@ -281,6 +291,7 @@ unsafe extern "system" fn low_level_keyboard_proc(
                             "originalSourceWsId": ctx.source_ws_id,
                             "draggedWindowLabel": ctx.dragged_label,
                             "originalIndex": ctx.original_tab_index,
+                            "wasPinned": ctx.was_pinned,
                             "reason": "esc",
                         }),
                     );
@@ -438,6 +449,7 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
                         "originalSourceWsId": ctx.source_ws_id,
                         "draggedWindowLabel": ctx.dragged_label,
                         "originalIndex": ctx.original_tab_index,
+                        "wasPinned": ctx.was_pinned,
                         "cursorX": cursor_x,
                         "cursorY": cursor_y,
                         "reason": "drop-on-source",

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -278,6 +278,7 @@ unsafe extern "system" fn low_level_keyboard_proc(
                         &serde_json::json!({
                             "tabId": ctx.tab_id,
                             "fromWsId": ctx.dest_ws_id,
+                            "originalSourceWsId": ctx.source_ws_id,
                             "draggedWindowLabel": ctx.dragged_label,
                             "originalIndex": ctx.original_tab_index,
                             "reason": "esc",
@@ -434,6 +435,7 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
                     &serde_json::json!({
                         "tabId": ctx.tab_id,
                         "fromWsId": ctx.dest_ws_id,
+                        "originalSourceWsId": ctx.source_ws_id,
                         "draggedWindowLabel": ctx.dragged_label,
                         "originalIndex": ctx.original_tab_index,
                         "cursorX": cursor_x,

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.428"
+version = "0.33.429"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.425"
+version = "0.33.426"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.422"
+version = "0.33.423"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.424"
+version = "0.33.425"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.420"
+version = "0.33.421"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.423"
+version = "0.33.424"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.426"
+version = "0.33.427"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.421"
+version = "0.33.422"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.427"
+version = "0.33.428"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.419"
+version = "0.33.420"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.424"
+version = "0.33.425"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.426"
+version = "0.33.427"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.421"
+version = "0.33.422"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.423"
+version = "0.33.424"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.428"
+version = "0.33.429"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.422"
+version = "0.33.423"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.427"
+version = "0.33.428"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.419"
+version = "0.33.420"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.420"
+version = "0.33.421"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.425"
+version = "0.33.426"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.426"
+version = "0.33.427"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.420"
+version = "0.33.421"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.425"
+version = "0.33.426"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.422"
+version = "0.33.423"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.424"
+version = "0.33.425"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.427"
+version = "0.33.428"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.428"
+version = "0.33.429"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.419"
+version = "0.33.420"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.423"
+version = "0.33.424"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.421"
+version = "0.33.422"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -337,13 +337,19 @@ pub fn restore_torn_off_tab(
         let source_now_empty =
             source_ws.tabids.is_empty() && source_ws.pinnedtabids.is_empty();
         if source_ws.activetabid == tab_id {
-            let new_active = source_ws
+            // Only assign a new active tab if one actually exists.
+            // When source_now_empty, both lists are empty and we go
+            // straight to delete below — no need to write an empty
+            // activetabid into the persisted record. (gemini PR #567
+            // round-8 MEDIUM)
+            if let Some(new_active) = source_ws
                 .tabids
                 .first()
                 .or(source_ws.pinnedtabids.first())
                 .cloned()
-                .unwrap_or_default();
-            source_ws.activetabid = new_active;
+            {
+                source_ws.activetabid = new_active;
+            }
         }
 
         // De-dup in destination before insert. A retried frontend request

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -281,6 +281,80 @@ pub fn tear_off_block(
     store.must_get::<Workspace>(&new_ws.oid)
 }
 
+/// Move a tab back from a tear-off workspace into a destination workspace.
+/// Unlike `move_tab_to_workspace`, this skips the "last tab" guard because
+/// tear-off workspaces always contain exactly one tab — and after the move
+/// the source workspace has zero tabs and is deleted.
+///
+/// Used by Phase 5 cancel-back (ESC / drop-on-source) and by Phase 4 merge
+/// (drop on another window's strip). Both paths produce a single-tab source
+/// workspace whose only purpose is to carry the dragged tab.
+pub fn restore_torn_off_tab(
+    store: &WaveStore,
+    tab_id: &str,
+    source_ws_id: &str,
+    dest_ws_id: &str,
+    insert_index: Option<usize>,
+) -> Result<(), StoreError> {
+    tracing::info!(
+        tab_id = %tab_id,
+        source_ws = %source_ws_id,
+        dest_ws = %dest_ws_id,
+        insert_index = ?insert_index,
+        "[dnd] restore_torn_off_tab"
+    );
+    if source_ws_id == dest_ws_id {
+        tracing::debug!("[dnd] restore_torn_off_tab: same workspace, no-op");
+        return Ok(());
+    }
+
+    // Verify tab exists.
+    let _tab = store.must_get::<Tab>(tab_id)?;
+
+    // Remove tab from source workspace. No last-tab guard: a tear-off
+    // workspace's only tab IS the one being restored.
+    let mut source_ws = store.must_get::<Workspace>(source_ws_id)?;
+    source_ws.tabids.retain(|id| id != tab_id);
+    source_ws.pinnedtabids.retain(|id| id != tab_id);
+    let source_now_empty =
+        source_ws.tabids.is_empty() && source_ws.pinnedtabids.is_empty();
+    if source_ws.activetabid == tab_id {
+        let new_active = source_ws
+            .tabids
+            .first()
+            .or(source_ws.pinnedtabids.first())
+            .cloned()
+            .unwrap_or_default();
+        source_ws.activetabid = new_active;
+    }
+    store.update(&mut source_ws)?;
+
+    // Add tab to destination workspace at requested index.
+    let mut dest_ws = store.must_get::<Workspace>(dest_ws_id)?;
+    let idx = insert_index.unwrap_or(dest_ws.tabids.len());
+    let insert_at = idx.min(dest_ws.tabids.len());
+    dest_ws.tabids.insert(insert_at, tab_id.to_string());
+    dest_ws.activetabid = tab_id.to_string();
+    store.update(&mut dest_ws)?;
+
+    // Delete the now-empty source workspace so the dragged window's
+    // close (which the frontend issues immediately after) doesn't
+    // attempt a redundant cascade. The tab record itself stays — it
+    // belongs to the destination workspace now.
+    if source_now_empty {
+        tracing::info!(source_ws = %source_ws_id, "[dnd] deleting empty tear-off workspace");
+        store.delete::<Workspace>(source_ws_id)?;
+    }
+
+    tracing::info!(
+        tab_id = %tab_id,
+        dest_ws = %dest_ws_id,
+        insert_at = %insert_at,
+        "[dnd] restore_torn_off_tab complete"
+    );
+    Ok(())
+}
+
 /// Tear off a tab into a new workspace.
 /// Removes the tab from the source workspace and creates a new workspace
 /// containing just that tab. Returns the new workspace.

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -308,12 +308,19 @@ pub fn restore_torn_off_tab(
         return Ok(());
     }
 
-    // Verify tab exists.
+    // Validate everything we're going to touch BEFORE mutating any of
+    // it. If `dest_ws_id` is stale (e.g. user closed the original
+    // window while the SC_MOVE loop was running, or sent a malformed
+    // request), `must_get::<Workspace>(dest_ws_id)` fails here and
+    // the source workspace is untouched — no orphaned tab.
+    // (codex PR #567 P1 / gemini HIGH)
     let _tab = store.must_get::<Tab>(tab_id)?;
-
-    // Remove tab from source workspace. No last-tab guard: a tear-off
-    // workspace's only tab IS the one being restored.
     let mut source_ws = store.must_get::<Workspace>(source_ws_id)?;
+    let mut dest_ws = store.must_get::<Workspace>(dest_ws_id)?;
+
+    // Compute source-side mutations in memory only (don't persist yet).
+    // No last-tab guard: a tear-off workspace's only tab IS the one
+    // being restored, and we'll delete the empty workspace below.
     source_ws.tabids.retain(|id| id != tab_id);
     source_ws.pinnedtabids.retain(|id| id != tab_id);
     let source_now_empty =
@@ -327,23 +334,33 @@ pub fn restore_torn_off_tab(
             .unwrap_or_default();
         source_ws.activetabid = new_active;
     }
-    store.update(&mut source_ws)?;
 
-    // Add tab to destination workspace at requested index.
-    let mut dest_ws = store.must_get::<Workspace>(dest_ws_id)?;
+    // De-dup in destination before insert. A retried frontend request
+    // could otherwise produce duplicate tab IDs in the workspace's
+    // `tabids` array. (gemini PR #567 MEDIUM)
+    dest_ws.tabids.retain(|id| id != tab_id);
+    dest_ws.pinnedtabids.retain(|id| id != tab_id);
     let idx = insert_index.unwrap_or(dest_ws.tabids.len());
     let insert_at = idx.min(dest_ws.tabids.len());
     dest_ws.tabids.insert(insert_at, tab_id.to_string());
     dest_ws.activetabid = tab_id.to_string();
+
+    // Persist destination FIRST. If this fails, source is still
+    // untouched and the tab keeps its tear-off home. If it succeeds
+    // the tab now lives in two workspaces' tabids — that's transient
+    // and resolves on the next persist below. Workspace records are
+    // single writers so no other actor can observe the intermediate
+    // state. (gemini PR #567 HIGH)
     store.update(&mut dest_ws)?;
 
-    // Delete the now-empty source workspace so the dragged window's
-    // close (which the frontend issues immediately after) doesn't
-    // attempt a redundant cascade. The tab record itself stays — it
-    // belongs to the destination workspace now.
+    // Now persist (or delete) source. If `source_now_empty`, skip the
+    // update entirely and go straight to delete — saves a write +
+    // avoids redundant Workspace update events to frontends.
     if source_now_empty {
         tracing::info!(source_ws = %source_ws_id, "[dnd] deleting empty tear-off workspace");
         store.delete::<Workspace>(source_ws_id)?;
+    } else {
+        store.update(&mut source_ws)?;
     }
 
     tracing::info!(

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -286,6 +286,14 @@ pub fn tear_off_block(
 /// tear-off workspaces always contain exactly one tab — and after the move
 /// the source workspace has zero tabs and is deleted.
 ///
+/// `was_pinned` controls which list in the destination receives the tab:
+/// true → `pinnedtabids` (preserves pinned status across cancel-back),
+/// false → `tabids`. Both paths de-dup before insert.
+///
+/// The whole operation runs inside a single SQLite transaction so frontend
+/// readers never observe a transient state where the tab lives in two
+/// workspaces' lists at once. (gemini PR #567 round-6 MEDIUM)
+///
 /// Used by Phase 5 cancel-back (ESC / drop-on-source) and by Phase 4 merge
 /// (drop on another window's strip). Both paths produce a single-tab source
 /// workspace whose only purpose is to carry the dragged tab.
@@ -295,12 +303,14 @@ pub fn restore_torn_off_tab(
     source_ws_id: &str,
     dest_ws_id: &str,
     insert_index: Option<usize>,
+    was_pinned: bool,
 ) -> Result<(), StoreError> {
     tracing::info!(
         tab_id = %tab_id,
         source_ws = %source_ws_id,
         dest_ws = %dest_ws_id,
         insert_index = ?insert_index,
+        was_pinned = %was_pinned,
         "[dnd] restore_torn_off_tab"
     );
     if source_ws_id == dest_ws_id {
@@ -308,68 +318,79 @@ pub fn restore_torn_off_tab(
         return Ok(());
     }
 
-    // Validate everything we're going to touch BEFORE mutating any of
-    // it. If `dest_ws_id` is stale (e.g. user closed the original
-    // window while the SC_MOVE loop was running, or sent a malformed
-    // request), `must_get::<Workspace>(dest_ws_id)` fails here and
-    // the source workspace is untouched — no orphaned tab.
-    // (codex PR #567 P1 / gemini HIGH)
-    let _tab = store.must_get::<Tab>(tab_id)?;
-    let mut source_ws = store.must_get::<Workspace>(source_ws_id)?;
-    let mut dest_ws = store.must_get::<Workspace>(dest_ws_id)?;
+    store.with_tx(|tx| {
+        // Validate everything we're going to touch BEFORE mutating any of
+        // it. If `dest_ws_id` is stale (e.g. user closed the original
+        // window while the SC_MOVE loop was running, or sent a malformed
+        // request), `must_get::<Workspace>(dest_ws_id)` fails here and
+        // the transaction rolls back without ever touching the source —
+        // no orphaned tab. (codex PR #567 P1 / gemini HIGH)
+        let _tab = tx.must_get::<Tab>(tab_id)?;
+        let mut source_ws = tx.must_get::<Workspace>(source_ws_id)?;
+        let mut dest_ws = tx.must_get::<Workspace>(dest_ws_id)?;
 
-    // Compute source-side mutations in memory only (don't persist yet).
-    // No last-tab guard: a tear-off workspace's only tab IS the one
-    // being restored, and we'll delete the empty workspace below.
-    source_ws.tabids.retain(|id| id != tab_id);
-    source_ws.pinnedtabids.retain(|id| id != tab_id);
-    let source_now_empty =
-        source_ws.tabids.is_empty() && source_ws.pinnedtabids.is_empty();
-    if source_ws.activetabid == tab_id {
-        let new_active = source_ws
-            .tabids
-            .first()
-            .or(source_ws.pinnedtabids.first())
-            .cloned()
-            .unwrap_or_default();
-        source_ws.activetabid = new_active;
-    }
+        // Compute source-side mutations in memory only (don't persist yet).
+        // No last-tab guard: a tear-off workspace's only tab IS the one
+        // being restored, and we'll delete the empty workspace below.
+        source_ws.tabids.retain(|id| id != tab_id);
+        source_ws.pinnedtabids.retain(|id| id != tab_id);
+        let source_now_empty =
+            source_ws.tabids.is_empty() && source_ws.pinnedtabids.is_empty();
+        if source_ws.activetabid == tab_id {
+            let new_active = source_ws
+                .tabids
+                .first()
+                .or(source_ws.pinnedtabids.first())
+                .cloned()
+                .unwrap_or_default();
+            source_ws.activetabid = new_active;
+        }
 
-    // De-dup in destination before insert. A retried frontend request
-    // could otherwise produce duplicate tab IDs in the workspace's
-    // `tabids` array. (gemini PR #567 MEDIUM)
-    dest_ws.tabids.retain(|id| id != tab_id);
-    dest_ws.pinnedtabids.retain(|id| id != tab_id);
-    let idx = insert_index.unwrap_or(dest_ws.tabids.len());
-    let insert_at = idx.min(dest_ws.tabids.len());
-    dest_ws.tabids.insert(insert_at, tab_id.to_string());
-    dest_ws.activetabid = tab_id.to_string();
+        // De-dup in destination before insert. A retried frontend request
+        // could otherwise produce duplicate tab IDs in the workspace's
+        // `tabids` array. (gemini PR #567 MEDIUM)
+        dest_ws.tabids.retain(|id| id != tab_id);
+        dest_ws.pinnedtabids.retain(|id| id != tab_id);
 
-    // Persist destination FIRST. If this fails, source is still
-    // untouched and the tab keeps its tear-off home. If it succeeds
-    // the tab now lives in two workspaces' tabids — that's transient
-    // and resolves on the next persist below. Workspace records are
-    // single writers so no other actor can observe the intermediate
-    // state. (gemini PR #567 HIGH)
-    store.update(&mut dest_ws)?;
+        // Choose pinnedtabids vs tabids based on the tab's original
+        // status. Without this, a pinned tab torn off and cancel-backed
+        // would silently come back as unpinned. (gemini PR #567 round-6
+        // MEDIUM @ tabbar.tsx:154 + dnd.rs:345)
+        let insert_at = if was_pinned {
+            let idx = insert_index.unwrap_or(dest_ws.pinnedtabids.len());
+            let insert_at = idx.min(dest_ws.pinnedtabids.len());
+            dest_ws.pinnedtabids.insert(insert_at, tab_id.to_string());
+            insert_at
+        } else {
+            let idx = insert_index.unwrap_or(dest_ws.tabids.len());
+            let insert_at = idx.min(dest_ws.tabids.len());
+            dest_ws.tabids.insert(insert_at, tab_id.to_string());
+            insert_at
+        };
+        dest_ws.activetabid = tab_id.to_string();
 
-    // Now persist (or delete) source. If `source_now_empty`, skip the
-    // update entirely and go straight to delete — saves a write +
-    // avoids redundant Workspace update events to frontends.
-    if source_now_empty {
-        tracing::info!(source_ws = %source_ws_id, "[dnd] deleting empty tear-off workspace");
-        store.delete::<Workspace>(source_ws_id)?;
-    } else {
-        store.update(&mut source_ws)?;
-    }
+        // Inside the transaction, persistence order doesn't matter for
+        // observers (they only see post-COMMIT state). Persist dest
+        // first anyway to keep the function flow obvious if the txn
+        // wrapper is ever removed. Skip source update entirely when
+        // it's becoming empty — go straight to delete.
+        tx.update(&mut dest_ws)?;
+        if source_now_empty {
+            tracing::info!(source_ws = %source_ws_id, "[dnd] deleting empty tear-off workspace");
+            tx.delete::<Workspace>(source_ws_id)?;
+        } else {
+            tx.update(&mut source_ws)?;
+        }
 
-    tracing::info!(
-        tab_id = %tab_id,
-        dest_ws = %dest_ws_id,
-        insert_at = %insert_at,
-        "[dnd] restore_torn_off_tab complete"
-    );
-    Ok(())
+        tracing::info!(
+            tab_id = %tab_id,
+            dest_ws = %dest_ws_id,
+            insert_at = %insert_at,
+            was_pinned = %was_pinned,
+            "[dnd] restore_torn_off_tab complete"
+        );
+        Ok(())
+    })
 }
 
 /// Tear off a tab into a new workspace.

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -771,8 +771,13 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Err(e) => return WebReturnType::error(e),
             };
             let insert_index: Option<usize> = service::get_arg(args, 3).ok();
-            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, "[dnd:svc] RestoreTornOffTab");
-            match wcore::restore_torn_off_tab(store, &tab_id, &source_ws_id, &dest_ws_id, insert_index) {
+            // arg 4 is `wasPinned: bool`. Default false — older clients
+            // and the merge path (which always restores into the target's
+            // tabids regardless of source pin status) don't need to pass
+            // it. Pinned-status preservation is a cancel-back-only feature.
+            let was_pinned: bool = service::get_arg(args, 4).unwrap_or(false);
+            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, was_pinned = %was_pinned, "[dnd:svc] RestoreTornOffTab");
+            match wcore::restore_torn_off_tab(store, &tab_id, &source_ws_id, &dest_ws_id, insert_index, was_pinned) {
                 Ok(()) => {
                     let mut updates = Vec::new();
                     // Source workspace: emit a delete update if we deleted

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -757,6 +757,60 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        ("workspace", "RestoreTornOffTab") => {
+            let tab_id: String = match service::get_arg(args, 0) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let source_ws_id: String = match service::get_arg(args, 1) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let dest_ws_id: String = match service::get_arg(args, 2) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e),
+            };
+            let insert_index: Option<usize> = service::get_arg(args, 3).ok();
+            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, "[dnd:svc] RestoreTornOffTab");
+            match wcore::restore_torn_off_tab(store, &tab_id, &source_ws_id, &dest_ws_id, insert_index) {
+                Ok(()) => {
+                    let mut updates = Vec::new();
+                    // Source workspace: emit a delete update if we deleted
+                    // it; otherwise an update with current state. Frontends
+                    // listening on the dragged window's workspace can react
+                    // to either.
+                    match store.get::<Workspace>(&source_ws_id) {
+                        Ok(Some(src_ws)) => {
+                            updates.push(WaveObjUpdate {
+                                updatetype: "update".into(),
+                                otype: OTYPE_WORKSPACE.to_string(),
+                                oid: source_ws_id.clone(),
+                                obj: Some(wave_obj_to_value(&src_ws)),
+                            });
+                        }
+                        Ok(None) => {
+                            updates.push(WaveObjUpdate {
+                                updatetype: "delete".into(),
+                                otype: OTYPE_WORKSPACE.to_string(),
+                                oid: source_ws_id.clone(),
+                                obj: None,
+                            });
+                        }
+                        Err(_) => {}
+                    }
+                    if let Ok(dst_ws) = store.must_get::<Workspace>(&dest_ws_id) {
+                        updates.push(WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: OTYPE_WORKSPACE.to_string(),
+                            oid: dest_ws_id.clone(),
+                            obj: Some(wave_obj_to_value(&dst_ws)),
+                        });
+                    }
+                    WebReturnType::success_with_updates(updates)
+                }
+                Err(e) => WebReturnType::error(e.to_string()),
+            }
+        }
         ("workspace", "TearOffBlock") => {
             let block_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -210,9 +210,10 @@ class WorkspaceServiceType {
     // Move the only tab out of a tear-off workspace and delete that workspace.
     // Used for cancel-back (ESC / drop-on-source) and merge — both produce a
     // single-tab source workspace that MoveTabToWorkspace would refuse to
-    // empty out. Returns object updates (source workspace deleted, dest
-    // workspace updated).
-    RestoreTornOffTab(tabId: string, sourceWsId: string, destWsId: string, insertIndex?: number): Promise<void> {
+    // empty out. `wasPinned` controls whether the tab lands in the dest's
+    // pinnedtabids (cancel-back of a pinned tab) or tabids (default).
+    // Returns object updates (source workspace deleted, dest workspace updated).
+    RestoreTornOffTab(tabId: string, sourceWsId: string, destWsId: string, insertIndex?: number, wasPinned?: boolean): Promise<void> {
         return WOS.callBackendService("workspace", "RestoreTornOffTab", Array.from(arguments))
     }
 

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -207,6 +207,15 @@ class WorkspaceServiceType {
         return WOS.callBackendService("workspace", "MoveTabToWorkspace", Array.from(arguments))
     }
 
+    // Move the only tab out of a tear-off workspace and delete that workspace.
+    // Used for cancel-back (ESC / drop-on-source) and merge — both produce a
+    // single-tab source workspace that MoveTabToWorkspace would refuse to
+    // empty out. Returns object updates (source workspace deleted, dest
+    // workspace updated).
+    RestoreTornOffTab(tabId: string, sourceWsId: string, destWsId: string, insertIndex?: number): Promise<void> {
+        return WOS.callBackendService("workspace", "RestoreTornOffTab", Array.from(arguments))
+    }
+
     // Tear off a block into a new workspace
     // @returns new workspace id (and object updates)
     TearOffBlock(blockId: string, sourceTabId: string, sourceWsId: string, autoClose?: boolean): Promise<string> {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -268,6 +268,20 @@ function TabBar(props: TabBarProps): JSX.Element {
                 unsub();
             }
         };
+        // Coordinate-space helper. `payload.cursorX/Y` come from
+        // Win32's WH_MOUSE_LL hook in PHYSICAL pixels (Windows
+        // reports per-monitor coords for DPI-aware processes, which
+        // CEF is). `window.screenX/Y` and `getBoundingClientRect()`
+        // return CSS / LOGICAL pixels. Subtract directly and you're
+        // off by a factor of devicePixelRatio at DPR ≠ 1.0 — the
+        // strip hit-test would never trigger on HiDPI. Convert
+        // physical → CSS by dividing by DPR before subtracting.
+        // (gemini PR #567 HIGH; same fix applies to Phase 4 merge
+        // handler below — both shared the bug.)
+        const physicalToClientX = (px: number) =>
+            px / (window.devicePixelRatio || 1) - window.screenX;
+        const physicalToClientY = (py: number) =>
+            py / (window.devicePixelRatio || 1) - window.screenY;
         fireAndForget(async () => {
             const { listenEvent } = await import("@/app/platform/ipc");
             if (!mounted) return;
@@ -285,8 +299,8 @@ function TabBar(props: TabBarProps): JSX.Element {
                             setInsertionPoint(null);
                             return;
                         }
-                        const clientX = payload.cursorX - window.screenX;
-                        const clientY = payload.cursorY - window.screenY;
+                        const clientX = physicalToClientX(payload.cursorX);
+                        const clientY = physicalToClientY(payload.cursorY);
                         if (clientY < stripRect.top || clientY > stripRect.bottom) {
                             setInsertionPoint(null);
                             return;
@@ -325,8 +339,8 @@ function TabBar(props: TabBarProps): JSX.Element {
                             // window's body would silently relocate
                             // the tab. (codex PR #565 P1)
                             const stripRect = tabBarScrollRef?.getBoundingClientRect();
-                            const clientX = payload.cursorX - window.screenX;
-                            const clientY = payload.cursorY - window.screenY;
+                            const clientX = physicalToClientX(payload.cursorX);
+                            const clientY = physicalToClientY(payload.cursorY);
                             if (
                                 !stripRect ||
                                 clientY < stripRect.top ||
@@ -418,7 +432,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 && payload.cursorY != null
                             ) {
                                 const stripRect = tabBarScrollRef?.getBoundingClientRect();
-                                const clientY = payload.cursorY - window.screenY;
+                                const clientY = physicalToClientY(payload.cursorY);
                                 if (
                                     !stripRect
                                     || clientY < stripRect.top

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -386,6 +386,8 @@ function TabBar(props: TabBarProps): JSX.Element {
                     fromWsId: string;
                     draggedWindowLabel: string;
                     originalIndex: number;
+                    cursorX?: number;
+                    cursorY?: number;
                     reason: string;
                 }>("tearoff:cancel-back", (payload) => {
                     fireAndForget(async () => {
@@ -394,6 +396,30 @@ function TabBar(props: TabBarProps): JSX.Element {
                             if (!ownWsId) {
                                 Logger.warn("dnd", "tearoff:cancel-back — no own workspace, skipping", payload);
                                 return;
+                            }
+                            // Strip-area hit test (drop-on-source path
+                            // only — ESC has no cursor coords). Mirrors
+                            // the merge handler's check: the host emits
+                            // cancel-back whenever the cursor's over
+                            // any part of the source window's HWND, but
+                            // we only restore if the cursor was
+                            // actually on the tab strip. Otherwise fall
+                            // through to standalone (do nothing — the
+                            // dragged window stays where it landed).
+                            if (payload.reason === "drop-on-source"
+                                && payload.cursorX != null
+                                && payload.cursorY != null
+                            ) {
+                                const stripRect = tabBarScrollRef?.getBoundingClientRect();
+                                const clientY = payload.cursorY - window.screenY;
+                                if (
+                                    !stripRect
+                                    || clientY < stripRect.top
+                                    || clientY > stripRect.bottom
+                                ) {
+                                    Logger.info("dnd", "tearoff:cancel-back — cursor over source body, leaving as standalone", payload);
+                                    return;
+                                }
                             }
                             await WorkspaceService.MoveTabToWorkspace(
                                 payload.tabId,

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -134,24 +134,22 @@ function TabBar(props: TabBarProps): JSX.Element {
                     const draggedTabId = source.data.tabId as string;
                     const wsId = props.workspace?.oid;
                     if (wsId) {
-                        // Phase 5: capture the original tab index BEFORE
-                        // TearOffTab moves the tab out, in the BACKEND's
-                        // reference frame (workspace.tabids — what
-                        // MoveTabToWorkspace's insertion index targets).
-                        //
-                        // Display is `tabIds()` = pinnedtabids + tabids;
-                        // backend is tabids only. Subtract pinnedCount
-                        // from the displayed index so:
-                        //   - regular tab in displayed-position N (with
-                        //     M pinned ahead of it) → backend index N-M
-                        //   - legacy pinned tab pre-migration → clamps
-                        //     to 0 (best-effort; full migration folds
-                        //     pinnedtabids into tabids[0..M] anyway, so
-                        //     index 0 is in the right neighbourhood).
+                        // Phase 5: capture the original position so cancel-back
+                        // can restore in place. We need TWO things:
+                        //   * `wasPinned` — which list the tab lived in
+                        //   * `originalTabIndex` — its index inside THAT list
+                        // The backend restores into `pinnedtabids` if
+                        // wasPinned, else `tabids`. Using one combined
+                        // displayed-index won't do: the lists are persisted
+                        // separately. (gemini PR #567 round-6 MEDIUM)
                         const ws = props.workspace;
-                        const pinnedCount = (ws?.pinnedtabids ?? []).length;
-                        const displayedIdx = tabIds().indexOf(draggedTabId);
-                        const originalTabIndex = Math.max(0, displayedIdx - pinnedCount);
+                        const pinnedIds = ws?.pinnedtabids ?? [];
+                        const tabIdsRaw = ws?.tabids ?? [];
+                        const pinnedIdx = pinnedIds.indexOf(draggedTabId);
+                        const wasPinned = pinnedIdx >= 0;
+                        const originalTabIndex = wasPinned
+                            ? pinnedIdx
+                            : Math.max(0, tabIdsRaw.indexOf(draggedTabId));
                         // openWindowAtPosition + SC_MOVE expect SCREEN
                         // coordinates, but `input.clientX/Y` are
                         // viewport-relative. Convert via window.screenX/Y
@@ -164,7 +162,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                         // host's SC_MOVE handshake will take over the
                         // cursor synchronously from Windows' point of view.
                         fireAndForget(() =>
-                            requestTearOff(draggedTabId, wsId, screenX, screenY, originalTabIndex),
+                            requestTearOff(draggedTabId, wsId, screenX, screenY, originalTabIndex, wasPinned),
                         );
                     }
                     // Continue updating insertionPoint below — until the
@@ -418,6 +416,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                     originalSourceWsId: string;
                     draggedWindowLabel: string;
                     originalIndex: number;
+                    wasPinned: boolean;
                     cursorX?: number;
                     cursorY?: number;
                     reason: string;
@@ -473,6 +472,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 payload.fromWsId,
                                 restoreWsId,
                                 payload.originalIndex,
+                                payload.wasPinned,
                             );
                             await getApi().closeWindowByLabel(payload.draggedWindowLabel);
                             Logger.info("dnd", "tearoff:cancel-back complete", {
@@ -598,6 +598,7 @@ async function requestTearOff(
     cursorX: number,
     cursorY: number,
     originalTabIndex: number,
+    wasPinned: boolean,
 ): Promise<void> {
     const t0 = performance.now();
     try {
@@ -643,7 +644,10 @@ async function requestTearOff(
             destWsId: newWsId,
             // Phase 5 — original tab index so ESC / drop-on-source
             // can restore at the right position rather than the end.
+            // wasPinned controls which list the index points into
+            // (pinnedtabids vs tabids).
             originalTabIndex,
+            wasPinned,
         });
         // Handshake succeeded — Windows now owns the move loop. Clear
         // the cross-window drag payload so the legacy dragend pipeline

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -137,9 +137,16 @@ function TabBar(props: TabBarProps): JSX.Element {
                         // Phase 5: capture the original tab index BEFORE
                         // TearOffTab moves the tab out. Used by cancel-back
                         // (ESC or drop-on-source) to restore at the
-                        // original position. Defaults to current array
-                        // position; -1 → 0 if not found (defensive).
-                        const originalTabIndex = Math.max(0, tabIds().indexOf(draggedTabId));
+                        // original position. Index against workspace.tabids
+                        // ONLY — `tabIds()` prepends legacy pinnedtabids
+                        // for display, but MoveTabToWorkspace applies its
+                        // index against tabids alone. Mixing would shift
+                        // by pinned count during the async pin-migration
+                        // window. (codex PR #567 P2)
+                        const originalTabIndex = Math.max(
+                            0,
+                            (props.workspace?.tabids ?? []).indexOf(draggedTabId),
+                        );
                         // openWindowAtPosition + SC_MOVE expect SCREEN
                         // coordinates, but `input.clientX/Y` are
                         // viewport-relative. Convert via window.screenX/Y

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -134,6 +134,12 @@ function TabBar(props: TabBarProps): JSX.Element {
                     const draggedTabId = source.data.tabId as string;
                     const wsId = props.workspace?.oid;
                     if (wsId) {
+                        // Phase 5: capture the original tab index BEFORE
+                        // TearOffTab moves the tab out. Used by cancel-back
+                        // (ESC or drop-on-source) to restore at the
+                        // original position. Defaults to current array
+                        // position; -1 → 0 if not found (defensive).
+                        const originalTabIndex = Math.max(0, tabIds().indexOf(draggedTabId));
                         // openWindowAtPosition + SC_MOVE expect SCREEN
                         // coordinates, but `input.clientX/Y` are
                         // viewport-relative. Convert via window.screenX/Y
@@ -145,16 +151,8 @@ function TabBar(props: TabBarProps): JSX.Element {
                         // Fire-and-forget — the user is mid-drag and the
                         // host's SC_MOVE handshake will take over the
                         // cursor synchronously from Windows' point of view.
-                        //
-                        // The cross-window drag payload is cleared INSIDE
-                        // requestTearOff after the SC_MOVE handshake
-                        // returns successfully — clearing it here would
-                        // strand the legacy dragend fallback if any step
-                        // (TearOffTab, openWindowAtPosition, handshake)
-                        // failed mid-flight, leaving the gesture as a
-                        // silent no-op.
                         fireAndForget(() =>
-                            requestTearOff(draggedTabId, wsId, screenX, screenY),
+                            requestTearOff(draggedTabId, wsId, screenX, screenY, originalTabIndex),
                         );
                     }
                     // Continue updating insertionPoint below — until the
@@ -376,6 +374,48 @@ function TabBar(props: TabBarProps): JSX.Element {
                     Logger.info("dnd", "tearoff:standalone", payload);
                 }),
             );
+
+            // Phase 5 — cancel-back. Source window receives this on
+            // either ESC during the SC_MOVE loop or drop-on-source-
+            // strip. Move the tab back from the dragged window's
+            // workspace into ours at its original index, then close
+            // the dragged window.
+            trackOrDispose(
+                await listenEvent<{
+                    tabId: string;
+                    fromWsId: string;
+                    draggedWindowLabel: string;
+                    originalIndex: number;
+                    reason: string;
+                }>("tearoff:cancel-back", (payload) => {
+                    fireAndForget(async () => {
+                        try {
+                            const ownWsId = props.workspace?.oid;
+                            if (!ownWsId) {
+                                Logger.warn("dnd", "tearoff:cancel-back — no own workspace, skipping", payload);
+                                return;
+                            }
+                            await WorkspaceService.MoveTabToWorkspace(
+                                payload.tabId,
+                                payload.fromWsId,
+                                ownWsId,
+                                payload.originalIndex,
+                            );
+                            await getApi().closeWindowByLabel(payload.draggedWindowLabel);
+                            Logger.info("dnd", "tearoff:cancel-back complete", {
+                                tabId: payload.tabId,
+                                originalIndex: payload.originalIndex,
+                                reason: payload.reason,
+                            });
+                        } catch (e) {
+                            Logger.error("dnd", "tearoff:cancel-back failed", {
+                                error: String(e),
+                                payload,
+                            });
+                        }
+                    });
+                }),
+            );
         });
         onCleanup(() => {
             mounted = false;
@@ -484,6 +524,7 @@ async function requestTearOff(
     workspaceId: string,
     cursorX: number,
     cursorY: number,
+    originalTabIndex: number,
 ): Promise<void> {
     const t0 = performance.now();
     try {
@@ -527,6 +568,9 @@ async function requestTearOff(
             tabId,
             sourceWsId: workspaceId,
             destWsId: newWsId,
+            // Phase 5 — original tab index so ESC / drop-on-source
+            // can restore at the right position rather than the end.
+            originalTabIndex,
         });
         // Handshake succeeded — Windows now owns the move loop. Clear
         // the cross-window drag payload so the legacy dragend pipeline

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -281,10 +281,12 @@ function TabBar(props: TabBarProps): JSX.Element {
         // physical → CSS by dividing by DPR before subtracting.
         // (gemini PR #567 HIGH; same fix applies to Phase 4 merge
         // handler below — both shared the bug.)
-        const physicalToClientX = (px: number) =>
-            px / (window.devicePixelRatio || 1) - window.screenX;
-        const physicalToClientY = (py: number) =>
-            py / (window.devicePixelRatio || 1) - window.screenY;
+        // Math.max(1, ...) defends against the (rare but possible) browser
+        // edge case where devicePixelRatio is 0 or negative; the falsy-||
+        // already covered undefined/NaN. (gemini PR #567 round-8 MEDIUM)
+        const dpr = () => Math.max(1, window.devicePixelRatio || 1);
+        const physicalToClientX = (px: number) => px / dpr() - window.screenX;
+        const physicalToClientY = (py: number) => py / dpr() - window.screenY;
         fireAndForget(async () => {
             const { listenEvent } = await import("@/app/platform/ipc");
             if (!mounted) return;

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -135,18 +135,23 @@ function TabBar(props: TabBarProps): JSX.Element {
                     const wsId = props.workspace?.oid;
                     if (wsId) {
                         // Phase 5: capture the original tab index BEFORE
-                        // TearOffTab moves the tab out. Used by cancel-back
-                        // (ESC or drop-on-source) to restore at the
-                        // original position. Index against workspace.tabids
-                        // ONLY — `tabIds()` prepends legacy pinnedtabids
-                        // for display, but MoveTabToWorkspace applies its
-                        // index against tabids alone. Mixing would shift
-                        // by pinned count during the async pin-migration
-                        // window. (codex PR #567 P2)
-                        const originalTabIndex = Math.max(
-                            0,
-                            (props.workspace?.tabids ?? []).indexOf(draggedTabId),
-                        );
+                        // TearOffTab moves the tab out, in the BACKEND's
+                        // reference frame (workspace.tabids — what
+                        // MoveTabToWorkspace's insertion index targets).
+                        //
+                        // Display is `tabIds()` = pinnedtabids + tabids;
+                        // backend is tabids only. Subtract pinnedCount
+                        // from the displayed index so:
+                        //   - regular tab in displayed-position N (with
+                        //     M pinned ahead of it) → backend index N-M
+                        //   - legacy pinned tab pre-migration → clamps
+                        //     to 0 (best-effort; full migration folds
+                        //     pinnedtabids into tabids[0..M] anyway, so
+                        //     index 0 is in the right neighbourhood).
+                        const ws = props.workspace;
+                        const pinnedCount = (ws?.pinnedtabids ?? []).length;
+                        const displayedIdx = tabIds().indexOf(draggedTabId);
+                        const originalTabIndex = Math.max(0, displayedIdx - pinnedCount);
                         // openWindowAtPosition + SC_MOVE expect SCREEN
                         // coordinates, but `input.clientX/Y` are
                         // viewport-relative. Convert via window.screenX/Y

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -372,7 +372,12 @@ function TabBar(props: TabBarProps): JSX.Element {
                                 insertIdx = tabs.indexOf(ip.afterTabId);
                                 if (insertIdx < 0) insertIdx = tabs.length;
                             }
-                            await WorkspaceService.MoveTabToWorkspace(
+                            // Tear-off workspaces always carry exactly one
+                            // tab, so MoveTabToWorkspace's last-tab guard
+                            // would reject this. RestoreTornOffTab bypasses
+                            // that and deletes the now-empty source ws so
+                            // closeWindowByLabel below doesn't cascade.
+                            await WorkspaceService.RestoreTornOffTab(
                                 payload.tabId,
                                 payload.fromWsId,
                                 ownWsId,
@@ -418,6 +423,10 @@ function TabBar(props: TabBarProps): JSX.Element {
                 }>("tearoff:cancel-back", (payload) => {
                     fireAndForget(async () => {
                         try {
+                            // Drop any stale insertion gap left over from
+                            // tearoff:hover-changed updates while the cursor
+                            // was still on the strip. (codex PR #567 P3)
+                            setInsertionPoint(null);
                             const ownWsId = props.workspace?.oid;
                             if (!ownWsId) {
                                 Logger.warn("dnd", "tearoff:cancel-back — no own workspace, skipping", payload);
@@ -447,7 +456,13 @@ function TabBar(props: TabBarProps): JSX.Element {
                                     return;
                                 }
                             }
-                            await WorkspaceService.MoveTabToWorkspace(
+                            // Tear-off workspace has exactly one tab —
+                            // MoveTabToWorkspace would reject moving it
+                            // out. RestoreTornOffTab bypasses the last-tab
+                            // guard and deletes the empty source ws, so
+                            // the dragged window's close cascade has
+                            // nothing left to do. (codex PR #567 P1)
+                            await WorkspaceService.RestoreTornOffTab(
                                 payload.tabId,
                                 payload.fromWsId,
                                 ownWsId,

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -415,6 +415,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                 await listenEvent<{
                     tabId: string;
                     fromWsId: string;
+                    originalSourceWsId: string;
                     draggedWindowLabel: string;
                     originalIndex: number;
                     cursorX?: number;
@@ -427,9 +428,14 @@ function TabBar(props: TabBarProps): JSX.Element {
                             // tearoff:hover-changed updates while the cursor
                             // was still on the strip. (codex PR #567 P3)
                             setInsertionPoint(null);
-                            const ownWsId = props.workspace?.oid;
-                            if (!ownWsId) {
-                                Logger.warn("dnd", "tearoff:cancel-back — no own workspace, skipping", payload);
+                            // Restore into the workspace the tab was torn
+                            // from, NOT this window's currently-active
+                            // workspace. If the user switched workspaces
+                            // mid-drag, ownWsId would put the tab in the
+                            // wrong place. (codex PR #567 round-5 P2)
+                            const restoreWsId = payload.originalSourceWsId;
+                            if (!restoreWsId) {
+                                Logger.warn("dnd", "tearoff:cancel-back — no original source workspace, skipping", payload);
                                 return;
                             }
                             // Strip-area hit test (drop-on-source path
@@ -465,7 +471,7 @@ function TabBar(props: TabBarProps): JSX.Element {
                             await WorkspaceService.RestoreTornOffTab(
                                 payload.tabId,
                                 payload.fromWsId,
-                                ownWsId,
+                                restoreWsId,
                                 payload.originalIndex,
                             );
                             await getApi().closeWindowByLabel(payload.draggedWindowLabel);

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -197,6 +197,10 @@ declare global {
             tabId?: string;
             sourceWsId?: string;
             destWsId?: string;
+            /** Phase 5 — tab's index in the source workspace at
+             *  tear-off time. Used by cancel-back (ESC or drop on
+             *  source strip) to restore at the original position. */
+            originalTabIndex?: number;
         }) => Promise<{ handshakeMs: number; totalMs: number }>;
         /** Close a specific AgentMux window by label. Used by Phase 4
          *  merge to clean up the dragged window after its tab is moved

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -199,8 +199,15 @@ declare global {
             destWsId?: string;
             /** Phase 5 — tab's index in the source workspace at
              *  tear-off time. Used by cancel-back (ESC or drop on
-             *  source strip) to restore at the original position. */
+             *  source strip) to restore at the original position.
+             *  When `wasPinned` is true, this is the index inside
+             *  `pinnedtabids`; otherwise inside `tabids`. */
             originalTabIndex?: number;
+            /** Phase 5 — was the tab pinned in its source workspace?
+             *  Threaded through to the cancel-back payload so the
+             *  backend can restore into pinnedtabids vs tabids and
+             *  preserve pinned status. */
+            wasPinned?: boolean;
         }) => Promise<{ handshakeMs: number; totalMs: number }>;
         /** Close a specific AgentMux window by label. Used by Phase 4
          *  merge to clean up the dragged window after its tab is moved

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.423",
+  "version": "0.33.424",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.423",
+      "version": "0.33.424",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.424",
+  "version": "0.33.425",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.424",
+      "version": "0.33.425",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.419",
+  "version": "0.33.420",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.419",
+      "version": "0.33.420",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.426",
+  "version": "0.33.427",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.426",
+      "version": "0.33.427",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.428",
+  "version": "0.33.429",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.428",
+      "version": "0.33.429",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.425",
+  "version": "0.33.426",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.425",
+      "version": "0.33.426",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.421",
+  "version": "0.33.422",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.421",
+      "version": "0.33.422",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.422",
+  "version": "0.33.423",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.422",
+      "version": "0.33.423",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.427",
+  "version": "0.33.428",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.427",
+      "version": "0.33.428",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.420",
+  "version": "0.33.421",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.420",
+      "version": "0.33.421",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.426",
+  "version": "0.33.427",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.423",
+  "version": "0.33.424",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.428",
+  "version": "0.33.429",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.424",
+  "version": "0.33.425",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.427",
+  "version": "0.33.428",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.421",
+  "version": "0.33.422",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.419",
+  "version": "0.33.420",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.420",
+  "version": "0.33.421",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.425",
+  "version": "0.33.426",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.422",
+  "version": "0.33.423",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the cancel-back goals (G7 / spec §0). Two trigger paths now restore the dragged tab to its **original index** in the source workspace instead of leaving a standalone window.

### Path 1: ESC during the SC_MOVE move-loop

Phase 4 caught ESC via WH_KEYBOARD_LL but emitted \`tearoff:standalone\`, leaving the dragged window where the cursor was. Phase 5 emits \`tearoff:cancel-back\` instead, with the original index.

### Path 2: drop on source window's own tab strip

Previously this fell through to the merge path which restored at the cursor X, not the original index. Now detected via \`candidate_label == ctx.source_label\` and routes to \`tearoff:cancel-back\` with \`reason=drop-on-source\`.

Both paths reuse the same frontend handler:
- \`MoveTabToWorkspace(tabId, draggedWsId, sourceWsId, originalIndex)\`
- \`closeWindowByLabel(draggedWindowLabel)\`

## Architecture

- Frontend captures the original tab index in \`onDrag\` at the moment the threshold is crossed (BEFORE \`TearOffTab\` moves the tab out): \`Math.max(0, tabIds().indexOf(draggedTabId))\`.
- New \`originalTabIndex\` field on the \`tearOffSCMoveHandshake\` IPC (optional; defaults to 0).
- \`HookContext\` gains \`original_tab_index: usize\`.
- ESC handler in \`low_level_keyboard_proc\` emits \`tearoff:cancel-back\` with \`reason=esc\`.
- \`handle_button_up\` branches before merge: \`candidate == source_label\` → cancel-back with \`reason=drop-on-source\`.
- \`tabbar.tsx\` adds a \`tearoff:cancel-back\` listener that performs the restore + close.

## Test plan

- [ ] Tear a tab off (drag past strip bottom). New window appears + follows cursor.
- [ ] Press ESC while moving → new window destroys, tab restores at its original index in source.
- [ ] Drag the new window back over the source strip and release → same restore behaviour.
- [ ] Drag to ANOTHER window's strip and release → still merges (Phase 4 path unchanged).
- [ ] Drop on empty desktop → still standalone (Phase 4 path unchanged).
- [ ] Verify the restored tab is at the SAME index where it started, not the end.

## Per-spec quality bar

- ✅ G7: cancel-back restores **exact original index** (not appended).
- ✅ ESC fires the same path as drop-on-source — no behavioural fork.
- ✅ Reuses Phase 4's hook + Phase 6's pool path; no new structural risk.

This completes Phases 1-6 of the spec. Phase 7 (cross-platform parity for macOS / Linux) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)