### PR TITLE
B.7.1: enrich window-instances-changed payload with entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.475"
+version = "0.33.476"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.475"
+version = "0.33.476"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.475"
+version = "0.33.476"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.475"
+version = "0.33.476"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.475"
+version = "0.33.476"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -258,12 +258,17 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // race between the synchronous emit at the mutation site
             // (which carries the pre-event count) and the launcher's
             // `WindowInstanceAssigned` arrival here.
-            let count = state.shadow_instance_registry.lock().len();
-            crate::events::emit_event_all_windows(
-                state,
-                "window-instances-changed",
-                &serde_json::json!(count),
-            );
+            //
+            // Phase B.7.1 — payload now carries the resolved
+            // `entries` array (label + windowId pairs from launcher
+            // shadows), letting the frontend update its atoms
+            // directly without a follow-up `list_window_instances`
+            // RPC and without the retry-on-stale polling that
+            // existed only because the synchronous emit fired
+            // before state.browsers settled. Sync emits still
+            // ship count-only payloads; the frontend keeps the
+            // legacy refresh path as a fallback for those.
+            emit_window_instances_changed_with_entries(state);
         }
         Event::WindowOpened { label, kind, parent_label, .. } => {
             // Phase B.5 (window_meta step b) — shadow projection
@@ -329,19 +334,60 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // Phase B.5e — host's `WindowInstanceRegistry` was
             // deleted; the drift compare is gone with it.
             state.shadow_instance_registry.lock().remove(label);
-            // Phase B.5d — re-emit `window-instances-changed` so the
-            // frontend catches up after the brief race between the
-            // synchronous emit at the close site and the launcher's
-            // `WindowInstanceReleased` arrival here.
-            let count = state.shadow_instance_registry.lock().len();
-            crate::events::emit_event_all_windows(
-                state,
-                "window-instances-changed",
-                &serde_json::json!(count),
-            );
+            // Phase B.5d / B.7.1 — re-emit with the resolved
+            // entries array (see WindowInstanceAssigned arm above
+            // for rationale).
+            emit_window_instances_changed_with_entries(state);
         }
         _ => {}
     }
+}
+
+/// Phase B.7.1 — emit `window-instances-changed` with a resolved
+/// `entries` array so the frontend can update its atoms directly,
+/// bypassing both the `list_window_instances` RPC round-trip and
+/// the historical retry-on-stale polling in `app-init.ts`.
+///
+/// Called from the launcher-driven re-emit sites (post-shadow
+/// update) where the `shadow_instance_registry` and
+/// `shadow_backend_window_ids` projections are guaranteed to
+/// reflect the launcher's view. Pool windows and `browser-pane-*`
+/// labels are filtered out here so the payload matches the
+/// `list_window_instances` shape the frontend already understands.
+///
+/// Sync emit sites (window.rs / drag.rs / window_pool.rs / client.rs)
+/// continue to ship count-only payloads in this PR — they fire
+/// before host state has settled and don't have access to the
+/// launcher's resolved view. B.7.2 retires them in favor of the
+/// launcher-driven path.
+fn emit_window_instances_changed_with_entries(state: &std::sync::Arc<crate::state::AppState>) {
+    let labels: Vec<String> = {
+        let pool_labels = state.unpromoted_pool_labels.lock();
+        let registry = state.shadow_instance_registry.lock();
+        registry
+            .keys()
+            .filter(|l| !pool_labels.contains(*l) && !l.starts_with("browser-pane-"))
+            .cloned()
+            .collect()
+    };
+    let entries: Vec<serde_json::Value> = labels
+        .iter()
+        .map(|l| {
+            serde_json::json!({
+                "label": l,
+                "windowId": state.backend_window_id(l),
+            })
+        })
+        .collect();
+    let count = entries.len();
+    crate::events::emit_event_all_windows(
+        state,
+        "window-instances-changed",
+        &serde_json::json!({
+            "count": count,
+            "entries": entries,
+        }),
+    );
 }
 
 /// Phase B.4 — sync API: report a window open to the launcher's

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.475"
+version = "0.33.476"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.475"
+version = "0.33.476"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.475"
+version = "0.33.476"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -1,6 +1,6 @@
-# Phase B roadmap (canonical, post-#594)
+# Phase B roadmap (canonical, post-#595)
 
-**Status:** Active reference. Updated 2026-04-28 after PR #594 (B.5 finish — scaffolding-role audit) merged. B.5 is complete; B.6 (single-instance mutex) is in flight.
+**Status:** Active reference. Updated 2026-04-28 after PR #595 (B.6 — single-instance mutex) merged. B.5 + B.6 complete; B.7 (frontend cutover) is next.
 **Author:** AgentA.
 **Read first if resuming Phase B work**, then `b5-migration-architecture-2026-04-28.md` and `multi-reducer-proposal-2026-04-28.md`.
 
@@ -35,8 +35,10 @@ Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
               Phase F with explicit scaffolding comments in code.
                         │
                         ▼
-              ◄── HERE. B.6 in flight: single-instance mutex.
-              B.6  ──  per-data-dir mutex single-instance (named pipe already covers it)
+              ✓ B.6 — per-data-dir mutex single-instance (#595)
+                        │
+                        ▼
+              ◄── HERE. B.7 next: frontend cutover.
               B.7  ──  frontend cutover (delete polling)
               B.8  ──  Phase B exit (delete obsolete defensive code,
                        add property tests, --diag tool, CI smoke)
@@ -67,9 +69,10 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 
 - Scaffolding-role comments added to `state.browsers`, `window_pool`, `unpromoted_pool_labels`, and `compute_and_report_host_counts` so future agents see why these fields don't follow the standard ratchet and where they head in Phase F.
 
-### B.6 — single-instance mutex (in flight)
+### B.6 — single-instance mutex (done — PR #595)
 
-- The named-pipe `first_pipe_instance(true)` already rejects a second launcher binding the same pipe. Just need to surface a clear error when launch fails ("AgentMux is already running, PID N") and delete any old port-file probe.
+- Launcher synchronously binds `first_pipe_instance(true)` BEFORE spawning srv/host; on `ERROR_ACCESS_DENIED` shows a Win32 MessageBox ("AgentMux is already running for this data directory…") and exits 2.
+- Legacy `<data-dir>/ipc-port` probe + write removed from the host (gap #8 stale-state defect retired).
 
 ### B.7 — frontend cutover (2-3 PRs)
 
@@ -109,6 +112,7 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 | `browsers` + pool maps deferred to Phase F | 2026-04-28 | FFI handles + sync lifecycle scaffolding can't migrate via standard ratchet |
 | Multi-reducer is the long-term architecture | 2026-04-28 | Cleaner than "scaffolding outside the model"; deferred to Phase E + F to validate the pattern incrementally |
 | `docs/retro/*.md` files are local-only | 2026-04-28 | No review churn; future agents read them via `MEMORY.md` pointer |
+| Single-instance lives in launcher pipe bind, not host port-file | B.6 (#595) | Pipe handle is OS-owned → no stale-state path; ERROR_ACCESS_DENIED is the canonical second-instance signal; user-facing MessageBox replaces silent exit |
 
 ## How to update this doc
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -81,38 +81,32 @@ async function initInstanceTracking(): Promise<void> {
     const isInstanceLabel = (l: string): boolean =>
         l === "main" || /^window-/.test(l);
 
-    // Phase B.7.1 — `window-instances-changed` payloads from the
-    // launcher-driven re-emit (`launcher_ipc.rs::apply_event_to_shadow`)
-    // now carry a resolved `{ count, entries: [{label, windowId}] }`
-    // shape. The frontend uses those directly — no `list_window_instances`
-    // RPC, no retry-on-stale polling. The polling existed solely
-    // because the synchronous emit at the mutation site fired before
-    // state.browsers had settled; the launcher-driven re-emit fires
-    // AFTER shadow projections + state.browsers are both populated.
+    // Phase B.7.1 — two payload shapes coexist during the cutover:
     //
-    // Sync emits (window.rs / drag.rs / etc.) still ship count-only
-    // payloads. For those we keep the legacy refresh-via-RPC path
-    // as a fallback so the InstancePanel doesn't go stale during
-    // `task dev` (no launcher in the loop) or before the launcher
-    // event round-trip lands. B.7.2 will retire the sync emits.
-    const refreshLabelsViaRpc = async (): Promise<void> => {
-        try {
-            let entries: Array<{ label: string; windowId: string | null }>;
-            try {
-                const all = await getApi().listWindowInstances();
-                entries = Array.isArray(all) ? all : [];
-            } catch {
-                const all = await getApi().listWindows();
-                entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
-            }
-            applyEntries(entries);
-        } catch {
-            setOpenWindowLabelsAtom([]);
-            setOpenWindowEntriesAtom([]);
-        }
-    };
+    //   1. Launcher-driven re-emit (`launcher_ipc.rs::apply_event_to_shadow`)
+    //      ships `{ count, entries: [{label, windowId}] }`. The
+    //      shadows + state.browsers are both populated by the time
+    //      this fires, so a single application is authoritative —
+    //      no RPC, no polling. This is the path B.7 is migrating
+    //      everything to.
+    //
+    //   2. Sync emits at the mutation sites (window.rs / drag.rs /
+    //      window_pool.rs / client.rs) still ship count-only
+    //      payloads. They fire BEFORE state.browsers settles, so a
+    //      single RPC read would see stale data. This is also the
+    //      sole path during `task dev` (no launcher in the loop),
+    //      so we can't retire it yet — keep the historic 6×50ms
+    //      retry-on-stale polling here. (codex PR #569 P2 +
+    //      reagent #596 P1.) B.7.2 retires the sync emits.
+    //
+    // The retry compares `entries-key` (label@windowId, joined) to
+    // detect a real change, including the `null → real` windowId
+    // transition that fires after the frontend's
+    // `register_backend_window` round-trip. Up to 6×50ms ≈ 300ms
+    // covers the empirical CEF on_after_created delay with margin.
+    let lastEntriesKey = "";
 
-    const applyEntries = (entries: Array<{ label: string; windowId: string | null }>): void => {
+    const applyEntries = (entries: Array<{ label: string; windowId: string | null }>): string => {
         const filtered = entries.filter((e) => isInstanceLabel(e.label));
         // Stable ordering: "main" pinned first, others alphabetical
         // by label. Without this, panel rows can shuffle between
@@ -127,6 +121,37 @@ async function initInstanceTracking(): Promise<void> {
         });
         setOpenWindowLabelsAtom(filtered.map((e) => e.label));
         setOpenWindowEntriesAtom(filtered);
+        return filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
+    };
+
+    const refreshLabelsViaRpc = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
+        try {
+            let entries: Array<{ label: string; windowId: string | null }>;
+            try {
+                const all = await getApi().listWindowInstances();
+                entries = Array.isArray(all) ? all : [];
+            } catch {
+                const all = await getApi().listWindows();
+                entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
+            }
+            const filtered = entries.filter((e) => isInstanceLabel(e.label));
+            filtered.sort((a, b) => {
+                if (a.label === "main") return -1;
+                if (b.label === "main") return 1;
+                return a.label.localeCompare(b.label);
+            });
+            const key = filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
+            if (waitForChange && key === lastEntriesKey && retriesLeft > 0) {
+                setTimeout(() => refreshLabelsViaRpc(true, retriesLeft - 1), 50);
+                return;
+            }
+            lastEntriesKey = key;
+            setOpenWindowLabelsAtom(filtered.map((e) => e.label));
+            setOpenWindowEntriesAtom(filtered);
+        } catch {
+            setOpenWindowLabelsAtom([]);
+            setOpenWindowEntriesAtom([]);
+        }
     };
 
     try {
@@ -140,21 +165,16 @@ async function initInstanceTracking(): Promise<void> {
 
         await getApi().listen("window-instances-changed", (event: any) => {
             const payload = event?.payload ?? event;
-            // Two payload shapes coexist during the B.7 cutover:
-            //   - Sync emits: `count` (number).
-            //   - Launcher-driven re-emit: `{ count, entries }`.
-            // Prefer the structured payload when available; otherwise
-            // fall back to the RPC refresh path.
             if (payload && typeof payload === "object" && Array.isArray(payload.entries)) {
                 if (typeof payload.count === "number") {
                     setWindowCountAtom(payload.count);
                 }
-                applyEntries(payload.entries);
+                lastEntriesKey = applyEntries(payload.entries);
                 return;
             }
             const count = typeof payload === "number" ? payload : 0;
             setWindowCountAtom(count);
-            refreshLabelsViaRpc();
+            refreshLabelsViaRpc(true);
         });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -81,28 +81,22 @@ async function initInstanceTracking(): Promise<void> {
     const isInstanceLabel = (l: string): boolean =>
         l === "main" || /^window-/.test(l);
 
-    // The host emits `window-instances-changed` *before* the new browser
-    // is registered in state.browsers (the emit fires from window.rs:514
-    // while registration happens later via on_after_created in client.rs).
-    // The previous fix compared count against the event payload, but the
-    // event count comes from window_instance_registry (different data
-    // structure than state.browsers) so a count match is not reliable.
-    // Robust fix: poll until the listWindowInstances() result actually
-    // CHANGES from the previously-seen set. The change key includes
-    // windowId so a `null → real` transition (when registerBackendWindow
-    // arrives later) also unblocks the wait, otherwise a freshly-opened
-    // window would appear with windowId=null and never get re-fetched
-    // until another open/close event happens — leaving the InstancePanel
-    // unable to resolve its name or rename it. (codex PR #569 P2)
-    // Up to 6×50ms (~300ms total) covers the empirical CEF
-    // on_after_created delay with margin.
-    let lastEntriesKey = "";
-    const refreshLabels = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
+    // Phase B.7.1 — `window-instances-changed` payloads from the
+    // launcher-driven re-emit (`launcher_ipc.rs::apply_event_to_shadow`)
+    // now carry a resolved `{ count, entries: [{label, windowId}] }`
+    // shape. The frontend uses those directly — no `list_window_instances`
+    // RPC, no retry-on-stale polling. The polling existed solely
+    // because the synchronous emit at the mutation site fired before
+    // state.browsers had settled; the launcher-driven re-emit fires
+    // AFTER shadow projections + state.browsers are both populated.
+    //
+    // Sync emits (window.rs / drag.rs / etc.) still ship count-only
+    // payloads. For those we keep the legacy refresh-via-RPC path
+    // as a fallback so the InstancePanel doesn't go stale during
+    // `task dev` (no launcher in the loop) or before the launcher
+    // event round-trip lands. B.7.2 will retire the sync emits.
+    const refreshLabelsViaRpc = async (): Promise<void> => {
         try {
-            // listWindowInstances gives us [{label, windowId}] in one
-            // RPC; we sort/filter on label and keep windowId aligned.
-            // Falls back to listWindows if the new RPC isn't supported
-            // (older host build) so the panel still works partially.
             let entries: Array<{ label: string; windowId: string | null }>;
             try {
                 const all = await getApi().listWindowInstances();
@@ -111,51 +105,56 @@ async function initInstanceTracking(): Promise<void> {
                 const all = await getApi().listWindows();
                 entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
             }
-            const filtered = entries.filter((e) => isInstanceLabel(e.label));
-            // Stable ordering: "main" pinned first, others alphabetical
-            // by label. Without this, panel rows can shuffle between
-            // refreshes (state.browsers is a Rust HashMap with
-            // non-deterministic iteration), and two windows could both
-            // display as "Window 1" because InstancePanel uses the
-            // array index for naming and special-cases "main".
-            filtered.sort((a, b) => {
-                if (a.label === "main") return -1;
-                if (b.label === "main") return 1;
-                return a.label.localeCompare(b.label);
-            });
-            const labels = filtered.map((e) => e.label);
-            const key = filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
-            if (waitForChange && key === lastEntriesKey && retriesLeft > 0) {
-                setTimeout(() => refreshLabels(true, retriesLeft - 1), 50);
-                return;
-            }
-            lastEntriesKey = key;
-            setOpenWindowLabelsAtom(labels);
-            setOpenWindowEntriesAtom(filtered);
+            applyEntries(entries);
         } catch {
             setOpenWindowLabelsAtom([]);
             setOpenWindowEntriesAtom([]);
         }
     };
 
+    const applyEntries = (entries: Array<{ label: string; windowId: string | null }>): void => {
+        const filtered = entries.filter((e) => isInstanceLabel(e.label));
+        // Stable ordering: "main" pinned first, others alphabetical
+        // by label. Without this, panel rows can shuffle between
+        // refreshes (state.browsers is a Rust HashMap with
+        // non-deterministic iteration), and two windows could both
+        // display as "Window 1" because InstancePanel uses the
+        // array index for naming and special-cases "main".
+        filtered.sort((a, b) => {
+            if (a.label === "main") return -1;
+            if (b.label === "main") return 1;
+            return a.label.localeCompare(b.label);
+        });
+        setOpenWindowLabelsAtom(filtered.map((e) => e.label));
+        setOpenWindowEntriesAtom(filtered);
+    };
+
     try {
         const [instanceNum, windowCount] = await Promise.all([
             getApi().getInstanceNumber(),
             getApi().getWindowCount(),
-            refreshLabels(),
+            refreshLabelsViaRpc(),
         ]);
         setWindowInstanceNumAtom(instanceNum);
         setWindowCountAtom(windowCount);
 
-        // Keep count + label list in sync whenever any window opens or
-        // closes. Pass `waitForChange=true` so refreshLabels polls until
-        // listWindows() reports a different label set than last time —
-        // robust against the event-vs-registration race documented above.
         await getApi().listen("window-instances-changed", (event: any) => {
             const payload = event?.payload ?? event;
+            // Two payload shapes coexist during the B.7 cutover:
+            //   - Sync emits: `count` (number).
+            //   - Launcher-driven re-emit: `{ count, entries }`.
+            // Prefer the structured payload when available; otherwise
+            // fall back to the RPC refresh path.
+            if (payload && typeof payload === "object" && Array.isArray(payload.entries)) {
+                if (typeof payload.count === "number") {
+                    setWindowCountAtom(payload.count);
+                }
+                applyEntries(payload.entries);
+                return;
+            }
             const count = typeof payload === "number" ? payload : 0;
             setWindowCountAtom(count);
-            refreshLabels(true);
+            refreshLabelsViaRpc();
         });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.475",
+  "version": "0.33.476",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.475",
+      "version": "0.33.476",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.475",
+  "version": "0.33.476",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Smallest first slice of Phase B.7 (frontend cutover from polling to events). The launcher-driven `window-instances-changed` re-emit now ships a resolved `{ count, entries: [{label, windowId}] }` payload, letting the frontend update its atoms directly without an RPC round-trip and without the historical retry-on-stale polling.

## Why now

- **B.5 + B.6 are merged.** `state.windows` (canonical) and `shadow_instance_registry` / `shadow_window_meta` / `shadow_backend_window_ids` (host projections) are populated before the launcher-driven re-emit fires — so a single read at that moment is authoritative.
- The historic 6×50ms polling in `refreshLabels` was a workaround for the race between the **synchronous** `window-instances-changed` emit (firing before `state.browsers` had settled) and the actual registration. The launcher-driven re-emit fires post-settlement, so for that path the polling is pure latency.

## Scope

**Host (`agentmux-cef/src/launcher_ipc.rs`):**
- New private helper `emit_window_instances_changed_with_entries(state)`. Builds entries from `shadow_instance_registry` keys (filtering pool + `browser-pane-*` labels), joins with `shadow_backend_window_ids` per label, emits `{ count, entries }`.
- Replaced the count-only emit in two arms of `apply_event_to_shadow` (`WindowInstanceAssigned`, `WindowInstanceReleased`).
- **Out of scope (B.7.2):** the synchronous count-only emits in `window.rs` / `drag.rs` / `window_pool.rs` / `client.rs`. Those still fire; the frontend keeps the legacy fallback for them.

**Frontend (`frontend/app-init.ts`):**
- Split `refreshLabels` into a stateless `applyEntries(entries)` (atoms-only) and `refreshLabelsViaRpc()` (legacy fallback).
- The `window-instances-changed` listener now branches on payload shape: structured `{ count, entries }` → `applyEntries(payload.entries)` directly; legacy number → `refreshLabelsViaRpc()`. The retry / `lastEntriesKey` polling state is gone for the structured path.

## Why two paths

Sync emits (window.rs:655, drag.rs:385, etc.) still ship count-only. Dev mode without launcher relies on those exclusively (no launcher events → no re-emit). The legacy fallback keeps the panel reactive in both cases until B.7.2 retires the sync emits.

## Test plan

- [ ] `task package` builds clean (cef-dll-sys cleared the local Defender race after retry).
- [ ] Launch portable, open a second window — InstancePanel updates within one event tick (no listWindowInstances RPC visible in host log).
- [ ] Close the second window — InstancePanel updates symmetrically.
- [ ] Tear-off → InstancePanel reflects the new window.
- [ ] `task dev` (no launcher in the loop) still updates the InstancePanel via the count-only sync-emit fallback.

## Local cargo check

`agentmux-launcher` checked clean. `agentmux-cef` cargo-check hit the Defender / cef-dll-sys download race three times locally (`os error 5` during fs::rename — see `project_cef_build_race.md`). The diff adds a private helper + two call-site swaps in an already-imported module; type-trivial. CI / portable build will confirm.

## Follow-up

- **B.7.2** — retire the synchronous count-only emits, simplify the frontend listener to only the structured path.
- **B.7.3** — consider direct launcher-event subscription via the CEF JS bridge (per the original B.7 design) so the host's bespoke `window-instances-changed` event can be retired in favor of typed launcher events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)