### PR TITLE
Phase B.2: launcher named-pipe IPC server + host client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.449"
+version = "0.33.450"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.449"
+version = "0.33.450"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.449"
+version = "0.33.450"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -62,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.449"
+version = "0.33.450"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.448"
+version = "0.33.449"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,18 +37,23 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.448"
+version = "0.33.449"
 dependencies = [
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.448"
+version = "0.33.449"
 dependencies = [
+ "agentmux-common",
  "chrono",
  "dirs",
+ "serde",
+ "serde_json",
  "tokio",
  "uuid",
  "windows-sys 0.59.0",
@@ -57,7 +62,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.448"
+version = "0.33.449"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.448"
+version = "0.33.449"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.449"
+version = "0.33.450"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -1,0 +1,161 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.2: host-side client for the launcher's named-pipe IPC
+// server. Connects on host startup, sends `Register`, holds the
+// connection open for the host's lifetime.
+//
+// Today (B.2) the connection is fire-and-hold — we Register and
+// then leave the read half idle. B.3 will start receiving `Event`s
+// from the launcher (state changes), B.4 will send `Command`s up,
+// B.7 will bridge events to the renderer process.
+//
+// Activated only when `AGENTMUX_LAUNCHER_PIPE` is set (production
+// portable / installed paths after PR #571 + this PR). Absent →
+// `task dev` mode where launcher isn't in the loop; host runs as
+// before.
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::{ClientKind, Command, Event};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+#[cfg(target_os = "windows")]
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+
+/// Handle the host holds for its lifetime so the launcher's IPC
+/// pipe stays open. The wrapped `NamedPipeClient` is kept alive by
+/// holding it inside the writer Mutex; dropping this handle closes
+/// the connection (which the launcher logs as a disconnect).
+pub struct LauncherIpcHandle {
+    /// Held purely as a keepalive; B.3+ will replace with a real
+    /// command-sender that uses this writer.
+    #[allow(dead_code)]
+    writer: Arc<Mutex<tokio::io::WriteHalf<NamedPipeClient>>>,
+    /// Read-half task handle. Currently just consumes bytes off the
+    /// wire and logs them. B.4+ replaces with an event dispatcher.
+    #[allow(dead_code)]
+    reader_task: tokio::task::JoinHandle<()>,
+}
+
+/// If `AGENTMUX_LAUNCHER_PIPE` is set, connect, Register as Host,
+/// and return a handle the caller (host main.rs) holds for the
+/// host's lifetime. If unset → return None and the host runs in
+/// pre-Phase-B mode (no launcher connection).
+///
+/// Errors are logged but non-fatal: a launcher-IPC failure should
+/// NOT prevent the host from running, since the launcher's
+/// authoritative state is still in environment / files for B.2.
+/// Phase B.5+ will tighten this when the host actually depends on
+/// IPC for state.
+#[cfg(target_os = "windows")]
+pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
+    let pipe_path = match std::env::var("AGENTMUX_LAUNCHER_PIPE") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            tracing::info!(
+                "AGENTMUX_LAUNCHER_PIPE unset — running without launcher IPC (dev mode)"
+            );
+            return None;
+        }
+    };
+
+    // Open the named pipe (client side). The launcher created it
+    // with `first_pipe_instance(true)` and is accept-looping; this
+    // call blocks briefly until accept lands. tokio retries
+    // ERROR_PIPE_BUSY internally.
+    let client = match ClientOptions::new().open(&pipe_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                "[launcher-ipc] failed to open {}: {} — continuing without launcher IPC",
+                pipe_path,
+                e
+            );
+            return None;
+        }
+    };
+    tracing::info!("[launcher-ipc] connected to {}", pipe_path);
+
+    let (read_half, write_half) = tokio::io::split(client);
+    let writer = Arc::new(Mutex::new(write_half));
+
+    // Send Register. Server enforces this is the first message; we
+    // satisfy the contract before any other traffic.
+    let register = Command::Register {
+        kind: ClientKind::Host,
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let mut buf = match serde_json::to_vec(&register) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!(
+                "[launcher-ipc] failed to serialize Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+    };
+    buf.push(b'\n');
+    {
+        let mut w = writer.lock().await;
+        if let Err(e) = w.write_all(&buf).await {
+            tracing::error!(
+                "[launcher-ipc] failed to send Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+        if let Err(e) = w.flush().await {
+            tracing::error!(
+                "[launcher-ipc] failed to flush Register: {} — continuing without IPC",
+                e
+            );
+            return None;
+        }
+    }
+
+    // Spawn a read-loop task. For B.2 it just logs every Event the
+    // server sends; B.3+ will dispatch them into host state.
+    let reader_task = tokio::spawn(async move {
+        let reader = BufReader::new(read_half);
+        let mut lines = reader.lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) if line.trim().is_empty() => continue,
+                Ok(Some(line)) => match serde_json::from_str::<Event>(&line) {
+                    Ok(event) => {
+                        tracing::info!("[launcher-ipc] received event: {:?}", event);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[launcher-ipc] could not parse event line ({}): {}",
+                            e,
+                            line
+                        );
+                    }
+                },
+                Ok(None) => {
+                    tracing::info!("[launcher-ipc] launcher pipe EOF — connection closed");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("[launcher-ipc] read error: {}", e);
+                    return;
+                }
+            }
+        }
+    });
+
+    Some(LauncherIpcHandle {
+        writer,
+        reader_task,
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
+    None
+}

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -25,9 +25,16 @@ use tokio::sync::Mutex;
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
 
 /// Handle the host holds for its lifetime so the launcher's IPC
-/// pipe stays open. The wrapped `NamedPipeClient` is kept alive by
-/// holding it inside the writer Mutex; dropping this handle closes
-/// the connection (which the launcher logs as a disconnect).
+/// pipe stays open. Dropping it closes the connection (launcher
+/// logs as a disconnect).
+///
+/// Cross-platform shape: the Windows variant carries the actual
+/// pipe writer + reader-task handles; the non-Windows variant is
+/// a unit-struct stub so `connect_to_launcher` keeps a uniform
+/// `Option<LauncherIpcHandle>` return type. Phase 7's cross-
+/// platform IPC (Unix domain sockets) will fill the non-Windows
+/// shape later. (reagent / codex P1 PR #573 round-1.)
+#[cfg(target_os = "windows")]
 pub struct LauncherIpcHandle {
     /// Held purely as a keepalive; B.3+ will replace with a real
     /// command-sender that uses this writer.
@@ -38,6 +45,9 @@ pub struct LauncherIpcHandle {
     #[allow(dead_code)]
     reader_task: tokio::task::JoinHandle<()>,
 }
+
+#[cfg(not(target_os = "windows"))]
+pub struct LauncherIpcHandle;
 
 /// If `AGENTMUX_LAUNCHER_PIPE` is set, connect, Register as Host,
 /// and return a handle the caller (host main.rs) holds for the

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -29,6 +29,7 @@ mod commands;
 mod dev_authfile;
 mod events;
 mod ipc;
+mod launcher_ipc;
 mod memory_heartbeat;
 mod pane;
 mod sidecar;
@@ -222,6 +223,14 @@ fn main() {
     *app_state.ipc_port.lock() = ipc_port;
 
     tracing::info!("IPC server started on port {}", ipc_port);
+
+    // Phase B.2: connect to launcher's named-pipe IPC (if launcher
+    // is in the loop) so the launcher can route Commands and Events
+    // through us. The handle is held in main scope for the host's
+    // lifetime — dropping it closes the pipe (logged by launcher).
+    // Failure to connect is non-fatal in B.2 (host can still run);
+    // B.5+ will tighten when the host depends on IPC for state.
+    let _launcher_ipc = runtime.block_on(launcher_ipc::connect_to_launcher());
 
     // Phase B.1: if launcher already spawned srv (the normal portable
     // / installed path post-PR-#570 + B.1), populate state from the

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.449"
+version = "0.33.450"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "agentmux-common"
-version = "0.33.448"
+version = "0.33.449"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 
 [dependencies]
 tokio = { version = "1", features = ["process"] }
 tracing = "0.1"
+# Phase B.2: shared IPC protocol types (Command/Event) between
+# launcher (server) and host (client). One source of truth so the
+# wire format can't drift between the two binaries on a version-
+# skew release. JSON over newline-delimited frames.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -1,0 +1,160 @@
+//! Phase B.2 IPC wire protocol — shared between agentmux-launcher
+//! (server) and agentmux-cef (client). One source of truth so the
+//! Command / Event shapes can't drift between binaries on a
+//! version-skew release.
+//!
+//! See `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` §5.
+//!
+//! Wire format: newline-delimited JSON. One message per line,
+//! parsed via serde_json. Format chosen for debuggability —
+//! operators can `cat` / `nc` the named pipe and read traffic
+//! without a binary protocol decoder.
+//!
+//! Backward compat policy (B.2 baseline; harden in Phase D):
+//!   * Externally tagged enums (`{"cmd":"register",...}`) so adding
+//!     variants is non-breaking; clients send what they know.
+//!   * Unknown commands → server replies `Event::Error` rather than
+//!     crashing.
+//!   * `version: u64` on every Event lets Phase D's GetSnapshot /
+//!     resync detect skew. For B.2 it's set but not enforced.
+
+use serde::{Deserialize, Serialize};
+
+/// Stable identifier for a connected client. Tagged so the launcher
+/// can route replies + log who said what.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClientKind {
+    /// The CEF host process (one per launcher run).
+    Host,
+    /// A frontend renderer (proxied via the host's CEF JS bridge — Phase B.7).
+    Renderer,
+    /// The agentmux-srv backend (proxy connection used for Quit ack
+    /// + process-tree facts; the workspace data path stays on
+    /// HTTP/WS through host).
+    Srv,
+    /// External tooling (`agentmux.exe --diag` etc.).
+    Tool,
+}
+
+/// Commands flow client → launcher.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+pub enum Command {
+    /// Identifies the connection. MUST be the first command on every
+    /// new connection. Server enforces.
+    Register {
+        kind: ClientKind,
+        /// PID of the connecting process — used for cross-checking
+        /// against the launcher's `ProcessRecord` map and for
+        /// log correlation.
+        pid: u32,
+        /// Free-form version string of the client binary, for log
+        /// correlation across version skew.
+        version: String,
+    },
+    /// Health probe — server replies with `Event::Pong` carrying the
+    /// same nonce. NOT a polling heartbeat (per spec §4.3) — sent
+    /// only on demand by clients that need round-trip confirmation.
+    Ping {
+        nonce: u64,
+    },
+    /// Graceful disconnect. Server logs and closes the connection.
+    /// In B.3+ this becomes `Quit { reason }` with shutdown semantics;
+    /// for B.2 it's just a polite goodbye.
+    Goodbye,
+}
+
+/// Events flow launcher → client. Versioned per spec §5.2 — every
+/// event carries a monotonic `version: u64` per launcher run, used
+/// by Phase D's resync protocol.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum Event {
+    /// Reply to `Command::Register`. Acknowledges the client kind +
+    /// confirms the launcher's view of the world.
+    Registered {
+        client_id: u64,
+        launcher_pid: u32,
+        launcher_version: String,
+        version: u64,
+    },
+    /// Reply to `Command::Ping`. Echoes the nonce.
+    Pong {
+        nonce: u64,
+        version: u64,
+    },
+    /// Sent when an incoming command can't be parsed or violates an
+    /// invariant (e.g. Command before Register). Connection stays
+    /// open unless `fatal: true`.
+    Error {
+        code: ErrorCode,
+        message: String,
+        fatal: bool,
+        version: u64,
+    },
+}
+
+/// Discriminant for `Event::Error` — keeps clients structured against
+/// failure modes without parsing message text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ErrorCode {
+    /// Couldn't deserialize the line into a Command.
+    InvalidCommand,
+    /// Command sent before Register.
+    NotRegistered,
+    /// Register sent twice on the same connection.
+    AlreadyRegistered,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_register_roundtrip() {
+        let c = Command::Register {
+            kind: ClientKind::Host,
+            pid: 12345,
+            version: "0.33.449".into(),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"cmd\":\"register\""));
+        assert!(json.contains("\"kind\":\"host\""));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        if let Command::Register { kind, pid, version } = back {
+            assert_eq!(kind, ClientKind::Host);
+            assert_eq!(pid, 12345);
+            assert_eq!(version, "0.33.449");
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn event_registered_roundtrip() {
+        let e = Event::Registered {
+            client_id: 1,
+            launcher_pid: 9999,
+            launcher_version: "0.33.449".into(),
+            version: 42,
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"event\":\"registered\""));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        if let Event::Registered { client_id, version, .. } = back {
+            assert_eq!(client_id, 1);
+            assert_eq!(version, 42);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn unknown_cmd_fails_to_deserialize() {
+        let json = r#"{"cmd":"banana"}"#;
+        let r: Result<Command, _> = serde_json::from_str(json);
+        assert!(r.is_err());
+    }
+}

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -1,5 +1,6 @@
 //! Shared utilities for AgentMux crates.
 
 mod cli;
+pub mod ipc;
 
 pub use cli::make_cli_cmd;

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.448"
+version = "0.33.449"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"
@@ -22,6 +22,8 @@ tokio = { version = "1", features = [
     "io-util",
     "time",
     "sync",
+    # Phase B.2: tokio::net::windows::named_pipe lives in this feature.
+    "net",
 ] }
 # Platform-default data_dir / config_dir resolution. Host already
 # uses this; launcher must compute the SAME paths so both processes
@@ -34,6 +36,12 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 # both srv (env var) and host (env var). Same generation method the
 # host uses today (uuid::Uuid::new_v4) so the format is identical.
 uuid = { version = "1", features = ["v4"] }
+# Phase B.2: typed Command / Event protocol over named pipes. The
+# wire types live in agentmux-common::ipc so launcher (server) and
+# host (client) share one definition; serde_json is the format.
+agentmux-common = { path = "../agentmux-common" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.449"
+version = "0.33.450"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/hash.rs
+++ b/agentmux-launcher/src/hash.rs
@@ -1,0 +1,81 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Stable 64-bit hash for deriving per-data-dir IPC names. Used to
+// build the named-pipe path `\\.\pipe\agentmux-{hash16}\command`
+// so each AgentMux instance (per CLAUDE.md, multiple parallel
+// instances are supported per-data-dir) gets a distinct IPC
+// surface, kernel-isolated from siblings.
+//
+// We hand-roll FNV-1a because:
+//   * Adding `sha2` for ~64 bits of stable hash is overkill (3+ MB
+//     deps) when this is non-cryptographic.
+//   * `std::collections::hash_map::DefaultHasher` is explicitly
+//     NOT documented as stable across runs / Rust versions; we
+//     need stability so the same launcher binary always picks the
+//     same pipe name for the same data dir.
+//   * FNV-1a is deterministic, well-known, and ~20 lines of code.
+//
+// Collisions are non-cryptographic but adequate for this scope:
+// the hash inputs are filesystem paths, the keyspace is tiny, and
+// a collision just means two installs at different paths share a
+// pipe name — they'd need to be running simultaneously AND have
+// the SAME data dir hash, which is astronomically unlikely with
+// 16 hex chars (64 bits) of namespace.
+
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// 64-bit FNV-1a hash of bytes. Stable across runs.
+pub fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash = FNV_OFFSET_BASIS;
+    for b in bytes {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// First 16 hex chars of FNV-1a-64 over the canonical-lowercase
+/// representation of the data_dir path. Used as the per-instance
+/// IPC namespace component.
+pub fn data_dir_hash16(data_dir: &std::path::Path) -> String {
+    // Canonicalize if possible (resolves `..`, mixed casing on
+    // Windows), but fall back to the raw path if canonicalize fails
+    // (e.g. data_dir doesn't exist yet during early startup).
+    let canonical = data_dir
+        .canonicalize()
+        .unwrap_or_else(|_| data_dir.to_path_buf());
+    let s = canonical.to_string_lossy().to_lowercase();
+    format!("{:016x}", fnv1a_64(s.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fnv1a_known_vector() {
+        // Standard test vector for FNV-1a-64 on empty input.
+        assert_eq!(fnv1a_64(b""), FNV_OFFSET_BASIS);
+        // From http://www.isthe.com/chongo/tech/comp/fnv/test_vectors.html
+        // ("foobar" → 0x85944171f73967e8)
+        assert_eq!(fnv1a_64(b"foobar"), 0x85944171f73967e8);
+    }
+
+    #[test]
+    fn data_dir_hash_stable_across_calls() {
+        let p = std::path::PathBuf::from("C:\\Users\\test\\AgentMux");
+        assert_eq!(data_dir_hash16(&p), data_dir_hash16(&p));
+        assert_eq!(data_dir_hash16(&p).len(), 16);
+    }
+
+    #[test]
+    fn data_dir_hash_case_insensitive() {
+        // Windows paths shouldn't produce different hashes for
+        // different casings of the same logical path.
+        let lower = std::path::PathBuf::from("c:\\users\\test");
+        let upper = std::path::PathBuf::from("C:\\Users\\Test");
+        assert_eq!(data_dir_hash16(&lower), data_dir_hash16(&upper));
+    }
+}

--- a/agentmux-launcher/src/ipc/mod.rs
+++ b/agentmux-launcher/src/ipc/mod.rs
@@ -1,0 +1,37 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.2: launcher-owned named-pipe IPC server.
+//
+// Per `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` §3.2 and §5,
+// the launcher hosts the canonical state machine and exposes it over a
+// pipe per data-dir-scoped namespace. Each subscriber (host, eventually
+// frontend renderers, srv) connects, sends `Command` messages, and
+// receives `Event` messages back.
+//
+// B.2 scope (this module): just the wire — types + accept loop +
+// per-connection read/write tasks. No reducer, no events emitted yet
+// (B.3 wires the reducer; B.4 pipes events back). This commit makes
+// the host able to register itself with the launcher and the launcher
+// to log incoming Commands. Foundation for everything else in Phase B.
+
+pub mod server;
+
+// Wire types live in agentmux-common::ipc so the host (client) and
+// launcher (server) compile against one definition. Re-exported
+// here for convenience.
+pub use agentmux_common::ipc::{Command, Event};
+pub use server::run_ipc_server;
+
+/// Construct the named-pipe path for a given data-dir hash.
+/// Format: `\\.\pipe\agentmux-{hash16}\command`.
+///
+/// Per-data-dir scoping preserves multi-instance support per
+/// `CLAUDE.md`: different portable folders / installed versions
+/// → different data dirs → different hashes → distinct pipes.
+/// Two launchers pointing at the SAME data dir will collide on
+/// the pipe name, which is also the single-instance signal
+/// Phase B.6 relies on.
+pub fn pipe_name(data_dir_hash16: &str) -> String {
+    format!("\\\\.\\pipe\\agentmux-{}\\command", data_dir_hash16)
+}

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -98,9 +98,25 @@ pub fn run_ipc_server(
 
         loop {
             // Wait for a client to connect to the existing instance.
+            // On error: log + recreate the instance + retry. Without
+            // the explicit `continue`, the failed (un-connected) pipe
+            // instance below would be moved into `accepted` and
+            // spawned in a handler that immediately fails to read,
+            // wasting a per-connection task slot. (reagent P1 + codex
+            // P1 PR #573 round-1.)
             if let Err(e) = current.connect().await {
-                crate::log(&format!("[ipc] connect failed: {}", e));
-                // Keep looping — recreating the server below.
+                crate::log(&format!("[ipc] connect failed: {} — recreating instance", e));
+                current = match ServerOptions::new().create(&pipe_name) {
+                    Ok(s) => s,
+                    Err(create_err) => {
+                        crate::log(&format!(
+                            "[ipc] FATAL: failed to recreate pipe after connect error: {} (server stopping)",
+                            create_err
+                        ));
+                        return;
+                    }
+                };
+                continue;
             }
 
             // Hand the accepted instance to a handler task, then
@@ -249,6 +265,27 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
                 .await;
             }
             Command::Goodbye => {
+                // Enforce the same Register-first invariant as Ping:
+                // Goodbye before Register lets a misbehaving client
+                // silently bypass the handshake contract. Reply with
+                // NotRegistered so handshake bugs are visible, then
+                // close. (codex P2 PR #573 round-1.)
+                if registered_kind.is_none() {
+                    let _ = send_event(
+                        &writer,
+                        Event::Error {
+                            code: ErrorCode::NotRegistered,
+                            message: "Goodbye before Register".into(),
+                            fatal: true,
+                            version: next_event_version(),
+                        },
+                    )
+                    .await;
+                    crate::log(
+                        "[ipc] goodbye from unregistered client — closing with error",
+                    );
+                    return;
+                }
                 crate::log(&format!(
                     "[ipc] goodbye from client_id={:?} kind={:?}",
                     client_id, registered_kind

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -1,0 +1,278 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Named-pipe IPC server — accept loop + per-connection handler.
+//
+// Tokio's `NamedPipeServer` lets us treat each accepted instance as
+// an independent bidirectional stream. We run one accept-loop task
+// that creates a fresh `NamedPipeServer` after each connection (so
+// the next client has something to connect to) and spawns a
+// per-connection task to drive it.
+//
+// Wire framing: newline-delimited JSON. Reads use `BufReader::lines()`,
+// writes use `write_all` + `\n`. Robust to partial reads since `lines`
+// already buffers until `\n`. Strict policy: `Register` MUST be the
+// first message; subsequent `Register` is ignored with an error.
+//
+// What this commit does NOT do:
+//   * Forward Commands to a reducer (no reducer yet — B.3).
+//   * Emit Events spontaneously (only Registered/Pong/Error replies).
+//   * Persist client_id assignment across reconnect.
+//
+// Connection lifecycle is intentionally short-lived for B.2: each
+// pipe instance handles one client connection, end-to-end. When the
+// client drops, the per-connection task ends and the accept loop
+// continues with a fresh instance.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::Mutex;
+
+#[cfg(target_os = "windows")]
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+
+use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event};
+
+/// Monotonic event-version counter. Each Event sent over any pipe
+/// gets a fresh version. Phase D uses this as the GetSnapshot resync
+/// anchor (`event.version > snapshot.version_at_snapshot` semantics).
+static EVENT_VERSION: AtomicU64 = AtomicU64::new(0);
+
+/// Monotonic client_id assigned per Register. Stable per
+/// launcher-run; not persisted.
+static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_event_version() -> u64 {
+    EVENT_VERSION.fetch_add(1, Ordering::Relaxed)
+}
+
+/// State the IPC server shares across connections. Today it's just
+/// the launcher's PID + version (for Registered echoes); the reducer
+/// (B.3) will land here.
+#[derive(Debug, Clone)]
+pub struct ServerCtx {
+    pub launcher_pid: u32,
+    pub launcher_version: String,
+}
+
+/// Run the named-pipe IPC server until cancelled (or task panics).
+///
+/// Returns a JoinHandle the caller (main.rs) holds for the life of
+/// the launcher. The server keeps accepting until the launcher's
+/// Tokio runtime shuts down.
+///
+/// Each accepted connection becomes a new tokio task running
+/// `handle_connection`. The accept loop creates a fresh
+/// `NamedPipeServer` instance for the next client BEFORE spawning
+/// the handler — without this, a slow handler could starve the next
+/// connect. Standard Win32 named-pipe pattern.
+#[cfg(target_os = "windows")]
+pub fn run_ipc_server(
+    pipe_name: String,
+    ctx: ServerCtx,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let ctx = Arc::new(ctx);
+        crate::log(&format!("[ipc] server starting on {}", pipe_name));
+
+        // First server instance — `first_pipe_instance(true)` rejects
+        // a second launcher trying to bind the same pipe (Phase B.6's
+        // single-instance check rides on this). For B.2 we use it
+        // defensively to surface name-collision bugs early.
+        let first = match ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_name)
+        {
+            Ok(s) => s,
+            Err(e) => {
+                crate::log(&format!(
+                    "[ipc] FATAL: bind failed for {}: {} (another launcher running for this data dir?)",
+                    pipe_name, e
+                ));
+                return;
+            }
+        };
+        let mut current = first;
+
+        loop {
+            // Wait for a client to connect to the existing instance.
+            if let Err(e) = current.connect().await {
+                crate::log(&format!("[ipc] connect failed: {}", e));
+                // Keep looping — recreating the server below.
+            }
+
+            // Hand the accepted instance to a handler task, then
+            // create the NEXT server instance so the next client
+            // doesn't have to wait for the handler to finish.
+            let accepted = current;
+            current = match ServerOptions::new().create(&pipe_name) {
+                Ok(s) => s,
+                Err(e) => {
+                    crate::log(&format!(
+                        "[ipc] FATAL: failed to create next pipe instance: {} (server stopping)",
+                        e
+                    ));
+                    // Drain the accepted client, then bail.
+                    tokio::spawn(handle_connection(accepted, Arc::clone(&ctx)));
+                    return;
+                }
+            };
+
+            tokio::spawn(handle_connection(accepted, Arc::clone(&ctx)));
+        }
+    })
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn run_ipc_server(
+    _pipe_name: String,
+    _ctx: ServerCtx,
+) -> tokio::task::JoinHandle<()> {
+    // Non-Windows: pipe IPC isn't built yet. Phase 7 of the broader
+    // tear-off cross-platform work (separate spec) will add Unix
+    // domain socket support. For now return an immediately-finished
+    // task so the caller can hold a handle uniformly.
+    tokio::spawn(async {})
+}
+
+/// Drive one connection: read newline-delimited JSON Commands,
+/// write back JSON Events. First message MUST be `Register`.
+#[cfg(target_os = "windows")]
+async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
+    // Split into read + write halves so we can call them
+    // independently. tokio's NamedPipeServer is bidi by default.
+    let (read_half, write_half) = tokio::io::split(stream);
+    let writer = Arc::new(Mutex::new(write_half));
+    let reader = BufReader::new(read_half);
+    let mut lines = reader.lines();
+
+    let mut registered_kind: Option<ClientKind> = None;
+    let mut client_id: Option<u64> = None;
+
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(l)) => l,
+            Ok(None) => {
+                crate::log(&format!(
+                    "[ipc] connection closed (client_id={:?}, kind={:?})",
+                    client_id, registered_kind
+                ));
+                return;
+            }
+            Err(e) => {
+                crate::log(&format!(
+                    "[ipc] read error (client_id={:?}): {}",
+                    client_id, e
+                ));
+                return;
+            }
+        };
+
+        // Skip blank lines so a stray newline doesn't churn errors.
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let cmd = match serde_json::from_str::<Command>(&line) {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = send_event(
+                    &writer,
+                    Event::Error {
+                        code: ErrorCode::InvalidCommand,
+                        message: format!("parse failed: {}", e),
+                        fatal: false,
+                        version: next_event_version(),
+                    },
+                )
+                .await;
+                continue;
+            }
+        };
+
+        match cmd {
+            Command::Register { kind, pid, version } => {
+                if registered_kind.is_some() {
+                    let _ = send_event(
+                        &writer,
+                        Event::Error {
+                            code: ErrorCode::AlreadyRegistered,
+                            message: "Register sent twice on the same connection".into(),
+                            fatal: false,
+                            version: next_event_version(),
+                        },
+                    )
+                    .await;
+                    continue;
+                }
+                let id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
+                registered_kind = Some(kind);
+                client_id = Some(id);
+                crate::log(&format!(
+                    "[ipc] registered client_id={} kind={:?} pid={} version={}",
+                    id, kind, pid, version
+                ));
+                let _ = send_event(
+                    &writer,
+                    Event::Registered {
+                        client_id: id,
+                        launcher_pid: ctx.launcher_pid,
+                        launcher_version: ctx.launcher_version.clone(),
+                        version: next_event_version(),
+                    },
+                )
+                .await;
+            }
+            Command::Ping { nonce } => {
+                if registered_kind.is_none() {
+                    let _ = send_event(
+                        &writer,
+                        Event::Error {
+                            code: ErrorCode::NotRegistered,
+                            message: "Ping before Register".into(),
+                            fatal: false,
+                            version: next_event_version(),
+                        },
+                    )
+                    .await;
+                    continue;
+                }
+                let _ = send_event(
+                    &writer,
+                    Event::Pong {
+                        nonce,
+                        version: next_event_version(),
+                    },
+                )
+                .await;
+            }
+            Command::Goodbye => {
+                crate::log(&format!(
+                    "[ipc] goodbye from client_id={:?} kind={:?}",
+                    client_id, registered_kind
+                ));
+                return;
+            }
+        }
+    }
+}
+
+/// Serialize an Event as one JSON line + `\n` and write atomically
+/// (under the per-connection writer mutex). Returns Err if the
+/// connection died mid-write.
+#[cfg(target_os = "windows")]
+async fn send_event(
+    writer: &Arc<Mutex<tokio::io::WriteHalf<NamedPipeServer>>>,
+    event: Event,
+) -> std::io::Result<()> {
+    let mut buf = serde_json::to_vec(&event).map_err(|e| {
+        std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string())
+    })?;
+    buf.push(b'\n');
+    let mut w = writer.lock().await;
+    w.write_all(&buf).await?;
+    w.flush().await?;
+    Ok(())
+}

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -21,6 +21,8 @@
 )]
 
 mod data_dir;
+mod hash;
+mod ipc;
 mod srv_spawner;
 
 #[tokio::main]
@@ -149,6 +151,29 @@ async fn run_windows(
     let job_handle: windows_sys::Win32::Foundation::HANDLE =
         job.as_ref().map(|j| j.0).unwrap_or(std::ptr::null_mut());
 
+    // Phase B.2: start the named-pipe IPC server BEFORE spawning
+    // any children. Host connects to this pipe at startup using the
+    // AGENTMUX_LAUNCHER_PIPE env var the launcher passes below.
+    //
+    // The server runs in its own Tokio task; the JoinHandle is held
+    // for the rest of run_windows so the task isn't cancelled mid-
+    // accept. Server owns the namespace `\\.\pipe\agentmux-{hash}\
+    // command` per data dir, so multi-instance launchers (different
+    // data dirs) get distinct pipes; a second launcher pointing at
+    // the SAME data dir would collide on `first_pipe_instance(true)`
+    // and surface as a clean error — Phase B.6 turns that collision
+    // into the single-instance enforcement signal.
+    let dir_hash = hash::data_dir_hash16(&paths.data_dir);
+    let pipe_path = ipc::pipe_name(&dir_hash);
+    let _ipc_handle = ipc::run_ipc_server(
+        pipe_path.clone(),
+        ipc::server::ServerCtx {
+            launcher_pid: std::process::id(),
+            launcher_version: env!("CARGO_PKG_VERSION").to_string(),
+        },
+    );
+    log(&format!("IPC server started on {}", pipe_path));
+
     // 3. Spawn srv first. Host needs srv's endpoints to skip its own
     // spawn_backend path. Srv signals readiness via WAVESRV-ESTART on
     // stderr; the spawner returns once we see that line (or after a
@@ -203,6 +228,10 @@ async fn run_windows(
             "AGENTMUX_USER_HOME_DIR",
             paths.user_home_dir.to_string_lossy().to_string(),
         )
+        // Phase B.2: tell the host where to find our IPC pipe so it
+        // can connect and Register itself. Absent → host runs the
+        // pre-Phase-B path (no IPC connection; standalone state).
+        .env("AGENTMUX_LAUNCHER_PIPE", &pipe_path)
         .creation_flags(CREATE_SUSPENDED)
         .kill_on_drop(false); // J0 handles cleanup; tokio's kill-on-drop would force-kill on every error path.
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.448"
+version = "0.33.449"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.449"
+version = "0.33.450"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.448",
+  "version": "0.33.449",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.448",
+      "version": "0.33.449",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.449",
+  "version": "0.33.450",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.449",
+      "version": "0.33.450",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.449",
+  "version": "0.33.450",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.448",
+  "version": "0.33.449",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Second sub-PR in Phase B (the redux-architecture migration per [SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md](specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md)). Adds the IPC wire foundation everything else in Phase B will sit on. No reducer yet, no state migration — just the typed Command/Event protocol + the named-pipe server + the host's Register handshake.

## What ships

- **\`agentmux-common::ipc\`** — shared \`Command\` / \`Event\` / \`ClientKind\` / \`ErrorCode\` types. One source of truth so the wire format can't drift between launcher and host on a version-skew release.
- **\`agentmux-launcher::ipc::server\`** — \`run_ipc_server(pipe_name, ctx)\`: tokio task that accepts, spawns per-connection handlers, and replies to Register / Ping / Goodbye. Externally-tagged JSON, newline-delimited.
- **\`agentmux-launcher::hash\`** — \`data_dir_hash16(path)\`: stable FNV-1a-64 (16 hex chars) so per-data-dir IPC namespaces are deterministic across runs without adding a crypto-hash dep.
- **\`agentmux-cef::launcher_ipc\`** — \`connect_to_launcher()\`: host opens the pipe (when \`AGENTMUX_LAUNCHER_PIPE\` env is set by launcher), Registers as Host, holds the connection alive for the host's lifetime. Failure logs but doesn't crash (host still runs in B.2).

## Pipe naming

\`\\.\pipe\agentmux-{hash16(canonical_lower(data_dir))}\command\`

Multi-instance launchers (different portable folders) → different data dirs → different hashes → distinct pipes. Same-data-dir collision = single-instance signal for B.6.

## Server enforcement (B.2 baseline)

- First message MUST be \`Register\` → else \`Event::Error { code: NotRegistered }\`.
- Second \`Register\` → \`AlreadyRegistered\`.
- Unparseable lines → \`InvalidCommand\`.
- Unknown command variants → fail to deserialize → \`InvalidCommand\`.

## Versioning

Every \`Event\` carries a monotonic \`version: u64\` (per launcher run). Set but not enforced in B.2 — Phase D's GetSnapshot resync protocol will use this as the anchor.

## What's NOT in this PR

- B.3: \`Command\` extensions (OpenWindow, CloseWindow, ...) + pure reducer skeleton in launcher
- B.4: launcher state mirror; reducer starts emitting Events
- B.5: migrate state stores HashMap-by-HashMap to launcher-authoritative
- B.6: per-data-dir mutex single-instance (pipe-name collision is the signal)
- B.7: frontend deletes polling loop, subscribes via host CEF JS bridge
- B.8: Phase B exit; delete host-side state stores

## Smoke-test result (v0.33.449)

Launcher log:
\`\`\`
[ipc] server starting on \\.\pipe\agentmux-7fed9f28cbc0b2bb\command
[ipc] registered client_id=1 kind=Host pid=6756 version=0.33.449
\`\`\`

Host log:
\`\`\`
[launcher-ipc] connected to \\.\pipe\agentmux-7fed9f28cbc0b2bb\command
[launcher-ipc] received event: Registered { client_id: 1, launcher_pid: 2680, launcher_version: \"0.33.449\", version: 0 }
\`\`\`

Process count: 11 (1 launcher + 1+1 srv + 7 host) — same as B.1 baseline. No regression.

## Test plan

- [ ] Build a portable, run it, confirm launcher log shows the new \`[ipc] server starting\` and \`[ipc] registered client_id=1 kind=Host\` lines.
- [ ] Confirm host log shows \`[launcher-ipc] connected\` and \`received event: Registered\`.
- [ ] Kill host via Task Manager → launcher logs connection close; tree reaped via J0 (B.1 behavior preserved).
- [ ] Kill launcher via Task Manager → tree reaped via KILL_ON_JOB_CLOSE.
- [ ] \`task dev\` mode: \`AGENTMUX_LAUNCHER_PIPE\` unset → host logs \"AGENTMUX_LAUNCHER_PIPE unset — running without launcher IPC (dev mode)\" and proceeds with the existing spawn_backend path.
- [ ] Two simultaneous launches with different portable folders → different pipe hashes → both run without IPC interference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)