### PR TITLE
fix: cleanup failed-pool-promote orphan from host browsers map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.460"
+version = "0.33.461"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.460"
+version = "0.33.461"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.460"
+version = "0.33.461"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.460"
+version = "0.33.461"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.461"
+version = "0.33.462"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.461"
+version = "0.33.462"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.461"
+version = "0.33.462"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.461"
+version = "0.33.462"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.460"
+version = "0.33.461"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.461"
+version = "0.33.462"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -476,17 +476,17 @@ pub fn promote_pool_window(
     // producing persistent windows-drift against the launcher mirror
     // (which correctly never received a `WindowOpened` for it).
     //
-    // Fix: trigger graceful close on the orphan. CEF's `on_before_close`
-    // will fire and run the standard cleanup path (drops from
-    // `state.browsers` + `window_meta`, fires `report_window_closed`
-    // — silent no-op in the launcher reducer for an unknown label).
-    // If host or browser handles are already gone, fall through to a
-    // direct `state.browsers` removal so our tracking doesn't lie.
+    // `cleanup_failed_promote_orphan` is responsible for ALL recovery
+    // including pool refill — see its contract. We deliberately do NOT
+    // call `spawn_pool_window` here since the cleanup helper either
+    // (a) issues `close_browser` → `on_before_close` → `on_pool_window_destroyed`
+    // already triggers refill, or (b) does direct cleanup + refill
+    // itself. Calling refill from both paths produces double refill.
+    // (codex P1 PR #582 round-1.)
     let raw_hwnd = match raw_hwnd {
         Some(h) => h,
         None => {
             cleanup_failed_promote_orphan(state, &label);
-            spawn_pool_window(state);
             return None;
         }
     };
@@ -605,14 +605,27 @@ pub fn promote_pool_window(
 /// drift. (Caught by B.4b drift detection during B.5c smoke test on
 /// v0.33.461.)
 ///
-/// Strategy: prefer graceful close via CEF's `close_browser` so the
-/// standard `on_before_close` cleanup path runs (drops from
-/// `state.browsers` + `window_meta`, sends `report_window_closed`
-/// which the launcher silently no-ops on the unknown label).
-/// Fall back to direct `state.browsers` removal if browser/host
-/// handles are already gone — the launcher mirror is unaffected
-/// either way; this is purely about keeping host's tracking
-/// consistent.
+/// Contract: this fn is responsible for ALL recovery including pool
+/// refill. The caller MUST NOT call `spawn_pool_window` itself —
+/// double refill would overshoot `POOL_TARGET_SIZE` and waste
+/// renderer capacity. (codex P1 PR #582 round-1.)
+///
+/// Two paths:
+///
+/// * **Graceful path** (browser+host alive in CEF): issue
+///   `close_browser(1)` and let CEF's `on_before_close` fire. That
+///   path runs the standard cleanup chain — drops from
+///   `state.browsers` + `window_meta`, calls
+///   `on_pool_window_destroyed` (which itself triggers refill via
+///   `spawn_pool_window` when pool size is below target), and
+///   triggers `compute_and_report_host_counts` from `client.rs`.
+/// * **Direct path** (browser or host already gone): `on_before_close`
+///   won't fire so we do its job inline — drop from browsers +
+///   window_meta, send `report_window_closed` (silent no-op in
+///   launcher reducer for an unknown label), spawn the refill
+///   ourselves, and emit a drift count snapshot so the orphan's
+///   removal is observable on the same tick. (reagent P2 PR #582
+///   round-1 — original direct path skipped the snapshot.)
 #[cfg(target_os = "windows")]
 fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
     use cef::{ImplBrowser, ImplBrowserHost};
@@ -628,22 +641,25 @@ fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
             tracing::info!(
                 target: "dnd:tearoff:pool",
                 label = %label,
-                "[pool] orphan close_browser issued — on_before_close will run cleanup"
+                "[pool] orphan close_browser issued — on_before_close will run cleanup + refill"
             );
             return;
         }
     }
-    // Browser or host already gone — clean up directly. on_before_close
-    // won't fire for this label, so do its job here: drop from browsers,
-    // window_meta, and notify the launcher (no-op if label was never
-    // reported as opened, which it wasn't on this failure path).
+    // Browser or host already gone — do `on_before_close`'s job
+    // inline since CEF won't fire it for this label.
     state.browsers.lock().remove(label);
     state.window_meta.lock().remove(label);
     crate::launcher_ipc::report_window_closed(label.to_string());
+    // Refill (graceful path gets this via on_pool_window_destroyed).
+    spawn_pool_window(state);
+    // Emit a count snapshot now so the orphan's removal is
+    // observable in the launcher's drift stream on the same tick.
+    crate::launcher_ipc::compute_and_report_host_counts(state);
     tracing::warn!(
         target: "dnd:tearoff:pool",
         label = %label,
-        "[pool] orphan browser already gone — cleaned host state directly"
+        "[pool] orphan browser already gone — cleaned host state directly + refilled"
     );
 }
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -463,13 +463,29 @@ pub fn promote_pool_window(
         }
     };
 
-    // Pool-slot leak guard: if HWND
-    // lookup fails after we've already popped the label, capacity
-    // permanently shrinks unless we refill. The orphan window (if
-    // any) is logged above and abandoned.
+    // Pool-slot leak guard: if HWND lookup fails after we've already
+    // popped the label, capacity permanently shrinks unless we refill.
+    //
+    // Orphan cleanup (B.5c smoke test caught this): the popped label is
+    // still in `state.browsers` but is no longer in `unpromoted_pool_labels`
+    // (we removed it at the top of this fn) and never became a real
+    // user-visible window (`report_window_opened` is gated on the
+    // post-validation success path). Without explicit cleanup the
+    // host's `compute_and_report_host_counts` filter
+    // (`browsers - panes - unpromoted`) counts the orphan as a window,
+    // producing persistent windows-drift against the launcher mirror
+    // (which correctly never received a `WindowOpened` for it).
+    //
+    // Fix: trigger graceful close on the orphan. CEF's `on_before_close`
+    // will fire and run the standard cleanup path (drops from
+    // `state.browsers` + `window_meta`, fires `report_window_closed`
+    // — silent no-op in the launcher reducer for an unknown label).
+    // If host or browser handles are already gone, fall through to a
+    // direct `state.browsers` removal so our tracking doesn't lie.
     let raw_hwnd = match raw_hwnd {
         Some(h) => h,
         None => {
+            cleanup_failed_promote_orphan(state, &label);
             spawn_pool_window(state);
             return None;
         }
@@ -577,6 +593,58 @@ pub fn promote_pool_window(
     spawn_pool_window(state);
 
     Some(label)
+}
+
+/// Phase B.5c follow-up — clean up an orphan pool window left behind
+/// when `promote_pool_window`'s HWND validation fails. Without this,
+/// the popped label sits in `state.browsers` but is no longer in
+/// `unpromoted_pool_labels` (promote removed it) and never became a
+/// real user window (no `WindowOpened` was reported). Host's
+/// `compute_and_report_host_counts` then counts it as a window, while
+/// the launcher mirror correctly does not — persistent off-by-one
+/// drift. (Caught by B.4b drift detection during B.5c smoke test on
+/// v0.33.461.)
+///
+/// Strategy: prefer graceful close via CEF's `close_browser` so the
+/// standard `on_before_close` cleanup path runs (drops from
+/// `state.browsers` + `window_meta`, sends `report_window_closed`
+/// which the launcher silently no-ops on the unknown label).
+/// Fall back to direct `state.browsers` removal if browser/host
+/// handles are already gone — the launcher mirror is unaffected
+/// either way; this is purely about keeping host's tracking
+/// consistent.
+#[cfg(target_os = "windows")]
+fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
+    use cef::{ImplBrowser, ImplBrowserHost};
+    let mut browser_clone = {
+        let browsers = state.browsers.lock();
+        browsers.get(label).cloned()
+    };
+    if let Some(ref mut browser) = browser_clone {
+        if let Some(host) = browser.host() {
+            // force_close = 1: don't run beforeunload, we know
+            // this window never reached a useful state.
+            host.close_browser(1);
+            tracing::info!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] orphan close_browser issued — on_before_close will run cleanup"
+            );
+            return;
+        }
+    }
+    // Browser or host already gone — clean up directly. on_before_close
+    // won't fire for this label, so do its job here: drop from browsers,
+    // window_meta, and notify the launcher (no-op if label was never
+    // reported as opened, which it wasn't on this failure path).
+    state.browsers.lock().remove(label);
+    state.window_meta.lock().remove(label);
+    crate::launcher_ipc::report_window_closed(label.to_string());
+    tracing::warn!(
+        target: "dnd:tearoff:pool",
+        label = %label,
+        "[pool] orphan browser already gone — cleaned host state directly"
+    );
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.461"
+version = "0.33.462"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.460"
+version = "0.33.461"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.460"
+version = "0.33.461"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.461"
+version = "0.33.462"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.460"
+version = "0.33.461"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.461"
+version = "0.33.462"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.460",
+  "version": "0.33.461",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.460",
+      "version": "0.33.461",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.461",
+  "version": "0.33.462",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.461",
+      "version": "0.33.462",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.460",
+  "version": "0.33.461",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.461",
+  "version": "0.33.462",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Bug caught by B.4b drift detection during the v0.33.461 smoke test of B.5c. When `promote_pool_window`'s HWND validation fails, the popped pool label is orphaned: gone from `unpromoted_pool_labels`, still in `state.browsers`, never reported as `WindowOpened` to the launcher. Host counts the orphan as a window; launcher mirror correctly doesn't. Persistent off-by-one drift logged as `Event::DriftDetected` on every failed promote.

This bug was likely present pre-Phase-B but silent. **B.4b's drift detection is the observability layer that made it visible.**

## Reproducer (real smoke test)

v0.33.461 portable, two cold-path tear-offs (~13:37:30, 13:37:40 UTC). The 2nd attempted a pool promote that hit the existing `host window handle is null` failure mode:

```
13:37:40.103 ERROR [pool] host window handle is null (state inconsistency)
                          label=\"window-pool-12f54698...\"
13:37:40.143 INFO  DriftDetected { kind: Windows, host_count: 4, mirror_count: 3 }
13:37:43.953 INFO  WindowClosed (user closed window-beedebce — the cold-path window)
13:37:43.953 INFO  DriftDetected { kind: Windows, host_count: 3, mirror_count: 2 }
                          ↑ drift persists — orphan still in host's browsers
```

## Fix

New `cleanup_failed_promote_orphan(state, label)` helper called from the HWND-failure branch:

- Browser still alive → `host.close_browser(1)` triggers graceful close. Standard `on_before_close` runs, drops from `browsers` + `window_meta`, fires `report_window_closed` (no-op in launcher reducer for unknown label).
- Browser/host already gone → direct `browsers.remove` + `window_meta.remove` + `report_window_closed`.

Either path keeps host's tracking consistent with the launcher mirror. Pool refill (`spawn_pool_window`) still runs, so pool capacity recovers.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check on the merge ref.
- [ ] Smoke test v0.33.462 portable: tear off 2-3 windows, watch for failed-promote scenarios in launcher log. Expect zero `DriftDetected { kind: Windows }` lines from this code path (would still log the underlying `state inconsistency` ERROR if HWND races, but no drift cascade).

## Note on B.5c

The B.5c read-cutover (PR #581) is independent of this bug. Instance numbers worked correctly throughout the smoke test (1, 2, 3 monotonic, paired open/close). The drift was on `kind: Windows`, not `kind: Pool` or instance numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)