### PR TITLE
feat: B.4 follow-up — launcher pool inventory tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.454"
+version = "0.33.455"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.454"
+version = "0.33.455"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.454"
+version = "0.33.455"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.454"
+version = "0.33.455"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.454"
+version = "0.33.455"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -329,10 +329,15 @@ impl AgentMuxHandler {
             if lbl.starts_with("window-pool-") {
                 crate::commands::window_pool::on_pool_window_destroyed(&self.state, lbl);
             }
-            // Phase B.4 — mirror the close to the launcher. Symmetric
-            // with the open-report in on_after_created: only top-level
-            // user-visible windows. No-op if launcher IPC absent.
-            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
+            // Phase B.4 — mirror the close to the launcher. Skip
+            // browser-pane child HWNDs only. Pool labels are NOT
+            // skipped here: a promoted pool window keeps its
+            // `window-pool-*` label and needs its close reflected;
+            // pre-promote destroys harmlessly hit the launcher's
+            // idempotent unknown-label path. Pool inventory updates
+            // travel via `ReportPoolWindowRemoved` from
+            // `on_pool_window_destroyed` and `promote_pool_window`.
+            if !lbl.starts_with("browser-pane-") {
                 crate::launcher_ipc::report_window_closed(lbl.clone());
             }
         }

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -319,17 +319,6 @@ impl AgentMuxHandler {
         // Pane-specific on_before_close work (drain lifecycle entry) lives
         // in `crate::pane::callbacks` after Phase 4.
         if let Some(ref lbl) = label {
-            // Snapshot pool-promotion state BEFORE pool callbacks
-            // mutate it so the close-report decision below uses the
-            // pre-callback membership. (codex P2 PR #577 round-1 —
-            // a `window-pool-*` label still in `unpromoted_pool_labels`
-            // means it crashed before promote and never got a
-            // matching `ReportWindowOpened`; emitting `WindowClosed`
-            // for it would break subscribers that assume open/close
-            // pairing.)
-            let was_unpromoted_pool = lbl.starts_with("window-pool-")
-                && self.state.unpromoted_pool_labels.lock().contains(lbl);
-
             if lbl.starts_with("browser-pane-") {
                 crate::pane::callbacks::on_before_close_pane(&self.state, lbl);
             }
@@ -340,14 +329,17 @@ impl AgentMuxHandler {
             if lbl.starts_with("window-pool-") {
                 crate::commands::window_pool::on_pool_window_destroyed(&self.state, lbl);
             }
-            // Phase B.4 — mirror the close to the launcher. Skip:
-            //   * browser-pane child HWNDs (never reported as open).
-            //   * unpromoted pool windows (pool inventory only —
-            //     close goes via ReportPoolWindowRemoved from
-            //     on_pool_window_destroyed). Promoted pool windows
-            //     retain `window-pool-*` labels and DO need close
-            //     reported here; the snapshot above gates correctly.
-            if !lbl.starts_with("browser-pane-") && !was_unpromoted_pool {
+            // Phase B.4 — mirror the close to the launcher. Skip
+            // browser-pane child HWNDs (never reported as open).
+            // For everything else, send unconditionally: the launcher
+            // reducer silently no-ops on unknown labels (codex P2
+            // PR #577 round-2 made `WindowClosed` strictly paired
+            // with `WindowOpened`), so pre-promote pool deaths and
+            // post-pop / pre-validation orphans are filtered there
+            // — no host-side guard needed. Pool inventory updates
+            // travel via `ReportPoolWindowRemoved` from
+            // `on_pool_window_destroyed` and `promote_pool_window`.
+            if !lbl.starts_with("browser-pane-") {
                 crate::launcher_ipc::report_window_closed(lbl.clone());
             }
         }

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -319,6 +319,17 @@ impl AgentMuxHandler {
         // Pane-specific on_before_close work (drain lifecycle entry) lives
         // in `crate::pane::callbacks` after Phase 4.
         if let Some(ref lbl) = label {
+            // Snapshot pool-promotion state BEFORE pool callbacks
+            // mutate it so the close-report decision below uses the
+            // pre-callback membership. (codex P2 PR #577 round-1 —
+            // a `window-pool-*` label still in `unpromoted_pool_labels`
+            // means it crashed before promote and never got a
+            // matching `ReportWindowOpened`; emitting `WindowClosed`
+            // for it would break subscribers that assume open/close
+            // pairing.)
+            let was_unpromoted_pool = lbl.starts_with("window-pool-")
+                && self.state.unpromoted_pool_labels.lock().contains(lbl);
+
             if lbl.starts_with("browser-pane-") {
                 crate::pane::callbacks::on_before_close_pane(&self.state, lbl);
             }
@@ -329,15 +340,14 @@ impl AgentMuxHandler {
             if lbl.starts_with("window-pool-") {
                 crate::commands::window_pool::on_pool_window_destroyed(&self.state, lbl);
             }
-            // Phase B.4 — mirror the close to the launcher. Skip
-            // browser-pane child HWNDs only. Pool labels are NOT
-            // skipped here: a promoted pool window keeps its
-            // `window-pool-*` label and needs its close reflected;
-            // pre-promote destroys harmlessly hit the launcher's
-            // idempotent unknown-label path. Pool inventory updates
-            // travel via `ReportPoolWindowRemoved` from
-            // `on_pool_window_destroyed` and `promote_pool_window`.
-            if !lbl.starts_with("browser-pane-") {
+            // Phase B.4 — mirror the close to the launcher. Skip:
+            //   * browser-pane child HWNDs (never reported as open).
+            //   * unpromoted pool windows (pool inventory only —
+            //     close goes via ReportPoolWindowRemoved from
+            //     on_pool_window_destroyed). Promoted pool windows
+            //     retain `window-pool-*` labels and DO need close
+            //     reported here; the snapshot above gates correctly.
+            if !lbl.starts_with("browser-pane-") && !was_unpromoted_pool {
                 crate::launcher_ipc::report_window_closed(lbl.clone());
             }
         }

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -87,6 +87,11 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
         .lock()
         .insert(label.clone());
 
+    // Phase B.4 follow-up — mirror the pool inventory in the launcher.
+    // Symmetric with the destroy/promote hooks below; a missing
+    // launcher pipe makes this a no-op.
+    crate::launcher_ipc::report_pool_window_added(label.clone());
+
     let ipc_port = *state.ipc_port.lock();
     let ipc_token = &state.ipc_token;
     let base_url = super::window::resolve_frontend_base_url(ipc_port);
@@ -251,6 +256,11 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     // pool. Independent of whether the window made it into the
     // queue (renderer crash before ready signal) or not.
     state.unpromoted_pool_labels.lock().remove(label);
+
+    // Phase B.4 follow-up — pool inventory shrunk. Idempotent in
+    // the launcher reducer so calling this for a label the launcher
+    // never saw (post-promote close path) is safe.
+    crate::launcher_ipc::report_pool_window_removed(label.to_string());
     // Single lock: drop the dead label + check whether we need to
     // refill, all in one critical section.
     let needs_refill = {
@@ -357,6 +367,18 @@ pub fn promote_pool_window(
     // The label is no longer "unpromoted" — drop it from the intent
     // set so list_windows starts treating this as a real instance.
     state.unpromoted_pool_labels.lock().remove(&label);
+
+    // Phase B.4 follow-up — atomic pool→windows transition in the
+    // launcher mirror. Removing from pool first, then opening as
+    // FullInstance preserves the invariant that a label is in
+    // exactly one of `state.pool` / `state.windows` at any moment
+    // (modulo the one-event window between the two reports).
+    crate::launcher_ipc::report_pool_window_removed(label.clone());
+    crate::launcher_ipc::report_window_opened(
+        label.clone(),
+        agentmux_common::ipc::WindowKind::FullInstance,
+        None,
+    );
 
     tracing::info!(
         target: "dnd:tearoff:pool",

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -368,17 +368,14 @@ pub fn promote_pool_window(
     // set so list_windows starts treating this as a real instance.
     state.unpromoted_pool_labels.lock().remove(&label);
 
-    // Phase B.4 follow-up — atomic pool→windows transition in the
-    // launcher mirror. Removing from pool first, then opening as
-    // FullInstance preserves the invariant that a label is in
-    // exactly one of `state.pool` / `state.windows` at any moment
-    // (modulo the one-event window between the two reports).
+    // Phase B.4 follow-up — pool inventory shrinks unconditionally on
+    // pop. The user-visible WindowOpened report is deferred until
+    // after HWND validation succeeds (codex P1 PR #577 round-1):
+    // emitting it before validation would record a `WindowOpened`
+    // for a label that may never become a real visible window in
+    // the failure path (HWND lookup returns None, function early-
+    // returns after refill), permanently desyncing the mirror.
     crate::launcher_ipc::report_pool_window_removed(label.clone());
-    crate::launcher_ipc::report_window_opened(
-        label.clone(),
-        agentmux_common::ipc::WindowKind::FullInstance,
-        None,
-    );
 
     tracing::info!(
         target: "dnd:tearoff:pool",
@@ -445,6 +442,16 @@ pub fn promote_pool_window(
             return None;
         }
     };
+
+    // HWND validated — the label IS becoming a real user-visible
+    // window. NOW report the open to the launcher mirror so a
+    // failure path above can't leave the mirror with a phantom
+    // entry. (codex P1 PR #577 round-1.)
+    crate::launcher_ipc::report_window_opened(
+        label.clone(),
+        agentmux_common::ipc::WindowKind::FullInstance,
+        None,
+    );
 
     // Compute position outside the unsafe block — these are pure
     // arithmetic, no FFI needed. Don't clamp with .max(0): Windows'

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -263,3 +263,30 @@ pub fn report_window_closed(label: String) {
         tracing::warn!("[launcher-ipc] report_window_closed: channel closed ({})", e);
     }
 }
+
+/// Phase B.4 follow-up — sync API: report a pool window being added
+/// to the warm pool inventory. Called from `spawn_pool_window` on
+/// the UI thread. No-op when launcher pipe is absent.
+pub fn report_pool_window_added(label: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportPoolWindowAdded { label };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_pool_window_added: channel closed ({})", e);
+    }
+}
+
+/// Phase B.4 follow-up — sync API: report a pool window leaving the
+/// pool (promote, destroy). On promote callers should also call
+/// `report_window_opened` so the label transitions atomically (from
+/// the launcher's perspective) from `pool` to `windows`.
+pub fn report_pool_window_removed(label: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportPoolWindowRemoved { label };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_pool_window_removed: channel closed ({})", e);
+    }
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.454"
+version = "0.33.455"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -85,6 +85,20 @@ pub enum Command {
     ReportWindowClosed {
         label: String,
     },
+    /// Phase B.4 follow-up — host reports a pre-warmed pool window
+    /// being added (`spawn_pool_window`). Pool windows live in a
+    /// SEPARATE map from the user-visible window mirror; the host
+    /// transitions them out of the pool with `ReportPoolWindowRemoved`
+    /// + `ReportWindowOpened` on promote, or just
+    /// `ReportPoolWindowRemoved` on pre-promote destroy.
+    ReportPoolWindowAdded {
+        label: String,
+    },
+    /// Phase B.4 follow-up — host reports a pool window leaving the
+    /// pool (promote, destroy, or app exit).
+    ReportPoolWindowRemoved {
+        label: String,
+    },
 }
 
 /// Wire-side enum for `WindowKind`. Mirrors `agentmux-cef::state::WindowKind`
@@ -176,6 +190,17 @@ pub enum Event {
     /// the host emits one ReportWindowClosed per window even on
     /// cascade closes, so subscribers see the same N events.
     WindowClosed {
+        label: String,
+        version: u64,
+    },
+    /// Phase B.4 follow-up — pool inventory transitioned. Emitted in
+    /// response to `ReportPoolWindow{Added,Removed}`. Subscribers
+    /// (Tool clients) use this to track pool warmth without polling.
+    PoolWindowAdded {
+        label: String,
+        version: u64,
+    },
+    PoolWindowRemoved {
         label: String,
         version: u64,
     },

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.454"
+version = "0.33.455"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -330,6 +330,12 @@ async fn enforce_register_first(
         Command::ReportWindowClosed { .. } => {
             ("ReportWindowClosed before Register".to_string(), true)
         }
+        Command::ReportPoolWindowAdded { .. } => {
+            ("ReportPoolWindowAdded before Register".to_string(), true)
+        }
+        Command::ReportPoolWindowRemoved { .. } => {
+            ("ReportPoolWindowRemoved before Register".to_string(), true)
+        }
     };
     let mut state = ctx.state.lock().await;
     let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -191,19 +191,23 @@ fn handle_report_window_opened(
     }]
 }
 
-/// Phase B.4 — drop a host-reported window from the mirror. Missing
-/// label is logged-only (no Error event) because the close-before-
-/// launcher-saw-the-open race is benign in B.4: the launcher's mirror
-/// is a passive copy, and the host's authoritative view will simply
-/// not have the window either. B.5 will tighten this contract.
+/// Phase B.4 — drop a host-reported window from the mirror. Returns
+/// `Event::WindowClosed` only when the label was actually in the
+/// mirror; an unknown-label close is a silent no-op (codex P2 PR
+/// #577 round-2). Without this gate, a `ReportWindowClosed` for a
+/// label the launcher never saw (e.g. a pool window that was popped
+/// from the queue but failed HWND validation in
+/// `promote_pool_window` — the orphan window's eventual
+/// `on_before_close` reaches us without a matching open) would
+/// emit an unpaired `WindowClosed` broadcast and break subscribers
+/// that assume open/close pairing.
 fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
     let was_present = state.windows.remove(&label).is_some();
-    let v = state.bump_version();
     if !was_present {
-        // Quiet: B.4 is read-only and the mirror can race with the
-        // host's authoritative store on first launch. We still emit
-        // the Closed event so subscribers stay consistent.
+        // Silent: only emit when the close pairs with a known open.
+        return vec![];
     }
+    let v = state.bump_version();
     vec![Event::WindowClosed { label, version: v }]
 }
 
@@ -594,7 +598,7 @@ mod tests {
     }
 
     #[test]
-    fn report_window_closed_on_unknown_label_is_idempotent() {
+    fn report_window_closed_on_unknown_label_is_silent_no_op() {
         let mut state = State::default();
         let host_ctx = register_host_and_get_ctx(&mut state, 1234);
         let events = update(
@@ -604,10 +608,10 @@ mod tests {
             },
             &host_ctx,
         );
-        // Still emits an event (so subscribers stay consistent) but
-        // doesn't error.
-        assert_eq!(events.len(), 1);
-        assert!(matches!(events[0], Event::WindowClosed { .. }));
+        // Codex P2 PR #577 round-2: NO broadcast for unknown labels.
+        // Pairs strictly with WindowOpened so subscribers can rely on
+        // open/close pairing.
+        assert_eq!(events.len(), 0);
         assert!(state.windows.is_empty());
     }
 

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -98,7 +98,37 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }
             handle_report_window_closed(state, label)
         }
+        Command::ReportPoolWindowAdded { label } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
+                return vec![err];
+            }
+            handle_report_pool_window_added(state, label)
+        }
+        Command::ReportPoolWindowRemoved { label } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowRemoved") {
+                return vec![err];
+            }
+            handle_report_pool_window_removed(state, label)
+        }
     }
+}
+
+/// Phase B.4 follow-up — record pool inventory growth. Idempotent
+/// on duplicate labels (HashSet semantics) but the event still fires
+/// so subscribers can track add-attempts even if redundant.
+fn handle_report_pool_window_added(state: &mut State, label: String) -> Vec<Event> {
+    state.pool.insert(label.clone());
+    let v = state.bump_version();
+    vec![Event::PoolWindowAdded { label, version: v }]
+}
+
+/// Phase B.4 follow-up — record pool inventory shrink (promote or
+/// destroy). Idempotent on unknown labels for the same reason
+/// `ReportWindowClosed` is: the host might race the launcher.
+fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
+    state.pool.remove(&label);
+    let v = state.bump_version();
+    vec![Event::PoolWindowRemoved { label, version: v }]
 }
 
 /// Phase B.4 — gate window-mirror reports to Host clients only. The
@@ -438,6 +468,8 @@ mod tests {
             | Event::Pong { version, .. }
             | Event::WindowOpened { version, .. }
             | Event::WindowClosed { version, .. }
+            | Event::PoolWindowAdded { version, .. }
+            | Event::PoolWindowRemoved { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -605,6 +637,100 @@ mod tests {
             state.windows["sub-1"].parent_label.as_deref(),
             Some("main")
         );
+    }
+
+    #[test]
+    fn report_pool_window_add_and_remove_round_trip() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let events = update(
+            &mut state,
+            Command::ReportPoolWindowAdded {
+                label: "window-pool-abc".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::PoolWindowAdded { label, .. } if label == "window-pool-abc"
+        ));
+        assert!(state.pool.contains("window-pool-abc"));
+
+        let events = update(
+            &mut state,
+            Command::ReportPoolWindowRemoved {
+                label: "window-pool-abc".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::PoolWindowRemoved { label, .. } if label == "window-pool-abc"
+        ));
+        assert!(!state.pool.contains("window-pool-abc"));
+    }
+
+    #[test]
+    fn pool_and_window_mirrors_are_independent() {
+        // The host transitions a pool window to a real window via
+        // (PoolRemoved, WindowOpened). Verify the launcher can hold
+        // both maps without collision and an entry can be in pool
+        // OR windows but not both.
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let _ = update(
+            &mut state,
+            Command::ReportPoolWindowAdded {
+                label: "window-pool-xyz".into(),
+            },
+            &host_ctx,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportPoolWindowRemoved {
+                label: "window-pool-xyz".into(),
+            },
+            &host_ctx,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "window-pool-xyz".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &host_ctx,
+        );
+        assert!(!state.pool.contains("window-pool-xyz"));
+        assert!(state.windows.contains_key("window-pool-xyz"));
+    }
+
+    #[test]
+    fn pool_commands_from_non_host_are_rejected() {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Tool,
+                pid: 9999,
+                version: "test".into(),
+            },
+            &ctx(1),
+        );
+        let events = update(
+            &mut state,
+            Command::ReportPoolWindowAdded {
+                label: "spoof-pool".into(),
+            },
+            &ctx_with_pid(1, 9999),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::NotRegistered, .. }
+        ));
+        assert!(state.pool.is_empty());
     }
 
     #[test]

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -123,10 +123,18 @@ fn handle_report_pool_window_added(state: &mut State, label: String) -> Vec<Even
 }
 
 /// Phase B.4 follow-up — record pool inventory shrink (promote or
-/// destroy). Idempotent on unknown labels for the same reason
-/// `ReportWindowClosed` is: the host might race the launcher.
+/// destroy). Strictly paired with `ReportPoolWindowAdded`: an
+/// unknown-label remove is a silent no-op so subscribers can rely
+/// on add/remove pairing in the broadcast stream. Same gate as
+/// `handle_report_window_closed`. (reagent P2 PR #577 round-3 —
+/// the original "idempotent" comment referenced behavior that was
+/// already removed for `ReportWindowClosed`; pool semantics now
+/// match.)
 fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
-    state.pool.remove(&label);
+    let was_present = state.pool.remove(&label);
+    if !was_present {
+        return vec![];
+    }
     let v = state.bump_version();
     vec![Event::PoolWindowRemoved { label, version: v }]
 }
@@ -709,6 +717,23 @@ mod tests {
         );
         assert!(!state.pool.contains("window-pool-xyz"));
         assert!(state.windows.contains_key("window-pool-xyz"));
+    }
+
+    #[test]
+    fn report_pool_window_removed_on_unknown_label_is_silent_no_op() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let events = update(
+            &mut state,
+            Command::ReportPoolWindowRemoved {
+                label: "ghost-pool".into(),
+            },
+            &host_ctx,
+        );
+        // Strict pairing — pool remove only emits an event when the
+        // label was in the pool. (reagent P2 PR #577 round-3.)
+        assert_eq!(events.len(), 0);
+        assert!(state.pool.is_empty());
     }
 
     #[test]

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -22,7 +22,7 @@
 //   * Event log ring buffer (B.4 — added when events first start
 //     accumulating beyond handshake replies)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use agentmux_common::ipc::{ClientKind, WindowKind};
 pub use agentmux_common::ipc::LifecyclePhase;
@@ -92,6 +92,14 @@ pub struct State {
     /// `ReportWindow*` commands. B.5 inverts the dependency: host
     /// queries this map instead of maintaining its own.
     pub windows: HashMap<String, WindowMirror>,
+    /// Phase B.4 follow-up — pre-warmed pool inventory. Tracked
+    /// separately from `windows` because pool entries are not
+    /// user-visible until promote. On promote the host emits
+    /// `ReportPoolWindowRemoved` + `ReportWindowOpened` so the same
+    /// label transitions atomically (from launcher's perspective)
+    /// from `pool` to `windows`. On pre-promote destroy: only
+    /// `ReportPoolWindowRemoved`.
+    pub pool: HashSet<String>,
     /// Monotonic counter for `Event.version`. Bumped by `bump_version()`.
     pub event_version: u64,
     /// Monotonic counter for client_id (returned in Registered events).
@@ -104,6 +112,7 @@ impl Default for State {
             lifecycle: LifecyclePhase::Starting,
             processes: HashMap::new(),
             windows: HashMap::new(),
+            pool: HashSet::new(),
             event_version: 0,
             next_client_id: 1,
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.454"
+version = "0.33.455"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.454",
+  "version": "0.33.455",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.454",
+      "version": "0.33.455",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.454",
+  "version": "0.33.455",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

B.4 follow-up: extend the read-only launcher state mirror to track the warm-pool inventory alongside user-visible windows. Pool entries live in a separate map from `state.windows` because they're not user-visible until promote — promote then becomes an atomic `(ReportPoolWindowRemoved, ReportWindowOpened)` pair so the same label transitions from `pool` to `windows`.

Foundation for B.5's authoritative cut-over (the launcher will eventually own the canonical pool state and host will query it).

## What's in here

**Wire** (`agentmux-common/src/ipc.rs`):
- `Command::ReportPoolWindowAdded { label }` — host→launcher.
- `Command::ReportPoolWindowRemoved { label }` — host→launcher.
- `Event::PoolWindowAdded` / `Event::PoolWindowRemoved` — broadcasts.

**Launcher** (`state.rs`, `reducer.rs`, `ipc/server.rs`):
- `State.pool: HashSet<String>` — separate from `windows`.
- Reducer handlers gated by existing `enforce_host_only`.
- `enforce_register_first` extended to handle the new variants (fatal-close on pre-Register pool reports).
- 3 new unit tests; 21 reducer tests pass total.

**Host** (`launcher_ipc.rs`, `commands/window_pool.rs`, `client.rs`):
- `report_pool_window_added` / `report_pool_window_removed` sync helpers.
- Hooks in `spawn_pool_window` (add), `on_pool_window_destroyed` (remove), and `promote_pool_window` (atomic remove + open as `FullInstance`).
- `on_before_close`: dropped the `window-pool-*` filter from the close-report path so promoted pool windows (which retain their `window-pool-*` label) get their close mirrored. Pre-promote destroys hit the launcher's idempotent unknown-label path.

## What's NOT in here

- **Drift detection** — comparing host's pool/browsers state against launcher mirror via a query event; separate small follow-up.
- **B.5 inversion** — host still owns the canonical pool state. This PR just extends the read-only mirror.

## Test plan

- [x] `cargo check -p agentmux-launcher -p agentmux-common` passes.
- [x] `cargo test -p agentmux-launcher --bin agentmux-launcher reducer` — 21 tests pass.
- [ ] CI workspace check + tests on the merge ref.
- [ ] Smoke test: open + tear off in portable build, confirm launcher log shows the pool add at startup, then `(PoolWindowRemoved, WindowOpened)` on tear-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)