### PR TITLE
fix(B.6.1): read response after forward POST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.480"
+version = "0.33.481"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.480"
+version = "0.33.481"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.480"
+version = "0.33.481"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.480"
+version = "0.33.481"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.481"
+version = "0.33.482"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.481"
+version = "0.33.482"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.481"
+version = "0.33.482"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.481"
+version = "0.33.482"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.480"
+version = "0.33.481"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.481"
+version = "0.33.482"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.480"
+version = "0.33.481"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.481"
+version = "0.33.482"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.481"
+version = "0.33.482"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.480"
+version = "0.33.481"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -639,10 +639,25 @@ fn forward_open_new_window(data_dir: &std::path::Path) -> Result<(), ForwardErro
         body.len(),
         body
     );
-    use std::io::Write;
+    use std::io::{Read, Write};
     stream
         .write_all(req.as_bytes())
         .map_err(|e| ForwardError::Fatal(format!("write request: {}", e)))?;
+    // CRITICAL: read at least the status line. The host's axum
+    // handler is async — if the launcher closes the TCP socket
+    // before axum has finished parsing + dispatching to
+    // `open_new_window`, the request can be dropped (smoke caught
+    // exactly this on v0.33.481: the launcher logged "forwarded"
+    // but no second window appeared because the process exited
+    // before axum ran the handler). We don't care about the body
+    // — `Connection: close` lets the server drop the socket once
+    // the response is written, so a single short read is enough
+    // to keep the connection alive past handler dispatch.
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+        .ok();
+    let mut sink = [0u8; 64];
+    let _ = stream.read(&mut sink);
     Ok(())
 }
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.480"
+version = "0.33.481"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.481"
+version = "0.33.482"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.481",
+  "version": "0.33.482",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.481",
+      "version": "0.33.482",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.480",
+  "version": "0.33.481",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.480",
+      "version": "0.33.481",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.480",
+  "version": "0.33.481",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.481",
+  "version": "0.33.482",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Symptom

After #598 + 2ffa63c5 + this branch's parent, v0.33.481 portable launches fine and the launcher correctly forwards on second-launch:

\`\`\`
[v0.33.481] pipe bind failed (already_running=true): Access is denied.
[v0.33.481] forwarded open_new_window to existing instance — exiting 0
\`\`\`

But **no second window appears.** Manually running curl with the same port + token + payload returns \`200 OK\` with a real \`window-...\` label, so the host handler is correct.

## Root cause

\`forward_open_new_window\` writes the HTTP request and returns. The launcher process exits, the kernel closes the TCP socket (RST). The host's axum handler is async — between the bytes arriving and the handler being dispatched to \`open_new_window\`, the connection is already gone. axum drops the in-flight request silently (no log line on the host either).

## Fix

After \`write_all\`, do a 2s-timeout read of up to 64 bytes from the socket. We don't care about the response — the read just keeps the connection alive past axum's handler dispatch. \`Connection: close\` lets the server drop the socket once the response is written, so the read returns naturally without blocking the launcher's exit.

## Test plan

- [ ] \`task package\` builds clean.
- [ ] Launch v0.33.482 portable, double-click \`agentmux.exe\` → second window pops, no dialog. Repeat 2-3 times rapidly to confirm each click yields one new window.
- [ ] Launcher log shows \`forwarded open_new_window to existing instance — exiting 0\` (unchanged).
- [ ] Host log now shows the corresponding \`open_new_window\` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)