### PR TITLE
feat: B.5a — launcher-authoritative window instance registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.456"
+version = "0.33.457"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.456"
+version = "0.33.457"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.456"
+version = "0.33.457"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.456"
+version = "0.33.457"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.456"
+version = "0.33.457"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.456"
+version = "0.33.457"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -246,6 +246,26 @@ pub enum Event {
         label: String,
         version: u64,
     },
+    /// Phase B.5 — sequential instance number assigned to a window
+    /// by the launcher's authoritative registry. Numbers start at 1
+    /// for "main" and increment for each subsequent open. Never
+    /// reused within a launcher run. The host caches these to
+    /// display window titles; B.5 step 2 will retire host's own
+    /// `WindowInstanceRegistry` in favor of this stream.
+    WindowInstanceAssigned {
+        label: String,
+        num: u32,
+        version: u64,
+    },
+    /// Phase B.5 — instance number released (window closed). The
+    /// launcher's authoritative registry drops the label; the slot
+    /// is NOT reused (numbers monotonic per spec invariant: stable
+    /// instance# across promotions / unregisters).
+    WindowInstanceReleased {
+        label: String,
+        num: u32,
+        version: u64,
+    },
     /// Phase B.4 follow-up — emitted when the launcher's mirror
     /// disagrees with the host's reported counts. Logged at WARN
     /// level so operators see drift immediately. Drift in B.4 is

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.456"
+version = "0.33.457"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -237,6 +237,12 @@ fn enforce_host_only(state: &mut State, ctx: &Ctx, op: &'static str) -> Option<E
 /// in a row): the second insert overwrites with fresh metadata and
 /// emits a fresh event. Subscribers must tolerate seeing the same
 /// label twice; cleaner once B.5 makes the launcher authoritative.
+///
+/// Phase B.5: also assigns an authoritative instance number from
+/// `state.instance_registry` and emits `WindowInstanceAssigned`.
+/// "main" is pre-seeded with 1; other labels get the next value of
+/// `next_instance_num`. Re-opens of an existing label preserve the
+/// original number — instance numbers are stable per-label-per-run.
 fn handle_report_window_opened(
     state: &mut State,
     ctx: &Ctx,
@@ -253,13 +259,30 @@ fn handle_report_window_opened(
             opened_at: ctx.now_rfc3339.clone(),
         },
     );
+    let mut out = Vec::with_capacity(2);
     let v = state.bump_version();
-    vec![Event::WindowOpened {
-        label,
+    out.push(Event::WindowOpened {
+        label: label.clone(),
         kind,
         parent_label,
         version: v,
-    }]
+    });
+
+    // Assign instance number if this label isn't already in the
+    // registry. Re-opens of an existing label keep the original
+    // number — matches host's `WindowInstanceRegistry` semantics
+    // where a label is only registered once per session.
+    let num = if let Some(existing) = state.instance_registry.get(&label).copied() {
+        existing
+    } else {
+        let n = state.next_instance_num;
+        state.instance_registry.insert(label.clone(), n);
+        state.next_instance_num += 1;
+        n
+    };
+    let v = state.bump_version();
+    out.push(Event::WindowInstanceAssigned { label, num, version: v });
+    out
 }
 
 /// Phase B.4 — drop a host-reported window from the mirror. Returns
@@ -272,14 +295,28 @@ fn handle_report_window_opened(
 /// `on_before_close` reaches us without a matching open) would
 /// emit an unpaired `WindowClosed` broadcast and break subscribers
 /// that assume open/close pairing.
+///
+/// Phase B.5 — also drops the label from `instance_registry` and
+/// emits `WindowInstanceReleased` if a number was assigned.
+/// `next_instance_num` is NOT decremented — instance numbers are
+/// monotonic per-launcher-run.
 fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
     let was_present = state.windows.remove(&label).is_some();
     if !was_present {
         // Silent: only emit when the close pairs with a known open.
         return vec![];
     }
+    let mut out = Vec::with_capacity(2);
     let v = state.bump_version();
-    vec![Event::WindowClosed { label, version: v }]
+    out.push(Event::WindowClosed {
+        label: label.clone(),
+        version: v,
+    });
+    if let Some(num) = state.instance_registry.remove(&label) {
+        let v = state.bump_version();
+        out.push(Event::WindowInstanceReleased { label, num, version: v });
+    }
+    out
 }
 
 fn handle_register(
@@ -545,6 +582,8 @@ mod tests {
             | Event::WindowClosed { version, .. }
             | Event::PoolWindowAdded { version, .. }
             | Event::PoolWindowRemoved { version, .. }
+            | Event::WindowInstanceAssigned { version, .. }
+            | Event::WindowInstanceReleased { version, .. }
             | Event::DriftDetected { version, .. }
             | Event::Error { version, .. } => *version,
         }
@@ -628,11 +667,16 @@ mod tests {
             },
             &host_ctx,
         );
-        assert_eq!(events.len(), 1);
+        // B.5 — open emits WindowOpened + WindowInstanceAssigned.
+        assert_eq!(events.len(), 2);
         assert!(matches!(
             &events[0],
             Event::WindowOpened { label, kind: WindowKind::FullInstance, parent_label: None, .. }
                 if label == "main"
+        ));
+        assert!(matches!(
+            &events[1],
+            Event::WindowInstanceAssigned { label, num: 1, .. } if label == "main"
         ));
         let mirror = &state.windows["main"];
         assert_eq!(mirror.label, "main");
@@ -662,11 +706,93 @@ mod tests {
             &host_ctx,
         );
         assert!(!state.windows.contains_key("main"));
-        assert_eq!(events.len(), 1);
+        // B.5 — close emits WindowClosed + WindowInstanceReleased.
+        assert_eq!(events.len(), 2);
         assert!(matches!(
             &events[0],
             Event::WindowClosed { label, .. } if label == "main"
         ));
+        assert!(matches!(
+            &events[1],
+            Event::WindowInstanceReleased { label, num: 1, .. } if label == "main"
+        ));
+    }
+
+    #[test]
+    fn instance_numbers_are_monotonic_per_launcher_run() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        // main pre-seeded as 1 (already in instance_registry from Default).
+        // Open second window → gets 2.
+        let events = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "window-2".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &host_ctx,
+        );
+        let assigned = events.iter().find_map(|e| match e {
+            Event::WindowInstanceAssigned { num, .. } => Some(*num),
+            _ => None,
+        });
+        assert_eq!(assigned, Some(2));
+
+        // Close it. Open a third window → gets 3 (NOT reused 2).
+        let _ = update(
+            &mut state,
+            Command::ReportWindowClosed {
+                label: "window-2".into(),
+            },
+            &host_ctx,
+        );
+        let events = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "window-3".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &host_ctx,
+        );
+        let assigned = events.iter().find_map(|e| match e {
+            Event::WindowInstanceAssigned { num, .. } => Some(*num),
+            _ => None,
+        });
+        assert_eq!(assigned, Some(3), "instance numbers must not be reused");
+    }
+
+    #[test]
+    fn re_open_of_same_label_keeps_original_instance_number() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "x".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &host_ctx,
+        );
+        let first_num = state.instance_registry["x"];
+        // Re-open without close (B.4 idempotent overwrite path).
+        let events = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "x".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &host_ctx,
+        );
+        let assigned = events.iter().find_map(|e| match e {
+            Event::WindowInstanceAssigned { num, .. } => Some(*num),
+            _ => None,
+        });
+        assert_eq!(assigned, Some(first_num));
+        assert_eq!(state.instance_registry["x"], first_num);
     }
 
     #[test]

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -100,6 +100,20 @@ pub struct State {
     /// from `pool` to `windows`. On pre-promote destroy: only
     /// `ReportPoolWindowRemoved`.
     pub pool: HashSet<String>,
+    /// Phase B.5 — authoritative window instance registry. Maps
+    /// label → sequential instance number (1 for "main", 2 for the
+    /// second window opened, etc.). Numbers are never reused within
+    /// a launcher run — when a window closes the entry is removed
+    /// but `next_instance_num` keeps advancing. Replaces the host's
+    /// `agentmux-cef::state::WindowInstanceRegistry` (host still
+    /// maintains its own copy in B.5a; B.5b retires it). Updated by
+    /// the same reducer paths that mutate `windows`.
+    pub instance_registry: HashMap<String, u32>,
+    /// Next instance number to assign. Starts at 2 — "main" is
+    /// pre-seeded with 1 in `Default` (matching host's
+    /// `WindowInstanceRegistry::new` behavior so a synthetic main
+    /// open wouldn't collide).
+    pub next_instance_num: u32,
     /// Monotonic counter for `Event.version`. Bumped by `bump_version()`.
     pub event_version: u64,
     /// Monotonic counter for client_id (returned in Registered events).
@@ -113,6 +127,12 @@ impl Default for State {
             processes: HashMap::new(),
             windows: HashMap::new(),
             pool: HashSet::new(),
+            instance_registry: {
+                let mut m = HashMap::new();
+                m.insert("main".to_string(), 1);
+                m
+            },
+            next_instance_num: 2,
             event_version: 0,
             next_client_id: 1,
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.456"
+version = "0.33.457"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.456",
+  "version": "0.33.457",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.456",
+      "version": "0.33.457",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.456",
+  "version": "0.33.457",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First step of B.5: launcher gains its own authoritative `instance_registry` that runs in parallel to the host's existing `WindowInstanceRegistry`. Pure addition — no host behavior change. B.5b will cut the host over to consume the launcher's events; B.5c removes the host's copy.

Smallest map first per the B.5 plan order (window_instance_registry → window_meta → browsers → window_id_map → window_pool + unpromoted_pool_labels).

## What's in here

**Wire** (`agentmux-common/src/ipc.rs`):
- `Event::WindowInstanceAssigned { label, num, version }` — emitted alongside `WindowOpened`.
- `Event::WindowInstanceReleased { label, num, version }` — emitted alongside `WindowClosed`.

**Launcher** (`state.rs`, `reducer.rs`):
- `State.instance_registry: HashMap<String, u32>` (pre-seeded with `{\"main\": 1}`).
- `State.next_instance_num: u32` (starts at 2; never decrements).
- `handle_report_window_opened`: assigns number, emits `WindowInstanceAssigned`. Re-opens of an existing label preserve the original number.
- `handle_report_window_closed`: removes from registry, emits `WindowInstanceReleased`.
- 4 reducer tests added/updated; 31 tests pass total.

## What's NOT in here

- Host changes — host still has its own `WindowInstanceRegistry`. B.5b cuts host over to consume launcher events; B.5c deletes the host copy.

## Test plan

- [x] `cargo test -p agentmux-launcher --bin agentmux-launcher reducer` — 31 tests pass (4 new for B.5a).
- [ ] CI workspace check + tests on the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)