### PR TITLE
fix(tab-tear-off): pool windows leaking to taskbar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.430"
+version = "0.33.431"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.430"
+version = "0.33.431"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.430"
+version = "0.33.431"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.430"
+version = "0.33.431"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.434"
+version = "0.33.435"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.434"
+version = "0.33.435"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.434"
+version = "0.33.435"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.434"
+version = "0.33.435"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.433"
+version = "0.33.434"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.433"
+version = "0.33.434"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.433"
+version = "0.33.434"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.433"
+version = "0.33.434"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.431"
+version = "0.33.432"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.431"
+version = "0.33.432"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.431"
+version = "0.33.432"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.431"
+version = "0.33.432"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.432"
+version = "0.33.433"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.432"
+version = "0.33.433"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.432"
+version = "0.33.433"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.432"
+version = "0.33.433"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.429"
+version = "0.33.430"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.429"
+version = "0.33.430"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.429"
+version = "0.33.430"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.429"
+version = "0.33.430"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.433"
+version = "0.33.434"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.434"
+version = "0.33.435"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.431"
+version = "0.33.432"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.430"
+version = "0.33.431"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.432"
+version = "0.33.433"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.429"
+version = "0.33.430"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -352,10 +352,44 @@ impl AgentMuxHandler {
 
         dlog(&format!("browser_list after remove: {}", self.browser_list.len()));
 
-        if self.browser_list.is_empty() && !self.is_pane {
-            dlog("last window — calling quit_message_loop");
-            // Last window — quit the message loop.
-            // The Job Object kills agentmux-srv which kills all shell processes.
+        // App-exit decision: count remaining USER-FACING browsers.
+        // Pool windows (`window-pool-*` labels still in `state.window_pool`)
+        // are pre-warmed scratch windows hidden from the user via
+        // WS_EX_TOOLWINDOW — they have no taskbar entry, can't be
+        // closed by the user, and would otherwise keep the app alive
+        // forever after the last visible window closes. Browser-pane
+        // child HWNDs (`browser-pane-*`) are sub-views of a parent
+        // window, not standalone instances, so they don't count
+        // either.
+        //
+        // Promoted pool windows ARE counted: they're popped off
+        // `state.window_pool` at promote time, so the pool_labels
+        // set excludes them.
+        let user_browser_count = {
+            let pool_labels: std::collections::HashSet<String> = self
+                .state
+                .window_pool
+                .lock()
+                .iter()
+                .cloned()
+                .collect();
+            let browsers = self.state.browsers.lock();
+            browsers
+                .iter()
+                .filter(|(label, _)| {
+                    !pool_labels.contains(*label) && !label.starts_with("browser-pane-")
+                })
+                .count()
+        };
+
+        if user_browser_count == 0 && !self.is_pane {
+            dlog(&format!(
+                "last user-facing window closed (browser_list.len()={}) — calling quit_message_loop",
+                self.browser_list.len()
+            ));
+            // Last user-facing window — quit the message loop.
+            // The Job Object kills agentmux-srv which kills all shell processes,
+            // and CEF tears down any remaining pool windows during shutdown.
             // Only the MAIN client's handler should trigger app exit — pane
             // clients own only their own pane browser and their list emptying
             // just means the user closed the pane, not the whole app.

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -353,26 +353,23 @@ impl AgentMuxHandler {
         dlog(&format!("browser_list after remove: {}", self.browser_list.len()));
 
         // App-exit decision: count remaining USER-FACING browsers.
-        // Pool windows (`window-pool-*` labels still in `state.window_pool`)
-        // are pre-warmed scratch windows hidden from the user via
-        // WS_EX_TOOLWINDOW — they have no taskbar entry, can't be
-        // closed by the user, and would otherwise keep the app alive
-        // forever after the last visible window closes. Browser-pane
-        // child HWNDs (`browser-pane-*`) are sub-views of a parent
-        // window, not standalone instances, so they don't count
-        // either.
+        // Unpromoted pool windows are pre-warmed scratch windows
+        // hidden from the user via WS_EX_TOOLWINDOW — they have no
+        // taskbar entry, can't be closed by the user, and would
+        // otherwise keep the app alive forever after the last
+        // visible window closes. Browser-pane child HWNDs
+        // (`browser-pane-*`) are sub-views of a parent window, not
+        // standalone instances, so they don't count either.
         //
-        // Promoted pool windows ARE counted: they're popped off
-        // `state.window_pool` at promote time, so the pool_labels
-        // set excludes them.
+        // Use `unpromoted_pool_labels` (populated at spawn time)
+        // rather than `window_pool` (populated only after the
+        // renderer-ready handshake) so this filter is correct
+        // even during the spawn → ready gap.
+        //
+        // Promoted pool windows ARE counted: they're removed from
+        // `unpromoted_pool_labels` at promote time.
         let user_browser_count = {
-            let pool_labels: std::collections::HashSet<String> = self
-                .state
-                .window_pool
-                .lock()
-                .iter()
-                .cloned()
-                .collect();
+            let pool_labels = self.state.unpromoted_pool_labels.lock().clone();
             let browsers = self.state.browsers.lock();
             browsers
                 .iter()

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -358,14 +358,15 @@ pub fn is_main_window(args: &serde_json::Value) -> serde_json::Value {
 /// in `list_windows` inflates the frontend's InstancePanel row count
 /// with phantom entries the user can't see or focus.
 ///
-/// `state.window_pool` is the authoritative "is this label still
-/// unpromoted" check — promote_pool_window pops the label off this
-/// queue, so promoted tear-off windows pass through here normally.
+/// Use `state.unpromoted_pool_labels` (NOT `state.window_pool`) as the
+/// "is unpromoted pool" oracle — the pool queue is only populated
+/// after the renderer-ready handshake (~100 ms after spawn), so it
+/// would miss freshly-spawned pool windows during the gap.
+/// `unpromoted_pool_labels` is populated synchronously in
+/// `spawn_pool_window` and removed in `promote_pool_window` /
+/// `on_pool_window_destroyed`.
 pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
-    let pool_labels: std::collections::HashSet<String> = {
-        let pool = state.window_pool.lock();
-        pool.iter().cloned().collect()
-    };
+    let pool_labels = state.unpromoted_pool_labels.lock().clone();
     let browsers = state.browsers.lock();
     let labels: Vec<&String> = browsers
         .keys()

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -352,10 +352,25 @@ pub fn is_main_window(args: &serde_json::Value) -> serde_json::Value {
     serde_json::json!(label == "main")
 }
 
-/// List all open window labels.
+/// List all open window labels, excluding unpromoted pool windows.
+/// Pool windows are pre-warmed tear-off scratch windows kept hidden
+/// from the user (WS_EX_TOOLWINDOW, no taskbar entry). Including them
+/// in `list_windows` inflates the frontend's InstancePanel row count
+/// with phantom entries the user can't see or focus.
+///
+/// `state.window_pool` is the authoritative "is this label still
+/// unpromoted" check — promote_pool_window pops the label off this
+/// queue, so promoted tear-off windows pass through here normally.
 pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
+    let pool_labels: std::collections::HashSet<String> = {
+        let pool = state.window_pool.lock();
+        pool.iter().cloned().collect()
+    };
     let browsers = state.browsers.lock();
-    let labels: Vec<&String> = browsers.keys().collect();
+    let labels: Vec<&String> = browsers
+        .keys()
+        .filter(|l| !pool_labels.contains(*l))
+        .collect();
     serde_json::json!(labels)
 }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -133,21 +133,98 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
 }
 
 /// Called from on_after_created when a pool window's browser is
-/// registered. Logs only — the actual queue insertion happens via
-/// `mark_pool_window_renderer_ready` once the frontend reports its
-/// `pool:promote` listener is installed. Without that gate we'd
-/// race emit_event_to_window against the renderer's listener
-/// install, dropping the promote signal and stranding the window
-/// in pool mode.
-pub fn register_pool_window(_state: &Arc<AppState>, label: &str) {
+/// registered. Logs + applies WS_EX_TOOLWINDOW so the off-screen
+/// pool window doesn't show up in the taskbar / Alt+Tab. The
+/// promote path (`promote_pool_window`) clears it again so the
+/// torn-off window IS taskbar-visible.
+///
+/// Queue insertion still waits for `mark_pool_window_renderer_ready`
+/// (frontend-side handshake) — without that gate emit_event_to_window
+/// could race the renderer's listener install and drop the promote
+/// signal.
+pub fn register_pool_window(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;
+    }
+    #[cfg(target_os = "windows")]
+    {
+        // Look up the HWND under a short browsers lock; release
+        // before any Win32 FFI. The HWND should exist by the time
+        // on_after_created fires; if it doesn't, log and bail —
+        // the pool entry is harmless until promote re-checks.
+        use cef::{ImplBrowser, ImplBrowserHost};
+        let raw_hwnd: Option<*mut std::ffi::c_void> = {
+            let browsers = state.browsers.lock();
+            browsers.get(label).and_then(|browser| {
+                browser.host().and_then(|host| {
+                    let h = host.window_handle();
+                    if h.0.is_null() {
+                        None
+                    } else {
+                        Some(h.0 as *mut std::ffi::c_void)
+                    }
+                })
+            })
+        };
+        if let Some(hwnd) = raw_hwnd {
+            set_taskbar_hidden(hwnd, true);
+        } else {
+            tracing::warn!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] HWND not yet available at register time — taskbar hide skipped"
+            );
+        }
     }
     tracing::debug!(
         target: "dnd:tearoff:pool",
         label = %label,
         "[pool] browser registered, awaiting renderer-ready signal"
     );
+}
+
+/// Toggle WS_EX_TOOLWINDOW on a window's extended style so it
+/// appears (or doesn't) in the taskbar / Alt+Tab. We use this so
+/// pre-warmed pool windows stay invisible to the user, then
+/// re-enter the taskbar when promoted to a real torn-off window.
+///
+/// Per Win32 docs, changing the ex-style after creation only
+/// updates the taskbar reliably if the window is hidden + reshown.
+/// We do that hide/show cycle here with SWP_FRAMECHANGED so
+/// the change takes effect even if SW_HIDE was already implicit.
+#[cfg(target_os = "windows")]
+fn set_taskbar_hidden(hwnd: *mut std::ffi::c_void, hidden: bool) {
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::{
+            GetWindowLongPtrW, SetWindowLongPtrW, SetWindowPos, ShowWindow,
+            GWL_EXSTYLE, SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
+            SWP_NOZORDER, SW_HIDE, SW_SHOWNA, WS_EX_APPWINDOW, WS_EX_TOOLWINDOW,
+        };
+        let mut ex = GetWindowLongPtrW(hwnd, GWL_EXSTYLE);
+        if hidden {
+            ex |= WS_EX_TOOLWINDOW as isize;
+            ex &= !(WS_EX_APPWINDOW as isize);
+        } else {
+            ex &= !(WS_EX_TOOLWINDOW as isize);
+            ex |= WS_EX_APPWINDOW as isize;
+        }
+        // Hide → write style → show forces the shell to re-evaluate
+        // the taskbar entry. Without the hide/show pair Windows often
+        // keeps the original taskbar state on style change.
+        let _ = ShowWindow(hwnd, SW_HIDE);
+        SetWindowLongPtrW(hwnd, GWL_EXSTYLE, ex);
+        let _ = SetWindowPos(
+            hwnd,
+            std::ptr::null_mut(),
+            0, 0, 0, 0,
+            SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED,
+        );
+        // Don't re-show pool windows — they should stay hidden until
+        // promote. Re-show only when transitioning OUT of toolwindow.
+        if !hidden {
+            let _ = ShowWindow(hwnd, SW_SHOWNA);
+        }
+    }
 }
 
 /// Called when a pool window is destroyed before it ever became
@@ -335,6 +412,12 @@ pub fn promote_pool_window(
     // grabbed from a secondary.
     let pos_x = screen_x - POOL_WIDTH / 2;
     let pos_y = screen_y - TITLE_BAR_OFFSET_PX;
+
+    // Take the window out of WS_EX_TOOLWINDOW so the promoted window
+    // appears in the taskbar / Alt+Tab like any other AgentMux
+    // instance. Must run BEFORE the position/show below; otherwise
+    // the taskbar entry won't appear until the next style refresh.
+    set_taskbar_hidden(raw_hwnd, false);
 
     // Reposition + raise to top + show. SWP_NOZORDER is intentionally
     // *not* set — for tear-off we need the new window at the top of

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -72,9 +72,20 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
     // Use the `window-pool-` prefix so existing `is_instance_label`
     // checks (tear_off_hook.rs, app-init.ts) pass naturally — they
     // accept anything starting with `window-`. After promotion the
-    // label stays the same; "is in window_pool queue" is the
-    // authoritative pool-vs-promoted distinction.
+    // label stays the same; `unpromoted_pool_labels` is the
+    // authoritative pool-vs-promoted distinction (cleared on
+    // promote — `window_pool` is populated only after the
+    // renderer-ready handshake, so it's not reliable as the
+    // distinguisher during the ~100ms spawn → ready gap).
     let label = format!("window-pool-{}", window_id.simple());
+
+    // Mark this label as an unpromoted pool window NOW — before any
+    // CEF work — so list_windows / app-exit can filter it out the
+    // moment on_after_created adds it to state.browsers.
+    state
+        .unpromoted_pool_labels
+        .lock()
+        .insert(label.clone());
 
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
@@ -235,6 +246,11 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;
     }
+    // Drop the label from both the queue and the intent set so
+    // list_windows / app-exit don't keep treating a dead label as
+    // pool. Independent of whether the window made it into the
+    // queue (renderer crash before ready signal) or not.
+    state.unpromoted_pool_labels.lock().remove(label);
     // Single lock: drop the dead label + check whether we need to
     // refill, all in one critical section.
     let needs_refill = {
@@ -337,6 +353,10 @@ pub fn promote_pool_window(
     screen_y: i32,
 ) -> Option<String> {
     let label = state.window_pool.lock().pop_front()?;
+
+    // The label is no longer "unpromoted" — drop it from the intent
+    // set so list_windows starts treating this as a real instance.
+    state.unpromoted_pool_labels.lock().remove(&label);
 
     tracing::info!(
         target: "dnd:tearoff:pool",

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -225,6 +225,16 @@ pub struct AppState {
     /// Cold-path (open_window_at_position) remains as defence-in-depth.
     /// See SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26 §4.5.
     pub window_pool: Mutex<VecDeque<String>>,
+    /// Labels of pool windows that have been spawned but NOT yet
+    /// promoted. Populated synchronously in `spawn_pool_window` so
+    /// callers (list_windows, app-exit decision) can identify pool
+    /// windows BEFORE the renderer-ready handshake fires and
+    /// `window_pool` gets populated. Removed on promote, on
+    /// destroy-before-promote, and during pool teardown.
+    /// Without this, list_windows reports unpromoted pool windows
+    /// as user-visible instances during the ~100ms gap between
+    /// spawn and renderer-ready.
+    pub unpromoted_pool_labels: Mutex<std::collections::HashSet<String>>,
     /// Single in-flight respawn semaphore — prevents pool refill from
     /// stacking spawns when the user does back-to-back tear-offs faster
     /// than CEF can create windows.
@@ -293,6 +303,7 @@ impl Default for AppState {
             window_meta: Mutex::new(HashMap::new()),
             pending_window_labels: Mutex::new(VecDeque::new()),
             window_pool: Mutex::new(VecDeque::new()),
+            unpromoted_pool_labels: Mutex::new(std::collections::HashSet::new()),
             window_pool_respawn_in_flight: std::sync::atomic::AtomicBool::new(false),
             version_data_dir: Mutex::new(None),
             version_config_dir: Mutex::new(None),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.434"
+version = "0.33.435"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.432"
+version = "0.33.433"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.433"
+version = "0.33.434"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.429"
+version = "0.33.430"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.431"
+version = "0.33.432"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.430"
+version = "0.33.431"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.433"
+version = "0.33.434"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.429"
+version = "0.33.430"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.434"
+version = "0.33.435"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.430"
+version = "0.33.431"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.431"
+version = "0.33.432"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.432"
+version = "0.33.433"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.430"
+version = "0.33.431"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.429"
+version = "0.33.430"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.431"
+version = "0.33.432"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.432"
+version = "0.33.433"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.433"
+version = "0.33.434"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.434"
+version = "0.33.435"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -80,22 +80,12 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         clipboardWriteText(`${label}: ${value}`);
     };
 
-    // Display label: "main" → "Window 1", "window-<uuid>" → use the
-    // hex prefix as a stable short name. The host doesn't track human-
-    // readable per-window names today; the user sees the index +
-    // short-id which is enough to disambiguate.
-    //
-    // The optional `pool-` group accepts promoted warm-pool tear-offs
-    // (`window-pool-XXXXXXXX...`) so they display the same hex-suffixed
-    // short name as cold-path tear-offs (`window-XXXXXXXX...`). Without
-    // it the warm-pool path would silently render as a bare "Window N"
-    // while cold-path siblings show "Window N · XXXXXXXX".
-    const displayLabel = (label: string, idx: number): string => {
-        if (label === "main") return "Window 1";
-        const m = /^window-(?:pool-)?([0-9a-f]{8})/i.exec(label);
-        if (m) return `Window ${idx + 1} · ${m[1]}`;
-        return `Window ${idx + 1}`;
-    };
+    // Display label: just "Window N" using the row index. Main is
+    // pinned at index 0 → "Window 1". Hex suffixes were dropped — a
+    // user-renameable display name lands in a follow-up per
+    // docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md.
+    const displayLabel = (_label: string, idx: number): string =>
+        `Window ${idx + 1}`;
 
     return (
         <div

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -84,9 +84,15 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     // hex prefix as a stable short name. The host doesn't track human-
     // readable per-window names today; the user sees the index +
     // short-id which is enough to disambiguate.
+    //
+    // The optional `pool-` group accepts promoted warm-pool tear-offs
+    // (`window-pool-XXXXXXXX...`) so they display the same hex-suffixed
+    // short name as cold-path tear-offs (`window-XXXXXXXX...`). Without
+    // it the warm-pool path would silently render as a bare "Window N"
+    // while cold-path siblings show "Window N · XXXXXXXX".
     const displayLabel = (label: string, idx: number): string => {
         if (label === "main") return "Window 1";
-        const m = /^window-([0-9a-f]{8})/i.exec(label);
+        const m = /^window-(?:pool-)?([0-9a-f]{8})/i.exec(label);
         if (m) return `Window ${idx + 1} · ${m[1]}`;
         return `Window ${idx + 1}`;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.430",
+  "version": "0.33.431",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.430",
+      "version": "0.33.431",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.431",
+  "version": "0.33.432",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.431",
+      "version": "0.33.432",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.432",
+  "version": "0.33.433",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.432",
+      "version": "0.33.433",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.433",
+  "version": "0.33.434",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.433",
+      "version": "0.33.434",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.434",
+  "version": "0.33.435",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.434",
+      "version": "0.33.435",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.429",
+  "version": "0.33.430",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.429",
+      "version": "0.33.430",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.432",
+  "version": "0.33.433",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.431",
+  "version": "0.33.432",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.430",
+  "version": "0.33.431",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.429",
+  "version": "0.33.430",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.434",
+  "version": "0.33.435",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.433",
+  "version": "0.33.434",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 6 (PR #566) shipped warm-pool windows at `(-32000, -32000)` to keep the body off-screen, but Win32 still gives top-level frameless windows taskbar entries by default. Each running AgentMux instance ended up with `POOL_TARGET_SIZE` (= 2) phantom taskbar entries, and right-clicking → Close on a phantom kicked off `on_pool_window_destroyed` → `spawn_pool_window`, instantly respawning a replacement. Whack-a-mole the user couldn't win.

## Fix

`register_pool_window` (called from `on_after_created`) now applies `WS_EX_TOOLWINDOW` (and clears `WS_EX_APPWINDOW`) on the freshly-registered HWND so the pre-warmed pool window doesn't appear in the taskbar or Alt+Tab.

`promote_pool_window` clears `WS_EX_TOOLWINDOW` (and re-adds `WS_EX_APPWINDOW`) before positioning + showing, so the *promoted* window — which becomes a real torn-off AgentMux instance — IS taskbar-visible like any other window.

The hide → write style → `SetWindowPos(SWP_FRAMECHANGED)` cycle is required: Windows doesn't always re-evaluate the taskbar entry on a bare `GWL_EXSTYLE` change.

## Why a focused PR

This was a real regression from #566 reported by the user when they tried to test Phase 5 cancel-back on a portable build. We branched off from a parallel attempt at window-size preservation (in `agenta/tab-tearoff-window-size`) that didn't land cleanly — that work needs a redesign with `GetAncestor(GA_ROOT)` + per-monitor DPI handling per the retro at `docs/retro/tab-tearoff-retro-2026-04-27.md`. Shipping this taskbar fix independently so users get the unblock without waiting on the size redesign.

## Test plan

- [ ] Launch a fresh AgentMux instance — verify only ONE taskbar entry appears (the main window). No phantom entries.
- [ ] Tear off a tab → verify the new window gets a taskbar entry.
- [ ] Close the main window → verify no respawning ghost windows in the taskbar.
- [ ] Tear off a tab → close it → verify the warm pool refills silently in the background (still 0ms first-paint flash on subsequent tear-offs).
- [ ] Alt+Tab through windows: pool windows should NOT appear; promoted/main windows SHOULD appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)