### PR TITLE
feat: B.5 (window_id_map) step c — read cutover via state helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.467"
+version = "0.33.468"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.467"
+version = "0.33.468"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.467"
+version = "0.33.468"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.467"
+version = "0.33.468"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.467"
+version = "0.33.468"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -387,15 +387,27 @@ pub fn get_double_click_time() -> serde_json::Value {
 /// fall back to label/index-based naming in that case.
 pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
     let pool_labels = state.unpromoted_pool_labels.lock().clone();
-    let window_id_map = state.window_id_map.lock();
     let browsers = state.browsers.lock();
-    let entries: Vec<serde_json::Value> = browsers
+    let labels: Vec<String> = browsers
         .keys()
         .filter(|l| !pool_labels.contains(*l) && !l.starts_with("browser-pane-"))
+        .cloned()
+        .collect();
+    drop(browsers);
+    // Phase B.5 (window_id_map step c) — read backend window IDs
+    // via `state.backend_window_id()`, which prefers the
+    // launcher-fed `shadow_backend_window_ids` (the source of
+    // truth post-B.5a-equivalent for this map) and falls back to
+    // host's `window_id_map` only for the race window between the
+    // frontend's `register_backend_window` and the launcher's
+    // reply event arriving back. We resolve labels OUTSIDE the
+    // browsers lock to avoid nesting (browsers + shadow).
+    let entries: Vec<serde_json::Value> = labels
+        .iter()
         .map(|l| {
             serde_json::json!({
                 "label": l,
-                "windowId": window_id_map.get(l),
+                "windowId": state.backend_window_id(l),
             })
         })
         .collect();

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -310,4 +310,27 @@ impl AppState {
     pub fn instance_count(&self) -> usize {
         self.shadow_instance_registry.lock().len()
     }
+
+    /// Phase B.5 (window_id_map step c) — authoritative
+    /// label→backend_window_id lookup. Prefers the launcher-fed
+    /// `shadow_backend_window_ids`; falls back to host's local
+    /// `window_id_map` for the race window where host has just
+    /// `insert`ed the mapping but the launcher's
+    /// `BackendWindowIdRegistered` event hasn't returned yet.
+    /// Same prefer-shadow pattern as `instance_num`.
+    pub fn backend_window_id(&self, label: &str) -> Option<String> {
+        if let Some(id) = self.shadow_backend_window_ids.lock().get(label).cloned() {
+            return Some(id);
+        }
+        let fallback = self.window_id_map.lock().get(label).cloned();
+        if let Some(ref id) = fallback {
+            tracing::debug!(
+                target: "launcher-ipc:fallback",
+                label = %label,
+                window_id = %id,
+                "[backend_window_id] shadow miss — falling back to host's window_id_map (B.5c transitional)"
+            );
+        }
+        fallback
+    }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.467"
+version = "0.33.468"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.467"
+version = "0.33.468"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.467"
+version = "0.33.468"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.467",
+  "version": "0.33.468",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.467",
+      "version": "0.33.468",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.467",
+  "version": "0.33.468",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step c of the window_id_map migration. New `AppState::backend_window_id(label)` helper prefers the launcher-fed `shadow_backend_window_ids` and falls back to host's `window_id_map` for the race window. Same pattern as `instance_num` from the previous map's migration.

## What's in here

- `AppState::backend_window_id(label) -> Option<String>` — shadow → host fallback → None. DEBUG-logs to `launcher-ipc:fallback` on miss.
- `commands/window.rs::list_window_instances` switched: `window_id_map.lock().get(l)` → `state.backend_window_id(l)`. Lock restructured to avoid nesting `browsers` + `shadow_backend_window_ids` (collect labels under browsers, drop, then resolve).
- Mutations untouched. The remove-and-read in `on_before_close` is intentionally left for step d.

## What's NOT in here

- Step d (drop host's `insert` + `remove`): next PR.
- Step e (delete `window_id_map` field): after d.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.
- [ ] Smoke test: open + close 2-3 tear-offs, confirm `list_window_instances` returns correct windowIds via the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)