### PR TITLE
B.6.1 fix: forward open_new_window on second launch (don't MessageBox)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.478"
+version = "0.33.479"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.478"
+version = "0.33.479"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.478"
+version = "0.33.479"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.478"
+version = "0.33.479"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.477"
+version = "0.33.478"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.477"
+version = "0.33.478"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.477"
+version = "0.33.478"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.477"
+version = "0.33.478"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.477"
+version = "0.33.478"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.478"
+version = "0.33.479"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -182,19 +182,20 @@ fn main() {
         "Initializing CEF browser process"
     );
 
-    // Phase B.6: legacy `<data-dir>/ipc-port` probe removed. Single-
-    // instance enforcement now lives in the launcher's named-pipe
-    // bind (`first_pipe_instance(true)`) which rejects a second
-    // launcher BEFORE the host is even spawned. The old probe had a
-    // known stale-state defect (gap #8 in
-    // specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md):
-    // a hard crash left the file behind and the next launch
-    // connected to a dead IPC server, sent open_new_window, and
-    // exited 0 with no window opened. The launcher's pipe handle is
-    // owned by the OS; on launcher death the pipe is reaped, so
-    // there is no stale-state path. Best-effort cleanup of any
-    // leftover file from a pre-B.6 install.
-    let _ = std::fs::remove_file(data_dir.join("ipc-port"));
+    // Phase B.6 (post-fix): the named-pipe bind in the launcher is
+    // the AUTHORITATIVE single-instance lock — a second launcher
+    // hits ERROR_ACCESS_DENIED and never reaches the host. We still
+    // publish `<data-dir>/ipc-port` (port:token) so the second
+    // launcher can FORWARD an `open_new_window` request to the
+    // existing instance over HTTP and exit silently — the legacy
+    // forwarding UX users expect when double-clicking the exe twice.
+    // The pipe-bind-first ordering closes the stale-state defect
+    // (gap #8 in specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md):
+    // a stale ipc-port file from a hard crash is irrelevant on the
+    // FIRST-instance path because pipe-bind succeeds and the file is
+    // overwritten; on the SECOND-instance path the live first
+    // instance wrote a fresh port:token, so forwarding lands.
+    let port_file = data_dir.join("ipc-port");
 
     // Create shared application state.
     let app_state = Arc::new(state::AppState::default());
@@ -374,11 +375,15 @@ fn main() {
     // Provides forensic data if the process later crashes from OOM / VA exhaustion.
     memory_heartbeat::start();
 
-    // Phase B.6: no `ipc-port` file write — the launcher's named pipe
-    // is the single-instance signal (see comment at the probe-removal
-    // site above). The IPC HTTP server still runs locally for the
-    // host's own command surface; it just no longer publishes its
-    // port for cross-process discovery.
+    // Phase B.6 (post-fix): publish port:token AFTER CEF init so a
+    // second launcher only forwards `open_new_window` when we're
+    // actually ready to handle it. Single-instance enforcement is
+    // the launcher's named-pipe bind — this file is purely a
+    // forwarding hint.
+    let _ = std::fs::write(
+        &port_file,
+        format!("{}:{}", ipc_port, app_state.ipc_token),
+    );
 
     // Run the CEF message loop. This blocks until quit_message_loop() is called
     // (triggered when all browser windows are closed in client.rs).
@@ -400,6 +405,12 @@ fn main() {
 
     // Drop the tokio runtime after CEF shutdown.
     drop(runtime);
+
+    // Phase B.6 (post-fix): clean up the forwarding hint so a stale
+    // file doesn't survive a graceful exit. (Hard crashes will leave
+    // it behind; harmless because pipe-bind on next launch is
+    // authoritative — see comment at the port_file declaration.)
+    let _ = std::fs::remove_file(&port_file);
 
     tracing::info!("AgentMux host shutdown complete");
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.477"
+version = "0.33.478"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.478"
+version = "0.33.479"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.478"
+version = "0.33.479"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.477"
+version = "0.33.478"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -197,18 +197,38 @@ async fn run_windows(
                         log("forwarded open_new_window to existing instance — exiting 0");
                         std::process::exit(0);
                     }
-                    Err(reason) => {
-                        log(&format!(
-                            "forward failed: {} — exiting silently to avoid surprise dialog",
-                            reason
-                        ));
-                        // Silent exit: the existing instance is alive
-                        // (pipe is held), but its forwarding hint is
-                        // unreadable / the HTTP server isn't ready
-                        // yet. A modal would be more annoying than
-                        // helpful for a transient race; the user can
-                        // double-click again.
+                    Err(ForwardError::Transient(reason)) => {
+                        // Transient race: the host is alive (pipe is
+                        // held by the first launcher) but its
+                        // forwarding hint isn't readable yet —
+                        // typically because the host is mid-CEF-init
+                        // and hasn't written `<data-dir>/ipc-port`
+                        // yet. Silent exit so the user isn't punished
+                        // for double-clicking quickly.
+                        log(&format!("forward transient: {} — exiting 0 silently", reason));
                         std::process::exit(0);
+                    }
+                    Err(ForwardError::Fatal(reason)) => {
+                        // Fatal forward failure: the port file IS
+                        // readable, so the host got far enough to
+                        // publish it, but the HTTP path is dead
+                        // (connect refused, write failed). Could be
+                        // a hung host, a port collision, or
+                        // ERROR_ACCESS_DENIED that wasn't really
+                        // "another instance" (namespace conflict).
+                        // Surface the dialog so the user sees that
+                        // something is genuinely broken rather than
+                        // a silent no-op. (codex P2 PR #598.)
+                        log(&format!("forward fatal: {} — surfacing dialog", reason));
+                        show_fatal_dialog(
+                            "AgentMux",
+                            &format!(
+                                "AgentMux appears to already be running but isn't responding.\n\nData dir: {}\nReason: {}\n\nClose any leftover AgentMux processes and try again. If the problem persists, check the launcher log.",
+                                paths.data_dir.display(),
+                                reason
+                            ),
+                        );
+                        std::process::exit(2);
                     }
                 }
             }
@@ -570,27 +590,44 @@ pub(crate) fn resume_main_thread(pid: u32) -> Result<(), String> {
 /// launcher binary should stay tiny (~325 KB) and the protocol is
 /// fixed, so a hand-rolled request is the right tool.
 ///
-/// Returns `Ok(())` only when the bytes were written to the socket.
-/// We don't parse the response — `open_new_window` is fire-and-
-/// forget and the host writes no useful body. Any failure (file
-/// missing, parse error, connect refused) returns `Err(reason)`;
-/// the caller exits 0 silently to avoid spamming a dialog on
-/// transient races (host mid-startup, etc.).
-fn forward_open_new_window(data_dir: &std::path::Path) -> Result<(), String> {
+/// Failure classification (codex P2 PR #598):
+/// - `Transient` — port file missing / unreadable / malformed.
+///   The host is alive (pipe held) but mid-startup; caller exits
+///   0 silently so the user isn't punished for double-clicking
+///   quickly.
+/// - `Fatal` — port file is readable, but the HTTP path failed
+///   (connect refused, write failed, timeout). Either a hung
+///   host or a non-running-instance source of
+///   `ERROR_ACCESS_DENIED` (namespace conflict, security
+///   descriptor failure). Caller surfaces the dialog so the user
+///   sees a real problem rather than a silent no-op.
+enum ForwardError {
+    Transient(String),
+    Fatal(String),
+}
+
+fn forward_open_new_window(data_dir: &std::path::Path) -> Result<(), ForwardError> {
     let port_file = data_dir.join("ipc-port");
-    let contents = std::fs::read_to_string(&port_file)
-        .map_err(|e| format!("read {}: {}", port_file.display(), e))?;
+    let contents = std::fs::read_to_string(&port_file).map_err(|e| {
+        ForwardError::Transient(format!("read {}: {}", port_file.display(), e))
+    })?;
     let trimmed = contents.trim();
-    let (port_str, token) = trimmed
-        .split_once(':')
-        .ok_or_else(|| format!("malformed port file (expected port:token): {}", trimmed))?;
+    let (port_str, token) = trimmed.split_once(':').ok_or_else(|| {
+        ForwardError::Transient(format!(
+            "malformed port file (expected port:token): {}",
+            trimmed
+        ))
+    })?;
     let port: u16 = port_str
         .parse()
-        .map_err(|e| format!("invalid port {:?}: {}", port_str, e))?;
+        .map_err(|e| ForwardError::Transient(format!("invalid port {:?}: {}", port_str, e)))?;
 
+    // From here on the file was readable: any failure is a fatal
+    // forward (the host got far enough to publish but isn't
+    // serving the IPC port).
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
     let mut stream = std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(2))
-        .map_err(|e| format!("connect 127.0.0.1:{}: {}", port, e))?;
+        .map_err(|e| ForwardError::Fatal(format!("connect 127.0.0.1:{}: {}", port, e)))?;
     stream
         .set_write_timeout(Some(std::time::Duration::from_secs(2)))
         .ok();
@@ -605,7 +642,7 @@ fn forward_open_new_window(data_dir: &std::path::Path) -> Result<(), String> {
     use std::io::Write;
     stream
         .write_all(req.as_bytes())
-        .map_err(|e| format!("write request: {}", e))?;
+        .map_err(|e| ForwardError::Fatal(format!("write request: {}", e)))?;
     Ok(())
 }
 

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -177,31 +177,50 @@ async fn run_windows(
         Err(e) => {
             // ERROR_ACCESS_DENIED (5) means another launcher already
             // owns this pipe — i.e., another AgentMux is running for
-            // this data dir. Anything else is unexpected (namespace
-            // misconfig, security descriptor failure) and we still
-            // refuse to start, but with a different message so support
-            // can tell them apart from a log line.
+            // this data dir. The user-facing behavior matches the
+            // status-bar version popup's "new window": forward an
+            // `open_new_window` IPC POST to the existing host and
+            // exit 0. The named-pipe bind is the AUTHORITATIVE
+            // single-instance signal; this HTTP call is just the
+            // forwarding hint. Other errors (namespace misconfig,
+            // security descriptor failure) genuinely fail — show
+            // the dialog and exit 2.
             const ERROR_ACCESS_DENIED: i32 = 5;
             let already_running = e.raw_os_error() == Some(ERROR_ACCESS_DENIED);
-            let title = "AgentMux";
-            let body = if already_running {
-                format!(
-                    "AgentMux is already running for this data directory.\n\nData dir: {}\n\nFocus the existing window, or close it before launching again.",
-                    paths.data_dir.display()
-                )
-            } else {
-                format!(
-                    "AgentMux failed to start: could not bind IPC pipe.\n\nPipe: {}\nError: {}\n\nIf the problem persists, check the launcher log.",
-                    pipe_path, e
-                )
-            };
             log(&format!(
-                "FATAL: pipe bind failed (already_running={}): {} pipe={}",
+                "pipe bind failed (already_running={}): {} pipe={}",
                 already_running, e, pipe_path
             ));
-            show_fatal_dialog(title, &body);
-            // Exit code 2 distinguishes the single-instance refusal from
-            // generic launch failures (code 1).
+            if already_running {
+                match forward_open_new_window(&paths.data_dir) {
+                    Ok(()) => {
+                        log("forwarded open_new_window to existing instance — exiting 0");
+                        std::process::exit(0);
+                    }
+                    Err(reason) => {
+                        log(&format!(
+                            "forward failed: {} — exiting silently to avoid surprise dialog",
+                            reason
+                        ));
+                        // Silent exit: the existing instance is alive
+                        // (pipe is held), but its forwarding hint is
+                        // unreadable / the HTTP server isn't ready
+                        // yet. A modal would be more annoying than
+                        // helpful for a transient race; the user can
+                        // double-click again.
+                        std::process::exit(0);
+                    }
+                }
+            }
+            // Genuine bind failure (not "already running"). Surface
+            // it loudly because it indicates a system-level problem.
+            show_fatal_dialog(
+                "AgentMux",
+                &format!(
+                    "AgentMux failed to start: could not bind IPC pipe.\n\nPipe: {}\nError: {}\n\nIf the problem persists, check the launcher log.",
+                    pipe_path, e
+                ),
+            );
             std::process::exit(2);
         }
     };
@@ -541,9 +560,58 @@ pub(crate) fn resume_main_thread(pid: u32) -> Result<(), String> {
     }
 }
 
-/// Show a modal error dialog before the launcher exits. Used by the
-/// Phase B.6 single-instance check so a user double-clicking the app
-/// while it is already running sees a clear message — without this,
+/// Phase B.6 (post-fix) — forward an `open_new_window` request to
+/// the already-running host and let this launcher exit 0.
+///
+/// The host writes `<data-dir>/ipc-port` after CEF init as
+/// `port:token`. We open a TCP connection to 127.0.0.1:port, send a
+/// minimal HTTP/1.1 POST to /ipc with the bearer token and a JSON
+/// body, and bail. We deliberately do NOT pull in reqwest: the
+/// launcher binary should stay tiny (~325 KB) and the protocol is
+/// fixed, so a hand-rolled request is the right tool.
+///
+/// Returns `Ok(())` only when the bytes were written to the socket.
+/// We don't parse the response — `open_new_window` is fire-and-
+/// forget and the host writes no useful body. Any failure (file
+/// missing, parse error, connect refused) returns `Err(reason)`;
+/// the caller exits 0 silently to avoid spamming a dialog on
+/// transient races (host mid-startup, etc.).
+fn forward_open_new_window(data_dir: &std::path::Path) -> Result<(), String> {
+    let port_file = data_dir.join("ipc-port");
+    let contents = std::fs::read_to_string(&port_file)
+        .map_err(|e| format!("read {}: {}", port_file.display(), e))?;
+    let trimmed = contents.trim();
+    let (port_str, token) = trimmed
+        .split_once(':')
+        .ok_or_else(|| format!("malformed port file (expected port:token): {}", trimmed))?;
+    let port: u16 = port_str
+        .parse()
+        .map_err(|e| format!("invalid port {:?}: {}", port_str, e))?;
+
+    let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
+    let mut stream = std::net::TcpStream::connect_timeout(&addr, std::time::Duration::from_secs(2))
+        .map_err(|e| format!("connect 127.0.0.1:{}: {}", port, e))?;
+    stream
+        .set_write_timeout(Some(std::time::Duration::from_secs(2)))
+        .ok();
+
+    let body = r#"{"cmd":"open_new_window"}"#;
+    let req = format!(
+        "POST /ipc HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nAuthorization: Bearer {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        token,
+        body.len(),
+        body
+    );
+    use std::io::Write;
+    stream
+        .write_all(req.as_bytes())
+        .map_err(|e| format!("write request: {}", e))?;
+    Ok(())
+}
+
+/// Show a modal error dialog before the launcher exits. Used for
+/// genuine bind failures (NOT the "already running" path — that
+/// silently forwards via `forward_open_new_window`). Without this,
 /// the launcher exit is silent (it has the `windows` subsystem in
 /// release, so eprintln! goes nowhere).
 #[cfg(target_os = "windows")]

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.477"
+version = "0.33.478"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.478"
+version = "0.33.479"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -72,10 +72,10 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 
 - Scaffolding-role comments added to `state.browsers`, `window_pool`, `unpromoted_pool_labels`, and `compute_and_report_host_counts` so future agents see why these fields don't follow the standard ratchet and where they head in Phase F.
 
-### B.6 — single-instance mutex (done — PR #595)
+### B.6 — single-instance mutex (done — PR #595, fix in B.6.1)
 
-- Launcher synchronously binds `first_pipe_instance(true)` BEFORE spawning srv/host; on `ERROR_ACCESS_DENIED` shows a Win32 MessageBox ("AgentMux is already running for this data directory…") and exits 2.
-- Legacy `<data-dir>/ipc-port` probe + write removed from the host (gap #8 stale-state defect retired).
+- Launcher synchronously binds `first_pipe_instance(true)` BEFORE spawning srv/host. The pipe bind is the AUTHORITATIVE single-instance signal.
+- **B.6.1 fix**: on `ERROR_ACCESS_DENIED`, the second launcher reads `<data-dir>/ipc-port` (still written by the host post-CEF-init) and forwards an `open_new_window` HTTP POST to the existing instance, then exits 0. Mirrors the status-bar version popup's "new window" UX. The MessageBox path is reserved for genuine bind failures (namespace misconfig). Stale-state defect (gap #8) is bounded because pipe-bind happens first: a stale port file is irrelevant on the first-instance path (overwritten); on the second-instance path the live first instance wrote a fresh port:token, so forwarding lands.
 
 ### B.7 — frontend cutover (2-3 PRs)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.478",
+  "version": "0.33.479",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.478",
+      "version": "0.33.479",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.477",
+  "version": "0.33.478",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.477",
+      "version": "0.33.478",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.478",
+  "version": "0.33.479",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.477",
+  "version": "0.33.478",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Fix the user-facing regression #595 introduced. Double-clicking \`agentmux.exe\` while an instance is already running should open another window in the existing instance (matching the status-bar version popup's "new window" UX), not pop a Win32 dialog.

## Root cause

#595 retired the legacy \`<data-dir>/ipc-port\` probe + write entirely. The probe was the WHOLE forwarding mechanism, not just a stale-state defect. Without it, the launcher's named-pipe rejection had nowhere to forward to and could only show "already running" or exit silently.

## Fix

The named-pipe bind in the launcher REMAINS the authoritative single-instance lock — that part of B.6 was right. The fix narrows the change to forwarding only:

- **agentmux-cef/src/main.rs**: re-publish \`<data-dir>/ipc-port\` (port:token) AFTER CEF init; remove on graceful exit. **The probe sites are NOT restored** — only the publishing side. Reading the port + forwarding moves to the launcher.
- **agentmux-launcher/src/main.rs**: on \`ERROR_ACCESS_DENIED\` from \`bind_first_pipe_instance\`, read \`<data-dir>/ipc-port\`, send a raw HTTP/1.1 POST to \`http://127.0.0.1:<port>/ipc\` with body \`{"cmd":"open_new_window"}\` and bearer auth, exit 0. No reqwest dep — \`std::net::TcpStream\` keeps the launcher binary small (~325 KB). Forwarding failures exit 0 silently to avoid surprise dialogs on transient startup races.
- **Genuine bind failures** (not "already running") still surface the MessageBox + exit 2 path. That's the only place the dialog fires now.

## Stale-state defect bounding

The gap-#8 defect (port file outliving a hard crash) is now bounded by the pipe-bind ordering:

- **First instance launch**: pipe-bind succeeds → continue normal startup → port file is overwritten. Stale file irrelevant.
- **Second instance launch**: pipe-bind fails with ERROR_ACCESS_DENIED → first instance is genuinely alive (it holds the pipe handle) → it wrote a fresh port:token → forwarding lands.
- **Crashed first instance, no live instance**: OS reaps the pipe handle → next launch's pipe-bind succeeds → first-instance path → port file overwritten.

The only failure mode is a *forwarding-time* race (HTTP server mid-startup). The silent \`exit 0\` covers that — user can double-click again.

## Test plan

- [ ] \`task package\` builds clean.
- [ ] Launch portable, double-click again → second window opens in the existing instance, no dialog. Verify with \`tasklist | grep agentmux\` that only one launcher / host pair runs.
- [ ] \`taskkill /F\` the launcher, then re-launch → starts fresh (pipe was reaped).
- [ ] Different version portable side-by-side → both run independently (different data dirs, different pipes).
- [ ] Genuine bind error path (manual: simulate by holding a pipe handle elsewhere) → MessageBox surfaces.

## Roadmap

\`docs/retro/phase-b-roadmap.md\` updated with B.6.1 entry under the B.6 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)