### PR TITLE
docs: roadmap update + track 4 untracked retro docs

### DIFF
--- a/docs/retro/b1-srv-spawner-design.md
+++ b/docs/retro/b1-srv-spawner-design.md
@@ -1,0 +1,164 @@
+# B.1 Concrete Design — Move srv spawn from host to launcher
+
+**Status:** to execute
+**Branch:** `agenta/phase-b1-launcher-srv-spawner` (off `c5f60944` — main with PR #570 merged)
+
+---
+
+## Goal
+
+After B.1 ships, the process tree is:
+
+```
+launcher (Job Object J0, KILL_ON_JOB_CLOSE)
+├── srv (assigned to J0 directly; survives host crash)
+└── host (assigned to J0; renderers inherit J0)
+```
+
+vs today (post PR #570):
+
+```
+launcher (Job Object J0)
+└── host (assigned to J0)
+    ├── srv (assigned to host-owned J1 — DIES when host dies)
+    └── renderers (inherit J0)
+```
+
+The key change: srv becomes a sibling of host under the launcher, so srv outlives a host crash. This is the foundation for Phase B's launcher-driven state machine, which needs to be able to restart the host while keeping srv (and its DB state) alive.
+
+## Non-goals for B.1
+
+- The reducer / state machine itself (Phase B sub-PRs B.3+).
+- Named-pipe IPC for commands/events (Phase B sub-PR B.2).
+- Removing host's `spawn_backend` entirely — kept as fallback for `task dev` where the launcher isn't in the loop.
+- Touching frontend.
+
+## Env-var contract launcher → host
+
+Launcher passes srv coordinates to host via env vars; host honors env if present, falls back to existing spawn-srv path otherwise (dev mode).
+
+| Env var | Set by | Consumed by | Meaning |
+|---|---|---|---|
+| `AGENTMUX_BACKEND_WS` | launcher | host | srv's WebSocket endpoint, e.g. `ws://127.0.0.1:8123/ws` |
+| `AGENTMUX_BACKEND_WEB` | launcher | host | srv's HTTP endpoint, e.g. `http://127.0.0.1:8123` |
+| `AGENTMUX_BACKEND_PID` | launcher | host | srv's PID, for diagnostics |
+| `AGENTMUX_DATA_DIR` | launcher | host | data dir already chosen by launcher; host uses for CEF cache + lockfile |
+| `AGENTMUX_CONFIG_DIR` | launcher | host | config dir |
+| `AGENTMUX_USER_HOME_DIR` | launcher | host | per-agent user home |
+| `AGENTMUX_AUTH_KEY` | launcher | host | shared auth key (also given to srv) |
+| `AGENTMUX_INSTANCE_ID` | launcher | host | `v{cargo_pkg_version}` |
+
+If `AGENTMUX_BACKEND_WS` is unset on host startup, host runs the existing `spawn_backend` path (`task dev` mode where the host runs without the launcher).
+
+## File-by-file changes
+
+### `agentmux-launcher/Cargo.toml`
+- Add `tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util", "time", "sync"] }`
+- Add `dirs = "5"` (path resolution matches host)
+- Add `chrono = { version = "0.4", default-features = false, features = ["clock"] }` (started_at logs)
+
+### `agentmux-launcher/src/data_dir.rs` (NEW, ~80 LoC)
+Mirror the path computation from `agentmux-cef/src/sidecar.rs:38–105`. Public API:
+```rust
+pub struct DataPaths {
+    pub data_dir: PathBuf,
+    pub config_dir: PathBuf,
+    pub user_home_dir: PathBuf,
+    pub portable_root: Option<PathBuf>,
+}
+pub fn resolve_paths(launcher_exe_dir: &Path, version: &str, is_dev: bool) -> Result<DataPaths, String>;
+```
+
+Portable detection: launcher's `exe_dir` IS the portable root if `runtime/` exists alongside. (Different from host's check, which has the host inside `runtime/` and the parent as the portable root — the launcher and host should arrive at the SAME data_dir paths.)
+
+### `agentmux-launcher/src/srv_spawner.rs` (NEW, ~250 LoC)
+Adapted from `agentmux-cef/src/sidecar.rs::spawn_backend`. Public API:
+```rust
+pub struct SrvSpawnResult {
+    pub pid: u32,
+    pub ws_endpoint: String,
+    pub web_endpoint: String,
+    pub instance_id: String,
+    pub auth_key: String,
+    pub started_at: String, // RFC3339
+    // Child handle held inside the launcher main loop; dropped on shutdown.
+    pub child: tokio::process::Child,
+}
+
+pub async fn spawn_srv(
+    paths: &DataPaths,
+    job_handle: HANDLE,
+) -> Result<SrvSpawnResult, String>;
+```
+
+Key adaptation vs host's version:
+- Uses `tokio::process::Command` for async stdio.
+- Spawns srv with **`CREATE_SUSPENDED`**, **assigns to launcher's J0**, then **`ResumeThread`** (same race-fix pattern as host spawn in PR #570).
+- Does NOT create a separate job for srv (launcher's J0 covers it).
+- Generates the auth key locally so launcher knows it (today the host generates it).
+
+### `agentmux-launcher/src/main.rs` (MODIFIED, ~+100 LoC)
+New `#[tokio::main]` entry point. Sequence:
+1. Resolve launcher's `exe_dir`.
+2. `SetDllDirectoryW("runtime")` (existing).
+3. Resolve real CEF host binary (existing).
+4. Acquire (placeholder for B.6 mutex; for now just compute paths).
+5. Resolve `DataPaths` via `data_dir::resolve_paths`.
+6. Create launcher's Job Object J0 (existing).
+7. Spawn srv suspended → assign to J0 → resume → wait for `WAVESRV-ESTART` (with 30s timeout). Get `SrvSpawnResult`.
+8. Spawn host suspended (existing) with all env vars from the table above set.
+9. Assign host to J0 → resume.
+10. `child.wait()` on host. (Srv runs independently; we'll need to wait for it too — see "concurrent waits" below.)
+11. On host exit: send `Quit` signal to srv (or just drop its handle, which closes its stdin → srv's existing PPID death detection takes over).
+12. Drop J0 → kernel reaps anything still alive.
+
+Concurrent waits: `tokio::select!` between `host.wait()` and `srv.wait()`. If host exits first → close srv gracefully (eventually, RPC-style; for now drop child handle). If srv exits first → that's a srv crash; log it, propagate exit code to host exit eventually (Phase B's reducer handles this; for B.1 just log).
+
+### `agentmux-cef/src/main.rs` (MODIFIED, ~+30/-10 LoC)
+Replace the unconditional `sidecar::spawn_backend(&app_state).await` call with:
+```rust
+let backend_ready = if env::var("AGENTMUX_BACKEND_WS").is_ok() {
+    // Launcher already spawned srv; ingest its endpoints from env.
+    use_env_endpoints(&app_state)
+} else {
+    // Dev mode: launcher not in loop, spawn srv ourselves.
+    runtime.block_on(sidecar::spawn_backend(&app_state)).is_ok()
+};
+```
+
+`use_env_endpoints` is a new helper that reads the env vars and stores endpoints + PID + auth_key into `app_state` exactly as `spawn_backend` would. ~20 LoC.
+
+### `agentmux-cef/src/sidecar.rs` (MODIFIED, ~-30 LoC)
+- **Delete** `create_job_object_for_child` and the call in `spawn_backend` (lines 180–199). Launcher's J0 covers srv via inheritance now (or directly if launcher spawns srv as in B.1). Host's J1 is redundant defense-in-depth that, after B.1, would actively HARM the goal of srv-survives-host-crash — so it goes.
+- Keep everything else for the `task dev` fallback path.
+
+## Verification (manual)
+
+After B.1:
+1. Build a portable, run it. Confirm srv spawns from the launcher (check `~/.agentmux/logs/agentmux-launcher.log` for the new srv-spawn entry).
+2. Open the InstancePanel; confirm UI works as before (no behavior change visible).
+3. Kill `agentmux-cef.exe` via Task Manager (NOT the launcher). Confirm srv stays alive (it's in launcher's J0, not host's job). Confirm launcher's `child.wait()` returns; launcher does its cleanup; srv dies via dropped handle / launcher's J0 close.
+4. Kill `agentmux.exe` (launcher) via Task Manager. Confirm both host and srv die immediately via OS-enforced J0 reap.
+5. `task dev`: confirm host still spawns srv via the fallback path; UI works as before.
+
+## Risks
+
+1. **Auth key ownership** — today host generates the auth key. B.1 moves this to launcher (so launcher can pass it to both srv and host). Need to verify nothing else in the host startup path depends on host being the auth-key author.
+2. **Backend-event forwarding** — host currently parses `WAVESRV-EVENT:` lines from srv's stderr and forwards to frontends as `agentmuxsrv-event`. If launcher captures srv's stderr, it can't forward to frontend (no IPC channel yet). For B.1: log them in launcher; events not forwarded. Phase B sub-PR B.2 (IPC) will properly forward.
+3. **AGENTMUX_DEV** env propagation — currently host sets it on the srv command. Launcher needs to do the same.
+4. **portable_root detection** — launcher's `exe_dir` IS the portable root; host's grandparent IS the portable root. Both must arrive at the same `data_dir` for CEF cache to work across both processes. Easy to get wrong; add a sanity log.
+5. **Tokio runtime in launcher** — adds ~3 MB to launcher binary. Acceptable per Phase B Decision 1.
+
+## Out of scope (queued for later sub-PRs)
+
+- B.2: Named-pipe IPC server in launcher (commands + events).
+- B.3: `Command` + `Event` types + pure reducer skeleton.
+- B.4: Launcher state mirror (read-only diff vs host state).
+- B.5: Migrate state stores to launcher-authoritative (one HashMap per sub-PR).
+- B.6: Per-data-dir mutex single-instance.
+- B.7: Frontend deletes polling loop; subscribes via host bridge.
+- B.8: Phase B exit; delete host-side state stores.
+
+---
+
+Going to execute this now. Starting with Cargo.toml + data_dir.rs.

--- a/docs/retro/migration-pattern.md
+++ b/docs/retro/migration-pattern.md
@@ -1,0 +1,149 @@
+# Migration pattern: moving state from host to launcher (Phase B)
+
+**Status:** Active reference for Phase B sub-PRs (B.4, B.5, B.7).
+**Author:** AgentA (extracted from PR #581 review-cycle conversation).
+**Date:** 2026-04-28.
+
+## TL;DR
+
+Phase B moves OS-level state (windows, pool, instance numbers, lifecycle) from the host's ad-hoc `HashMap`s into the launcher's pure-reducer state machine. We can't atomically swap a state store that has ~5 read/write call sites, so each migration is a **5-step ratchet** (a → b → c → d → e). The "shadow" naming refers to the host-side projection of the launcher's authoritative state during the transition.
+
+## End state: the Redux/state-machine model
+
+The launcher owns the canonical OS-level state. It runs a **pure reducer**:
+
+```
+update(state, command, ctx) → Vec<Event>
+```
+
+* **Commands** flow client→launcher — "I did a thing" or "do a thing."
+* **Events** flow launcher→clients — broadcast state changes.
+* **State** lives only in the launcher. Other processes hold *projections* of state that they maintain by consuming events.
+
+This is the Elm/Redux pattern: state is data, transitions are functions, side effects fire from events. Spec source: `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md`.
+
+The contract is enforced by:
+* The reducer being pure (no I/O, no clocks, no env reads — context is injected).
+* The `update` function being **total** — never panics on input.
+* `proptest` over arbitrary command sequences (asserts version monotonicity, lifecycle invariants, etc.).
+* Strict layering: only the reducer mutates state.
+
+## The problem this solves
+
+Pre-Phase-B, host's `AppState` (`agentmux-cef/src/state.rs`) was the de-facto authority for everything: `browsers`, `window_meta`, `window_id_map`, `window_instance_registry`, `window_pool`, `unpromoted_pool_labels`, `window_pool_respawn_in_flight`, etc. — 13 separate Mutex-wrapped fields per `ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md`. Each map was mutated by ~5 call sites scattered through CEF lifecycle callbacks, IPC handlers, drag/drop code.
+
+Symptoms of this fragmentation (recurring bugs the spec analyzed):
+
+| Bug | Why |
+|---|---|
+| Pool windows leak to taskbar after tear-off crash | `WindowInstanceRegistry::register()` and `unregister()` had non-symmetric call paths — `unregister` called from `on_pool_window_destroyed` for labels that were never registered → silent no-op + leaked instance number. |
+| Burst tear-offs empty the pool | `window_pool_respawn_in_flight: AtomicBool` released on render-ready, not on spawn-complete; second spawn saw stale `false`. |
+| Pool windows mixed into main map | `unpromoted_pool_labels: HashSet` set parallel to `browsers` — not a typed distinction. |
+
+No invariants enforced centrally; bugs came from these maps falling out of sync. The fix isn't more careful coding — it's **eliminating the parallel maps**: one state, one mutator, one place to enforce invariants.
+
+## The migration ratchet (per state field)
+
+You can't atomically swap a state field that has 5 read/write call sites. So each field migrates in 5 steps:
+
+| step | who's authoritative | who's the "shadow" | what changes | risk |
+|---|---|---|---|---|
+| **a** | host | (none) | launcher gains its own copy, fed by host's `Report*` commands. Pure addition. | low |
+| **b** | host | launcher's projection in host `AppState` | host caches the launcher's events, drift-logs disagreements. Pure observation. | low |
+| **c** | shadow (read), host (write) | host's old field | host's reads route through helpers like `state.instance_num()` which prefers shadow with host fallback for race window. Host still writes to its old field. | medium — read paths now depend on the launcher round-trip working |
+| **d** | shadow | host's old field (vestigial — still mutated for fallback semantics, but reads go to shadow) | host stops mutating its old field. Shadow is the only source of truth for reads. The fallback in step (c) is removed. | medium — exposes any code that read host's field directly |
+| **e** | launcher mirror | (deleted) | host's old field is removed. Read sites go through the launcher's events end-to-end. | low (mostly delete-only) |
+
+For `window_instance_registry`, we just finished step **c** (PR #581).
+
+## Why this naming is awkward
+
+The field is called `shadow_instance_registry` because in steps **a**/**b**/**c** it shadows the host's authoritative copy. But once we hit step **d**, the shadow IS the read path and the "shadow" name is misleading.
+
+The fix is to rename at step (e) when the old field is deleted. Until then we keep the name to signal that this is mid-migration code, not a permanent design.
+
+## Concrete example: window_instance_registry
+
+The instance-number registry assigns sequential numbers (main=1, second=2, …) for window-title display. Migration timeline:
+
+* **B.5a** (PR #579, merged): launcher gained `State.instance_registry: HashMap<String, u32>` + `State.next_instance_num: u32`. `handle_report_window_opened` now also assigns a number and emits `Event::WindowInstanceAssigned`. **Pure addition** — host untouched.
+* **B.5b** (PR #580, merged): host gained `AppState.shadow_instance_registry: Mutex<HashMap<String, u32>>`. `launcher_ipc::apply_event_to_shadow` consumes `WindowInstanceAssigned`/`Released` events into the shadow. On every event the launcher's value is compared to host's `window_instance_registry`; disagreements log to `target = "launcher-ipc:drift"`. **Pure observation** — host's existing code untouched.
+* **B.5c** (PR #581, merged): added `AppState::instance_num(label)` and `AppState::instance_count()` helpers that prefer the shadow with host fallback. Switched 5 read sites (`get_instance_number`, `get_window_count`, count emits in `register_backend_window`/`on_before_close`/`drag.rs`/`window_pool.rs`) to use the helpers. Host's `register()`/`unregister()` mutations preserved for the race window.
+* **B.5d** (next): drop host's eager `register()`/`unregister()` calls. Two open design questions:
+  * Without host mutations, the fallback in `instance_count` returns the seed-only host count (1) — fallback is moot. Either drop fallback (race exposure) or drive count emits from shadow updates (more invasive).
+  * Frontend's `get_instance_number` IPC could race the launcher round-trip on first window load. Mitigation options: frontend retry, host pre-seeds expected number, or accept a brief `unwrap_or(1)` flash.
+* **B.5e** (after B.5d validates): delete `AppState.window_instance_registry` field + `WindowInstanceRegistry` struct entirely. Rename `shadow_instance_registry` → `instance_registry`.
+
+The smoke test before/after each step is the key validation: PR #580's B.5b smoke test showed two cold-path tear-offs assigning 2 + 3, monotonic, zero `DRIFT` lines. That gave us confidence to proceed to read cutover (B.5c) without any behavior change.
+
+## How the layers fit together
+
+```
+                 ┌─────────────┐
+                 │   LAUNCHER  │
+                 │  (reducer)  │
+                 │  STATE = {  │  ← canonical state
+                 │   windows,  │
+                 │   pool,     │
+                 │   instance_ │
+                 │     registry│
+                 │   processes,│
+                 │   …         │
+                 │  }          │
+                 └─────┬───────┘
+                       │ events (broadcast)
+        ┌──────────────┼─────────────────┐
+        ▼              ▼                 ▼
+   ┌─────────┐   ┌─────────┐       ┌─────────┐
+   │  HOST   │   │   SRV   │       │  TOOL   │
+   │ (proj.) │   │ (proj.) │       │ --diag  │
+   │ AppState│   │  ...    │       │  ...    │
+   │ has no  │   │         │       │         │
+   │ canonical│  │         │       │         │
+   │ state — │   │         │       │         │
+   │ just a  │   │         │       │         │
+   │projection│  │         │       │         │
+   └────┬────┘   └─────────┘       └─────────┘
+        │ commands
+        ▼
+  (back to launcher reducer)
+```
+
+Once all 13 host maps complete a→e:
+* Bugs from "host's `window_meta` and `window_instance_registry` fell out of sync" become structurally impossible — one state, one reducer.
+* `agentmux.exe --diag` (Phase D) becomes a Tool client that just reads launcher state and prints it.
+* Frontend stops polling — it subscribes to events via the JS bridge (Phase B.7).
+* Phase D resync (versioned events + GetSnapshot) becomes implementable: clients detect missed events by version-number gap and replay from a snapshot.
+
+## Why we did B.4 first as a "mirror"
+
+B.4 (window mirror + pool tracking + drift detection) is the same idea applied to maps the host was already tracking. The launcher's `state.windows` and `state.pool` are projections built from `Report*` commands. `ReportHostCounts` → `DriftDetected` was the validation loop that proves the projection tracks reality before any code DEPENDS on it.
+
+B.5 then says: now that the projection is trusted, let's invert the dependency — host READS from the projection (via shadow) instead of its own copy.
+
+## Layer reference
+
+| concern | location | mutates? |
+|---|---|---|
+| Wire events | `agentmux-common/src/ipc.rs` (`Command`, `Event`) | — |
+| Canonical state | `agentmux-launcher/src/state.rs` | only via reducer |
+| Pure reducer | `agentmux-launcher/src/reducer.rs::update()` | the function |
+| IPC server | `agentmux-launcher/src/ipc/server.rs` | dispatches commands → reducer → broadcasts events |
+| Host outbound | `agentmux-cef/src/launcher_ipc.rs::report_*` | sends commands |
+| Host inbound | `agentmux-cef/src/launcher_ipc.rs::apply_event_to_shadow` | updates host shadows from events |
+| Host shadows | `agentmux-cef/src/state.rs::AppState.shadow_*` | only by `apply_event_to_shadow` |
+| Host old fields (being retired) | `agentmux-cef/src/state.rs::AppState.window_*` etc. | by host code; progressively shrinking surface |
+
+## Anti-patterns to avoid
+
+* **Don't read directly from `shadow_*` fields.** Always go through helpers like `state.instance_num()`. The helper encapsulates the prefer-shadow / fallback / drift-log policy. Direct reads bypass the policy and make the migration step (d→e) harder.
+* **Don't add new mutations to host's old fields.** Once a field is in step (b)+, all new mutations should go via `report_*` commands. Direct mutation of e.g. `window_instance_registry` from a new code path resets the migration progress for that field.
+* **Don't wait synchronously on launcher events.** The IPC channel can be slow under load and CEF callbacks run on the UI thread — blocking would freeze the renderer. Frontend retries are the correct race mitigation.
+* **Don't conflate the migration steps.** Each PR should be exactly one step (a, b, c, d, or e) for one field. Cross-step combinations make rollback expensive.
+
+## Related docs
+
+* `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` — the driving spec.
+* `specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md` — pre-migration inventory of host's 13 state stores.
+* `docs/retro/phase-b-plan-2026-04-28.md` — sub-PR sequence (B.1–B.8) with line-by-line risk analysis.
+* `docs/retro/audit-vestigial-types-2026-04-28.md` — pre-Phase-E cleanup audit.

--- a/docs/retro/phase-b-plan-2026-04-28.md
+++ b/docs/retro/phase-b-plan-2026-04-28.md
@@ -1,0 +1,234 @@
+# Phase B Implementation Plan — Launcher-Owned State Machine
+
+**Date:** 2026-04-28
+**Author:** AgentA-asaf
+**Status:** Draft for review — surface decisions, then execute
+**Inputs:** `SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md`, `docs/retro/pr-570-implementation-plan-2026-04-27.md`, current code in `agentmux-launcher/`, `agentmux-cef/`, `agentmux-srv/`, `frontend/`.
+
+---
+
+## Locked decisions (to confirm before execution)
+
+1. **Strict layering wins.** Launcher = state machine + Job Object. Host = thin executor + HWNDs. Srv = persistent app data only, stays window-agnostic. Frontend = passive mirror.
+2. **Robust > performance.** Pure sync reducer, exhaustive matches, panic-on-invariant-violation (kernel reaps via Job Object).
+3. **No heartbeats / no polling.** Liveness comes from kernel signals (`child.wait()`, pipe-EOF). Already locked in spec edits via PR #570.
+4. **Truth in launcher.** Deliberate departure from Chromium pattern (which puts truth in the privileged window-owning process) — justified by "launcher survives host crashes."
+
+---
+
+## Phase B deliverable (one-line)
+
+A pure Rust state machine in the launcher that owns all window/process runtime state, drives the host via named-pipe IPC, broadcasts versioned events to all renderers, and survives host crashes without state loss.
+
+---
+
+## Architecture (concrete)
+
+### Process tree (post-Phase B)
+
+```
+launcher (agentmux.exe)
+│   • Per-data-dir mutex
+│   • Job Object (KILL_ON_JOB_CLOSE)
+│   • Pure reducer: update(state, Command) → (state, Vec<Event>)
+│   • Effects runner (Tokio runtime; out of reducer hot path)
+│   • State: Map<WindowId, WindowState>, Map<ProcessId, ProcessRecord>,
+│            WarmPool, LifecyclePhase, EventLog (ring buffer)
+│   • Named-pipe IPC server
+│       \\.\pipe\agentmux-{data_dir_hash}\command   (host + frontend writes)
+│       \\.\pipe\agentmux-{data_dir_hash}\events    (one per subscriber)
+│
+├── host (agentmux-cef-{ver}.exe)
+│   • CEF + HWNDs
+│   • Connects to launcher pipes on startup
+│   • Receives Commands (do this Win32 thing)
+│   • Emits Facts (this HWND was created / destroyed)
+│   • Forwards launcher events to renderers via CEF JS bindings
+│
+└── srv (agentmux-srv-{ver}-win.exe)
+    • Workspace/Tab/Block SQLite DB (unchanged)
+    • Connects to launcher pipe
+    • Reports started/ready (no heartbeat — pipe-EOF is liveness)
+    • Receives Quit { reason } command; ack with "done"
+```
+
+The big change vs today:
+- **Srv moves from host-spawned to launcher-spawned.** Both are children of the launcher's Job Object. Srv survives host crashes; the launcher can restart the host without losing srv state.
+- **Launcher gains substantial logic** — currently ~270 lines, will grow to ~2000 lines (reducer + IPC + state + tests).
+- **Host loses ~13 state stores** (the HashMaps in `AppState`). Becomes a thin executor.
+- **Frontend deletes the polling loop in `app-init.ts`** and subscribes to the launcher's event stream via the host's CEF JS bindings.
+
+### IPC layout
+
+**One pipe per concern**, named after the data_dir hash so multi-instance still works:
+
+| Pipe | Purpose | Server | Clients |
+|---|---|---|---|
+| `\\.\pipe\agentmux-{hash}\command` | Commands → launcher; one bidi stream per client | launcher | host (1), frontend renderers (N), srv (1), tooling |
+| `\\.\pipe\agentmux-{hash}\events-{client_id}` | Events ← launcher; one ordered stream per client | launcher | each host/frontend renderer/srv subscriber |
+
+Per spec §5.3: "ordering is guaranteed only within a single pipe" (Mojo guidance). Each subscriber gets its own event pipe so order is preserved per-subscriber.
+
+The frontend doesn't connect to launcher directly; it goes **through the host** via CEF's JS bindings (host has the launcher pipe open; host's JS bridge forwards both directions). This avoids exposing the launcher pipe to renderer-process untrusted code.
+
+### Reducer types (sketch)
+
+```rust
+// agentmux-launcher/src/reducer/mod.rs
+
+pub enum Command {
+    OpenWindow {
+        workspace_id: String,
+        position: Option<(i32, i32)>,
+        source: WindowSource,
+    },
+    CloseWindow { id: WindowId },
+    PromoteWarm { warm_id: WarmId, become: WindowId, position: (i32, i32) },
+    BringToFront { id: WindowId },
+    HostReportsHwndCreated { id: WindowId, hwnd_handle: u64 },
+    HostReportsHwndDestroyed { id: WindowId },
+    HostReportsCrash { kind: ProcessKind, pid: u32, exit_code: i32 },
+    Quit { reason: QuitReason },
+    GetSnapshot { client_id: ClientId },
+}
+
+pub enum Event {
+    WindowAdded { id: WindowId, source: WindowSource, version: u64 },
+    WindowStateChanged { id: WindowId, from: WindowState, to: WindowState, version: u64 },
+    WindowRemoved { id: WindowId, reason: CloseReason, version: u64 },
+    ProcessSpawned { pid: u32, kind: ProcessKind, version: u64 },
+    ProcessExited { pid: u32, code: i32, version: u64 },
+    LifecyclePhaseChanged { from: LifecyclePhase, to: LifecyclePhase, version: u64 },
+    WarmPoolChanged { ready: usize, spawning: usize, version: u64 },
+}
+
+pub fn update(state: &State, cmd: Command) -> (State, Vec<Event>) {
+    // exhaustive match; no I/O; no panics on input; panics on invariant violation
+}
+```
+
+Effects (NOT in the reducer; driven by reducer events):
+
+```rust
+pub enum Effect {
+    SpawnHost,
+    SpawnSrv,
+    TellHostToCreateWindow { workspace_id, position },
+    TellHostToCloseWindow { hwnd_handle },
+    TellHostToShowSize { hwnd_handle, x, y, w, h, ws_visible: bool },
+    BroadcastEvent(Event),
+    QuitSrv { timeout: Duration },
+    CloseJobHandle, // last resort
+}
+```
+
+The effects runner converts events → effects, executes side effects on a Tokio runtime, and reports back via more `Command::HostReports*` calls.
+
+---
+
+## Migration plan — incremental, app stays working
+
+The constraint: AgentMux must keep working after every PR. We can't have a "Phase B starts" cutover. Strategy: **parallel state during migration**, with the new launcher-side state machine watching what the host already does, gated behind a feature flag. Once the launcher's state matches reality across all observable scenarios, we cut the host's state stores out and the launcher becomes authoritative.
+
+### Sub-PR sequence (estimated)
+
+| # | Sub-PR | New code | Changed code | Risk |
+|---|---|---|---|---|
+| **B.1** | Move srv from host-spawned to launcher-spawned | ~150 LoC launcher | ~80 LoC host (delete srv-spawn) | Medium — process-tree restructure |
+| **B.2** | Tokio runtime in launcher + named-pipe IPC server (commands only, no events yet) | ~400 LoC launcher | 0 host | Low — additive |
+| **B.3** | `Command` + `Event` types + pure reducer skeleton (no real state yet, just routes commands to host's existing IPC) | ~600 LoC launcher | ~50 LoC host (new IPC client) | Low — additive |
+| **B.4** | Add launcher state mirror (read-only): launcher subscribes to host's existing state events, builds parallel state. Launch with diagnostic logging that compares launcher state to host state every transition; alert on drift. | ~500 LoC launcher | ~30 LoC host (emit state transitions) | Low — read-only, can't break anything |
+| **B.5** | Migrate one HashMap at a time to launcher-authoritative (host queries launcher instead of its own map). Order: `window_instance_registry` first (smallest), then `window_meta`, then `browsers`, then `window_id_map`, then `window_pool` + `unpromoted_pool_labels`. Each migration is its own PR. | ~100 LoC per migration | ~50 LoC per migration | Medium — touches active state paths |
+| **B.6** | Per-data-dir mutex single-instance (now trivial because launcher already has the named-pipe IPC) | ~80 LoC launcher | -50 LoC host (delete port-file check) | Low |
+| **B.7** | Frontend: delete polling loop in `app-init.ts`; subscribe to event stream via CEF JS bridge | -50 LoC frontend | ~80 LoC host (JS bridge for events) | Low — frontend gets simpler |
+| **B.8** | Phase B exit criteria: full lifecycle scenarios pass with launcher as sole authority. Delete host-side state stores. | 0 | -300 LoC host | Medium — atomic cut-over |
+
+**Total**: ~9 PRs. Each ships independently. App remains usable throughout. Estimated calendar time: 4–6 weeks at one PR every 2–3 days.
+
+### Pre-Phase B work (already done or in-flight)
+
+- ✅ Job Object on launcher with CREATE_SUSPENDED race fix (PR #570 — in review)
+- ✅ Spec lock: no heartbeats / no polling
+- ✅ Strict-layering decision
+
+### Phase B exit criteria
+
+- All 13 state stores from `ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md` either deleted from host or remain only as effects-runner local state.
+- Reducer is a pure function tested with property-based testing (`proptest`) over arbitrary command sequences.
+- Frontend's `app-init.ts` polling loop (`refreshLabels(true, retriesLeft)`) is gone; rows update via event push.
+- `agentmux.exe --diag` prints the canonical state and a process inventory; CI runs it after a synthetic close-all and asserts equality.
+- Six invariants (spec §7) checked at every transition; violations panic.
+
+---
+
+## Concrete decisions to make before B.1 starts
+
+### Decision 1: Tokio runtime in launcher?
+
+The launcher is currently sync (~270 lines, no async runtime). Phase B needs async I/O for named pipes + multiple subscribers. Options:
+
+**(a) Full Tokio runtime in launcher.** ~3 MB binary growth (Tokio + dependencies). Standard pattern.
+**(b) Hand-rolled threads + sync I/O.** Smaller binary (~50 KB growth). More code (one thread per pipe accept + read).
+**(c) Async-std or smol.** Lighter than Tokio (~1 MB). Less mature, fewer deps.
+
+**Recommendation**: (a) Tokio. Standard, battle-tested, srv already uses it (so it's already in the build pipeline). Binary growth is acceptable for a redesign.
+
+### Decision 2: Reducer state persistence?
+
+Should the reducer's state survive launcher restarts? E.g., after a crash, should we restore the window list?
+
+**(a) No persistence.** State lives in memory only. Crash → fresh start. Spec's default per §11.1.
+**(b) Event log persisted to disk.** Replay on restart. Forensics-friendly but adds I/O overhead.
+**(c) Snapshot every N events.** Compromise.
+
+**Recommendation**: (a) for Phase B. Add (b) in Phase D as a forensics tool, gated behind `--diagnostics` flag. The user's workspaces/tabs already persist via srv's DB, so window restoration is a separate UX feature (deferred per spec non-goal).
+
+### Decision 3: Frontend ↔ launcher path
+
+The frontend can talk to the launcher via:
+
+**(a) Through the host (CEF JS bridge).** Frontend → host's JS function → host forwards to launcher pipe. Two hops.
+**(b) Direct named-pipe access from renderer.** Renderer process opens the pipe directly. One hop, but renderers are sandboxed and exposing pipe access is a security smell.
+**(c) Through srv's existing WS.** Srv subscribes to launcher events, forwards to frontend. Two hops; reuses srv's WS infrastructure.
+
+**Recommendation**: (a) Through host. Renderers stay sandboxed. Host is the trust boundary. Two hops adds ~ms latency, irrelevant for state events.
+
+### Decision 4: Migration vs greenfield
+
+**(a) Migrate incrementally** (the sub-PR sequence above). 9 PRs, weeks of work, lower risk.
+**(b) Greenfield rewrite** in a feature branch. Single big merge. Higher risk but cleaner.
+
+**Recommendation**: (a) Migrate. Bugs in this codebase are rarely from architecture; they're from edge cases. Migration keeps the codebase running while the new model gets exercised.
+
+---
+
+## Risks
+
+1. **Process-tree restructure (B.1)** — moving srv from host-spawned to launcher-spawned changes who's responsible for srv's lifecycle. Need to verify on every supported platform: portable Windows, dev Windows, dev Linux/Mac (the spec is Windows-target but we don't want to break dev workflows). Phase B.1 should include a smoke test.
+2. **Frontend event subscription latency** — going through CEF JS bridge adds ~1ms per event. For typical use (open/close window, tear-off) this is invisible. For high-frequency events (mouse position during drag) it could matter — but those events are NOT in the reducer (they're host-internal). Verify this assumption when wiring B.3.
+3. **Multi-instance handling in mutex name** — must be deterministic from data_dir. Confirm hash strategy: `SHA-256(canonical_lowercase(data_dir))[..16]` as hex.
+4. **Reducer panic on invariant violation** — spec §7 says panic + Job Object reaps. Need to verify Job Object actually does reap when launcher panics (it should — process exit closes handles regardless of exit reason).
+5. **Backward compatibility during migration** — sub-PRs B.4 / B.5 / B.7 deliberately keep two state systems alive simultaneously. This means a bug in either could be confusing. Mitigation: aggressive logging + diagnostic flag that pretty-prints both states.
+6. **Performance** — reducer is sync; effects runner is async on Tokio. Reducer hot path must stay fast (sub-millisecond) so it doesn't block IPC. Property-based tests should include throughput assertions.
+
+---
+
+## Phase C / D preview (post-B)
+
+**Phase C** (warm pool consolidation) becomes near-trivial after Phase B — the warm pool is just another piece of state in the launcher reducer. The state-machine invariant (spec §7.1: pool windows can't be in `main_registry`) is enforced by the type system: `WarmPool` and `Map<WindowId, WindowState>` are different types.
+
+**Phase D** (IPC contract hardening) is real work but additive: versioned event types, GetSnapshot resync protocol, echo-loop guard in frontend store. ~1–2 weeks.
+
+**Estimated total time to fully realized state machine**: 6–8 weeks calendar time, assuming one PR every 2–3 days. PR #570 (Job Object) is the only piece not part of Phase B; it stands alone.
+
+---
+
+## Open questions to confirm before B.1
+
+1. **Tokio in launcher: yes?**
+2. **Mutex name format: SHA-256 first 16 hex of canonical-lowercase data_dir?** Or use launcher exe path?
+3. **PR cadence: one B sub-PR at a time, or stack 2–3 in flight?** Stacking lets bots review smaller surfaces but complicates rebase.
+4. **B.1 priority: ship first standalone, or roll into B.2?** B.1 is a process-tree restructure; B.2 is the IPC server; both touch launcher main.rs.
+5. **Test strategy: unit tests + integration tests + manual?** Property-based tests via `proptest` for the reducer; `tempfile`-based integration tests for the IPC layer; manual for full lifecycle scenarios.
+
+I have opinions on all five (see "Recommendation" lines above). Want to confirm or change?

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -1,0 +1,185 @@
+# Phase B roadmap to the golden vision
+
+**Status:** Active reference. Updated 2026-04-28 after PR #582 (B.5c orphan cleanup) merged.
+**Author:** AgentA.
+**Companion docs:**
+* `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` — driving spec
+* `specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md` — pre-migration inventory of host's 13 state stores
+* `docs/retro/phase-b-plan-2026-04-28.md` — original sub-PR sequence (B.1–B.8) with risk analysis
+* `docs/retro/migration-pattern.md` — the a/b/c/d/e ratchet pattern per state field
+* `docs/retro/audit-vestigial-types-2026-04-28.md` — pre-Phase-E cleanup audit
+
+## Golden vision
+
+The launcher owns canonical OS-level state via a pure reducer:
+
+```
+update(state, command, ctx) → Vec<Event>
+```
+
+* **Commands** flow client → launcher.
+* **Events** flow launcher → clients (broadcast).
+* **State** lives only in the launcher.
+* Other processes (host, srv, frontend, tools) hold *projections* of state that they maintain by consuming events.
+
+Bugs from "host's `window_meta` and `window_instance_registry` fell out of sync" become structurally impossible: one state, one mutator, one place to enforce invariants.
+
+## Where we are (2026-04-28)
+
+```
+Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
+                        │
+                        │  B.1 (#570/571/572)  ──  srv as launcher-spawned sibling
+                        │  B.2 (#573)          ──  named-pipe IPC server
+                        │  B.3 (#574)          ──  pure reducer skeleton
+                        ▼
+              Foundation laid: launcher has Tokio + IPC + reducer ✓
+                        │
+                        │  B.4  (#576)  ──  window mirror (read-only)
+                        │  B.4a (#577)  ──  pool tracking
+                        │  B.4b (#578)  ──  drift detection
+                        ▼
+              Mirror tracks reality, drift observable ✓
+                        │
+                        │  B.5 (a→b→c→d→e per map, smallest first)
+                        │     window_instance_registry:
+                        │       a (#579)  ──  launcher-authoritative registry
+                        │       b (#580)  ──  host shadow + drift logs
+                        │       c (#581)  ──  read-path cuts over to shadow
+                        │       c-fix (#582) ── orphan cleanup, surfaced by drift
+                        ▼
+              ◄── HERE (after PR #592 merged 2026-04-28).
+                  ✓ window_instance_registry — fully migrated (a→e)
+                  ✓ window_id_map — fully migrated (a→e)
+                  ✓ window_meta — migrated with refinement (host_meta
+                    kept as synchronous cache; see "window_meta
+                    exception" below)
+                  Remaining: `browsers` (full a→e), pool maps (c/d/e),
+                  then B.6/B.7/B.8.
+                        │
+                        ▼
+              B.6  ──  per-data-dir mutex single-instance
+              B.7  ──  frontend cutover (delete polling)
+              B.8  ──  Phase B exit (delete host state stores)
+                        │
+                        ▼
+                  Phase B done — golden vision reached
+```
+
+## What's left
+
+### B.5 — migrate the remaining maps (a/b/c/d/e per the migration-pattern doc)
+
+| Map | step a | step b | step c | step d | step e |
+|---|---|---|---|---|---|
+| `window_instance_registry` | ✓ #579 | ✓ #580 | ✓ #581 + #582 | ✓ #583 | ✓ #584 |
+| `window_id_map` | ✓ #585 | ✓ #586 | ✓ #587 | ✓ #588 | ✓ #589 |
+| `window_meta` | ✓ baked into B.4 | ✓ #590 | ✓ #591 | ✓ #592 (refined — see below) | not applicable |
+| `browsers` | — | — | — | — | — |
+| `window_pool` + `unpromoted_pool_labels` | partial via B.4 | partial via B.4 | — | — | — |
+
+### window_meta exception
+
+The standard a→e ratchet calls for step e to fully delete the host's field. For `window_meta`, codex's PR #592 review caught two cases where the launcher-fed shadow alone is insufficient:
+
+1. **task dev mode** — launcher IPC absent; shadow stays empty. `open_subwindow`'s parent-validation needs a synchronous local source.
+2. **Cascade-close race** — child opens just before parent closes; launcher round-trip hasn't completed by the time `on_before_close` fires; `subwindow_children_of` would miss the child.
+
+The refined design keeps `host.window_meta` as a **synchronous local cache**, written from a single canonical site (`on_after_created` from the popped `PendingWindowCreation` entry) and removed from the symmetric `on_before_close`. The launcher's `state.windows` remains canonical for cross-process queries; `window_meta` covers same-process synchronous lookups.
+
+**Implication:** for any future map migration, before step e, check whether the field has any same-process synchronous lifecycle-checking consumer. If yes, that map likely follows the same cache-not-delete pattern.
+
+**Pool maps note:** B.4 already added launcher's `state.pool` + host-fed reports. So pool migration starts at step c, not a. The combined map (`window_pool` queue + `unpromoted_pool_labels` set) is also conceptually one in the launcher (`State.pool: HashSet`), so the cutover collapses two host fields into one.
+
+**Recommended order** (3 maps done, 2 remaining):
+1. ~~Finish `window_instance_registry`~~ ✓ done.
+2. ~~`window_id_map`~~ ✓ done.
+3. ~~`window_meta`~~ ✓ done (with sync-cache refinement).
+4. **`browsers`** — biggest. CEF `Browser` handles can't be sent over the wire, so this map's launcher representation is just labels + metadata; the actual `Browser` object stays in host as a non-reducer field. Likely follows the window_meta cache-not-delete pattern (same-process synchronous lookup needed).
+5. Pool maps — c/d/e only (skips a/b since B.4 covered them).
+
+**Estimated PRs**: ~14 more (4 remaining maps × ~3 steps avg + 2 for `window_instance_registry`'s d/e).
+
+### B.6 — single-instance mutex
+
+* Spec invariant: at most one launcher per data dir (multi-launcher races the named pipe + corrupts state).
+* Pre-Phase-B used a TCP port-file probe. Now trivial: `ServerOptions::first_pipe_instance(true)` already rejects a second launcher binding the same pipe.
+* Work: delete the old port-file check in srv/host, add a clear error message when the second launch fails to bind, surface to user as a dialog.
+* **~1 PR, ~80 LoC.**
+
+### B.7 — frontend cutover
+
+* Currently: frontend polls `list_windows()` / `get_window_count()` via `app-init.ts::refreshLabels(true, retriesLeft)` — the retry loop exists because host's state was racy.
+* B.5 makes host's state authoritative-via-launcher, but frontend still polls.
+* B.7: wire the launcher's event stream to the frontend via CEF JS bridge. Frontend subscribes once, gets push updates instead of polling.
+* Bonus: deletes `app-init.ts`'s ~50 LoC retry loop. Frontend becomes simpler, not more complex.
+* **~2-3 PRs**: JS bridge plumbing (host emits to renderer process); frontend reducer + atom integration; delete polling loop.
+
+### B.8 — Phase B exit (cleanup)
+
+* Delete host-side state stores entirely. After B.5 step e for every map, host's `AppState` shrinks from 13 fields to ~3 (CEF browser handles, IPC port, etc. — non-reducer infrastructure).
+* Property-based tests assert all 13 store-related invariants from the inventory analysis.
+* `agentmux.exe --diag` (Tool client) prints canonical state + CI runs a synthetic close-all + assertion.
+* Six core invariants from spec §7 checked at every transition; violations panic (Job Object reaps via OS).
+* **~1-2 PRs.**
+
+## Beyond Phase B
+
+| Phase | Scope | Why now-easy-because-of-B |
+|---|---|---|
+| **C** | Warm pool consolidation — typed `WarmPool` separate from main registry, type system prevents mixing pool with full instances | After B, pool is already its own type in launcher; just delete the parallel host fields |
+| **D** | `GetSnapshot` / resync protocol, persisted event log, `--diag` tool | Foundations laid: versioned events, monotonic counters, host-IPC pipe. Need to add the snapshot RPC + ring-buffer log + replay logic |
+| **E** (proposed, not blocking B) | srv state machine for tabs/panes/layout | Independent of B — could happen in parallel; same reducer pattern applied to srv. Audit doc covered the prep |
+
+## Decisions log (so future sessions don't relitigate)
+
+| Decision | When | Reasoning |
+|---|---|---|
+| Tokio runtime in launcher (3 MB binary growth) | B.2 design | Standard, battle-tested, srv already uses it. Hand-rolled threads were 50 KB but ~5× more code. |
+| No reducer state persistence (memory only) | B.3 design | Spec default. Workspaces/tabs persist via srv DB; window restoration is a separate UX feature, deferred. |
+| Frontend ↔ launcher via host JS bridge (not direct pipe) | B.7 design | Renderers stay sandboxed. Host is trust boundary. ~1ms latency irrelevant for state events. |
+| Migrate incrementally (9-PR sequence vs greenfield rewrite) | B plan | Bugs in this codebase are usually from edge cases, not architecture. Migration keeps app running while new model gets exercised. |
+| Codex hallucinates < gemini hallucinates | empirical, PRs #573-582 | Merge gate: reagent + codex. Gemini auto-review disabled (#582 was the last straw — gemini misread the orphan-cleanup bug). On-demand `@gemini review` still works. |
+| `WindowInstanceRegistry` migrates first in B.5 | B.5 plan | Smallest map, simplest semantics (just `HashMap<String, u32>` + monotonic counter). Validates the migration pattern on the easiest case. |
+| Window-count drift detection only on window-level transitions | B.4b round-2 fix | Pool transitions can fire during in-flight close paths where window counts are mid-mutation; pool-only check (`ReportHostPoolCount`) preserves "check every transition" without false positives. |
+
+## Tech debt + open items
+
+| Item | Source | Plan |
+|---|---|---|
+| Cross-thread interleaving in drift detection produces transient false positives | codex P2 round-5 on PR #578, accepted as known limitation | Defer to B.5 cleanup or B.8; needs transition-ID protocol |
+| Reagent silently drops on GitHub 504 | filed `a5af/reagent#114` | Wait for upstream fix |
+| `docs/retro/b1-srv-spawner-design.md` + `phase-b-plan-2026-04-28.md` untracked | sitting locally for ~10 PRs | Land in a small docs-only commit when convenient |
+| Smoke tests are manual | every PR cycle | Phase B exit criteria: synthetic close-all in CI |
+| Codex round-5 P2 (transition IDs) | PR #578 | Above; same issue |
+
+## Calendar estimate
+
+At our recent pace (~3-6 hours of bot-review cycles per PR-merge cycle, ~1-3 PRs per session):
+
+* **B.5 remaining maps**: ~3-5 working sessions
+* **B.6**: 1 session
+* **B.7**: 2-3 sessions (frontend territory; expect surprises)
+* **B.8**: 1 session if everything before went smoothly
+
+**Total to golden vision: ~7-10 working sessions.**
+
+## Recommended next moves (post-PR #582)
+
+1. **Smoke v0.33.463** when current build lands. Validates B.5c orphan-cleanup fix; specifically watch for:
+   * `[pool] orphan close_browser issued` log line on failed promote
+   * Zero sustained `DriftDetected { kind: Windows, ... }` events
+   * Pool size stable at `POOL_TARGET_SIZE = 2` after failed promote
+2. **B.5d for `window_instance_registry`** — drop host's eager register/unregister. Open design question: race on first frontend lookup. Two options:
+   * Frontend retries on `unwrap_or(0)` lookup miss
+   * Host pre-seeds shadow synchronously when calling `report_window_opened` (computes expected number locally — risky if launcher state diverges)
+   Recommendation: option 1, simpler.
+3. **B.5e** — delete `WindowInstanceRegistry` struct + rename `shadow_*` field. Almost pure delete.
+4. Start the next map — `window_id_map`. Re-runs the a/b/c/d/e ratchet on a fresh field; if anything in the migration-pattern doc needs revision based on lessons from #579-582, update it then.
+
+## How to use this doc in future sessions
+
+1. **Read this first** before opening a new B.5 sub-PR. It tells you which step you're on and what's already done.
+2. **Update the "Where we are" diagram + the B.5 migration table** when a PR merges.
+3. **Add to "Decisions log"** when a non-obvious choice is made (so we don't relitigate).
+4. **Add to "Tech debt"** when something is deferred — even if you think you'll come back to it (you might not).


### PR DESCRIPTION
## Summary

Pure docs PR. Two halves:

### 1. Roadmap update for post-#592 state
- Migration table fills in PR numbers for the 3 completed maps (window_instance_registry #579-#584, window_id_map #585-#589, window_meta #590-#592).
- New \"window_meta exception\" section explaining the sync-cache-not-delete refinement codex's #592 reviews drove. Sets expectations for `browsers` migration: any map with a same-process synchronous lifecycle-check consumer likely follows this pattern.

### 2. Track 4 untracked retro docs
These have been sitting in `docs/retro/` locally through ~20 PRs but never committed:
- `b1-srv-spawner-design.md` — pre-B.1 design (PR #571).
- `migration-pattern.md` — the a→b→c→d→e ratchet, referenced from every B.5 sub-PR.
- `phase-b-plan-2026-04-28.md` — original B sub-PR sequence + risk analysis.
- `phase-b-roadmap.md` — current state + decisions log.

Landing them makes the doc trail navigable from fresh checkouts.

## Test plan

Pure docs — no behavior change. CI markdown lint should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)