### PR TITLE
B.7.2: re-emit window-instances-changed on BackendWindowId events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.476"
+version = "0.33.477"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.476"
+version = "0.33.477"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.476"
+version = "0.33.477"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.476"
+version = "0.33.477"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.476"
+version = "0.33.477"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -325,10 +325,25 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 .shadow_backend_window_ids
                 .lock()
                 .insert(label.clone(), window_id.clone());
+            // Phase B.7.2 — windowId becoming available is the
+            // second half of an open: the entries array's windowId
+            // for `label` transitions from `null` to a real GUID
+            // here. Re-emit so the InstancePanel can resolve the
+            // backend Window record (display name, workspace) for
+            // a freshly-opened window without waiting for another
+            // unrelated event to fire. This was the codex PR #569
+            // P2 race that the now-removed `lastEntriesKey`
+            // polling existed to paper over.
+            emit_window_instances_changed_with_entries(state);
         }
         Event::BackendWindowIdUnregistered { label, .. } => {
             // Phase B.5 (window_id_map step e) — drift compare gone.
             state.shadow_backend_window_ids.lock().remove(label);
+            // Phase B.7.2 — symmetric re-emit so `windowId`
+            // becoming `null` (e.g. backend window record removed
+            // before the launcher's WindowClosed event arrives)
+            // surfaces in the InstancePanel immediately.
+            emit_window_instances_changed_with_entries(state);
         }
         Event::WindowInstanceReleased { label, .. } => {
             // Phase B.5e — host's `WindowInstanceRegistry` was

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.476"
+version = "0.33.477"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.476"
+version = "0.33.477"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.476"
+version = "0.33.477"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -38,7 +38,10 @@ Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
               ✓ B.6 — per-data-dir mutex single-instance (#595)
                         │
                         ▼
-              ◄── HERE. B.7 next: frontend cutover.
+              ✓ B.7.1 — entries-bearing window-instances-changed (#596)
+                        │
+                        ▼
+              ◄── HERE. B.7.2 in flight: windowId-reemit.
               B.7  ──  frontend cutover (delete polling)
               B.8  ──  Phase B exit (delete obsolete defensive code,
                        add property tests, --diag tool, CI smoke)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.476",
+  "version": "0.33.477",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.476",
+      "version": "0.33.477",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.476",
+  "version": "0.33.477",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #596 (B.7.1). Adds the entries-bearing `window-instances-changed` re-emit to two more arms of `apply_event_to_shadow` so the windowId-resolution race no longer falls through to the legacy RPC retry path.

## Background

A freshly-opened window arrives in entries with `windowId=null` because the launcher's `WindowInstanceAssigned` fires before the frontend's `register_backend_window` round-trip completes. Pre-B.7.1, the `lastEntriesKey` retry polled until the `null → real` transition was observed. B.7.1 retired the polling for the structured-payload path — but only the `WindowInstanceAssigned` and `WindowInstanceReleased` arms re-emitted with entries. The `null → real` transition (which fires on the launcher's `BackendWindowIdRegistered` event, originating from `report_backend_window_id_registered` after the frontend round-trip) was still served by the host's count-only sync emit at `window.rs:511`, falling through to `refreshLabelsViaRpc(true)` + retry.

## Change

- `agentmux-cef/src/launcher_ipc.rs::apply_event_to_shadow`:
  - `BackendWindowIdRegistered` arm: after updating `shadow_backend_window_ids`, call `emit_window_instances_changed_with_entries(state)`.
  - `BackendWindowIdUnregistered` arm: same, symmetric for the reverse direction.
- Roadmap: tick B.7.1 (#596), mark B.7.2 in flight.

No frontend changes. No protocol changes. Net ~+25 LoC.

## Effect

After this lands, the launcher-driven path is the sole source of truth for InstancePanel updates (open / close / windowId-resolved / windowId-nulled). The frontend's RPC + retry fallback only fires for sync emits — primarily `task dev` mode (no launcher).

## Test plan

- [ ] `task package` builds clean.
- [ ] Launch portable, open a second window — InstancePanel resolves the windowId without visible delay (no \"Window 1\" placeholder period before the real name).
- [ ] `task dev` (no launcher) — the legacy fallback path still updates the panel via RPC retry.

## Local cargo check

agentmux-cef cargo check hit the documented Defender / cef-dll-sys download race locally (`project_cef_build_race.md`). The diff is two small additions in an already-imported function; type-trivial.

## Follow-up

- **B.7.3** — wire the host's CEF JS bridge to forward typed launcher events directly to the renderer (the original B.7 design). Once that lands, the bespoke `window-instances-changed` event can be retired in favor of typed launcher events, and the count-only sync emits can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)