### PR TITLE
B.6: launcher single-instance mutex via named-pipe bind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.474"
+version = "0.33.475"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.474"
+version = "0.33.475"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.474"
+version = "0.33.475"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.474"
+version = "0.33.475"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.474"
+version = "0.33.475"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -169,7 +169,6 @@ fn main() {
         (cef_dir, log_dir)
     };
     std::fs::create_dir_all(&data_dir).ok();
-    let port_file = data_dir.join("ipc-port");
 
     // Initialize dual-output tracing: rolling log file + stderr.
     // The log file guard must live for the entire process to ensure flushing.
@@ -183,34 +182,19 @@ fn main() {
         "Initializing CEF browser process"
     );
 
-    // If port file exists and we can connect, another instance is running.
-    // Send it a "new window" request and exit.
-    if port_file.exists() {
-        if let Ok(contents) = std::fs::read_to_string(&port_file) {
-            let parts: Vec<&str> = contents.trim().splitn(2, ':').collect();
-            if parts.len() == 2 {
-                let addr: Result<std::net::SocketAddr, _> = format!("127.0.0.1:{}", parts[0]).parse();
-                if let Ok(addr) = addr {
-                if let Ok(mut stream) = std::net::TcpStream::connect_timeout(
-                    &addr,
-                    std::time::Duration::from_secs(2),
-                ) {
-                    use std::io::Write;
-                    let body = r#"{"cmd":"open_new_window"}"#;
-                    let req = format!(
-                        "POST /ipc HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                        parts[1], body.len(), body
-                    );
-                    let _ = stream.write_all(req.as_bytes());
-                    tracing::info!("Sent new-window request to existing instance");
-                    std::process::exit(0);
-                }
-                // Connection failed — stale port file, continue with fresh launch
-                tracing::info!("Stale port file (connection refused), launching fresh");
-            }
-            } // addr parse
-        }
-    }
+    // Phase B.6: legacy `<data-dir>/ipc-port` probe removed. Single-
+    // instance enforcement now lives in the launcher's named-pipe
+    // bind (`first_pipe_instance(true)`) which rejects a second
+    // launcher BEFORE the host is even spawned. The old probe had a
+    // known stale-state defect (gap #8 in
+    // specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md):
+    // a hard crash left the file behind and the next launch
+    // connected to a dead IPC server, sent open_new_window, and
+    // exited 0 with no window opened. The launcher's pipe handle is
+    // owned by the OS; on launcher death the pipe is reaped, so
+    // there is no stale-state path. Best-effort cleanup of any
+    // leftover file from a pre-B.6 install.
+    let _ = std::fs::remove_file(data_dir.join("ipc-port"));
 
     // Create shared application state.
     let app_state = Arc::new(state::AppState::default());
@@ -390,12 +374,11 @@ fn main() {
     // Provides forensic data if the process later crashes from OOM / VA exhaustion.
     memory_heartbeat::start();
 
-    // Write port + token to file AFTER CEF init so a second instance
-    // only connects when we're ready to handle new-window requests.
-    let _ = std::fs::write(
-        &port_file,
-        format!("{}:{}", ipc_port, app_state.ipc_token),
-    );
+    // Phase B.6: no `ipc-port` file write — the launcher's named pipe
+    // is the single-instance signal (see comment at the probe-removal
+    // site above). The IPC HTTP server still runs locally for the
+    // host's own command surface; it just no longer publishes its
+    // port for cross-process discovery.
 
     // Run the CEF message loop. This blocks until quit_message_loop() is called
     // (triggered when all browser windows are closed in client.rs).
@@ -417,9 +400,6 @@ fn main() {
 
     // Drop the tokio runtime after CEF shutdown.
     drop(runtime);
-
-    // Clean up port file so stale data doesn't confuse future launches.
-    let _ = std::fs::remove_file(&port_file);
 
     tracing::info!("AgentMux host shutdown complete");
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.474"
+version = "0.33.475"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.474"
+version = "0.33.475"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"
@@ -54,6 +54,9 @@ windows-sys = { version = "0.59", features = [
     # feature in windows-sys 0.59 even though the function lives in
     # Win32_System_JobObjects. Without it, CreateJobObjectW is absent.
     "Win32_Security",
+    # Phase B.6: MessageBoxW for the user-facing "AgentMux is already
+    # running" dialog when the named-pipe single-instance bind fails.
+    "Win32_UI_WindowsAndMessaging",
 ] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -47,11 +47,35 @@ pub struct ServerCtx {
     pub state: Mutex<State>,
 }
 
+/// Bind the first named-pipe instance synchronously.
+///
+/// Phase B.6: the bind is the single-instance signal. Splitting it
+/// out of `run_ipc_server` lets the caller (main.rs) detect a
+/// collision BEFORE spawning srv/host and surface a user-visible
+/// error ("AgentMux is already running"). `ServerOptions::create`
+/// requires a Tokio runtime context for IOCP registration, so this
+/// must be called from inside `#[tokio::main]` (or any task on the
+/// runtime) — not from a plain sync entrypoint.
+///
+/// On Windows, a second launcher hitting the same pipe gets
+/// `ERROR_ACCESS_DENIED` (raw OS error 5); other errors mean the
+/// pipe namespace itself is misconfigured.
+#[cfg(target_os = "windows")]
+pub fn bind_first_pipe_instance(pipe_name: &str) -> std::io::Result<NamedPipeServer> {
+    ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(pipe_name)
+}
+
 /// Run the named-pipe IPC server until cancelled (or task panics).
 ///
 /// Returns a JoinHandle the caller (main.rs) holds for the life of
 /// the launcher. The server keeps accepting until the launcher's
 /// Tokio runtime shuts down.
+///
+/// The first pipe instance is passed in pre-bound by the caller (see
+/// `bind_first_pipe_instance`) so a collision can be surfaced
+/// synchronously before any children are spawned (Phase B.6).
 ///
 /// Each accepted connection becomes a new tokio task running
 /// `handle_connection`. The accept loop creates a fresh
@@ -61,29 +85,13 @@ pub struct ServerCtx {
 #[cfg(target_os = "windows")]
 pub fn run_ipc_server(
     pipe_name: String,
+    first: NamedPipeServer,
     ctx: ServerCtx,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let ctx = Arc::new(ctx);
         crate::log(&format!("[ipc] server starting on {}", pipe_name));
 
-        // First server instance — `first_pipe_instance(true)` rejects
-        // a second launcher trying to bind the same pipe (Phase B.6's
-        // single-instance check rides on this). For B.2 we use it
-        // defensively to surface name-collision bugs early.
-        let first = match ServerOptions::new()
-            .first_pipe_instance(true)
-            .create(&pipe_name)
-        {
-            Ok(s) => s,
-            Err(e) => {
-                crate::log(&format!(
-                    "[ipc] FATAL: bind failed for {}: {} (another launcher running for this data dir?)",
-                    pipe_name, e
-                ));
-                return;
-            }
-        };
         let mut current = first;
 
         loop {

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -161,14 +161,53 @@ async fn run_windows(
     // for the rest of run_windows so the task isn't cancelled mid-
     // accept. Server owns the namespace `\\.\pipe\agentmux-{hash}\
     // command` per data dir, so multi-instance launchers (different
-    // data dirs) get distinct pipes; a second launcher pointing at
-    // the SAME data dir would collide on `first_pipe_instance(true)`
-    // and surface as a clean error — Phase B.6 turns that collision
-    // into the single-instance enforcement signal.
+    // data dirs) get distinct pipes.
+    //
+    // Phase B.6: the bind itself is the single-instance signal.
+    // `bind_first_pipe_instance` synchronously reserves the pipe;
+    // a second launcher pointing at the same data dir gets
+    // ERROR_ACCESS_DENIED. We surface that to the user as
+    // "AgentMux is already running for this data directory" and
+    // exit cleanly BEFORE spawning srv/host (otherwise the second
+    // host would briefly contend on the CEF cache lockfile).
     let dir_hash = hash::data_dir_hash16(&paths.data_dir);
     let pipe_path = ipc::pipe_name(&dir_hash);
+    let first_pipe = match ipc::server::bind_first_pipe_instance(&pipe_path) {
+        Ok(p) => p,
+        Err(e) => {
+            // ERROR_ACCESS_DENIED (5) means another launcher already
+            // owns this pipe — i.e., another AgentMux is running for
+            // this data dir. Anything else is unexpected (namespace
+            // misconfig, security descriptor failure) and we still
+            // refuse to start, but with a different message so support
+            // can tell them apart from a log line.
+            const ERROR_ACCESS_DENIED: i32 = 5;
+            let already_running = e.raw_os_error() == Some(ERROR_ACCESS_DENIED);
+            let title = "AgentMux";
+            let body = if already_running {
+                format!(
+                    "AgentMux is already running for this data directory.\n\nData dir: {}\n\nFocus the existing window, or close it before launching again.",
+                    paths.data_dir.display()
+                )
+            } else {
+                format!(
+                    "AgentMux failed to start: could not bind IPC pipe.\n\nPipe: {}\nError: {}\n\nIf the problem persists, check the launcher log.",
+                    pipe_path, e
+                )
+            };
+            log(&format!(
+                "FATAL: pipe bind failed (already_running={}): {} pipe={}",
+                already_running, e, pipe_path
+            ));
+            show_fatal_dialog(title, &body);
+            // Exit code 2 distinguishes the single-instance refusal from
+            // generic launch failures (code 1).
+            std::process::exit(2);
+        }
+    };
     let _ipc_handle = ipc::run_ipc_server(
         pipe_path.clone(),
+        first_pipe,
         ipc::server::ServerCtx {
             launcher_pid: std::process::id(),
             launcher_version: env!("CARGO_PKG_VERSION").to_string(),
@@ -500,6 +539,40 @@ pub(crate) fn resume_main_thread(pid: u32) -> Result<(), String> {
         }
         Ok(())
     }
+}
+
+/// Show a modal error dialog before the launcher exits. Used by the
+/// Phase B.6 single-instance check so a user double-clicking the app
+/// while it is already running sees a clear message — without this,
+/// the launcher exit is silent (it has the `windows` subsystem in
+/// release, so eprintln! goes nowhere).
+#[cfg(target_os = "windows")]
+fn show_fatal_dialog(title: &str, body: &str) {
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        MessageBoxW, MB_ICONWARNING, MB_OK, MB_SETFOREGROUND, MB_TOPMOST,
+    };
+    let title_w: Vec<u16> = std::ffi::OsStr::new(title)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    let body_w: Vec<u16> = std::ffi::OsStr::new(body)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    unsafe {
+        MessageBoxW(
+            std::ptr::null_mut(),
+            body_w.as_ptr(),
+            title_w.as_ptr(),
+            MB_OK | MB_ICONWARNING | MB_SETFOREGROUND | MB_TOPMOST,
+        );
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn show_fatal_dialog(_title: &str, body: &str) {
+    eprintln!("{}", body);
 }
 
 /// Find the CEF host binary in the runtime directory.

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.474"
+version = "0.33.475"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -1,6 +1,6 @@
-# Phase B roadmap (canonical, post-#592)
+# Phase B roadmap (canonical, post-#594)
 
-**Status:** Active reference. Updated 2026-04-28 after PR #592 (window_meta step d) merged and the multi-reducer direction was accepted.
+**Status:** Active reference. Updated 2026-04-28 after PR #594 (B.5 finish — scaffolding-role audit) merged. B.5 is complete; B.6 (single-instance mutex) is in flight.
 **Author:** AgentA.
 **Read first if resuming Phase B work**, then `b5-migration-architecture-2026-04-28.md` and `multi-reducer-proposal-2026-04-28.md`.
 
@@ -27,15 +27,15 @@ Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
                         │     ✓ window_instance_registry (#579-#584)
                         │     ✓ window_id_map (#585-#589)
                         │     ✓ window_meta (#590-#592, sync-cache refinement)
+                        │     ✓ B.5 finish — scaffolding-role audit (#594)
                         │     deferred: browsers, pool maps (Phase F — see
                         │       multi-reducer-proposal-2026-04-28.md)
                         ▼
-              ◄── HERE. 3 of 5 maps fully migrated; 2 deferred to Phase F.
+              B.5 complete. 3 of 5 maps fully migrated; 2 deferred to
+              Phase F with explicit scaffolding comments in code.
                         │
                         ▼
-              B.5 finish: small audit PR (~30-50 LoC) — switch any
-                          remaining label-set reads from `browsers.keys()`
-                          / pool maps to `state.windows` / `shadow_window_meta`.
+              ◄── HERE. B.6 in flight: single-instance mutex.
               B.6  ──  per-data-dir mutex single-instance (named pipe already covers it)
               B.7  ──  frontend cutover (delete polling)
               B.8  ──  Phase B exit (delete obsolete defensive code,
@@ -63,14 +63,13 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 
 ## What's left for Phase B
 
-### B.5 finish (small)
+### B.5 finish (done — PR #594)
 
-- Single audit PR: switch any remaining `browsers.keys()` label-set reads to `state.windows` or `shadow_window_meta`. Same for pool-map iterations that are really asking "which labels exist in launcher's view." ~30-50 LoC.
-- Add a comment to `state.browsers` and the pool maps declaring them as scaffolding pending Phase F (host reducer).
+- Scaffolding-role comments added to `state.browsers`, `window_pool`, `unpromoted_pool_labels`, and `compute_and_report_host_counts` so future agents see why these fields don't follow the standard ratchet and where they head in Phase F.
 
-### B.6 — single-instance mutex (1 PR, ~80 LoC)
+### B.6 — single-instance mutex (in flight)
 
-- The named-pipe `first_pipe_instance(true)` already rejects a second launcher binding the same pipe. Just need to surface a clear error when launch fails ("AgentMux is already running, PID N") and delete any old port-file probe in srv.
+- The named-pipe `first_pipe_instance(true)` already rejects a second launcher binding the same pipe. Just need to surface a clear error when launch fails ("AgentMux is already running, PID N") and delete any old port-file probe.
 
 ### B.7 — frontend cutover (2-3 PRs)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.474",
+  "version": "0.33.475",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.474",
+      "version": "0.33.475",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.474",
+  "version": "0.33.475",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase B.6 — turn the launcher's existing `first_pipe_instance(true)` bind into the single-instance enforcement signal, with a user-visible error when a second launcher hits the same data dir. Retire the legacy `<data-dir>/ipc-port` probe + write in the host.

Per `docs/retro/phase-b-roadmap.md` (B.6 row) and the gap-8 stale-state defect documented in `specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md`.

## What changed

- `agentmux-launcher/src/ipc/server.rs`: split the synchronous bind out of the spawn loop into `bind_first_pipe_instance(pipe_name)`. `run_ipc_server` now takes a pre-bound `NamedPipeServer`.
- `agentmux-launcher/src/main.rs`: binds the pipe before spawning srv/host. On `ERROR_ACCESS_DENIED` (second launcher), shows a `MessageBoxW` ("AgentMux is already running for this data directory…") and exits 2. Other bind errors get a distinct message but the same exit code. New helper `show_fatal_dialog` for the modal.
- `agentmux-launcher/Cargo.toml`: enable `Win32_UI_WindowsAndMessaging` feature for `MessageBoxW`.
- `agentmux-cef/src/main.rs`: remove the legacy `ipc-port` probe (lines 188–213), the post-CEF-init port-file write (lines 393–398), and the shutdown cleanup. Best-effort `remove_file` of any leftover from a pre-B.6 install. The `open_new_window` IPC command itself stays — only the cross-process discovery via the port file goes away. The launcher's pipe is OS-owned; on launcher death the pipe is reaped, so there is no stale-state path.
- `docs/retro/phase-b-roadmap.md`: tick B.5 finish (PR #594), mark B.6 in flight.

## Why exit code 2

Distinguishes single-instance refusal from generic launch failure (exit 1). Lets shell wrappers / CI easily tell "user double-clicked while running" from "config broken."

## Test plan

- [ ] `task package` builds clean.
- [ ] Launch portable AgentMux, then double-click the same `.exe` again — expect a MessageBox, not a silent exit. Check exit code is 2.
- [ ] Launch two portable instances at DIFFERENT versions (different data dirs) — both should run side-by-side (the pipe name is namespaced per `data_dir_hash16`).
- [ ] `task dev` still works (host runs without launcher in dev mode).
- [ ] Hard-kill (taskkill /F) the launcher — next launch should succeed (no stale state, OS reaped the pipe).

## Follow-up

After this lands, **B.5 + B.6 are complete**; **B.7** is the frontend cutover from polling to events (delete `app-init.ts::refreshLabels(retriesLeft)` polling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)