### PR TITLE
hotfix(launcher): keep srv stdin alive past tokio wait() (post-B.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.447"
+version = "0.33.448"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.447"
+version = "0.33.448"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.447"
+version = "0.33.448"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.447"
+version = "0.33.448"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.446"
+version = "0.33.447"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.446"
+version = "0.33.447"
 dependencies = [
  "tokio",
  "tracing",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.446"
+version = "0.33.447"
 dependencies = [
  "chrono",
  "dirs",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.446"
+version = "0.33.447"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.447"
+version = "0.33.448"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.446"
+version = "0.33.447"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.446"
+version = "0.33.447"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.447"
+version = "0.33.448"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.446"
+version = "0.33.447"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.447"
+version = "0.33.448"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -169,6 +169,19 @@ async fn run_windows(
         }
     };
 
+    // CRITICAL: tokio::process::Child::wait() proactively drops
+    // self.stdin before waiting (tokio source comment: "Ensure stdin
+    // is closed so the child can't read from it any more"). agentmux-
+    // srv has a parent-watch loop on its own stdin — when stdin reads
+    // 0 bytes (EOF from a closed write end), it interprets that as
+    // "parent died" and shuts itself down. tokio's wait() would
+    // trigger that within milliseconds, causing srv to exit before
+    // the host even mounts its first browser. Move srv's stdin out
+    // of the Child into a launcher-scope binding so tokio can't see
+    // it (its take() returns None) and the pipe stays open for the
+    // launcher's lifetime. (Smoke test on v0.33.447 caught this.)
+    let _srv_stdin_keepalive = srv_child.stdin.take();
+
     // 4. Spawn host SUSPENDED with srv endpoints in env vars. Host
     // honors AGENTMUX_BACKEND_WS et al. and skips its own spawn_backend.
     // Same CREATE_SUSPENDED → assign-to-job → resume race-fix pattern

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.447"
+version = "0.33.448"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.446"
+version = "0.33.447"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.447",
+  "version": "0.33.448",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.447",
+      "version": "0.33.448",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.446",
+  "version": "0.33.447",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.446",
+      "version": "0.33.447",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.447",
+  "version": "0.33.448",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.446",
+  "version": "0.33.447",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Hotfix for a bug introduced by PR #571 (B.1) that the smoke test caught immediately: launching the portable failed within milliseconds with srv shutting down voluntarily.

## Symptom

Launcher log on first launch of v0.33.447 portable:
\`\`\`
spawned CEF host pid=4572 (suspended)
Job Object assigned to host pid=4572, KILL_ON_JOB_CLOSE active
entering host + srv concurrent wait
[srv 7836 stderr] stdin closed, shutting down
[srv 7836 stderr] shutdown signal received, exiting
srv exited UNEXPECTEDLY (host still running) with code 0 — terminating launcher
launcher exiting with code 1
\`\`\`

User-visible: AgentMux fails to launch. UI never appears.

## Root cause

\`tokio::process::Child::wait()\` proactively drops \`self.stdin\` before waiting. From [tokio source](https://github.com/tokio-rs/tokio/blob/master/tokio/src/process/mod.rs):

\`\`\`rust
// "Ensure stdin is closed so the child can't read from it any more."
drop(self.stdin.take());
\`\`\`

agentmux-srv has a parent-watch loop on its own stdin (\`agentmux-srv/src/main.rs:526-548\`): when stdin reads 0 bytes (EOF from a closed write end), it interprets that as "parent died" and shuts down as defense-in-depth against orphans.

The host's existing \`spawn_backend\` uses \`std::process::Command\` (stdin stays open as long as Child is alive in app_state). Switching to \`tokio::process::Command\` for the launcher introduced this divergence: tokio's \`wait()\` deliberately drops stdin → srv sees EOF within milliseconds → srv exits → launcher's \`tokio::select\` fires the \`srv-exited-unexpectedly\` branch → launcher kills the host and exits.

## Fix

Take \`srv_child.stdin\` out into a launcher-scope binding BEFORE the \`tokio::select\` runs. With \`srv_child.stdin = None\`, tokio's \`wait()\` finds nothing to drop, and the launcher holds the \`ChildStdin\` alive for the entire lifetime of \`run_windows\`. srv's stdin pipe stays open as long as the launcher is running — exactly the lifetime contract srv expects.

\`\`\`rust
// New, before tokio::select:
let _srv_stdin_keepalive = srv_child.stdin.take();
\`\`\`

One-line addition; the fix is the binding's lifetime, not its content.

## Verification

Re-running v0.33.448 portable: launcher log no longer shows the \"srv exited UNEXPECTEDLY\" line; host + srv both stay running; UI loads as expected.

## Why not in PR #571

Caught by manual smoke testing immediately after merge. PR #571's review focused on Job Object semantics + race conditions, not tokio's stdio defaults — the bots had no way to know srv had a parent-watch on stdin without reading agentmux-srv. Smoke testing is the right backstop for this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)