### PR TITLE
feat: B.5 (window_meta) step b — host shadow + drift + #589 doc fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.470"
+version = "0.33.471"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.470"
+version = "0.33.471"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.470"
+version = "0.33.471"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.470"
+version = "0.33.471"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.470"
+version = "0.33.471"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -265,6 +265,53 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 &serde_json::json!(count),
             );
         }
+        Event::WindowOpened { label, kind, parent_label, .. } => {
+            // Phase B.5 (window_meta step b) — shadow projection
+            // + drift compare. Map the wire `WindowKind` back to
+            // host's `crate::state::WindowKind` (one-to-one).
+            let host_kind = match kind {
+                agentmux_common::ipc::WindowKind::FullInstance => crate::state::WindowKind::FullInstance,
+                agentmux_common::ipc::WindowKind::Subwindow => crate::state::WindowKind::Subwindow,
+            };
+            let shadow_meta = crate::state::WindowMeta {
+                label: label.clone(),
+                kind: host_kind,
+                parent_instance_id: parent_label.clone(),
+            };
+            // Drift compare to host's authoritative `window_meta`.
+            // Race-tolerant: host's local insert (in
+            // `on_after_created`) may not have run yet if the
+            // launcher event raced ahead. Skip in that case.
+            let host_meta = state.window_meta.lock().get(label).cloned();
+            if let Some(host_meta) = host_meta {
+                if host_meta.kind != shadow_meta.kind
+                    || host_meta.parent_instance_id != shadow_meta.parent_instance_id
+                {
+                    tracing::warn!(
+                        target: "launcher-ipc:drift",
+                        label = %label,
+                        launcher_kind = ?shadow_meta.kind,
+                        launcher_parent = ?shadow_meta.parent_instance_id,
+                        host_kind = ?host_meta.kind,
+                        host_parent = ?host_meta.parent_instance_id,
+                        "[launcher-ipc] window_meta drift: host and launcher disagree"
+                    );
+                }
+            }
+            state
+                .shadow_window_meta
+                .lock()
+                .insert(label.clone(), shadow_meta);
+        }
+        Event::WindowClosed { label, .. } => {
+            // Phase B.5 (window_meta step b) — symmetric drop.
+            // Drift compare on close is omitted: the launcher's
+            // strict-pairing semantic (PR #577 round-2) means we
+            // only see this event when the open was paired, so a
+            // host-side missing entry would have surfaced at
+            // open time.
+            state.shadow_window_meta.lock().remove(label);
+        }
         Event::BackendWindowIdRegistered { label, window_id, .. } => {
             // Phase B.5 (window_id_map step e) — host's
             // `window_id_map` was deleted; the drift compare is

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -138,16 +138,27 @@ pub struct AppState {
     /// arrives).
     pub shadow_instance_registry: Mutex<HashMap<String, u32>>,
 
-    /// Phase B.5 (window_id_map step b) — shadow projection of the
+    /// Phase B.5 (window_id_map) — host's projection of the
     /// launcher's authoritative `state.backend_window_ids`. Fed by
     /// `Event::BackendWindowIdRegistered` /
     /// `Event::BackendWindowIdUnregistered` via
-    /// `apply_event_to_shadow`. Maintained in parallel to
-    /// `window_id_map` (which remains authoritative until step c
-    /// flips reads, step d drops mutations, step e deletes the
-    /// host field). On every event the reader compares the two
-    /// and logs drift via `target = "launcher-ipc:drift"`.
+    /// `apply_event_to_shadow`. Sole source of truth post-step-e
+    /// (host's `window_id_map` was deleted). Read via
+    /// `Self::backend_window_id`; never mutated directly by host
+    /// code.
     pub shadow_backend_window_ids: Mutex<HashMap<String, String>>,
+
+    /// Phase B.5 (window_meta step b) — host's projection of the
+    /// launcher's authoritative `state.windows: HashMap<String,
+    /// WindowMirror>` (B.4). The launcher already mirrors all
+    /// `WindowMeta` data via `Event::WindowOpened`/`WindowClosed`
+    /// (carrying `{label, kind, parent_label}` since B.4); this
+    /// host-side cache makes it readable without a launcher
+    /// round-trip. Maintained in parallel to `window_meta` until
+    /// step c flips reads, step d drops mutations, step e deletes
+    /// the host field. Drift logged via
+    /// `target = "launcher-ipc:drift"`.
+    pub shadow_window_meta: Mutex<HashMap<String, WindowMeta>>,
 
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
@@ -255,6 +266,7 @@ impl Default for AppState {
             active_tab_id: Mutex::new(None),
             window_init_status: Mutex::new(String::new()),
             shadow_backend_window_ids: Mutex::new(HashMap::new()),
+            shadow_window_meta: Mutex::new(HashMap::new()),
             shadow_instance_registry: Mutex::new({
                 // Pre-seed with main=1 to mirror the launcher's
                 // pre-seeded `instance_registry` (B.5a). Without

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.470"
+version = "0.33.471"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.470"
+version = "0.33.471"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.470"
+version = "0.33.471"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.470",
+  "version": "0.33.471",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.470",
+      "version": "0.33.471",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.470",
+  "version": "0.33.471",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two bundled per the new merge-gate workflow:

### #589 reagent P2 doc fix (deferred)
Stale comment on `shadow_backend_window_ids` referenced step-b parallel-mode semantics that no longer apply post-step-e. Updated to describe the post-migration sole-source-of-truth state.

### B.5 (window_meta) step b

Important observation: this map is structurally a twin of B.4's `state.windows: HashMap<String, WindowMirror>`. The launcher already mirrors all `WindowMeta { label, kind, parent_instance_id }` data via `Event::WindowOpened`/`WindowClosed` (which carry `{label, kind, parent_label}` since B.4). **Step a is a no-op** — the wire and launcher state already exist.

Step b adds:
- `AppState.shadow_window_meta: Mutex<HashMap<String, WindowMeta>>`.
- New `Event::WindowOpened` arm in `apply_event_to_shadow`: maps wire `WindowKind` → host's `WindowKind`, constructs `WindowMeta`, drift-compares to host's authoritative `window_meta`, inserts into shadow.
- New `Event::WindowClosed` arm: drops from shadow. No drift compare on close — launcher's strict open/close pairing (codex P2 PR #577 round-2) means a missing host entry would have surfaced at open.

Pure observation. No behavior change.

## Migration cycle progress

- `window_instance_registry`: ✓ complete (#579-#584)
- `window_id_map`: ✓ complete (#585-#589)
- **`window_meta`**: step b in flight (this PR)
- `browsers`: pending
- pool maps: partial-B.4 shortcut

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)