### PR TITLE
docs(b5-finish): scaffolding-role comments on host residual fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.473"
+version = "0.33.474"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.473"
+version = "0.33.474"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.473"
+version = "0.33.474"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.473"
+version = "0.33.474"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.473"
+version = "0.33.474"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -499,6 +499,16 @@ pub fn report_host_pool_count(count: u32) {
 ///   excluding `browser-pane-*` child HWNDs and any label still
 ///   in `unpromoted_pool_labels`.
 /// * `pool` — pre-promote pool labels (`unpromoted_pool_labels.len()`).
+///
+/// **Why this reads host's `browsers` and `unpromoted_pool_labels`
+/// directly (not the shadow):** this fn IS the source for the
+/// launcher's mirror — its output is what gets compared against
+/// `state.windows.len()` / `state.pool.len()` in the drift-detection
+/// path. Reading from the shadow would compare the shadow against
+/// itself (always agrees) and defeat the entire B.4 drift-detection
+/// design. Once the host reducer arrives in Phase F (see
+/// `docs/retro/multi-reducer-proposal-2026-04-28.md`), this becomes
+/// "report host's authoritative reducer-state to the launcher."
 pub fn compute_and_report_host_counts(state: &std::sync::Arc<crate::state::AppState>) {
     let unpromoted = state.unpromoted_pool_labels.lock();
     let browsers = state.browsers.lock();

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -198,12 +198,28 @@ pub struct AppState {
 
     /// CEF Browser handles keyed by window label (multi-window support).
     /// "main" is the primary window; tear-off windows get "window-{UUID}" labels.
+    ///
+    /// **Phase B / multi-reducer status**: this map is intentionally NOT
+    /// migrated to launcher under the standard B.5 a→b→c→d→e ratchet because
+    /// `cef::Browser` is an FFI handle to a Chromium browser object in this
+    /// process — it can't serialize over IPC and must stay co-located with
+    /// the CEF runtime. The KEY-SET role (label set queries) is already
+    /// covered by the launcher's `state.windows` mirror (B.4) +
+    /// `shadow_window_meta`. This field will be retired into a host-side
+    /// reducer in Phase F (see `docs/retro/multi-reducer-proposal-2026-04-28.md`).
     pub browsers: Mutex<HashMap<String, Browser>>,
 
-    /// Per-window metadata (kind, parent linkage). Maintained in parallel with
-    /// `browsers` — any `browsers.insert()` for a real window must also record
-    /// a `WindowMeta` here so on_after_created knows whether to hide the HWND
-    /// from the taskbar and so on_before_close can cascade sub-window closure.
+    /// Per-window metadata (kind, parent linkage).
+    ///
+    /// **Phase B status**: synchronous host-side cache mirroring the
+    /// launcher's `state.windows` mirror. Single canonical mutation site:
+    /// inserted in `client.rs::on_after_created` from the popped
+    /// `PendingWindowCreation` entry, removed in `on_before_close`.
+    /// Required for synchronous lookups that can't tolerate the launcher
+    /// round-trip lag (`open_subwindow` parent-liveness check; cascade-close
+    /// child enumeration). See `docs/retro/migration-pattern.md` for the
+    /// sync-cache exception and `b5-migration-architecture-2026-04-28.md`
+    /// for why step e ≠ delete here.
     pub window_meta: Mutex<HashMap<String, WindowMeta>>,
 
     /// Phase B.5 (window_meta step d) — FIFO queue of pre-create
@@ -227,6 +243,15 @@ pub struct AppState {
     /// On tear-off: pop a label, reposition + show + emit `pool:promote`.
     /// Cold-path (open_window_at_position) remains as defence-in-depth.
     /// See SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26 §4.5.
+    ///
+    /// **Phase B / multi-reducer status**: this map is intentionally NOT
+    /// migrated to launcher under the B.5 ratchet — pool decisions need
+    /// synchronous host-local state (e.g., `window_pool.len() <
+    /// POOL_TARGET_SIZE` for refill triggers) that can't tolerate the
+    /// launcher round-trip lag. The launcher's `state.pool: HashSet<String>`
+    /// (B.4) mirrors the conceptual inventory for cross-process queries.
+    /// Will become host-reducer state in Phase F (see
+    /// `docs/retro/multi-reducer-proposal-2026-04-28.md`).
     pub window_pool: Mutex<VecDeque<String>>,
     /// Labels of pool windows that have been spawned but NOT yet
     /// promoted. Populated synchronously in `spawn_pool_window` so
@@ -237,10 +262,16 @@ pub struct AppState {
     /// Without this, list_windows reports unpromoted pool windows
     /// as user-visible instances during the ~100ms gap between
     /// spawn and renderer-ready.
+    ///
+    /// **Phase B / multi-reducer status**: same as `window_pool` —
+    /// host-only synchronous lifecycle scaffolding; not migrated under B.5
+    /// ratchet. Phase F (host reducer) will retire it.
     pub unpromoted_pool_labels: Mutex<std::collections::HashSet<String>>,
     /// Single in-flight respawn semaphore — prevents pool refill from
     /// stacking spawns when the user does back-to-back tear-offs faster
     /// than CEF can create windows.
+    ///
+    /// **Phase B status**: host-only sync primitive; not migrate-able.
     pub window_pool_respawn_in_flight: std::sync::atomic::AtomicBool,
 
     /// Version-specific data directory (e.g. ai.agentmux.cef.v0-32-111/)

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.473"
+version = "0.33.474"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.473"
+version = "0.33.474"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.473"
+version = "0.33.474"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/b5-migration-architecture-2026-04-28.md
+++ b/docs/retro/b5-migration-architecture-2026-04-28.md
@@ -1,0 +1,215 @@
+# B.5 migration architecture — what's possible, what's not, and how we finish
+
+> **READER NOTE (2026-04-28, post-decision):** This doc analyzed the migration wall and proposed the "scaffolding model" as the Phase B end state. Direction was subsequently refined: scaffolding is **intermediate**, not permanent. The long-term destination is **multi-reducer** (host gets its own reducer in Phase F). See `multi-reducer-proposal-2026-04-28.md` for the accepted plan, and `phase-b-roadmap.md` for current sequencing. This doc remains valid as an analysis of WHY the standard ratchet hit a wall on `browsers` and pool maps.
+
+**Status:** Analysis doc, partly superseded by multi-reducer-proposal-2026-04-28.md.
+**Author:** AgentA.
+**Date:** 2026-04-28, after PRs #579-#592.
+**Companions:**
+* `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` — the driving spec
+* `specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md` — pre-migration inventory
+* `docs/retro/migration-pattern.md` — the a→b→c→d→e ratchet
+* `docs/retro/phase-b-roadmap.md` — sub-PR sequencing
+
+---
+
+## TL;DR
+
+- **3 of 5 host maps fully migrated** through the standard a→b→c→d→e ratchet (window_instance_registry, window_id_map, window_meta — the last with a sync-cache refinement).
+- **2 maps fundamentally cannot follow the same ratchet**: `browsers` (holds CEF FFI handles) and the pool maps (`window_pool` + `unpromoted_pool_labels` — coupled with CEF lifecycle scaffolding).
+- The architectural insight: the original "host has no canonical state" framing was a useful simplification, but the practical end state has **two host residual classes**: synchronous caches that mirror launcher state, and pure scaffolding for FFI/lifecycle that never crosses process boundaries.
+- Phase B can still complete, but the Phase B exit criteria document needs updating to acknowledge the residual scaffolding fields.
+
+---
+
+## What the original B.5 vision said
+
+From the spec, §"Migration":
+
+> Migrate the existing `browsers` / `window_meta` / `window_id_map` / `window_instance_registry` HashMaps into one `Map<WindowId, WindowState>` in the launcher reducer.
+
+The implied final state: host's `AppState` shrinks to non-state infrastructure (CEF runtime objects, IPC handles, etc.). Launcher owns everything queryable.
+
+This worked beautifully for 3 maps. For the other 2, it doesn't work, and the reason is structural — not a coding gap.
+
+---
+
+## What worked: 3 successful migrations
+
+### `window_instance_registry` (PR #579-#584)
+
+Sequential window numbering (`{ "main": 1, "window-abc": 2 }`). Pure data, no FFI coupling, no lifecycle scaffolding role. **Clean a→b→c→d→e**, ending with the host field deleted entirely.
+
+### `window_id_map` (PR #585-#589)
+
+Label → backend window UUID. Same shape as instance_registry — pure data, no FFI coupling. **Clean a→b→c→d→e**.
+
+### `window_meta` (PR #590-#592, refined)
+
+Per-window kind + parent_instance_id. Looked migrate-able (data is pure JSON), but step d ran into two same-process synchronous-lookup consumers:
+
+1. `open_subwindow`'s parent-liveness check (must reflect "is this parent currently open" with no async lag).
+2. Cascade-close enumeration during a parent's `on_before_close` (must include children opened just before).
+
+The shadow-fed-from-launcher-events pattern lags by milliseconds. For these synchronous consumers, that lag was a correctness regression.
+
+**Refinement**: kept `host.window_meta` as a synchronous local cache, written from a single canonical site (`on_after_created` from the popped `PendingWindowCreation` entry) and removed at `on_before_close`. The launcher's `state.windows` is still canonical for cross-process queries; `host.window_meta` covers same-process synchronous lookups.
+
+This is the first migration where step e ≠ "delete the field." Step e became a doc-only acknowledgment.
+
+---
+
+## What hit a wall: 2 maps that can't follow the ratchet
+
+### `browsers: HashMap<String, cef::Browser>`
+
+Holds CEF `Browser` handles — FFI pointers to Chromium browser objects in the same process. Properties:
+
+- **Cannot serialize over the IPC pipe.** A `Browser` is an opaque pointer to native CEF state. Sending it across processes is meaningless.
+- **Must stay co-located with CEF.** Calls like `browser.host().close_browser()`, `browser.is_same()`, finding HWNDs from browser handles — all are in-process FFI calls. The launcher doesn't have a CEF runtime; it can't make these calls.
+- **Lifetime owned by CEF.** The browser exists from `on_after_created` to `on_before_close`. Host inserts on creation, removes on close.
+
+The KEY-SET role (label set queries) IS migrate-able — and is **already covered** by B.4's `state.windows: HashMap<String, WindowMirror>` + B.5's `shadow_window_meta`. Label-set queries can read from those instead of `browsers.keys()`.
+
+What `browsers` is, post-migration: a thin host-side scaffolding map that wraps CEF FFI handles for in-process access. Not state. Not authoritative. Just a typed container for handles.
+
+### Pool maps: `window_pool` + `unpromoted_pool_labels`
+
+`window_pool: VecDeque<String>` is the queue of pre-painted ready-to-promote windows. `unpromoted_pool_labels: HashSet<String>` tracks "spawned but not yet ready." Both are intertwined with CEF lifecycle:
+
+- `spawn_pool_window` writes both, kicks off CEF window creation.
+- The renderer-ready handshake (an IPC from frontend) moves a label from `unpromoted_pool_labels` into `window_pool`.
+- `promote_pool_window` pops from `window_pool`, removes from `unpromoted_pool_labels`, calls Win32 to reposition + show the window.
+- `on_pool_window_destroyed` (from `on_before_close` for `window-pool-*` labels) cleans up.
+
+Properties:
+
+- **Pool decisions need synchronous local state.** "Should I refill?" answers depend on `window_pool.len() < POOL_TARGET_SIZE`. Race-tolerant async-mirrored state would produce incorrect refill decisions.
+- **Renderer-ready handshake is host-internal.** The frontend sends an IPC to the host; host moves the label between maps. The launcher could be informed but it's a host-internal sequence.
+- **List filtering needs synchronous reads.** `list_windows` filters out unpromoted pool labels — needs to know "right now" which labels are pool, not "as of the last launcher event."
+
+The launcher already has `state.pool: HashSet<String>` (B.4) which mirrors the conceptual inventory. But the FINE-GRAINED states (pre-render-ready vs in-queue) and the synchronous decision points are inherently host-side.
+
+What the pool maps are, post-Phase-B: synchronous lifecycle scaffolding. Launcher's `state.pool` is the cross-process projection. Host's two maps are the working set.
+
+---
+
+## The architectural insight
+
+The original "host has no canonical state" framing held up under three migrations and broke on two. The pattern of breakage is consistent:
+
+| Map | Role | Migrate-able? |
+|---|---|---|
+| `window_instance_registry` | Pure data, cross-process queryable | ✓ Fully |
+| `window_id_map` | Pure data, cross-process queryable | ✓ Fully |
+| `window_meta` | Pure data + synchronous lifecycle consumers | Partial (sync cache stays) |
+| `browsers` | FFI handles | ✗ Host-only by nature |
+| Pool maps | Synchronous lifecycle scaffolding | ✗ Host-only by nature |
+
+The **refined model** for Phase B end state:
+
+```
+LAUNCHER (canonical, cross-process queryable):
+  state.windows: HashMap<String, WindowMirror>     ← B.4
+  state.pool: HashSet<String>                       ← B.4
+  state.instance_registry: HashMap<String, u32>     ← B.5a
+  state.next_instance_num: u32                      ← B.5a
+  state.backend_window_ids: HashMap<String, String> ← B.5 (id_map)
+  state.processes: HashMap<u32, ProcessRecord>      ← B.3
+  state.lifecycle: LifecyclePhase                   ← B.3
+
+HOST (synchronous caches — mirror of launcher state for hot-path lookups):
+  shadow_instance_registry                           ← B.5b
+  shadow_backend_window_ids                          ← B.5 (id_map step b)
+  shadow_window_meta                                 ← B.5 (meta step b)
+  window_meta                                        ← sync cache (refinement)
+
+HOST (scaffolding — never authoritative, FFI/lifecycle only):
+  browsers                                           ← CEF FFI handles
+  window_pool, unpromoted_pool_labels                ← pool lifecycle
+  window_pool_respawn_in_flight: AtomicBool          ← pool lifecycle
+  pending_window_creations                           ← pre-create handoff
+  sidecar_child, backend_pid, backend_endpoints      ← srv handles
+  ipc_port, ipc_token, ...                           ← network handles
+```
+
+The taxonomy isn't "13 stores deleted" — it's "every host field falls into one of three classes, and only the **canonical** class moved." The other two classes are intrinsically host-internal, not bugs to migrate away.
+
+---
+
+## What "completely delivered" actually means
+
+Refining the Phase B exit criteria from the original spec:
+
+| Original criterion | Refined |
+|---|---|
+| "All 13 state stores from inventory either deleted from host or remain only as effects-runner local state." | All 13 state stores either: (1) deleted post-migration, (2) preserved as a synchronous host-side cache mirroring launcher state, or (3) preserved as host-internal scaffolding (FFI/lifecycle). Each surviving field has a comment classifying its role. |
+| "Reducer is a pure function tested with property-based testing over arbitrary command sequences." | ✓ Already done (proptest in `agentmux-launcher/src/reducer.rs`). |
+| "Frontend's `app-init.ts` polling loop is gone; rows update via event push." | B.7. Unchanged. |
+| "`agentmux.exe --diag` prints canonical state." | B.8. Unchanged. |
+| "Six invariants checked at every transition." | ✓ Already done (reducer panics on violations). |
+
+---
+
+## Concrete remaining work
+
+### B.5 finish — small audit
+
+1. Add a comment to `state.browsers` declaring it as scaffolding (not authoritative). Same for the pool maps.
+2. Audit label-set reads of `browsers.keys()` and pool maps for cases where they're really asking "which labels exist in the launcher's view." Switch those to read from `state.windows` / `shadow_window_meta`. (~30-50 LoC, one PR.)
+3. Update `phase-b-roadmap.md` (local) to reflect this refined understanding.
+
+### B.6 — single-instance mutex (1 PR)
+
+The named-pipe `first_pipe_instance(true)` already rejects a second launcher. Just need to:
+- Surface a clear error when launch fails due to existing instance.
+- Delete the old TCP port-file probe in `agentmux-srv` if any remains.
+- Maybe show a dialog to the user: "AgentMux is already running (PID N)."
+
+### B.7 — frontend cutover (2-3 PRs)
+
+Replace `app-init.ts::refreshLabels(true, retriesLeft)` polling with subscription to launcher events via the CEF JS bridge. Frontend reducer fed by event stream.
+
+### B.8 — Phase B exit (1-2 PRs)
+
+- Property tests for the 13 invariants in `ANALYSIS_*.md`.
+- `agentmux.exe --diag` Tool client that prints launcher state.
+- CI synthetic close-all + assertion.
+- Delete obsolete defensive code (e.g., the host-side fallbacks in `state.window_meta()` if no longer needed post-`task dev` reconciliation).
+
+### Spec addendum
+
+Update `SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` §"Migration" to reflect the three-class taxonomy. The original "single `Map<WindowId, WindowState>`" framing is partially impossible (WindowState can't carry FFI handles); needs to be split into a launcher-side `WindowState` for queryable data and a host-side `CefHandles<WindowId, Browser>` for FFI ownership.
+
+---
+
+## Implications for the golden vision
+
+The "Redux/state-machine model" is intact. State changes flow through the reducer. Events flow out. Host/srv/frontend hold projections.
+
+The refinement: **some host residuals are not state**. They're FFI-coupled scaffolding or synchronous lifecycle helpers. They don't violate the state-machine model — they're outside its scope (boundary infrastructure, not domain state).
+
+A cleaner mental frame:
+
+> The launcher reducer owns all **domain state** — everything that has meaning across processes and that any subscriber might want to query.
+>
+> Host owns **boundary scaffolding** — FFI handles, lifecycle helpers, synchronous local caches of domain state for hot-path reads.
+>
+> The state machine is intact for domain state. Boundary scaffolding never participated in the state-machine in the first place.
+
+This is a useful refinement for any future B-equivalent migration: identify what's domain state vs boundary scaffolding before assuming everything is migrate-able. Boundary scaffolding doesn't need a ratchet; it just needs a comment explaining its role.
+
+---
+
+## Calendar implications
+
+Original estimate (post-#582): "B.5 remaining: 3-5 sessions." Revised: **B.5 finish is one small audit PR, ~1 hour.** The "remaining maps" turned out to mean "audit existing read-paths" rather than "run the full ratchet on 2 more maps."
+
+This accelerates the path to golden vision:
+
+- B.5 finish: ~1 PR (~1 hour)
+- B.6: 1 PR (~1 hour)
+- B.7: 2-3 PRs (~1 session)
+- B.8: 1-2 PRs (~1 session)
+
+**Total to Phase B done: ~1.5-2 sessions.** Then Phase C/D become trivial; Phase E is parallel work.

--- a/docs/retro/migration-pattern.md
+++ b/docs/retro/migration-pattern.md
@@ -1,0 +1,106 @@
+# Migration pattern: a→b→c→d→e ratchet (with sync-cache exception)
+
+**Status:** Reference. Read AFTER `phase-b-roadmap.md` if you're resuming Phase B work.
+**Author:** AgentA.
+**Date:** 2026-04-28 (post-#592, post-multi-reducer decision).
+
+---
+
+## TL;DR
+
+Phase B.5 migrates host-owned state to launcher-owned state one field at a time using a 5-step ratchet (a→b→c→d→e). 3 fields completed; 2 deferred to Phase F because they require a host-side reducer (multi-reducer architecture). One field (window_meta) used a refined version of the ratchet with a synchronous host cache instead of step-e deletion.
+
+---
+
+## When to use the ratchet
+
+Apply the a→b→c→d→e ratchet when:
+- The state is queryable across processes.
+- The state has well-defined commands that mutate it.
+- The state doesn't carry FFI handles or other in-process-only objects.
+- The state can tolerate eventually-consistent reads (with a synchronous cache where needed).
+
+**Don't apply it when** the state holds FFI pointers (e.g., CEF `Browser` handles), or when synchronous lifecycle decisions depend on it without tolerance for round-trip lag. In those cases the field is **boundary scaffolding** (current Phase B framing) or **host-reducer state** (Phase F destination — see `multi-reducer-proposal-2026-04-28.md`).
+
+---
+
+## The five steps
+
+| Step | Who is canonical | Who is the shadow | What changes | Risk |
+|---|---|---|---|---|
+| **a** | host | (none) | Launcher gains its own copy, fed by host's `Report*` commands. Pure addition. | Low |
+| **b** | host | launcher's projection in host AppState | Host caches launcher events into a `shadow_*` field; drift logged. Pure observation. | Low |
+| **c** | shadow (read), host (write) | host's old field | Reads route through `state.<helper>()` which prefers shadow with host fallback. Host still writes. | Medium — read paths now depend on launcher round-trip |
+| **d** | shadow | host's old field (vestigial) | Host stops writing. Shadow is the only source for reads. | Medium — exposes any code that read the field directly |
+| **e** | launcher mirror | (deleted) | Host field removed; helper fallback removed. | Low (mostly delete-only) |
+
+---
+
+## Worked example: `window_instance_registry` (PRs #579-#584)
+
+* **a (#579)**: launcher gained `State.instance_registry: HashMap<String, u32>` + `State.next_instance_num: u32`. `handle_report_window_opened` assigns numbers and emits `Event::WindowInstanceAssigned`.
+* **b (#580)**: host gained `AppState.shadow_instance_registry`. `apply_event_to_shadow` consumes the events; on every event compares to host's `WindowInstanceRegistry` and logs drift.
+* **c (#581 + #582)**: `state.instance_num()` / `state.instance_count()` helpers added (shadow-first, host fallback). 5 read sites switched. Host writes preserved. Smoke test caught a pre-existing orphan-pool-window bug (#582) — drift detection earned its keep.
+* **d (#583)**: 4 mutation sites removed. `instance_count` fallback removed (host's count is now seed-only and would be stale). Shadow-driven re-emit added so InstancePanel catches up.
+* **e (#584)**: `WindowInstanceRegistry` struct + field deleted. Helper fallback removed. Drift compares removed. **Net: -161 LoC / +52 LoC.**
+
+Same pattern worked for `window_id_map` (#585-#589).
+
+---
+
+## The sync-cache exception: `window_meta` (PRs #590-#592)
+
+`window_meta` looked like a normal candidate but step d hit two synchronous-lookup consumers:
+
+1. `open_subwindow`'s parent-liveness check — must reflect "is this parent currently open" with no async lag.
+2. Cascade-close enumeration during `on_before_close` — must include children opened just before.
+
+The shadow lags by milliseconds; for these consumers, the lag was a correctness regression (orphan subwindows on race).
+
+**Refinement**: keep `host.window_meta` as a **synchronous local cache**, written from a single canonical site (`on_after_created` from the popped `PendingWindowCreation` entry) and removed at `on_before_close`. Step e becomes a doc acknowledgment, not a delete.
+
+The data flow:
+- Caller (`drag.rs`, `window.rs`, `window_pool.rs`) pushes `PendingWindowCreation { label, kind, parent }` to a queue.
+- `on_after_created` pops the queue, writes host's `window_meta` (sync cache), and emits `ReportWindowOpened` to launcher.
+- Launcher's reducer updates `state.windows` and broadcasts `Event::WindowOpened`.
+- Host's `apply_event_to_shadow` updates `shadow_window_meta`.
+- Both host's sync cache and the launcher's projection are populated.
+
+**Lesson for future migrations**: before step e, check whether the field has any same-process synchronous lifecycle-checking consumer. If yes, expect step e to become a sync-cache acknowledgment.
+
+---
+
+## When the ratchet doesn't work at all: `browsers` + pool maps
+
+`browsers: HashMap<String, cef::Browser>` holds CEF FFI handles. The handles can't serialize over IPC and must stay co-located with the CEF runtime. The KEY-SET role (label set queries) is migratable and is already covered by B.4's `state.windows` + B.5's `shadow_window_meta` — but the field itself stays.
+
+`window_pool` + `unpromoted_pool_labels` are coupled with CEF lifecycle callbacks and synchronous pool decisions. Same story.
+
+These fields are **boundary scaffolding** in the current Phase B framing. Long-term they become host-reducer state under the multi-reducer model — see `multi-reducer-proposal-2026-04-28.md`. Phase B is finishing without retiring them.
+
+---
+
+## Anti-patterns
+
+* **Don't read directly from `shadow_*` fields.** Always go through helpers (`state.instance_num()`, `state.window_meta()`, etc.). The helper encapsulates prefer-shadow / fallback / drift policy. Direct reads bypass the policy.
+* **Don't add new mutations to host's old field once you're in step b+.** All new mutations should go via `report_*` commands. Direct mutation resets migration progress for that field.
+* **Don't wait synchronously on launcher events from CEF callbacks.** UI thread can't block. Frontend retries are the correct race mitigation.
+* **Don't conflate steps.** Each PR should be exactly one step (a, b, c, d, or e) for one field. Combining steps makes rollback expensive.
+* **Don't try to fully retire a field with synchronous lifecycle consumers.** Use the sync-cache pattern (`window_meta`) instead of pushing all the way to step e.
+* **Don't try to retire `browsers` or pool maps via this ratchet.** Read `b5-migration-architecture-2026-04-28.md` first; they need a host-side reducer (Phase F).
+
+---
+
+## Layer reference
+
+| Concern | Location | Mutates? |
+|---|---|---|
+| Wire events | `agentmux-common/src/ipc.rs` | — |
+| Canonical state (launcher reducer) | `agentmux-launcher/src/state.rs` | Only via reducer |
+| Pure reducer | `agentmux-launcher/src/reducer.rs::update()` | The function |
+| IPC server | `agentmux-launcher/src/ipc/server.rs` | Dispatches commands → reducer → broadcasts events |
+| Host outbound | `agentmux-cef/src/launcher_ipc.rs::report_*` | Sends commands |
+| Host inbound | `agentmux-cef/src/launcher_ipc.rs::apply_event_to_shadow` | Updates host shadows from events |
+| Host shadows | `agentmux-cef/src/state.rs::AppState.shadow_*` | Only by `apply_event_to_shadow` |
+| Host sync caches (`window_meta`, etc.) | Same file | Single canonical mutation site (`on_after_created` / `on_before_close`) |
+| Host scaffolding (`browsers`, pool maps) | Same file | Direct CEF lifecycle / saga code paths; NOT migrate-able under current model |

--- a/docs/retro/multi-reducer-proposal-2026-04-28.md
+++ b/docs/retro/multi-reducer-proposal-2026-04-28.md
@@ -1,0 +1,216 @@
+# Multi-reducer architecture (accepted direction)
+
+> **STATUS UPDATE (2026-04-28):** Originally written as a proposal; **direction accepted** later same day. This is now the agreed long-term plan. Sequencing: finish Phase B with the scaffolding model (per `b5-migration-architecture-2026-04-28.md`), then Phase D (snapshot/replay), then Phase E (srv reducer), then Phase F (host reducer — retires the scaffolding model). See `phase-b-roadmap.md` for current state.
+
+**Author:** AgentA.
+**Date:** 2026-04-28.
+**Companions:**
+* `b5-migration-architecture-2026-04-28.md` — the analysis that prompted this proposal
+* `migration-pattern.md` — the a→b→c→d→e ratchet (single-reducer migration)
+* `phase-b-roadmap.md` — phase B sub-PR sequence
+* `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` — the driving spec
+
+---
+
+## TL;DR
+
+The "host has scaffolding outside the state machine" framing in `b5-migration-architecture-2026-04-28.md` is pragmatic but conceptually awkward. A cleaner alternative: **three reducers** (launcher, host, srv), each canonical for its domain, communicating via versioned events.
+
+This proposal sketches the design, the cross-reducer-sync patterns, and a recommended sequence for adopting it. Net recommendation: **adopt eventually, but not as part of Phase B**. Finish Phase B with the scaffolding model, then layer multi-reducer in Phase E (srv reducer, already planned) and Phase F (host reducer, new).
+
+---
+
+## The proposal
+
+Three reducers, each owning a coherent slice of state:
+
+| Reducer | Scope | Examples |
+|---|---|---|
+| **Launcher** | OS-level cross-process facts | process tree, window inventory, instance numbers, lifecycle phase |
+| **Host** | CEF integration + lifecycle scaffolding | browsers, pool, pool-respawn-in-flight, pre-create handoff, taskbar/HWND state |
+| **Srv** (planned Phase E) | App domain | tabs, panes, layouts, agents, workspaces |
+
+The key flip: **`browsers` + pool maps stop being "scaffolding outside the state machine"** — they become host-reducer domain state with reducer-enforced invariants. Things like:
+
+* "no label in both `unpromoted_pool_labels` and `window_pool` simultaneously"
+* "pool size ≤ POOL_TARGET_SIZE"
+* "every `window-pool-*` label is in either pool or promoted-windows, never both"
+
+become reducer-enforced rather than convention-enforced. These are exactly the kinds of invariants that produced the bugs the spec calls out (instance count inflates after tear-off crash, burst tear-offs empty the pool, pool windows leak to taskbar).
+
+---
+
+## The cross-reducer-sync problem
+
+This is well-trodden territory in distributed event-sourced systems. The patterns that work, applied here:
+
+### 1. Local-canonical, global-eventually-consistent
+
+Each reducer is **canonical for its domain**. Other reducers hold **projections** (read-only mirrors) updated via events. We already built this for launcher↔host with `shadow_*` fields. Generalizing to 3 reducers: each pair has the same relationship.
+
+```
+Launcher canonical: state.processes, state.lifecycle, state.windows (label set)
+Host canonical:     state.browsers, state.pool, state.pre_create_queue
+Srv canonical:      state.tabs, state.panes, state.layouts, state.agents
+
+Projections each reducer holds:
+- Launcher holds projections of host (window-set events) + srv (workspace events)
+- Host holds projections of launcher (instance numbers, etc.) + srv (window→workspace mapping)
+- Srv holds projections of launcher (window-set) + host (window labels)
+- Frontend holds projections of all three via JS bridge
+```
+
+### 2. Events as the only cross-reducer contract
+
+**Commands** stay within the issuing reducer's domain. **Events** are the only thing crossing boundaries. **No reducer ever directly mutates another's state** — they emit events, and the other reducer's `apply_event_from_X` handler decides what to do (typically: update a projection field).
+
+This is the discipline that makes the system tractable. Without it, "reducer X writes to reducer Y's state through a back-channel" defeats the purpose.
+
+### 3. Sagas for cross-reducer operations
+
+A tear-off touches all three reducers:
+- **Host**: pop pool window from queue, transition to user-visible.
+- **Srv**: assign the workspace data to the new window.
+- **Launcher**: register new instance number, update window inventory.
+
+Express it as a **saga** — a state machine that lives OUTSIDE the reducers, sequences commands across them, waits for confirming events, handles failures with compensating actions. Pseudocode shape:
+
+```
+saga TearOff(workspace_id):
+  1. cmd Host::PromotePoolWindow(workspace_id) → expect Host::PoolWindowPromoted{label}
+  2. cmd Srv::AssignWindowToWorkspace(label, workspace_id) → expect Srv::WindowWorkspaceAssigned
+  3. cmd Launcher::RegisterWindowInstance(label) → expect Launcher::WindowInstanceAssigned{num}
+  4. (all three confirm) → saga complete
+
+  on any step failure:
+    compensate: emit Host::DepromoteWindow(label), Srv::UnassignWorkspace, …
+```
+
+Each step is observable; partial failures recover via compensating events. The user sees one logical operation; internally it's a sequenced multi-reducer transaction.
+
+### 4. Versioned events + snapshot-replay
+
+Each reducer's events are versioned within its scope. Subscribers detect gaps (`event.version > last_seen + 1`) and request a snapshot to resync. Phase D's `GetSnapshot` protocol generalizes naturally.
+
+### 5. Single-writer per state field (enforced structurally)
+
+Only the canonical reducer's `update()` can mutate its fields. Projections in other reducers are read-only — they only have `apply_event` handlers, no `mutate_field`. This is what we already do informally; multi-reducer makes it explicit and types it.
+
+### 6. Drift detection between projections and canonical
+
+Per-transition: subscriber reports its count/checksum; canonical compares to its own; emit drift events on mismatch. We built this for B.4 between host and launcher. Same pattern between launcher↔srv, host↔srv.
+
+### 7. Bounded staleness + synchronous local caches
+
+Projections lag by a bounded delay. Code requiring zero-lag uses synchronous local state (the "sync cache" pattern we landed for `window_meta`). This is unchanged in multi-reducer; it's just clearer that the cache is a property of the consuming reducer, not "scaffolding outside the model."
+
+### 8. Idempotent event handlers
+
+Every `apply_event` must be safe to apply twice. Critical for replay during resync. We've been doing this informally; should be a typed contract (Rust trait: `IdempotentApply`).
+
+### 9. Per-reducer property tests + cross-reducer integration tests
+
+Each reducer gets its own proptest battery (already done for launcher). Cross-reducer invariants tested via integration tests that drive sagas end-to-end against three running reducers.
+
+### 10. Coordinator pattern for sagas
+
+Sagas don't live in any reducer — they need a coordinator. Two options:
+
+* **Centralized in launcher**: launcher hosts a saga runtime that drives cross-reducer flows. Heavier in launcher; easier to debug.
+* **Distributed**: each saga has a "primary" reducer that owns its lifecycle; commands flow peer-to-peer. Lighter; harder to debug.
+
+For our scale, centralized in launcher is simpler. The launcher already has Tokio + IPC + reducer; saga runtime is one more component.
+
+---
+
+## What this changes vs the current path
+
+If we adopt multi-reducer:
+
+* The `b5-migration-architecture-2026-04-28.md` framing of "scaffolding vs state" gets replaced with "host-reducer-state vs launcher-reducer-state vs srv-reducer-state." Cleaner.
+* `browsers` + pool maps stop being awkward. They're host-reducer state with explicit invariants.
+* B.5 finish becomes: define the host reducer, dispatch host state changes through it, expose its events to launcher.
+* B.7 (frontend cutover): frontend subscribes to all three reducers' event streams via the CEF JS bridge.
+* Phase E (srv reducer): natural fit — same pattern, third instantiation.
+
+The existing single-reducer-in-launcher work stays valid. We don't retrofit `window_instance_registry` etc. into a host reducer; they genuinely are launcher domain (cross-process visibility was the goal).
+
+---
+
+## Trade-offs
+
+### Pros
+
+* Conceptually clean — every state has an explicit reducer enforcing its invariants.
+* Better testability — each reducer property-tested in isolation; cross-reducer behavior tested via saga integration tests.
+* Failure isolation — reducer bugs don't cross processes (panic in srv reducer doesn't corrupt launcher state).
+* Aligns with Phase E plan — srv reducer was already going to happen; adding host reducer makes the system uniform.
+* Eliminates the "scaffolding" exception that currently sits awkwardly in `b5-migration-architecture-2026-04-28.md`.
+
+### Cons / costs
+
+* **More boilerplate per process** (~500 LoC for host reducer infrastructure: types, dispatch, event apply, proptest harness). Same scale as launcher's reducer plumbing was.
+* **Saga pattern is more complex than direct mutation** for cross-reducer ops. Mistakes here are subtle (compensating actions, partial failures). Need careful design + tests.
+* **Three sources of truth for different aspects** → potential confusion about which reducer owns what. Mitigated by clear scope definitions and a single source-of-truth doc.
+* **Performance: every state change goes through a reducer** — even host-internal ones. CEF callbacks now route through a dispatch instead of direct mutation. Probably fine (microseconds), but worth measuring.
+
+---
+
+## Sequencing recommendation
+
+**Yes, adopt — but as Phase E+ work, not blocking Phase B exit.**
+
+Phase B as planned can finish with the "scaffolding" framing — it's pragmatic and ships the launcher reducer cleanly. Phase E adds the srv reducer (already planned). After Phase E, retrofitting the host into a reducer is a smaller step because the patterns are already validated in two places.
+
+Recommended sequence:
+
+| Step | Goal | Validates |
+|---|---|---|
+| **Finish Phase B** (current scaffolding model) | Launcher reducer + host scaffolding | Single-reducer pattern at scale |
+| **Phase D** (snapshot/replay) | Generic resync infrastructure | Versioned events + snapshot pattern |
+| **Phase E** (srv reducer) | Second reducer + cross-process events | Multi-reducer pattern, saga skeleton |
+| **Phase F** (host reducer) | Third reducer, retire scaffolding model | Generalization to N reducers |
+
+Each step builds on validated patterns from the previous. Doing host-reducer right after Phase B would mean designing the multi-reducer infrastructure on the fly, against just one new reducer (no validation point).
+
+---
+
+## Why not now (defending the deferral)
+
+The temptation is real: the architectural model gets cleaner and the "scaffolding exception" goes away. But:
+
+1. **The scaffolding model isn't broken.** It works, ships, has invariants enforced via the launcher's drift detection. The cleanliness gap is aesthetic, not functional.
+
+2. **We don't have a second reducer yet.** Designing N-reducer infrastructure with N=2 (launcher + host) is harder than designing it with N=3 (launcher + srv + host) because the patterns are clearer with three. Phase E gives us that third reducer for free, since it was already planned.
+
+3. **Phase B exit unlocks downstream value (B.7 frontend cutover, Phase D snapshots) sooner.** Each session of "polish the architecture before shipping" delays user-visible improvements.
+
+4. **The migration cost is bounded if we wait.** Adding a host reducer in Phase F is a localized refactor; the host's existing state is well-understood and the events it would emit are already half-defined (just the inbound `Report*` commands today, become outbound events post-reducer).
+
+---
+
+## What to write down before deferring
+
+Even if we defer, capture the design intent now so future-us (or a Phase F PR reviewer) doesn't relitigate:
+
+* This doc.
+* A line in `phase-b-roadmap.md` (local) noting that "scaffolding" is provisional pending Phase F.
+* A spec addendum in `SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` acknowledging the multi-reducer trajectory.
+
+---
+
+## Open design questions (for whenever we adopt)
+
+* **Do reducers share a Tokio runtime or run separately?** Launcher has its own; srv does too. Host gets a third runtime? Or do we host-reducer-as-a-task in the existing host runtime? Cleanest: each reducer is a Rust struct, called from whatever runtime hosts the process. No new runtimes.
+* **How are saga states persisted across launcher restarts?** If the launcher crashes mid-saga, do we resume? For Phase B/E, probably no — saga restart-on-launcher-restart is Phase D resync territory.
+* **What's the granularity of events?** Per-field? Per-domain-action? Phase D's `GetSnapshot` performance depends on this.
+* **How do we handle backward-compatibility when adding new event variants?** The serde tagged-enum strategy we use scales fine, but each reducer's event log on disk needs forward-migration tools.
+* **Cross-reducer transactions vs sagas — when each?** Strict transactions need a coordinator with all reducers blocking. Sagas are eventually-consistent. Probably: sagas for everything; if we need a strict transaction, that's a sign the reducer scope is wrong.
+
+---
+
+## Bottom line
+
+The multi-reducer pattern is the right long-term architecture. It generalizes from where we are. The "scaffolding" framing is a useful intermediate state, not a permanent design.
+
+Sequencing: finish Phase B, do Phase D + E, then come back and do Phase F (host reducer). Total additional cost: 1 session for Phase F's infrastructure, 1-2 sessions for the actual host-reducer migration of `browsers` + pool maps.

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -1,0 +1,119 @@
+# Phase B roadmap (canonical, post-#592)
+
+**Status:** Active reference. Updated 2026-04-28 after PR #592 (window_meta step d) merged and the multi-reducer direction was accepted.
+**Author:** AgentA.
+**Read first if resuming Phase B work**, then `b5-migration-architecture-2026-04-28.md` and `multi-reducer-proposal-2026-04-28.md`.
+
+---
+
+## Where we are
+
+```
+Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
+                        │
+                        │  B.1 (#570/571/572)  ──  srv as launcher-spawned sibling
+                        │  B.2 (#573)          ──  named-pipe IPC server
+                        │  B.3 (#574)          ──  pure reducer skeleton
+                        ▼
+              Foundation laid: launcher has Tokio + IPC + reducer ✓
+                        │
+                        │  B.4  (#576)  ──  window mirror (read-only)
+                        │  B.4a (#577)  ──  pool tracking
+                        │  B.4b (#578)  ──  drift detection
+                        ▼
+              Mirror tracks reality, drift observable ✓
+                        │
+                        │  B.5 (a→b→c→d→e per map, smallest first)
+                        │     ✓ window_instance_registry (#579-#584)
+                        │     ✓ window_id_map (#585-#589)
+                        │     ✓ window_meta (#590-#592, sync-cache refinement)
+                        │     deferred: browsers, pool maps (Phase F — see
+                        │       multi-reducer-proposal-2026-04-28.md)
+                        ▼
+              ◄── HERE. 3 of 5 maps fully migrated; 2 deferred to Phase F.
+                        │
+                        ▼
+              B.5 finish: small audit PR (~30-50 LoC) — switch any
+                          remaining label-set reads from `browsers.keys()`
+                          / pool maps to `state.windows` / `shadow_window_meta`.
+              B.6  ──  per-data-dir mutex single-instance (named pipe already covers it)
+              B.7  ──  frontend cutover (delete polling)
+              B.8  ──  Phase B exit (delete obsolete defensive code,
+                       add property tests, --diag tool, CI smoke)
+                        │
+                        ▼
+                  Phase B done — golden vision (intermediate form)
+                        │
+                        │  Phase D, E, F — see multi-reducer-proposal
+                        ▼
+                  Multi-reducer architecture (long-term destination)
+```
+
+## Migration table (B.5)
+
+| Map | step a | step b | step c | step d | step e | Notes |
+|---|---|---|---|---|---|---|
+| `window_instance_registry` | ✓ #579 | ✓ #580 | ✓ #581 + #582 | ✓ #583 | ✓ #584 | Pure data, fully retired |
+| `window_id_map` | ✓ #585 | ✓ #586 | ✓ #587 | ✓ #588 | ✓ #589 | Pure data, fully retired |
+| `window_meta` | ✓ via B.4 | ✓ #590 | ✓ #591 | ✓ #592 | n/a | Sync-cache exception — host_meta stays |
+| `browsers` | n/a | n/a | n/a | n/a | n/a | **Deferred to Phase F** (FFI handles) |
+| `window_pool` + `unpromoted_pool_labels` | partial via B.4 | partial via B.4 | n/a | n/a | n/a | **Deferred to Phase F** (sync lifecycle scaffolding) |
+
+See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps can't follow the standard ratchet, and `multi-reducer-proposal-2026-04-28.md` for the long-term plan.
+
+## What's left for Phase B
+
+### B.5 finish (small)
+
+- Single audit PR: switch any remaining `browsers.keys()` label-set reads to `state.windows` or `shadow_window_meta`. Same for pool-map iterations that are really asking "which labels exist in launcher's view." ~30-50 LoC.
+- Add a comment to `state.browsers` and the pool maps declaring them as scaffolding pending Phase F (host reducer).
+
+### B.6 — single-instance mutex (1 PR, ~80 LoC)
+
+- The named-pipe `first_pipe_instance(true)` already rejects a second launcher binding the same pipe. Just need to surface a clear error when launch fails ("AgentMux is already running, PID N") and delete any old port-file probe in srv.
+
+### B.7 — frontend cutover (2-3 PRs)
+
+- Replace `app-init.ts::refreshLabels(retriesLeft)` polling with subscription to launcher events via the CEF JS bridge.
+- Wire host's outbound JS bridge to forward launcher events to the renderer.
+- Frontend reducer fed by the event stream.
+
+### B.8 — Phase B exit (1-2 PRs)
+
+- Property tests for invariants from `ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md`.
+- `agentmux.exe --diag` Tool client that prints launcher state.
+- CI synthetic close-all + assertion.
+- Delete obsolete defensive code (e.g., host-side `app-init.ts` retries that polling drove).
+
+## Beyond Phase B
+
+| Phase | Scope | Why deferrable |
+|---|---|---|
+| **Phase D** | `GetSnapshot` resync, `--diag` Tool, persisted event log | Foundations laid (versioned events, monotonic counters); just need snapshot RPC + ring-buffer + replay |
+| **Phase E** | srv state machine for tabs/panes/layout | Independent of B; same reducer pattern applied to srv. **First validation point for multi-reducer** |
+| **Phase F** | Host state machine — retire scaffolding model | After E validates multi-reducer infrastructure, retrofit host. Migrates `browsers` + pool maps into host-reducer state |
+
+## Decisions log
+
+(Don't relitigate these.)
+
+| Decision | When | Rationale |
+|---|---|---|
+| Tokio runtime in launcher | B.2 design | Standard, srv already uses it |
+| No reducer state persistence (memory only) | B.3 design | Spec default; workspaces persist via srv DB |
+| Frontend ↔ launcher via host JS bridge | B.7 design | Renderers stay sandboxed; host is trust boundary |
+| Migrate incrementally (sub-PR sequence) | B plan | Bugs are usually edge cases not architecture; migration keeps app running |
+| Codex hallucinates < gemini hallucinates | empirical, PRs #573-592 | Gemini auto-review disabled; reagent + codex is the merge gate |
+| `WindowInstanceRegistry` migrates first | B.5 plan | Smallest map, simplest semantics |
+| Window-count drift only on window-level transitions | B.4b round-2 | Pool transitions can fire mid-flight; pool-only check via `ReportHostPoolCount` |
+| `window_meta` keeps sync cache (not full delete) | B.5 step d round-2 (codex P1) | `open_subwindow` parent check + cascade-close need synchronous local state |
+| `browsers` + pool maps deferred to Phase F | 2026-04-28 | FFI handles + sync lifecycle scaffolding can't migrate via standard ratchet |
+| Multi-reducer is the long-term architecture | 2026-04-28 | Cleaner than "scaffolding outside the model"; deferred to Phase E + F to validate the pattern incrementally |
+| `docs/retro/*.md` files are local-only | 2026-04-28 | No review churn; future agents read them via `MEMORY.md` pointer |
+
+## How to update this doc
+
+1. After every Phase B PR merges: tick the box in the migration table; update "Where we are."
+2. After a major direction change (like the multi-reducer decision): add a row to the decisions log.
+3. Don't open a PR for changes here — local working notes only.
+4. Future agents resuming work should read this first; if you're confused after a context compression, the answer is here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.473",
+  "version": "0.33.474",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.473",
+      "version": "0.33.474",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.473",
+  "version": "0.33.474",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

B.5 finish PR — comment-only. Closes out the per-map migration phase.

After 3 successful migrations (window_instance_registry, window_id_map, window_meta), 2 host fields remain (`browsers` + pool maps) that intentionally **don't** follow the standard a→e ratchet. This PR adds explicit doc comments on each surviving field declaring its role, so future readers don't try to migrate them via the same pattern.

## Three classes (per analysis)

- **FFI scaffolding** (`browsers`): `cef::Browser` handles can't serialize across IPC. KEY-SET role already covered by launcher's `state.windows`.
- **Sync lifecycle scaffolding** (`window_pool`, `unpromoted_pool_labels`, `window_pool_respawn_in_flight`): pool decisions need sync-local state. Launcher's `state.pool` mirrors for cross-process queries.
- **Sync cache** (`window_meta`): mirrors launcher's `state.windows`; written from a single canonical site (on_after_created / on_before_close); needed for synchronous parent-liveness + cascade-close.

All three retire into a host-side reducer in Phase F (sequenced after Phase E srv reducer).

## What's next after this merges

- **B.6** — single-instance mutex (named pipe already covers it, just delete old port-file probe + add clear error)
- **B.7** — frontend cutover (replace polling with event subscription)
- **B.8** — Phase B exit (property tests, --diag, CI smoke)

## Test plan

- [x] `cargo check -p agentmux-launcher` passes.
- [ ] CI workspace check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)