### PR TITLE
feat: B.5 (window_id_map) step d — drop host's window_id_map mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.468"
+version = "0.33.469"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.468"
+version = "0.33.469"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.468"
+version = "0.33.469"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.468"
+version = "0.33.469"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.468"
+version = "0.33.469"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -348,18 +348,17 @@ impl AgentMuxHandler {
             }
         }
 
-        // Phase B.5e — host's `WindowInstanceRegistry` is gone; the
-        // launcher's `state.instance_registry` is sole authority,
-        // close-side updates flow via `Event::WindowInstanceReleased`
-        // → `apply_event_to_shadow`. We still clean up
-        // `window_id_map` here (B.5 hasn't migrated that map yet —
-        // it's the current target).
+        // Phase B.5 (window_id_map step d) — host no longer mutates
+        // `window_id_map`. The launcher's `state.backend_window_ids`
+        // (B.5 step a) is the sole authority; we look up the wid
+        // via the shadow-first helper before notifying the launcher
+        // to drop it. The wid lookup at close time is safe even
+        // without the host fallback because the frontend's original
+        // `register_backend_window` ran long before close — shadow
+        // has been populated for the entire window lifetime.
         let backend_window_id = label.as_deref().and_then(|lbl| {
-            let wid = self.state.window_id_map.lock().remove(lbl);
-            dlog(&format!("window_id_map.remove({:?}) => {:?}", lbl, wid));
-            // Phase B.5 (window_id_map step b) — mirror the
-            // unregister to the launcher. Fires whether or not we
-            // actually had an entry; the reducer is idempotent.
+            let wid = self.state.backend_window_id(lbl);
+            dlog(&format!("backend_window_id({:?}) => {:?}", lbl, wid));
             crate::launcher_ipc::report_backend_window_id_unregistered(lbl.to_string());
             wid
         });

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -494,11 +494,12 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
     tracing::info!(label = %label, window_id = %window_id, "[window] register_backend_window received");
     crate::client::dlog(&format!("register_backend_window: label={} window_id={}", label, window_id));
     if !window_id.is_empty() {
-        state.window_id_map.lock().insert(label.to_string(), window_id.to_string());
-        let keys: Vec<String> = state.window_id_map.lock().keys().cloned().collect();
-        crate::client::dlog(&format!("window_id_map now has keys: {:?}", keys));
+        // Phase B.5 (window_id_map step d) — host no longer mutates
+        // `window_id_map` locally. The launcher's
+        // `state.backend_window_ids` (B.5 step a) is sole authority;
+        // we just send the report and the shadow update populates
+        // the host-side projection.
         tracing::info!(label = %label, window_id = %window_id, "[window] registered backend window ID");
-        // Phase B.5 (window_id_map step b) — mirror to launcher.
         crate::launcher_ipc::report_backend_window_id_registered(
             label.to_string(),
             window_id.to_string(),

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.468"
+version = "0.33.469"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.468"
+version = "0.33.469"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.468"
+version = "0.33.469"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.468",
+  "version": "0.33.469",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.468",
+      "version": "0.33.469",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.468",
+  "version": "0.33.469",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step d of the window_id_map migration. Host's two `window_id_map` mutation sites are removed:

- `commands/window.rs::register_backend_window` — local `insert` is gone; only the launcher report fires.
- `client.rs::on_before_close` — local `remove` is gone; wid looked up via `state.backend_window_id(lbl)` before the launcher report.

The wid lookup at close is safe without the host fallback because the frontend's original `register_backend_window` ran long before close — shadow has been populated for the entire window lifetime.

After this lands, host's `window_id_map` is empty (initialized empty, no mutations) and vestigial. Step e deletes it.

## What's NOT in here

- Step e: delete `AppState.window_id_map`, host-fallback branch in `backend_window_id`, drift compares in `apply_event_to_shadow`. Almost-pure-delete.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.
- [ ] Smoke test: open + close a tear-off, confirm `register_backend_window` IPC still works (frontend sees no failure), close path correctly notifies backend with the right wid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)