### PR TITLE
feat(InstancePanel): user-renameable window display names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.436"
+version = "0.33.437"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.436"
+version = "0.33.437"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.436"
+version = "0.33.437"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.436"
+version = "0.33.437"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.437"
+version = "0.33.438"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.437"
+version = "0.33.438"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.437"
+version = "0.33.438"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.437"
+version = "0.33.438"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.438"
+version = "0.33.439"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.438"
+version = "0.33.439"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.438"
+version = "0.33.439"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.438"
+version = "0.33.439"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.435"
+version = "0.33.436"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.435"
+version = "0.33.436"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.435"
+version = "0.33.436"
 dependencies = [
  "windows-sys 0.59.0",
  "winres",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.435"
+version = "0.33.436"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.435"
+version = "0.33.436"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.438"
+version = "0.33.439"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.436"
+version = "0.33.437"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.437"
+version = "0.33.438"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -366,10 +366,12 @@ pub fn get_double_click_time() -> serde_json::Value {
     #[cfg(target_os = "windows")]
     {
         let ms = unsafe { windows_sys::Win32::UI::Input::KeyboardAndMouse::GetDoubleClickTime() };
-        return serde_json::json!(ms);
+        serde_json::json!(ms)
     }
-    #[allow(unreachable_code)]
-    serde_json::json!(500u32)
+    #[cfg(not(target_os = "windows"))]
+    {
+        serde_json::json!(500u32)
+    }
 }
 
 /// List all open window instances with their backend window IDs.

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -459,6 +459,19 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
         let keys: Vec<String> = state.window_id_map.lock().keys().cloned().collect();
         crate::client::dlog(&format!("window_id_map now has keys: {:?}", keys));
         tracing::info!(label = %label, window_id = %window_id, "[window] registered backend window ID");
+        // Notify listeners that the label→windowId mapping changed.
+        // The InstancePanel needs `windowId` to look up the backend
+        // Window record (display name in meta, workspace fallback).
+        // Without this emit, sibling windows would never re-fetch
+        // listWindowInstances after a freshly-opened window's
+        // windowId becomes available, leaving its row's name
+        // unresolvable and rename disabled. (codex PR #569 P2)
+        let count = state.window_instance_registry.lock().count();
+        crate::events::emit_event_all_windows(
+            state,
+            "window-instances-changed",
+            &serde_json::json!(count),
+        );
     } else {
         tracing::warn!(label = %label, "[window] register_backend_window called with empty window_id — skipped");
     }

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -352,6 +352,26 @@ pub fn is_main_window(args: &serde_json::Value) -> serde_json::Value {
     serde_json::json!(label == "main")
 }
 
+/// Return the OS double-click interval in milliseconds.
+/// On Windows: `GetDoubleClickTime()` — typically 500ms, user-configurable
+/// via Mouse settings. On non-Windows: hardcoded 500ms (the Win32 default,
+/// also a common cross-platform default; Phase 7 can refine per platform).
+///
+/// Used by the InstancePanel to defer single-click focus past the user's
+/// dblclick threshold so dblclick-to-rename works for everyone, not just
+/// users with the default-or-faster setting. Without this query, a fixed
+/// constant would make rename unreliable for slow double-clickers
+/// (codex PR #569 round-2 P2).
+pub fn get_double_click_time() -> serde_json::Value {
+    #[cfg(target_os = "windows")]
+    {
+        let ms = unsafe { windows_sys::Win32::UI::Input::KeyboardAndMouse::GetDoubleClickTime() };
+        return serde_json::json!(ms);
+    }
+    #[allow(unreachable_code)]
+    serde_json::json!(500u32)
+}
+
 /// List all open window instances with their backend window IDs.
 /// Same filtering as `list_windows` (excludes unpromoted pool windows
 /// and browser-pane child HWNDs), but returns `[{label, windowId}]`

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -352,6 +352,34 @@ pub fn is_main_window(args: &serde_json::Value) -> serde_json::Value {
     serde_json::json!(label == "main")
 }
 
+/// List all open window instances with their backend window IDs.
+/// Same filtering as `list_windows` (excludes unpromoted pool windows
+/// and browser-pane child HWNDs), but returns `[{label, windowId}]`
+/// pairs so the frontend can resolve per-window backend objects
+/// (Window record → meta["window:displayname"], etc.) without an
+/// extra round-trip per row.
+///
+/// `windowId` is `None` for windows that haven't yet completed the
+/// `register_backend_window` round-trip — typically a freshly-spawned
+/// window before its frontend has finished init. Callers should
+/// fall back to label/index-based naming in that case.
+pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
+    let pool_labels = state.unpromoted_pool_labels.lock().clone();
+    let window_id_map = state.window_id_map.lock();
+    let browsers = state.browsers.lock();
+    let entries: Vec<serde_json::Value> = browsers
+        .keys()
+        .filter(|l| !pool_labels.contains(*l) && !l.starts_with("browser-pane-"))
+        .map(|l| {
+            serde_json::json!({
+                "label": l,
+                "windowId": window_id_map.get(l),
+            })
+        })
+        .collect();
+    serde_json::json!(entries)
+}
+
 /// List all open window labels, excluding unpromoted pool windows.
 /// Pool windows are pre-warmed tear-off scratch windows kept hidden
 /// from the user (WS_EX_TOOLWINDOW, no taskbar entry). Including them

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -275,6 +275,7 @@ async fn route_command(
             .map_err(|e| format!("tear_off_sc_move_handshake join error: {}", e))?
         }
         "list_windows" => Ok(commands::window::list_windows(state)),
+        "list_window_instances" => Ok(commands::window::list_window_instances(state)),
         "focus_window" => commands::window::focus_window(state, args),
         "close_window_by_label" => commands::window::close_window_by_label(state, args),
 

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -276,6 +276,7 @@ async fn route_command(
         }
         "list_windows" => Ok(commands::window::list_windows(state)),
         "list_window_instances" => Ok(commands::window::list_window_instances(state)),
+        "get_double_click_time" => Ok(commands::window::get_double_click_time()),
         "focus_window" => commands::window::focus_window(state, args),
         "close_window_by_label" => commands::window::close_window_by_label(state, args),
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.435"
+version = "0.33.436"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.437"
+version = "0.33.438"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.438"
+version = "0.33.439"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.436"
+version = "0.33.437"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.437"
+version = "0.33.438"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.435"
+version = "0.33.436"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.436"
+version = "0.33.437"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.438"
+version = "0.33.439"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.436"
+version = "0.33.437"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.437"
+version = "0.33.438"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.438"
+version = "0.33.439"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.435"
+version = "0.33.436"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md
+++ b/docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md
@@ -1,0 +1,248 @@
+# Window Rename + Click Behaviors in InstancePanel
+
+**Date**: 2026-04-27
+**Author**: AgentA-asaf
+**Status**: Draft (proposed; not yet implemented)
+**Scope**: `frontend/app/statusbar/InstancePanel.tsx`, plus light backend support for persisting the user's chosen window name across restarts.
+
+---
+
+## 0. Quality bar
+
+- Single source of truth for the name (no display-vs-stored drift).
+- Rename UX matches the platform conventions users already see in this app (inline edit, Enter/Escape, blur-to-commit).
+- Rename survives full app restart and survives tear-off / merge / cancel-back.
+- Default name when unset is computed (not blank), so the panel is never empty rows.
+- Empty / whitespace-only names are rejected silently — the row reverts to the previous name.
+
+## 1. Goals
+
+The InstancePanel rows currently display either `Window 1` (main) or `Window N` (others), with no way to distinguish between two same-shaped instances at a glance. This spec covers:
+
+1. **Single click on a row** → focus that window (bring to foreground, switch to it).
+2. **Double click on a row** → enter rename mode for that row's display name.
+3. **Persistence** so renamed windows keep their names across:
+   - Full app restart
+   - Tear-off / cancel-back round-trips
+   - Multi-instance launches (each instance preserves its own names)
+
+## 2. UX behavior
+
+### 2.1 Single click → focus
+
+- Hover state: row gets the existing `instance-panel-row-hover` style (already present).
+- Click anywhere on the row (label area, padding) → call `getApi().focusWindow(label)`.
+- Already focused row (label === own window's label): no-op (current behavior preserved).
+- After focus, the panel closes (current behavior).
+
+This is **already implemented** in `InstancePanel.tsx::handleFocusWindow` — no spec changes needed beyond keeping current behavior.
+
+### 2.2 Double click → enter rename mode
+
+- Double click on a row → row's label converts to an inline `<input type="text">`:
+  - Pre-filled with the current name
+  - All text selected (so typing replaces it immediately)
+  - Receives focus
+- The row's icon / hover affordances (focus indicator) remain visible during rename.
+- The window-focus side-effect of single click is suppressed during the rename. Specifically: after the user starts a double-click (mousedown count = 2), do NOT fire `focusWindow`.
+
+#### 2.2.1 Commit / cancel
+
+- **Enter** key → commit. Validate (see §2.3); if valid, persist and exit edit mode.
+- **Escape** key → cancel. Discard input value, revert display to pre-edit name.
+- **Blur** (click outside the input, or the panel closes) → commit (treat as Enter).
+- The input's keyboard events are stopped from propagating to the global key handler — Enter must not trigger app-wide actions while in rename mode.
+
+#### 2.2.2 Validation
+
+- Trim leading/trailing whitespace before commit.
+- Reject:
+  - Empty string after trim → revert to previous name (no error toast — silent revert is fine for this UX).
+  - Length > 64 characters → truncate to 64.
+- Accept any other Unicode (no character whitelist — let the user use emoji, non-ASCII, etc.).
+
+### 2.3 Default name when unset
+
+When the user has not assigned a name, derive a default in this priority:
+
+1. **Workspace name** — `workspace.name` if non-empty.
+2. **Index-based fallback** — `Window 1`, `Window 2`, ... by row position (current behavior).
+
+The user's renamed value, if any, takes precedence over both.
+
+The default is computed at render time only — it is NOT persisted as the user's chosen name. This way, renaming the underlying workspace is reflected in unset windows (because they fall through to step 1), without overwriting any user-set names.
+
+## 3. Data model
+
+### 3.1 Where the name lives
+
+Two storage candidates with their tradeoffs:
+
+| Candidate | Pros | Cons |
+|---|---|---|
+| **Window record (backend `obj.rs::Window`)** | Persisted across restarts, follows the window's `oid`, single writer | Requires a backend object change + RPC; subwindow / pool windows wouldn't have a backend Window record yet |
+| **WindowMeta (host `state::WindowMeta`)** | Process-local, fast | Lost on restart; user expectations on "rename a window" imply persistence |
+
+**Decision: store on the backend `Window` record** as a new optional field `display_name: Option<String>`. Justification: rename is a deliberate user action; the user expects it to survive restart. Process-local would force them to re-rename every launch.
+
+Plumbing already exists: each frontend window has a `windowId` (`WaveWindow.oid`, distinct from the host label). The frontend resolves backend Window via existing channels. The renamed value goes through `ObjectService.UpdateObjectMeta` — same path used for workspace name/icon/color.
+
+### 3.2 Schema change
+
+In `agentmux-srv/src/backend/obj.rs`, the `Window` struct gains:
+
+```rust
+pub struct Window {
+    pub oid: String,
+    pub version: i64,
+    pub workspaceid: String,
+    // ... existing fields ...
+    /// User-assigned display name shown in the InstancePanel and any
+    /// other window-list UI. None → fall back to workspace name, then
+    /// to the index-based "Window N" label. Persisted across restarts.
+    /// Trimmed and length-capped at 64 chars on write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+```
+
+`#[serde(default)]` ensures forward/backward compat with existing on-disk Windows.
+
+### 3.3 RPC
+
+Use `ObjectService.UpdateObjectMeta` (already exists) with key `"window:displayname"` rather than adding a dedicated RPC. The meta map is the standard place for user-tunable per-object fields and avoids growing the service surface.
+
+Storing in meta vs the typed field is a coin-flip; meta is preferred here because:
+- No backend schema bump needed
+- Existing code paths handle meta updates uniformly
+- Other tunables (workspace color, tab color) follow the same pattern
+
+The typed field option from §3.2 is the alternative if we ever need stronger typing for tools that introspect Window records. For now: meta.
+
+## 4. Frontend changes
+
+### 4.1 Component shape
+
+Change `InstancePanel.tsx`'s row rendering:
+
+```tsx
+// Pseudo-code shape, not final source
+const [editingLabel, setEditingLabel] = createSignal<string | null>(null);
+const [editValue, setEditValue] = createSignal("");
+
+const handleRowClick = (label: string) => {
+    if (editingLabel() === label) return; // ignore inside-input clicks
+    handleFocusWindow(label);
+};
+
+const handleRowDblClick = (label: string, currentName: string) => {
+    setEditingLabel(label);
+    setEditValue(currentName);
+    // focus + select on next tick
+};
+
+const commitRename = async (label: string) => {
+    const trimmed = editValue().trim().slice(0, 64);
+    setEditingLabel(null);
+    if (!trimmed) return; // silent revert on empty
+    const windowId = await getWindowIdForLabel(label); // see §4.2
+    if (!windowId) return;
+    await ObjectService.UpdateObjectMeta(
+        makeORef("window", windowId),
+        { "window:displayname": trimmed },
+    );
+};
+```
+
+Row JSX:
+
+```tsx
+<div onClick={[handleRowClick, label]} onDblClick={[handleRowDblClick, label, currentName]}>
+    {editingLabel() === label
+        ? <input
+            value={editValue()}
+            onInput={e => setEditValue(e.currentTarget.value)}
+            onKeyDown={e => {
+                if (e.key === "Enter") commitRename(label);
+                else if (e.key === "Escape") setEditingLabel(null);
+                e.stopPropagation();
+            }}
+            onBlur={() => commitRename(label)}
+            ref={el => el && (el.focus(), el.select())}
+          />
+        : <span>{currentName}</span>}
+</div>
+```
+
+### 4.2 Resolving label → backend windowId
+
+The host already maps host-label → backend windowId via `state.window_id_map` (see `client.rs`). Frontend reads it via the existing `registerBackendWindow` round-trip; the InstancePanel will need access. Two options:
+
+1. **Add a host RPC** `getBackendWindowIdForLabel(label) → Option<string>`.
+2. **Pre-load** the mapping into `openWindowLabelsAtom` as `Array<{ label: string, windowId: string }>` instead of `Array<string>`.
+
+**Decision: (2)** — fewer round-trips, the data is already at hand, and the InstancePanel needs both pieces (label for focus, windowId for rename).
+
+### 4.3 Reactive name resolution
+
+The displayed name for each row is computed from a chain of fallbacks:
+
+```ts
+function resolveName(entry: { label: string, windowId: string }, workspaces: WorkspaceMap): string {
+    const win = getObjectValue<Window>(makeORef("window", entry.windowId));
+    const userName = win?.meta?.["window:displayname"];
+    if (typeof userName === "string" && userName.trim()) return userName.trim();
+    const ws = workspaces[win?.workspaceid ?? ""];
+    if (ws?.name) return ws.name;
+    return null; // signal "use index fallback"
+}
+```
+
+The row uses `resolveName(...) ?? \`Window ${idx + 1}\``. Updates to `window:displayname` flow through Wave's existing object subscription (the panel already subscribes to `WaveWindow` objects).
+
+## 5. Edge cases
+
+- **Two windows with the same name**: allowed. Disambiguation falls to the user; no auto-suffix.
+- **Renaming the main window** (label `"main"`, windowId is the primary client's): allowed. Same path as any other window.
+- **Tear-off mid-rename**: if the user is editing a row when a tear-off completes (new row appears), the edit state should NOT be disrupted — `editingLabel()` is keyed by label, so the new row renders normally.
+- **Window closed mid-rename**: the row disappears from `openWindowLabelsAtom`. The edit input unmounts; no commit fires (no `onBlur` on an unmounted element). User's typed value is lost — acceptable, the window is gone.
+- **Pool window in the list**: should not happen post-PR-#568 (pool windows are filtered from `list_windows`), so no rename UX needed for pool windows.
+- **Keyboard chord mode**: while in rename, prevent global chord shortcuts (Ctrl+T, Ctrl+W, etc.) from firing. The `e.stopPropagation()` in §4.1 handles this for keys; verify no document-level capture-phase listener bypasses it.
+
+## 6. Implementation phases
+
+| Phase | Scope | LOC est. |
+|---|---|---|
+| 1 | Backend meta key contract — write/read `window:displayname` via existing UpdateObjectMeta. No schema change. | 0 (uses existing) |
+| 2 | Frontend `openWindowLabelsAtom` shape change → `Array<{ label, windowId }>`. Add host RPC if needed. | ~30 |
+| 3 | InstancePanel row state machine (focus / dblclick / rename / commit / cancel). | ~80 |
+| 4 | Default-name fallback chain (user → workspace → index). | ~20 |
+| 5 | Tests for: empty-string revert, 64-char truncation, blur-commit, Escape-cancel. | ~50 |
+
+## 7. Out of scope
+
+- Renaming workspaces from this panel (workspaces have their own UI).
+- Custom icons / colors per window (workspace color already serves this).
+- Drag-to-reorder rows (rows are sorted "main first, then alphabetical by label" today).
+- Right-click context menu on rows (separate ask if needed).
+- Renaming via keyboard shortcut from outside the panel (open panel + dblclick is the entry point).
+
+## 8. Open questions
+
+- Should the row's hover affordance change during rename mode (e.g. dim other rows to indicate focus is captured)? Default: no, keep hover behavior consistent.
+- Should there be an explicit "rename" button on each row in addition to dblclick? Discoverability is a concern — dblclick is invisible to a first-time user. Consider adding a small pencil icon on hover, but that's an optional follow-up.
+- Should rename announce the new name via accessibility live region? Defer to A11y review.
+
+## 9. Acceptance tests
+
+- [ ] Single click on a non-focused row → that window comes to the foreground; panel closes.
+- [ ] Single click on already-focused row → no-op; panel closes.
+- [ ] Double click on a row → input appears with current name selected; subsequent typing replaces.
+- [ ] Type "My Window" + Enter → row displays "My Window".
+- [ ] Restart the app → "My Window" still displays.
+- [ ] Type "  " (spaces) + Enter → row reverts to previous name (no commit).
+- [ ] Type 100 chars + Enter → row displays the first 64 chars.
+- [ ] Press Escape during edit → row reverts to pre-edit name.
+- [ ] Click outside the input → commits as if Enter was pressed.
+- [ ] Tear off a tab from a renamed window → original window keeps its name; tear-off window gets the index-based default.
+- [ ] Rename a window, close it (last visible) → app exits cleanly; on next launch the window's name was attached to that *windowId*, not the label, so a re-spawn under a different label correctly shows the index default (the previously-renamed window record may be GC'd by `close_window` — verify cleanup path).

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -29,6 +29,7 @@ import {
     setWindowInstanceNumAtom,
     setWindowCountAtom,
     setOpenWindowLabelsAtom,
+    setOpenWindowEntriesAtom,
     setReinitVersion,
     setUpdaterStatusAtom,
     setUpdaterVersionAtom,
@@ -104,8 +105,25 @@ async function initInstanceTracking(): Promise<void> {
     let lastLabelsKey = "";
     const refreshLabels = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
         try {
-            const all = await getApi().listWindows();
-            const labels = sortInstanceLabels((Array.isArray(all) ? all : []).filter(isInstanceLabel));
+            // listWindowInstances gives us [{label, windowId}] in one
+            // RPC; we sort/filter on label and keep windowId aligned.
+            // Falls back to listWindows if the new RPC isn't supported
+            // (older host build) so the panel still works partially.
+            let entries: Array<{ label: string; windowId: string | null }>;
+            try {
+                const all = await getApi().listWindowInstances();
+                entries = Array.isArray(all) ? all : [];
+            } catch {
+                const all = await getApi().listWindows();
+                entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
+            }
+            const filtered = entries.filter((e) => isInstanceLabel(e.label));
+            filtered.sort((a, b) => {
+                if (a.label === "main") return -1;
+                if (b.label === "main") return 1;
+                return a.label.localeCompare(b.label);
+            });
+            const labels = filtered.map((e) => e.label);
             const key = labels.join("|");
             if (waitForChange && key === lastLabelsKey && retriesLeft > 0) {
                 setTimeout(() => refreshLabels(true, retriesLeft - 1), 50);
@@ -113,8 +131,10 @@ async function initInstanceTracking(): Promise<void> {
             }
             lastLabelsKey = key;
             setOpenWindowLabelsAtom(labels);
+            setOpenWindowEntriesAtom(filtered);
         } catch {
             setOpenWindowLabelsAtom([]);
+            setOpenWindowEntriesAtom([]);
         }
     };
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -81,28 +81,22 @@ async function initInstanceTracking(): Promise<void> {
     const isInstanceLabel = (l: string): boolean =>
         l === "main" || /^window-/.test(l);
 
-    // Stable ordering: "main" pinned first, others alphabetical. Without
-    // this the panel rows can shuffle between refreshes (state.browsers
-    // is a Rust HashMap with non-deterministic iteration), and two
-    // windows could both display as "Window 1" because InstancePanel
-    // uses the array index for naming and special-cases "main".
-    const sortInstanceLabels = (labels: string[]): string[] =>
-        [...labels].sort((a, b) => {
-            if (a === "main") return -1;
-            if (b === "main") return 1;
-            return a.localeCompare(b);
-        });
-
     // The host emits `window-instances-changed` *before* the new browser
     // is registered in state.browsers (the emit fires from window.rs:514
     // while registration happens later via on_after_created in client.rs).
     // The previous fix compared count against the event payload, but the
     // event count comes from window_instance_registry (different data
     // structure than state.browsers) so a count match is not reliable.
-    // Robust fix: poll until the listWindows() result actually CHANGES
-    // from the previously-seen set. Up to 6×50ms (~300ms total) covers
-    // the empirical CEF on_after_created delay with margin.
-    let lastLabelsKey = "";
+    // Robust fix: poll until the listWindowInstances() result actually
+    // CHANGES from the previously-seen set. The change key includes
+    // windowId so a `null → real` transition (when registerBackendWindow
+    // arrives later) also unblocks the wait, otherwise a freshly-opened
+    // window would appear with windowId=null and never get re-fetched
+    // until another open/close event happens — leaving the InstancePanel
+    // unable to resolve its name or rename it. (codex PR #569 P2)
+    // Up to 6×50ms (~300ms total) covers the empirical CEF
+    // on_after_created delay with margin.
+    let lastEntriesKey = "";
     const refreshLabels = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
         try {
             // listWindowInstances gives us [{label, windowId}] in one
@@ -118,18 +112,24 @@ async function initInstanceTracking(): Promise<void> {
                 entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
             }
             const filtered = entries.filter((e) => isInstanceLabel(e.label));
+            // Stable ordering: "main" pinned first, others alphabetical
+            // by label. Without this, panel rows can shuffle between
+            // refreshes (state.browsers is a Rust HashMap with
+            // non-deterministic iteration), and two windows could both
+            // display as "Window 1" because InstancePanel uses the
+            // array index for naming and special-cases "main".
             filtered.sort((a, b) => {
                 if (a.label === "main") return -1;
                 if (b.label === "main") return 1;
                 return a.label.localeCompare(b.label);
             });
             const labels = filtered.map((e) => e.label);
-            const key = labels.join("|");
-            if (waitForChange && key === lastLabelsKey && retriesLeft > 0) {
+            const key = filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
+            if (waitForChange && key === lastEntriesKey && retriesLeft > 0) {
                 setTimeout(() => refreshLabels(true, retriesLeft - 1), 50);
                 return;
             }
-            lastLabelsKey = key;
+            lastEntriesKey = key;
             setOpenWindowLabelsAtom(labels);
             setOpenWindowEntriesAtom(filtered);
         } catch {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -15,10 +15,15 @@
  * Per-window token totals deferred until token-usage is per-window.
  */
 
-import { getApi, openWindowLabelsAtom } from "@/store/global";
+import { getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { ObjectService } from "@/store/services";
+import { getObjectValue, makeORef } from "@/store/wos";
 import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+
+const DISPLAY_NAME_META_KEY = "window:displayname";
+const DISPLAY_NAME_MAX_LEN = 64;
 
 interface InstancePanelProps {
     anchorRect: DOMRect | null;
@@ -46,9 +51,15 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         };
     });
 
-    const labels = openWindowLabelsAtom;
+    const entries = openWindowEntriesAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
+
+    // Rename mode state — keyed by host label so the row's identity
+    // survives entries() reordering. Single rename at a time.
+    const [editingLabel, setEditingLabel] = createSignal<string | null>(null);
+    const [editValue, setEditValue] = createSignal("");
+    let activeInputRef: HTMLInputElement | undefined;
 
     const positioning = createMemo(() => {
         const r = props.anchorRect;
@@ -67,6 +78,59 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         }
     };
 
+    // Resolve a row's display name in priority order:
+    //   1. user-set name in Window meta (`window:displayname`)
+    //   2. workspace.name (when the user has named the workspace)
+    //   3. index-based fallback "Window N"
+    // Returns the resolved string for rendering. Reactive via Wave's
+    // object subscriptions because getObjectValue reads through atoms.
+    const resolveName = (entry: WindowEntry, idx: number): string => {
+        if (entry.windowId) {
+            const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
+            const userName = (win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined)?.trim();
+            if (userName) return userName;
+            if (win?.workspaceid) {
+                const ws = getObjectValue<Workspace>(makeORef("workspace", win.workspaceid));
+                if (ws?.name?.trim()) return ws.name.trim();
+            }
+        }
+        return `Window ${idx + 1}`;
+    };
+
+    const enterRename = (entry: WindowEntry, currentName: string) => {
+        if (!entry.windowId) return; // can't rename a window without a backend record yet
+        setEditingLabel(entry.label);
+        setEditValue(currentName);
+    };
+
+    const cancelRename = () => {
+        setEditingLabel(null);
+        setEditValue("");
+    };
+
+    const commitRename = async (entry: WindowEntry) => {
+        const editing = editingLabel();
+        if (editing !== entry.label) return; // stale
+        if (!entry.windowId) {
+            cancelRename();
+            return;
+        }
+        const trimmed = editValue().trim().slice(0, DISPLAY_NAME_MAX_LEN);
+        // Empty after trim → silent revert per spec §2.2.2.
+        const next = editingLabel();
+        setEditingLabel(null);
+        setEditValue("");
+        if (!trimmed || next !== entry.label) return;
+        try {
+            await ObjectService.UpdateObjectMeta(
+                makeORef("window", entry.windowId),
+                { [DISPLAY_NAME_META_KEY]: trimmed } as MetaType,
+            );
+        } catch (e) {
+            console.error("[InstancePanel] rename failed:", e);
+        }
+    };
+
     const handleOpenNewWindow = async () => {
         try {
             await getApi().openNewWindow();
@@ -80,12 +144,6 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         clipboardWriteText(`${label}: ${value}`);
     };
 
-    // Display label: just "Window N" using the row index. Main is
-    // pinned at index 0 → "Window 1". Hex suffixes were dropped — a
-    // user-renameable display name lands in a follow-up per
-    // docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md.
-    const displayLabel = (_label: string, idx: number): string =>
-        `Window ${idx + 1}`;
 
     return (
         <div
@@ -131,26 +189,77 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
             <div class="instance-panel-divider" />
             <div class="instance-panel-section">
                 <div class="instance-panel-section-title">
-                    This process — {labels().length} window{labels().length !== 1 ? "s" : ""}
+                    This process — {entries().length} window{entries().length !== 1 ? "s" : ""}
                 </div>
-                <For each={labels()}>
-                    {(label, i) => {
-                        const isCurrent = () => label === myLabel();
+                <For each={entries()}>
+                    {(entry, i) => {
+                        const isCurrent = () => entry.label === myLabel();
+                        const isEditing = () => editingLabel() === entry.label;
+                        const currentName = () => resolveName(entry, i());
                         return (
-                            <button
-                                type="button"
+                            <div
                                 class="instance-panel-window-row"
-                                classList={{ "instance-panel-window-row-current": isCurrent() }}
-                                onClick={() => handleFocusWindow(label)}
-                                disabled={isCurrent()}
-                                title={isCurrent() ? "This window" : `Focus ${label}`}
+                                classList={{
+                                    "instance-panel-window-row-current": isCurrent(),
+                                    "instance-panel-window-row-editing": isEditing(),
+                                }}
+                                onClick={(e) => {
+                                    if (isEditing()) {
+                                        e.stopPropagation();
+                                        return;
+                                    }
+                                    handleFocusWindow(entry.label);
+                                }}
+                                onDblClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    enterRename(entry, currentName());
+                                }}
+                                title={isCurrent() ? "This window — double-click to rename" : `Click to focus, double-click to rename`}
+                                role="button"
+                                tabIndex={0}
                             >
                                 <span class="instance-panel-window-dot">{isCurrent() ? "●" : "○"}</span>
-                                <span class="instance-panel-window-name">{displayLabel(label, i())}</span>
-                                <Show when={isCurrent()}>
+                                <Show
+                                    when={isEditing()}
+                                    fallback={
+                                        <span class="instance-panel-window-name">{currentName()}</span>
+                                    }
+                                >
+                                    <input
+                                        ref={(el) => {
+                                            activeInputRef = el;
+                                            if (el) {
+                                                queueMicrotask(() => {
+                                                    el.focus();
+                                                    el.select();
+                                                });
+                                            }
+                                        }}
+                                        class="instance-panel-window-name-input"
+                                        value={editValue()}
+                                        maxLength={DISPLAY_NAME_MAX_LEN}
+                                        onInput={(e) => setEditValue(e.currentTarget.value)}
+                                        onKeyDown={(e) => {
+                                            // Stop global key handlers from firing while editing.
+                                            e.stopPropagation();
+                                            if (e.key === "Enter") {
+                                                e.preventDefault();
+                                                commitRename(entry);
+                                            } else if (e.key === "Escape") {
+                                                e.preventDefault();
+                                                cancelRename();
+                                            }
+                                        }}
+                                        onBlur={() => commitRename(entry)}
+                                        onClick={(e) => e.stopPropagation()}
+                                        onDblClick={(e) => e.stopPropagation()}
+                                    />
+                                </Show>
+                                <Show when={isCurrent() && !isEditing()}>
                                     <span class="instance-panel-window-badge">this</span>
                                 </Show>
-                            </button>
+                            </div>
                         );
                     }}
                 </For>

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -134,7 +134,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         setEditValue("");
     };
 
-    const commitRename = async (entry: WindowEntry) => {
+    // Single shared persistence path used by both commitRename
+    // (Enter / blur) and the onCleanup unmount-flush. Keeps the
+    // trim + cap + RPC + error-log shape consistent. (gemini
+    // PR #569 round-3 MEDIUM @ L176)
+    const performRename = (windowId: string, name: string) => {
+        ObjectService.UpdateObjectMeta(
+            makeORef("window", windowId),
+            { [DISPLAY_NAME_META_KEY]: name } as MetaType,
+        ).catch((e) => console.error("[InstancePanel] rename failed:", e));
+    };
+
+    const commitRename = (entry: WindowEntry) => {
         const editing = editingLabel();
         if (editing !== entry.label) return; // stale
         if (!entry.windowId) {
@@ -143,36 +154,30 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         }
         const trimmed = editValue().trim().slice(0, DISPLAY_NAME_MAX_LEN);
         // Empty after trim → silent revert per spec §2.2.2.
-        const next = editingLabel();
         setEditingLabel(null);
         setEditValue("");
-        if (!trimmed || next !== entry.label) return;
-        try {
-            await ObjectService.UpdateObjectMeta(
-                makeORef("window", entry.windowId),
-                { [DISPLAY_NAME_META_KEY]: trimmed } as MetaType,
-            );
-        } catch (e) {
-            console.error("[InstancePanel] rename failed:", e);
-        }
+        if (!trimmed) return;
+        performRename(entry.windowId, trimmed);
     };
 
-    // Commit any in-flight rename on panel unmount. The panel can be
-    // dismissed by StatusBar's outside-click handler before the input's
-    // onBlur fires, which would otherwise silently lose the typed
-    // value. fireAndForget — the panel is going away regardless and
-    // we don't block teardown on the RPC. (codex PR #569 round-2 P1)
+    // Panel-unmount cleanup:
+    //   1. Cancel any pending focus timer so it doesn't fire after
+    //      the panel is gone (focus call would still hit a real
+    //      window, but it's a wasted call + a small leak).
+    //      (gemini PR #569 round-3 MEDIUM @ L77)
+    //   2. Flush any in-flight rename. StatusBar's outside-click
+    //      dismiss can unmount the input before its onBlur fires,
+    //      which would otherwise silently lose the typed value.
+    //      (codex PR #569 round-2 P1)
     onCleanup(() => {
+        cancelPendingFocus();
         const editing = editingLabel();
         if (!editing) return;
         const entry = entries().find((e) => e.label === editing);
         if (!entry || !entry.windowId) return;
         const trimmed = editValue().trim().slice(0, DISPLAY_NAME_MAX_LEN);
         if (!trimmed) return;
-        ObjectService.UpdateObjectMeta(
-            makeORef("window", entry.windowId),
-            { [DISPLAY_NAME_META_KEY]: trimmed } as MetaType,
-        ).catch((e) => console.error("[InstancePanel] cleanup rename failed:", e));
+        performRename(entry.windowId, trimmed);
     });
 
     const handleOpenNewWindow = async () => {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -20,7 +20,7 @@ import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
 import { getObjectValue, makeORef } from "@/store/wos";
-import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 
 const DISPLAY_NAME_META_KEY = "window:displayname";
 const DISPLAY_NAME_MAX_LEN = 64;
@@ -67,7 +67,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     // focus by row label so a click on row B while a focus is
     // pending for row A still treats B as a fresh single click.
     // (reagent / codex / gemini PR #569 P1)
-    const DBLCLICK_DELAY_MS = 230;
+    //
+    // Threshold queried from the OS (Win32 GetDoubleClickTime,
+    // user-configurable, default 500ms) so slow double-clickers
+    // are accommodated. Defaults to 500ms while the query is
+    // in flight, plus a 50ms buffer to absorb event-dispatch jitter.
+    // (codex PR #569 round-2 P2)
+    const [dblclickDelayMs, setDblclickDelayMs] = createSignal(550);
+    getApi()
+        .getDoubleClickTime()
+        .then((ms) => setDblclickDelayMs(Math.max(120, ms + 50)))
+        .catch(() => {/* keep default */});
+
     let pendingFocus: { label: string; timer: number } | null = null;
     const cancelPendingFocus = () => {
         if (pendingFocus) {
@@ -145,6 +156,24 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
             console.error("[InstancePanel] rename failed:", e);
         }
     };
+
+    // Commit any in-flight rename on panel unmount. The panel can be
+    // dismissed by StatusBar's outside-click handler before the input's
+    // onBlur fires, which would otherwise silently lose the typed
+    // value. fireAndForget — the panel is going away regardless and
+    // we don't block teardown on the RPC. (codex PR #569 round-2 P1)
+    onCleanup(() => {
+        const editing = editingLabel();
+        if (!editing) return;
+        const entry = entries().find((e) => e.label === editing);
+        if (!entry || !entry.windowId) return;
+        const trimmed = editValue().trim().slice(0, DISPLAY_NAME_MAX_LEN);
+        if (!trimmed) return;
+        ObjectService.UpdateObjectMeta(
+            makeORef("window", entry.windowId),
+            { [DISPLAY_NAME_META_KEY]: trimmed } as MetaType,
+        ).catch((e) => console.error("[InstancePanel] cleanup rename failed:", e));
+    });
 
     const handleOpenNewWindow = async () => {
         try {
@@ -240,7 +269,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         timer: window.setTimeout(() => {
                                             pendingFocus = null;
                                             handleFocusWindow(label);
-                                        }, DBLCLICK_DELAY_MS),
+                                        }, dblclickDelayMs()),
                                     };
                                 }}
                                 onDblClick={(e) => {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -59,7 +59,22 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     // survives entries() reordering. Single rename at a time.
     const [editingLabel, setEditingLabel] = createSignal<string | null>(null);
     const [editValue, setEditValue] = createSignal("");
-    let activeInputRef: HTMLInputElement | undefined;
+
+    // Defer single-click focus past the dblclick threshold so
+    // double-clicking a row enters rename mode WITHOUT first
+    // bringing the other window forward (which would close /
+    // hide this panel and abort the rename). Tracks the pending
+    // focus by row label so a click on row B while a focus is
+    // pending for row A still treats B as a fresh single click.
+    // (reagent / codex / gemini PR #569 P1)
+    const DBLCLICK_DELAY_MS = 230;
+    let pendingFocus: { label: string; timer: number } | null = null;
+    const cancelPendingFocus = () => {
+        if (pendingFocus) {
+            clearTimeout(pendingFocus.timer);
+            pendingFocus = null;
+        }
+    };
 
     const positioning = createMemo(() => {
         const r = props.anchorRect;
@@ -208,14 +223,45 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         e.stopPropagation();
                                         return;
                                     }
-                                    handleFocusWindow(entry.label);
+                                    // If a focus was pending on THIS row, this is
+                                    // the second click of a dblclick — let dblClick
+                                    // handle it; cancel the pending focus.
+                                    if (pendingFocus && pendingFocus.label === entry.label) {
+                                        cancelPendingFocus();
+                                        return;
+                                    }
+                                    // Otherwise schedule a fresh focus past the
+                                    // dblclick threshold so a follow-up click can
+                                    // promote it to rename instead.
+                                    cancelPendingFocus();
+                                    const label = entry.label;
+                                    pendingFocus = {
+                                        label,
+                                        timer: window.setTimeout(() => {
+                                            pendingFocus = null;
+                                            handleFocusWindow(label);
+                                        }, DBLCLICK_DELAY_MS),
+                                    };
                                 }}
                                 onDblClick={(e) => {
                                     e.preventDefault();
                                     e.stopPropagation();
+                                    cancelPendingFocus();
                                     enterRename(entry, currentName());
                                 }}
-                                title={isCurrent() ? "This window — double-click to rename" : `Click to focus, double-click to rename`}
+                                onKeyDown={(e) => {
+                                    if (isEditing()) return; // input owns key handling
+                                    if (e.key === "Enter" || e.key === " ") {
+                                        e.preventDefault();
+                                        cancelPendingFocus();
+                                        handleFocusWindow(entry.label);
+                                    } else if (e.key === "F2") {
+                                        e.preventDefault();
+                                        cancelPendingFocus();
+                                        enterRename(entry, currentName());
+                                    }
+                                }}
+                                title={isCurrent() ? "This window — double-click to rename (F2)" : `Click to focus, double-click to rename (F2)`}
                                 role="button"
                                 tabIndex={0}
                             >
@@ -228,7 +274,6 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                 >
                                     <input
                                         ref={(el) => {
-                                            activeInputRef = el;
                                             if (el) {
                                                 queueMicrotask(() => {
                                                     el.focus();

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -137,6 +137,15 @@ export const [lanInstancesAtom, setLanInstancesAtom] = createSignal<LanInstance[
 // See SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md.
 export const [openWindowLabelsAtom, setOpenWindowLabelsAtom] = createSignal<string[]>([]);
 
+// Same list, but each entry carries the backend window id alongside the
+// host label so the InstancePanel can resolve per-window Window records
+// (display name in meta, workspace name fallback) without an extra RPC.
+// `windowId` may be null for windows whose `registerBackendWindow`
+// round-trip hasn't fired yet (typical during the first ~100ms of a
+// new window). See SPEC_WINDOW_RENAME_2026_04_27.md.
+export type WindowEntry = { label: string; windowId: string | null };
+export const [openWindowEntriesAtom, setOpenWindowEntriesAtom] = createSignal<WindowEntry[]>([]);
+
 // ---------------------------------------------------------------------------
 // GlobalAtomsType-compatible export (used in wos.ts callBackendService)
 // ---------------------------------------------------------------------------

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -128,6 +128,13 @@ declare global {
          *  to look up per-window backend Window records (display name
          *  in meta, workspace fallback, etc.) without an extra RPC. */
         listWindowInstances: () => Promise<Array<{ label: string; windowId: string | null }>>;
+        /** OS-reported double-click interval in milliseconds. Used by
+         *  InstancePanel to defer single-click focus past the user's
+         *  configured threshold so double-click-to-rename works for
+         *  slow double-clickers (Win32 GetDoubleClickTime, default
+         *  500ms, user-configurable). Falls back to 500ms on non-
+         *  Windows. */
+        getDoubleClickTime: () => Promise<number>;
         focusWindow: (label: string) => Promise<void>;
         getInstanceNumber: () => Promise<number>;
         getWindowCount: () => Promise<number>;

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -122,6 +122,12 @@ declare global {
         isMainWindow: () => Promise<boolean>;
         registerBackendWindow: (label: string, windowId: string) => void;
         listWindows: () => Promise<string[]>;
+        /** Like listWindows but returns `[{label, windowId}]` pairs.
+         *  `windowId` is null for windows that haven't yet completed
+         *  the registerBackendWindow round-trip. Used by InstancePanel
+         *  to look up per-window backend Window records (display name
+         *  in meta, workspace fallback, etc.) without an extra RPC. */
+        listWindowInstances: () => Promise<Array<{ label: string; windowId: string | null }>>;
         focusWindow: (label: string) => Promise<void>;
         getInstanceNumber: () => Promise<number>;
         getWindowCount: () => Promise<number>;

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -421,6 +421,11 @@ export function buildCefApi(): AppApi {
         listWindows: async () => {
             return await invokeCommand<string[]>("list_windows");
         },
+        listWindowInstances: async () => {
+            return await invokeCommand<Array<{ label: string; windowId: string | null }>>(
+                "list_window_instances",
+            );
+        },
         focusWindow: async (label: string) => {
             await invokeCommand("focus_window", { label });
         },

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -426,6 +426,9 @@ export function buildCefApi(): AppApi {
                 "list_window_instances",
             );
         },
+        getDoubleClickTime: async () => {
+            return await invokeCommand<number>("get_double_click_time");
+        },
         focusWindow: async (label: string) => {
             await invokeCommand("focus_window", { label });
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.435",
+  "version": "0.33.436",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.435",
+      "version": "0.33.436",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.437",
+  "version": "0.33.438",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.437",
+      "version": "0.33.438",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.436",
+  "version": "0.33.437",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.436",
+      "version": "0.33.437",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.438",
+  "version": "0.33.439",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.438",
+      "version": "0.33.439",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.436",
+  "version": "0.33.437",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.435",
+  "version": "0.33.436",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.437",
+  "version": "0.33.438",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.438",
+  "version": "0.33.439",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements [docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md](docs/specs/SPEC_WINDOW_RENAME_2026_04_27.md).

InstancePanel rows now show a resolved display name with a priority chain:

1. User-set `window:displayname` in Window meta
2. Workspace.name (when the user has named the workspace)
3. Index-based fallback ("Window 1", "Window 2"...)

## Interactions

| Gesture | Action |
|---|---|
| Single click on a row | Focus that window (existing behavior) |
| Double click on a row | Enter inline rename mode |
| `Enter` while editing | Commit (trim, length-cap 64) |
| `Escape` while editing | Cancel; revert to pre-edit name |
| Click outside / blur | Commit |
| Empty / whitespace-only input | Silent revert |

## Plumbing

- **New host RPC** `list_window_instances` returns `[{label, windowId}]` so the panel can resolve per-window backend Window records (display name in meta, workspace fallback) without an extra round-trip per row. Frontend falls back to `list_windows` if the new RPC fails (older host).
- **New `openWindowEntriesAtom`** carries `{label, windowId}` pairs; `openWindowLabelsAtom` is kept for backward compat with CrossWindowDragMonitor (label-only consumer).
- **Persistence** via existing `ObjectService.UpdateObjectMeta` writing `window:displayname` — no backend schema change. Same pattern as workspace color, tab color, etc.

## Test plan

- [ ] Single click on a non-current row → focuses that window
- [ ] Double click on any row → enters edit mode with current name selected
- [ ] Type "My Window" + Enter → row displays "My Window"
- [ ] Restart app → rename persists
- [ ] Type "  " (spaces only) + Enter → row reverts (silent)
- [ ] Type 100 chars + Enter → truncates to 64
- [ ] Press Escape during edit → reverts to pre-edit name
- [ ] Click outside the input → commits
- [ ] Rename a workspace → unset windows in that workspace pick up the new workspace name; user-set names are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)