### PR TITLE
feat: B.5 (window_id_map) step b — host shadow + drift logs + emits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.466"
+version = "0.33.467"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.466"
+version = "0.33.467"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.466"
+version = "0.33.467"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.466"
+version = "0.33.467"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.466"
+version = "0.33.467"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -357,6 +357,10 @@ impl AgentMuxHandler {
         let backend_window_id = label.as_deref().and_then(|lbl| {
             let wid = self.state.window_id_map.lock().remove(lbl);
             dlog(&format!("window_id_map.remove({:?}) => {:?}", lbl, wid));
+            // Phase B.5 (window_id_map step b) — mirror the
+            // unregister to the launcher. Fires whether or not we
+            // actually had an entry; the reducer is idempotent.
+            crate::launcher_ipc::report_backend_window_id_unregistered(lbl.to_string());
             wid
         });
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -486,6 +486,11 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
         let keys: Vec<String> = state.window_id_map.lock().keys().cloned().collect();
         crate::client::dlog(&format!("window_id_map now has keys: {:?}", keys));
         tracing::info!(label = %label, window_id = %window_id, "[window] registered backend window ID");
+        // Phase B.5 (window_id_map step b) — mirror to launcher.
+        crate::launcher_ipc::report_backend_window_id_registered(
+            label.to_string(),
+            window_id.to_string(),
+        );
         // Notify listeners that the label→windowId mapping changed.
         // The InstancePanel needs `windowId` to look up the backend
         // Window record (display name in meta, workspace fallback).

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -265,6 +265,71 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 &serde_json::json!(count),
             );
         }
+        Event::BackendWindowIdRegistered { label, window_id, .. } => {
+            // Phase B.5 (window_id_map step b) — shadow projection
+            // + drift compare. Host's `window_id_map` is still
+            // authoritative through step c; we log when the two
+            // disagree so the soak period before cutover surfaces
+            // any reporting bugs. Race-tolerant: host's
+            // `register_backend_window` mutation may not have run
+            // yet, so a "missing in host" case is benign and skipped.
+            let host_id = state
+                .window_id_map
+                .lock()
+                .get(label)
+                .cloned();
+            if let Some(host_id) = host_id {
+                if &host_id != window_id {
+                    tracing::warn!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        launcher_id = %window_id,
+                        host_id = %host_id,
+                        "[launcher-ipc] backend_window_id drift: host and launcher disagree"
+                    );
+                }
+            }
+            state
+                .shadow_backend_window_ids
+                .lock()
+                .insert(label.clone(), window_id.clone());
+        }
+        Event::BackendWindowIdUnregistered { label, window_id, .. } => {
+            // Phase B.5 (window_id_map step b) — symmetric drift
+            // check on release. Two cases:
+            // * host has a different ID for this label → split-brain
+            //   on the original registration, log WARN.
+            // * host has the same ID → either host hasn't run its
+            //   own `remove()` yet (race) or never will (bug).
+            //   Log INFO; sustained presence indicates a bug
+            //   (mirrors the B.5b/c WindowInstanceReleased pattern
+            //   that survived only briefly because we deleted the
+            //   compare in B.5e).
+            let host_id = state
+                .window_id_map
+                .lock()
+                .get(label)
+                .cloned();
+            if let Some(host_id) = host_id {
+                if &host_id != window_id {
+                    tracing::warn!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        launcher_released_id = %window_id,
+                        host_id = %host_id,
+                        "[launcher-ipc] backend_window_id release-side split-brain"
+                    );
+                } else {
+                    tracing::info!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        window_id = %window_id,
+                        "[launcher-ipc] backend_window_id release-side: host still has matching entry — race or unregister bug"
+                    );
+                }
+            }
+            state.shadow_backend_window_ids.lock().remove(label);
+        }
         Event::WindowInstanceReleased { label, .. } => {
             // Phase B.5e — host's `WindowInstanceRegistry` was
             // deleted; the drift compare is gone with it.
@@ -361,6 +426,41 @@ pub fn report_host_counts(windows: u32, pool: u32) {
     let cmd = Command::ReportHostCounts { windows, pool };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!("[launcher-ipc] report_host_counts: channel closed ({})", e);
+    }
+}
+
+/// Phase B.5 (window_id_map step b) — sync API: report the
+/// frontend's `register_backend_window` IPC to the launcher.
+/// Called from `commands/window.rs::register_backend_window`
+/// after the host's local `window_id_map` insert. No-op if the
+/// launcher pipe isn't connected.
+pub fn report_backend_window_id_registered(label: String, window_id: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportBackendWindowIdRegistered { label, window_id };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!(
+            "[launcher-ipc] report_backend_window_id_registered: channel closed ({})",
+            e
+        );
+    }
+}
+
+/// Phase B.5 (window_id_map step b) — sync API: report a window's
+/// backend ID being dropped (close path). Called from
+/// `client.rs::on_before_close` after the host's local
+/// `window_id_map.remove`. No-op if launcher pipe absent.
+pub fn report_backend_window_id_unregistered(label: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportBackendWindowIdUnregistered { label };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!(
+            "[launcher-ipc] report_backend_window_id_unregistered: channel closed ({})",
+            e
+        );
     }
 }
 

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -138,6 +138,17 @@ pub struct AppState {
     /// arrives).
     pub shadow_instance_registry: Mutex<HashMap<String, u32>>,
 
+    /// Phase B.5 (window_id_map step b) — shadow projection of the
+    /// launcher's authoritative `state.backend_window_ids`. Fed by
+    /// `Event::BackendWindowIdRegistered` /
+    /// `Event::BackendWindowIdUnregistered` via
+    /// `apply_event_to_shadow`. Maintained in parallel to
+    /// `window_id_map` (which remains authoritative until step c
+    /// flips reads, step d drops mutations, step e deletes the
+    /// host field). On every event the reader compares the two
+    /// and logs drift via `target = "launcher-ipc:drift"`.
+    pub shadow_backend_window_ids: Mutex<HashMap<String, String>>,
+
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 
@@ -244,6 +255,7 @@ impl Default for AppState {
             window_id: Mutex::new(None),
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
+            shadow_backend_window_ids: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({
                 // Pre-seed with main=1 to mirror the launcher's
                 // pre-seeded `instance_registry` (B.5a). Without

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.466"
+version = "0.33.467"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.466"
+version = "0.33.467"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.466"
+version = "0.33.467"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.466",
+  "version": "0.33.467",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.466",
+      "version": "0.33.467",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.466",
+  "version": "0.33.467",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step b of the window_id_map migration. Host now mirrors the launcher's `BackendWindowIdRegistered` / `BackendWindowIdUnregistered` events into a passive shadow + logs drift between host's authoritative copy and the launcher's view. Pure observation; no behavior change.

## What's in here

**Host emits** (so the launcher's `state.backend_window_ids` from #585 actually gets populated):
- `commands/window.rs::register_backend_window` → `report_backend_window_id_registered(label, window_id)` after the local `window_id_map.insert`.
- `client.rs::on_before_close` → `report_backend_window_id_unregistered(label)` after the local `window_id_map.remove`.

**Host shadow** (`state.rs`, `launcher_ipc.rs`):
- `AppState.shadow_backend_window_ids: Mutex<HashMap<String, String>>`.
- `apply_event_to_shadow`'s new `BackendWindowIdRegistered` arm:
  - Drift compare to host's `window_id_map` (skip if host doesn't have it yet — race-tolerant).
  - Insert into shadow.
- `apply_event_to_shadow`'s new `BackendWindowIdUnregistered` arm:
  - Same race-vs-bug compare pattern as the now-deleted WindowInstanceReleased compare (split-brain → WARN; same-id → INFO).
  - Drop from shadow.

## What's NOT in here

- Step c (read cutover): host's `register_backend_window` reads come through a shadow-first helper (next PR).
- Step d (drop host writes), step e (delete field): subsequent PRs.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.
- [ ] Smoke test: launch portable, open + close a tear-off. Watch launcher log for `BackendWindowIdRegistered` / `Unregistered` events appearing post-`register_backend_window` IPC. Watch host log for `launcher-ipc:drift` — should be empty in steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)