### PR TITLE
Phase B.1: launcher spawns srv as sibling of host

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,9 @@ dependencies = [
 name = "agentmux-launcher"
 version = "0.33.441"
 dependencies = [
+ "chrono",
+ "dirs",
+ "tokio",
  "windows-sys 0.59.0",
  "winres",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.443"
+version = "0.33.444"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.443"
+version = "0.33.444"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.443"
+version = "0.33.444"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.443"
+version = "0.33.444"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "chrono",
  "dirs",
  "tokio",
+ "uuid",
  "windows-sys 0.59.0",
  "winres",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.445"
+version = "0.33.446"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.445"
+version = "0.33.446"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.445"
+version = "0.33.446"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.445"
+version = "0.33.446"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.444"
+version = "0.33.445"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.444"
+version = "0.33.445"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.444"
+version = "0.33.445"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.444"
+version = "0.33.445"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.442"
+version = "0.33.443"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.442"
+version = "0.33.443"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.442"
+version = "0.33.443"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.442"
+version = "0.33.443"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.441"
+version = "0.33.442"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.441"
+version = "0.33.442"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.441"
+version = "0.33.442"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.441"
+version = "0.33.442"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.445"
+version = "0.33.446"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.443"
+version = "0.33.444"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.441"
+version = "0.33.442"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.442"
+version = "0.33.443"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.444"
+version = "0.33.445"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/backend.rs
+++ b/agentmux-cef/src/commands/backend.rs
@@ -83,8 +83,26 @@ pub fn fe_log_structured(args: &serde_json::Value) -> serde_json::Value {
 }
 
 /// Restart the agentmux-srv backend sidecar.
+///
+/// Phase B.1: in launcher-managed runs (`AGENTMUX_BACKEND_PID` env
+/// is set by the launcher), the host does NOT own the srv child
+/// handle — `state.sidecar_child` stays None. Naively running the
+/// kill-then-spawn flow here would skip killing the launcher's srv
+/// (no handle to kill) and spawn a SECOND srv touching the same
+/// data dir, corrupting state. Refuse with a clear message until
+/// Phase B.2 wires a Quit command from host to launcher to do the
+/// restart cleanly. (codex P2 @ sidecar.rs:58, PR #571 round-3.)
 pub async fn restart_backend(state: Arc<AppState>) -> Result<serde_json::Value, String> {
     tracing::info!("[restart_backend] user-initiated restart");
+
+    if std::env::var("AGENTMUX_BACKEND_PID").is_ok() {
+        let msg = "backend lifecycle is owned by the launcher in this run \
+                   (AGENTMUX_BACKEND_PID set); host-initiated restart is \
+                   disabled until Phase B.2 wires the launcher RPC. \
+                   Restart the entire app to get a fresh srv.";
+        tracing::warn!("[restart_backend] refused: {}", msg);
+        return Err(msg.to_string());
+    }
 
     // Kill existing sidecar if still alive
     {

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -223,12 +223,42 @@ fn main() {
 
     tracing::info!("IPC server started on port {}", ipc_port);
 
-    // Spawn the backend sidecar SYNCHRONOUSLY — block until it signals ready
-    // (WAVESRV-ESTART) before creating the browser window. This eliminates the
-    // race condition where CEF loads the frontend before the backend is available,
-    // which causes a "raw browser" appearance on slow machines or first launch.
+    // Phase B.1: if launcher already spawned srv (the normal portable
+    // / installed path post-PR-#570 + B.1), populate state from the
+    // env vars launcher set — no need to re-spawn srv. Falls back to
+    // spawn_backend() ONLY when env vars are absent (`task dev` mode
+    // where the host runs without the launcher).
+    //
+    // Spawn the backend sidecar SYNCHRONOUSLY — block until it
+    // signals ready (WAVESRV-ESTART) before creating the browser
+    // window. This eliminates the race condition where CEF loads the
+    // frontend before the backend is available, which causes a "raw
+    // browser" appearance on slow machines or first launch.
     let backend_ready = runtime.block_on(async {
-        match sidecar::spawn_backend(&app_state).await {
+        let launcher_provided = sidecar::use_launcher_endpoints(&app_state);
+        let result = match launcher_provided {
+            Some(Ok(r)) => {
+                tracing::info!(
+                    "Using launcher-provided backend endpoints: ws={} web={} pid={}",
+                    r.ws_endpoint,
+                    r.web_endpoint,
+                    r.instance_id
+                );
+                Ok(r)
+            }
+            Some(Err(e)) => {
+                tracing::error!(
+                    "Launcher set AGENTMUX_BACKEND_WS but env was malformed: {} — refusing to fall back to spawn_backend (would fight launcher's srv)",
+                    e
+                );
+                Err(e)
+            }
+            None => {
+                tracing::info!("No launcher-provided backend env (dev mode) — spawning srv ourselves");
+                sidecar::spawn_backend(&app_state).await
+            }
+        };
+        match result {
             Ok(result) => {
                 {
                     let mut endpoints = app_state.backend_endpoints.lock();
@@ -243,7 +273,7 @@ fn main() {
                 true
             }
             Err(e) => {
-                tracing::error!("Failed to spawn backend: {}", e);
+                tracing::error!("Failed to set up backend: {}", e);
                 false
             }
         }

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -30,9 +30,26 @@ pub struct BackendSpawnResult {
 pub fn use_launcher_endpoints(
     state: &Arc<AppState>,
 ) -> Option<Result<BackendSpawnResult, String>> {
+    // The env var being absent means "host is running standalone";
+    // fall through to spawn_backend. The env var being PRESENT but
+    // empty means the launcher set it (we're in launcher-managed
+    // mode) but with a malformed value — likely an ESTART parse
+    // mismatch in the launcher. Treat that as Err, NOT as
+    // "fall back to spawn_backend" — the latter would spawn a
+    // SECOND srv against the same data dir while the launcher's
+    // already-running srv keeps going, corrupting state. Better to
+    // fail fast and surface the launcher bug. (codex P2 @
+    // sidecar.rs:35, PR #571 round-4.)
     let ws = std::env::var("AGENTMUX_BACKEND_WS").ok()?;
     if ws.is_empty() {
-        return None;
+        return Some(Err(
+            "launcher set AGENTMUX_BACKEND_WS but it was empty — \
+             refusing to fall back to spawn_backend (would create a \
+             duplicate srv against the same data dir). This is a \
+             launcher bug; check the WAVESRV-ESTART parse path in \
+             agentmux-launcher/src/srv_spawner.rs::parse_estart."
+                .to_string(),
+        ));
     }
     // From here on we KNOW the launcher provided env; missing fields
     // mean a launcher bug, so emit Err rather than fall through to

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -233,26 +233,23 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     *state.backend_pid.lock() = Some(child_pid);
     *state.backend_started_at.lock() = Some(chrono::Utc::now().to_rfc3339());
 
-    // 8. Windows: Job Object (KILL_ON_JOB_CLOSE)
-    #[cfg(target_os = "windows")]
-    {
-        match create_job_object_for_child(child_pid) {
-            Ok(job_handle) => {
-                tracing::info!(
-                    "Created Job Object for backend (pid={}), KILL_ON_JOB_CLOSE active",
-                    child_pid
-                );
-                *state.job_handle.lock() =
-                    Some(crate::state::JobHandle::new(job_handle));
-            }
-            Err(e) => {
-                tracing::error!(
-                    "Failed to create Job Object for backend: {}. Backend may orphan on crash.",
-                    e
-                );
-            }
-        }
-    }
+    // (Phase B.1: removed host-owned Job Object J1 on srv. The
+    // launcher's J0 covers srv via direct AssignProcessToJobObject.
+    //
+    // Why not "defense-in-depth": the spec originally suggested
+    // keeping host's J1 as a backstop, but on inspection it would
+    // ACTIVELY defeat B.1's goal. KILL_ON_JOB_CLOSE on J1 fires
+    // when the host process exits — taking srv with it. After B.1,
+    // we want srv to survive host crashes (so the launcher can
+    // restart the host without losing srv state). The two reapers
+    // are mutually exclusive given that goal: launcher's J0 wants
+    // srv to live; host's J1 wants srv to die. We picked J0.
+    //
+    // The `task dev` fallback path (host runs without launcher)
+    // still loses kernel-level reaping for srv on host crash.
+    // That's an accepted regression for dev-mode-only — production
+    // (portable / installed) is unaffected. Phase 7 may add a
+    // separate Job Object for the dev path.)
 
     // 9. Parse stderr for ESTART (30s timeout)
     let stderr = child.stderr.take().expect("Failed to get stderr");
@@ -475,55 +472,7 @@ fn parse_estart(line: &str) -> BackendSpawnResult {
     }
 }
 
-/// Create a Windows Job Object and assign the child process to it.
-#[cfg(target_os = "windows")]
-fn create_job_object_for_child(pid: u32) -> Result<*mut std::ffi::c_void, String> {
-    use windows_sys::Win32::Foundation::CloseHandle;
-    use windows_sys::Win32::System::JobObjects::*;
-    use windows_sys::Win32::System::Threading::*;
-
-    // CreateJobObjectW is not exported by windows-sys 0.59's JobObjects feature,
-    // so we link to kernel32.dll directly.
-    #[link(name = "kernel32")]
-    extern "system" {
-        fn CreateJobObjectW(
-            lpjobattributes: *const std::ffi::c_void,
-            lpname: *const u16,
-        ) -> *mut std::ffi::c_void;
-    }
-
-    unsafe {
-        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
-        if job.is_null() {
-            return Err("Failed to create job object".into());
-        }
-
-        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
-        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        let ok = SetInformationJobObject(
-            job,
-            JobObjectExtendedLimitInformation,
-            &info as *const _ as *const std::ffi::c_void,
-            std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-        );
-        if ok == 0 {
-            CloseHandle(job);
-            return Err("Failed to set job object info".into());
-        }
-
-        let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
-        if process.is_null() {
-            CloseHandle(job);
-            return Err(format!("Failed to open process {}", pid));
-        }
-
-        let ok = AssignProcessToJobObject(job, process);
-        CloseHandle(process);
-        if ok == 0 {
-            CloseHandle(job);
-            return Err("Failed to assign process to job object".into());
-        }
-
-        Ok(job)
-    }
-}
+// Phase B.1: removed `create_job_object_for_child`. Host no longer
+// owns a Job Object; launcher's J0 (in agentmux-launcher/src/main.rs)
+// covers srv via direct AssignProcessToJobObject. The same windows-sys
+// FFI pattern lives in the launcher now.

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -18,6 +18,62 @@ pub struct BackendSpawnResult {
     pub instance_id: String,
 }
 
+/// Phase B.1: when the launcher has already spawned srv (env var
+/// `AGENTMUX_BACKEND_WS` is set), populate `state` from the env vars
+/// the launcher passed and return Ok — no need to spawn srv ourselves.
+///
+/// Returns `Ok(BackendSpawnResult)` mirroring the shape of
+/// `spawn_backend` so the caller in main.rs is symmetric. Returns
+/// `Err` only if env vars are present but malformed; if they're
+/// absent the caller should fall through to `spawn_backend` (the
+/// `task dev` path where the launcher isn't in the loop).
+pub fn use_launcher_endpoints(
+    state: &Arc<AppState>,
+) -> Option<Result<BackendSpawnResult, String>> {
+    let ws = std::env::var("AGENTMUX_BACKEND_WS").ok()?;
+    if ws.is_empty() {
+        return None;
+    }
+    // From here on we KNOW the launcher provided env; missing fields
+    // mean a launcher bug, so emit Err rather than fall through to
+    // the dev-mode spawn (which would fight the launcher's srv).
+    let try_get = |key: &str| -> Result<String, String> {
+        std::env::var(key).map_err(|_| format!("launcher set AGENTMUX_BACKEND_WS but not {}", key))
+    };
+    let result = (|| -> Result<BackendSpawnResult, String> {
+        let web = try_get("AGENTMUX_BACKEND_WEB")?;
+        let pid_str = try_get("AGENTMUX_BACKEND_PID")?;
+        let pid: u32 = pid_str
+            .parse()
+            .map_err(|_| format!("AGENTMUX_BACKEND_PID not a u32: {}", pid_str))?;
+        let auth_key = try_get("AGENTMUX_AUTH_KEY")?;
+        let instance_id = try_get("AGENTMUX_INSTANCE_ID")?;
+        let data_dir = try_get("AGENTMUX_DATA_DIR")?;
+        let config_dir = try_get("AGENTMUX_CONFIG_DIR")?;
+        let user_home_dir = try_get("AGENTMUX_USER_HOME_DIR")?;
+
+        // Populate AppState in the same shape `spawn_backend` would.
+        // Notably we do NOT take ownership of a Child handle (launcher
+        // owns it) and we do NOT create a Job Object (launcher's J0
+        // already covers srv via assignment, not inheritance).
+        *state.auth_key.lock() = auth_key;
+        *state.backend_pid.lock() = Some(pid);
+        *state.backend_started_at.lock() = Some(chrono::Utc::now().to_rfc3339());
+        *state.version_data_dir.lock() = Some(data_dir);
+        *state.version_config_dir.lock() = Some(config_dir);
+        *state.user_home_dir.lock() = Some(user_home_dir);
+
+        let version = env!("CARGO_PKG_VERSION").to_string();
+        Ok(BackendSpawnResult {
+            ws_endpoint: ws,
+            web_endpoint: web,
+            version,
+            instance_id,
+        })
+    })();
+    Some(result)
+}
+
 /// Spawn the agentmux-srv backend sidecar and wait for it to signal
 /// readiness via a `WAVESRV-ESTART` line on stderr (30s timeout).
 pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, String> {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -80,33 +80,10 @@ impl WindowInstanceRegistry {
     }
 }
 
-/// Wrapper for a Windows HANDLE that is Send + Sync.
-/// Windows HANDLEs are safe to use from any thread.
-#[cfg(target_os = "windows")]
-pub struct JobHandle(*mut std::ffi::c_void);
-
-#[cfg(target_os = "windows")]
-unsafe impl Send for JobHandle {}
-#[cfg(target_os = "windows")]
-unsafe impl Sync for JobHandle {}
-
-#[cfg(target_os = "windows")]
-impl JobHandle {
-    pub fn new(handle: *mut std::ffi::c_void) -> Self {
-        Self(handle)
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl Drop for JobHandle {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe {
-                windows_sys::Win32::Foundation::CloseHandle(self.0);
-            }
-        }
-    }
-}
+// Phase B.1: removed `JobHandle` wrapper. Host no longer owns a Job
+// Object on srv; the launcher's J0 covers srv directly via
+// AssignProcessToJobObject. The same RAII pattern lives in
+// agentmux-launcher/src/main.rs::JobHandle.
 
 /// Backend (agentmux-srv) connection endpoints.
 #[derive(Default, Clone, serde::Serialize)]
@@ -275,9 +252,8 @@ pub struct AppState {
     /// pane targets. See `docs/specs/SPEC_BROWSER_DOM_API.md` §6.
     pub debug_port: Mutex<u16>,
 
-    /// Windows Job Object handle -- keeps backend alive until frontend exits
-    #[cfg(target_os = "windows")]
-    pub job_handle: Mutex<Option<JobHandle>>,
+    // Phase B.1 removed `job_handle` (was Windows-only). Launcher
+    // owns J0 wrapping srv now; host no longer needs its own job.
 }
 
 impl Default for AppState {
@@ -312,8 +288,6 @@ impl Default for AppState {
             browser_panes: crate::browser_panes::BrowserPaneManager::new(),
             browser_api: crate::browser_api::BrowserApiState::new(),
             debug_port: Mutex::new(0),
-            #[cfg(target_os = "windows")]
-            job_handle: Mutex::new(None),
         }
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.444"
+version = "0.33.445"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.442"
+version = "0.33.443"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.445"
+version = "0.33.446"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.443"
+version = "0.33.444"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.441"
+version = "0.33.442"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.445"
+version = "0.33.446"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.444"
+version = "0.33.445"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.442"
+version = "0.33.443"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.441"
+version = "0.33.442"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.443"
+version = "0.33.444"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -30,6 +30,10 @@ dirs = "5"
 # RFC3339 timestamps for backend_started_at logs, kept stable for
 # log-format compatibility with the host's existing format.
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+# UUID v4 for the shared auth key launcher generates and gives to
+# both srv (env var) and host (env var). Same generation method the
+# host uses today (uuid::Uuid::new_v4) so the format is identical.
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -9,6 +9,28 @@ edition = "2021"
 name = "agentmux-launcher"
 path = "src/main.rs"
 
+[dependencies]
+# Phase B foundation: launcher gains a Tokio runtime so it can
+# manage srv + host concurrently and (in later sub-PRs) host the
+# named-pipe IPC server. Prior to Phase B the launcher was a tiny
+# sync DLL-path-fixup + spawner; now it's the privileged owner per
+# specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md.
+tokio = { version = "1", features = [
+    "rt-multi-thread",
+    "macros",
+    "process",
+    "io-util",
+    "time",
+    "sync",
+] }
+# Platform-default data_dir / config_dir resolution. Host already
+# uses this; launcher must compute the SAME paths so both processes
+# agree on the data dir for CEF cache, srv DB, etc.
+dirs = "5"
+# RFC3339 timestamps for backend_started_at logs, kept stable for
+# log-format compatibility with the host's existing format.
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_System_LibraryLoader",

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -68,11 +68,24 @@ pub fn resolve_paths(
     };
 
     let (data_dir, config_dir) = if let Some(ref root) = portable_root {
-        // Portable: data_dir = <root>/data/cef ; config_dir = <root>/data/config.
-        // The "data" parent is shared with `data/logs` (launcher log already
-        // writes there in main.rs::log) and `data/db` (srv).
+        // Portable backend layout (must match
+        // `agentmux-cef/src/sidecar.rs:54-56` — that's the `task dev`
+        // fallback path, both branches must agree on where srv reads
+        // and writes its DB):
+        //   data_dir   = <root>/data           (srv DB at data/db)
+        //   config_dir = <root>/data/config
+        //   cef cache  = <root>/data/cef       (host-only, computed in
+        //                                       host main.rs from the
+        //                                       host's own portable
+        //                                       detection — NOT this
+        //                                       function's concern)
+        //
+        // Important: data_dir is NOT data/cef. Earlier B.1 draft
+        // had `base.join("cef")` here which would have moved srv DB
+        // to data/cef/db on upgrade — silent data loss for existing
+        // portable users. (reagent P1 + codex P1 on PR #571 round-1.)
         let base = root.join("data");
-        (base.join("cef"), base.join("config"))
+        (base.clone(), base.join("config"))
     } else {
         // Installed: version-isolated dirs in platform AppData.
         let dir_name = if is_dev {

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -1,0 +1,129 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Path resolution mirroring `agentmux-cef/src/sidecar.rs` so the
+// launcher and host arrive at IDENTICAL data_dir / config_dir / user
+// home paths. Phase B's launcher-spawns-srv flow needs the launcher
+// to know these paths so it can pass them to both srv (via env) and
+// host (via env) — and the host's own copy of the resolution logic
+// must agree, since the host falls back to its own computation in
+// dev mode (`task dev`) where the launcher isn't in the loop.
+//
+// Portable detection differs slightly between the two processes:
+//   * Launcher's `exe_dir` IS the portable root if `runtime/` exists
+//     alongside it (because the launcher binary lives at the top of
+//     the portable folder).
+//   * Host's `exe_dir` is INSIDE `runtime/`, so the host's portable
+//     root is `exe_dir.parent()`.
+// Both arrive at the same `<portable-root>/data/` directory.
+//
+// Installed mode is identical for both: `dirs::data_dir() / "ai.agentmux.cef.v{version_slug}"`.
+//
+// Spec: specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md §3.2
+
+use std::path::{Path, PathBuf};
+
+/// Resolved per-instance paths shared by host + srv + (after B.1)
+/// the launcher itself.
+#[derive(Debug, Clone)]
+pub struct DataPaths {
+    /// CEF cache + srv DB live here.
+    /// Portable: `<portable-root>/data/cef/`.
+    /// Installed: `%LOCALAPPDATA%/ai.agentmux.cef.v{ver}/`.
+    pub data_dir: PathBuf,
+    /// Per-instance config + settings.
+    /// Portable: `<portable-root>/data/config/`.
+    /// Installed: `%APPDATA%/ai.agentmux.cef.v{ver}/`.
+    pub config_dir: PathBuf,
+    /// Per-agent user home (workspaces, GH_CONFIG_DIR, etc.).
+    /// Portable: same as `data_dir`.
+    /// Installed: `~/.agentmux`.
+    /// Overridden by `AGENTMUX_DATA_HOME` env if set.
+    pub user_home_dir: PathBuf,
+    /// Some(<root>) when running portable, else None.
+    pub portable_root: Option<PathBuf>,
+}
+
+/// Resolve all paths from the LAUNCHER's vantage point.
+///
+/// `launcher_exe_dir` should be `current_exe().parent()` — the directory
+/// the launcher binary lives in. In portable mode this is the portable
+/// root (because the launcher is at the top of the portable folder).
+///
+/// `version` is the cargo package version (e.g. `0.33.442`).
+///
+/// `is_dev` mirrors `cfg!(debug_assertions)` from the host so installed-
+/// mode dirs match between the two processes.
+pub fn resolve_paths(
+    launcher_exe_dir: &Path,
+    version: &str,
+    is_dev: bool,
+) -> Result<DataPaths, String> {
+    // Portable detection from the launcher's perspective: if a `runtime/`
+    // subdir exists alongside us, we're at the top of the portable folder.
+    let portable_root: Option<PathBuf> = if launcher_exe_dir.join("runtime").is_dir() {
+        Some(launcher_exe_dir.to_path_buf())
+    } else {
+        None
+    };
+
+    let (data_dir, config_dir) = if let Some(ref root) = portable_root {
+        // Portable: data_dir = <root>/data/cef ; config_dir = <root>/data/config.
+        // The "data" parent is shared with `data/logs` (launcher log already
+        // writes there in main.rs::log) and `data/db` (srv).
+        let base = root.join("data");
+        (base.join("cef"), base.join("config"))
+    } else {
+        // Installed: version-isolated dirs in platform AppData.
+        let dir_name = if is_dev {
+            "ai.agentmux.cef.dev".to_string()
+        } else {
+            let version_slug = version.replace('.', "-");
+            format!("ai.agentmux.cef.v{}", version_slug)
+        };
+        let data = dirs::data_dir()
+            .ok_or_else(|| "dirs::data_dir() returned None".to_string())?
+            .join(&dir_name);
+        let config = dirs::config_dir()
+            .ok_or_else(|| "dirs::config_dir() returned None".to_string())?
+            .join(&dir_name);
+        (data, config)
+    };
+
+    // user_home_dir mirrors the host's logic (sidecar.rs):
+    //   1. AGENTMUX_DATA_HOME env override wins
+    //   2. Portable: same as data_dir
+    //   3. Installed: ~/.agentmux
+    let user_home_dir = std::env::var("AGENTMUX_DATA_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            if portable_root.is_some() {
+                data_dir.clone()
+            } else {
+                dirs::home_dir()
+                    .unwrap_or_default()
+                    .join(".agentmux")
+            }
+        });
+
+    Ok(DataPaths {
+        data_dir,
+        config_dir,
+        user_home_dir,
+        portable_root,
+    })
+}
+
+/// Ensure the directories the launcher + srv expect to exist.
+///
+/// Mirrors host's `spawn_backend` (sidecar.rs:78–81) — creates
+/// `data_dir/db` and `config_dir`. Idempotent.
+pub fn ensure_dirs(paths: &DataPaths) -> Result<(), String> {
+    std::fs::create_dir_all(paths.data_dir.join("db"))
+        .map_err(|e| format!("create data_dir/db failed: {}", e))?;
+    std::fs::create_dir_all(&paths.config_dir)
+        .map_err(|e| format!("create config_dir failed: {}", e))?;
+    Ok(())
+}

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -27,9 +27,16 @@ use std::path::{Path, PathBuf};
 /// the launcher itself.
 #[derive(Debug, Clone)]
 pub struct DataPaths {
-    /// CEF cache + srv DB live here.
-    /// Portable: `<portable-root>/data/cef/`.
+    /// Backend data dir — srv reads/writes its DB here (under
+    /// `data_dir/db/`) and gets it as `--wavedata`.
+    /// Portable: `<portable-root>/data/`.
     /// Installed: `%LOCALAPPDATA%/ai.agentmux.cef.v{ver}/`.
+    ///
+    /// NOT the CEF cache dir — that's a separate path computed in the
+    /// host's main.rs (`<portable-root>/data/cef/` for portable). The
+    /// two coincide in installed mode but diverge in portable. Don't
+    /// conflate them — doing so silently moves srv DB on upgrade.
+    /// (reagent / codex P1 + P2 on PR #571 round-1.)
     pub data_dir: PathBuf,
     /// Per-instance config + settings.
     /// Portable: `<portable-root>/data/config/`.

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -1,13 +1,19 @@
-// AgentMux Launcher — Sets DLL search path then spawns the real CEF binary.
+// AgentMux Launcher — Sets DLL search path then spawns srv + the CEF host.
 //
-// This tiny exe lives at the top of the portable directory. It:
-// 1. Adds runtime/ to the DLL search path (so libcef.dll is found)
-// 2. Spawns runtime/agentmux-<version>.exe with the same arguments
-// 3. Waits for it to exit and forwards the exit code
+// Phase B.1: launcher now spawns srv directly (sibling of host) so srv
+// survives host crashes. Both children are assigned to the launcher's
+// Job Object J0 with KILL_ON_JOB_CLOSE; killing the launcher reaps
+// the entire tree atomically via the OS.
 //
-// This is needed because libcef.dll is a load-time dependency of the CEF
-// host — the OS loader needs it before main() runs, so SetDllDirectoryW
-// in the CEF host's main() would be too late.
+// This was previously a tiny sync wrapper that just SetDllDirectoryW'd
+// runtime/ then spawned the CEF host. Phase B grew it into the
+// privileged owner per
+// specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md.
+//
+// Process tree after B.1:
+//   launcher (J0)
+//     ├── srv     (assigned to J0; survives host crash)
+//     └── host    (assigned to J0; CEF render workers inherit J0)
 
 #![cfg_attr(
     all(not(debug_assertions), target_os = "windows"),
@@ -17,14 +23,22 @@
 mod data_dir;
 mod srv_spawner;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");
     let exe_dir = exe_path.parent().expect("exe has no parent directory");
     let runtime_dir = exe_dir.join("runtime");
 
-    log(&format!("starting — exe={} runtime={}", exe_path.display(), runtime_dir.display()));
+    log(&format!(
+        "starting — exe={} runtime={}",
+        exe_path.display(),
+        runtime_dir.display()
+    ));
 
-    // Set DLL search path so libcef.dll (in runtime/) is found by the child process
+    // Set DLL search path so libcef.dll (in runtime/) is found by the
+    // CEF host's load-time linker. SetDllDirectoryW is process-local
+    // and inherited by child processes — both srv (which doesn't
+    // need libcef but harmless) and host (which absolutely does).
     #[cfg(target_os = "windows")]
     {
         use std::os::windows::ffi::OsStrExt;
@@ -39,12 +53,13 @@ fn main() {
     }
     log("SetDllDirectoryW done");
 
-    // Resolve the real CEF host binary in runtime/.
     let real_exe = find_cef_binary(&runtime_dir);
     log(&format!("resolved CEF binary: {}", real_exe.display()));
-
     if !real_exe.exists() {
-        log(&format!("FATAL: CEF binary not found at {}", real_exe.display()));
+        log(&format!(
+            "FATAL: CEF binary not found at {}",
+            real_exe.display()
+        ));
         eprintln!(
             "AgentMux runtime not found in: {}\nMake sure the runtime/ folder is intact.",
             runtime_dir.display()
@@ -52,120 +67,19 @@ fn main() {
         std::process::exit(1);
     }
 
-    // Forward all CLI arguments
     let args: Vec<String> = std::env::args().skip(1).collect();
-    log(&format!("spawning CEF host with {} args", args.len()));
+    log(&format!("forwarding {} CLI args to host", args.len()));
 
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
-
-        // Spawn the host SUSPENDED so its main thread can't run — and
-        // therefore can't spawn the srv sidecar or CEF render-process
-        // children — before we've assigned it to the Job Object.
-        // Without CREATE_SUSPENDED there's a real race where the host
-        // forks children in the gap between Command::spawn and
-        // AssignProcessToJobObject; those children would escape the
-        // job's KILL_ON_JOB_CLOSE backstop. (Microsoft / Raymond Chen
-        // pattern; codex P2 + gemini HIGH on PR #570 round-1.)
-        let child = std::process::Command::new(&real_exe)
-            .args(&args)
-            .creation_flags(CREATE_SUSPENDED)
-            .spawn();
-
-        let mut child = match child {
-            Ok(c) => c,
-            Err(e) => {
-                log(&format!("FATAL: failed to spawn CEF host: {}", e));
-                eprintln!("Failed to launch AgentMux: {}", e);
-                std::process::exit(1);
-            }
-        };
-
-        let host_pid = child.id();
-        log(&format!("spawned CEF host pid={} (suspended)", host_pid));
-
-        // Create a Job Object with KILL_ON_JOB_CLOSE and assign the
-        // suspended host to it. CEF render-process workers and the srv
-        // sidecar that the host will spawn AFTER resume inherit the job
-        // automatically. When this launcher process exits — for any
-        // reason, including hard-kill via Task Manager — the OS closes
-        // the job handle and the entire process tree is reaped.
-        //
-        // If creation/assignment fails, log + still resume the host
-        // (degraded cleanup is better than a dead suspended host).
-        let job = match create_job_object_for_child(host_pid) {
-            Ok(handle) => {
-                log(&format!(
-                    "Job Object assigned to pid={}, KILL_ON_JOB_CLOSE active",
-                    host_pid
-                ));
-                Some(JobHandle(handle))
-            }
-            Err(e) => {
-                log(&format!(
-                    "WARN: Job Object setup failed: {} (process-tree cleanup degraded)",
-                    e
-                ));
-                None
-            }
-        };
-
-        // Now resume the host. With CREATE_SUSPENDED only the main
-        // thread exists at this point, so we just need to find it via
-        // a Toolhelp32 thread snapshot and ResumeThread it. From here
-        // the host runs normally, but every child it spawns will
-        // inherit the job we just attached.
-        if let Err(e) = resume_main_thread(host_pid) {
-            log(&format!(
-                "FATAL: failed to resume host pid={}: {} — terminating",
-                host_pid, e
-            ));
-            // The host is currently suspended and will never run.
-            // If Job Object setup succeeded, dropping it reaps the
-            // tree via KILL_ON_JOB_CLOSE. If the job is None (creation
-            // failed earlier with the WARN log), drop is a no-op and
-            // the suspended host would survive as a permanent zombie
-            // holding resources and blocking subsequent launches —
-            // explicitly child.kill() it as a backstop.
-            // (reagent P1 + codex P2 + gemini MEDIUM, PR #570 round-2)
-            let _ = child.kill();
-            drop(job);
-            std::process::exit(1);
-        }
-
-        match child.wait() {
-            Ok(s) => {
-                let code = s.code().unwrap_or(1);
-                log(&format!("CEF host exited with code {}", code));
-                // Drop the job handle. KILL_ON_JOB_CLOSE then reaps
-                // any child the host left behind (srv, CEF render
-                // workers) — it's the backstop for unclean host
-                // exits, not a no-op. On a clean host exit those
-                // children typically already exited via their own
-                // job/parent-watcher chains; this guarantees they
-                // don't survive even when those mechanisms didn't
-                // fire. (gemini PR #570 round-1 MEDIUM L105.)
-                drop(job);
-                std::process::exit(code);
-            }
-            Err(e) => {
-                log(&format!("FATAL: wait failed: {}", e));
-                // Same backstop as the resume-failure path: if the job
-                // is None (creation failed), we must explicitly kill
-                // the host to avoid leaving an orphan running with no
-                // cleanup signal. (gemini MEDIUM @ L148, PR #570
-                // round-2.)
-                let _ = child.kill();
-                drop(job);
-                std::process::exit(1);
-            }
-        }
+        run_windows(exe_dir, &real_exe, &args).await;
     }
 
     #[cfg(not(target_os = "windows"))]
     {
+        // Phase 7 covers cross-platform parity. For now the legacy
+        // exec-into-host path is preserved on macOS/Linux. Phase B.1
+        // is Windows-only.
         log("exec into CEF host (Unix)");
         use std::os::unix::process::CommandExt;
         let err = std::process::Command::new(&real_exe).args(&args).exec();
@@ -175,9 +89,221 @@ fn main() {
     }
 }
 
+/// Windows main flow: resolve paths → create J0 → spawn srv → spawn
+/// host with srv endpoints in env → concurrent wait → cleanup.
+#[cfg(target_os = "windows")]
+async fn run_windows(
+    launcher_exe_dir: &std::path::Path,
+    real_exe: &std::path::Path,
+    args: &[String],
+) {
+    use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+
+    let version = env!("CARGO_PKG_VERSION");
+    let is_dev = cfg!(debug_assertions);
+
+    // 1. Resolve data_dir / config_dir / user_home_dir. Both srv and
+    // host receive these via env so they don't recompute (and so they
+    // can't drift). Host's existing data_dir computation in sidecar.rs
+    // still runs as a fallback for `task dev` mode where the launcher
+    // is not in the loop.
+    let paths = match data_dir::resolve_paths(launcher_exe_dir, version, is_dev) {
+        Ok(p) => p,
+        Err(e) => {
+            log(&format!("FATAL: path resolution failed: {}", e));
+            eprintln!("Failed to resolve AgentMux data directories: {}", e);
+            std::process::exit(1);
+        }
+    };
+    log(&format!(
+        "paths resolved: data={} config={} user_home={} portable={}",
+        paths.data_dir.display(),
+        paths.config_dir.display(),
+        paths.user_home_dir.display(),
+        paths.portable_root.is_some(),
+    ));
+    if let Err(e) = data_dir::ensure_dirs(&paths) {
+        log(&format!("FATAL: failed to create data dirs: {}", e));
+        eprintln!("{}", e);
+        std::process::exit(1);
+    }
+
+    // 2. Create the launcher's Job Object J0 BEFORE any spawn. Both
+    // srv and host will be assigned to it (so they're siblings under
+    // a single OS-enforced cleanup contract). Failure here drops us
+    // into "degraded mode" — children spawn but won't be reaped on
+    // launcher death.
+    let job: Option<JobHandle> = match create_job_object() {
+        Ok(handle) => {
+            log("Job Object created (KILL_ON_JOB_CLOSE active)");
+            Some(JobHandle(handle))
+        }
+        Err(e) => {
+            log(&format!(
+                "WARN: Job Object setup failed: {} (process-tree cleanup degraded)",
+                e
+            ));
+            None
+        }
+    };
+    let job_handle: windows_sys::Win32::Foundation::HANDLE =
+        job.as_ref().map(|j| j.0).unwrap_or(std::ptr::null_mut());
+
+    // 3. Spawn srv first. Host needs srv's endpoints to skip its own
+    // spawn_backend path. Srv signals readiness via WAVESRV-ESTART on
+    // stderr; the spawner returns once we see that line (or after a
+    // 30s timeout).
+    let (srv_result, mut srv_child) = match srv_spawner::spawn_srv(
+        launcher_exe_dir,
+        &paths,
+        job_handle,
+    )
+    .await
+    {
+        Ok(pair) => pair,
+        Err(e) => {
+            log(&format!("FATAL: srv spawn failed: {}", e));
+            eprintln!("Failed to start backend: {}", e);
+            drop(job);
+            std::process::exit(1);
+        }
+    };
+
+    // 4. Spawn host SUSPENDED with srv endpoints in env vars. Host
+    // honors AGENTMUX_BACKEND_WS et al. and skips its own spawn_backend.
+    // Same CREATE_SUSPENDED → assign-to-job → resume race-fix pattern
+    // as PR #570 (codex P2 / gemini HIGH).
+    let mut host_cmd = tokio::process::Command::new(real_exe);
+    host_cmd
+        .args(args)
+        .env("AGENTMUX_BACKEND_WS", &srv_result.ws_endpoint)
+        .env("AGENTMUX_BACKEND_WEB", &srv_result.web_endpoint)
+        .env("AGENTMUX_BACKEND_PID", srv_result.pid.to_string())
+        .env("AGENTMUX_AUTH_KEY", &srv_result.auth_key)
+        .env("AGENTMUX_INSTANCE_ID", &srv_result.instance_id)
+        .env("AGENTMUX_DATA_DIR", paths.data_dir.to_string_lossy().to_string())
+        .env(
+            "AGENTMUX_CONFIG_DIR",
+            paths.config_dir.to_string_lossy().to_string(),
+        )
+        .env(
+            "AGENTMUX_USER_HOME_DIR",
+            paths.user_home_dir.to_string_lossy().to_string(),
+        )
+        .creation_flags(CREATE_SUSPENDED)
+        .kill_on_drop(false); // J0 handles cleanup; tokio's kill-on-drop would force-kill on every error path.
+
+    let mut host_child = match host_cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            log(&format!("FATAL: failed to spawn CEF host: {}", e));
+            eprintln!("Failed to launch AgentMux: {}", e);
+            // srv is already running; let J0's drop reap it.
+            drop(job);
+            std::process::exit(1);
+        }
+    };
+    let host_pid = host_child.id().unwrap_or(0);
+    log(&format!("spawned CEF host pid={} (suspended)", host_pid));
+
+    // 5. Assign host to J0 BEFORE resuming. Without this, host could
+    // spawn renderer processes (CEF subprocess) before joining J0 —
+    // those renderers would escape KILL_ON_JOB_CLOSE.
+    if job.is_some() && host_pid != 0 {
+        if let Err(e) = srv_spawner::assign_pid_to_job(host_pid, job_handle) {
+            log(&format!(
+                "WARN: AssignProcessToJobObject(host) failed: {} — host children may escape job",
+                e
+            ));
+        } else {
+            log(&format!(
+                "Job Object assigned to host pid={}, KILL_ON_JOB_CLOSE active",
+                host_pid
+            ));
+        }
+    }
+
+    // 6. Resume host. With CREATE_SUSPENDED only the main thread
+    // exists at this point, so we just need to find it via a
+    // Toolhelp32 thread snapshot and ResumeThread it. From here the
+    // host runs normally; every CEF render child it spawns inherits J0.
+    if let Err(e) = resume_main_thread(host_pid) {
+        log(&format!(
+            "FATAL: failed to resume host pid={}: {} — terminating",
+            host_pid, e
+        ));
+        // Same defensive backstop as PR #570 round-2: if the job is
+        // None, drop is a no-op and the suspended host would be a
+        // permanent zombie. Explicit start_kill is the backstop.
+        let _ = host_child.start_kill();
+        // srv is alive; J0 (if held) reaps it on drop. Otherwise srv
+        // outlives us as an orphan (logged warning above).
+        drop(job);
+        std::process::exit(1);
+    }
+
+    // 7. Concurrent wait. Whichever child exits first triggers
+    // launcher shutdown. tokio::select cancels the other branch's
+    // wait future when one fires — both children's borrows are
+    // released after the macro returns.
+    //
+    // We don't manually kill the surviving child in the happy path:
+    // dropping `job` below triggers KILL_ON_JOB_CLOSE which reaps
+    // the entire J0 membership. The explicit start_kill is only the
+    // backstop for the degraded mode (job == None) where J0 doesn't
+    // exist to do the reaping. (PR #570 round-2 backstop pattern.)
+    log("entering host + srv concurrent wait");
+    let exit_code = tokio::select! {
+        host_status = host_child.wait() => {
+            match host_status {
+                Ok(s) => {
+                    let code = s.code().unwrap_or(1);
+                    log(&format!("CEF host exited with code {}", code));
+                    code
+                }
+                Err(e) => {
+                    log(&format!("FATAL: host wait failed: {}", e));
+                    1
+                }
+            }
+        }
+        srv_status = srv_child.wait() => {
+            match srv_status {
+                Ok(s) => {
+                    let code = s.code().unwrap_or(1);
+                    log(&format!(
+                        "srv exited UNEXPECTEDLY (host still running) with code {} — terminating launcher",
+                        code
+                    ));
+                    1
+                }
+                Err(e) => {
+                    log(&format!("FATAL: srv wait failed: {}", e));
+                    1
+                }
+            }
+        }
+    };
+
+    // 8. Cleanup. Happy path: drop(job) → KILL_ON_JOB_CLOSE reaps
+    // the surviving child + CEF renderers. Degraded path (job is
+    // None): explicit start_kill on both — neither will be reaped
+    // by the OS, so we have to terminate them ourselves to avoid
+    // orphans. (gemini PR #570 round-1 MEDIUM L105 / round-2 P1
+    // backstop pattern.)
+    if job.is_none() {
+        log("WARN: J0 absent — explicitly killing surviving children");
+        let _ = host_child.start_kill();
+        let _ = srv_child.start_kill();
+    }
+    drop(job);
+    log(&format!("launcher exiting with code {}", exit_code));
+    std::process::exit(exit_code);
+}
+
 /// Append a timestamped line to ~/.agentmux/logs/agentmux-launcher.log.
 /// Best-effort — silently no-ops if the log dir doesn't exist yet.
-fn log(msg: &str) {
+pub(crate) fn log(msg: &str) {
     let log_dir = dirs_fallback_home().join(".agentmux").join("logs");
     let _ = std::fs::create_dir_all(&log_dir);
     let path = log_dir.join("agentmux-launcher.log");
@@ -195,7 +321,10 @@ fn log(msg: &str) {
     }
 }
 
-/// Home dir without the `dirs` crate (keep launcher zero-dep beyond windows-sys).
+/// Home dir without depending on `dirs` for THIS specific lookup.
+/// Kept to avoid a dirs dep cycle from log() — log() is called from
+/// data_dir::resolve_paths via failure paths, and we want it to work
+/// even if `dirs` itself is mid-failure.
 fn dirs_fallback_home() -> std::path::PathBuf {
     std::env::var("USERPROFILE")
         .or_else(|_| std::env::var("HOME"))
@@ -224,24 +353,18 @@ impl Drop for JobHandle {
     }
 }
 
-/// Create a Job Object with `KILL_ON_JOB_CLOSE` and assign the given PID.
-/// Mirrors `agentmux-cef::sidecar::create_job_object_for_child`; lifted to
-/// the launcher so the entire host process tree (host + srv + CEF render
-/// children) is wrapped one level higher.
+/// Create a Job Object J0 with `KILL_ON_JOB_CLOSE`. Caller assigns
+/// processes to it via `srv_spawner::assign_pid_to_job(pid, job)`.
 #[cfg(target_os = "windows")]
-fn create_job_object_for_child(
-    pid: u32,
-) -> Result<windows_sys::Win32::Foundation::HANDLE, String> {
+fn create_job_object() -> Result<windows_sys::Win32::Foundation::HANDLE, String> {
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::JobObjects::*;
-    use windows_sys::Win32::System::Threading::*;
 
     unsafe {
         let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
         if job.is_null() {
-            return Err("Failed to create job object".into());
+            return Err("CreateJobObjectW returned null".into());
         }
-
         let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
         info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
         let ok = SetInformationJobObject(
@@ -252,22 +375,8 @@ fn create_job_object_for_child(
         );
         if ok == 0 {
             CloseHandle(job);
-            return Err("Failed to set job object info".into());
+            return Err("SetInformationJobObject failed".into());
         }
-
-        let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
-        if process.is_null() {
-            CloseHandle(job);
-            return Err(format!("Failed to open process {}", pid));
-        }
-
-        let ok = AssignProcessToJobObject(job, process);
-        CloseHandle(process);
-        if ok == 0 {
-            CloseHandle(job);
-            return Err("Failed to assign process to job object".into());
-        }
-
         Ok(job)
     }
 }
@@ -283,7 +392,7 @@ fn create_job_object_for_child(
 /// was already running (impossible if the process was just created
 /// suspended) — treated as success.
 #[cfg(target_os = "windows")]
-fn resume_main_thread(pid: u32) -> Result<(), String> {
+pub(crate) fn resume_main_thread(pid: u32) -> Result<(), String> {
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
     use windows_sys::Win32::System::Diagnostics::ToolHelp::{
         CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD,
@@ -321,7 +430,6 @@ fn resume_main_thread(pid: u32) -> Result<(), String> {
                         break;
                     }
                 }
-                // Reset dwSize before each Thread32Next per Win32 contract.
                 entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
                 if Thread32Next(snap, &mut entry) == 0 {
                     break;
@@ -330,7 +438,6 @@ fn resume_main_thread(pid: u32) -> Result<(), String> {
         }
 
         CloseHandle(snap);
-
         if !found {
             return Err(format!("no thread found for pid={}", pid));
         }
@@ -345,22 +452,18 @@ fn resume_main_thread(pid: u32) -> Result<(), String> {
 fn find_cef_binary(runtime_dir: &std::path::Path) -> std::path::PathBuf {
     let ext = if cfg!(target_os = "windows") { ".exe" } else { "" };
 
-    // 1. Try exact versioned name matching this launcher's version (new naming)
     let versioned = format!("agentmux-{}{}", env!("CARGO_PKG_VERSION"), ext);
     let versioned_path = runtime_dir.join(&versioned);
     if versioned_path.exists() {
         return versioned_path;
     }
 
-    // 2. Scan for any agentmux-<version>.exe — handles minor version mismatch
-    //    between launcher and CEF host (new naming, no "cef" in artifact name)
     if let Ok(entries) = std::fs::read_dir(runtime_dir) {
         let prefix = "agentmux-";
         let cef_prefix = "agentmux-cef";
         for entry in entries.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            // Match agentmux-<version>.exe but not agentmux-cef*.exe or agentmux-srv*.exe
             if name.starts_with(prefix)
                 && !name.starts_with(cef_prefix)
                 && !name.starts_with("agentmux-srv")
@@ -371,13 +474,11 @@ fn find_cef_binary(runtime_dir: &std::path::Path) -> std::path::PathBuf {
         }
     }
 
-    // 3. Backwards compat: old naming used agentmux-cef-<version>.exe
     let versioned_old = format!("agentmux-cef-{}{}", env!("CARGO_PKG_VERSION"), ext);
     let versioned_old_path = runtime_dir.join(&versioned_old);
     if versioned_old_path.exists() {
         return versioned_old_path;
     }
 
-    // 4. Fall back to plain name (dev mode)
     runtime_dir.join(format!("agentmux-cef{}", ext))
 }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -198,7 +198,15 @@ async fn run_windows(
         Err(e) => {
             log(&format!("FATAL: failed to spawn CEF host: {}", e));
             eprintln!("Failed to launch AgentMux: {}", e);
-            // srv is already running; let J0's drop reap it.
+            // Happy path: drop(job) → KILL_ON_JOB_CLOSE reaps srv.
+            // Degraded path (job is None, J0 absent): kill srv
+            // explicitly because kill_on_drop(false) means the Child
+            // drop wouldn't terminate it; otherwise srv orphans on
+            // launcher exit. (reagent P1 + codex P2 @ main.rs:201,
+            // PR #571 round-3.)
+            if job.is_none() {
+                let _ = srv_child.start_kill();
+            }
             drop(job);
             std::process::exit(1);
         }
@@ -232,12 +240,16 @@ async fn run_windows(
             "FATAL: failed to resume host pid={}: {} — terminating",
             host_pid, e
         ));
-        // Same defensive backstop as PR #570 round-2: if the job is
-        // None, drop is a no-op and the suspended host would be a
-        // permanent zombie. Explicit start_kill is the backstop.
+        // Always kill the suspended host: if J0 is held it'd reap
+        // anyway, but in degraded mode (job is None) the suspended
+        // host would be a permanent zombie. (PR #570 round-2 pattern.)
         let _ = host_child.start_kill();
-        // srv is alive; J0 (if held) reaps it on drop. Otherwise srv
-        // outlives us as an orphan (logged warning above).
+        // Same backstop for srv in degraded mode — J0 absent, kill_on
+        // _drop(false), so dropping the Child wouldn't terminate it.
+        // (reagent P1 @ main.rs:238, PR #571 round-3.)
+        if job.is_none() {
+            let _ = srv_child.start_kill();
+        }
         drop(job);
         std::process::exit(1);
     }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -15,6 +15,7 @@
 )]
 
 mod data_dir;
+mod srv_spawner;
 
 fn main() {
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -14,6 +14,8 @@
     windows_subsystem = "windows"
 )]
 
+mod data_dir;
+
 fn main() {
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");
     let exe_dir = exe_path.parent().expect("exe has no parent directory");

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -138,7 +138,6 @@ pub async fn spawn_srv(
     // the job — those resources would survive launcher death.
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
         const CREATE_SUSPENDED: u32 = 0x00000004;
         const CREATE_NO_WINDOW: u32 = 0x08000000;
         cmd.creation_flags(CREATE_SUSPENDED | CREATE_NO_WINDOW);
@@ -152,10 +151,15 @@ pub async fn spawn_srv(
         .ok_or_else(|| SrvSpawnError::SpawnFailed("child has no PID".to_string()))?;
 
     // Windows: assign srv to launcher's job, then resume.
+    // Skip job assignment if launcher's job creation failed (J0 is
+    // null) — that's the degraded mode logged by main.rs. Srv still
+    // runs but won't be reaped on launcher death.
     #[cfg(target_os = "windows")]
     {
-        assign_to_job(pid, job_handle)
-            .map_err(SrvSpawnError::JobAssignFailed)?;
+        if !job_handle.is_null() {
+            assign_pid_to_job(pid, job_handle)
+                .map_err(SrvSpawnError::JobAssignFailed)?;
+        }
         crate::resume_main_thread(pid)
             .map_err(SrvSpawnError::ResumeFailed)?;
     }
@@ -308,11 +312,12 @@ fn parse_estart(line: &str) -> EstartFields {
     }
 }
 
-/// Assign a process to the launcher's Job Object J0. Matches the
-/// pattern in main.rs::create_job_object_for_child but separated
-/// because we already HAVE the job handle (don't create a new one).
+/// Assign a process to the launcher's Job Object J0. Used by
+/// `spawn_srv` for srv and exported for `main.rs` to use for the
+/// host. Separated from job creation because both children join
+/// the SAME job (only one J0 ever exists per launcher run).
 #[cfg(target_os = "windows")]
-fn assign_to_job(
+pub fn assign_pid_to_job(
     pid: u32,
     job: windows_sys::Win32::Foundation::HANDLE,
 ) -> Result<(), String> {

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -1,0 +1,339 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Spawn the agentmux-srv backend sidecar from the LAUNCHER (Phase B.1).
+//
+// Today's flow (pre-Phase-B): launcher spawns host; host spawns srv;
+// host owns a Job Object J1 wrapping srv; renderers inherit launcher's
+// J0 via host. Result: when host crashes, J1 closes and srv dies.
+//
+// Phase B.1 flow: launcher spawns BOTH srv and host as siblings,
+// assigns BOTH to launcher's J0 directly. Host's J1 on srv is
+// deleted (it would actively defeat "srv survives host crash" if
+// kept). Renderers continue to inherit J0 via host as before.
+//
+// The launcher passes srv's endpoints to the host via env vars
+// (AGENTMUX_BACKEND_WS, _WEB, _PID). Host detects them and skips
+// its own spawn_backend path (which is preserved for `task dev`
+// fallback where launcher isn't in the loop).
+//
+// Adapted from `agentmux-cef/src/sidecar.rs::spawn_backend` —
+// kept structurally similar so divergence is auditable. Key
+// differences:
+//   * Tokio process API (not std::process)
+//   * CREATE_SUSPENDED + assign-to-job + ResumeThread (PR #570 race
+//     pattern, applied to srv too)
+//   * No separate Job Object on srv; launcher's J0 covers it
+//   * Auth key generated here, not consumed from a shared AppState
+//   * stderr ESTART parsing returns the result via tokio mpsc
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc;
+
+use crate::data_dir::DataPaths;
+
+/// What the launcher learns about srv after it signals ready.
+/// Held by the launcher and used to populate env vars the host reads.
+#[derive(Debug, Clone)]
+pub struct SrvSpawnResult {
+    pub pid: u32,
+    pub ws_endpoint: String,
+    pub web_endpoint: String,
+    pub instance_id: String,
+    pub auth_key: String,
+    pub started_at: String, // RFC3339
+}
+
+/// Errors during srv spawn — granular enough that the launcher can
+/// log the right diagnostic.
+#[derive(Debug)]
+pub enum SrvSpawnError {
+    BinaryNotFound(String),
+    SpawnFailed(String),
+    JobAssignFailed(String),
+    ResumeFailed(String),
+    EstartTimeout,
+    EstartChannelClosed,
+}
+
+impl std::fmt::Display for SrvSpawnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BinaryNotFound(s) => write!(f, "srv binary not found: {}", s),
+            Self::SpawnFailed(s) => write!(f, "spawn failed: {}", s),
+            Self::JobAssignFailed(s) => write!(f, "AssignProcessToJobObject failed: {}", s),
+            Self::ResumeFailed(s) => write!(f, "ResumeThread failed: {}", s),
+            Self::EstartTimeout => write!(f, "timeout waiting for WAVESRV-ESTART (30s)"),
+            Self::EstartChannelClosed => {
+                write!(f, "ESTART channel closed before srv signalled ready")
+            }
+        }
+    }
+}
+
+/// Spawn srv as a child of the launcher, assigned to launcher's
+/// Job Object J0 so it dies cleanly with the launcher tree.
+///
+/// `launcher_exe_dir` is used to locate the srv binary alongside the
+/// launcher (or in `runtime/` for portable). `paths` carries the
+/// data + config dirs and is propagated to srv via env vars.
+/// `job_handle` is the launcher's Job Object so srv joins the same
+/// kill-on-job-close contract as the host. Returns once srv prints
+/// `WAVESRV-ESTART` (or the 30s timeout fires).
+///
+/// Caller keeps the returned `Child` alive — drop closes srv's
+/// stdin and srv's existing PPID death-watcher takes over (already
+/// part of agentmux-srv per `SPEC_BACKEND_LIFECYCLE.md`).
+pub async fn spawn_srv(
+    launcher_exe_dir: &Path,
+    paths: &DataPaths,
+    #[cfg(target_os = "windows")] job_handle: windows_sys::Win32::Foundation::HANDLE,
+) -> Result<(SrvSpawnResult, Child), SrvSpawnError> {
+    let backend_path = resolve_srv_binary(launcher_exe_dir)?;
+
+    // Generate a fresh auth_key per run (UUID v4 — same as host did).
+    // This is the launcher's responsibility now; host receives it via
+    // AGENTMUX_AUTH_KEY env so srv + host + frontend agree on the key.
+    let auth_key = uuid::Uuid::new_v4().to_string();
+    let version = env!("CARGO_PKG_VERSION");
+    let instance_id = format!("v{}", version);
+
+    // app_path = launcher's exe dir (used by srv for finding bundled
+    // tooling like jq.exe / rg.exe). In portable mode this is the
+    // top of the portable folder; the runtime/tools/bin/ subdir
+    // lives under runtime/, but srv's app_path lookup is currently
+    // exe_dir-based per the host's code.
+    //
+    // For B.1 we keep parity: pass exe_dir of the LAUNCHER. If srv
+    // tooling lookup breaks, follow up — log it loudly.
+    let app_path_str = launcher_exe_dir.to_string_lossy().to_string();
+
+    let mut cmd = Command::new(&backend_path);
+    cmd.args([
+        "--wavedata",
+        &paths.data_dir.to_string_lossy(),
+        "--instance",
+        &instance_id,
+    ])
+    .env("AGENTMUX_AUTH_KEY", &auth_key)
+    .env("AGENTMUX_CONFIG_HOME", paths.config_dir.to_string_lossy().to_string())
+    .env("AGENTMUX_DATA_HOME", paths.data_dir.to_string_lossy().to_string())
+    .env("AGENTMUX_SETTINGS_DIR", paths.config_dir.to_string_lossy().to_string())
+    .env("AGENTMUX_APP_PATH", &app_path_str)
+    .env("AGENTMUX_DEV", if cfg!(debug_assertions) { "1" } else { "" })
+    .env("WCLOUD_ENDPOINT", "https://api.agentmux.ai/central")
+    .env("WCLOUD_WS_ENDPOINT", "wss://wsapi.agentmux.ai/")
+    .stdin(Stdio::piped())
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .kill_on_drop(false); // Job Object handles cleanup; tokio's kill-on-drop would force-kill.
+
+    // Windows: spawn suspended so we can assign-to-job before any
+    // child code runs (PR #570 race pattern, now applied to srv).
+    // Without this, srv could open files / sockets before joining
+    // the job — those resources would survive launcher death.
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_SUSPENDED: u32 = 0x00000004;
+        const CREATE_NO_WINDOW: u32 = 0x08000000;
+        cmd.creation_flags(CREATE_SUSPENDED | CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| SrvSpawnError::SpawnFailed(e.to_string()))?;
+    let pid = child
+        .id()
+        .ok_or_else(|| SrvSpawnError::SpawnFailed("child has no PID".to_string()))?;
+
+    // Windows: assign srv to launcher's job, then resume.
+    #[cfg(target_os = "windows")]
+    {
+        assign_to_job(pid, job_handle)
+            .map_err(SrvSpawnError::JobAssignFailed)?;
+        crate::resume_main_thread(pid)
+            .map_err(SrvSpawnError::ResumeFailed)?;
+    }
+
+    let started_at = chrono::Utc::now().to_rfc3339();
+
+    // Forward srv stdout to our log (info level; the launcher's log
+    // file is the same one srv-logs end up in once we wire log
+    // forwarding properly).
+    if let Some(stdout) = child.stdout.take() {
+        let pid_for_log = pid;
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                crate::log(&format!("[srv {} stdout] {}", pid_for_log, line));
+            }
+        });
+    }
+
+    // Parse stderr for WAVESRV-ESTART (the readiness signal). srv
+    // writes other diagnostic lines too (WAVESRV-EVENT:..., plain
+    // text); for B.1 we just log them. Phase B sub-PR B.2 will
+    // forward WAVESRV-EVENT messages to subscribers via the IPC
+    // event stream.
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| SrvSpawnError::SpawnFailed("no stderr handle".to_string()))?;
+    let (tx, mut rx) = mpsc::channel::<SrvSpawnResult>(1);
+    let auth_key_for_estart = auth_key.clone();
+    let started_at_for_estart = started_at.clone();
+    let pid_for_log = pid;
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr).lines();
+        let mut estart_sent = false;
+        while let Ok(Some(line)) = reader.next_line().await {
+            if !estart_sent && line.starts_with("WAVESRV-ESTART") {
+                let parsed = parse_estart(&line);
+                let result = SrvSpawnResult {
+                    pid: pid_for_log,
+                    ws_endpoint: parsed.ws_endpoint,
+                    web_endpoint: parsed.web_endpoint,
+                    instance_id: parsed.instance_id,
+                    auth_key: auth_key_for_estart.clone(),
+                    started_at: started_at_for_estart.clone(),
+                };
+                crate::log(&format!(
+                    "srv {} ready: ws={} web={} instance={}",
+                    result.pid, result.ws_endpoint, result.web_endpoint, result.instance_id
+                ));
+                let _ = tx.send(result).await;
+                estart_sent = true;
+            } else if line.starts_with("WAVESRV-EVENT:") {
+                crate::log(&format!("[srv {} event] {}", pid_for_log, line));
+                // Phase B.2 will forward these to subscribers.
+            } else {
+                crate::log(&format!("[srv {} stderr] {}", pid_for_log, line));
+            }
+        }
+        // EOF on stderr → srv exited (or its stderr closed). Logged
+        // by the wait-task in main; nothing else to do here.
+    });
+
+    let result = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv())
+        .await
+        .map_err(|_| SrvSpawnError::EstartTimeout)?
+        .ok_or(SrvSpawnError::EstartChannelClosed)?;
+
+    Ok((result, child))
+}
+
+/// Resolve the agentmux-srv binary path from the LAUNCHER's vantage
+/// point.
+///
+/// Search order, mirroring the host's `resolve_backend_binary`
+/// (sidecar.rs:318-402) but anchored at the launcher's exe dir:
+///   1. `<launcher_dir>/runtime/agentmux-srv-{ver}-{os}.{arch}.exe`
+///      (versioned portable layout)
+///   2. `<launcher_dir>/runtime/agentmux-srv.exe` (dev fallback)
+///   3. `<launcher_dir>/agentmux-srv-{ver}-{os}.{arch}.exe`
+///      (launcher in same dir as srv — should not happen in portable
+///      but covers cargo-built dev mode where launcher + srv both
+///      land in target/release/)
+///   4. `<launcher_dir>/agentmux-srv.exe` (dev fallback)
+fn resolve_srv_binary(launcher_exe_dir: &Path) -> Result<PathBuf, SrvSpawnError> {
+    let backend_name = "agentmux-srv";
+    let exe_suffix = if cfg!(target_os = "windows") { ".exe" } else { "" };
+    let version = env!("CARGO_PKG_VERSION");
+    let (os_name, arch) = if cfg!(target_os = "macos") {
+        ("darwin", if cfg!(target_arch = "aarch64") { "arm64" } else { "x64" })
+    } else if cfg!(target_os = "linux") {
+        ("linux", if cfg!(target_arch = "aarch64") { "arm64" } else { "x64" })
+    } else {
+        ("windows", if cfg!(target_arch = "aarch64") { "arm64" } else { "x64" })
+    };
+
+    let candidates = [
+        // Portable: srv lives in launcher_dir/runtime/
+        launcher_exe_dir
+            .join("runtime")
+            .join(format!("{}-{}-{}.{}{}", backend_name, version, os_name, arch, exe_suffix)),
+        launcher_exe_dir
+            .join("runtime")
+            .join(format!("{}{}", backend_name, exe_suffix)),
+        // Dev: launcher and srv side-by-side in target/release/
+        launcher_exe_dir
+            .join(format!("{}-{}-{}.{}{}", backend_name, version, os_name, arch, exe_suffix)),
+        launcher_exe_dir.join(format!("{}{}", backend_name, exe_suffix)),
+    ];
+
+    for p in &candidates {
+        if p.exists() {
+            return Ok(p.clone());
+        }
+    }
+
+    Err(SrvSpawnError::BinaryNotFound(format!(
+        "{} v{} not found. Searched:\n  {}",
+        backend_name,
+        version,
+        candidates
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n  ")
+    )))
+}
+
+/// Parsed fields out of a `WAVESRV-ESTART` line. Same shape as the
+/// host's `parse_estart` (sidecar.rs:404-420).
+struct EstartFields {
+    ws_endpoint: String,
+    web_endpoint: String,
+    instance_id: String,
+}
+
+fn parse_estart(line: &str) -> EstartFields {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    let get = |prefix: &str| -> String {
+        parts
+            .iter()
+            .find_map(|p| p.strip_prefix(prefix))
+            .unwrap_or_default()
+            .to_string()
+    };
+    EstartFields {
+        ws_endpoint: get("ws:"),
+        web_endpoint: get("web:"),
+        instance_id: get("instance:"),
+    }
+}
+
+/// Assign a process to the launcher's Job Object J0. Matches the
+/// pattern in main.rs::create_job_object_for_child but separated
+/// because we already HAVE the job handle (don't create a new one).
+#[cfg(target_os = "windows")]
+fn assign_to_job(
+    pid: u32,
+    job: windows_sys::Win32::Foundation::HANDLE,
+) -> Result<(), String> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_SET_QUOTA, PROCESS_TERMINATE,
+    };
+    unsafe {
+        let process = OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+        if process.is_null() {
+            return Err(format!("OpenProcess({}) returned null", pid));
+        }
+        let ok = AssignProcessToJobObject(job, process);
+        CloseHandle(process);
+        if ok == 0 {
+            return Err(format!(
+                "AssignProcessToJobObject failed for pid={}",
+                pid
+            ));
+        }
+        Ok(())
+    }
+}

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -154,14 +154,25 @@ pub async fn spawn_srv(
     // Skip job assignment if launcher's job creation failed (J0 is
     // null) — that's the degraded mode logged by main.rs. Srv still
     // runs but won't be reaped on launcher death.
+    //
+    // Both error paths must explicitly start_kill the suspended
+    // child before returning. We set kill_on_drop(false) (J0 normally
+    // handles cleanup), so dropping the Child wouldn't terminate the
+    // suspended srv — it would orphan as a permanent zombie holding
+    // resources and the data dir lockfile, blocking subsequent
+    // launches. (codex P1 @ srv_spawner.rs:161, PR #571 round-3.)
     #[cfg(target_os = "windows")]
     {
         if !job_handle.is_null() {
-            assign_pid_to_job(pid, job_handle)
-                .map_err(SrvSpawnError::JobAssignFailed)?;
+            if let Err(e) = assign_pid_to_job(pid, job_handle) {
+                let _ = child.start_kill();
+                return Err(SrvSpawnError::JobAssignFailed(e));
+            }
         }
-        crate::resume_main_thread(pid)
-            .map_err(SrvSpawnError::ResumeFailed)?;
+        if let Err(e) = crate::resume_main_thread(pid) {
+            let _ = child.start_kill();
+            return Err(SrvSpawnError::ResumeFailed(e));
+        }
     }
 
     let started_at = chrono::Utc::now().to_rfc3339();

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -234,12 +234,24 @@ pub async fn spawn_srv(
         // by the wait-task in main; nothing else to do here.
     });
 
-    let result = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv())
-        .await
-        .map_err(|_| SrvSpawnError::EstartTimeout)?
-        .ok_or(SrvSpawnError::EstartChannelClosed)?;
-
-    Ok((result, child))
+    // Wait for ESTART. Both error paths must explicitly start_kill
+    // the child before returning — same kill_on_drop(false) leak
+    // class as the assign/resume failures above. Without this, the
+    // 30s timeout in degraded mode (J0 absent) would leak a fully-
+    // running srv that keeps the data dir lockfile, blocking the
+    // next launch. (codex P2 @ srv_spawner.rs:240, PR #571 round-4.)
+    let recv = tokio::time::timeout(std::time::Duration::from_secs(30), rx.recv()).await;
+    match recv {
+        Err(_) => {
+            let _ = child.start_kill();
+            Err(SrvSpawnError::EstartTimeout)
+        }
+        Ok(None) => {
+            let _ = child.start_kill();
+            Err(SrvSpawnError::EstartChannelClosed)
+        }
+        Ok(Some(result)) => Ok((result, child)),
+    }
 }
 
 /// Resolve the agentmux-srv binary path from the LAUNCHER's vantage

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.443"
+version = "0.33.444"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.442"
+version = "0.33.443"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.445"
+version = "0.33.446"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.441"
+version = "0.33.442"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.444"
+version = "0.33.445"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.442",
+  "version": "0.33.443",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.442",
+      "version": "0.33.443",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.441",
+  "version": "0.33.442",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.441",
+      "version": "0.33.442",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.445",
+  "version": "0.33.446",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.445",
+      "version": "0.33.446",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.443",
+  "version": "0.33.444",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.443",
+      "version": "0.33.444",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.444",
+  "version": "0.33.445",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.444",
+      "version": "0.33.445",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.443",
+  "version": "0.33.444",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.442",
+  "version": "0.33.443",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.444",
+  "version": "0.33.445",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.445",
+  "version": "0.33.446",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.441",
+  "version": "0.33.442",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First substantive PR in Phase B (the redux-architecture migration per [SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md](specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md)). Restructures the process tree so srv is a sibling of host under the launcher, not a child of host. Foundation for the launcher-owned reducer (B.2+).

**Process tree after this PR:**
\`\`\`
launcher (Job Object J0, KILL_ON_JOB_CLOSE)
├── srv     (assigned to J0; survives host crash)
└── host    (assigned to J0; CEF render workers inherit J0)
\`\`\`

vs today (post-PR-#570):
\`\`\`
launcher (J0)
└── host
    ├── srv     (assigned to host-owned J1; DIES when host dies)
    └── renderers
\`\`\`

## Why srv-survives-host-crash matters

Phase B's launcher-owned state machine needs to be able to restart the host while keeping srv (and its DB state) alive. With today's tree, killing the host also kills srv, losing all workspace/tab state. After this PR, srv outlives any host crash.

## Key change: deleted host's J1 on srv

Removed the host-owned Job Object that wrapped srv. Spec originally suggested keeping it as defense-in-depth, but on inspection it would **actively defeat B.1's goal**: KILL_ON_JOB_CLOSE on J1 fires when host dies, taking srv with it. The two reapers are mutually exclusive given the goal "srv survives host crash" — picked launcher's J0.

Trade-off: in \`task dev\` mode (host runs without launcher), srv loses kernel-level reaping on host crash. Acceptable for dev-mode-only; production (portable / installed) is unaffected.

## Env-var contract launcher → host

Launcher passes srv coordinates via env vars; host honors them and skips its own \`spawn_backend\`. Falls back to the existing \`spawn_backend\` only when env is absent (the dev path).

| Env var | Source | Consumer | Meaning |
|---|---|---|---|
| \`AGENTMUX_BACKEND_WS\` | launcher | host | srv WebSocket endpoint |
| \`AGENTMUX_BACKEND_WEB\` | launcher | host | srv HTTP endpoint |
| \`AGENTMUX_BACKEND_PID\` | launcher | host | srv PID for diagnostics |
| \`AGENTMUX_AUTH_KEY\` | launcher | host (and srv) | shared auth key (UUID v4) |
| \`AGENTMUX_INSTANCE_ID\` | launcher | host | \`v{cargo_pkg_version}\` |
| \`AGENTMUX_DATA_DIR\` / \`_CONFIG_DIR\` / \`_USER_HOME_DIR\` | launcher | host | paths already chosen by launcher |

## What's NOT in this PR (deferred to later Phase B sub-PRs)

- B.2: named-pipe IPC server in launcher (commands + events)
- B.3: \`Command\` + \`Event\` types + pure reducer skeleton
- B.4: launcher state mirror (read-only diff vs host state)
- B.5: migrate state stores to launcher-authoritative
- B.6: per-data-dir mutex single-instance
- B.7: frontend deletes polling loop, subscribes via host bridge
- B.8: Phase B exit; delete host-side state stores

Plan: [\`docs/retro/phase-b-plan-2026-04-28.md\`](docs/retro/phase-b-plan-2026-04-28.md). Concrete design for this PR: \`docs/retro/b1-srv-spawner-design.md\` (untracked working doc).

## File changes

- **\`agentmux-launcher/Cargo.toml\`**: add tokio, dirs, chrono, uuid deps
- **\`agentmux-launcher/src/data_dir.rs\`** (NEW, 130 LoC): launcher-side path resolver mirroring host's \`spawn_backend\` paths logic so both processes arrive at identical data_dir / config_dir / user_home_dir
- **\`agentmux-launcher/src/srv_spawner.rs\`** (NEW, ~330 LoC): adapted from host's \`spawn_backend\`. Tokio process API, CREATE_SUSPENDED → assign-to-J0 → ResumeThread (PR #570 race pattern, applied to srv too), no separate Job Object, generates auth_key
- **\`agentmux-launcher/src/main.rs\`** (rewritten, ~250/-160 LoC): #[tokio::main]; sequence is paths → J0 → srv-spawn → host-spawn-with-env → tokio::select on both waits → cleanup. Job Object handles cleanup in happy path; explicit start_kill is the degraded-mode backstop (no J0)
- **\`agentmux-cef/src/sidecar.rs\`** (-80 LoC, +60 LoC): new \`use_launcher_endpoints\` helper reads env vars and populates AppState. Removed J1-on-srv code (now redundant + harmful)
- **\`agentmux-cef/src/main.rs\`** (~+30 LoC): branch on launcher-provided env vs spawn_backend fallback
- **\`agentmux-cef/src/state.rs\`** (-25 LoC): removed \`JobHandle\` wrapper + \`AppState.job_handle\` field

## Test plan

- [ ] Build a portable. Open it. Confirm UI works as before (no behavior change visible).
- [ ] \`muxlog host\` shows \"Using launcher-provided backend endpoints\" instead of \"Spawning agentmux-srv\".
- [ ] Tail \`~/.agentmux/logs/agentmux-launcher.log\`: confirm new lines for path resolution + srv spawn + ESTART + host spawn.
- [ ] Kill \`agentmux-cef.exe\` via Task Manager (NOT the launcher). Confirm srv stays alive briefly (it's in J0, not host's job). Launcher's tokio::select fires on host.wait, drops J0, srv dies via KILL_ON_JOB_CLOSE.
- [ ] Kill \`agentmux.exe\` (launcher) via Task Manager. Confirm both host and srv die immediately.
- [ ] \`task dev\`: confirm host still spawns srv via the fallback path; UI works.
- [ ] Run multiple AgentMux versions (different portable folders) simultaneously — each gets its own J0; no interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)