### PR TITLE
chore: cleanup vestigial WaveTerm-era types and stale specs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.452"
+version = "0.33.453"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.452"
+version = "0.33.453"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.452"
+version = "0.33.453"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.452"
+version = "0.33.453"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1459,9 +1459,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3369,9 +3369,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3382,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3392,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3402,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3415,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3458,9 +3458,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.452"
+version = "0.33.453"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -239,7 +239,7 @@ fn main() {
     // where the host runs without the launcher).
     //
     // Spawn the backend sidecar SYNCHRONOUSLY — block until it
-    // signals ready (WAVESRV-ESTART) before creating the browser
+    // signals ready (AGENTMUXSRV-ESTART) before creating the browser
     // window. This eliminates the race condition where CEF loads the
     // frontend before the backend is available, which causes a "raw
     // browser" appearance on slow machines or first launch.

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -46,7 +46,7 @@ pub fn use_launcher_endpoints(
             "launcher set AGENTMUX_BACKEND_WS but it was empty — \
              refusing to fall back to spawn_backend (would create a \
              duplicate srv against the same data dir). This is a \
-             launcher bug; check the WAVESRV-ESTART parse path in \
+             launcher bug; check the AGENTMUXSRV-ESTART parse path in \
              agentmux-launcher/src/srv_spawner.rs::parse_estart."
                 .to_string(),
         ));
@@ -92,7 +92,7 @@ pub fn use_launcher_endpoints(
 }
 
 /// Spawn the agentmux-srv backend sidecar and wait for it to signal
-/// readiness via a `WAVESRV-ESTART` line on stderr (30s timeout).
+/// readiness via a `AGENTMUXSRV-ESTART` line on stderr (30s timeout).
 pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, String> {
     tracing::info!("spawn_backend() called");
 
@@ -298,7 +298,7 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
         for line in reader.lines() {
             match line {
                 Ok(l) => {
-                    if l.starts_with("WAVESRV-ESTART") {
+                    if l.starts_with("AGENTMUXSRV-ESTART") {
                         let result = parse_estart(&l);
                         tracing::info!(
                             "Backend started: ws={} web={} version={} instance={}",
@@ -309,7 +309,7 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
                         );
                         estart_received = true;
                         let _ = tx.blocking_send(result);
-                    } else if let Some(event_data) = l.strip_prefix("WAVESRV-EVENT:") {
+                    } else if let Some(event_data) = l.strip_prefix("AGENTMUXSRV-EVENT:") {
                         tracing::debug!("Backend event: {}", event_data);
                         // Forward events to the frontend
                         if let Ok(payload) = serde_json::from_str::<serde_json::Value>(event_data)
@@ -469,7 +469,7 @@ fn resolve_backend_binary(
     ))
 }
 
-/// Parse the key=value fields out of a `WAVESRV-ESTART` line.
+/// Parse the key=value fields out of a `AGENTMUXSRV-ESTART` line.
 fn parse_estart(line: &str) -> BackendSpawnResult {
     let parts: Vec<&str> = line.split_whitespace().collect();
     let get = |prefix: &str| -> String {

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -227,8 +227,6 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
         "AGENTMUX_DEV",
         if cfg!(debug_assertions) { "1" } else { "" },
     )
-    .env("WCLOUD_ENDPOINT", "https://api.agentmux.ai/central")
-    .env("WCLOUD_WS_ENDPOINT", "wss://wsapi.agentmux.ai/")
     .stdin(std::process::Stdio::piped())
     .stdout(std::process::Stdio::piped())
     .stderr(std::process::Stdio::piped());

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.452"
+version = "0.33.453"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.452"
+version = "0.33.453"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -178,7 +178,7 @@ async fn run_windows(
     log(&format!("IPC server started on {}", pipe_path));
 
     // 3. Spawn srv first. Host needs srv's endpoints to skip its own
-    // spawn_backend path. Srv signals readiness via WAVESRV-ESTART on
+    // spawn_backend path. Srv signals readiness via AGENTMUXSRV-ESTART on
     // stderr; the spawner returns once we see that line (or after a
     // 30s timeout).
     let (srv_result, mut srv_child) = match srv_spawner::spawn_srv(

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -67,7 +67,7 @@ impl std::fmt::Display for SrvSpawnError {
             Self::SpawnFailed(s) => write!(f, "spawn failed: {}", s),
             Self::JobAssignFailed(s) => write!(f, "AssignProcessToJobObject failed: {}", s),
             Self::ResumeFailed(s) => write!(f, "ResumeThread failed: {}", s),
-            Self::EstartTimeout => write!(f, "timeout waiting for WAVESRV-ESTART (30s)"),
+            Self::EstartTimeout => write!(f, "timeout waiting for AGENTMUXSRV-ESTART (30s)"),
             Self::EstartChannelClosed => {
                 write!(f, "ESTART channel closed before srv signalled ready")
             }
@@ -83,7 +83,7 @@ impl std::fmt::Display for SrvSpawnError {
 /// data + config dirs and is propagated to srv via env vars.
 /// `job_handle` is the launcher's Job Object so srv joins the same
 /// kill-on-job-close contract as the host. Returns once srv prints
-/// `WAVESRV-ESTART` (or the 30s timeout fires).
+/// `AGENTMUXSRV-ESTART` (or the 30s timeout fires).
 ///
 /// Caller keeps the returned `Child` alive — drop closes srv's
 /// stdin and srv's existing PPID death-watcher takes over (already
@@ -188,10 +188,10 @@ pub async fn spawn_srv(
         });
     }
 
-    // Parse stderr for WAVESRV-ESTART (the readiness signal). srv
-    // writes other diagnostic lines too (WAVESRV-EVENT:..., plain
+    // Parse stderr for AGENTMUXSRV-ESTART (the readiness signal). srv
+    // writes other diagnostic lines too (AGENTMUXSRV-EVENT:..., plain
     // text); for B.1 we just log them. Phase B sub-PR B.2 will
-    // forward WAVESRV-EVENT messages to subscribers via the IPC
+    // forward AGENTMUXSRV-EVENT messages to subscribers via the IPC
     // event stream.
     let stderr = child
         .stderr
@@ -205,7 +205,7 @@ pub async fn spawn_srv(
         let mut reader = BufReader::new(stderr).lines();
         let mut estart_sent = false;
         while let Ok(Some(line)) = reader.next_line().await {
-            if !estart_sent && line.starts_with("WAVESRV-ESTART") {
+            if !estart_sent && line.starts_with("AGENTMUXSRV-ESTART") {
                 let parsed = parse_estart(&line);
                 let result = SrvSpawnResult {
                     pid: pid_for_log,
@@ -221,7 +221,7 @@ pub async fn spawn_srv(
                 ));
                 let _ = tx.send(result).await;
                 estart_sent = true;
-            } else if line.starts_with("WAVESRV-EVENT:") {
+            } else if line.starts_with("AGENTMUXSRV-EVENT:") {
                 crate::log(&format!("[srv {} event] {}", pid_for_log, line));
                 // Phase B.2 will forward these to subscribers.
             } else {
@@ -309,7 +309,7 @@ fn resolve_srv_binary(launcher_exe_dir: &Path) -> Result<PathBuf, SrvSpawnError>
     )))
 }
 
-/// Parsed fields out of a `WAVESRV-ESTART` line. Same shape as the
+/// Parsed fields out of a `AGENTMUXSRV-ESTART` line. Same shape as the
 /// host's `parse_estart` (sidecar.rs:404-420).
 struct EstartFields {
     ws_endpoint: String,

--- a/agentmux-launcher/src/srv_spawner.rs
+++ b/agentmux-launcher/src/srv_spawner.rs
@@ -125,8 +125,6 @@ pub async fn spawn_srv(
     .env("AGENTMUX_SETTINGS_DIR", paths.config_dir.to_string_lossy().to_string())
     .env("AGENTMUX_APP_PATH", &app_path_str)
     .env("AGENTMUX_DEV", if cfg!(debug_assertions) { "1" } else { "" })
-    .env("WCLOUD_ENDPOINT", "https://api.agentmux.ai/central")
-    .env("WCLOUD_WS_ENDPOINT", "wss://wsapi.agentmux.ai/")
     .stdin(Stdio::piped())
     .stdout(Stdio::piped())
     .stderr(Stdio::piped())

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.452"
+version = "0.33.453"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -348,10 +348,6 @@ pub struct Workspace {
     pub version: i64,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub icon: String,
-    #[serde(default, skip_serializing_if = "String::is_empty")]
-    pub color: String,
     #[serde(default)]
     pub tabids: Vec<String>,
     #[serde(default)]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -195,7 +195,6 @@ pub const COMMAND_EVENT_READ_HISTORY: &str = "eventreadhistory";
 
 // Stream/test commands
 pub const COMMAND_STREAM_TEST: &str = "streamtest";
-pub const COMMAND_STREAM_WAVE_AI: &str = "streamwaveai";
 pub const COMMAND_STREAM_CPU_DATA: &str = "streamcpudata";
 pub const COMMAND_TEST: &str = "test";
 
@@ -253,11 +252,7 @@ pub const COMMAND_VDOM_URL_REQUEST: &str = "vdomurlrequest";
 
 // AI commands
 pub const COMMAND_AI_SEND_MESSAGE: &str = "aisendmessage";
-pub const COMMAND_AI_ENABLE_TELEMETRY: &str = "waveaienabletelemetry";
-pub const COMMAND_GET_AI_CHAT: &str = "getwaveaichat";
 pub const COMMAND_GET_AI_RATE_LIMIT: &str = "getwaveairatelimit";
-pub const COMMAND_AI_TOOL_APPROVE: &str = "waveaitoolapprove";
-pub const COMMAND_AI_ADD_CONTEXT: &str = "waveaiaddcontext";
 
 // Screenshot
 pub const COMMAND_CAPTURE_BLOCK_SCREENSHOT: &str = "captureblockscreenshot";

--- a/agentmux-srv/src/backend/service.rs
+++ b/agentmux-srv/src/backend/service.rs
@@ -282,9 +282,6 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
             arg_names: vec![
                 "ctx".into(),
                 "name".into(),
-                "icon".into(),
-                "color".into(),
-                "applyDefaults".into(),
             ],
             return_desc: Some("workspaceId".into()),
         }),
@@ -294,9 +291,6 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
                 "ctx".into(),
                 "workspaceId".into(),
                 "name".into(),
-                "icon".into(),
-                "color".into(),
-                "applyDefaults".into(),
             ],
             return_desc: None,
         }),
@@ -324,16 +318,6 @@ pub fn get_method_meta(service: &str, method: &str) -> Option<MethodMeta> {
                 "pinned".into(),
             ],
             return_desc: Some("tabId".into()),
-        }),
-        ("workspace", "GetColors") => Some(MethodMeta {
-            desc: Some("get workspace colors".into()),
-            arg_names: vec![],
-            return_desc: Some("colors".into()),
-        }),
-        ("workspace", "GetIcons") => Some(MethodMeta {
-            desc: Some("get workspace icons".into()),
-            arg_names: vec![],
-            return_desc: Some("icons".into()),
         }),
         ("workspace", "UpdateTabIds") => Some(MethodMeta {
             desc: Some("update tab ordering".into()),

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -233,7 +233,7 @@ pub fn tear_off_block(
     store.update(&mut source_layout)?;
 
     // Create new workspace
-    let new_ws = create_workspace(store, "", "", "")?;
+    let new_ws = create_workspace(store, "")?;
     // create_tab adds a tab and sets it as active
     let new_tab = create_tab(store, &new_ws.oid)?;
 
@@ -436,8 +436,6 @@ pub fn tear_off_tab(
     let mut new_ws = Workspace {
         oid: Uuid::new_v4().to_string(),
         name: String::new(),
-        icon: String::new(),
-        color: String::new(),
         tabids: vec![tab_id.to_string()],
         pinnedtabids: vec![],
         activetabid: tab_id.to_string(),

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -29,29 +29,6 @@ use super::storage::wstore::WaveStore;
 use super::storage::StoreError;
 use super::obj::*;
 
-// ---- Workspace defaults (match Go's WorkspaceColors/Icons) ----
-
-pub const WORKSPACE_COLORS: &[&str] = &[
-    "#58C142", "#00D1EC", "#FA2D01", "#FBB500", "#8B54FF", "#FF5E8E", "#2B80FF",
-];
-
-pub const WORKSPACE_ICONS: &[&str] = &[
-    "custom@wave-logo-solid",
-    "triangle",
-    "star",
-    "cube",
-    "gem",
-    "chess-knight",
-    "heart",
-    "plane",
-    "rocket",
-    "flask",
-    "bolt",
-    "music",
-    "globe",
-    "leaf",
-];
-
 // ---- Layout action types (match Go) ----
 
 pub const LAYOUT_ACTION_INSERT: &str = "insert";
@@ -105,12 +82,7 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
     store.update(&mut client)?;
 
     // Create starter workspace
-    let ws = create_workspace(
-        store,
-        "Starter workspace",
-        WORKSPACE_ICONS[0],
-        WORKSPACE_COLORS[0],
-    )?;
+    let ws = create_workspace(store, "Starter workspace")?;
 
     // Create window pointing to workspace
     let win = create_window(store, &ws.oid)?;
@@ -271,7 +243,7 @@ mod tests {
     #[test]
     fn test_create_and_delete_workspace() {
         let store = make_store();
-        let ws = create_workspace(&store, "Test WS", "star", "#FF0000").unwrap();
+        let ws = create_workspace(&store, "Test WS").unwrap();
         assert_eq!(ws.name, "Test WS");
 
         // Create tabs in workspace
@@ -293,7 +265,7 @@ mod tests {
     #[test]
     fn test_create_and_delete_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
 
@@ -311,7 +283,7 @@ mod tests {
     #[test]
     fn test_set_active_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let _tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
 
@@ -327,7 +299,7 @@ mod tests {
     #[test]
     fn test_create_and_delete_block() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab = create_tab(&store, &ws.oid).unwrap();
 
         let mut meta = MetaMapType::new();
@@ -356,7 +328,7 @@ mod tests {
         let client = get_client(&store).unwrap();
         let initial_count = client.windowids.len();
 
-        let ws = create_workspace(&store, "WS2", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS2").unwrap();
         let window = create_window(&store, &ws.oid).unwrap();
 
         // Add to client
@@ -375,7 +347,7 @@ mod tests {
         let store = make_store();
         ensure_initial_data(&store).unwrap();
 
-        let ws = create_workspace(&store, "WS2", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS2").unwrap();
         let w2 = create_window(&store, &ws.oid).unwrap();
         let mut client = get_client(&store).unwrap();
         client.windowids.push(w2.oid.clone());
@@ -397,7 +369,7 @@ mod tests {
         let window = store.must_get::<Window>(window_id).unwrap();
         let old_ws = window.workspaceid.clone();
 
-        let new_ws = create_workspace(&store, "New WS", "star", "#000").unwrap();
+        let new_ws = create_workspace(&store, "New WS").unwrap();
         switch_workspace(&store, window_id, &new_ws.oid).unwrap();
 
         let window = store.must_get::<Window>(window_id).unwrap();
@@ -408,7 +380,7 @@ mod tests {
     #[test]
     fn test_resolve_block_id_prefix() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab = create_tab(&store, &ws.oid).unwrap();
 
         let meta = MetaMapType::new();
@@ -426,9 +398,9 @@ mod tests {
     #[test]
     fn test_list_workspaces() {
         let store = make_store();
-        create_workspace(&store, "WS1", "star", "#000").unwrap();
-        create_workspace(&store, "WS2", "star", "#111").unwrap();
-        create_workspace(&store, "WS3", "star", "#222").unwrap();
+        create_workspace(&store, "WS1").unwrap();
+        create_workspace(&store, "WS2").unwrap();
+        create_workspace(&store, "WS3").unwrap();
 
         let all = list_workspaces(&store).unwrap();
         assert_eq!(all.len(), 3);
@@ -463,7 +435,7 @@ mod tests {
     #[test]
     fn test_move_block_to_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
 
@@ -493,7 +465,7 @@ mod tests {
     #[test]
     fn test_move_block_to_tab_auto_close() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
 
@@ -514,7 +486,7 @@ mod tests {
     #[test]
     fn test_move_block_same_tab_noop() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab = create_tab(&store, &ws.oid).unwrap();
         let block = create_block(&store, &tab.oid, MetaMapType::new()).unwrap();
 
@@ -528,7 +500,7 @@ mod tests {
     #[test]
     fn test_promote_block_to_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab = create_tab(&store, &ws.oid).unwrap();
         let block = create_block(&store, &tab.oid, MetaMapType::new()).unwrap();
 
@@ -555,7 +527,7 @@ mod tests {
     #[test]
     fn test_reorder_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
         let tab3 = create_tab(&store, &ws.oid).unwrap();
@@ -580,8 +552,8 @@ mod tests {
     #[test]
     fn test_move_tab_to_workspace() {
         let store = make_store();
-        let ws1 = create_workspace(&store, "WS1", "star", "#000").unwrap();
-        let ws2 = create_workspace(&store, "WS2", "moon", "#fff").unwrap();
+        let ws1 = create_workspace(&store, "WS1").unwrap();
+        let ws2 = create_workspace(&store, "WS2").unwrap();
         let tab1 = create_tab(&store, &ws1.oid).unwrap();
         let tab2 = create_tab(&store, &ws1.oid).unwrap();
         let tab3 = create_tab(&store, &ws2.oid).unwrap();
@@ -605,8 +577,8 @@ mod tests {
     #[test]
     fn test_move_tab_to_workspace_last_tab_blocked() {
         let store = make_store();
-        let ws1 = create_workspace(&store, "WS1", "star", "#000").unwrap();
-        let ws2 = create_workspace(&store, "WS2", "moon", "#fff").unwrap();
+        let ws1 = create_workspace(&store, "WS1").unwrap();
+        let ws2 = create_workspace(&store, "WS2").unwrap();
         let tab1 = create_tab(&store, &ws1.oid).unwrap();
         let _tab2 = create_tab(&store, &ws2.oid).unwrap();
 
@@ -618,7 +590,7 @@ mod tests {
     #[test]
     fn test_tear_off_block() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab = create_tab(&store, &ws.oid).unwrap();
         let block = create_block(&store, &tab.oid, MetaMapType::new()).unwrap();
         let block2 = create_block(&store, &tab.oid, MetaMapType::new()).unwrap();
@@ -645,7 +617,7 @@ mod tests {
     #[test]
     fn test_tear_off_tab() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
         let tab2 = create_tab(&store, &ws.oid).unwrap();
         set_active_tab(&store, &ws.oid, &tab1.oid).unwrap();
@@ -665,7 +637,7 @@ mod tests {
     #[test]
     fn test_tear_off_last_tab_blocked() {
         let store = make_store();
-        let ws = create_workspace(&store, "WS", "star", "#000").unwrap();
+        let ws = create_workspace(&store, "WS").unwrap();
         let tab1 = create_tab(&store, &ws.oid).unwrap();
 
         // Should fail — can't tear off the only tab

--- a/agentmux-srv/src/backend/wcore/window.rs
+++ b/agentmux-srv/src/backend/wcore/window.rs
@@ -9,7 +9,7 @@ use crate::backend::storage::wstore::WaveStore;
 use crate::backend::storage::StoreError;
 use crate::backend::obj::*;
 
-use super::{get_client, WORKSPACE_COLORS, WORKSPACE_ICONS};
+use super::get_client;
 use super::tab::create_tab;
 use super::workspace::create_workspace;
 
@@ -20,7 +20,7 @@ pub fn create_window(
     workspace_id: &str,
 ) -> Result<Window, StoreError> {
     let ws_id = if workspace_id.is_empty() {
-        let ws = create_workspace(store, "", "", "")?;
+        let ws = create_workspace(store, "")?;
         let _tab = create_tab(store, &ws.oid)?;
         ws.oid
     } else {
@@ -58,8 +58,6 @@ pub fn create_window_full(
             let mut ws = Workspace {
                 oid: Uuid::new_v4().to_string(),
                 name: String::new(),
-                icon: String::new(),
-                color: String::new(),
                 tabids: vec![],
                 pinnedtabids: vec![],
                 activetabid: String::new(),
@@ -200,7 +198,7 @@ pub(super) fn check_and_fix_window(store: &WaveStore, window_id: &str) -> Result
         Some(ws) => ws,
         None => {
             // Workspace missing — create a new one
-            let ws = create_workspace(store, "", WORKSPACE_ICONS[0], WORKSPACE_COLORS[0])?;
+            let ws = create_workspace(store, "")?;
             let mut window = window;
             window.workspaceid = ws.oid.clone();
             store.update(&mut window)?;

--- a/agentmux-srv/src/backend/wcore/workspace.rs
+++ b/agentmux-srv/src/backend/wcore/workspace.rs
@@ -10,18 +10,11 @@ use crate::backend::storage::wstore::WaveStore;
 use crate::backend::storage::StoreError;
 use crate::backend::obj::*;
 
-/// Create a new workspace with name, icon, and color.
-pub fn create_workspace(
-    store: &WaveStore,
-    name: &str,
-    icon: &str,
-    color: &str,
-) -> Result<Workspace, StoreError> {
+/// Create a new workspace with the given name.
+pub fn create_workspace(store: &WaveStore, name: &str) -> Result<Workspace, StoreError> {
     let mut ws = Workspace {
         oid: Uuid::new_v4().to_string(),
         name: name.to_string(),
-        icon: icon.to_string(),
-        color: color.to_string(),
         tabids: vec![],
         pinnedtabids: vec![],
         activetabid: String::new(),
@@ -51,7 +44,7 @@ pub fn get_workspace(store: &WaveStore, ws_id: &str) -> Result<Workspace, StoreE
 }
 
 /// List all workspaces as WorkspaceListEntry (matching Go's behavior).
-/// Go returns [{workspaceid, windowid}] — filters out workspaces without name/icon/color.
+/// Returns [{workspaceid, windowid}] — filters out unnamed workspaces.
 pub fn list_workspaces(store: &WaveStore) -> Result<Vec<WorkspaceListEntry>, StoreError> {
     let workspaces = store.get_all::<Workspace>()?;
     let windows = store.get_all::<Window>()?;
@@ -64,8 +57,7 @@ pub fn list_workspaces(store: &WaveStore) -> Result<Vec<WorkspaceListEntry>, Sto
 
     let mut entries = Vec::new();
     for ws in &workspaces {
-        // Go skips workspaces missing name, icon, or color
-        if ws.name.is_empty() || ws.icon.is_empty() || ws.color.is_empty() {
+        if ws.name.is_empty() {
             continue;
         }
         entries.push(WorkspaceListEntry {

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -38,10 +38,6 @@ pub const EVENT_USER_INPUT: &str = "userinput";
 pub const EVENT_AGENT_MESSAGE_ACCEPTED: &str = "agent-message-accepted";
 #[allow(dead_code)]
 pub const EVENT_ROUTE_GONE: &str = "route:gone";
-#[allow(dead_code)]
-pub const EVENT_WORKSPACE_UPDATE: &str = "workspace:update";
-#[allow(dead_code)]
-pub const EVENT_WAVE_AI_RATE_LIMIT: &str = "waveai:ratelimit";
 pub const EVENT_BLOCK_STATS: &str = "blockstats";
 pub const EVENT_AGENT_HEALTH: &str = "agenthealth";
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -511,9 +511,9 @@ async fn main() {
         process_tracker,
     };
 
-    // 6. Emit WAVESRV-ESTART on stderr (exact format from cmd/server/main-server.go:617)
+    // 6. Emit AGENTMUXSRV-ESTART on stderr (exact format from cmd/server/main-server.go:617)
     eprintln!(
-        "WAVESRV-ESTART ws:{} web:{} version:{} buildtime:{} instance:{}",
+        "AGENTMUXSRV-ESTART ws:{} web:{} version:{} buildtime:{} instance:{}",
         ws_addr, web_addr, version, build_time, config.instance_id
     );
 

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -382,9 +382,7 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
         // ---- WorkspaceService ----
         ("workspace", "CreateWorkspace") => {
             let name: String = service::get_arg(args, 0).unwrap_or_default();
-            let icon: String = service::get_arg(args, 1).unwrap_or_default();
-            let color: String = service::get_arg(args, 2).unwrap_or_default();
-            match wcore::create_workspace(store, &name, &icon, &color) {
+            match wcore::create_workspace(store, &name) {
                 Ok(ws) => WebReturnType::success(serde_json::to_value(&ws).unwrap_or_default()),
                 Err(e) => WebReturnType::error(e.to_string()),
             }
@@ -520,30 +518,16 @@ fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType {
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
-        ("workspace", "GetColors") => {
-            WebReturnType::success(json!(wcore::WORKSPACE_COLORS))
-        }
-        ("workspace", "GetIcons") => {
-            WebReturnType::success(json!(wcore::WORKSPACE_ICONS))
-        }
         ("workspace", "UpdateWorkspace") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
             let name: Option<String> = service::get_optional_arg(args, 1).unwrap_or(None);
-            let icon: Option<String> = service::get_optional_arg(args, 2).unwrap_or(None);
-            let color: Option<String> = service::get_optional_arg(args, 3).unwrap_or(None);
             match store.must_get::<Workspace>(&ws_id) {
                 Ok(mut ws) => {
                     if let Some(n) = name {
                         ws.name = n;
-                    }
-                    if let Some(i) = icon {
-                        ws.icon = i;
-                    }
-                    if let Some(c) = color {
-                        ws.color = c;
                     }
                     match store.update(&mut ws) {
                         Ok(_) => WebReturnType::success_empty(),

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -266,25 +266,3 @@ async fn reactive_poller_status() {
     assert!(json.is_object());
 }
 
-#[tokio::test]
-async fn workspace_colors_and_icons() {
-    let state = test_state();
-    let app = build_router(state);
-    let req = Request::builder()
-        .uri("/agentmux/service")
-        .method("POST")
-        .header("X-AuthKey", "test-secret-key")
-        .header("Content-Type", "application/json")
-        .body(Body::from(
-            r#"{"service":"workspace","method":"GetColors"}"#,
-        ))
-        .unwrap();
-    let resp = app.oneshot(req).await.unwrap();
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert!(json["success"].as_bool().unwrap());
-    assert!(json["data"].is_array());
-    assert!(json["data"].as_array().unwrap().len() > 0);
-}

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -24,7 +24,7 @@ fn spawn_backend() -> (std::process::Child, String, String, String) {
 
     for line in reader.lines() {
         let line = line.expect("failed to read stderr");
-        if line.contains("WAVESRV-ESTART") {
+        if line.contains("AGENTMUXSRV-ESTART") {
             let parts: Vec<&str> = line.split_whitespace().collect();
             for part in &parts {
                 if let Some(addr) = part.strip_prefix("ws:") {

--- a/agentmux-srv/tests/integration_test.rs
+++ b/agentmux-srv/tests/integration_test.rs
@@ -1,7 +1,7 @@
 use std::io::{BufRead, BufReader};
 use std::process::{Command, Stdio};
 
-/// Helper: spawn agentmux-srv as a subprocess and parse WAVESRV-ESTART.
+/// Helper: spawn agentmux-srv as a subprocess and parse AGENTMUXSRV-ESTART.
 /// Returns (child, web_addr, ws_addr, auth_key).
 fn spawn_backend() -> (std::process::Child, String, String, String) {
     let auth_key = "integration-test-key-12345";
@@ -9,7 +9,7 @@ fn spawn_backend() -> (std::process::Child, String, String, String) {
     let binary = env!("CARGO_BIN_EXE_agentmux-srv");
 
     let mut child = Command::new(binary)
-        .env("WAVETERM_AUTH_KEY", auth_key)
+        .env("AGENTMUX_AUTH_KEY", auth_key)
         .stdin(Stdio::piped())
         .stderr(Stdio::piped())
         .stdout(Stdio::null())

--- a/docs/retro/audit-vestigial-types-2026-04-28.md
+++ b/docs/retro/audit-vestigial-types-2026-04-28.md
@@ -1,0 +1,104 @@
+# Audit: Vestigial WaveTerm/WaveMux Types in AgentMux
+
+**Date:** 2026-04-28
+**Scope:** Pre-Phase-E cleanup audit. AgentMux was rebranded from WaveTerm; this surveys types, names, and abstractions that still mirror the WaveTerm era.
+**Method:** Static grep + read across `agentmux-srv`, `agentmux-cef`, `agentmux-launcher`, `agentmux-common`, `frontend/`, and `specs/`. No runtime tracing.
+**Output:** Triage table — one row per candidate.
+
+---
+
+## Summary
+
+- **Total candidates examined:** 23
+- **Recommended for delete:** 4 (3 dead env vars / config + 1 unused field set)
+- **Recommended for rename:** 9 (`Wave*` symbol-set rebrands)
+- **Recommended for merge into another type:** 1 (`Workspace.{icon,color}` into `Window.meta`; `Workspace` itself stays — see row)
+- **Recommended for archive (specs):** 12 (shipped or stale Drafts older than ~6 weeks)
+- **Recommended keep-as-is:** 9 (Wave-named modules with real abstractions; rename later if name still rankles)
+
+### Top 3 highest-value cleanups (blast-radius vs payoff)
+
+1. **Drop `WCLOUD_ENDPOINT` / `WCLOUD_WS_ENDPOINT` env vars.** Set by both launcher and cef, never read by srv (zero `WCLOUD` reference in `agentmux-srv/src/`). Pure superstition. Deleting the two `.env(...)` calls is safe and removes the only `WCLOUD_*` surface still active in code. Blast radius: tiny (4 lines across 2 files).
+2. **Rename `WAVESRV-ESTART` / `WAVESRV-EVENT:` wire markers to `AGENTMUXSRV-ESTART` / `AGENTMUXSRV-EVENT:`.** The hardcoded string is one of the last user-visible WaveTerm names — it appears in srv stderr at every startup and in launcher logs. Producers: srv `main.rs:516`, srv `tests/integration_test.rs:27`. Consumers: launcher `srv_spawner.rs:210,226`, cef `sidecar.rs:303,314,474`. Coordinated change in 4 files; symmetric on both sides; small comment churn. Phase E is touching srv-spawn anyway.
+3. **Rename TS `WaveWindow` to `Window` (or `Win`) and `WaveObj`/`WaveObjUpdate`/`waveWindow` accordingly in `frontend/types/gotypes.d.ts` and 30 frontend files.** The Rust side already uses `Window` (not `WaveWindow`); the TS naming is the inconsistency. Pure rename, no semantics change. Blast radius: medium (~30 frontend files), but tractable as a single PR with `rg -l` + `replace_all`.
+
+Note: the original guess that `Workspace` could fold into `Window` does **not** survive close inspection. Tear-off (block + tab) creates new workspaces independently of windows (`wcore::dnd::tear_off_block`, `tear_off_tab`), and a workspace is the natural cascade root for tab/block deletion (`close_window` deletes the workspace, but the workspace also exists transiently before its window does in tear-off paths). 1:1-with-window is the *steady state* but not invariant. See row 1 below.
+
+---
+
+## Triage Table
+
+| Type / Name | Defined at | Referenced in | Still earns its keep? | Recommended action |
+|---|---|---|---|---|
+| `Workspace` struct (Rust) | `agentmux-srv/src/backend/obj.rs:346` | `wcore/{workspace,window,tab,dnd,mod}.rs`, `server/service.rs` (~89 hits), `storage/wstore.rs`, `frontend/types/gotypes.d.ts:1624` (~30 frontend files via `Workspace` & `WorkspaceListEntry`) | **Yes, conditionally.** Workspace owns `tabids`, `pinnedtabids`, `activetabid`. These are real fields with no sensible home on `Window`. Tear-off creates fresh workspaces, so the relationship is logically 1:N-from-window-over-time even if 1:1 in steady state. Folding into Window would conflate "what's on the screen" with "what kind of screen." | **keep-as-is** (small). Revisit only if Phase E moves tab-ownership off Workspace. The `name`/`icon`/`color` fields, however, see next row. |
+| `Workspace.icon` / `Workspace.color` fields | `agentmux-srv/src/backend/obj.rs:352-354` | Backend: `wcore/workspace.rs` (passed through `create_workspace`), `WORKSPACE_COLORS`/`WORKSPACE_ICONS` constants in `wcore/mod.rs:34-53`. Frontend: zero usages of `workspace.icon` or `workspace.color` (only stub stub `WorkspaceService.GetColors`/`GetIcons` in `services.ts:523-526`, never called). | **No.** Vestigial WaveTerm "named workspace switcher" UI that AgentMux never reimplemented. `WORKSPACE_ICONS[0]` is `"custom@wave-logo-solid"` — a literal Wave logo reference. | **delete** (small): drop fields, the two color/icon constants, and the dead `GetColors`/`GetIcons` service stubs. Keep `Workspace.name` (used by `InstancePanel.tsx:120` as a window display fallback). |
+| `Workspace.name` field | `agentmux-srv/src/backend/obj.rs:350` | `InstancePanel.tsx:120` (fallback window display name); set via `UpdateWorkspace` service (which has zero callers). | **Marginally.** The only read site uses it as a *fallback* after `window:displayname`. The user has no UI to set it. So it's really just always `""`. | **delete** if Phase E moves the display-name story onto Window meta directly. **keep-as-is** if you want the fallback path for legacy DBs (small blast). |
+| `wcore` module | `agentmux-srv/src/backend/wcore/mod.rs` | All of `agentmux-srv`; one of the central modules (workspace.rs, window.rs, tab.rs, block.rs, dnd.rs, event.rs, mod.rs ~676 lines). | **Yes — the code earns its keep, but the *name* is pure rebrand candidate.** "Wave Core" comment block at line 5 still says "Wave Core: application coordinator." It really is the workspace/window/tab/block CRUD facade. | **rename** to `core` or `entities` (medium). Touches every backend file that does `use crate::backend::wcore` — about a dozen call sites. Mechanical. |
+| `wconfig` module | `agentmux-srv/src/backend/wconfig/mod.rs:5` ("Port of Go's pkg/wconfig/.") | `backend/{config_watcher_fs,blockcontroller/shell,rpc/router,rpc_types,reactive,...}.rs` — 29 hits across 10 files. | **Yes; rename-only candidate.** It's the settings loader; nothing wave-specific. | **rename** to `config` (medium). Conflicts with existing `crate::config` (the CLI-args `Config`) — pick `appconfig` or `usrconfig` to disambiguate. |
+| `wps` module (Wave Pub/Sub) | `agentmux-srv/src/backend/wps.rs:5` | Internally imported as `wps::{EVENT_*, Broker}` across blockcontroller, server, wcore; ~15 files. | **Yes; rename-only.** Just a generic pub/sub broker. | **rename** to `pubsub` or `eventbroker` (medium — affects `EVENT_WAVE_OBJ_UPDATE` constant name too, see below). |
+| `wshutil` module | `agentmux-srv/src/backend/wshutil/mod.rs` | Used by `backend/blockcontroller`, `backend/rpc`, `agentmux-srv/src/server`. ~30 hits. | **Partly.** "WSH" was Wave Shell; `agentmux-wsh` crate has been retired (per `SPEC_RETIRE_WSH_2026_04_12.md`). The remaining `wshutil` is OSC encoding, RPC proxy, event listener, I/O adapters — used by the agent and terminal panes. The *name* dangles. | **rename** to `rpcutil` or `osc_rpc` (medium). |
+| `WshRpc` (in `wshutil/wshrpc.rs:144`) | `wshrpc.rs` | `wshutil/mod.rs`, `rpc/engine.rs:188` (which already says "Port of Go's `WshRpc`" and renamed itself to `WshRpcEngine`) | **Yes; the `WshRpc` struct in `wshrpc.rs` is the original transport-only RPC client; `WshRpcEngine` is the dispatch engine. Both are used.** Names are wave-flavored but not duplicated logic. | **rename** in lockstep with `wshutil` rename (medium). `WshRpc` → `OscRpc`, `WshRpcEngine` → `RpcEngine`. |
+| `WaveStore` (SQLite wrapper) | `agentmux-srv/src/backend/storage/wstore.rs:23` | 39 hits internal + 9 across server/blockcontroller/wcore call sites; 2070 lines. | **It's a real abstraction (generic `WaveObj`-typed CRUD over SQLite + a transaction wrapper), but it's a "thin trait around SQLite + serde_json"**. The genericity is justified by the OType dispatch. | **rename** to `ObjStore` (medium). Logic stays. Touches the `WaveStore::` and `&WaveStore` references — about 70 sites; mechanical. |
+| `WaveObj` trait | `agentmux-srv/src/backend/obj.rs:121` | 17 hits in `obj.rs` + impl macros for Client/Window/Workspace/Tab/Block/LayoutState; used by `WaveStore` generics. | **Yes — this is the polymorphic store abstraction (otype-tagged objects with a uniform CRUD shape). It does unify 6 distinct types across a single dispatch path. Not vestigial.** Name is wave-flavored. | **rename** to `Obj` (or `Entity`) (medium). Lockstep with WaveStore rename. ~17 trait-method implementations + use sites in `wstore.rs` generic bounds. |
+| `WaveObjUpdate` struct (Rust) + TS `WaveObjUpdate` | `agentmux-srv/src/backend/obj.rs:462`; `frontend/types/gotypes.d.ts:1536` | Rust: returned in WS update payloads. TS: only in `gotypes.d.ts` as a generic update envelope. | **Yes.** It's the websocket update envelope (`{updatetype, otype, oid, obj}`) — a real schema. | **rename** to `ObjUpdate` (medium). Wire format `{updatetype, otype, oid, obj}` is shape-not-name, so safe across boundaries if both sides updated together. |
+| `wave_obj_to_value` / `wave_obj_to_json` / `wave_obj_from_json` helpers | `agentmux-srv/src/backend/obj.rs:478,488,498` | 63 call sites across 8 files (server/service.rs:26, server/app_api.rs:6, blockcontroller/{persistent,subprocess,shell}.rs, wstore.rs, websocket.rs). Most heavily in service.rs (every Update emits `wave_obj_to_value(&...)`). | **Yes — actually does dispatch over multiple types via the `WaveObj` trait. `wave_obj_to_value` injects the runtime `otype` field that the wire requires for polymorphic updates. This isn't one-type-per-call.** | **rename** to `obj_to_value`, `obj_to_json`, `obj_from_json` (medium). Tied to the `WaveObj` → `Obj` rename above. |
+| TS `WaveObj` / `WaveWindow` aliases | `frontend/types/gotypes.d.ts:1528,1564` | ~30 frontend files (`app-init.ts`, `store/global.ts`, `store/services.ts`, `wos.ts`, `InstancePanel.tsx`, all view models, all layout files…). | **Yes — same role as Rust trait, but on the TS side `WaveWindow` is *just* `Window`. There's a name asymmetry: backend Rust calls it `Window`; TS calls it `WaveWindow`.** | **rename** TS `WaveWindow` → `Window` (or alias `WaveWindow = Window` for one release then drop). `WaveObj` → `Obj`. Medium blast (~30 files), all mechanical. |
+| `WAVESRV-ESTART` / `WAVESRV-EVENT:` wire markers | Producer: `agentmux-srv/src/main.rs:516`. | Consumers: `agentmux-launcher/src/srv_spawner.rs:210,226,314`; `agentmux-cef/src/sidecar.rs:303,314,474`; `agentmux-srv/tests/integration_test.rs:27`. Six total sites. | **No.** This is a literal-string handshake between processes. Renaming it is a coordinated 6-line change inside this repo (no external consumers). It's the most user-visible WaveTerm artifact in the runtime — leaks into stderr on every srv startup. | **rename** to `AGENTMUXSRV-ESTART` / `AGENTMUXSRV-EVENT:` (small, but coordinated). Highest payoff per LOC. |
+| `WCLOUD_ENDPOINT` / `WCLOUD_WS_ENDPOINT` env vars | Set in `agentmux-launcher/src/srv_spawner.rs:128-129` and `agentmux-cef/src/sidecar.rs:230-231`. | **Zero readers** in `agentmux-srv/src/`. Confirmed via `rg "WCLOUD" agentmux-srv/src` → 0 hits. | **No.** They point at `api.agentmux.ai` but nothing in the running process reads them. Pure ritual. | **delete** (small — 4 lines across 2 files). |
+| `--wavedata` CLI flag (srv) | Producer: `agentmux-launcher/src/srv_spawner.rs:117`, `agentmux-cef/src/sidecar.rs:207`. Consumer: `agentmux-srv/src/config.rs:8` (Clap `arg(long = "wavedata")`). | 3 source sites + 4 test/doc references. | **It's an active flag**, but the name is a 1:1 WaveTerm rebrand candidate. | **rename** to `--data-dir` (small). Update the two callers in lockstep with the Clap definition. |
+| `WAVETERM_DEV` / `WAVETERM_DEV_VITE` env vars (frontend) | `frontend/util/isdev.ts:7-8` (`WaveDevVarName`, `WaveDevViteVarName`). | Read via `getEnv()` for `isDev()`/`isDevVite()` flags. | **Active code path, but the literal env var name is unmigrated.** Memory says elsewhere `WAVETERM_*` → `AGENTMUX_*` was already done; these two slipped through. | **rename** env vars to `AGENTMUX_DEV` / `AGENTMUX_DEV_VITE` and rename the consts to `AgentMuxDevVarName` etc. (small — single file change + whatever sets them in build env). |
+| `WAVETERM_AUTH_KEY` (test only) | `agentmux-srv/tests/integration_test.rs:12` | Test code only. | **No.** Production uses `AGENTMUX_AUTH_KEY` (`config.rs:34`); this is a stale test fixture. Test will not actually authenticate srv with this name today. | **delete / fix** (small). Either the test is broken (unlikely — would have been noticed) or it's redundant. Either way, replace with `AGENTMUX_AUTH_KEY`. |
+| `EVENT_WAVE_OBJ_UPDATE`, `EVENT_WAVE_AI_RATE_LIMIT`, `EVENT_WORKSPACE_UPDATE` event-type constants | `agentmux-srv/src/backend/wps.rs:27,42,44` | `EVENT_WAVE_OBJ_UPDATE` widely used (waveobj:update wire string). `EVENT_WAVE_AI_RATE_LIMIT` flagged `#[allow(dead_code)]`. `EVENT_WORKSPACE_UPDATE` flagged `#[allow(dead_code)]`. | **`EVENT_WAVE_OBJ_UPDATE` earns its keep** (wire string `"waveobj:update"` is consumed by every frontend subscription). The other two are dead — `dead_code` allow attributes are a tell. | `EVENT_WAVE_OBJ_UPDATE`: **rename const to `EVENT_OBJ_UPDATE`** but keep wire string as `"waveobj:update"` for now (or migrate both — but wire compat with existing dev DBs may bite). The other two: **delete**. (small) |
+| `COMMAND_STREAM_WAVE_AI`, `COMMAND_AI_ENABLE_TELEMETRY`, `COMMAND_GET_AI_CHAT`, `COMMAND_GET_AI_RATE_LIMIT`, `COMMAND_AI_TOOL_APPROVE`, `COMMAND_AI_ADD_CONTEXT` | `agentmux-srv/src/backend/rpc_types.rs:198,256-260` | Only `COMMAND_GET_AI_RATE_LIMIT` is registered (`websocket.rs:589`) — and the handler returns a hardcoded "no rate limits" stub. The other 5 constants have zero references outside their declaration. **No frontend code calls any of them.** | **No.** All 6 are leftovers from WaveTerm's WaveAI panel feature, which `specs/archive/remove-aipanel-sidebar.md` says was deleted. | **delete** the five unused constants. **delete or simplify** `COMMAND_GET_AI_RATE_LIMIT` and its stub registration — the frontend never calls it. (small) |
+| `get_wave_init_opts` IPC command | `agentmux-cef/src/commands/backend.rs:26`; dispatch in `ipc.rs:210`. | No frontend caller (renamed to `onAgentMuxInit` callback path; this stale Rust-side name lingers). | **Yes, the function itself feeds `onAgentMuxInit`**, but the name is wave-flavored. | **rename** to `get_init_opts` (small — 2 sites in cef + the IPC string). |
+| TS `WaveObjUpdate.obj?: WaveObj` polymorphic shape | `frontend/types/gotypes.d.ts:1540` | Used wherever `WebReturnType.updates: WaveObjUpdate[]` is consumed. | **Yes** — same role as Rust side. | Rename in lockstep with TS `WaveObj` → `Obj` (medium). |
+| `meta_get_string`, `meta_get_bool`, `MetaMapType`, `merge_meta` | `agentmux-srv/src/backend/obj.rs:59,65,105,113` | Used everywhere object meta is touched. | **Yes — generic meta-map helpers.** Not WaveTerm-specific despite living in `obj.rs`. | **keep-as-is** (no action). |
+| `ORef` (otype:oid string) | `agentmux-srv/src/backend/oref.rs:17` | Wire-format identifier; passed everywhere. | **Yes — concrete abstraction tied to the polymorphic store; not vestigial.** | **keep-as-is**. |
+
+---
+
+## Specs Triage (`specs/` — 87 files)
+
+Method: read header (Status / Date / explicit "Implemented") and cross-check key features against current code (`frontend/`, `agentmux-srv/`).
+
+### Recommended for `specs/archive/` (shipped or executed)
+
+| Spec | Reason |
+|---|---|
+| `SPEC_PANE_CYCLE_FOCUS.md` | Header says `Status: Implemented` (2026-03-05). |
+| `widget-icon-only.md` | Header says `Status: Implemented`, PR #69 (2026-03-07). |
+| `SPEC_RETIRE_WSH_2026_04_12.md` | `agentmux-wsh` crate no longer exists — spec was executed. |
+| `per-pane-zoom.md` | Per memory: merged at v0.31.90 (PR #86). |
+| `pane-context-menu.md` | Per memory: PR #360 fixed context-menu event name; v1 spec body acknowledges shipped. |
+| `SPEC_TAB_DND_REORDER.md` | `frontend/app/tab/{tabbar,tab,droppable-tab}.tsx` all have `dragstart`/`draggable` paths; shipped. |
+| `SPEC_TAB_DND_DIAGNOSIS.md` | Sibling diagnosis doc — companion to the shipped reorder spec. |
+| `SPEC_TAB_DND_ANIMATION.md` | Same. |
+| `solidjs-appimage-launch-fix.md` | `Status: Required` (per-fix); AppImage builds active in Taskfile. |
+| `chrome-zoom-linux-label-shift.md` | `Status: Fixed`. |
+| `tabbar-enhancements.md` | Dated 2026-02-12 (oldest open Draft); all three sub-features either shipped or abandoned (`netstat -ano | grep` for "tabbar version" finds nothing in `frontend/`). |
+| `bench-results-20260329.md` | Historical bench output — not active design surface. |
+
+### Likely-stale Drafts to flag for owner triage (no clear shipped/abandoned signal)
+
+These are old-ish (>3 weeks old as of 2026-04-28) and labeled Draft. They may still matter; flagging only:
+
+`tauri-vs-cef-performance.md`, `swarm-analysis.md`, `tab-styling.md`, `themes-spec.md`, `web-widget.md`, `widget-dnd-reorder.md`, `cef-isolation-audit.md`, `cef-portable-layout.md`, `lan-awareness-and-embedded-jekt-api.md`, `local-messagebus-architecture.md`, `process-lifecycle-v2.md`, `console-flash-report.md`.
+
+### Specs that look active (keep where they are)
+
+Anything dated 2026-04-13 or later AND labeled Draft that I didn't tag above (most `SPEC_AGENT_*`, `SPEC_FORGE_*`, `SPEC_TOOL_OVERLAY_*`, `SPEC_SLASH_*`, `SPEC_BROWSER_PANE_*`, `SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md`, `ANALYSIS_*_2026_04_27.md`).
+
+`SPEC_REMOVE_WEBVIEW.md` is dated 2026-03-05 / `Status: Pre-implementation` — but `frontend/app/view/browser/` still has the full browser pane. Either the spec was rejected or never executed; the owner should decide.
+
+---
+
+## Notes on `Workspace` 1:1 question
+
+Asked: "is the 1:1 strict in all code paths?" Looking at the actual graph:
+
+- `wcore::create_window` / `create_window_full` always associate the new window with a workspace (creating one if none provided).
+- `wcore::tear_off_block` / `tear_off_tab` (`dnd.rs:195,406`) create a brand-new workspace **before** the new window exists — it's a transient orphan workspace until the frontend opens a window for it (see `frontend/app/drag/CrossWindowDragMonitor.*.tsx:223,240` calling `WorkspaceService.TearOffBlock`/`TearOffTab` and only then opening a window for the returned workspace ID).
+- `service.rs` `("workspace", "DeleteWorkspace")` deletes by id without a window check.
+- `Window.workspaceid` is a single-value string; **a window cannot point at multiple workspaces**.
+
+**Conclusion:** AgentMux preserves WaveTerm's "workspace = container of tabs that a window can point at" model. It is *not* a 1:1 rebrand candidate at the type level — but the workspace's *user-facing fields* (`name`, `icon`, `color`) are vestigial because no UI surfaces them. Hence the split recommendation: keep the type, drop the dead fields.

--- a/frontend/app/store/services.ts
+++ b/frontend/app/store/services.ts
@@ -150,16 +150,6 @@ class WorkspaceServiceType {
         return WOS.callBackendService("workspace", "DeleteWorkspace", Array.from(arguments))
     }
 
-    // @returns colors
-    GetColors(): Promise<string[]> {
-        return WOS.callBackendService("workspace", "GetColors", Array.from(arguments))
-    }
-
-    // @returns icons
-    GetIcons(): Promise<string[]> {
-        return WOS.callBackendService("workspace", "GetIcons", Array.from(arguments))
-    }
-
     // @returns workspace
     GetWorkspace(workspaceId: string): Promise<Workspace> {
         return WOS.callBackendService("workspace", "GetWorkspace", Array.from(arguments))
@@ -179,7 +169,7 @@ class WorkspaceServiceType {
     }
 
     // @returns object updates
-    UpdateWorkspace(workspaceId: string, name: string, icon: string, color: string, applyDefaults: boolean): Promise<void> {
+    UpdateWorkspace(workspaceId: string, name: string): Promise<void> {
         return WOS.callBackendService("workspace", "UpdateWorkspace", Array.from(arguments))
     }
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1623,8 +1623,6 @@ declare global {
     // waveobj.Workspace
     type Workspace = WaveObj & {
         name?: string;
-        icon?: string;
-        color?: string;
         tabids: string[];
         pinnedtabids: string[];
         activetabid: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.452",
+  "version": "0.33.453",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.452",
+      "version": "0.33.453",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.452",
+  "version": "0.33.453",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/smoke-test-portable.cjs
+++ b/scripts/smoke-test-portable.cjs
@@ -100,7 +100,7 @@ function diskChecks() {
     push("libGLESv2.dll", fs.existsSync(path.join(runtimeDir, "libGLESv2.dll")));
 }
 
-// ─── Spawn srv, parse WAVESRV-ESTART, return ws port ─────────────────────
+// ─── Spawn srv, parse AGENTMUXSRV-ESTART, return ws port ─────────────────────
 
 function spawnSrv() {
     return new Promise((resolve, reject) => {
@@ -123,12 +123,12 @@ function spawnSrv() {
         let wsPort = null;
         let stderrBuf = "";
         const timer = setTimeout(() => {
-            reject(new Error("WAVESRV-ESTART timeout after 15s"));
+            reject(new Error("AGENTMUXSRV-ESTART timeout after 15s"));
         }, 15000);
 
         proc.stderr.on("data", (chunk) => {
             stderrBuf += chunk.toString();
-            const match = stderrBuf.match(/WAVESRV-ESTART ws:127\.0\.0\.1:(\d+)/);
+            const match = stderrBuf.match(/AGENTMUXSRV-ESTART ws:127\.0\.0\.1:(\d+)/);
             if (match && wsPort === null) {
                 wsPort = parseInt(match[1], 10);
                 clearTimeout(timer);

--- a/specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md
+++ b/specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md
@@ -77,7 +77,7 @@ spec, not here.
 │    child.kill() sidecar (fire-and-forget) → shutdown() CEF →      │
 │    delete port file → exit                                         │
 └────────────────┬────────────────────────────────────────────────────┘
-                 │ spawn (blocking on WAVESRV-ESTART)
+                 │ spawn (blocking on AGENTMUXSRV-ESTART)
                  │
 ┌────────────────▼────────────────────────────────────────────────────┐
 │ SIDECAR (agentmux-srv) — BACKEND SERVICE                           │
@@ -140,7 +140,7 @@ spec, not here.
 1. Launcher starts; spawns host, waits.
 2. Host initializes CEF, creates `AppState`.
 3. Host checks port file → none found (first run).
-4. Host spawns sidecar (blocks until WAVESRV-ESTART).
+4. Host spawns sidecar (blocks until AGENTMUXSRV-ESTART).
 5. Host starts IPC server, writes port file (`port:token`).
 6. Host creates "main" browser → `on_after_created` fires.
 7. `on_after_created`: registers "main", calls `init_pool()` → spawns 2 pool windows at offscreen coords with `?pool=1` flags.

--- a/specs/agentmux-local-url-injection.md
+++ b/specs/agentmux-local-url-injection.md
@@ -63,7 +63,7 @@ When `AGENTMUX_LOCAL_URL` is set, the client routes all `inject_terminal` calls 
 
 `main.rs` sets `AGENTMUX_LOCAL_URL` as a process-level env var immediately after binding the web listener. Child processes (PTY shells) inherit the parent process's environment, so every pane automatically gets the correct URL. `shell.rs` re-injects it explicitly via `c.env(...)` to ensure it survives any env filtering in portable-pty.
 
-**`main.rs`** — after binding `web_listener`, before `WAVESRV-ESTART`:
+**`main.rs`** — after binding `web_listener`, before `AGENTMUXSRV-ESTART`:
 
 ```rust
 let web_addr = web_listener.local_addr().unwrap();

--- a/specs/archive/SPEC_PANE_CYCLE_FOCUS.md
+++ b/specs/archive/SPEC_PANE_CYCLE_FOCUS.md
@@ -3,7 +3,7 @@
 **Date:** 2026-03-05
 **Author:** Agent2
 **Branch:** agent2/tab-pane-cycling
-**Status:** Implemented
+**Status:** SHIPPED
 
 ---
 

--- a/specs/archive/SPEC_RETIRE_WSH_2026_04_12.md
+++ b/specs/archive/SPEC_RETIRE_WSH_2026_04_12.md
@@ -1,6 +1,6 @@
 # Spec: Retire `agentmux-wsh`
 
-**Status:** Draft — investigation complete, implementation pending approval
+**Status:** SHIPPED
 **Date:** 2026-04-12
 **Author:** AgentA
 **Related:** `specs/SPEC_RETRO_FOLLOWUPS_2026_04_12.md` §4 (the earlier `deploy_wsh` no-op fix, now superseded by this spec)

--- a/specs/archive/SPEC_TAB_DND_ANIMATION.md
+++ b/specs/archive/SPEC_TAB_DND_ANIMATION.md
@@ -1,6 +1,7 @@
 # Spec: Tab Drag-and-Drop Animation System
 
 **Date:** 2026-03-20
+**Status:** SHIPPED
 
 ---
 

--- a/specs/archive/SPEC_TAB_DND_DIAGNOSIS.md
+++ b/specs/archive/SPEC_TAB_DND_DIAGNOSIS.md
@@ -1,7 +1,7 @@
 # Spec: Tab DnD — Root Cause Analysis & Architecture
 
 **Date:** 2026-03-20
-**Status:** Diagnosis — not working on Windows
+**Status:** SHIPPED
 
 ---
 

--- a/specs/archive/SPEC_TAB_DND_REORDER.md
+++ b/specs/archive/SPEC_TAB_DND_REORDER.md
@@ -1,6 +1,7 @@
 # Spec: Tab Drag-and-Drop Reordering
 
 **Date:** 2026-03-20
+**Status:** SHIPPED
 **Goal:** Drag tabs horizontally along the tab bar to reorder them within the same window.
 
 ---

--- a/specs/archive/bench-results-20260329.md
+++ b/specs/archive/bench-results-20260329.md
@@ -1,5 +1,6 @@
 # Benchmark Results: Tauri vs CEF
 
+**Status:** ARCHIVED (historical record)
 **Date:** 2026-03-29 20:27 PDT
 **Machine:** Area54 — Windows 10 Pro x64 (22H2, 19045)
 **Tauri build:** v0.32.106 portable (WebView2 / Edge Chromium)

--- a/specs/archive/chrome-zoom-linux-label-shift.md
+++ b/specs/archive/chrome-zoom-linux-label-shift.md
@@ -1,6 +1,6 @@
 # Spec: Chrome Zoom — Widget Labels Shift Left on Linux
 
-**Status:** Fixed
+**Status:** SHIPPED
 **Date:** 2026-03-19
 **Component:** `frontend/app/window/window-header.scss`, `frontend/app/store/zoom.ts`
 

--- a/specs/archive/pane-context-menu.md
+++ b/specs/archive/pane-context-menu.md
@@ -1,7 +1,7 @@
 # Pane Context Menu — Spec (v2)
 
 **Version:** 2.0
-**Status:** Draft (v1 implemented splits + Open in VSCode on header only)
+**Status:** SHIPPED
 **Updated:** 2026-03-01
 **Author:** AgentA
 

--- a/specs/archive/per-pane-zoom.md
+++ b/specs/archive/per-pane-zoom.md
@@ -1,7 +1,7 @@
 # Per-Pane Terminal Zoom Specification - AgentMux
 
 **Version:** 1.0
-**Status:** Draft
+**Status:** SHIPPED
 **Target Release:** 0.28.0
 **Created:** 2026-02-15
 **Author:** AgentX

--- a/specs/archive/solidjs-appimage-launch-fix.md
+++ b/specs/archive/solidjs-appimage-launch-fix.md
@@ -1,6 +1,6 @@
 # Spec: Port AppImage Launch Fixes to SolidJS
 
-**Status:** Required — app does not open on Linux AppImage
+**Status:** SHIPPED
 **Date:** 2026-03-14
 **Component:** `frontend/tauri-bootstrap.ts`, `frontend/wave.ts`, `frontend/app/store/contextmenu.ts`
 **Tracks:** Issues first fixed for React in PR #116, now regressed after SolidJS migration (PR #120)

--- a/specs/archive/tabbar-enhancements.md
+++ b/specs/archive/tabbar-enhancements.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-12
 **Version:** 1.0
-**Status:** Draft
+**Status:** SHIPPED
 
 ## Overview
 

--- a/specs/archive/widget-icon-only.md
+++ b/specs/archive/widget-icon-only.md
@@ -1,6 +1,6 @@
 # Spec: Widget Icon-Only Mode
 
-**Status:** Implemented
+**Status:** SHIPPED
 **PR:** https://github.com/agentmuxai/agentmux/pull/69
 **Date:** 2026-03-07
 


### PR DESCRIPTION
## Summary

Pre-Phase-E cleanup of WaveTerm-era cruft so the upcoming srv state
machine work doesn't carry baggage forward. Four small commits, each
independently reviewable; no behavior changes (just dead-code removal
and naming consistency).

Triage doc: `docs/retro/audit-vestigial-types-2026-04-28.md` (added in
commit 2; lists what was kept vs. dropped and why).

## What's in here

1. **Archive 12 shipped/historical specs** to `specs/archive/` and stamp
   `Status: SHIPPED` so the top-level `specs/` directory reflects only
   in-flight work. (Pane cycling, per-pane zoom, widget icon-only, tab DnD
   reorder/diagnosis/animation, pane context menu, wsh retirement,
   tabbar enhancements, AppImage launch fix, chrome zoom shift,
   Tauri-vs-CEF benchmark report.)

2. **Drop dead WCLOUD env + unused AI/event constants**:
   - `WCLOUD_ENDPOINT` / `WCLOUD_WS_ENDPOINT` env vars (set by launcher
     + cef sidecar, never read by srv).
   - `EVENT_WAVE_AI_RATE_LIMIT`, `EVENT_WORKSPACE_UPDATE` (zero callers).
   - `COMMAND_STREAM_WAVE_AI`, `COMMAND_AI_ENABLE_TELEMETRY`,
     `COMMAND_GET_AI_CHAT`, `COMMAND_AI_TOOL_APPROVE`,
     `COMMAND_AI_ADD_CONTEXT` (no readers; `COMMAND_GET_AI_RATE_LIMIT`
     and `COMMAND_AI_SEND_MESSAGE` retained — both have live callers).
   - Replace `WAVETERM_AUTH_KEY` with `AGENTMUX_AUTH_KEY` in
     `agentmux-srv/tests/integration_test.rs`.

3. **Drop unused `Workspace.icon` / `Workspace.color`** fields and the
   `WORKSPACE_COLORS` / `WORKSPACE_ICONS` constants. The frontend has no
   UI to set or display them, never calls `GetIcons` / `GetColors`. Also
   simplifies `create_workspace`'s 4-arg signature → 1-arg, drops the
   `GetIcons` / `GetColors` service stubs, and trims the frontend
   `Workspace` type.

4. **Rename `WAVESRV-ESTART` / `WAVESRV-EVENT:` to `AGENTMUXSRV-`** so
   log greps for "agentmux" find the srv-readiness signal. Producer in
   `agentmux-srv/src/main.rs`; consumers in launcher `srv_spawner.rs`,
   cef `sidecar.rs`, and `scripts/smoke-test-portable.cjs` updated in
   lockstep. Active specs updated; archived specs and historical retros
   left as-is (they record the contract as it was at the time).

## Test plan

- [x] `cargo check -p agentmux-srv -p agentmux-launcher` passes (ran locally).
- [ ] CI: full workspace check + tests on the merge ref.
- [ ] Smoke test: portable build still launches and srv signals ready
      via `AGENTMUXSRV-ESTART`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)