### PR TITLE
feat: B.5 (window_id_map) step a + #584 stale-comment fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.465"
+version = "0.33.466"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.465"
+version = "0.33.466"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.465"
+version = "0.33.466"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.465"
+version = "0.33.466"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.465"
+version = "0.33.466"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -348,12 +348,12 @@ impl AgentMuxHandler {
             }
         }
 
-        // Phase B.5d — host no longer mutates `window_instance_registry`.
-        // The launcher's `state.instance_registry` (B.5a) is now the
-        // sole authority; close-side updates flow via
-        // `Event::WindowInstanceReleased` → `apply_event_to_shadow`.
-        // We still clean up `window_id_map` here (B.5 hasn't migrated
-        // that map yet — it's the next target).
+        // Phase B.5e — host's `WindowInstanceRegistry` is gone; the
+        // launcher's `state.instance_registry` is sole authority,
+        // close-side updates flow via `Event::WindowInstanceReleased`
+        // → `apply_event_to_shadow`. We still clean up
+        // `window_id_map` here (B.5 hasn't migrated that map yet —
+        // it's the current target).
         let backend_window_id = label.as_deref().and_then(|lbl| {
             let wid = self.state.window_id_map.lock().remove(lbl);
             dlog(&format!("window_id_map.remove({:?}) => {:?}", lbl, wid));

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.465"
+version = "0.33.466"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -141,6 +141,23 @@ pub enum Command {
     ReportHostPoolCount {
         count: u32,
     },
+    /// Phase B.5 (window_id_map step a) — host reports the
+    /// frontend's `register_backend_window` call: a window's label
+    /// → backend window ID (a srv-side UUID the frontend resolves
+    /// via `WOS.makeORef`). The launcher mirrors it for the same
+    /// reasons it mirrors `instance_registry`: host's authoritative
+    /// copy will be retired through the a→b→c→d→e ratchet.
+    ReportBackendWindowIdRegistered {
+        label: String,
+        window_id: String,
+    },
+    /// Phase B.5 (window_id_map step a) — host reports a window
+    /// closing, so the launcher should drop the label→window_id
+    /// mapping. Sent from the same close path that emits
+    /// `ReportWindowClosed`.
+    ReportBackendWindowIdUnregistered {
+        label: String,
+    },
 }
 
 /// Wire-side enum for `WindowKind`. Mirrors `agentmux-cef::state::WindowKind`
@@ -244,6 +261,22 @@ pub enum Event {
     },
     PoolWindowRemoved {
         label: String,
+        version: u64,
+    },
+    /// Phase B.5 (window_id_map step a) — launcher recorded the
+    /// label → backend window ID mapping. Subscribers (host's
+    /// shadow, eventually srv-side consumers) update their
+    /// projections.
+    BackendWindowIdRegistered {
+        label: String,
+        window_id: String,
+        version: u64,
+    },
+    /// Phase B.5 (window_id_map step a) — launcher dropped the
+    /// label → backend window ID mapping (window closed).
+    BackendWindowIdUnregistered {
+        label: String,
+        window_id: String,
         version: u64,
     },
     /// Phase B.5 — sequential instance number assigned to a window

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.465"
+version = "0.33.466"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -356,6 +356,18 @@ async fn enforce_register_first(
         Command::ReportHostPoolCount { .. } => {
             ("ReportHostPoolCount before Register".to_string(), true)
         }
+        Command::ReportBackendWindowIdRegistered { .. } => {
+            (
+                "ReportBackendWindowIdRegistered before Register".to_string(),
+                true,
+            )
+        }
+        Command::ReportBackendWindowIdUnregistered { .. } => {
+            (
+                "ReportBackendWindowIdUnregistered before Register".to_string(),
+                true,
+            )
+        }
     };
     let mut state = ctx.state.lock().await;
     let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -122,7 +122,59 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }
             handle_report_host_pool_count(state, count)
         }
+        Command::ReportBackendWindowIdRegistered { label, window_id } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdRegistered") {
+                return vec![err];
+            }
+            handle_report_backend_window_id_registered(state, label, window_id)
+        }
+        Command::ReportBackendWindowIdUnregistered { label } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdUnregistered") {
+                return vec![err];
+            }
+            handle_report_backend_window_id_unregistered(state, label)
+        }
     }
+}
+
+/// Phase B.5 (window_id_map step a) — record the host-reported
+/// label → backend_window_id mapping. Idempotent on duplicate
+/// label (overwrites with the new ID and emits a fresh event so
+/// subscribers see the latest mapping).
+fn handle_report_backend_window_id_registered(
+    state: &mut State,
+    label: String,
+    window_id: String,
+) -> Vec<Event> {
+    state
+        .backend_window_ids
+        .insert(label.clone(), window_id.clone());
+    let v = state.bump_version();
+    vec![Event::BackendWindowIdRegistered {
+        label,
+        window_id,
+        version: v,
+    }]
+}
+
+/// Phase B.5 (window_id_map step a) — drop the host-reported label
+/// from the map. Strict pairing: emits `BackendWindowIdUnregistered`
+/// only when the label was present (mirrors `WindowClosed` and
+/// `PoolWindowRemoved` semantics — codex P2 PR #577 round-2).
+fn handle_report_backend_window_id_unregistered(
+    state: &mut State,
+    label: String,
+) -> Vec<Event> {
+    let removed = state.backend_window_ids.remove(&label);
+    let Some(window_id) = removed else {
+        return vec![];
+    };
+    let v = state.bump_version();
+    vec![Event::BackendWindowIdUnregistered {
+        label,
+        window_id,
+        version: v,
+    }]
 }
 
 /// Phase B.4 follow-up — pool-only drift check. Called from
@@ -584,6 +636,8 @@ mod tests {
             | Event::PoolWindowRemoved { version, .. }
             | Event::WindowInstanceAssigned { version, .. }
             | Event::WindowInstanceReleased { version, .. }
+            | Event::BackendWindowIdRegistered { version, .. }
+            | Event::BackendWindowIdUnregistered { version, .. }
             | Event::DriftDetected { version, .. }
             | Event::Error { version, .. } => *version,
         }
@@ -872,6 +926,86 @@ mod tests {
             Event::PoolWindowRemoved { label, .. } if label == "window-pool-abc"
         ));
         assert!(!state.pool.contains("window-pool-abc"));
+    }
+
+    #[test]
+    fn report_backend_window_id_round_trip() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let events = update(
+            &mut state,
+            Command::ReportBackendWindowIdRegistered {
+                label: "main".into(),
+                window_id: "wid-abc".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::BackendWindowIdRegistered { label, window_id, .. }
+                if label == "main" && window_id == "wid-abc"
+        ));
+        assert_eq!(state.backend_window_ids.get("main").map(|s| s.as_str()), Some("wid-abc"));
+
+        let events = update(
+            &mut state,
+            Command::ReportBackendWindowIdUnregistered {
+                label: "main".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::BackendWindowIdUnregistered { label, window_id, .. }
+                if label == "main" && window_id == "wid-abc"
+        ));
+        assert!(state.backend_window_ids.is_empty());
+    }
+
+    #[test]
+    fn report_backend_window_id_unregister_unknown_label_is_silent() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let events = update(
+            &mut state,
+            Command::ReportBackendWindowIdUnregistered {
+                label: "ghost".into(),
+            },
+            &host_ctx,
+        );
+        // Strict pairing — same as WindowClosed/PoolWindowRemoved.
+        assert_eq!(events.len(), 0);
+    }
+
+    #[test]
+    fn report_backend_window_id_overwrites_on_duplicate() {
+        // Frontend can re-register if it reloads — the launcher should
+        // accept the new ID and emit a fresh event so subscribers see
+        // the latest mapping.
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let _ = update(
+            &mut state,
+            Command::ReportBackendWindowIdRegistered {
+                label: "main".into(),
+                window_id: "wid-old".into(),
+            },
+            &host_ctx,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportBackendWindowIdRegistered {
+                label: "main".into(),
+                window_id: "wid-new".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(
+            state.backend_window_ids.get("main").map(|s| s.as_str()),
+            Some("wid-new")
+        );
     }
 
     #[test]

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -104,9 +104,10 @@ pub struct State {
     /// label → sequential instance number (1 for "main", 2 for the
     /// second window opened, etc.). Numbers are never reused within
     /// a launcher run — when a window closes the entry is removed
-    /// but `next_instance_num` keeps advancing. Replaces the host's
-    /// `agentmux-cef::state::WindowInstanceRegistry` (host still
-    /// maintains its own copy in B.5a; B.5b retires it). Updated by
+    /// but `next_instance_num` keeps advancing. Sole source of truth
+    /// post-B.5e (host's `WindowInstanceRegistry` was deleted in
+    /// PR #584); host holds a passive shadow projection in
+    /// `agentmux-cef::AppState.shadow_instance_registry`. Updated by
     /// the same reducer paths that mutate `windows`.
     pub instance_registry: HashMap<String, u32>,
     /// Next instance number to assign. Starts at 2 — "main" is
@@ -114,6 +115,15 @@ pub struct State {
     /// `WindowInstanceRegistry::new` behavior so a synthetic main
     /// open wouldn't collide).
     pub next_instance_num: u32,
+    /// Phase B.5 (window_id_map step a) — authoritative
+    /// label → backend window ID map. Mirrors host's existing
+    /// `agentmux-cef::AppState.window_id_map`. Populated by
+    /// `Command::ReportBackendWindowIdRegistered` (sent from host
+    /// when the frontend calls `register_backend_window` IPC
+    /// after init); drained by `ReportBackendWindowIdUnregistered`
+    /// on close. Will become host-side authoritative through the
+    /// standard a→b→c→d→e ratchet.
+    pub backend_window_ids: HashMap<String, String>,
     /// Monotonic counter for `Event.version`. Bumped by `bump_version()`.
     pub event_version: u64,
     /// Monotonic counter for client_id (returned in Registered events).
@@ -133,6 +143,7 @@ impl Default for State {
                 m
             },
             next_instance_num: 2,
+            backend_window_ids: HashMap::new(),
             event_version: 0,
             next_client_id: 1,
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.465"
+version = "0.33.466"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.465",
+  "version": "0.33.466",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.465",
+      "version": "0.33.466",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.465",
+  "version": "0.33.466",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two bundled per user request to roll #584 follow-ups into this PR:

### #584 stale-comment fixes (reagent P2 deferred)

- `agentmux-cef/src/client.rs`: comment said host \"no longer mutates `window_instance_registry`\" — true, but the field was deleted in #584. Updated.
- `agentmux-launcher/src/state.rs`: docstring referenced wrong PR (B.5b, should be B.5e). Updated.

### B.5 (window_id_map) step a

Second host map to migrate per `docs/retro/migration-pattern.md`. `window_id_map: HashMap<String, String>` (label → backend window UUID) is mutated by frontend's `register_backend_window` IPC and read by `on_before_close` to notify backend.

Pure addition — no host changes. Subsequent steps (b/c/d/e) follow the same ratchet that worked for `window_instance_registry` (#579–#584).

**Wire** (`agentmux-common/src/ipc.rs`):
- `Command::ReportBackendWindowIdRegistered { label, window_id }`
- `Command::ReportBackendWindowIdUnregistered { label }`
- `Event::BackendWindowIdRegistered { label, window_id, version }`
- `Event::BackendWindowIdUnregistered { label, window_id, version }` — includes `window_id` so subscribers can clean up their projections without re-lookup.

**Launcher** (`state.rs`, `reducer.rs`, `ipc/server.rs`):
- `State.backend_window_ids: HashMap<String, String>` — empty at startup (no pre-seed; main has no backend ID until frontend registers).
- Reducer handlers gated by `enforce_host_only`.
- `enforce_register_first` extended.
- 3 new reducer tests (round-trip, unknown-label silent, duplicate-overwrites). 34 reducer tests pass total.

## Test plan

- [x] `cargo test -p agentmux-launcher --bin agentmux-launcher reducer` — 34 pass (3 new for B.5 step a).
- [ ] CI workspace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)