### PR TITLE
feat: B.5 (window_id_map) step e — delete host's window_id_map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.469"
+version = "0.33.470"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.469"
+version = "0.33.470"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.469"
+version = "0.33.470"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.469"
+version = "0.33.470"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.469"
+version = "0.33.470"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -394,14 +394,10 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
         .cloned()
         .collect();
     drop(browsers);
-    // Phase B.5 (window_id_map step c) — read backend window IDs
-    // via `state.backend_window_id()`, which prefers the
-    // launcher-fed `shadow_backend_window_ids` (the source of
-    // truth post-B.5a-equivalent for this map) and falls back to
-    // host's `window_id_map` only for the race window between the
-    // frontend's `register_backend_window` and the launcher's
-    // reply event arriving back. We resolve labels OUTSIDE the
-    // browsers lock to avoid nesting (browsers + shadow).
+    // Read backend window IDs via `state.backend_window_id()`,
+    // which queries the launcher-fed `shadow_backend_window_ids`
+    // (sole source of truth post-B.5e). Resolve labels OUTSIDE
+    // the browsers lock to avoid nesting (browsers + shadow).
     let entries: Vec<serde_json::Value> = labels
         .iter()
         .map(|l| {

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -266,68 +266,16 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             );
         }
         Event::BackendWindowIdRegistered { label, window_id, .. } => {
-            // Phase B.5 (window_id_map step b) — shadow projection
-            // + drift compare. Host's `window_id_map` is still
-            // authoritative through step c; we log when the two
-            // disagree so the soak period before cutover surfaces
-            // any reporting bugs. Race-tolerant: host's
-            // `register_backend_window` mutation may not have run
-            // yet, so a "missing in host" case is benign and skipped.
-            let host_id = state
-                .window_id_map
-                .lock()
-                .get(label)
-                .cloned();
-            if let Some(host_id) = host_id {
-                if &host_id != window_id {
-                    tracing::warn!(
-                        target: "launcher-ipc:drift",
-                        label = %label,
-                        launcher_id = %window_id,
-                        host_id = %host_id,
-                        "[launcher-ipc] backend_window_id drift: host and launcher disagree"
-                    );
-                }
-            }
+            // Phase B.5 (window_id_map step e) — host's
+            // `window_id_map` was deleted; the drift compare is
+            // gone with it. Shadow is sole source of truth.
             state
                 .shadow_backend_window_ids
                 .lock()
                 .insert(label.clone(), window_id.clone());
         }
-        Event::BackendWindowIdUnregistered { label, window_id, .. } => {
-            // Phase B.5 (window_id_map step b) — symmetric drift
-            // check on release. Two cases:
-            // * host has a different ID for this label → split-brain
-            //   on the original registration, log WARN.
-            // * host has the same ID → either host hasn't run its
-            //   own `remove()` yet (race) or never will (bug).
-            //   Log INFO; sustained presence indicates a bug
-            //   (mirrors the B.5b/c WindowInstanceReleased pattern
-            //   that survived only briefly because we deleted the
-            //   compare in B.5e).
-            let host_id = state
-                .window_id_map
-                .lock()
-                .get(label)
-                .cloned();
-            if let Some(host_id) = host_id {
-                if &host_id != window_id {
-                    tracing::warn!(
-                        target: "launcher-ipc:drift",
-                        label = %label,
-                        launcher_released_id = %window_id,
-                        host_id = %host_id,
-                        "[launcher-ipc] backend_window_id release-side split-brain"
-                    );
-                } else {
-                    tracing::info!(
-                        target: "launcher-ipc:drift",
-                        label = %label,
-                        window_id = %window_id,
-                        "[launcher-ipc] backend_window_id release-side: host still has matching entry — race or unregister bug"
-                    );
-                }
-            }
+        Event::BackendWindowIdUnregistered { label, .. } => {
+            // Phase B.5 (window_id_map step e) — drift compare gone.
             state.shadow_backend_window_ids.lock().remove(label);
         }
         Event::WindowInstanceReleased { label, .. } => {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -91,10 +91,10 @@ pub struct WindowMeta {
 /// `tauri::State<AppState>`. The sidecar child is `std::process::Child` instead
 /// of `tauri_plugin_shell::process::CommandChild`.
 pub struct AppState {
-    /// Maps window label (e.g. "main", "window-{uuid}") to the backend window ID.
-    /// Populated when the frontend calls `register_backend_window` during init.
-    /// Used by `on_before_close` to notify the backend to clean up.
-    pub window_id_map: Mutex<HashMap<String, String>>,
+    // Phase B.5 (window_id_map step e) — `window_id_map` field
+    // deleted. Authoritative copy lives in the launcher's
+    // `state.backend_window_ids`. Host's projection is in
+    // `shadow_backend_window_ids` (below).
 
     /// Auth key for backend communication
     pub auth_key: Mutex<String>,
@@ -244,7 +244,6 @@ pub struct AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self {
-            window_id_map: Mutex::new(HashMap::new()),
             auth_key: Mutex::new(uuid::Uuid::new_v4().to_string()),
             backend_endpoints: Mutex::new(BackendEndpoints::default()),
             sidecar_child: Mutex::new(None),
@@ -311,26 +310,11 @@ impl AppState {
         self.shadow_instance_registry.lock().len()
     }
 
-    /// Phase B.5 (window_id_map step c) — authoritative
-    /// label→backend_window_id lookup. Prefers the launcher-fed
-    /// `shadow_backend_window_ids`; falls back to host's local
-    /// `window_id_map` for the race window where host has just
-    /// `insert`ed the mapping but the launcher's
-    /// `BackendWindowIdRegistered` event hasn't returned yet.
-    /// Same prefer-shadow pattern as `instance_num`.
+    /// Phase B.5 (window_id_map step e) — authoritative
+    /// label→backend_window_id lookup. Reads from the
+    /// launcher-fed `shadow_backend_window_ids`. Sole source of
+    /// truth post-step-e (host's `window_id_map` was deleted).
     pub fn backend_window_id(&self, label: &str) -> Option<String> {
-        if let Some(id) = self.shadow_backend_window_ids.lock().get(label).cloned() {
-            return Some(id);
-        }
-        let fallback = self.window_id_map.lock().get(label).cloned();
-        if let Some(ref id) = fallback {
-            tracing::debug!(
-                target: "launcher-ipc:fallback",
-                label = %label,
-                window_id = %id,
-                "[backend_window_id] shadow miss — falling back to host's window_id_map (B.5c transitional)"
-            );
-        }
-        fallback
+        self.shadow_backend_window_ids.lock().get(label).cloned()
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.469"
+version = "0.33.470"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.469"
+version = "0.33.470"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.469"
+version = "0.33.470"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.469",
+  "version": "0.33.470",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.469",
+      "version": "0.33.470",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.469",
+  "version": "0.33.470",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Final step of the window_id_map migration. After step d (#588) removed all mutations, the host field is vestigial. Deleted now:

- `AppState.window_id_map: Mutex<HashMap<String, String>>` field + initializer.
- Host-fallback branch in `state.backend_window_id()` — reads shadow directly.
- Drift-compare branches in both `Registered` and `Unregistered` arms of `apply_event_to_shadow`.
- Stale doc comment in `list_window_instances`.

Net: **+18 / -90**.

## Migration cycle #2 complete

Per `docs/retro/migration-pattern.md`'s a→b→c→d→e:

| Step | PR |
|---|---|
| a | #585 |
| b | #586 |
| c | #587 |
| d | #588 |
| **e** | **#589 (this)** |

Same pattern as `window_instance_registry` (#579-#584). Ratchet twice-validated. Remaining: `window_meta`, `browsers`, pool maps (partial-B.4 shortcut).

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)