### PR TITLE
feat: Phase B.4 — launcher window state mirror (read-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.453"
+version = "0.33.454"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.453"
+version = "0.33.454"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.453"
+version = "0.33.454"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.453"
+version = "0.33.454"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.453"
+version = "0.33.454"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -190,6 +190,35 @@ impl AgentMuxHandler {
             crate::pane::callbacks::on_after_created_pane(&self.state, &browser);
         }
 
+        // Phase B.4 — report top-level windows to the launcher's
+        // read-only state mirror. Skips browser-pane child HWNDs and
+        // pool windows (they're not user-visible until promoted; the
+        // pool->user transition gets its own report in a follow-up).
+        // No-op if launcher IPC isn't connected (`task dev` mode).
+        if is_top_level_window && !label.starts_with("window-pool-") {
+            let (wire_kind, parent_label) = {
+                let metas = self.state.window_meta.lock();
+                metas
+                    .get(&label)
+                    .map(|m| {
+                        let k = match m.kind {
+                            WindowKind::FullInstance => {
+                                agentmux_common::ipc::WindowKind::FullInstance
+                            }
+                            WindowKind::Subwindow => {
+                                agentmux_common::ipc::WindowKind::Subwindow
+                            }
+                        };
+                        (k, m.parent_instance_id.clone())
+                    })
+                    .unwrap_or((
+                        agentmux_common::ipc::WindowKind::FullInstance,
+                        None,
+                    ))
+            };
+            crate::launcher_ipc::report_window_opened(label.clone(), wire_kind, parent_label);
+        }
+
         self.browser_list.push(browser);
 
         // Tear-off Phase 6 — pre-warmed window pool.
@@ -299,6 +328,12 @@ impl AgentMuxHandler {
             // the pool would never refill.
             if lbl.starts_with("window-pool-") {
                 crate::commands::window_pool::on_pool_window_destroyed(&self.state, lbl);
+            }
+            // Phase B.4 — mirror the close to the launcher. Symmetric
+            // with the open-report in on_after_created: only top-level
+            // user-visible windows. No-op if launcher IPC absent.
+            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
+                crate::launcher_ipc::report_window_closed(lbl.clone());
             }
         }
 

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -103,45 +103,15 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
     let (read_half, write_half) = tokio::io::split(client);
     let writer = Arc::new(Mutex::new(write_half));
 
-    // Phase B.4 — wire up the outbound command channel. Sync callers
-    // push Commands; a dedicated drain task writes them as
-    // newline-delimited JSON. Ordered (preserves report order from
-    // the UI thread). Bounded? No — UnboundedSender so `try_send`
-    // can stay non-blocking on the UI thread; the drain task is
-    // fast (single async write) and the volume is one event per
-    // window create/close, not high-frequency.
-    let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
-    if COMMAND_TX.set(tx).is_err() {
-        tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
-    }
-    let writer_for_drain = Arc::clone(&writer);
-    tokio::spawn(async move {
-        while let Some(cmd) = rx.recv().await {
-            let mut buf = match serde_json::to_vec(&cmd) {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::warn!("[launcher-ipc] failed to serialize {:?}: {}", cmd, e);
-                    continue;
-                }
-            };
-            buf.push(b'\n');
-            let mut w = writer_for_drain.lock().await;
-            if let Err(e) = w.write_all(&buf).await {
-                tracing::warn!(
-                    "[launcher-ipc] write failed for {:?}: {} — dropping further commands",
-                    cmd, e
-                );
-                return;
-            }
-            if let Err(e) = w.flush().await {
-                tracing::warn!("[launcher-ipc] flush failed: {}", e);
-                return;
-            }
-        }
-    });
-
-    // Send Register. Server enforces this is the first message; we
-    // satisfy the contract before any other traffic.
+    // Send Register FIRST. Server's `enforce_register_first` requires
+    // it as the very first message on the wire, and a fatal-close
+    // on violation would permanently disable the mirror (no
+    // reconnect path in B.4). The drain task that processes
+    // outbound commands gets spawned + the global sender published
+    // only AFTER this succeeds. (reagent P1 + codex P2 PR #576
+    // round-1 — race where a `report_window_*` call between
+    // `COMMAND_TX.set` and the Register flush could land first on
+    // the wire.)
     let register = Command::Register {
         kind: ClientKind::Host,
         pid: std::process::id(),
@@ -175,6 +145,44 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
             return None;
         }
     }
+
+    // Phase B.4 — Register confirmed on the wire; safe to expose the
+    // outbound command channel. Sync callers push Commands; a
+    // dedicated drain task writes them as newline-delimited JSON.
+    // Ordered (preserves report order from the UI thread). Bounded?
+    // No — UnboundedSender so `try_send` can stay non-blocking on
+    // the UI thread; the drain task is fast (single async write)
+    // and the volume is one event per window create/close, not
+    // high-frequency.
+    let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+    if COMMAND_TX.set(tx).is_err() {
+        tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
+    }
+    let writer_for_drain = Arc::clone(&writer);
+    tokio::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            let mut buf = match serde_json::to_vec(&cmd) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("[launcher-ipc] failed to serialize {:?}: {}", cmd, e);
+                    continue;
+                }
+            };
+            buf.push(b'\n');
+            let mut w = writer_for_drain.lock().await;
+            if let Err(e) = w.write_all(&buf).await {
+                tracing::warn!(
+                    "[launcher-ipc] write failed for {:?}: {} — dropping further commands",
+                    cmd, e
+                );
+                return;
+            }
+            if let Err(e) = w.flush().await {
+                tracing::warn!("[launcher-ipc] flush failed: {}", e);
+                return;
+            }
+        }
+    });
 
     // Spawn a read-loop task. For B.2 it just logs every Event the
     // server sends; B.3+ will dispatch them into host state.

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -16,13 +16,25 @@
 // before.
 
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use agentmux_common::ipc::{ClientKind, Command, Event};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 
 #[cfg(target_os = "windows")]
 use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+
+/// Phase B.4 — global outbound command channel. Set once when the
+/// launcher pipe connects; sync callers (CEF lifecycle callbacks
+/// fire on the UI thread) post `Command`s without needing a
+/// tokio runtime handle. Drained by a task spawned in
+/// `connect_to_launcher` that writes to the pipe.
+///
+/// `None` semantics: launcher IPC isn't connected (e.g. `task dev`
+/// mode where launcher isn't in the loop). `report_window_*` calls
+/// are silently no-ops; the host runs as before.
+static COMMAND_TX: OnceLock<mpsc::UnboundedSender<Command>> = OnceLock::new();
 
 /// Handle the host holds for its lifetime so the launcher's IPC
 /// pipe stays open. Dropping it closes the connection (launcher
@@ -90,6 +102,43 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
 
     let (read_half, write_half) = tokio::io::split(client);
     let writer = Arc::new(Mutex::new(write_half));
+
+    // Phase B.4 — wire up the outbound command channel. Sync callers
+    // push Commands; a dedicated drain task writes them as
+    // newline-delimited JSON. Ordered (preserves report order from
+    // the UI thread). Bounded? No — UnboundedSender so `try_send`
+    // can stay non-blocking on the UI thread; the drain task is
+    // fast (single async write) and the volume is one event per
+    // window create/close, not high-frequency.
+    let (tx, mut rx) = mpsc::unbounded_channel::<Command>();
+    if COMMAND_TX.set(tx).is_err() {
+        tracing::warn!("[launcher-ipc] COMMAND_TX already set — connect_to_launcher called twice");
+    }
+    let writer_for_drain = Arc::clone(&writer);
+    tokio::spawn(async move {
+        while let Some(cmd) = rx.recv().await {
+            let mut buf = match serde_json::to_vec(&cmd) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!("[launcher-ipc] failed to serialize {:?}: {}", cmd, e);
+                    continue;
+                }
+            };
+            buf.push(b'\n');
+            let mut w = writer_for_drain.lock().await;
+            if let Err(e) = w.write_all(&buf).await {
+                tracing::warn!(
+                    "[launcher-ipc] write failed for {:?}: {} — dropping further commands",
+                    cmd, e
+                );
+                return;
+            }
+            if let Err(e) = w.flush().await {
+                tracing::warn!("[launcher-ipc] flush failed: {}", e);
+                return;
+            }
+        }
+    });
 
     // Send Register. Server enforces this is the first message; we
     // satisfy the contract before any other traffic.
@@ -168,4 +217,41 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
 #[cfg(not(target_os = "windows"))]
 pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
     None
+}
+
+/// Phase B.4 — sync API: report a window open to the launcher's
+/// state mirror. Called from CEF lifecycle callbacks on the UI
+/// thread. No-op if the launcher pipe isn't connected (`task dev`
+/// mode); failures to enqueue (channel closed, drain task died)
+/// are logged but don't propagate — the host's authoritative state
+/// is unaffected, the mirror just falls behind. B.5 tightens.
+pub fn report_window_opened(
+    label: String,
+    kind: agentmux_common::ipc::WindowKind,
+    parent_label: Option<String>,
+) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return; // launcher not in the loop
+    };
+    let cmd = Command::ReportWindowOpened {
+        label,
+        kind,
+        parent_label,
+    };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_window_opened: channel closed ({})", e);
+    }
+}
+
+/// Phase B.4 — sync API: report a window close to the launcher's
+/// state mirror. Same no-op-if-disconnected semantics as
+/// `report_window_opened`.
+pub fn report_window_closed(label: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportWindowClosed { label };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_window_closed: channel closed ({})", e);
+    }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.453"
+version = "0.33.454"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -63,6 +63,41 @@ pub enum Command {
     /// In B.3+ this becomes `Quit { reason }` with shutdown semantics;
     /// for B.2 it's just a polite goodbye.
     Goodbye,
+    /// Phase B.4: host reports that a real window has been created
+    /// (CEF `on_after_created` fired). Launcher records it in its
+    /// read-only mirror and broadcasts `Event::WindowOpened` to other
+    /// subscribers. Pool windows do NOT report via this command —
+    /// they get their own `ReportPool*` commands in a follow-up so
+    /// the mirror can distinguish user-visible windows from pool
+    /// inventory.
+    ReportWindowOpened {
+        /// Stable label assigned by the host (e.g. "main", "window-{uuid}").
+        label: String,
+        kind: WindowKind,
+        /// For `Subwindow` only: label of the `FullInstance` parent.
+        /// `None` for `FullInstance`.
+        parent_label: Option<String>,
+    },
+    /// Phase B.4: host reports a window is closing (`on_before_close`).
+    /// Launcher removes from mirror, broadcasts `Event::WindowClosed`.
+    /// Idempotent: a missing label is logged but not an error (covers
+    /// the close-before-launcher-saw-the-open race).
+    ReportWindowClosed {
+        label: String,
+    },
+}
+
+/// Wire-side enum for `WindowKind`. Mirrors `agentmux-cef::state::WindowKind`
+/// — kept here so the launcher can deserialize without depending on the
+/// host crate. The host serializes its own type via `serde(rename_all =
+/// "snake_case")` so the JSON shape matches exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowKind {
+    /// Independent AgentMux window. Appears in the Windows taskbar.
+    FullInstance,
+    /// Hidden from the taskbar; closes when its parent FullInstance closes.
+    Subwindow,
 }
 
 /// Events flow launcher → client. Versioned per spec §5.2 — every
@@ -123,6 +158,25 @@ pub enum Event {
     LifecyclePhaseChanged {
         from: LifecyclePhase,
         to: LifecyclePhase,
+        version: u64,
+    },
+    /// Phase B.4: a window joined the launcher's mirror. Emitted in
+    /// response to `Command::ReportWindowOpened` from the host. Other
+    /// subscribers (Tool clients, eventually srv) receive this to
+    /// keep their own views consistent.
+    WindowOpened {
+        label: String,
+        kind: WindowKind,
+        parent_label: Option<String>,
+        version: u64,
+    },
+    /// Phase B.4: a window left the launcher's mirror. Emitted on
+    /// `Command::ReportWindowClosed`. Cascades for FullInstance
+    /// closures are NOT modeled here yet (B.5 tightens) — for now
+    /// the host emits one ReportWindowClosed per window even on
+    /// cascade closes, so subscribers see the same N events.
+    WindowClosed {
+        label: String,
         version: u64,
     },
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.453"
+version = "0.33.454"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -324,6 +324,12 @@ async fn enforce_register_first(
         Command::Register { .. } => return None,
         Command::Ping { .. } => ("Ping before Register".to_string(), false),
         Command::Goodbye => ("Goodbye before Register".to_string(), true),
+        Command::ReportWindowOpened { .. } => {
+            ("ReportWindowOpened before Register".to_string(), true)
+        }
+        Command::ReportWindowClosed { .. } => {
+            ("ReportWindowClosed before Register".to_string(), true)
+        }
     };
     let mut state = ctx.state.lock().await;
     let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -833,5 +833,83 @@ mod tests {
             prop_assert_eq!(state.processes[&pid].kind, initial_kind);
             prop_assert_eq!(&state.processes[&pid].version, "v1");
         }
+
+        /// B.4 mirror invariants under arbitrary host-driven traffic.
+        /// State seeded with a registered Host so the host-only gate
+        /// doesn't trivially reject every command (reagent P2 round-1
+        /// PR #576). Two invariants checked:
+        ///   1. Mirror size is bounded by total opens minus successful
+        ///      closes — no phantom entries appear.
+        ///   2. Every label in `state.windows` has a `WindowMirror`
+        ///      whose `label` field matches the map key (no key/value
+        ///      drift).
+        #[test]
+        fn window_mirror_invariants_under_host_traffic(
+            cmds in proptest::collection::vec(arb_window_cmd(), 1..100)
+        ) {
+            const HOST_PID: u32 = 1;
+            let mut state = State::default();
+            let _ = update(
+                &mut state,
+                Command::Register {
+                    kind: ClientKind::Host,
+                    pid: HOST_PID,
+                    version: "host".into(),
+                },
+                &ctx(1),
+            );
+            let host_ctx = ctx_with_pid(1, HOST_PID);
+
+            let mut opens = 0u64;
+            let mut closes = 0u64;
+            for cmd in cmds {
+                match &cmd {
+                    Command::ReportWindowOpened { .. } => opens += 1,
+                    Command::ReportWindowClosed { .. } => closes += 1,
+                    _ => {}
+                }
+                let _ = update(&mut state, cmd, &host_ctx);
+            }
+
+            // Bound: mirror can't hold more entries than distinct opens
+            // (idempotent overwrite ensures opens are dedup'd by label,
+            // and any open can be cancelled by its matching close).
+            prop_assert!(
+                state.windows.len() as u64 <= opens,
+                "mirror size {} > total opens {}",
+                state.windows.len(), opens
+            );
+            // Key/value coherence — if this ever fails, the reducer
+            // wrote a value with a mismatched label.
+            for (k, v) in &state.windows {
+                prop_assert_eq!(k, &v.label);
+            }
+            // Closes are observable (each emits an event regardless
+            // of mirror state). Just sanity-check nothing is leaking
+            // into negative counters.
+            let _ = (opens, closes); // referenced for failure messages
+        }
+    }
+
+    /// B.4 — generate ONLY window-mirror commands. Used by the
+    /// host-driven proptest above to guarantee exercise of the
+    /// mirror insert/remove paths (general `arb_command` mixes in
+    /// Register / Ping / Goodbye which dilute window coverage).
+    fn arb_window_cmd() -> impl proptest::strategy::Strategy<Value = Command> {
+        use proptest::prelude::*;
+        prop_oneof![
+            (
+                "[a-c]{1,3}",
+                prop_oneof![
+                    Just(WindowKind::FullInstance),
+                    Just(WindowKind::Subwindow),
+                ],
+                prop_oneof![Just(None::<String>), Just(Some("a".into()))],
+            )
+                .prop_map(|(label, kind, parent_label)| {
+                    Command::ReportWindowOpened { label, kind, parent_label }
+                }),
+            "[a-c]{1,3}".prop_map(|label| Command::ReportWindowClosed { label }),
+        ]
     }
 }

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -41,9 +41,9 @@
 //     register. Running → Quitting on Quit (B.3 placeholder).
 //     Quitting → Dead on cleanup-done (B.3 placeholder). No skipping.
 
-use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event};
+use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event, WindowKind};
 
-use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State};
+use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State, WindowMirror};
 
 /// Context the reducer needs but can't read from State (clocks,
 /// connection identity). Passed in per-call so update remains pure.
@@ -82,7 +82,59 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             vec![Event::Pong { nonce, version: v }]
         }
         Command::Goodbye => handle_goodbye(state, ctx.registered_pid.unwrap_or(0)),
+        Command::ReportWindowOpened {
+            label,
+            kind,
+            parent_label,
+        } => handle_report_window_opened(state, ctx, label, kind, parent_label),
+        Command::ReportWindowClosed { label } => handle_report_window_closed(state, label),
     }
+}
+
+/// Phase B.4 — record a host-reported window opening in the launcher's
+/// read-only mirror. Idempotent on duplicate opens (same label twice
+/// in a row): the second insert overwrites with fresh metadata and
+/// emits a fresh event. Subscribers must tolerate seeing the same
+/// label twice; cleaner once B.5 makes the launcher authoritative.
+fn handle_report_window_opened(
+    state: &mut State,
+    ctx: &Ctx,
+    label: String,
+    kind: WindowKind,
+    parent_label: Option<String>,
+) -> Vec<Event> {
+    state.windows.insert(
+        label.clone(),
+        WindowMirror {
+            label: label.clone(),
+            kind,
+            parent_label: parent_label.clone(),
+            opened_at: ctx.now_rfc3339.clone(),
+        },
+    );
+    let v = state.bump_version();
+    vec![Event::WindowOpened {
+        label,
+        kind,
+        parent_label,
+        version: v,
+    }]
+}
+
+/// Phase B.4 — drop a host-reported window from the mirror. Missing
+/// label is logged-only (no Error event) because the close-before-
+/// launcher-saw-the-open race is benign in B.4: the launcher's mirror
+/// is a passive copy, and the host's authoritative view will simply
+/// not have the window either. B.5 will tighten this contract.
+fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
+    let was_present = state.windows.remove(&label).is_some();
+    let v = state.bump_version();
+    if !was_present {
+        // Quiet: B.4 is read-only and the mirror can race with the
+        // host's authoritative store on first launch. We still emit
+        // the Closed event so subscribers stay consistent.
+    }
+    vec![Event::WindowClosed { label, version: v }]
 }
 
 fn handle_register(
@@ -344,6 +396,8 @@ mod tests {
             | Event::LifecyclePhaseChanged { version, .. }
             | Event::Registered { version, .. }
             | Event::Pong { version, .. }
+            | Event::WindowOpened { version, .. }
+            | Event::WindowClosed { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -395,6 +449,102 @@ mod tests {
             state.processes[&1234].state,
             ProcessState::Exited { code: 0 }
         ));
+    }
+
+    #[test]
+    fn report_window_opened_inserts_into_mirror_and_emits_event() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "main".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::WindowOpened { label, kind: WindowKind::FullInstance, parent_label: None, .. }
+                if label == "main"
+        ));
+        let mirror = &state.windows["main"];
+        assert_eq!(mirror.label, "main");
+        assert_eq!(mirror.kind, WindowKind::FullInstance);
+        assert_eq!(mirror.parent_label, None);
+    }
+
+    #[test]
+    fn report_window_closed_removes_from_mirror() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "main".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &ctx(1),
+        );
+        assert!(state.windows.contains_key("main"));
+        let events = update(
+            &mut state,
+            Command::ReportWindowClosed {
+                label: "main".into(),
+            },
+            &ctx(1),
+        );
+        assert!(!state.windows.contains_key("main"));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::WindowClosed { label, .. } if label == "main"
+        ));
+    }
+
+    #[test]
+    fn report_window_closed_on_unknown_label_is_idempotent() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::ReportWindowClosed {
+                label: "ghost".into(),
+            },
+            &ctx(1),
+        );
+        // Still emits an event (so subscribers stay consistent) but
+        // doesn't error.
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], Event::WindowClosed { .. }));
+        assert!(state.windows.is_empty());
+    }
+
+    #[test]
+    fn subwindow_open_records_parent_label() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "main".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &ctx(1),
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "sub-1".into(),
+                kind: WindowKind::Subwindow,
+                parent_label: Some("main".into()),
+            },
+            &ctx(1),
+        );
+        assert_eq!(
+            state.windows["sub-1"].parent_label.as_deref(),
+            Some("main")
+        );
     }
 
     #[test]
@@ -469,6 +619,22 @@ mod tests {
                 .prop_map(|(kind, pid, version)| Command::Register { kind, pid, version }),
             1 => any::<u64>().prop_map(|nonce| Command::Ping { nonce }),
             1 => Just(Command::Goodbye),
+            // B.4: window mirror commands. Labels drawn from a small
+            // alphabet so duplicates (open then close) are common
+            // enough for the proptest to exercise the idempotent
+            // close path.
+            2 => (
+                "[a-c]{1,3}",
+                prop_oneof![
+                    Just(WindowKind::FullInstance),
+                    Just(WindowKind::Subwindow),
+                ],
+                prop_oneof![Just(None::<String>), Just(Some("a".into()))],
+            )
+                .prop_map(|(label, kind, parent_label)| {
+                    Command::ReportWindowOpened { label, kind, parent_label }
+                }),
+            2 => "[a-c]{1,3}".prop_map(|label| Command::ReportWindowClosed { label }),
         ]
     }
 

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -86,9 +86,49 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             label,
             kind,
             parent_label,
-        } => handle_report_window_opened(state, ctx, label, kind, parent_label),
-        Command::ReportWindowClosed { label } => handle_report_window_closed(state, label),
+        } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportWindowOpened") {
+                return vec![err];
+            }
+            handle_report_window_opened(state, ctx, label, kind, parent_label)
+        }
+        Command::ReportWindowClosed { label } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportWindowClosed") {
+                return vec![err];
+            }
+            handle_report_window_closed(state, label)
+        }
     }
+}
+
+/// Phase B.4 — gate window-mirror reports to Host clients only. The
+/// host is the only source of truth about its own window lifecycle;
+/// allowing Renderer/Srv/Tool clients to mutate the mirror would let
+/// any registered process spoof open/close traffic and break the
+/// host-authoritative model. (codex P1 PR #576 round-1.)
+///
+/// Returns `Some(Error)` if the calling connection is not a Host;
+/// `None` if the call is allowed to proceed. Looks up the kind by
+/// PID rather than threading it through `Ctx` because `processes`
+/// is already the canonical source — single source of truth, no
+/// extra plumbing.
+fn enforce_host_only(state: &mut State, ctx: &Ctx, op: &'static str) -> Option<Event> {
+    let kind = ctx
+        .registered_pid
+        .and_then(|pid| state.processes.get(&pid).map(|r| r.kind));
+    if kind == Some(ClientKind::Host) {
+        return None;
+    }
+    let v = state.bump_version();
+    Some(Event::Error {
+        code: ErrorCode::NotRegistered,
+        message: format!(
+            "{} is Host-only; caller kind={:?}",
+            op, kind
+        ),
+        fatal: false,
+        version: v,
+    })
 }
 
 /// Phase B.4 — record a host-reported window opening in the launcher's
@@ -451,9 +491,26 @@ mod tests {
         ));
     }
 
+    /// B.4 reports require a Host registration first (codex P1
+    /// PR #576). Helper to set that up so each window-mirror test
+    /// doesn't repeat the boilerplate.
+    fn register_host_and_get_ctx(state: &mut State, pid: u32) -> Ctx {
+        let _ = update(
+            state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid,
+                version: "test".into(),
+            },
+            &ctx(1),
+        );
+        ctx_with_pid(1, pid)
+    }
+
     #[test]
     fn report_window_opened_inserts_into_mirror_and_emits_event() {
         let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
         let events = update(
             &mut state,
             Command::ReportWindowOpened {
@@ -461,7 +518,7 @@ mod tests {
                 kind: WindowKind::FullInstance,
                 parent_label: None,
             },
-            &ctx(1),
+            &host_ctx,
         );
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -478,6 +535,7 @@ mod tests {
     #[test]
     fn report_window_closed_removes_from_mirror() {
         let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
         let _ = update(
             &mut state,
             Command::ReportWindowOpened {
@@ -485,7 +543,7 @@ mod tests {
                 kind: WindowKind::FullInstance,
                 parent_label: None,
             },
-            &ctx(1),
+            &host_ctx,
         );
         assert!(state.windows.contains_key("main"));
         let events = update(
@@ -493,7 +551,7 @@ mod tests {
             Command::ReportWindowClosed {
                 label: "main".into(),
             },
-            &ctx(1),
+            &host_ctx,
         );
         assert!(!state.windows.contains_key("main"));
         assert_eq!(events.len(), 1);
@@ -506,12 +564,13 @@ mod tests {
     #[test]
     fn report_window_closed_on_unknown_label_is_idempotent() {
         let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
         let events = update(
             &mut state,
             Command::ReportWindowClosed {
                 label: "ghost".into(),
             },
-            &ctx(1),
+            &host_ctx,
         );
         // Still emits an event (so subscribers stay consistent) but
         // doesn't error.
@@ -523,6 +582,7 @@ mod tests {
     #[test]
     fn subwindow_open_records_parent_label() {
         let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
         let _ = update(
             &mut state,
             Command::ReportWindowOpened {
@@ -530,7 +590,7 @@ mod tests {
                 kind: WindowKind::FullInstance,
                 parent_label: None,
             },
-            &ctx(1),
+            &host_ctx,
         );
         let _ = update(
             &mut state,
@@ -539,12 +599,60 @@ mod tests {
                 kind: WindowKind::Subwindow,
                 parent_label: Some("main".into()),
             },
-            &ctx(1),
+            &host_ctx,
         );
         assert_eq!(
             state.windows["sub-1"].parent_label.as_deref(),
             Some("main")
         );
+    }
+
+    #[test]
+    fn report_window_opened_from_non_host_is_rejected() {
+        let mut state = State::default();
+        // Register as Renderer (not Host) at PID 4321.
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Renderer,
+                pid: 4321,
+                version: "test".into(),
+            },
+            &ctx(1),
+        );
+        let events = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "spoof".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &ctx_with_pid(1, 4321),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::NotRegistered, fatal: false, .. }
+        ));
+        // Mirror NOT mutated.
+        assert!(state.windows.is_empty());
+    }
+
+    #[test]
+    fn report_window_closed_from_unregistered_conn_is_rejected() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::ReportWindowClosed {
+                label: "x".into(),
+            },
+            &ctx(1), // No Register first.
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::NotRegistered, fatal: false, .. }
+        ));
     }
 
     #[test]

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -24,7 +24,7 @@
 
 use std::collections::HashMap;
 
-use agentmux_common::ipc::ClientKind;
+use agentmux_common::ipc::{ClientKind, WindowKind};
 pub use agentmux_common::ipc::LifecyclePhase;
 
 /// Lifecycle of a single process the launcher knows about. The
@@ -60,6 +60,23 @@ pub struct ProcessRecord {
     pub version: String,
 }
 
+/// Phase B.4 read-only mirror of one host-owned window. The launcher
+/// learns about windows via `Command::ReportWindowOpened`; the host
+/// remains authoritative until B.5 flips the direction. `opened_at`
+/// is the launcher's clock at the time the report arrived (RFC3339)
+/// — useful for correlating launcher logs with host logs across
+/// version skew.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowMirror {
+    pub label: String,
+    pub kind: WindowKind,
+    /// Set only for `Subwindow`; identifies the FullInstance that
+    /// owns this window so the eventual cascade-close logic (B.5)
+    /// has the parent linkage.
+    pub parent_label: Option<String>,
+    pub opened_at: String,
+}
+
 /// Top-level launcher state. Single Arc<Mutex<State>> owned by the
 /// IPC server; passed into `update(state, cmd, conn)` for every
 /// incoming command.
@@ -69,6 +86,12 @@ pub struct State {
     /// Keyed by PID. Multiple records per PID would be a bug — the
     /// reducer enforces unique-pid on insert.
     pub processes: HashMap<u32, ProcessRecord>,
+    /// Read-only window mirror (Phase B.4). Keyed by label. Source of
+    /// truth still lives in `agentmux-cef::AppState.browsers` /
+    /// `window_meta`; this is a passive copy fed by host
+    /// `ReportWindow*` commands. B.5 inverts the dependency: host
+    /// queries this map instead of maintaining its own.
+    pub windows: HashMap<String, WindowMirror>,
     /// Monotonic counter for `Event.version`. Bumped by `bump_version()`.
     pub event_version: u64,
     /// Monotonic counter for client_id (returned in Registered events).
@@ -80,6 +103,7 @@ impl Default for State {
         Self {
             lifecycle: LifecyclePhase::Starting,
             processes: HashMap::new(),
+            windows: HashMap::new(),
             event_version: 0,
             next_client_id: 1,
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.453"
+version = "0.33.454"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.453",
+  "version": "0.33.454",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.453",
+      "version": "0.33.454",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.453",
+  "version": "0.33.454",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Per `docs/retro/phase-b-plan-2026-04-28.md` row **B.4**: launcher gains a passive, read-only mirror of host-owned windows. Host stays authoritative; mirror is fed by new `ReportWindow*` commands the host sends from its CEF lifecycle callbacks. B.5 will invert the dependency once the mirror has been validated against reality.

This is the additive half of B.4. Pool window tracking and drift detection ship as small follow-ups.

## What's in here

**Wire protocol** (`agentmux-common/src/ipc.rs`):
- `Command::ReportWindowOpened { label, kind, parent_label }` — host→launcher.
- `Command::ReportWindowClosed { label }` — host→launcher.
- `Event::WindowOpened` / `Event::WindowClosed` — broadcast so Tool clients (and eventually srv) stay in sync.
- Wire-side `WindowKind` enum mirrors `agentmux-cef::state::WindowKind` (matching snake_case serde) so launcher can deserialize without depending on the host crate.

**Launcher** (`state.rs`, `reducer.rs`, `ipc/server.rs`):
- `WindowMirror { label, kind, parent_label, opened_at }` and `State.windows: HashMap<String, WindowMirror>`.
- Pure-reducer handlers for both new commands. `ReportWindowOpened` is idempotent (overwrites); `ReportWindowClosed` is idempotent on unknown labels (still emits an event so subscribers stay consistent).
- 4 new unit tests + the proptest command generator extended with the new variants. All 15 reducer tests pass.

**Host** (`launcher_ipc.rs`, `client.rs`):
- `OnceLock<UnboundedSender<Command>>` bridges sync UI-thread callbacks to the tokio writer task. Drain task writes newline-delimited JSON.
- `report_window_opened` / `report_window_closed` no-op when launcher pipe is absent (`task dev` mode).
- Hooks added in `on_after_created` and `on_before_close` for top-level windows. Browser panes and pool windows are skipped; pool→user transitions will be a follow-up.

## What's NOT in here

- **Pool window tracking** — pool spawn/promote events are their own report types; out of scope here so B.4 stays small + reviewable.
- **Drift detection** — comparing host `browsers.len()` to mirror size needs a query event; follow-up.
- **Migration** — host still owns `browsers` / `window_meta` / `window_id_map`. B.5 starts deleting those once the mirror is trusted.

## Test plan

- [x] `cargo check -p agentmux-launcher -p agentmux-common` passes.
- [x] `cargo test -p agentmux-launcher --bin agentmux-launcher reducer` passes (15 tests, including 4 new B.4 tests + the extended proptest).
- [ ] CI: workspace check + tests on the merge ref.
- [ ] Smoke test: open a tear-off subwindow in the portable build, verify launcher log shows `WindowOpened` for both the parent and child labels with correct `kind` / `parent_label`. Close → `WindowClosed` for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)