### PR TITLE
feat: B.5 (window_meta) step c — read cutover via state helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.471"
+version = "0.33.472"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.471"
+version = "0.33.472"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.471"
+version = "0.33.472"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.471"
+version = "0.33.472"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2399,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.471"
+version = "0.33.472"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -175,7 +175,14 @@ impl AgentMuxHandler {
                 // Subwindow? Hide from taskbar. Full instances and browser-pane
                 // child HWNDs skip this branch.
                 if is_top_level_window {
-                    let kind = self.state.window_meta.lock().get(&label).map(|m| m.kind);
+                    // Phase B.5 (window_meta step c) — read via
+                    // shadow-first helper. Brief race window for
+                    // newly-created windows where shadow doesn't
+                    // have the entry yet; falls back to host's
+                    // `window_meta` (still authoritative through
+                    // step d) which has the pre-create handoff
+                    // entry.
+                    let kind = self.state.window_meta(&label).map(|m| m.kind);
                     if kind == Some(WindowKind::Subwindow) {
                         unsafe { skip_taskbar(hwnd); }
                     }
@@ -366,22 +373,24 @@ impl AgentMuxHandler {
         // Pull and remove the closing window's meta; if it's a FullInstance,
         // cascade-close every Subwindow whose parent_instance_id points to it.
         // See `docs/specs/SPEC_MULTIWINDOW_TASKBAR_GROUPING.md` §2.3.
+        //
+        // Phase B.5 (window_meta step c) — read closing meta via
+        // shadow-first helper, then enumerate children via
+        // `state.subwindow_children_of`. The local `remove` is
+        // still done for now (step d retires it) so the host's
+        // mutation surface stays consistent with the rest of B.5
+        // step c.
         let closing_meta = label
             .as_deref()
-            .and_then(|lbl| self.state.window_meta.lock().remove(lbl));
+            .and_then(|lbl| self.state.window_meta(lbl));
+        // Drop the host-side entry to keep the eager-mutation
+        // contract through step d.
+        if let Some(lbl) = label.as_deref() {
+            self.state.window_meta.lock().remove(lbl);
+        }
         if let Some(meta) = &closing_meta {
             if meta.kind == WindowKind::FullInstance {
-                let child_labels: Vec<String> = self
-                    .state
-                    .window_meta
-                    .lock()
-                    .values()
-                    .filter(|m| {
-                        m.kind == WindowKind::Subwindow
-                            && m.parent_instance_id.as_deref() == Some(&meta.label)
-                    })
-                    .map(|m| m.label.clone())
-                    .collect();
+                let child_labels = self.state.subwindow_children_of(&meta.label);
                 for child_label in child_labels {
                     if let Some(mut child) = self.state.browsers.lock().get(&child_label).cloned() {
                         if let Some(host) = child.host() {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -354,47 +354,39 @@ impl AppState {
 
     /// Phase B.5 (window_meta step c) — collect labels of Subwindows
     /// whose `parent_instance_id` points to `parent_label`. Used by
-    /// `on_before_close`'s cascade-close logic. Reads from the
-    /// shadow first; falls back to host's `window_meta` if shadow
-    /// is empty (early in startup, before any events have arrived).
+    /// `on_before_close`'s cascade-close logic.
+    ///
+    /// Returns the **union** of matches from `shadow_window_meta`
+    /// (the launcher-fed projection) and host's `window_meta` (the
+    /// eager pre-create handoff). The union covers a critical race:
+    /// a parent may already have one mirrored subwindow AND a newly
+    /// opened sibling whose `WindowOpened` event hasn't returned to
+    /// host yet. The newer sibling lives in host's `window_meta`
+    /// only; the mirrored one lives in shadow only (post-step-d
+    /// the shadow becomes the sole source). Cascade-close MUST
+    /// catch both — short-circuiting on shadow-non-empty would
+    /// leave the race-window sibling orphaned. (codex P1 PR #591
+    /// round-1.)
+    ///
+    /// Dedup is by label; if a label is in both, it's reported
+    /// once. Labels collected via a HashSet to dedup, returned as
+    /// a Vec.
     pub fn subwindow_children_of(&self, parent_label: &str) -> Vec<String> {
-        let from_shadow: Vec<String> = self
-            .shadow_window_meta
-            .lock()
-            .values()
-            .filter(|m| {
-                m.kind == WindowKind::Subwindow
-                    && m.parent_instance_id.as_deref() == Some(parent_label)
-            })
-            .map(|m| m.label.clone())
-            .collect();
-        if !from_shadow.is_empty() {
-            return from_shadow;
+        let mut out: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for m in self.shadow_window_meta.lock().values() {
+            if m.kind == WindowKind::Subwindow
+                && m.parent_instance_id.as_deref() == Some(parent_label)
+            {
+                out.insert(m.label.clone());
+            }
         }
-        // Shadow had no matches — either there genuinely are no
-        // subwindow children, OR shadow hasn't been populated yet
-        // (race during early startup before any WindowOpened event
-        // has arrived). Fall back to host's window_meta to cover
-        // the latter; if shadow is correct (no children), this
-        // returns the same empty Vec.
-        let from_host: Vec<String> = self
-            .window_meta
-            .lock()
-            .values()
-            .filter(|m| {
-                m.kind == WindowKind::Subwindow
-                    && m.parent_instance_id.as_deref() == Some(parent_label)
-            })
-            .map(|m| m.label.clone())
-            .collect();
-        if !from_host.is_empty() {
-            tracing::debug!(
-                target: "launcher-ipc:fallback",
-                parent_label = %parent_label,
-                count = %from_host.len(),
-                "[subwindow_children_of] shadow miss — falling back to host's window_meta"
-            );
+        for m in self.window_meta.lock().values() {
+            if m.kind == WindowKind::Subwindow
+                && m.parent_instance_id.as_deref() == Some(parent_label)
+            {
+                out.insert(m.label.clone());
+            }
         }
-        from_host
+        out.into_iter().collect()
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -329,4 +329,72 @@ impl AppState {
     pub fn backend_window_id(&self, label: &str) -> Option<String> {
         self.shadow_backend_window_ids.lock().get(label).cloned()
     }
+
+    /// Phase B.5 (window_meta step c) — authoritative WindowMeta
+    /// lookup. Prefers the launcher-fed `shadow_window_meta`; falls
+    /// back to host's local `window_meta` for the race window
+    /// where host has just inserted the pre-create handoff but
+    /// the launcher's `WindowOpened` event hasn't returned yet.
+    /// Same prefer-shadow pattern as `instance_num` and
+    /// `backend_window_id`.
+    pub fn window_meta(&self, label: &str) -> Option<WindowMeta> {
+        if let Some(meta) = self.shadow_window_meta.lock().get(label).cloned() {
+            return Some(meta);
+        }
+        let fallback = self.window_meta.lock().get(label).cloned();
+        if fallback.is_some() {
+            tracing::debug!(
+                target: "launcher-ipc:fallback",
+                label = %label,
+                "[window_meta] shadow miss — falling back to host's window_meta (B.5c transitional)"
+            );
+        }
+        fallback
+    }
+
+    /// Phase B.5 (window_meta step c) — collect labels of Subwindows
+    /// whose `parent_instance_id` points to `parent_label`. Used by
+    /// `on_before_close`'s cascade-close logic. Reads from the
+    /// shadow first; falls back to host's `window_meta` if shadow
+    /// is empty (early in startup, before any events have arrived).
+    pub fn subwindow_children_of(&self, parent_label: &str) -> Vec<String> {
+        let from_shadow: Vec<String> = self
+            .shadow_window_meta
+            .lock()
+            .values()
+            .filter(|m| {
+                m.kind == WindowKind::Subwindow
+                    && m.parent_instance_id.as_deref() == Some(parent_label)
+            })
+            .map(|m| m.label.clone())
+            .collect();
+        if !from_shadow.is_empty() {
+            return from_shadow;
+        }
+        // Shadow had no matches — either there genuinely are no
+        // subwindow children, OR shadow hasn't been populated yet
+        // (race during early startup before any WindowOpened event
+        // has arrived). Fall back to host's window_meta to cover
+        // the latter; if shadow is correct (no children), this
+        // returns the same empty Vec.
+        let from_host: Vec<String> = self
+            .window_meta
+            .lock()
+            .values()
+            .filter(|m| {
+                m.kind == WindowKind::Subwindow
+                    && m.parent_instance_id.as_deref() == Some(parent_label)
+            })
+            .map(|m| m.label.clone())
+            .collect();
+        if !from_host.is_empty() {
+            tracing::debug!(
+                target: "launcher-ipc:fallback",
+                parent_label = %parent_label,
+                count = %from_host.len(),
+                "[subwindow_children_of] shadow miss — falling back to host's window_meta"
+            );
+        }
+        from_host
+    }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.471"
+version = "0.33.472"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.471"
+version = "0.33.472"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.471"
+version = "0.33.472"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.471",
+  "version": "0.33.472",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.471",
+      "version": "0.33.472",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.471",
+  "version": "0.33.472",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step c of the window_meta migration. Two new helpers route reads through the launcher-fed shadow:

- `state.window_meta(label)` — single-label lookup with shadow-first / host-fallback (mirrors `instance_num`, `backend_window_id`).
- `state.subwindow_children_of(parent_label)` — Vec of Subwindow children of a FullInstance, for cascade-close.

## Read sites switched (2)

- `on_after_created` line 178 — Subwindow taskbar-hide check.
- `on_before_close` lines 369-394 — closing-window meta + cascade-close child enumeration.

## What's NOT switched

The pre-create handoff read at `on_after_created` line 200. That's where `report_window_opened` reads kind/parent_label that the caller (drag/window/pool) wrote into `window_meta` ~ms earlier. Shadow is empty there (no launcher round-trip yet); host fallback is correct. **Step d redesigns the handoff to bypass `window_meta` entirely** — that's where the bigger structural change lives.

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.
- [ ] Smoke test: open a tear-off (FullInstance) + a Subwindow if possible. Verify the Subwindow's taskbar-hide still works (helper finds the kind), and closing the FullInstance still cascade-closes its Subwindow children.

🤖 Generated with [Claude Code](https://claude.com/claude-code)