### PR TITLE
feat: B.5b — host shadow instance registry from launcher events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.457"
+version = "0.33.458"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.457"
+version = "0.33.458"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.457"
+version = "0.33.458"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.457"
+version = "0.33.458"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.457"
+version = "0.33.458"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -272,21 +272,22 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
         Event::WindowInstanceReleased { label, num, .. } => {
             // Symmetric drift check: launcher just released the
             // label, so host's authoritative registry SHOULD also
-            // not contain it. If host still has it, that's a
-            // host-side unregister bug (wrong label removed, or
-            // never removed) — log so we can catch it before
-            // B.5c cutover. (codex P2 PR #580 round-1.)
+            // not contain it. Two cases produce different signals:
             //
-            // Race-tolerant: host's local `unregister()` may not
-            // have run yet (the launcher might emit Released
-            // before the host's own close-path code reaches the
-            // unregister call). We log only the SUSTAINED case —
-            // see the next sentence — so transient ordering doesn't
-            // produce noise. Specifically: if host still has a
-            // DIFFERENT number for this label than the launcher
-            // released, that's actual drift (split-brain on the
-            // assignment); if host has the same number, we treat
-            // it as the benign "host hasn't unregistered yet" race.
+            // * host_num != launcher_num → split-brain on the
+            //   original assignment. Always a bug.
+            // * host_num == launcher_num → either (a) benign race
+            //   (host's local `unregister()` hasn't run yet — the
+            //   launcher's Released event raced ahead of the host's
+            //   own close-path code), OR (b) host-side unregister
+            //   bug (entry never removed). We can't distinguish at
+            //   the moment of this event, so we log it at INFO to
+            //   surface it without flooding WARN. The race resolves
+            //   on the host's next register/unregister cycle; a
+            //   true bug will sustain across events. (codex P2
+            //   PR #580 round-2 — original round-1 fix suppressed
+            //   the same-num case entirely, which silenced real
+            //   unregister bugs forever.)
             let host_num = state.window_instance_registry.lock().get(label);
             if let Some(host_num) = host_num {
                 if host_num != *num {
@@ -295,7 +296,14 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                         label = %label,
                         launcher_released_num = %num,
                         host_num = %host_num,
-                        "[launcher-ipc] release-side instance# drift: host has a different number than the launcher released"
+                        "[launcher-ipc] release-side instance# split-brain: host has a different number than the launcher released"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        num = %num,
+                        "[launcher-ipc] release-side: host still has matching entry after launcher Released — race or unregister bug; sustained presence indicates bug"
                     );
                 }
             }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -72,7 +72,9 @@ pub struct LauncherIpcHandle;
 /// Phase B.5+ will tighten this when the host actually depends on
 /// IPC for state.
 #[cfg(target_os = "windows")]
-pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
+pub async fn connect_to_launcher(
+    state: std::sync::Arc<crate::state::AppState>,
+) -> Option<LauncherIpcHandle> {
     let pipe_path = match std::env::var("AGENTMUX_LAUNCHER_PIPE") {
         Ok(p) if !p.is_empty() => p,
         _ => {
@@ -184,8 +186,14 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
         }
     });
 
-    // Spawn a read-loop task. For B.2 it just logs every Event the
-    // server sends; B.3+ will dispatch them into host state.
+    // Spawn a read-loop task. Logs every event and (B.5b) feeds the
+    // instance-number shadow registry from the launcher's
+    // authoritative `WindowInstanceAssigned` / `WindowInstanceReleased`
+    // stream. The shadow runs in parallel to the host's existing
+    // `WindowInstanceRegistry`; on each event we compare the two and
+    // log drift. B.5c will swap roles — launcher becomes
+    // authoritative, this shadow becomes the read path.
+    let state_for_reader = std::sync::Arc::clone(&state);
     let reader_task = tokio::spawn(async move {
         let reader = BufReader::new(read_half);
         let mut lines = reader.lines();
@@ -195,6 +203,7 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
                 Ok(Some(line)) => match serde_json::from_str::<Event>(&line) {
                     Ok(event) => {
                         tracing::info!("[launcher-ipc] received event: {:?}", event);
+                        apply_event_to_shadow(&state_for_reader, &event);
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -223,8 +232,48 @@ pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub async fn connect_to_launcher() -> Option<LauncherIpcHandle> {
+pub async fn connect_to_launcher(
+    _state: std::sync::Arc<crate::state::AppState>,
+) -> Option<LauncherIpcHandle> {
     None
+}
+
+/// Phase B.5b — apply launcher events that affect the shadow
+/// instance registry. Compares the launcher's authoritative
+/// assignment to the host's existing `WindowInstanceRegistry` and
+/// logs drift. Other event types are no-ops here (they're already
+/// logged at the call site).
+fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: &Event) {
+    match event {
+        Event::WindowInstanceAssigned { label, num, .. } => {
+            // Compare to host's authoritative registry FIRST so we
+            // see drift even if the shadow update would otherwise
+            // mask it. Host's registry might not contain the label
+            // yet (race: launcher emits before host's local
+            // `register()` runs); skip the compare in that case
+            // rather than log a noisy "missing" message.
+            let host_num = state.window_instance_registry.lock().get(label);
+            if let Some(host_num) = host_num {
+                if host_num != *num {
+                    tracing::warn!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        launcher_num = %num,
+                        host_num = %host_num,
+                        "[launcher-ipc] instance# drift: host and launcher disagree"
+                    );
+                }
+            }
+            state
+                .shadow_instance_registry
+                .lock()
+                .insert(label.clone(), *num);
+        }
+        Event::WindowInstanceReleased { label, .. } => {
+            state.shadow_instance_registry.lock().remove(label);
+        }
+        _ => {}
+    }
 }
 
 /// Phase B.4 — sync API: report a window open to the launcher's

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -269,7 +269,36 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 .lock()
                 .insert(label.clone(), *num);
         }
-        Event::WindowInstanceReleased { label, .. } => {
+        Event::WindowInstanceReleased { label, num, .. } => {
+            // Symmetric drift check: launcher just released the
+            // label, so host's authoritative registry SHOULD also
+            // not contain it. If host still has it, that's a
+            // host-side unregister bug (wrong label removed, or
+            // never removed) — log so we can catch it before
+            // B.5c cutover. (codex P2 PR #580 round-1.)
+            //
+            // Race-tolerant: host's local `unregister()` may not
+            // have run yet (the launcher might emit Released
+            // before the host's own close-path code reaches the
+            // unregister call). We log only the SUSTAINED case —
+            // see the next sentence — so transient ordering doesn't
+            // produce noise. Specifically: if host still has a
+            // DIFFERENT number for this label than the launcher
+            // released, that's actual drift (split-brain on the
+            // assignment); if host has the same number, we treat
+            // it as the benign "host hasn't unregistered yet" race.
+            let host_num = state.window_instance_registry.lock().get(label);
+            if let Some(host_num) = host_num {
+                if host_num != *num {
+                    tracing::warn!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        launcher_released_num = %num,
+                        host_num = %host_num,
+                        "[launcher-ipc] release-side instance# drift: host has a different number than the launcher released"
+                    );
+                }
+            }
             state.shadow_instance_registry.lock().remove(label);
         }
         _ => {}

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -230,7 +230,7 @@ fn main() {
     // lifetime — dropping it closes the pipe (logged by launcher).
     // Failure to connect is non-fatal in B.2 (host can still run);
     // B.5+ will tighten when the host depends on IPC for state.
-    let _launcher_ipc = runtime.block_on(launcher_ipc::connect_to_launcher());
+    let _launcher_ipc = runtime.block_on(launcher_ipc::connect_to_launcher(app_state.clone()));
 
     // Phase B.1: if launcher already spawned srv (the normal portable
     // / installed path post-PR-#570 + B.1), populate state from the

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -164,6 +164,15 @@ pub struct AppState {
     /// Sequential instance numbers for each open window
     pub window_instance_registry: Mutex<WindowInstanceRegistry>,
 
+    /// Phase B.5b — shadow registry fed by the launcher's
+    /// `WindowInstanceAssigned` / `WindowInstanceReleased` events.
+    /// Maintained in parallel to `window_instance_registry` (which
+    /// remains authoritative for now); on every launcher event the
+    /// reader task compares the two and logs drift. B.5c will swap
+    /// the roles — launcher becomes authoritative, this map becomes
+    /// the read path, and `window_instance_registry` is retired.
+    pub shadow_instance_registry: Mutex<HashMap<String, u32>>,
+
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 
@@ -271,6 +280,16 @@ impl Default for AppState {
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
             window_instance_registry: Mutex::new(WindowInstanceRegistry::new()),
+            shadow_instance_registry: Mutex::new({
+                // Pre-seed with main=1 to mirror the launcher's
+                // pre-seeded `instance_registry` (B.5a). Without
+                // this, the very first drift compare would log a
+                // spurious mismatch for "main" before any event
+                // arrives.
+                let mut m = HashMap::new();
+                m.insert("main".to_string(), 1);
+                m
+            }),
             cli_login_cancel: Mutex::new(None),
             cli_login_stdin: Mutex::new(None),
             ipc_port: Mutex::new(0),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.457"
+version = "0.33.458"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.457"
+version = "0.33.458"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.457"
+version = "0.33.458"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.457",
+  "version": "0.33.458",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.457",
+      "version": "0.33.458",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.457",
+  "version": "0.33.458",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 2 of B.5. Host gains a passive shadow registry fed by launcher events from B.5a (`WindowInstanceAssigned` / `WindowInstanceReleased`). Runs in parallel to the existing host-authoritative `WindowInstanceRegistry`; drift between the two is logged at WARN level via `target = \"launcher-ipc:drift\"`.

Pure observation — no behavior change. Validates that the launcher's authoritative numbering matches the host's in real workloads before B.5c cuts over.

## What's in here

**Host** (`state.rs`, `launcher_ipc.rs`, `main.rs`):
- `AppState.shadow_instance_registry: Mutex<HashMap<String, u32>>` — pre-seeded with `{\"main\": 1}` to mirror the launcher's pre-seed.
- `connect_to_launcher` now takes `Arc<AppState>` so the reader task can update the shadow.
- `apply_event_to_shadow` handles the two B.5a events: `Assigned` updates the shadow + drift-compares to host's `window_instance_registry`; `Released` removes from shadow.
- Drift compare skips when host's registry hasn't yet seen the label (race-tolerant).

## What's NOT in here

- Cutover. B.5c will swap which registry is authoritative, then B.5d deletes host's `WindowInstanceRegistry`.

## Test plan

- [x] `cargo check -p agentmux-launcher -p agentmux-common` passes (cef-dll-sys env issue blocks full cef check; my changes are minimal + syntactically clear).
- [ ] CI workspace check + tests on the merge ref.
- [ ] Smoke test: open + close a tear-off in portable build, confirm no `launcher-ipc:drift` lines in launcher/host logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)