### PR TITLE
Phase B.3: pure reducer + state machine in launcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.450"
+version = "0.33.451"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.450"
+version = "0.33.451"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,11 +47,12 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.450"
+version = "0.33.451"
 dependencies = [
  "agentmux-common",
  "chrono",
  "dirs",
+ "proptest",
  "serde",
  "serde_json",
  "tokio",
@@ -62,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.450"
+version = "0.33.451"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -360,6 +361,21 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -910,6 +926,12 @@ dependencies = [
  "futures-sink",
  "spin",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -2046,6 +2068,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,6 +2234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2382,6 +2438,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3102,6 +3170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3308,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.451"
+version = "0.33.452"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.451"
+version = "0.33.452"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.451"
+version = "0.33.452"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.451"
+version = "0.33.452"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.451"
+version = "0.33.452"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.450"
+version = "0.33.451"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.450"
+version = "0.33.451"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.451"
+version = "0.33.452"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -68,7 +68,13 @@ pub enum Command {
 /// Events flow launcher → client. Versioned per spec §5.2 — every
 /// event carries a monotonic `version: u64` per launcher run, used
 /// by Phase D's resync protocol.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// Phase B.3 introduces the first non-handshake events
+/// (ProcessSpawned, ProcessExited, LifecyclePhaseChanged) emitted
+/// by the launcher's reducer when commands transition state. B.4+
+/// adds the window-state events (WindowAdded, WindowStateChanged,
+/// WindowRemoved) per spec §5.2.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum Event {
     /// Reply to `Command::Register`. Acknowledges the client kind +
@@ -93,6 +99,52 @@ pub enum Event {
         fatal: bool,
         version: u64,
     },
+    /// A process joined the launcher's canonical registry. Emitted
+    /// when a client first Registers (B.3) and, in B.4+, when the
+    /// launcher itself spawns a child.
+    ProcessSpawned {
+        pid: u32,
+        kind: ClientKind,
+        client_version: String,
+        version: u64,
+    },
+    /// A process exited or disconnected gracefully. Emitted on
+    /// Goodbye (B.3) and, in B.4+, on detected child exit.
+    ProcessExited {
+        pid: u32,
+        /// Exit code. 0 = clean Goodbye; non-zero = OS-reported
+        /// exit code or synthetic value for crashes.
+        code: i32,
+        version: u64,
+    },
+    /// The launcher's lifecycle phase changed. Spec §4 defines the
+    /// valid transitions: Starting → Running → Quitting → Dead.
+    /// Emitted at most once per transition.
+    LifecyclePhaseChanged {
+        from: LifecyclePhase,
+        to: LifecyclePhase,
+        version: u64,
+    },
+}
+
+/// Coarse-grained launcher state. Spec §4: Starting → Running →
+/// Quitting → Dead, no other transitions allowed. The reducer in
+/// agentmux-launcher::reducer enforces this; a violation panics
+/// (Job Object reaps via OS).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LifecyclePhase {
+    /// Initial state; launcher has not yet seen the host register.
+    Starting,
+    /// Host has registered and the canonical state is being
+    /// maintained. Steady state.
+    Running,
+    /// Quit { reason } received, ack outstanding to subscribers.
+    /// Phase B.3 keeps this state-shape only — the actual Quit
+    /// command lands in a later sub-PR.
+    Quitting,
+    /// Cleanup done; launcher about to exit. Transient.
+    Dead,
 }
 
 /// Discriminant for `Event::Error` — keeps clients structured against

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.450"
+version = "0.33.451"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"
@@ -58,3 +58,10 @@ windows-sys = { version = "0.59", features = [
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
+
+[dev-dependencies]
+# Phase B.3: property-based testing for the reducer. Generates
+# arbitrary command sequences and asserts the reducer's invariants
+# hold across all of them — catches edge cases unit tests miss.
+# Dev-only: zero impact on release binary size.
+proptest = "1"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.451"
+version = "0.33.452"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -213,11 +213,18 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
         };
 
         // Per-connection invariants: enforce here so reducer doesn't
-        // need to know about connection identity.
+        // need to know about connection identity. Honor the `fatal`
+        // bit — Ping-before-Register is non-fatal (clients can
+        // recover by sending Register next), Goodbye-before-Register
+        // is fatal (can't recover from a closed-by-them connection).
+        // (reagent P1 + codex P1 PR #574 round-1.)
         if let Some(reply) = enforce_register_first(&cmd, &registered_kind, &ctx).await {
+            let close = matches!(&reply, Event::Error { fatal: true, .. });
             let _ = send_event(&writer, reply).await;
-            // Goodbye-before-Register and similar are fatal — close.
-            return;
+            if close {
+                return;
+            }
+            continue;
         }
         if let Command::Register { .. } = &cmd {
             if registered_kind.is_some() {
@@ -248,12 +255,17 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
             None
         };
 
-        // Dispatch through the reducer. Mutex held briefly.
+        // Dispatch through the reducer. Mutex held briefly — compute
+        // the timestamp BEFORE acquiring so syscalls + string
+        // formatting don't show up in lock-hold time. (gemini
+        // MEDIUM @ server.rs:259, PR #574 round-1.)
+        let now_rfc3339 = chrono::Utc::now().to_rfc3339();
         let events = {
             let mut state = ctx.state.lock().await;
             let rctx = reducer::Ctx {
-                now_rfc3339: chrono::Utc::now().to_rfc3339(),
+                now_rfc3339,
                 conn_id,
+                registered_pid,
             };
             reducer::update(&mut state, cmd.clone(), &rctx)
         };

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -3,28 +3,25 @@
 //
 // Named-pipe IPC server — accept loop + per-connection handler.
 //
-// Tokio's `NamedPipeServer` lets us treat each accepted instance as
-// an independent bidirectional stream. We run one accept-loop task
-// that creates a fresh `NamedPipeServer` after each connection (so
-// the next client has something to connect to) and spawns a
-// per-connection task to drive it.
-//
-// Wire framing: newline-delimited JSON. Reads use `BufReader::lines()`,
-// writes use `write_all` + `\n`. Robust to partial reads since `lines`
-// already buffers until `\n`. Strict policy: `Register` MUST be the
-// first message; subsequent `Register` is ignored with an error.
+// Phase B.3: every Command goes through the pure reducer
+// (`crate::reducer::update`) which mutates the shared State and
+// returns a Vec<Event>. The handler then writes those events back
+// over the connection. State is held inside Arc<Mutex<State>> and
+// the mutex is acquired only for the duration of the reducer call —
+// never across an await.
 //
 // What this commit does NOT do:
-//   * Forward Commands to a reducer (no reducer yet — B.3).
-//   * Emit Events spontaneously (only Registered/Pong/Error replies).
-//   * Persist client_id assignment across reconnect.
+//   * Per-subscriber broadcast routing (B.4 splits replies vs broadcasts;
+//     today every event goes back over the originating connection).
+//   * Server-initiated events (no spontaneous emissions yet — only
+//     reducer outputs).
+//   * Persisted client_id (still per-launcher-run).
 //
-// Connection lifecycle is intentionally short-lived for B.2: each
-// pipe instance handles one client connection, end-to-end. When the
-// client drops, the per-connection task ends and the accept loop
-// continues with a fresh instance.
+// Connection lifecycle: each accepted pipe instance handles one
+// client connection end-to-end. When the client drops, the per-
+// connection task ends and the accept loop continues with a fresh
+// instance.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -35,26 +32,19 @@ use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
 
 use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event};
 
-/// Monotonic event-version counter. Each Event sent over any pipe
-/// gets a fresh version. Phase D uses this as the GetSnapshot resync
-/// anchor (`event.version > snapshot.version_at_snapshot` semantics).
-static EVENT_VERSION: AtomicU64 = AtomicU64::new(0);
+use crate::reducer;
+use crate::state::State;
 
-/// Monotonic client_id assigned per Register. Stable per
-/// launcher-run; not persisted.
-static NEXT_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
-
-fn next_event_version() -> u64 {
-    EVENT_VERSION.fetch_add(1, Ordering::Relaxed)
-}
-
-/// State the IPC server shares across connections. Today it's just
-/// the launcher's PID + version (for Registered echoes); the reducer
-/// (B.3) will land here.
-#[derive(Debug, Clone)]
+/// State the IPC server shares across connections. Carries the
+/// launcher's identity (for patching into Registered events the
+/// reducer emits with sentinel values) plus the canonical State.
+#[derive(Debug)]
 pub struct ServerCtx {
     pub launcher_pid: u32,
     pub launcher_version: String,
+    /// Canonical state owned by the server. Mutex held only during
+    /// reducer dispatch — sub-millisecond.
+    pub state: Mutex<State>,
 }
 
 /// Run the named-pipe IPC server until cancelled (or task panics).
@@ -155,38 +145,49 @@ pub fn run_ipc_server(
 
 /// Drive one connection: read newline-delimited JSON Commands,
 /// write back JSON Events. First message MUST be `Register`.
+///
+/// Phase B.3: every Command goes through `reducer::update`. The
+/// reducer is sync; we hold the state mutex only while it runs.
+/// Events come back from the reducer as Vec<Event>; we patch sentinel
+/// fields (Registered.launcher_pid / launcher_version — the reducer
+/// can't read those) and write each line.
 #[cfg(target_os = "windows")]
 async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
-    // Split into read + write halves so we can call them
-    // independently. tokio's NamedPipeServer is bidi by default.
     let (read_half, write_half) = tokio::io::split(stream);
     let writer = Arc::new(Mutex::new(write_half));
     let reader = BufReader::new(read_half);
     let mut lines = reader.lines();
 
+    // Per-connection state the server (not reducer) tracks: have we
+    // seen a Register yet? Reducer-level dedup is keyed by PID across
+    // all connections; this is the per-connection enforcement so a
+    // single connection can't send Ping before Register.
     let mut registered_kind: Option<ClientKind> = None;
-    let mut client_id: Option<u64> = None;
+    let mut registered_pid: Option<u32> = None;
+    // Connection ID is server-allocated (not state-allocated) and
+    // exists only for log correlation; the reducer-allocated
+    // client_id (returned in Registered) is the wire-visible one.
+    let conn_id = NEXT_CONN_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     loop {
         let line = match lines.next_line().await {
             Ok(Some(l)) => l,
             Ok(None) => {
                 crate::log(&format!(
-                    "[ipc] connection closed (client_id={:?}, kind={:?})",
-                    client_id, registered_kind
+                    "[ipc] connection conn_id={} closed (kind={:?}, pid={:?})",
+                    conn_id, registered_kind, registered_pid
                 ));
                 return;
             }
             Err(e) => {
                 crate::log(&format!(
-                    "[ipc] read error (client_id={:?}): {}",
-                    client_id, e
+                    "[ipc] read error conn_id={}: {}",
+                    conn_id, e
                 ));
                 return;
             }
         };
 
-        // Skip blank lines so a stray newline doesn't churn errors.
         if line.trim().is_empty() {
             continue;
         }
@@ -194,13 +195,16 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
         let cmd = match serde_json::from_str::<Command>(&line) {
             Ok(c) => c,
             Err(e) => {
+                let mut state = ctx.state.lock().await;
+                let v = state.bump_version();
+                drop(state);
                 let _ = send_event(
                     &writer,
                     Event::Error {
                         code: ErrorCode::InvalidCommand,
                         message: format!("parse failed: {}", e),
                         fatal: false,
-                        version: next_event_version(),
+                        version: v,
                     },
                 )
                 .await;
@@ -208,91 +212,134 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
             }
         };
 
-        match cmd {
-            Command::Register { kind, pid, version } => {
-                if registered_kind.is_some() {
-                    let _ = send_event(
-                        &writer,
-                        Event::Error {
-                            code: ErrorCode::AlreadyRegistered,
-                            message: "Register sent twice on the same connection".into(),
-                            fatal: false,
-                            version: next_event_version(),
-                        },
-                    )
-                    .await;
-                    continue;
-                }
-                let id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
+        // Per-connection invariants: enforce here so reducer doesn't
+        // need to know about connection identity.
+        if let Some(reply) = enforce_register_first(&cmd, &registered_kind, &ctx).await {
+            let _ = send_event(&writer, reply).await;
+            // Goodbye-before-Register and similar are fatal — close.
+            return;
+        }
+        if let Command::Register { .. } = &cmd {
+            if registered_kind.is_some() {
+                let mut state = ctx.state.lock().await;
+                let v = state.bump_version();
+                drop(state);
+                let _ = send_event(
+                    &writer,
+                    Event::Error {
+                        code: ErrorCode::AlreadyRegistered,
+                        message: "Register sent twice on the same connection".into(),
+                        fatal: false,
+                        version: v,
+                    },
+                )
+                .await;
+                continue;
+            }
+        }
+
+        // Track local registration before dispatch so we can update
+        // our per-connection state if the reducer accepts it. The
+        // reducer's PID-uniqueness check might reject the Register;
+        // we re-check the events for that case below.
+        let pre_register = if let Command::Register { kind, pid, .. } = &cmd {
+            Some((*kind, *pid))
+        } else {
+            None
+        };
+
+        // Dispatch through the reducer. Mutex held briefly.
+        let events = {
+            let mut state = ctx.state.lock().await;
+            let rctx = reducer::Ctx {
+                now_rfc3339: chrono::Utc::now().to_rfc3339(),
+                conn_id,
+            };
+            reducer::update(&mut state, cmd.clone(), &rctx)
+        };
+
+        // If the reducer accepted the Register (no AlreadyRegistered
+        // error in the output), commit the local connection state.
+        if let Some((kind, pid)) = pre_register {
+            let rejected = events
+                .iter()
+                .any(|e| matches!(e, Event::Error { code: ErrorCode::AlreadyRegistered, .. }));
+            if !rejected {
                 registered_kind = Some(kind);
-                client_id = Some(id);
-                crate::log(&format!(
-                    "[ipc] registered client_id={} kind={:?} pid={} version={}",
-                    id, kind, pid, version
-                ));
-                let _ = send_event(
-                    &writer,
-                    Event::Registered {
-                        client_id: id,
-                        launcher_pid: ctx.launcher_pid,
-                        launcher_version: ctx.launcher_version.clone(),
-                        version: next_event_version(),
-                    },
-                )
-                .await;
+                registered_pid = Some(pid);
             }
-            Command::Ping { nonce } => {
-                if registered_kind.is_none() {
-                    let _ = send_event(
-                        &writer,
-                        Event::Error {
-                            code: ErrorCode::NotRegistered,
-                            message: "Ping before Register".into(),
-                            fatal: false,
-                            version: next_event_version(),
-                        },
-                    )
-                    .await;
-                    continue;
-                }
-                let _ = send_event(
-                    &writer,
-                    Event::Pong {
-                        nonce,
-                        version: next_event_version(),
-                    },
-                )
-                .await;
-            }
-            Command::Goodbye => {
-                // Enforce the same Register-first invariant as Ping:
-                // Goodbye before Register lets a misbehaving client
-                // silently bypass the handshake contract. Reply with
-                // NotRegistered so handshake bugs are visible, then
-                // close. (codex P2 PR #573 round-1.)
-                if registered_kind.is_none() {
-                    let _ = send_event(
-                        &writer,
-                        Event::Error {
-                            code: ErrorCode::NotRegistered,
-                            message: "Goodbye before Register".into(),
-                            fatal: true,
-                            version: next_event_version(),
-                        },
-                    )
-                    .await;
-                    crate::log(
-                        "[ipc] goodbye from unregistered client — closing with error",
-                    );
-                    return;
-                }
-                crate::log(&format!(
-                    "[ipc] goodbye from client_id={:?} kind={:?}",
-                    client_id, registered_kind
-                ));
+        }
+
+        // Write events back over the same connection. Patch the
+        // sentinel launcher_pid / launcher_version fields the reducer
+        // left blank.
+        let goodbye = matches!(cmd, Command::Goodbye);
+        for event in events {
+            let event = patch_launcher_identity(event, &ctx);
+            if send_event(&writer, event).await.is_err() {
                 return;
             }
         }
+        if goodbye {
+            crate::log(&format!(
+                "[ipc] goodbye from conn_id={} kind={:?} pid={:?}",
+                conn_id, registered_kind, registered_pid
+            ));
+            return;
+        }
+    }
+}
+
+/// Per-connection counter for log-correlation IDs (NOT the wire
+/// client_id — that comes from the reducer). Allocated even for
+/// pre-Register failures so log lines can be correlated.
+static NEXT_CONN_ID: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1);
+
+/// Enforce the "first message must be Register" invariant. Returns
+/// `Some(Event::Error)` if the command violates the contract; the
+/// caller sends it and closes the connection.
+#[cfg(target_os = "windows")]
+async fn enforce_register_first(
+    cmd: &Command,
+    registered_kind: &Option<ClientKind>,
+    ctx: &Arc<ServerCtx>,
+) -> Option<Event> {
+    if registered_kind.is_some() {
+        return None;
+    }
+    let (msg, fatal) = match cmd {
+        Command::Register { .. } => return None,
+        Command::Ping { .. } => ("Ping before Register".to_string(), false),
+        Command::Goodbye => ("Goodbye before Register".to_string(), true),
+    };
+    let mut state = ctx.state.lock().await;
+    let v = state.bump_version();
+    Some(Event::Error {
+        code: ErrorCode::NotRegistered,
+        message: msg,
+        fatal,
+        version: v,
+    })
+}
+
+/// Patch `launcher_pid` + `launcher_version` into `Event::Registered`.
+/// The reducer leaves these as sentinels (it can't read env without
+/// breaking determinism) — the server fills them in here, just
+/// before serializing to the wire.
+fn patch_launcher_identity(event: Event, ctx: &Arc<ServerCtx>) -> Event {
+    if let Event::Registered {
+        client_id, version, ..
+    } = event
+    {
+        Event::Registered {
+            client_id,
+            launcher_pid: ctx.launcher_pid,
+            launcher_version: ctx.launcher_version.clone(),
+            version,
+        }
+    } else {
+        event
     }
 }
 

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -23,7 +23,9 @@
 mod data_dir;
 mod hash;
 mod ipc;
+mod reducer;
 mod srv_spawner;
+mod state;
 
 #[tokio::main]
 async fn main() {
@@ -170,6 +172,7 @@ async fn run_windows(
         ipc::server::ServerCtx {
             launcher_pid: std::process::id(),
             launcher_version: env!("CARGO_PKG_VERSION").to_string(),
+            state: tokio::sync::Mutex::new(state::State::default()),
         },
     );
     log(&format!("IPC server started on {}", pipe_path));

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -1,0 +1,473 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.3 — pure reducer.
+//
+// Per `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` §5.1:
+//
+//   pub fn update(state: &State, cmd: Command) -> (State, Vec<Event>);
+//
+// We deviate slightly: the function takes `&mut State` (mutating in
+// place rather than returning a new value) because cloning a HashMap
+// per-command in the IPC hot path is wasteful and not needed for
+// the testability properties we want — `proptest` works equally well
+// against a mutating-reducer (apply commands one by one, assert
+// invariants hold after each).
+//
+// Strict properties of `update`:
+//   1. **Total**. Every (cmd, state) combination produces a result;
+//      never panics on input. (Panics ARE used to enforce internal
+//      invariants — those are bugs in the reducer or upstream code,
+//      not user input. See spec §7 / §8.)
+//   2. **Deterministic**. Same (state, cmd, conn) → same (state',
+//      events). No clocks, no UUIDs, no env reads inside update —
+//      injected via the `Reducer` context if needed (B.4 will need
+//      it for spawned_at timestamps; for B.3 the conn carries one).
+//   3. **No I/O**. update never blocks or awaits. Mutex is held for
+//      the duration of update — must stay sub-millisecond.
+//
+// Connection context: every command arrives over a specific
+// connection and the resulting events that are *replies* (Registered,
+// Pong) belong to that connection only, while *broadcasts*
+// (ProcessSpawned, LifecyclePhaseChanged) belong to all subscribers.
+// Phase B.3 ships in a simplified model where every event goes over
+// the originating connection; B.4 splits the routing.
+//
+// Invariants checked:
+//   * Register on a PID that's already registered → AlreadyRegistered
+//     error. (Connection-level enforcement that "Register sent twice"
+//     also lives in the server; this is the cross-connection guard.)
+//   * Lifecycle transitions: Starting → Running on first Host
+//     register. Running → Quitting on Quit (B.3 placeholder).
+//     Quitting → Dead on cleanup-done (B.3 placeholder). No skipping.
+
+use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event};
+
+use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State};
+
+/// Context the reducer needs but can't read from State (clocks,
+/// connection identity). Passed in per-call so update remains pure.
+#[derive(Debug, Clone)]
+pub struct Ctx {
+    /// RFC3339 timestamp to stamp on new ProcessRecords. Injected
+    /// (rather than read from chrono::Utc::now() inside update) to
+    /// keep the function deterministic for tests.
+    pub now_rfc3339: String,
+    /// The connection on which this command arrived. Currently
+    /// just used for log correlation; B.4+ will use it to route
+    /// per-connection replies.
+    pub conn_id: u64,
+}
+
+/// Apply one Command to State, returning the resulting Events. State
+/// is mutated in place. Total function — never panics on input
+/// (panics are reserved for internal invariant violations).
+pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
+    let _ = ctx.conn_id; // reserved for B.4 routing
+    match cmd {
+        Command::Register {
+            kind,
+            pid,
+            version,
+        } => handle_register(state, ctx, kind, pid, version),
+        Command::Ping { nonce } => {
+            let v = state.bump_version();
+            vec![Event::Pong { nonce, version: v }]
+        }
+        Command::Goodbye => handle_goodbye(state, /*pid=*/ ctx_pid_or_zero(ctx)),
+    }
+}
+
+/// Helper used until the IPC server passes the registered pid
+/// alongside the connection. For B.3 we don't have that wiring yet
+/// (server still tracks Registered separately); placeholder returns
+/// 0 which the reducer treats as "no pid known". B.4 will pipe the
+/// connection's registered pid in via the Ctx.
+fn ctx_pid_or_zero(_ctx: &Ctx) -> u32 {
+    0
+}
+
+fn handle_register(
+    state: &mut State,
+    ctx: &Ctx,
+    kind: ClientKind,
+    pid: u32,
+    version: String,
+) -> Vec<Event> {
+    let mut out = Vec::with_capacity(3);
+
+    // Cross-connection invariant: PIDs must be unique. If the same
+    // PID Registers twice (different connections from same process,
+    // or stale entry never cleaned up), reject the second so we
+    // don't end up with two ProcessRecords pointing at the same OS
+    // process.
+    if state.processes.contains_key(&pid) {
+        let v = state.bump_version();
+        out.push(Event::Error {
+            code: ErrorCode::AlreadyRegistered,
+            message: format!("pid {} already in process registry", pid),
+            fatal: true,
+            version: v,
+        });
+        return out;
+    }
+
+    let record = ProcessRecord {
+        pid,
+        kind,
+        state: ProcessState::Running,
+        spawned_at: ctx.now_rfc3339.clone(),
+        version: version.clone(),
+    };
+    state.processes.insert(pid, record);
+
+    let spawned_v = state.bump_version();
+    out.push(Event::ProcessSpawned {
+        pid,
+        kind,
+        client_version: version,
+        version: spawned_v,
+    });
+
+    // Lifecycle: Starting → Running when the first Host registers.
+    // Subsequent Host re-registers (after a host crash + restart in
+    // some future world) won't double-fire because we'd already be
+    // in Running. Other client kinds (Renderer, Srv, Tool) don't
+    // drive the transition.
+    if state.lifecycle == LifecyclePhase::Starting && kind == ClientKind::Host {
+        let from = state.lifecycle;
+        state.lifecycle = LifecyclePhase::Running;
+        let v = state.bump_version();
+        out.push(Event::LifecyclePhaseChanged {
+            from,
+            to: LifecyclePhase::Running,
+            version: v,
+        });
+    }
+
+    let registered_v = state.bump_version();
+    let client_id = state.alloc_client_id();
+    out.push(Event::Registered {
+        client_id,
+        // launcher_pid + launcher_version are filled in by the
+        // server before broadcast — they don't belong in the pure
+        // reducer (env reads). We use a sentinel here; the server
+        // patches these before sending.
+        launcher_pid: 0,
+        launcher_version: String::new(),
+        version: registered_v,
+    });
+
+    out
+}
+
+fn handle_goodbye(state: &mut State, pid: u32) -> Vec<Event> {
+    if pid == 0 {
+        // No pid known for this connection (B.3 limitation). Just
+        // emit a synthetic ProcessExited with pid=0 to signal the
+        // graceful close; the server will log + close.
+        let v = state.bump_version();
+        return vec![Event::ProcessExited {
+            pid: 0,
+            code: 0,
+            version: v,
+        }];
+    }
+    if let Some(record) = state.processes.get_mut(&pid) {
+        record.state = ProcessState::Exited { code: 0 };
+    }
+    let v = state.bump_version();
+    vec![Event::ProcessExited {
+        pid,
+        code: 0,
+        version: v,
+    }]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(conn_id: u64) -> Ctx {
+        Ctx {
+            now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
+            conn_id,
+        }
+    }
+
+    #[test]
+    fn first_host_register_transitions_starting_to_running() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1234,
+                version: "0.33.450".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(state.lifecycle, LifecyclePhase::Running);
+        assert!(state.processes.contains_key(&1234));
+        // Should emit ProcessSpawned + LifecyclePhaseChanged + Registered.
+        assert_eq!(events.len(), 3);
+        assert!(matches!(
+            events[0],
+            Event::ProcessSpawned { pid: 1234, .. }
+        ));
+        assert!(matches!(
+            events[1],
+            Event::LifecyclePhaseChanged {
+                from: LifecyclePhase::Starting,
+                to: LifecyclePhase::Running,
+                ..
+            }
+        ));
+        assert!(matches!(events[2], Event::Registered { .. }));
+    }
+
+    #[test]
+    fn second_host_register_does_not_re_emit_lifecycle_change() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1234,
+                version: "0.33.450".into(),
+            },
+            &ctx(1),
+        );
+        // Different PID, second Host (e.g. test harness or doc)
+        let events = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 5678,
+                version: "0.33.450".into(),
+            },
+            &ctx(2),
+        );
+        // Lifecycle stays Running; no LifecyclePhaseChanged event.
+        assert_eq!(state.lifecycle, LifecyclePhase::Running);
+        assert_eq!(events.len(), 2); // ProcessSpawned + Registered
+        assert!(events
+            .iter()
+            .all(|e| !matches!(e, Event::LifecyclePhaseChanged { .. })));
+    }
+
+    #[test]
+    fn duplicate_pid_register_returns_already_registered() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1234,
+                version: "0.33.450".into(),
+            },
+            &ctx(1),
+        );
+        let events = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Renderer,
+                pid: 1234, // SAME pid
+                version: "0.33.450".into(),
+            },
+            &ctx(2),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            Event::Error {
+                code: ErrorCode::AlreadyRegistered,
+                fatal: true,
+                ..
+            }
+        ));
+        // Second register doesn't overwrite the first.
+        assert_eq!(state.processes[&1234].kind, ClientKind::Host);
+    }
+
+    #[test]
+    fn renderer_register_does_not_drive_lifecycle() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Renderer,
+                pid: 4321,
+                version: "0.33.450".into(),
+            },
+            &ctx(1),
+        );
+        // Lifecycle stays Starting until a HOST registers.
+        assert_eq!(state.lifecycle, LifecyclePhase::Starting);
+        assert_eq!(events.len(), 2); // ProcessSpawned + Registered
+    }
+
+    #[test]
+    fn ping_returns_pong_with_same_nonce() {
+        let mut state = State::default();
+        let events = update(&mut state, Command::Ping { nonce: 42 }, &ctx(1));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Event::Pong { nonce: 42, .. }));
+    }
+
+    /// Helper used by both the unit test below and the proptest: extract
+    /// the version number from any Event variant. New variants must be
+    /// added here OR the helper switched to a generic accessor when
+    /// the variant set grows large.
+    fn extract_version(e: &Event) -> u64 {
+        match e {
+            Event::ProcessSpawned { version, .. }
+            | Event::ProcessExited { version, .. }
+            | Event::LifecyclePhaseChanged { version, .. }
+            | Event::Registered { version, .. }
+            | Event::Pong { version, .. }
+            | Event::Error { version, .. } => *version,
+        }
+    }
+
+    #[test]
+    fn event_versions_are_strictly_monotonic() {
+        let mut state = State::default();
+        let mut versions = vec![];
+        for pid in [100, 200, 300] {
+            let events = update(
+                &mut state,
+                Command::Register {
+                    kind: ClientKind::Host,
+                    pid,
+                    version: "0.33.450".into(),
+                },
+                &ctx(1),
+            );
+            versions.extend(events.iter().map(extract_version));
+        }
+        for w in versions.windows(2) {
+            assert!(w[1] > w[0], "versions not monotonic: {:?}", versions);
+        }
+    }
+
+    // ===== Property-based tests =====
+    //
+    // The unit tests above cover specific scenarios; these prove
+    // the reducer's INVARIANTS hold across arbitrary input
+    // sequences. Per spec §7 + the Phase B plan's testing strategy.
+
+    use proptest::prelude::*;
+
+    /// Generate an arbitrary Command. Constrained to the value-space
+    /// the IPC server can actually produce: PIDs are realistic-ish
+    /// u32s, version strings are short ASCII.
+    fn arb_command() -> impl Strategy<Value = Command> {
+        prop_oneof![
+            // Register dominates the distribution because that's
+            // where most state-machine logic lives.
+            5 => (
+                prop_oneof![
+                    Just(ClientKind::Host),
+                    Just(ClientKind::Renderer),
+                    Just(ClientKind::Srv),
+                    Just(ClientKind::Tool),
+                ],
+                1u32..10000u32,
+                "[a-zA-Z0-9.]{1,16}",
+            )
+                .prop_map(|(kind, pid, version)| Command::Register { kind, pid, version }),
+            1 => any::<u64>().prop_map(|nonce| Command::Ping { nonce }),
+            1 => Just(Command::Goodbye),
+        ]
+    }
+
+    proptest! {
+        /// Versions across an arbitrary sequence of commands are
+        /// always strictly monotonic. This is the foundation of
+        /// Phase D's GetSnapshot resync: clients detect missed
+        /// events by gap in version numbers.
+        #[test]
+        fn versions_strictly_monotonic_under_any_command_sequence(
+            cmds in proptest::collection::vec(arb_command(), 1..50)
+        ) {
+            let mut state = State::default();
+            let mut all_versions = vec![];
+            for cmd in cmds {
+                let events = update(&mut state, cmd, &ctx(1));
+                all_versions.extend(events.iter().map(extract_version));
+            }
+            for w in all_versions.windows(2) {
+                prop_assert!(
+                    w[1] > w[0],
+                    "version regression: {} → {}",
+                    w[0], w[1]
+                );
+            }
+        }
+
+        /// Lifecycle invariant (spec §4): only ever Starting →
+        /// Running → Quitting → Dead. No other transition.
+        /// In B.3 we exercise just the Starting → Running edge
+        /// since later transitions don't have triggering commands
+        /// yet, but the harness is ready for B.4+.
+        #[test]
+        fn lifecycle_only_progresses_forward(
+            cmds in proptest::collection::vec(arb_command(), 1..50)
+        ) {
+            let mut state = State::default();
+            let mut prev = state.lifecycle;
+            for cmd in cmds {
+                let _ = update(&mut state, cmd, &ctx(1));
+                let next = state.lifecycle;
+                let valid = match (prev, next) {
+                    (a, b) if a == b => true,
+                    (LifecyclePhase::Starting, LifecyclePhase::Running) => true,
+                    (LifecyclePhase::Running, LifecyclePhase::Quitting) => true,
+                    (LifecyclePhase::Quitting, LifecyclePhase::Dead) => true,
+                    _ => false,
+                };
+                prop_assert!(
+                    valid,
+                    "illegal lifecycle transition {:?} → {:?}",
+                    prev, next
+                );
+                prev = next;
+            }
+        }
+
+        /// Process map invariant: a successful Register inserts the
+        /// PID; a duplicate Register (same PID) NEVER overwrites the
+        /// existing record. This is what the server relies on for
+        /// stale-state safety.
+        #[test]
+        fn duplicate_register_never_overwrites(
+            initial_kind in prop_oneof![Just(ClientKind::Host), Just(ClientKind::Renderer)],
+            second_kind in prop_oneof![Just(ClientKind::Srv), Just(ClientKind::Tool)],
+            pid in 1u32..10000u32,
+        ) {
+            let mut state = State::default();
+            let _ = update(
+                &mut state,
+                Command::Register {
+                    kind: initial_kind,
+                    pid,
+                    version: "v1".into(),
+                },
+                &ctx(1),
+            );
+            let _ = update(
+                &mut state,
+                Command::Register {
+                    kind: second_kind,
+                    pid,
+                    version: "v2".into(),
+                },
+                &ctx(2),
+            );
+            // Original record preserved across the rejected dup.
+            prop_assert_eq!(state.processes[&pid].kind, initial_kind);
+            prop_assert_eq!(&state.processes[&pid].version, "v1");
+        }
+    }
+}

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -57,6 +57,13 @@ pub struct Ctx {
     /// just used for log correlation; B.4+ will use it to route
     /// per-connection replies.
     pub conn_id: u64,
+    /// PID the connection has Registered under, if any. The server
+    /// tracks this server-side and passes it on every command after
+    /// the initial Register so the reducer can mark the right
+    /// process Exited on Goodbye. None for the very first command
+    /// on a connection (which MUST be Register, enforced server-
+    /// side). (codex P1 + gemini HIGH PR #574 round-1.)
+    pub registered_pid: Option<u32>,
 }
 
 /// Apply one Command to State, returning the resulting Events. State
@@ -74,17 +81,8 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             let v = state.bump_version();
             vec![Event::Pong { nonce, version: v }]
         }
-        Command::Goodbye => handle_goodbye(state, /*pid=*/ ctx_pid_or_zero(ctx)),
+        Command::Goodbye => handle_goodbye(state, ctx.registered_pid.unwrap_or(0)),
     }
-}
-
-/// Helper used until the IPC server passes the registered pid
-/// alongside the connection. For B.3 we don't have that wiring yet
-/// (server still tracks Registered separately); placeholder returns
-/// 0 which the reducer treats as "no pid known". B.4 will pipe the
-/// connection's registered pid in via the Ctx.
-fn ctx_pid_or_zero(_ctx: &Ctx) -> u32 {
-    0
 }
 
 fn handle_register(
@@ -96,20 +94,31 @@ fn handle_register(
 ) -> Vec<Event> {
     let mut out = Vec::with_capacity(3);
 
-    // Cross-connection invariant: PIDs must be unique. If the same
-    // PID Registers twice (different connections from same process,
-    // or stale entry never cleaned up), reject the second so we
-    // don't end up with two ProcessRecords pointing at the same OS
-    // process.
-    if state.processes.contains_key(&pid) {
-        let v = state.bump_version();
-        out.push(Event::Error {
-            code: ErrorCode::AlreadyRegistered,
-            message: format!("pid {} already in process registry", pid),
-            fatal: true,
-            version: v,
-        });
-        return out;
+    // Cross-connection invariant: only ONE live ProcessRecord per
+    // PID. We DO allow re-registration if the existing record is
+    // Exited — the OS recycles PIDs over a long-running launcher,
+    // so a new process can legitimately end up with a PID that was
+    // previously held by a process that has cleanly Goodbye'd.
+    // Without this carve-out, the process map would accumulate dead
+    // records and the launcher would reject increasingly many real
+    // registrations. (gemini MEDIUM PR #574 round-1.)
+    let existing_state = state.processes.get(&pid).map(|r| r.state);
+    if let Some(existing_state) = existing_state {
+        if !matches!(existing_state, ProcessState::Exited { .. }) {
+            let v = state.bump_version();
+            out.push(Event::Error {
+                code: ErrorCode::AlreadyRegistered,
+                message: format!(
+                    "pid {} already in process registry (state={:?})",
+                    pid, existing_state
+                ),
+                fatal: true,
+                version: v,
+            });
+            return out;
+        }
+        // Else: fall through. The insert below replaces the Exited
+        // record with the new live one — same entry, fresh state.
     }
 
     let record = ProcessRecord {
@@ -192,6 +201,15 @@ mod tests {
         Ctx {
             now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
             conn_id,
+            registered_pid: None,
+        }
+    }
+
+    fn ctx_with_pid(conn_id: u64, pid: u32) -> Ctx {
+        Ctx {
+            now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
+            conn_id,
+            registered_pid: Some(pid),
         }
     }
 
@@ -349,6 +367,78 @@ mod tests {
         for w in versions.windows(2) {
             assert!(w[1] > w[0], "versions not monotonic: {:?}", versions);
         }
+    }
+
+    #[test]
+    fn goodbye_marks_registered_pid_as_exited() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1234,
+                version: "0.33.451".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(
+            state.processes[&1234].state,
+            ProcessState::Running
+        ));
+        let events = update(&mut state, Command::Goodbye, &ctx_with_pid(1, 1234));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            events[0],
+            Event::ProcessExited { pid: 1234, code: 0, .. }
+        ));
+        assert!(matches!(
+            state.processes[&1234].state,
+            ProcessState::Exited { code: 0 }
+        ));
+    }
+
+    #[test]
+    fn register_replaces_exited_record_for_recycled_pid() {
+        let mut state = State::default();
+        // First process registers + cleanly exits
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1234,
+                version: "first".into(),
+            },
+            &ctx(1),
+        );
+        let _ = update(&mut state, Command::Goodbye, &ctx_with_pid(1, 1234));
+        assert!(matches!(
+            state.processes[&1234].state,
+            ProcessState::Exited { .. }
+        ));
+
+        // OS recycles PID 1234 to a new process which Registers
+        let events = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Renderer,
+                pid: 1234,
+                version: "second".into(),
+            },
+            &ctx(2),
+        );
+        // Should NOT emit AlreadyRegistered — record replaced.
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::Error {
+                code: ErrorCode::AlreadyRegistered,
+                ..
+            })));
+        assert!(matches!(
+            state.processes[&1234].state,
+            ProcessState::Running
+        ));
+        assert_eq!(state.processes[&1234].kind, ClientKind::Renderer);
+        assert_eq!(state.processes[&1234].version, "second");
     }
 
     // ===== Property-based tests =====

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -90,16 +90,25 @@ impl State {
     /// Bump and return the new event version. Always called inside
     /// the reducer when constructing an Event so version numbers
     /// stay strictly monotonic.
+    ///
+    /// Strict (non-wrapping) add: Phase D's GetSnapshot resync
+    /// protocol relies on monotonicity (`event.version >
+    /// snapshot.version`), and a wrap to 0 would silently break
+    /// that contract. u64 at one event/ns would take 584 years to
+    /// overflow — never going to happen in practice; if it ever
+    /// does, the panic is the right failure mode.
+    /// (gemini MEDIUM PR #574 round-1.)
     pub fn bump_version(&mut self) -> u64 {
-        self.event_version = self.event_version.wrapping_add(1);
+        self.event_version += 1;
         self.event_version
     }
 
     /// Bump and return the next client_id. Client IDs are stable
-    /// per launcher run; not persisted across restart.
+    /// per launcher run; not persisted across restart. Same strict-
+    /// add reasoning as bump_version.
     pub fn alloc_client_id(&mut self) -> u64 {
         let id = self.next_client_id;
-        self.next_client_id = self.next_client_id.wrapping_add(1);
+        self.next_client_id += 1;
         id
     }
 }

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -1,0 +1,105 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.3 launcher state. Held inside Arc<Mutex<...>> by the IPC
+// server; mutated only by the pure reducer (`crate::reducer::update`).
+// Mutex is held for microseconds at a time — never across an .await
+// boundary, never across I/O. Mirrors the Elm/Redux pattern: state
+// is data, transitions are functions, side effects fire after the
+// state mutation commits.
+//
+// What's here in B.3:
+//   * `LifecyclePhase` (re-exported from agentmux-common::ipc so the
+//     wire and internal types are the same enum)
+//   * `ProcessRecord` — pid, kind, state, spawned_at
+//   * `ProcessState` — Spawning / Running / Exited
+//   * `State` — top-level container: lifecycle + process map +
+//     monotonic version counter + monotonic client_id counter
+//
+// What's intentionally NOT here yet:
+//   * Window state machine (B.4–B.5)
+//   * Warm-pool (B.5)
+//   * Event log ring buffer (B.4 — added when events first start
+//     accumulating beyond handshake replies)
+
+use std::collections::HashMap;
+
+use agentmux_common::ipc::ClientKind;
+pub use agentmux_common::ipc::LifecyclePhase;
+
+/// Lifecycle of a single process the launcher knows about. The
+/// reducer transitions through these in order — there's no skipping
+/// (Spawning → Running → Exited).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessState {
+    /// Spawn issued; child handle returned but process hasn't
+    /// confirmed it's alive yet. In B.3 we transition straight to
+    /// Running on Register because that's the first authoritative
+    /// signal. B.4+ adds intermediate state for "spawned but not
+    /// yet registered."
+    Spawning,
+    /// Process has registered with the launcher and is doing its
+    /// work. Healthy.
+    Running,
+    /// Process exited (clean Goodbye → code=0, crash → non-zero).
+    Exited { code: i32 },
+}
+
+/// One process in the launcher's canonical view. Updated by the
+/// reducer; read by IPC handlers + the eventual `--diag` printer.
+#[derive(Debug, Clone)]
+pub struct ProcessRecord {
+    pub pid: u32,
+    pub kind: ClientKind,
+    pub state: ProcessState,
+    /// RFC3339 timestamp of the spawn (or first-register, whichever
+    /// the launcher learned about first).
+    pub spawned_at: String,
+    /// Free-form version string of the registered binary. For log
+    /// correlation across version skew during a Phase B rollout.
+    pub version: String,
+}
+
+/// Top-level launcher state. Single Arc<Mutex<State>> owned by the
+/// IPC server; passed into `update(state, cmd, conn)` for every
+/// incoming command.
+#[derive(Debug)]
+pub struct State {
+    pub lifecycle: LifecyclePhase,
+    /// Keyed by PID. Multiple records per PID would be a bug — the
+    /// reducer enforces unique-pid on insert.
+    pub processes: HashMap<u32, ProcessRecord>,
+    /// Monotonic counter for `Event.version`. Bumped by `bump_version()`.
+    pub event_version: u64,
+    /// Monotonic counter for client_id (returned in Registered events).
+    pub next_client_id: u64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            lifecycle: LifecyclePhase::Starting,
+            processes: HashMap::new(),
+            event_version: 0,
+            next_client_id: 1,
+        }
+    }
+}
+
+impl State {
+    /// Bump and return the new event version. Always called inside
+    /// the reducer when constructing an Event so version numbers
+    /// stay strictly monotonic.
+    pub fn bump_version(&mut self) -> u64 {
+        self.event_version = self.event_version.wrapping_add(1);
+        self.event_version
+    }
+
+    /// Bump and return the next client_id. Client IDs are stable
+    /// per launcher run; not persisted across restart.
+    pub fn alloc_client_id(&mut self) -> u64 {
+        let id = self.next_client_id;
+        self.next_client_id = self.next_client_id.wrapping_add(1);
+        id
+    }
+}

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.451"
+version = "0.33.452"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.450"
+version = "0.33.451"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.451",
+  "version": "0.33.452",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.451",
+      "version": "0.33.452",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.450",
+  "version": "0.33.451",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.450",
+      "version": "0.33.451",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.450",
+  "version": "0.33.451",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.451",
+  "version": "0.33.452",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third sub-PR in Phase B. Introduces the actual state-machine logic the entire phase has been building toward. Every Command from the IPC server now goes through a pure reducer that mutates the shared State and returns Vec<Event>; the server writes those events back over the connection.

## Architecture

\`\`\`
┌─────────────────────────────────────────────────────────────────┐
│ launcher (agentmux.exe)                                         │
│  ┌───────────────────────┐                                      │
│  │ State (Arc<Mutex<>>)  │ ← held only during reducer.update()  │
│  │  • LifecyclePhase     │   (sub-millisecond)                  │
│  │  • processes: HashMap │                                      │
│  │  • event_version: u64 │                                      │
│  └───────────┬───────────┘                                      │
│              │                                                  │
│  ┌───────────▼───────────┐    ┌─────────────────────────────┐   │
│  │ pure reducer::update  │───▶│ IPC server                  │   │
│  │  (Command, Ctx) → Vec │    │  per-conn handler writes    │   │
│  │  no I/O, no clocks    │    │  events back over the pipe  │   │
│  └───────────────────────┘    └─────────────────────────────┘   │
└─────────────────────────────────────────────────────────────────┘
\`\`\`

Per spec §5.1, §7. Phase B plan: pure / sync / total / deterministic reducer; state behind Arc<Mutex<>>; mutex acquired only during update(); property-based tests for cross-command invariants.

## What the reducer handles in B.3

| Command | State changes | Events emitted |
|---|---|---|
| \`Register { kind, pid, version }\` | Insert ProcessRecord; if first Host Register → lifecycle Starting → Running | ProcessSpawned, (maybe) LifecyclePhaseChanged, Registered |
| \`Ping { nonce }\` | None | Pong (echoes nonce) |
| \`Goodbye\` | Mark process Exited | ProcessExited |

**Cross-connection dedup**: duplicate PID returns \`AlreadyRegistered\` (fatal) without overwriting the existing record.

**Lifecycle transitions** (spec §4):
- Starting → Running on first Host Register
- Running → Quitting (placeholder; no triggering command yet)
- Quitting → Dead (same)

## Tests (all 12 pass)

| Type | Count | What |
|---|---|---|
| Unit | 9 | First-host transition, second-host doesn't re-fire, dup-PID rejection, Renderer doesn't drive lifecycle, Ping echoes, version monotonicity |
| Proptest | 3 | Versions strictly monotonic across any command sequence; lifecycle only progresses forward; duplicate Register never overwrites |

\`proptest\` is \`[dev-dependencies]\` only — zero impact on release binary.

## Smoke-test result (v0.33.451 portable)

Host log shows exact event sequence on startup:
\`\`\`
[launcher-ipc] received event: ProcessSpawned { pid: 12052, kind: Host, version: 1 }
[launcher-ipc] received event: LifecyclePhaseChanged { from: Starting, to: Running, version: 2 }
[launcher-ipc] received event: Registered { client_id: 1, launcher_pid: 13060, version: 3 }
\`\`\`

Versions strictly monotonic; launcher_pid + launcher_version patched from sentinels by the server (reducer can't read env without breaking determinism). 11-process tree (1 launcher + 1+1 srv + 7 host) — same as B.1/B.2 baseline.

## What's NOT in this PR

- B.4: per-subscriber broadcast routing (today every event goes back over the originating connection only)
- B.4–B.5: Window state machine + WarmPool migration
- B.5: state migration from host HashMaps
- B.6: per-data-dir mutex single-instance
- B.7: frontend event subscription via host CEF JS bridge
- B.8: Phase B exit; delete host-side state stores

## Test plan

- [ ] Build a portable, run it. Confirm host log shows ProcessSpawned + LifecyclePhaseChanged + Registered events with strictly monotonic versions.
- [ ] Kill host via Task Manager → launcher reaps tree via J0 (B.1 behavior preserved).
- [ ] Kill launcher via Task Manager → tree reaped via KILL_ON_JOB_CLOSE.
- [ ] \`task dev\` mode: \`AGENTMUX_LAUNCHER_PIPE\` unset → host runs without launcher IPC; pre-Phase-B path active.
- [ ] \`cargo test --release -p agentmux-launcher\` → 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)