### PR TITLE
feat: B.5d — drop host's instance-registry mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.463"
+version = "0.33.464"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.463"
+version = "0.33.464"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.463"
+version = "0.33.464"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.463"
+version = "0.33.464"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.462"
+version = "0.33.463"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.462"
+version = "0.33.463"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.462"
+version = "0.33.463"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.462"
+version = "0.33.463"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.463"
+version = "0.33.464"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.462"
+version = "0.33.463"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -348,9 +348,13 @@ impl AgentMuxHandler {
             }
         }
 
-        // Unregister from instance registry; retrieve backend window ID for cleanup.
+        // Phase B.5d — host no longer mutates `window_instance_registry`.
+        // The launcher's `state.instance_registry` (B.5a) is now the
+        // sole authority; close-side updates flow via
+        // `Event::WindowInstanceReleased` → `apply_event_to_shadow`.
+        // We still clean up `window_id_map` here (B.5 hasn't migrated
+        // that map yet — it's the next target).
         let backend_window_id = label.as_deref().and_then(|lbl| {
-            self.state.window_instance_registry.lock().unregister(lbl);
             let wid = self.state.window_id_map.lock().remove(lbl);
             dlog(&format!("window_id_map.remove({:?}) => {:?}", lbl, wid));
             wid

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -378,14 +378,12 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
         true,
     );
 
-    // Register instance number
-    {
-        let mut reg = state.window_instance_registry.lock();
-        let num = reg.register(&label);
-        tracing::info!(label = %label, instance = %num, "[dnd:cef] tear-off window registered");
-    }
-
-    // Notify all windows
+    // Phase B.5d — host no longer registers locally. The launcher
+    // assigns the instance number from `ReportWindowOpened`
+    // (triggered by on_after_created) and the shadow update emits
+    // a fresh `window-instances-changed` once it lands. The early
+    // emit below carries the pre-mutation count; frontend updates
+    // it again ~ms later when the shadow event arrives.
     let count = state.instance_count();
     events::emit_event_all_windows(state, "window-instances-changed", &serde_json::json!(count));
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -613,14 +613,16 @@ fn open_window_with_kind(
         },
     );
 
-    // Register instance number BEFORE creating the browser, so the new window's
-    // frontend can query its instance number immediately on load.
-    {
-        let mut reg = state.window_instance_registry.lock();
-        let num = reg.register(&label);
-        tracing::info!(label = %label, instance = %num, "[window] new window registered");
-    }
-
+    // Phase B.5d — host no longer assigns instance numbers locally.
+    // The launcher assigns from `ReportWindowOpened` (sent by the
+    // host's `on_after_created` callback) and the shadow update
+    // emits `window-instances-changed`. Brief race: the new window's
+    // frontend may query `get_instance_number` before the launcher's
+    // `WindowInstanceAssigned` event has returned, getting a None →
+    // `unwrap_or(1)` fallback. Frontend's existing
+    // `app-init.ts::refreshLabels(true, retriesLeft)` retry loop
+    // catches up within a few hundred ms. B.7 will replace polling
+    // with direct event subscription, eliminating the race entirely.
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -552,26 +552,13 @@ pub fn promote_pool_window(
         let _ = ShowWindow(raw_hwnd, SW_SHOW);
     }
 
-    // Register the promoted window in the instance registry +
-    // broadcast the count change. Cold-path open_window_at_position
-    // does this same step (drag.rs:~390); without it warm-path
-    // tear-offs would bypass instance tracking entirely — get_instance
-    // _number would fall back to 1 for the new window and other
-    // windows would keep a stale count, throwing off the InstancePanel
-    // and any other consumer of windowCountAtom.
-    // Phase B.5c — keep host's local register() (B.5d will remove
-    // it once read-path validation has run on real workloads), but
-    // read the count via the launcher-authoritative path.
-    {
-        let mut reg = state.window_instance_registry.lock();
-        let num = reg.register(&label);
-        tracing::info!(
-            target: "dnd:tearoff:pool",
-            label = %label,
-            instance = %num,
-            "[pool] promoted window registered as instance"
-        );
-    }
+    // Phase B.5d — host no longer registers locally on pool promote.
+    // The launcher assigns the instance number from
+    // `ReportWindowOpened` (sent immediately above this line in the
+    // promote path) and the shadow update emits a fresh
+    // `window-instances-changed` once it lands. The synchronous emit
+    // below carries the pre-mutation count; the shadow's later emit
+    // catches up.
     let count = state.instance_count();
     crate::events::emit_event_all_windows(
         state,

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -246,12 +246,12 @@ pub async fn connect_to_launcher(
 fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: &Event) {
     match event {
         Event::WindowInstanceAssigned { label, num, .. } => {
-            // Compare to host's authoritative registry FIRST so we
-            // see drift even if the shadow update would otherwise
-            // mask it. Host's registry might not contain the label
-            // yet (race: launcher emits before host's local
-            // `register()` runs); skip the compare in that case
-            // rather than log a noisy "missing" message.
+            // Phase B.5b drift compare: kept for B.5d transition —
+            // host's `window_instance_registry` is now seed-only
+            // ({"main": 1}, never mutated), so this only fires on
+            // "main" (where it should agree). For non-main labels
+            // host_num will always be None and the compare skips.
+            // Removed entirely in B.5e along with the host field.
             let host_num = state.window_instance_registry.lock().get(label);
             if let Some(host_num) = host_num {
                 if host_num != *num {
@@ -268,6 +268,17 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 .shadow_instance_registry
                 .lock()
                 .insert(label.clone(), *num);
+            // Phase B.5d — re-emit `window-instances-changed` so the
+            // frontend's InstancePanel catches up after the brief
+            // race between the synchronous emit at the mutation site
+            // (which carries the pre-event count) and the launcher's
+            // `WindowInstanceAssigned` arrival here.
+            let count = state.shadow_instance_registry.lock().len();
+            crate::events::emit_event_all_windows(
+                state,
+                "window-instances-changed",
+                &serde_json::json!(count),
+            );
         }
         Event::WindowInstanceReleased { label, num, .. } => {
             // Symmetric drift check: launcher just released the
@@ -308,6 +319,16 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 }
             }
             state.shadow_instance_registry.lock().remove(label);
+            // Phase B.5d — re-emit `window-instances-changed` so the
+            // frontend catches up after the brief race between the
+            // synchronous emit at the close site and the launcher's
+            // `WindowInstanceReleased` arrival here.
+            let count = state.shadow_instance_registry.lock().len();
+            crate::events::emit_event_all_windows(
+                state,
+                "window-instances-changed",
+                &serde_json::json!(count),
+            );
         }
         _ => {}
     }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -281,24 +281,17 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             );
         }
         Event::WindowInstanceReleased { label, num, .. } => {
-            // Symmetric drift check: launcher just released the
-            // label, so host's authoritative registry SHOULD also
-            // not contain it. Two cases produce different signals:
-            //
-            // * host_num != launcher_num → split-brain on the
-            //   original assignment. Always a bug.
-            // * host_num == launcher_num → either (a) benign race
-            //   (host's local `unregister()` hasn't run yet — the
-            //   launcher's Released event raced ahead of the host's
-            //   own close-path code), OR (b) host-side unregister
-            //   bug (entry never removed). We can't distinguish at
-            //   the moment of this event, so we log it at INFO to
-            //   surface it without flooding WARN. The race resolves
-            //   on the host's next register/unregister cycle; a
-            //   true bug will sustain across events. (codex P2
-            //   PR #580 round-2 — original round-1 fix suppressed
-            //   the same-num case entirely, which silenced real
-            //   unregister bugs forever.)
+            // Drift check kept for B.5d transition — host's
+            // `window_instance_registry` is now seed-only
+            // ({"main": 1}, never mutated since B.5d retired the
+            // four `register()`/`unregister()` call sites). The
+            // only label that can land in the host fallback range
+            // is "main" → 1, which the launcher pre-seeds with the
+            // same value, so this compare effectively never fires
+            // post-B.5d. Removed entirely in B.5e along with the
+            // host field. Original race-vs-bug rationale lived
+            // here pre-B.5d; see git history for codex P2 PR #580
+            // round-2 context.
             let host_num = state.window_instance_registry.lock().get(label);
             if let Some(host_num) = host_num {
                 if host_num != *num {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -314,14 +314,18 @@ impl Default for AppState {
 }
 
 impl AppState {
-    /// Phase B.5c — authoritative instance-number lookup. Prefers
-    /// the launcher-fed `shadow_instance_registry` (the source of
-    /// truth post-B.5a); falls back to host's local
-    /// `window_instance_registry` for the race window where host
-    /// has just `register()`'d a label but the launcher's
-    /// `WindowInstanceAssigned` event hasn't returned yet. Logs
-    /// every fallback at DEBUG so we can quantify the race
-    /// frequency before B.5e removes the fallback entirely.
+    /// Phase B.5d — authoritative instance-number lookup. Reads
+    /// from the launcher-fed `shadow_instance_registry`. Falls
+    /// back to host's `window_instance_registry`, which post-B.5d
+    /// is seed-only (contains just `{"main": 1}` — the four
+    /// `register()`/`unregister()` call sites were retired in
+    /// B.5d). The fallback is therefore harmless (only resolves
+    /// "main" → 1, which matches the launcher's pre-seed) but
+    /// vestigial; B.5e removes it along with the host field.
+    /// `launcher-ipc:fallback` DEBUG events should rarely fire
+    /// post-B.5d — only on early `get_instance_number("main")`
+    /// queries that race the launcher's first
+    /// `WindowInstanceAssigned` event.
     pub fn instance_num(&self, label: &str) -> Option<u32> {
         if let Some(num) = self.shadow_instance_registry.lock().get(label).copied() {
             return Some(num);

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -339,34 +339,22 @@ impl AppState {
         None
     }
 
-    /// Phase B.5c — authoritative instance count. Same prefer-shadow
-    /// fallback semantics as `instance_num`: returns the shadow's
-    /// count when it agrees with host's authoritative
-    /// `WindowInstanceRegistry`; falls back to host's count
-    /// otherwise. Used by frontend event emits
-    /// ("window-instances-changed").
+    /// Phase B.5d — authoritative instance count. Returns the
+    /// shadow's count directly. The B.5c-era host fallback was
+    /// removed because host no longer mutates
+    /// `window_instance_registry` (B.5d retired the four
+    /// `register()`/`unregister()` call sites), so host's count
+    /// is permanently stuck at the seed value (1) and would give
+    /// stale answers if used as fallback.
     ///
-    /// The fallback is essential during the transition: every read
-    /// site is called RIGHT AFTER a host mutation
-    /// (`register()`/`unregister()`) but BEFORE the launcher's
-    /// reply event has returned. Without falling back, the emitted
-    /// count is off by one on every open (shadow not yet populated)
-    /// and every close (shadow not yet drained), and no re-emission
-    /// fires when the shadow catches up — leaving stale counts in
-    /// the InstancePanel until the next user action. (reagent P1
-    /// PR #581 round-1.)
+    /// The synchronous emit at mutation sites still fires (it sees
+    /// the pre-launcher-event count, briefly off by one) but a
+    /// subsequent `window-instances-changed` emit fires from
+    /// `apply_event_to_shadow` once the launcher's
+    /// `WindowInstanceAssigned`/`Released` event arrives
+    /// (~ms later), bringing the InstancePanel back to the correct
+    /// count.
     pub fn instance_count(&self) -> usize {
-        let shadow_count = self.shadow_instance_registry.lock().len();
-        let host_count = self.window_instance_registry.lock().count();
-        if shadow_count == host_count {
-            return shadow_count;
-        }
-        tracing::debug!(
-            target: "launcher-ipc:fallback",
-            shadow = %shadow_count,
-            host = %host_count,
-            "[instance_count] shadow vs host disagreement — falling back to host count (eager-mutation source)"
-        );
-        host_count
+        self.shadow_instance_registry.lock().len()
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.463"
+version = "0.33.464"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.462"
+version = "0.33.463"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.463"
+version = "0.33.464"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.462"
+version = "0.33.463"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.462"
+version = "0.33.463"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.463"
+version = "0.33.464"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.462",
+  "version": "0.33.463",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.462",
+      "version": "0.33.463",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.463",
+  "version": "0.33.464",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.463",
+      "version": "0.33.464",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.462",
+  "version": "0.33.463",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.463",
+  "version": "0.33.464",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 4 of the B.5 migration for `window_instance_registry`. After B.5c routed reads through `state.instance_num()` / `state.instance_count()`, the host's local `register()`/`unregister()` calls are the only remaining writers. This PR drops them. The launcher's `state.instance_registry` (B.5a) is now the sole authority; host's `WindowInstanceRegistry` becomes seed-only (`{\"main\": 1}`, never mutated) and will be deleted entirely in B.5e.

## What's in here

**Mutation sites removed** (4):
- `client.rs::on_before_close` — `unregister(lbl)`
- `commands/drag.rs::tear_off` — cold-path `register(&label)`
- `commands/window.rs::open_new_window` — `register(&label)` before CEF create
- `commands/window_pool.rs::promote_pool_window` — pool-promote `register(&label)`

**Read-path adjustments**:
- `state.instance_count()`: removed the host-count fallback. Host's count is permanently `1` (seed only) post-B.5d, so it would give stale answers. Returns shadow count directly.
- `state.instance_num(label)`: kept the host fallback for now — harmless (only \"main\" → 1 is in seed range, which is correct). B.5e removes with the field.

**Race coverage** (this is the design-question mentioned in the roadmap):
- Synchronous `window-instances-changed` emit at mutation sites fires BEFORE the launcher's reply, so it briefly carries an off-by-one count.
- `apply_event_to_shadow` now re-emits `window-instances-changed` on every `WindowInstanceAssigned` / `WindowInstanceReleased`, catching up InstancePanel within ~ms.
- Frontend `get_instance_number` may race the launcher reply on first window load, returning `unwrap_or(1)` briefly. Existing `app-init.ts::refreshLabels(retriesLeft)` retry loop covers it. B.7 replaces this with direct event subscription.

## What's NOT in here

- B.5e: delete `WindowInstanceRegistry` field + struct entirely. Almost-pure delete after this PR validates.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.
- [ ] Smoke test: open + close 2-3 tear-offs. Confirm:
  - InstancePanel count updates correctly (synchronous emit + shadow-update emit cadence).
  - No `launcher-ipc:drift` warnings.
  - `launcher-ipc:fallback` DEBUG entries should now mostly disappear (host is seed-only).
  - Window title flicker (briefly showing \"main\" name on a tear-off) for ~10-100ms is acceptable transitional behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)