### PR TITLE
B.9: Window Reality Reconciliation (observation + pure-reducer self-heal)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.487"
+version = "0.33.488"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.487"
+version = "0.33.488"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.487"
+version = "0.33.488"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.487"
+version = "0.33.488"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.488"
+version = "0.33.489"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.488"
+version = "0.33.489"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.488"
+version = "0.33.489"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.488"
+version = "0.33.489"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.486"
+version = "0.33.487"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.486"
+version = "0.33.487"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.486"
+version = "0.33.487"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.486"
+version = "0.33.487"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.485"
+version = "0.33.486"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.485"
+version = "0.33.486"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.485"
+version = "0.33.486"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.485"
+version = "0.33.486"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.482"
+version = "0.33.483"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.482"
+version = "0.33.483"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.482"
+version = "0.33.483"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.482"
+version = "0.33.483"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.483"
+version = "0.33.484"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.483"
+version = "0.33.484"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.483"
+version = "0.33.484"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.483"
+version = "0.33.484"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.484"
+version = "0.33.485"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.484"
+version = "0.33.485"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.484"
+version = "0.33.485"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.484"
+version = "0.33.485"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.485"
+version = "0.33.486"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.486"
+version = "0.33.487"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.482"
+version = "0.33.483"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.484"
+version = "0.33.485"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.488"
+version = "0.33.489"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.487"
+version = "0.33.488"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.483"
+version = "0.33.484"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"
@@ -65,6 +65,11 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Com",
     "Win32_Security",
     "Win32_Security_Authorization",
+    # Phase B.9.1 (WRR) — SetWinEventHook / UnhookWinEvent /
+    # HWINEVENTHOOK live under Accessibility (they originated as
+    # MSAA hooks; later events like EVENT_OBJECT_LOCATIONCHANGE
+    # piggyback on the same infrastructure).
+    "Win32_UI_Accessibility",
 ] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -242,6 +242,52 @@ impl AgentMuxHandler {
                 WindowKind::Subwindow => agentmux_common::ipc::WindowKind::Subwindow,
             };
             crate::launcher_ipc::report_window_opened(label.clone(), wire_kind, pending_parent.clone());
+
+            // Phase B.9.1 (WRR) — authoritative HWND link. We have
+            // both the label (popped from PendingWindowCreation
+            // above) and the native HWND (computed in the
+            // #[cfg(target_os = "windows")] block above as
+            // `views_top_hwnd` / `hwnd`). Sending an explicit
+            // ReportHwndOpened with `label_hint = Some(label)` here
+            // eliminates the race between the OS-driven
+            // EVENT_OBJECT_CREATE (which my hook captures with
+            // `label_hint = None` because pending_window_creations
+            // may already have been popped by the time the OS event
+            // bubbles back) and CEF's lifecycle. The OS-event path
+            // still runs as belt-and-suspenders for non-CEF windows
+            // / future detection of strays. (The prior pending_hwnds
+            // entry from the OS event is harmless — it ages out on
+            // the next event-driven reconciliation pass.)
+            #[cfg(target_os = "windows")]
+            {
+                // Recompute the HWND here — the prior #[cfg] block
+                // computed `hwnd` as a local that's not in scope at
+                // this site. The CEF Browser API is cheap to query
+                // a second time. Same precedence: Views' window
+                // handle first, host's window handle as fallback.
+                let mut browser_for_wrr = browser.clone();
+                let views_hwnd = browser_view_get_for_browser(Some(&mut browser_for_wrr))
+                    .and_then(|bv| bv.window())
+                    .map(|w| w.window_handle().0 as *mut std::ffi::c_void)
+                    .filter(|p| !p.is_null());
+                let host_hwnd = browser.host().and_then(|h| {
+                    let wh = h.window_handle();
+                    if wh.0.is_null() {
+                        None
+                    } else {
+                        Some(wh.0 as *mut std::ffi::c_void)
+                    }
+                });
+                let hwnd_val = views_hwnd.or(host_hwnd).map(|p| p as u64).unwrap_or(0);
+                if hwnd_val != 0 {
+                    crate::launcher_ipc::report_hwnd_opened(
+                        hwnd_val,
+                        "Chrome_WidgetWin_1".to_string(),
+                        label.clone(),
+                        Some(label.clone()),
+                    );
+                }
+            }
             // Phase B.4 follow-up — drift check after the open.
             crate::launcher_ipc::compute_and_report_host_counts(&self.state);
         }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -354,6 +354,30 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
             // for rationale).
             emit_window_instances_changed_with_entries(state);
         }
+        Event::CorrectiveWindowMove { hwnd, target_rect, reason, .. } => {
+            // Phase B.9.2 — pure-reducer self-heal. Reducer detected
+            // an off-monitor / sentinel-parked window that the user
+            // has never foregrounded, and computed an on-monitor
+            // target rect. Apply `SetWindowPos` to move the window
+            // before the user notices the orphan taskbar entry.
+            // The CEF UI thread is the safe caller for SetWindowPos
+            // on a CEF Views-managed window — post a UI task rather
+            // than calling from this tokio task directly.
+            tracing::warn!(
+                target: "wrr",
+                "[wrr] CorrectiveWindowMove hwnd={:#x} reason={:?} target=({},{})-({},{})",
+                hwnd, reason,
+                target_rect.left, target_rect.top, target_rect.right, target_rect.bottom
+            );
+            crate::ui_tasks::post_corrective_window_move(
+                state,
+                *hwnd,
+                target_rect.left,
+                target_rect.top,
+                target_rect.right - target_rect.left,
+                target_rect.bottom - target_rect.top,
+            );
+        }
         _ => {}
     }
 }
@@ -534,6 +558,99 @@ pub fn report_host_pool_count(count: u32) {
     let cmd = Command::ReportHostPoolCount { count };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!("[launcher-ipc] report_host_pool_count: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 (WRR) — sync API: report a Win32 HWND created.
+/// Called from the WRR `SetWinEventHook` callback. No-op if the
+/// launcher pipe isn't connected (`task dev` mode); reducer arm
+/// stashes pending-without-label until reconciliation.
+pub fn report_hwnd_opened(
+    hwnd: u64,
+    class_name: String,
+    title: String,
+    label_hint: Option<String>,
+) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndOpened {
+        hwnd,
+        class_name,
+        title,
+        label_hint,
+    };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_opened: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report a Win32 HWND destroyed.
+pub fn report_hwnd_destroyed(hwnd: u64) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndDestroyed { hwnd };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_destroyed: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report visibility change.
+pub fn report_hwnd_visibility_changed(hwnd: u64, visible: bool) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndVisibilityChanged { hwnd, visible };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_visibility_changed: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report foreground change.
+pub fn report_hwnd_foreground_changed(hwnd: u64) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndForegroundChanged { hwnd };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_foreground_changed: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report iconic (minimized) change.
+pub fn report_hwnd_iconic_changed(hwnd: u64, iconic: bool) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndIconicChanged { hwnd, iconic };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_iconic_changed: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report position change. Caller is
+/// responsible for debouncing — see `wrr/position_debounce.rs`.
+pub fn report_hwnd_position_changed(hwnd: u64, rect: agentmux_common::ipc::Rect) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportHwndPositionChanged { hwnd, rect };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_hwnd_position_changed: channel closed ({})", e);
+    }
+}
+
+/// Phase B.9.1 — sync API: report current monitor topology. Sent
+/// once at install time; mid-session topology changes are a B.9.2
+/// follow-up.
+pub fn report_monitor_topology_changed(rects: Vec<agentmux_common::ipc::Rect>) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportMonitorTopologyChanged { rects };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_monitor_topology_changed: channel closed ({})", e);
     }
 }
 

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -35,6 +35,7 @@ mod pane;
 mod sidecar;
 mod state;
 mod ui_tasks;
+mod wrr;
 
 use std::sync::Arc;
 
@@ -399,11 +400,27 @@ fn main() {
         format!("{}:{}", ipc_port, app_state.ipc_token),
     );
 
+    // Phase B.9.1 (WRR) — install Win32 event hooks. Must come
+    // AFTER `connect_to_launcher` so the report_hwnd_* sync APIs
+    // have a live `COMMAND_TX` to push into; AFTER CEF init so
+    // any HWNDs CEF creates during initialize() are missed
+    // (acceptable — they predate the user's session and are
+    // accounted for by main-window startup paths). Idempotent;
+    // safe to call multiple times. State arg lets the callback
+    // peek `pending_window_creations` for `label_hint`.
+    wrr::install_hooks(app_state.clone());
+
     // Run the CEF message loop. This blocks until quit_message_loop() is called
     // (triggered when all browser windows are closed in client.rs).
     run_message_loop();
 
     tracing::info!("CEF message loop exited, shutting down");
+
+    // Phase B.9.1 (WRR) — tear down Win32 event hooks before any
+    // further teardown. UnhookWinEvent is cheap; doing it early
+    // prevents stray callbacks during shutdown from racing the
+    // launcher_ipc channel close.
+    wrr::uninstall_hooks();
 
     // Kill the backend sidecar on shutdown.
     {

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -180,6 +180,66 @@ pub fn post_move_window(state: &Arc<AppState>, label: &str, dx: i32, dy: i32) {
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Phase B.9.2 (WRR) — corrective absolute-position move ─────────────────
+//
+// Reducer-driven self-heal. Triggered by `Event::CorrectiveWindowMove` when
+// the reducer detects an off-monitor / sentinel-parked window that the user
+// has never foregrounded. We bypass `state.browsers` lookup-by-label (the
+// label might not be registered yet at correction time) and use Win32
+// SetWindowPos directly against the HWND. Must run on the UI thread because
+// CEF Views' window backing the HWND is owned by the UI thread.
+
+wrap_task! {
+    pub struct CorrectiveWindowMoveTask {
+        state: Arc<AppState>,
+        hwnd: u64,
+        x: i32,
+        y: i32,
+        w: i32,
+        h: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            #[cfg(target_os = "windows")]
+            unsafe {
+                use windows_sys::Win32::Foundation::HWND;
+                use windows_sys::Win32::UI::WindowsAndMessaging::{
+                    SetWindowPos, SWP_NOACTIVATE, SWP_NOZORDER,
+                };
+                let h = self.hwnd as HWND;
+                let ok = SetWindowPos(
+                    h,
+                    std::ptr::null_mut(),
+                    self.x,
+                    self.y,
+                    self.w,
+                    self.h,
+                    SWP_NOZORDER | SWP_NOACTIVATE,
+                );
+                tracing::info!(
+                    target: "wrr",
+                    "[wrr] corrective SetWindowPos hwnd={:#x} -> ({},{}) {}x{} ok={}",
+                    self.hwnd, self.x, self.y, self.w, self.h, ok != 0
+                );
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = &self.state; // suppress unused on non-Windows
+                tracing::warn!(
+                    target: "wrr",
+                    "[wrr] corrective move requested on non-Windows host: ignored"
+                );
+            }
+        }
+    }
+}
+
+pub fn post_corrective_window_move(state: &Arc<AppState>, hwnd: u64, x: i32, y: i32, w: i32, h: i32) {
+    let mut task = CorrectiveWindowMoveTask::new(state.clone(), hwnd, x, y, w, h);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Create new window (CEF Views) ───────────────────────────────────────
 
 wrap_task! {

--- a/agentmux-cef/src/wrr/classify.rs
+++ b/agentmux-cef/src/wrr/classify.rs
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — class-name filter for the WRR Win32 event hook.
+//
+// Hook callbacks fire for every window-object event in the host
+// process: CEF browser top-levels (the ones we care about), CEF
+// subprocess HWNDs, OS-managed transient HWNDs (tooltips, IME
+// candidate lists, message-only windows), and so on. Forwarding
+// every event over the IPC pipe would flood the wire with noise
+// the reducer can't act on.
+//
+// `is_app_class` filters at the hook callback so only candidate
+// AgentMux top-level windows produce IPC traffic. The classifier
+// is allowlist-based — false negatives (a real window we silently
+// drop) are worse than false positives (a non-app HWND that the
+// reducer just ignores), so we keep the allowlist conservative
+// and let the reducer's `pending_hwnds` machinery age out spurious
+// entries.
+
+/// Phase B.9.1 — does this Win32 window class look like an
+/// AgentMux top-level window?
+///
+/// CEF's top-level windows in CEF 146 use the
+/// `Chrome_WidgetWin_*` class family (CEF Views wraps each native
+/// window in a Chromium widget host). AgentMux's main window
+/// shows up as `Chrome_WidgetWin_1`. Browser-pane child HWNDs and
+/// CEF subprocess HWNDs use `Chrome_RenderWidgetHostHWND` and
+/// related — those are explicitly excluded.
+pub fn is_app_class(class_name: &str) -> bool {
+    // Chromium widget host windows. CEF wraps every top-level
+    // CefWindow in one. The numeric suffix varies (`_0` `_1` etc.)
+    // depending on CEF init order.
+    if class_name.starts_with("Chrome_WidgetWin_") {
+        return true;
+    }
+    // CEF Views Native Window (rare in our build but possible).
+    if class_name == "CefBrowserWindow" {
+        return true;
+    }
+    false
+}
+
+/// Phase B.9.1 — explicit excludes for class names that LOOK
+/// app-like but should never produce drift. Currently empty
+/// because `is_app_class` is allowlist-based; kept as a hook for
+/// follow-up tuning if the allowlist gets too permissive.
+pub fn is_explicitly_excluded(_class_name: &str) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chrome_widget_win_classes_match() {
+        assert!(is_app_class("Chrome_WidgetWin_0"));
+        assert!(is_app_class("Chrome_WidgetWin_1"));
+        assert!(is_app_class("Chrome_WidgetWin_42"));
+    }
+
+    #[test]
+    fn cef_browser_window_matches() {
+        assert!(is_app_class("CefBrowserWindow"));
+    }
+
+    #[test]
+    fn renderer_subprocess_class_is_filtered_out() {
+        assert!(!is_app_class("Chrome_RenderWidgetHostHWND"));
+        assert!(!is_app_class("Intermediate D3D Window"));
+    }
+
+    #[test]
+    fn unrelated_classes_filtered_out() {
+        assert!(!is_app_class("tooltips_class32"));
+        assert!(!is_app_class("Static"));
+        assert!(!is_app_class(""));
+    }
+}

--- a/agentmux-cef/src/wrr/mod.rs
+++ b/agentmux-cef/src/wrr/mod.rs
@@ -1,0 +1,41 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — Window Reality Reconciliation (WRR), host-side
+// hook layer.
+//
+// Subscribes to Win32 events that surface HWND lifecycle and
+// observability transitions, and forwards each as a typed
+// `Command::ReportHwnd*` over the existing launcher IPC pipe.
+// The launcher's reducer arm classifies divergences and emits
+// `Event::HwndDriftDetected` (see
+// `agentmux-launcher/src/wrr/mod.rs`).
+//
+// Pure event-driven: every report is in response to an OS
+// notification, never on a timer. The one heartbeat-shaped
+// caveat — position-change debounce — is purely a wire-volume
+// optimization (drag a window to its final position; the
+// reducer only needs the final rect, not 60 intermediate ones).
+// Debounce IS bounded; a final position event always lands
+// after the burst settles (see `position_debounce.rs`).
+//
+// Design lives at `docs/retro/wrr-design-2026-04-28.md`.
+
+#[cfg(target_os = "windows")]
+pub mod classify;
+#[cfg(target_os = "windows")]
+pub mod position_debounce;
+#[cfg(target_os = "windows")]
+pub mod win_event;
+
+#[cfg(target_os = "windows")]
+pub use win_event::{install_hooks, uninstall_hooks};
+
+#[cfg(not(target_os = "windows"))]
+pub fn install_hooks() {
+    // WRR is Windows-only — Phase 7 will revisit when cross-platform
+    // window-state mirroring lands.
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn uninstall_hooks() {}

--- a/agentmux-cef/src/wrr/mod.rs
+++ b/agentmux-cef/src/wrr/mod.rs
@@ -32,9 +32,11 @@ pub mod win_event;
 pub use win_event::{install_hooks, uninstall_hooks};
 
 #[cfg(not(target_os = "windows"))]
-pub fn install_hooks() {
+pub fn install_hooks(_state: std::sync::Arc<crate::state::AppState>) {
     // WRR is Windows-only — Phase 7 will revisit when cross-platform
-    // window-state mirroring lands.
+    // window-state mirroring lands. Stub matches the Windows signature
+    // so callers in main.rs compile across all targets without
+    // platform gating at the call site. (reagent #600 P1.)
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/agentmux-cef/src/wrr/position_debounce.rs
+++ b/agentmux-cef/src/wrr/position_debounce.rs
@@ -1,0 +1,118 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — position-event debounce.
+//
+// `EVENT_OBJECT_LOCATIONCHANGE` fires on every WM_WINDOWPOSCHANGED
+// dispatch, including during a drag (60+ events/sec). The reducer
+// only needs the FINAL rect after the burst settles — the
+// `OffMonitor` classification is the same at every intermediate
+// position as at the final position, but emitting 60 redundant
+// drift events spams the launcher log.
+//
+// Strategy: per-HWND last-emit timestamp. When a new event fires,
+// drop it if the previous emit was less than `DEBOUNCE_MS` ago.
+// We accept up to `DEBOUNCE_MS` of staleness in the launcher's
+// last-known rect — fine for B.9.1's observation purpose.
+//
+// This is NOT a heartbeat — there is no thread waking periodically.
+// We only ever emit in response to OS events, just sometimes drop
+// them.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+/// Maximum frequency at which any single HWND will produce a
+/// position report. Currently 50ms ≈ 20 Hz.
+const DEBOUNCE_MS: u128 = 50;
+
+/// Per-HWND last-emit time. Lock is held only for HashMap
+/// operations — never across IPC. Mutex-poisoning is treated as
+/// unrecoverable (poison = a panic in the WRR hook callback,
+/// which means the hook is broken anyway); we recover via
+/// `into_inner` so the next caller starts fresh.
+fn map() -> &'static Mutex<HashMap<u64, Instant>> {
+    static M: std::sync::OnceLock<Mutex<HashMap<u64, Instant>>> = std::sync::OnceLock::new();
+    M.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Phase B.9.1 — should we emit a position report for this HWND
+/// right now? Returns `true` if at least `DEBOUNCE_MS` has
+/// elapsed since the last emit for this HWND (or this is the
+/// first emit for it). Updates the timestamp atomically with the
+/// decision.
+pub fn should_emit(hwnd: u64) -> bool {
+    let now = Instant::now();
+    let mut m = match map().lock() {
+        Ok(g) => g,
+        Err(poisoned) => {
+            // Recover: clear the poisoned state and continue.
+            let mut g = poisoned.into_inner();
+            g.clear();
+            g
+        }
+    };
+    let last = m.get(&hwnd).copied();
+    let allow = match last {
+        None => true,
+        Some(t) => now.duration_since(t).as_millis() >= DEBOUNCE_MS,
+    };
+    if allow {
+        m.insert(hwnd, now);
+    }
+    allow
+}
+
+/// Phase B.9.1 — drop the debounce entry for an HWND. Called from
+/// the destroy hook so a recycled HWND value doesn't inherit the
+/// previous occupant's debounce state.
+pub fn forget(hwnd: u64) {
+    let mut m = match map().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    m.remove(&hwnd);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    #[test]
+    fn first_emit_for_an_hwnd_is_allowed() {
+        // Use a unique value to avoid interference with other tests.
+        let h = 0xABCD_0001;
+        forget(h);
+        assert!(should_emit(h));
+    }
+
+    #[test]
+    fn rapid_second_emit_is_dropped() {
+        let h = 0xABCD_0002;
+        forget(h);
+        assert!(should_emit(h));
+        assert!(!should_emit(h));
+    }
+
+    #[test]
+    fn after_debounce_window_emits_again() {
+        let h = 0xABCD_0003;
+        forget(h);
+        assert!(should_emit(h));
+        sleep(Duration::from_millis(60));
+        assert!(should_emit(h));
+    }
+
+    #[test]
+    fn forget_resets_state() {
+        let h = 0xABCD_0004;
+        forget(h);
+        assert!(should_emit(h));
+        forget(h);
+        // Forget cleared the entry, so the next emit is the "first" again.
+        assert!(should_emit(h));
+    }
+}

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -130,9 +130,13 @@ pub fn install_hooks(state: Arc<AppState>) {
         handles.push(HookHandle(h));
     }
 
+    let installed_count = handles.len();
     drop(handles);
 
-    tracing::info!("[wrr] installed {} WinEventHook range(s) for pid={}", 4, pid);
+    tracing::info!(
+        "[wrr] installed {}/{} WinEventHook range(s) for pid={}",
+        installed_count, 4, pid
+    );
 
     // Enumerate the initial monitor topology and report it once.
     // Without this, `state.monitors` stays empty in the launcher

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -23,7 +23,7 @@
 
 use std::sync::{Arc, OnceLock};
 
-use windows_sys::Win32::Foundation::{HWND, POINT, RECT};
+use windows_sys::Win32::Foundation::{HWND, RECT};
 use windows_sys::Win32::Graphics::Gdi::{
     EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFO,
 };
@@ -418,12 +418,4 @@ fn enumerate_monitors() -> Vec<agentmux_common::ipc::Rect> {
         EnumDisplayMonitors(std::ptr::null_mut(), std::ptr::null(), Some(enum_proc), 0);
     }
     MONITORS.with(|m| m.borrow().clone())
-}
-
-#[allow(dead_code)]
-fn _unused_point() {
-    // Silence unused warning from POINT import — keep the import
-    // since EnumDisplayMonitors signature evolves between
-    // windows-sys releases and we may need POINT later.
-    let _: POINT = unsafe { std::mem::zeroed() };
 }

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -1,0 +1,429 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — `SetWinEventHook` installation + callback.
+//
+// One install at startup, one teardown at shutdown. The hook
+// runs WINEVENT_OUTOFCONTEXT (callback fires on the calling
+// thread of the hooking process — no DLL injection, no extra
+// thread). We filter to the host's own PID via the `idProcess`
+// parameter so we don't see events from other processes.
+//
+// The callback fires synchronously per OS event. It:
+//   1. Filters out non-window object events (OBJID != OBJID_WINDOW
+//      or CHILDID != CHILDID_SELF).
+//   2. Reads the HWND's class name; bails if not in
+//      `classify::is_app_class`.
+//   3. Maps the event ID to a launcher_ipc::report_hwnd_*
+//      function and dispatches.
+//
+// The `report_hwnd_*` functions on the launcher_ipc side are
+// non-blocking sync APIs (UnboundedSender → drain task) so this
+// callback returns quickly even under burst load.
+
+use std::sync::{Arc, OnceLock};
+
+use windows_sys::Win32::Foundation::{HWND, POINT, RECT};
+use windows_sys::Win32::Graphics::Gdi::{
+    EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFO,
+};
+use windows_sys::Win32::UI::Accessibility::{
+    SetWinEventHook, UnhookWinEvent, HWINEVENTHOOK,
+};
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    GetClassNameW, GetWindowRect, GetWindowTextW, GetWindowThreadProcessId, IsIconic,
+    IsWindowVisible, CHILDID_SELF, EVENT_OBJECT_CREATE, EVENT_OBJECT_DESTROY, EVENT_OBJECT_HIDE,
+    EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_SHOW, EVENT_SYSTEM_FOREGROUND,
+    EVENT_SYSTEM_MINIMIZEEND, EVENT_SYSTEM_MINIMIZESTART, OBJID_WINDOW, WINEVENT_OUTOFCONTEXT,
+};
+
+use crate::launcher_ipc;
+use crate::state::AppState;
+use crate::wrr::{classify, position_debounce};
+
+/// Phase B.9.1 — handle to host AppState for the static
+/// `SetWinEventHook` callback (the OS API takes a fixed-shape
+/// `extern "system" fn`, so AppState has to be reachable through
+/// a static). Set once by `install_hooks(state)`. The callback
+/// reads `pending_window_creations` to supply `label_hint` on
+/// `EVENT_OBJECT_CREATE`, eliminating the launcher-side
+/// "pending HWND with no matching mirror" race.
+fn app_state() -> &'static OnceLock<Arc<AppState>> {
+    static S: OnceLock<Arc<AppState>> = OnceLock::new();
+    &S
+}
+
+/// Phase B.9.1 — handles to the installed hooks. Held in a
+/// `OnceLock<Mutex<Option<...>>>` so install_hooks is idempotent
+/// (no-op on second call) and uninstall can drop them on shutdown.
+fn hook_handles() -> &'static std::sync::Mutex<Vec<HookHandle>> {
+    static H: OnceLock<std::sync::Mutex<Vec<HookHandle>>> = OnceLock::new();
+    H.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+#[derive(Debug)]
+struct HookHandle(HWINEVENTHOOK);
+
+// SAFETY: HWINEVENTHOOK is a HANDLE (opaque pointer). Send + Sync
+// are needed to store it in a static Mutex; the Win32 API doesn't
+// document any thread-affinity for the handle itself (Unhook can
+// be called from any thread).
+unsafe impl Send for HookHandle {}
+unsafe impl Sync for HookHandle {}
+
+/// Phase B.9.1 — install the WRR hooks. Idempotent (logs and
+/// returns if hooks are already installed). Must be called from a
+/// thread that owns a Win32 message pump — the host's CEF UI
+/// thread does, so we install from there at startup.
+///
+/// Also enumerates the current monitor topology and reports it
+/// once. WM_DISPLAYCHANGE wiring for mid-session topology updates
+/// is a B.9.2 follow-up.
+///
+/// `state` is stashed in a static `OnceLock` so the static callback
+/// can read `pending_window_creations` to supply `label_hint`.
+pub fn install_hooks(state: Arc<AppState>) {
+    if app_state().set(state).is_err() {
+        tracing::debug!("[wrr] install_hooks called twice — already installed (state set)");
+    }
+    let mut handles = match hook_handles().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    if !handles.is_empty() {
+        tracing::debug!("[wrr] install_hooks called twice — already installed");
+        return;
+    }
+
+    let pid = std::process::id();
+
+    // Hook range 1: object create / destroy / show / hide.
+    // EVENT_OBJECT_CREATE..=EVENT_OBJECT_HIDE happens to be a
+    // contiguous range (0x8000..=0x8003); install one hook with
+    // bracketing endpoints.
+    let h1 = install_one(EVENT_OBJECT_CREATE, EVENT_OBJECT_HIDE, pid);
+    if let Some(h) = h1 {
+        handles.push(HookHandle(h));
+    }
+
+    // Hook range 2: foreground change. Discrete event; installed
+    // as a degenerate range (start == end).
+    let h2 = install_one(EVENT_SYSTEM_FOREGROUND, EVENT_SYSTEM_FOREGROUND, pid);
+    if let Some(h) = h2 {
+        handles.push(HookHandle(h));
+    }
+
+    // Hook range 3: minimize start / end.
+    let h3 = install_one(EVENT_SYSTEM_MINIMIZESTART, EVENT_SYSTEM_MINIMIZEEND, pid);
+    if let Some(h) = h3 {
+        handles.push(HookHandle(h));
+    }
+
+    // Hook range 4: location change (debounced — see
+    // position_debounce.rs). Discrete event.
+    let h4 = install_one(
+        EVENT_OBJECT_LOCATIONCHANGE,
+        EVENT_OBJECT_LOCATIONCHANGE,
+        pid,
+    );
+    if let Some(h) = h4 {
+        handles.push(HookHandle(h));
+    }
+
+    drop(handles);
+
+    tracing::info!("[wrr] installed {} WinEventHook range(s) for pid={}", 4, pid);
+
+    // Enumerate the initial monitor topology and report it once.
+    // Without this, `state.monitors` stays empty in the launcher
+    // and `OffMonitor` drift is suppressed (per the design doc).
+    let monitors = enumerate_monitors();
+    if !monitors.is_empty() {
+        launcher_ipc::report_monitor_topology_changed(monitors.clone());
+        tracing::info!("[wrr] reported initial monitor topology: {} monitor(s)", monitors.len());
+    } else {
+        tracing::warn!("[wrr] initial monitor enumeration returned 0 monitors — OffMonitor drift will be suppressed");
+    }
+}
+
+fn install_one(event_min: u32, event_max: u32, pid: u32) -> Option<HWINEVENTHOOK> {
+    unsafe {
+        let h = SetWinEventHook(
+            event_min,
+            event_max,
+            std::ptr::null_mut(),
+            Some(win_event_callback),
+            pid,
+            0, // idThread = 0 means all threads in the process
+            WINEVENT_OUTOFCONTEXT,
+        );
+        if h.is_null() {
+            tracing::error!(
+                "[wrr] SetWinEventHook failed for range {:#x}..={:#x}",
+                event_min,
+                event_max
+            );
+            None
+        } else {
+            Some(h)
+        }
+    }
+}
+
+/// Phase B.9.1 — uninstall the hooks. Called from host shutdown.
+pub fn uninstall_hooks() {
+    let mut handles = match hook_handles().lock() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let mut count = 0;
+    for h in handles.drain(..) {
+        unsafe {
+            if UnhookWinEvent(h.0) != 0 {
+                count += 1;
+            }
+        }
+    }
+    if count > 0 {
+        tracing::info!("[wrr] unhooked {} WinEventHook range(s)", count);
+    }
+}
+
+/// Phase B.9.1 — hook callback. Runs OUT-OF-CONTEXT (on the
+/// hooking thread, posted via the message pump). Must not block
+/// for long: we only do quick HWND-property reads and dispatch
+/// non-blocking sync IPC reports.
+unsafe extern "system" fn win_event_callback(
+    _hook: HWINEVENTHOOK,
+    event: u32,
+    hwnd: HWND,
+    id_object: i32,
+    id_child: i32,
+    _id_event_thread: u32,
+    _dwms_event_time: u32,
+) {
+    // 1. Only OBJID_WINDOW with CHILDID_SELF — events for child
+    // controls and accessibility objects are noise.
+    if id_object != OBJID_WINDOW || id_child != CHILDID_SELF as i32 {
+        return;
+    }
+    if hwnd.is_null() {
+        return;
+    }
+
+    // 2. Confirm the HWND belongs to our process (defense-in-
+    // depth — `idProcess` filter on the hook should already
+    // restrict this, but the OS occasionally bubbles events for
+    // ancestor / desktop windows).
+    let mut hwnd_pid: u32 = 0;
+    GetWindowThreadProcessId(hwnd, &mut hwnd_pid);
+    if hwnd_pid != std::process::id() {
+        return;
+    }
+
+    let raw_hwnd = hwnd as u64;
+
+    // Phase B.9.1 — diagnostic. INFO-level for B.9.1 smoke;
+    // dial back to debug! once we've confirmed the chain is
+    // wired end-to-end. Volume is bounded by the OBJID_WINDOW
+    // + CHILDID_SELF + idProcess filters above; for normal use
+    // this fires at ~5-20/sec during user activity.
+    tracing::info!(
+        target: "wrr",
+        "[wrr] callback event=0x{:x} hwnd={:#x}",
+        event, raw_hwnd
+    );
+
+    // 3. Per-event dispatch. Reads HWND properties as needed.
+    match event {
+        EVENT_OBJECT_CREATE => {
+            let class = read_class_name(hwnd);
+            // Cheap filter at the hook so we don't IPC every
+            // tooltip / IME / message-only window.
+            if !classify::is_app_class(&class) || classify::is_explicitly_excluded(&class) {
+                return;
+            }
+            let title = read_window_text(hwnd);
+            // Phase B.9.1 diagnostic — log app-class creates so
+            // smoke can correlate with launcher-side reception.
+            tracing::info!(
+                target: "wrr",
+                "[wrr] EVENT_OBJECT_CREATE app-class hwnd={:#x} class={} title={:?}",
+                raw_hwnd, class, title
+            );
+            // Phase B.9.1 — peek the back of `pending_window_creations`
+            // to supply `label_hint`. CEF's `OnAfterCreated`
+            // (which becomes `ReportWindowOpened`) fires AFTER
+            // this OS event, but the host pushed the
+            // `PendingWindowCreation` BEFORE calling
+            // `post_create_window`, so by the time we get here
+            // the back-of-queue label is the right one for the
+            // window we're seeing. Pool windows that don't push a
+            // pending entry get `None` and rely on the launcher
+            // reducer's drain-on-WindowOpened fallback.
+            let label_hint = app_state()
+                .get()
+                .and_then(|s| s.pending_window_creations.lock().back().cloned())
+                .map(|p| p.label);
+            launcher_ipc::report_hwnd_opened(raw_hwnd, class, title, label_hint);
+
+            // Fire synthetic position + visibility events after
+            // create so the reducer has a complete state for this
+            // HWND right away (LOCATIONCHANGE wouldn't fire on a
+            // window that lands at its final position immediately).
+            if let Some(rect) = read_window_rect(hwnd) {
+                if position_debounce::should_emit(raw_hwnd) {
+                    launcher_ipc::report_hwnd_position_changed(raw_hwnd, rect);
+                }
+            }
+            let visible = IsWindowVisible(hwnd) != 0;
+            launcher_ipc::report_hwnd_visibility_changed(raw_hwnd, visible);
+            let iconic = IsIconic(hwnd) != 0;
+            launcher_ipc::report_hwnd_iconic_changed(raw_hwnd, iconic);
+        }
+        EVENT_OBJECT_DESTROY => {
+            // No class-name filter on destroy — the HWND may be
+            // mid-teardown so its class is unreliable. The
+            // launcher reducer handles "destroy of an unknown
+            // HWND" as a no-op via pending_hwnds + windows
+            // membership check.
+            position_debounce::forget(raw_hwnd);
+            launcher_ipc::report_hwnd_destroyed(raw_hwnd);
+        }
+        EVENT_OBJECT_SHOW => {
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            launcher_ipc::report_hwnd_visibility_changed(raw_hwnd, true);
+        }
+        EVENT_OBJECT_HIDE => {
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            launcher_ipc::report_hwnd_visibility_changed(raw_hwnd, false);
+        }
+        EVENT_SYSTEM_FOREGROUND => {
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            launcher_ipc::report_hwnd_foreground_changed(raw_hwnd);
+        }
+        EVENT_SYSTEM_MINIMIZESTART => {
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            launcher_ipc::report_hwnd_iconic_changed(raw_hwnd, true);
+        }
+        EVENT_SYSTEM_MINIMIZEEND => {
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            launcher_ipc::report_hwnd_iconic_changed(raw_hwnd, false);
+        }
+        EVENT_OBJECT_LOCATIONCHANGE => {
+            // Heavy event during drags — debounce per HWND.
+            if !position_debounce::should_emit(raw_hwnd) {
+                return;
+            }
+            let class = read_class_name(hwnd);
+            if !classify::is_app_class(&class) {
+                return;
+            }
+            if let Some(rect) = read_window_rect(hwnd) {
+                launcher_ipc::report_hwnd_position_changed(raw_hwnd, rect);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Read the Win32 class name into an owned `String`.
+unsafe fn read_class_name(hwnd: HWND) -> String {
+    let mut buf = [0u16; 256];
+    let n = GetClassNameW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+    if n <= 0 {
+        return String::new();
+    }
+    String::from_utf16_lossy(&buf[..n as usize])
+}
+
+/// Read the window's text (title) into an owned `String`. Empty
+/// string if no title.
+unsafe fn read_window_text(hwnd: HWND) -> String {
+    let mut buf = [0u16; 512];
+    let n = GetWindowTextW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+    if n <= 0 {
+        return String::new();
+    }
+    String::from_utf16_lossy(&buf[..n as usize])
+}
+
+/// Read the window's screen-coordinate rectangle. `None` if the
+/// API call fails (window torn down between our event and the
+/// read — common during destroy).
+unsafe fn read_window_rect(hwnd: HWND) -> Option<agentmux_common::ipc::Rect> {
+    let mut r: RECT = std::mem::zeroed();
+    if GetWindowRect(hwnd, &mut r) == 0 {
+        return None;
+    }
+    Some(agentmux_common::ipc::Rect {
+        left: r.left,
+        top: r.top,
+        right: r.right,
+        bottom: r.bottom,
+    })
+}
+
+/// Phase B.9.1 — initial monitor enumeration. Called once from
+/// install_hooks. Mid-session topology changes (a follow-up
+/// concern for B.9.2) would re-enumerate via WM_DISPLAYCHANGE.
+fn enumerate_monitors() -> Vec<agentmux_common::ipc::Rect> {
+    use std::cell::RefCell;
+    thread_local! {
+        // Per-thread accumulator so the callback below can push
+        // into it without locking. EnumDisplayMonitors is
+        // synchronous — we drain after it returns.
+        static MONITORS: RefCell<Vec<agentmux_common::ipc::Rect>> =
+            RefCell::new(Vec::new());
+    }
+
+    unsafe extern "system" fn enum_proc(
+        h: HMONITOR,
+        _hdc: HDC,
+        _rect: *mut RECT,
+        _data: windows_sys::Win32::Foundation::LPARAM,
+    ) -> windows_sys::Win32::Foundation::BOOL {
+        let mut info: MONITORINFO = std::mem::zeroed();
+        info.cbSize = std::mem::size_of::<MONITORINFO>() as u32;
+        if GetMonitorInfoW(h, &mut info) != 0 {
+            MONITORS.with(|m| {
+                m.borrow_mut().push(agentmux_common::ipc::Rect {
+                    left: info.rcMonitor.left,
+                    top: info.rcMonitor.top,
+                    right: info.rcMonitor.right,
+                    bottom: info.rcMonitor.bottom,
+                });
+            });
+        }
+        1 // continue enumeration
+    }
+
+    MONITORS.with(|m| m.borrow_mut().clear());
+    unsafe {
+        EnumDisplayMonitors(std::ptr::null_mut(), std::ptr::null(), Some(enum_proc), 0);
+    }
+    MONITORS.with(|m| m.borrow().clone())
+}
+
+#[allow(dead_code)]
+fn _unused_point() {
+    // Silence unused warning from POINT import — keep the import
+    // since EnumDisplayMonitors signature evolves between
+    // windows-sys releases and we may need POINT later.
+    let _: POINT = unsafe { std::mem::zeroed() };
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.487"
+version = "0.33.488"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.488"
+version = "0.33.489"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.483"
+version = "0.33.484"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.484"
+version = "0.33.485"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.482"
+version = "0.33.483"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.486"
+version = "0.33.487"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.485"
+version = "0.33.486"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -399,6 +399,31 @@ pub enum Event {
         severity: Severity,
         version: u64,
     },
+    /// Phase B.9.2 — pure-reducer self-heal. Emitted alongside an
+    /// `HwndDriftDetected` when the reducer is confident the bug
+    /// happened at OPEN TIME (not from later user action) and a
+    /// safe corrective rect is computable. The host's WRR
+    /// subscriber listens for this and applies `SetWindowPos` on
+    /// the UI thread. No timers — the trigger is the same OS
+    /// event tick that surfaced the bug, so the correction lands
+    /// before the user has time to notice the orphan window.
+    ///
+    /// Guard for emission (per the design, suppress over-correction):
+    /// - The window's `mirror.foregrounded_since_open == false`
+    ///   (we never auto-move a window the user has already
+    ///   touched).
+    /// - The reducer can compute a target rect from
+    ///   `state.monitors` (i.e., monitors are known).
+    CorrectiveWindowMove {
+        /// Win32 HWND to move.
+        hwnd: u64,
+        /// Reducer-computed target rect. Default policy:
+        /// primary-monitor-centered at default window size.
+        target_rect: Rect,
+        /// Why correction fired — surfaces in host log + audit.
+        reason: HwndDriftKind,
+        version: u64,
+    },
 }
 
 /// Phase B.9.1 — six classes of CEF↔Win32 disagreement the reducer

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -158,6 +158,73 @@ pub enum Command {
     ReportBackendWindowIdUnregistered {
         label: String,
     },
+    /// Phase B.9.1 (WRR — Window Reality Reconciliation) — host
+    /// reports a Win32 top-level window was created. Hooked off
+    /// `EVENT_OBJECT_CREATE` (objid=`OBJID_WINDOW`) via
+    /// `SetWinEventHook(WINEVENT_OUTOFCONTEXT)`. The host filters
+    /// CEF subprocess HWNDs (renderer, GPU, plugin) at the hook
+    /// callback so the launcher only sees plausible app windows.
+    /// `label_hint` is the host's best guess from
+    /// `pending_window_creations` if it can disambiguate; `None`
+    /// when the create event arrives before the host has linked
+    /// the HWND back to a label (caught up later by the reducer's
+    /// pending_hwnds).
+    ReportHwndOpened {
+        hwnd: u64,
+        class_name: String,
+        title: String,
+        label_hint: Option<String>,
+    },
+    /// Phase B.9.1 — host reports a Win32 top-level window was
+    /// destroyed. Hooked off `EVENT_OBJECT_DESTROY`.
+    ReportHwndDestroyed {
+        hwnd: u64,
+    },
+    /// Phase B.9.1 — `EVENT_OBJECT_SHOW` / `EVENT_OBJECT_HIDE`.
+    ReportHwndVisibilityChanged {
+        hwnd: u64,
+        visible: bool,
+    },
+    /// Phase B.9.1 — `EVENT_SYSTEM_FOREGROUND`. Tells the launcher
+    /// the user actually saw this window (not just opened it).
+    /// Used to distinguish "opened but never foregrounded" (drift)
+    /// from "opened and shown".
+    ReportHwndForegroundChanged {
+        hwnd: u64,
+    },
+    /// Phase B.9.1 — `EVENT_SYSTEM_MINIMIZESTART` /
+    /// `EVENT_SYSTEM_MINIMIZEEND`.
+    ReportHwndIconicChanged {
+        hwnd: u64,
+        iconic: bool,
+    },
+    /// Phase B.9.1 — `WM_WINDOWPOSCHANGED` from the host's wndproc
+    /// wrapper. The host coalesces bursts (50ms debounce per HWND)
+    /// before sending so the wire stays light during topology
+    /// changes. Reducer compares `rect` against `state.monitors` to
+    /// classify off-monitor drift.
+    ReportHwndPositionChanged {
+        hwnd: u64,
+        rect: Rect,
+    },
+    /// Phase B.9.1 — `WM_DISPLAYCHANGE`. Replaces the launcher's
+    /// `state.monitors` wholesale; reducer re-evaluates every
+    /// known window's last_rect against the new topology and
+    /// emits `OffMonitor` drift for any that newly fall off.
+    ReportMonitorTopologyChanged {
+        rects: Vec<Rect>,
+    },
+}
+
+/// Phase B.9.1 — rectangle in Win32 screen coordinates (pixels).
+/// Matches Windows' `RECT` semantics: `right` and `bottom` are one
+/// past the last included pixel, so `right - left == width`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Rect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
 }
 
 /// Wire-side enum for `WindowKind`. Mirrors `agentmux-cef::state::WindowKind`
@@ -311,6 +378,69 @@ pub enum Event {
         mirror_count: u32,
         version: u64,
     },
+    /// Phase B.9.1 (WRR) — emitted when the launcher's reducer
+    /// detects a divergence between CEF browser identity (tracked
+    /// in `state.windows` / `state.pool` via `ReportWindow*`) and
+    /// Win32 reality (newly tracked via `ReportHwnd*`). Each variant
+    /// of `kind` is emitted at the moment the OS event that
+    /// surfaces it is dispatched through the reducer — there is no
+    /// timer / heartbeat. See `docs/retro/wrr-design-2026-04-28.md`
+    /// for the full classification table.
+    HwndDriftDetected {
+        kind: HwndDriftKind,
+        /// Affected label, when known.
+        label: Option<String>,
+        /// Affected HWND, when known. `u64` to keep the wire format
+        /// stable across pointer-width differences.
+        hwnd: Option<u64>,
+        /// Human-readable description for the launcher log + `--diag`
+        /// output. Free-form; not parsed by any consumer.
+        detail: String,
+        severity: Severity,
+        version: u64,
+    },
+}
+
+/// Phase B.9.1 — six classes of CEF↔Win32 disagreement the reducer
+/// can detect at event-dispatch time. See the WRR design doc for
+/// the per-kind triggering Command and reducer action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HwndDriftKind {
+    /// `state.windows` has a label whose `hwnd` field never got
+    /// populated, AND a follow-up event arrived that should have
+    /// reconciled it. CEF says open, Win32 has no matching HWND.
+    BrowserWithoutHwnd,
+    /// HWND in the host's report doesn't map to any
+    /// `state.windows` / `state.pool` label. Win32 has it, CEF
+    /// didn't open it. The "stray taskbar" case.
+    HwndWithoutBrowser,
+    /// HWND for a known label was never SHOWN (no foreground
+    /// event) since open and a subsequent state transition has
+    /// elapsed. User can't see it.
+    HiddenSinceOpen,
+    /// Window rect doesn't intersect any monitor in
+    /// `state.monitors`. Off-screen orphan.
+    OffMonitor,
+    /// `ReportHwndDestroyed` arrived without a preceding
+    /// `ReportWindowClosed` for the matching label. Renderer
+    /// crashed, took the HWND with it.
+    OrphanDestroy,
+    /// `ReportWindowClosed` arrived, but subsequent OS events for
+    /// the HWND keep firing (it never went away on the Win32 side).
+    LingeringHwnd,
+}
+
+/// Phase B.9.1 — drift severity. Operator-tunable severity floor
+/// in `WrrConfig.severity_floor` controls which events get
+/// broadcast (ones below the floor are still logged at DEBUG so
+/// they show up in `--diag wrr` post-mortem).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, PartialOrd, Ord)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Warn,
+    Error,
 }
 
 /// Coarse-grained launcher state. Spec §4: Starting → Running →

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.488"
+version = "0.33.489"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.483"
+version = "0.33.484"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.482"
+version = "0.33.483"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.486"
+version = "0.33.487"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.485"
+version = "0.33.486"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.484"
+version = "0.33.485"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.487"
+version = "0.33.488"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -268,12 +268,18 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
         // formatting don't show up in lock-hold time. (gemini
         // MEDIUM @ server.rs:259, PR #574 round-1.)
         let now_rfc3339 = chrono::Utc::now().to_rfc3339();
+        // Phase B.9.1 — monotonic ms since launcher start. Used by
+        // the WRR arm for per-window observability ages.
+        // `LAUNCHER_START_INSTANT` is a once-init `Instant`; the
+        // first request seeds it, subsequent ones read its delta.
+        let now_ms = launcher_start_ms();
         let events = {
             let mut state = ctx.state.lock().await;
             let rctx = reducer::Ctx {
                 now_rfc3339,
                 conn_id,
                 registered_pid,
+                now_ms,
             };
             reducer::update(&mut state, cmd.clone(), &rctx)
         };
@@ -309,6 +315,25 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
                     kind, host_count, mirror_count, conn_id
                 ));
             }
+            // Phase B.9.1 (WRR) — drift logged at the launcher level
+            // so operators see Win32 reality divergence in
+            // launcher.log regardless of subscriber wiring. Severity
+            // tag in the log line lets a future `--diag wrr` (B.9.2)
+            // grep precisely.
+            if let Event::HwndDriftDetected {
+                kind,
+                label,
+                hwnd,
+                detail,
+                severity,
+                ..
+            } = &event
+            {
+                crate::log(&format!(
+                    "[ipc] WRR-DRIFT [{:?}] {:?} label={:?} hwnd={:?}: {} (conn_id={})",
+                    severity, kind, label, hwnd, detail, conn_id
+                ));
+            }
             let event = patch_launcher_identity(event, &ctx);
             if send_event(&writer, event).await.is_err() {
                 return;
@@ -329,6 +354,18 @@ async fn handle_connection(stream: NamedPipeServer, ctx: Arc<ServerCtx>) {
 /// pre-Register failures so log lines can be correlated.
 static NEXT_CONN_ID: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(1);
+
+/// Phase B.9.1 — milliseconds since the launcher's IPC server
+/// started (first call seeds the epoch). Used as the monotonic
+/// clock for WRR observability timestamps in `reducer::Ctx::now_ms`.
+/// Distinct from `chrono::Utc::now()` because the WRR arm wants
+/// elapsed time, not wall clock — and we don't want clock-skew
+/// jitter (NTP adjustment, DST) showing up as drift.
+fn launcher_start_ms() -> u64 {
+    static START: std::sync::OnceLock<std::time::Instant> = std::sync::OnceLock::new();
+    let start = START.get_or_init(std::time::Instant::now);
+    start.elapsed().as_millis() as u64
+}
 
 /// Enforce the "first message must be Register" invariant. Returns
 /// `Some(Event::Error)` if the command violates the contract; the
@@ -373,6 +410,40 @@ async fn enforce_register_first(
         Command::ReportBackendWindowIdUnregistered { .. } => {
             (
                 "ReportBackendWindowIdUnregistered before Register".to_string(),
+                true,
+            )
+        }
+        // Phase B.9.1 (WRR) — host-only Win32 reality reports.
+        Command::ReportHwndOpened { .. } => {
+            ("ReportHwndOpened before Register".to_string(), true)
+        }
+        Command::ReportHwndDestroyed { .. } => {
+            ("ReportHwndDestroyed before Register".to_string(), true)
+        }
+        Command::ReportHwndVisibilityChanged { .. } => {
+            (
+                "ReportHwndVisibilityChanged before Register".to_string(),
+                true,
+            )
+        }
+        Command::ReportHwndForegroundChanged { .. } => {
+            (
+                "ReportHwndForegroundChanged before Register".to_string(),
+                true,
+            )
+        }
+        Command::ReportHwndIconicChanged { .. } => {
+            ("ReportHwndIconicChanged before Register".to_string(), true)
+        }
+        Command::ReportHwndPositionChanged { .. } => {
+            (
+                "ReportHwndPositionChanged before Register".to_string(),
+                true,
+            )
+        }
+        Command::ReportMonitorTopologyChanged { .. } => {
+            (
+                "ReportMonitorTopologyChanged before Register".to_string(),
                 true,
             )
         }

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -26,6 +26,7 @@ mod ipc;
 mod reducer;
 mod srv_spawner;
 mod state;
+mod wrr;
 
 #[tokio::main]
 async fn main() {

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -1842,6 +1842,73 @@ mod tests {
     }
 
     #[test]
+    fn wrr_orphan_destroy_emits_window_closed_and_instance_released() {
+        // reagent #600 P1: a renderer crash that takes the HWND
+        // with it must produce the same shutdown events the normal
+        // close path would, otherwise the frontend keeps a stale
+        // window in its atoms after the crash.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        // Renderer crashes — Win32 fires the destroy without CEF's
+        // close path running, so no ReportWindowClosed precedes it.
+        let evs = update(
+            &mut state,
+            Command::ReportHwndDestroyed { hwnd: 0xAA },
+            &c,
+        );
+
+        // All three: drift (operator alert) + WindowClosed
+        // (frontend prune) + WindowInstanceReleased (count drop).
+        assert!(
+            evs.iter()
+                .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanDestroy, .. })),
+            "expected OrphanDestroy drift, got {:?}", evs
+        );
+        assert!(
+            evs.iter().any(|e| matches!(
+                e,
+                Event::WindowClosed { label, .. } if label == "w1"
+            )),
+            "expected WindowClosed for w1, got {:?}", evs
+        );
+        assert!(
+            evs.iter().any(|e| matches!(
+                e,
+                Event::WindowInstanceReleased { label, .. } if label == "w1"
+            )),
+            "expected WindowInstanceReleased for w1, got {:?}", evs
+        );
+        // State pruned.
+        assert!(!state.windows.contains_key("w1"));
+        assert!(!state.instance_registry.contains_key("w1"));
+    }
+
+    #[test]
     fn wrr_off_monitor_with_no_known_monitors_emits_neither() {
         // No `ReportMonitorTopologyChanged` => state.monitors is
         // empty => we don't know what "off-monitor" means yet.

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -1935,6 +1935,84 @@ mod tests {
     }
 
     #[test]
+    fn wrr_orphan_destroy_runs_even_with_stale_pending_entry() {
+        // reagent #600 P1: the dual-source design (WinEvent CREATE
+        // hook with label_hint=None, then explicit on_after_created
+        // with label_hint=Some(label)) can leave a stale entry in
+        // `pending_hwnds` AFTER the mirror is linked. Pre-fix,
+        // `apply_hwnd_destroyed` early-returned on the stale
+        // pending entry and skipped the OrphanDestroy chain. Post-
+        // fix, the link drains pending and destroy runs the chain
+        // correctly. This test reproduces the exact race.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        // Step 1: WinEvent CREATE fires first with label_hint=None.
+        // No mirror match → stash in pending_hwnds.
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: None,
+            },
+            &c,
+        );
+        assert!(state.pending_hwnds.contains_key(&0xAA), "pending entry expected after step 1");
+        // Step 2: on_after_created fires with label_hint=Some(w1).
+        // Should link the mirror AND drain the stale pending.
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        assert!(
+            !state.pending_hwnds.contains_key(&0xAA),
+            "stale pending entry should be drained on link, but still present: {:?}",
+            state.pending_hwnds
+        );
+        // Step 3: renderer crash → ReportHwndDestroyed.
+        let evs = update(
+            &mut state,
+            Command::ReportHwndDestroyed { hwnd: 0xAA },
+            &c,
+        );
+        // Even with the (drained) pending entry history, the
+        // orphan-destroy chain must run.
+        assert!(
+            evs.iter()
+                .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanDestroy, .. })),
+            "OrphanDestroy must fire on renderer crash even after dual-source link, got {:?}",
+            evs
+        );
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::WindowClosed { .. })),
+            "WindowClosed must fire so frontend prunes its atoms, got {:?}",
+            evs
+        );
+    }
+
+    #[test]
     fn wrr_orphan_destroy_emits_window_closed_and_instance_released() {
         // reagent #600 P1: a renderer crash that takes the HWND
         // with it must produce the same shutdown events the normal

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -64,6 +64,13 @@ pub struct Ctx {
     /// on a connection (which MUST be Register, enforced server-
     /// side). (codex P1 + gemini HIGH PR #574 round-1.)
     pub registered_pid: Option<u32>,
+    /// Phase B.9.1 — monotonic milliseconds since some reference
+    /// epoch (the IPC server uses launcher start as the epoch).
+    /// Used by the WRR arm for per-window observability timestamps
+    /// (`last_foreground_at_ms`, `pending_hwnds[hwnd].arrived_at_ms`).
+    /// Distinct from `now_rfc3339` (wall clock) because operators
+    /// reading `--diag wrr` want age, not absolute time.
+    pub now_ms: u64,
 }
 
 /// Apply one Command to State, returning the resulting Events. State
@@ -133,6 +140,52 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 return vec![err];
             }
             handle_report_backend_window_id_unregistered(state, label)
+        }
+        // Phase B.9.1 (WRR) — Win32 reality events. Host-only
+        // because only the host installs the SetWinEventHook /
+        // wndproc wrapper. Same enforce-host pattern as the other
+        // observability reports.
+        Command::ReportHwndOpened { hwnd, class_name, title, label_hint } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndOpened") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_opened(state, hwnd, class_name, title, label_hint, ctx.now_ms)
+        }
+        Command::ReportHwndDestroyed { hwnd } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndDestroyed") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_destroyed(state, hwnd)
+        }
+        Command::ReportHwndVisibilityChanged { hwnd, visible } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndVisibilityChanged") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_visibility_changed(state, hwnd, visible)
+        }
+        Command::ReportHwndForegroundChanged { hwnd } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndForegroundChanged") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_foreground_changed(state, hwnd, ctx.now_ms)
+        }
+        Command::ReportHwndIconicChanged { hwnd, iconic } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndIconicChanged") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_iconic_changed(state, hwnd, iconic)
+        }
+        Command::ReportHwndPositionChanged { hwnd, rect } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportHwndPositionChanged") {
+                return vec![err];
+            }
+            crate::wrr::apply_hwnd_position_changed(state, hwnd, rect)
+        }
+        Command::ReportMonitorTopologyChanged { rects } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportMonitorTopologyChanged") {
+                return vec![err];
+            }
+            crate::wrr::apply_monitor_topology_changed(state, rects)
         }
     }
 }
@@ -309,6 +362,16 @@ fn handle_report_window_opened(
             kind,
             parent_label: parent_label.clone(),
             opened_at: ctx.now_rfc3339.clone(),
+            // Phase B.9.1 — observability axis defaults; populated
+            // later by the WRR `ReportHwnd*` arms when the host's
+            // Win32 hooks fire. Pre-B.9 (no host hooks installed)
+            // these stay at defaults — drift checks tolerate this.
+            hwnd: None,
+            visible: false,
+            iconic: false,
+            last_rect: None,
+            last_foreground_at_ms: None,
+            foregrounded_since_open: false,
         },
     );
     let mut out = Vec::with_capacity(2);
@@ -488,6 +551,7 @@ mod tests {
             now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
             conn_id,
             registered_pid: None,
+            now_ms: 0,
         }
     }
 
@@ -496,6 +560,7 @@ mod tests {
             now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
             conn_id,
             registered_pid: Some(pid),
+            now_ms: 0,
         }
     }
 
@@ -639,6 +704,7 @@ mod tests {
             | Event::BackendWindowIdRegistered { version, .. }
             | Event::BackendWindowIdUnregistered { version, .. }
             | Event::DriftDetected { version, .. }
+            | Event::HwndDriftDetected { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -1842,6 +1842,99 @@ mod tests {
     }
 
     #[test]
+    fn wrr_duplicate_hwnd_open_for_same_label_is_idempotent() {
+        // codex #600 P2: ReportHwndOpened arrives twice (once from
+        // the WinEvent CREATE hook with label_hint=None, then again
+        // from CEF's on_after_created with label_hint=Some(label)).
+        // The second report carries the SAME hwnd that's now
+        // linked to the mirror. Should be a no-op, NOT drift.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        // First link.
+        let evs1 = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        assert!(
+            evs1.is_empty(),
+            "first ReportHwndOpened should silently link, got {:?}", evs1
+        );
+        // Duplicate: same label, same hwnd.
+        let evs2 = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        assert!(
+            evs2.is_empty(),
+            "duplicate ReportHwndOpened with same hwnd must be no-op, got {:?}", evs2
+        );
+    }
+
+    #[test]
+    fn wrr_double_link_with_different_hwnd_for_same_label_emits_drift() {
+        // The non-duplicate path: a second ReportHwndOpened for
+        // the same label but a DIFFERENT HWND is genuine drift —
+        // host is reporting a related popup or there's a real bug.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        let evs = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xBB,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        assert!(
+            evs.iter().any(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HwndWithoutBrowser, .. }
+            )),
+            "different HWND for same label must fire drift, got {:?}", evs
+        );
+    }
+
+    #[test]
     fn wrr_orphan_destroy_emits_window_closed_and_instance_released() {
         // reagent #600 P1: a renderer crash that takes the HWND
         // with it must produce the same shutdown events the normal

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -355,6 +355,30 @@ fn handle_report_window_opened(
     kind: WindowKind,
     parent_label: Option<String>,
 ) -> Vec<Event> {
+    // Phase B.9.1 (WRR) — drain-on-WindowOpened fallback. The
+    // host's `EVENT_OBJECT_CREATE` callback fires before its CEF
+    // `OnAfterCreated` (which becomes this Command), so the
+    // matching `ReportHwndOpened` may have already been processed
+    // and stashed in `state.pending_hwnds` (with `label_hint=None`
+    // if the host couldn't determine it from
+    // `pending_window_creations`). Find the most recent pending
+    // HWND that arrived within the last 2 seconds and link it to
+    // the new mirror. The 2s window is generous compared to the
+    // typical < 50ms create→ReportWindowOpened gap, but bounded
+    // enough that a stale pending HWND from a prior open won't
+    // mis-link.
+    const PENDING_AGE_LIMIT_MS: u64 = 2_000;
+    let drained_hwnd: Option<u64> = state
+        .pending_hwnds
+        .iter()
+        .filter(|(_, p)| p.label_hint.is_none())
+        .filter(|(_, p)| ctx.now_ms.saturating_sub(p.arrived_at_ms) <= PENDING_AGE_LIMIT_MS)
+        .max_by_key(|(_, p)| p.arrived_at_ms)
+        .map(|(hwnd, _)| *hwnd);
+    if let Some(hwnd) = drained_hwnd {
+        state.pending_hwnds.remove(&hwnd);
+    }
+
     state.windows.insert(
         label.clone(),
         WindowMirror {
@@ -362,11 +386,14 @@ fn handle_report_window_opened(
             kind,
             parent_label: parent_label.clone(),
             opened_at: ctx.now_rfc3339.clone(),
-            // Phase B.9.1 — observability axis defaults; populated
-            // later by the WRR `ReportHwnd*` arms when the host's
-            // Win32 hooks fire. Pre-B.9 (no host hooks installed)
-            // these stay at defaults — drift checks tolerate this.
-            hwnd: None,
+            // Phase B.9.1 — observability axis. `hwnd` is
+            // populated from the drained pending entry above
+            // (host's WRR hook fired before this Command landed)
+            // OR remains None until the host's
+            // `ReportHwndOpened` with matching `label_hint`
+            // arrives via `apply_hwnd_opened`. Either path
+            // converges on the same linked state.
+            hwnd: drained_hwnd,
             visible: false,
             iconic: false,
             last_rect: None,
@@ -705,6 +732,7 @@ mod tests {
             | Event::BackendWindowIdUnregistered { version, .. }
             | Event::DriftDetected { version, .. }
             | Event::HwndDriftDetected { version, .. }
+            | Event::CorrectiveWindowMove { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -1628,5 +1656,226 @@ mod tests {
                 }),
             "[a-c]{1,3}".prop_map(|label| Command::ReportWindowClosed { label }),
         ]
+    }
+
+    // -----------------------------------------------------------
+    // Phase B.9 (WRR) — reducer arm tests
+    // -----------------------------------------------------------
+
+    use agentmux_common::ipc::{HwndDriftKind, Rect};
+
+    /// Helper: drive the reducer through a host Register so
+    /// subsequent host-only WRR commands are accepted. Returns the
+    /// state ready to receive WRR commands.
+    fn registered_host_state() -> (State, Ctx) {
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Host,
+                pid: 1,
+                version: "test".into(),
+            },
+            &ctx(1),
+        );
+        (state, ctx_with_pid(1, 1))
+    }
+
+    #[test]
+    fn wrr_off_monitor_position_for_unseen_window_emits_drift_and_corrective() {
+        let (mut state, c) = registered_host_state();
+        // Set monitor topology: a single 1920x1080 monitor.
+        let _ = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+            },
+            &c,
+        );
+        // Open a window.
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        // Link an HWND to it.
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "w1".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        // Position event: rect is fully off the monitor and NOT
+        // the Win32 hidden sentinel (so drift fires).
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xAA,
+                rect: Rect { left: -5000, top: -5000, right: -4000, bottom: -4000 },
+            },
+            &c,
+        );
+        // Expect both: drift + corrective move.
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. })),
+            "expected OffMonitor drift, got {:?}", evs
+        );
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::CorrectiveWindowMove { hwnd: 0xAA, .. })),
+            "expected CorrectiveWindowMove, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn wrr_sentinel_position_suppresses_drift_but_emits_corrective() {
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        // Sentinel position — CEF Views' "hidden" parking spot.
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xAA,
+                rect: Rect { left: -31970, top: -31970, right: -31340, bottom: -30871 },
+            },
+            &c,
+        );
+        // Drift suppressed (sentinel is a known transient).
+        assert!(
+            !evs.iter().any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. })),
+            "sentinel position should NOT fire drift, got {:?}", evs
+        );
+        // Corrective fires regardless — we want to move it before
+        // the user notices the orphan taskbar entry.
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::CorrectiveWindowMove { hwnd: 0xAA, .. })),
+            "sentinel position should fire CorrectiveWindowMove, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn wrr_off_monitor_after_user_foregrounded_does_not_correct() {
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        // Foreground event — user has interacted with this window.
+        let _ = update(
+            &mut state,
+            Command::ReportHwndForegroundChanged { hwnd: 0xAA },
+            &c,
+        );
+        // User then drags it off-monitor (legitimate state).
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xAA,
+                rect: Rect { left: -5000, top: -5000, right: -4000, bottom: -4000 },
+            },
+            &c,
+        );
+        // Drift fires — operator should still see it.
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. })),
+            "drift should fire even for user-touched windows, got {:?}", evs
+        );
+        // BUT no corrective — we trust the user.
+        assert!(
+            !evs.iter().any(|e| matches!(e, Event::CorrectiveWindowMove { .. })),
+            "corrective must NOT fire after user has foregrounded the window, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn wrr_off_monitor_with_no_known_monitors_emits_neither() {
+        // No `ReportMonitorTopologyChanged` => state.monitors is
+        // empty => we don't know what "off-monitor" means yet.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportHwndOpened {
+                hwnd: 0xAA,
+                class_name: "Chrome_WidgetWin_1".into(),
+                title: "".into(),
+                label_hint: Some("w1".into()),
+            },
+            &c,
+        );
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xAA,
+                rect: Rect { left: -5000, top: -5000, right: -4000, bottom: -4000 },
+            },
+            &c,
+        );
+        assert!(
+            evs.is_empty(),
+            "no monitors known => no drift, no corrective; got {:?}", evs
+        );
     }
 }

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -24,7 +24,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use agentmux_common::ipc::{ClientKind, WindowKind};
+use agentmux_common::ipc::{ClientKind, Rect, WindowKind};
 pub use agentmux_common::ipc::LifecyclePhase;
 
 /// Lifecycle of a single process the launcher knows about. The
@@ -66,6 +66,17 @@ pub struct ProcessRecord {
 /// is the launcher's clock at the time the report arrived (RFC3339)
 /// — useful for correlating launcher logs with host logs across
 /// version skew.
+///
+/// Phase B.9.1 (WRR) — the observability axis (`hwnd`, `visible`,
+/// `iconic`, `last_rect`, `last_foreground_at_ms`,
+/// `foregrounded_since_open`) is populated by the host's Win32
+/// event hooks. Pre-B.9 these all sit at default values, which is
+/// fine: the WRR drift checks only fire when at least one of the
+/// `ReportHwnd*` Commands arrives, and they don't arrive in
+/// `task dev` mode (no launcher → no IPC) or installed mode until
+/// the host-side hooks land. Existing reducer paths
+/// (`ReportWindowOpened`, `ReportWindowClosed`, etc.) ignore these
+/// fields entirely.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WindowMirror {
     pub label: String,
@@ -75,6 +86,28 @@ pub struct WindowMirror {
     /// has the parent linkage.
     pub parent_label: Option<String>,
     pub opened_at: String,
+    /// Phase B.9.1 — Win32 HWND linked to this label by the WRR
+    /// reducer arm (via `ReportHwndOpened` with matching
+    /// `label_hint` or via the post-hoc reconciliation against
+    /// `pending_hwnds`). `None` until the host's
+    /// `ReportHwndOpened` for this label arrives.
+    pub hwnd: Option<u64>,
+    /// Phase B.9.1 — last-known `IsWindowVisible` state.
+    pub visible: bool,
+    /// Phase B.9.1 — last-known minimized state.
+    pub iconic: bool,
+    /// Phase B.9.1 — last-known window rect. `None` until the
+    /// first `ReportHwndPositionChanged` arrives for the linked
+    /// HWND.
+    pub last_rect: Option<Rect>,
+    /// Phase B.9.1 — milliseconds-since-launcher-start of the most
+    /// recent `ReportHwndForegroundChanged` for this label's HWND.
+    /// `None` if the window has never been foregrounded.
+    pub last_foreground_at_ms: Option<u64>,
+    /// Phase B.9.1 — has this label been foregrounded at any point
+    /// since its `ReportWindowOpened`? Used to fire `HiddenSinceOpen`
+    /// drift on the first hide event when this is still false.
+    pub foregrounded_since_open: bool,
 }
 
 /// Top-level launcher state. Single Arc<Mutex<State>> owned by the
@@ -128,6 +161,46 @@ pub struct State {
     pub event_version: u64,
     /// Monotonic counter for client_id (returned in Registered events).
     pub next_client_id: u64,
+    /// Phase B.9.1 (WRR) — current monitor topology, replaced
+    /// wholesale on `ReportMonitorTopologyChanged`. Empty by default
+    /// until the host's `wrr/wndproc.rs` reports the first
+    /// `WM_DISPLAYCHANGE`-equivalent (or its initial topology probe
+    /// at startup). `OffMonitor` drift is suppressed when this is
+    /// empty — we don't know enough to classify yet.
+    pub monitors: Vec<Rect>,
+    /// Phase B.9.1 — HWNDs the reducer has seen via `ReportHwndOpened`
+    /// but couldn't yet associate with a `WindowMirror`. Three
+    /// reasons an entry lives here transiently:
+    ///   1. The OS create event raced ahead of the host's
+    ///      `OnAfterCreated` → `ReportWindowOpened` chain.
+    ///   2. The host couldn't determine `label_hint` at create time.
+    ///   3. The HWND belongs to a pool window not yet promoted.
+    /// Drained on each `ReportWindowOpened` (we try to match a
+    /// pending HWND by `label_hint`/timing). Anything still here
+    /// after a follow-up event is classified as `HwndWithoutBrowser`.
+    pub pending_hwnds: HashMap<u64, PendingHwnd>,
+    /// Phase B.9.1 — milliseconds since launcher start, used as the
+    /// monotonic clock for WRR observability timestamps. Set to
+    /// `None` until `Ctx` injects the first now-value; the reducer
+    /// updates it on every dispatch. Distinct from `event_version`
+    /// (causality counter) because operators reading `--diag wrr`
+    /// want wall-clock-ish age, not event count.
+    pub launcher_start_ms: Option<u64>,
+}
+
+/// Phase B.9.1 — transient HWND record held until the reducer can
+/// link it to a `WindowMirror`. See `State::pending_hwnds`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingHwnd {
+    pub class_name: String,
+    pub title: String,
+    pub label_hint: Option<String>,
+    /// Milliseconds-since-launcher-start when the
+    /// `ReportHwndOpened` arrived. Used to age out pending entries
+    /// — if we still have it when a *different* event arrives that
+    /// should have caused reconciliation, classify as
+    /// `HwndWithoutBrowser`.
+    pub arrived_at_ms: u64,
 }
 
 impl Default for State {
@@ -146,6 +219,9 @@ impl Default for State {
             backend_window_ids: HashMap::new(),
             event_version: 0,
             next_client_id: 1,
+            monitors: Vec::new(),
+            pending_hwnds: HashMap::new(),
+            launcher_start_ms: None,
         }
     }
 }

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -144,10 +144,20 @@ pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64) -> Vec<Event> {
         // what CEF thinks. Future `ReportWindowClosed` for the
         // label will be a no-op (closed-on-missing is silently
         // tolerated upstream).
+        //
+        // Emit the SAME shutdown events the normal close path
+        // (`handle_report_window_closed`) would emit:
+        // `WindowClosed` (so subscribers prune mirrors / atoms)
+        // and `WindowInstanceReleased` (so the InstancePanel
+        // count drops). Without these the frontend would show a
+        // stale window after a renderer crash. Order: drift first
+        // (so logs lead with "this is bad"), then the shutdown
+        // events. (reagent #600 P1.)
         let _ = state.windows.remove(&label);
-        let _ = state.instance_registry.remove(&label);
-        let v = state.bump_version();
-        return vec![Event::HwndDriftDetected {
+        let released_num = state.instance_registry.remove(&label);
+        let _ = state.backend_window_ids.remove(&label);
+        let v_drift = state.bump_version();
+        let drift = Event::HwndDriftDetected {
             kind: HwndDriftKind::OrphanDestroy,
             label: Some(label.clone()),
             hwnd: Some(hwnd),
@@ -156,8 +166,23 @@ pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64) -> Vec<Event> {
                 label
             ),
             severity: severity_for(HwndDriftKind::OrphanDestroy),
-            version: v,
-        }];
+            version: v_drift,
+        };
+        let v_closed = state.bump_version();
+        let closed = Event::WindowClosed {
+            label: label.clone(),
+            version: v_closed,
+        };
+        let mut out = vec![drift, closed];
+        if let Some(num) = released_num {
+            let v_released = state.bump_version();
+            out.push(Event::WindowInstanceReleased {
+                label,
+                num,
+                version: v_released,
+            });
+        }
+        return out;
     }
 
     // Case 1 (or: HWND was already removed from a mirror by a

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -75,6 +75,16 @@ pub fn apply_hwnd_opened(
                 mirror.hwnd = Some(hwnd);
                 HwndOpenedOutcome::Linked
             }
+            Some(mirror) if mirror.hwnd == Some(hwnd) => {
+                // Same HWND already linked. This is a benign
+                // duplicate from the dual-source design: WinEvent
+                // CREATE hook reports first (label_hint=None,
+                // pending), then `on_after_created` reports
+                // explicitly (label_hint=Some, this path). Or
+                // vice versa under timing variation. No-op,
+                // no drift. (codex #600 P2.)
+                HwndOpenedOutcome::Linked
+            }
             Some(mirror) => {
                 HwndOpenedOutcome::DoubleLinkedWith(mirror.hwnd.unwrap_or(0))
             }
@@ -89,7 +99,7 @@ pub fn apply_hwnd_opened(
                     label: Some(label.to_string()),
                     hwnd: Some(hwnd),
                     detail: format!(
-                        "ReportHwndOpened label_hint={} already linked to hwnd={}",
+                        "ReportHwndOpened label_hint={} already linked to a different hwnd={}",
                         label, existing
                     ),
                     severity: severity_for(HwndDriftKind::HwndWithoutBrowser),

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -70,9 +70,20 @@ pub fn apply_hwnd_opened(
         // it before calling `state.bump_version()` (which needs &mut
         // self on State). Result tells us which branch to take
         // outside the borrow.
+        //
+        // `drain_pending` is set when the link succeeds so we can
+        // remove a matching stale `pending_hwnds` entry AFTER
+        // releasing the mirror borrow. The dual-source design
+        // (WinEvent CREATE + on_after_created) can leave a stale
+        // pending entry; without draining it,
+        // `apply_hwnd_destroyed` would early-return on the
+        // stale entry and skip the orphan-destroy chain.
+        // (reagent #600 P1.)
+        let mut drain_pending = false;
         let outcome: HwndOpenedOutcome = match state.windows.get_mut(label) {
             Some(mirror) if mirror.hwnd.is_none() => {
                 mirror.hwnd = Some(hwnd);
+                drain_pending = true;
                 HwndOpenedOutcome::Linked
             }
             Some(mirror) if mirror.hwnd == Some(hwnd) => {
@@ -83,6 +94,12 @@ pub fn apply_hwnd_opened(
                 // explicitly (label_hint=Some, this path). Or
                 // vice versa under timing variation. No-op,
                 // no drift. (codex #600 P2.)
+                //
+                // Drain any matching stale pending entry. Without
+                // this, `apply_hwnd_destroyed` would early-return
+                // on the stale pending entry instead of running
+                // the orphan-destroy chain. (reagent #600 P1.)
+                drain_pending = true;
                 HwndOpenedOutcome::Linked
             }
             Some(mirror) => {
@@ -90,6 +107,9 @@ pub fn apply_hwnd_opened(
             }
             None => HwndOpenedOutcome::NoMatchingLabel,
         };
+        if drain_pending {
+            state.pending_hwnds.remove(&hwnd);
+        }
         match outcome {
             HwndOpenedOutcome::Linked => return vec![],
             HwndOpenedOutcome::DoubleLinkedWith(existing) => {
@@ -136,10 +156,13 @@ pub fn apply_hwnd_opened(
 ///   3. HWND was pending (never linked) → drop the pending entry,
 ///      no drift (it never claimed to be a real window).
 pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64) -> Vec<Event> {
-    // Case 3: pending → just drop.
-    if state.pending_hwnds.remove(&hwnd).is_some() {
-        return vec![];
-    }
+    // Drain any pending entry first. Don't early-return: the
+    // dual-source design (WinEvent CREATE + explicit
+    // on_after_created link) can leave a stale pending entry
+    // co-existing with a linked mirror — we still need to run
+    // the mirror check below to fire the orphan-destroy chain
+    // on a renderer crash. (reagent #600 P1.)
+    let _ = state.pending_hwnds.remove(&hwnd);
 
     // Find the label whose mirror is linked to this HWND, if any.
     let orphan_label: Option<String> = state

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -232,25 +232,74 @@ pub fn apply_hwnd_iconic_changed(state: &mut State, hwnd: u64, iconic: bool) -> 
 /// the topology — first `ReportMonitorTopologyChanged` will
 /// reconcile every label's `last_rect` against fresh monitors).
 pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect) -> Vec<Event> {
-    let mut drift: Vec<Event> = Vec::new();
+    let mut events: Vec<Event> = Vec::new();
     let monitors = state.monitors.clone();
-    let label_for_drift: Option<String> = state
+
+    // Phase B.9.1 diagnostic — single line per position event so
+    // operators can correlate with host-side hook activity.
+    let linked_label_diag: Option<String> = state
+        .windows
+        .iter()
+        .find(|(_, m)| m.hwnd == Some(hwnd))
+        .map(|(label, _)| label.clone());
+    crate::log(&format!(
+        "[ipc] WRR-POS hwnd={:#x} rect=({},{})-({},{}) linked={:?} monitors={} pending={}",
+        hwnd, new_rect.left, new_rect.top, new_rect.right, new_rect.bottom,
+        linked_label_diag, monitors.len(), state.pending_hwnds.len()
+    ));
+
+    // Sentinel-aware drift suppression: CEF Views creates Win32
+    // top-level windows at the (-32000,-32000) / (-31970,-31970)
+    // hidden-sentinel positions for a brief moment between
+    // CreateWindow and the first SetWindowPos that places them.
+    // Firing OffMonitor on every window's open transient produces
+    // log noise without surfacing a real bug. Suppress drift for
+    // these positions; if the window stays at the sentinel
+    // (genuine bug), the *follow-up* event that lands at a
+    // non-sentinel off-monitor position WILL fire — and if it
+    // never moves, the corrective branch below acts on the FIRST
+    // sentinel report (since the foregrounded_since_open guard
+    // catches it).
+    let is_sentinel = is_win32_hidden_sentinel(&new_rect);
+
+    // Resolve the mirror: collect everything we need from a scoped
+    // borrow, then release it before calling `state.bump_version()`
+    // (rustc E0499 — same trick as `apply_hwnd_opened`).
+    struct Resolved {
+        label: String,
+        off_monitor: bool,
+        foregrounded_since_open: bool,
+    }
+    let resolved: Option<Resolved> = state
         .windows
         .iter_mut()
         .find(|(_, m)| m.hwnd == Some(hwnd))
-        .and_then(|(label, mirror)| {
+        .map(|(label, mirror)| {
             mirror.last_rect = Some(new_rect);
-            if !monitors.is_empty() && !rect::intersects_any(&new_rect, &monitors) {
-                Some(label.clone())
-            } else {
-                None
+            let off_monitor =
+                !monitors.is_empty() && !rect::intersects_any(&new_rect, &monitors);
+            Resolved {
+                label: label.clone(),
+                off_monitor,
+                foregrounded_since_open: mirror.foregrounded_since_open,
             }
         });
-    if let Some(label) = label_for_drift {
+
+    let Some(r) = resolved else {
+        return events;
+    };
+
+    if !r.off_monitor {
+        return events;
+    }
+
+    // Window is off all monitors. Fire drift unless we're in the
+    // open-transient sentinel state (per above).
+    if !is_sentinel {
         let v = state.bump_version();
-        drift.push(Event::HwndDriftDetected {
+        events.push(Event::HwndDriftDetected {
             kind: HwndDriftKind::OffMonitor,
-            label: Some(label),
+            label: Some(r.label.clone()),
             hwnd: Some(hwnd),
             detail: format!(
                 "Window rect ({},{})-({},{}) does not intersect any of {} monitors",
@@ -261,7 +310,65 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
             version: v,
         });
     }
-    drift
+
+    // Phase B.9.2 — pure-reducer self-heal. If the window has
+    // never been foregrounded, this off-monitor state is from the
+    // open transition (NOT user action), so we emit a corrective
+    // move. The host's WRR subscriber applies it via SetWindowPos
+    // on the UI thread. The Win32 hidden sentinel is INCLUDED in
+    // the corrective trigger (we always want to move a window off
+    // the sentinel before the user notices), even though it's
+    // suppressed for drift to avoid log noise.
+    if !r.foregrounded_since_open {
+        if let Some(target) = pick_primary_centered(&monitors) {
+            let v = state.bump_version();
+            events.push(Event::CorrectiveWindowMove {
+                hwnd,
+                target_rect: target,
+                reason: HwndDriftKind::OffMonitor,
+                version: v,
+            });
+        }
+    }
+
+    events
+}
+
+/// Phase B.9.1 — Win32 sentinel positions for "this window is
+/// hidden." CEF parks new windows here briefly between create
+/// and first paint; same value family (`SW_HIDE` analog used by
+/// `ITaskbarList::DeleteTab` removed windows). We suppress drift
+/// emission for these but DO trigger corrective move (the user
+/// shouldn't see the sentinel).
+fn is_win32_hidden_sentinel(r: &Rect) -> bool {
+    // Both classic ((-32000,-32000)) and the (-31970, -31970)
+    // CEF-Views variant. Plus a generous epsilon for either
+    // axis since the bottom-right corner is offset by a default
+    // window size (e.g. (-31840,-31972)).
+    (r.left <= -31000 && r.top <= -31000) || (r.right <= -31000 && r.bottom <= -31000)
+}
+
+/// Phase B.9.2 — pick a corrective target rect: centered on the
+/// first monitor at a sensible default size (1280x800 or 70% of
+/// monitor, whichever is smaller). `None` if the monitor list is
+/// empty (caller suppresses corrective in that case).
+fn pick_primary_centered(monitors: &[Rect]) -> Option<Rect> {
+    let primary = monitors.first()?;
+    let mw = primary.right - primary.left;
+    let mh = primary.bottom - primary.top;
+    if mw <= 0 || mh <= 0 {
+        return None;
+    }
+    let w = std::cmp::min(1280, (mw as f32 * 0.7) as i32);
+    let h = std::cmp::min(800, (mh as f32 * 0.7) as i32);
+    let cx = primary.left + (mw - w) / 2;
+    let cy = primary.top + (mh - h) / 2;
+    Some(Rect {
+        left: cx,
+        top: cy,
+        right: cx + w,
+        bottom: cy + h,
+    })
 }
 
 /// Phase B.9.1 — handle `Command::ReportMonitorTopologyChanged`.

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -1,0 +1,329 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — Window Reality Reconciliation (WRR) reducer arm.
+//
+// Catches the class of bug surfaced during the B.6.1 smoke test:
+// a CEF browser opens, gets a Win32 HWND, and is then "lost" to
+// the user (off-screen, behind another window, never foregrounded).
+// The pre-B.9 reducer tracked identity (`label`, `kind`, `parent`)
+// but not observability (visible? on-monitor? has the user seen
+// it?), so its drift detector compared `host.browsers.len() ==
+// launcher.windows.len()` — both can be in lockstep wrong about
+// Win32 reality.
+//
+// Design lives at `docs/retro/wrr-design-2026-04-28.md`. This
+// module implements the launcher-side reducer arm:
+//
+//   * `apply_*` functions: one per `Command::ReportHwnd*` /
+//     `ReportMonitorTopologyChanged`. Each mutates `State` and
+//     emits `Event::HwndDriftDetected` for every classification
+//     it can determine at this transition.
+//   * `severity_for(kind)`: the per-kind severity floor classifier.
+//
+// Pure event-driven. There is no clock task, no heartbeat — drift
+// is emitted at the moment the OS-driven Command is dispatched
+// through the reducer. See the design doc for the trade-off ("we
+// don't catch steady-state staleness without an event").
+
+use agentmux_common::ipc::{Event, HwndDriftKind, Rect, Severity};
+
+use crate::state::{PendingHwnd, State};
+
+pub mod rect;
+
+/// Internal — the three branches of `apply_hwnd_opened` against a
+/// known `label_hint`. Lifted into its own enum so the function
+/// can drop the `&mut WindowMirror` borrow before calling
+/// `state.bump_version()` on the `Linked`-double-link path
+/// (rustc E0499).
+enum HwndOpenedOutcome {
+    /// Existing mirror was waiting for an HWND; linked successfully.
+    Linked,
+    /// Existing mirror was already linked to a different HWND. Carry
+    /// the prior HWND for the drift message.
+    DoubleLinkedWith(u64),
+    /// No mirror exists for that label — fall through to pending
+    /// stash (caller responsibility).
+    NoMatchingLabel,
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndOpened`. Either:
+///   1. The hwnd's `label_hint` matches an existing
+///      `state.windows[label]` whose `hwnd` is `None` → link them.
+///   2. No matching label → stash in `state.pending_hwnds` for a
+///      later reconciliation. If the class name doesn't look like
+///      an AgentMux window (filtered at the host hook, but
+///      defense-in-depth here too), don't even stash.
+pub fn apply_hwnd_opened(
+    state: &mut State,
+    hwnd: u64,
+    class_name: String,
+    title: String,
+    label_hint: Option<String>,
+    now_ms: u64,
+) -> Vec<Event> {
+    // Case 1: label_hint maps to an existing WindowMirror that's
+    // waiting for an HWND. Happy path — link them, no drift.
+    if let Some(label) = label_hint.as_deref() {
+        // Read mirror state via a scoped borrow so we can release
+        // it before calling `state.bump_version()` (which needs &mut
+        // self on State). Result tells us which branch to take
+        // outside the borrow.
+        let outcome: HwndOpenedOutcome = match state.windows.get_mut(label) {
+            Some(mirror) if mirror.hwnd.is_none() => {
+                mirror.hwnd = Some(hwnd);
+                HwndOpenedOutcome::Linked
+            }
+            Some(mirror) => {
+                HwndOpenedOutcome::DoubleLinkedWith(mirror.hwnd.unwrap_or(0))
+            }
+            None => HwndOpenedOutcome::NoMatchingLabel,
+        };
+        match outcome {
+            HwndOpenedOutcome::Linked => return vec![],
+            HwndOpenedOutcome::DoubleLinkedWith(existing) => {
+                let v = state.bump_version();
+                return vec![Event::HwndDriftDetected {
+                    kind: HwndDriftKind::HwndWithoutBrowser,
+                    label: Some(label.to_string()),
+                    hwnd: Some(hwnd),
+                    detail: format!(
+                        "ReportHwndOpened label_hint={} already linked to hwnd={}",
+                        label, existing
+                    ),
+                    severity: severity_for(HwndDriftKind::HwndWithoutBrowser),
+                    version: v,
+                }];
+            }
+            HwndOpenedOutcome::NoMatchingLabel => { /* fall through to pending */ }
+        }
+    }
+
+    // Case 2: stash as pending. Filtered class names get dropped
+    // here too as belt-and-suspenders — host hook is the primary
+    // filter (see `wrr/classify.rs::is_app_class` in agentmux-cef).
+    state.pending_hwnds.insert(
+        hwnd,
+        PendingHwnd {
+            class_name,
+            title,
+            label_hint,
+            arrived_at_ms: now_ms,
+        },
+    );
+    vec![]
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndDestroyed`. Three
+/// outcomes:
+///   1. HWND links to a `WindowMirror` AND we already received a
+///      `ReportWindowClosed` for that label (mirror is gone) →
+///      no drift, expected ordering.
+///   2. HWND links to a `WindowMirror` that's STILL in
+///      `state.windows` → CEF didn't report close yet. Renderer
+///      probably crashed → `OrphanDestroy` drift.
+///   3. HWND was pending (never linked) → drop the pending entry,
+///      no drift (it never claimed to be a real window).
+pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64) -> Vec<Event> {
+    // Case 3: pending → just drop.
+    if state.pending_hwnds.remove(&hwnd).is_some() {
+        return vec![];
+    }
+
+    // Find the label whose mirror is linked to this HWND, if any.
+    let orphan_label: Option<String> = state
+        .windows
+        .iter()
+        .find(|(_, m)| m.hwnd == Some(hwnd))
+        .map(|(label, _)| label.clone());
+
+    if let Some(label) = orphan_label {
+        // Case 2: orphan destroy. Clear the link AND the mirror
+        // entry — the window is gone from Win32, regardless of
+        // what CEF thinks. Future `ReportWindowClosed` for the
+        // label will be a no-op (closed-on-missing is silently
+        // tolerated upstream).
+        let _ = state.windows.remove(&label);
+        let _ = state.instance_registry.remove(&label);
+        let v = state.bump_version();
+        return vec![Event::HwndDriftDetected {
+            kind: HwndDriftKind::OrphanDestroy,
+            label: Some(label.clone()),
+            hwnd: Some(hwnd),
+            detail: format!(
+                "HWND destroyed without preceding ReportWindowClosed for label={}",
+                label
+            ),
+            severity: severity_for(HwndDriftKind::OrphanDestroy),
+            version: v,
+        }];
+    }
+
+    // Case 1 (or: HWND was already removed from a mirror by a
+    // prior `WindowClosed`, then this destroy is the natural
+    // follow-up). No drift.
+    vec![]
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndVisibilityChanged`.
+/// Drift fires only on `visible=false` for a known label that has
+/// not been foregrounded since open: the user can't see this
+/// window and never has.
+pub fn apply_hwnd_visibility_changed(
+    state: &mut State,
+    hwnd: u64,
+    visible: bool,
+) -> Vec<Event> {
+    let mut drift: Option<Event> = None;
+    let mut version_to_bump = false;
+    let label_for_drift: Option<String> = state
+        .windows
+        .iter_mut()
+        .find(|(_, m)| m.hwnd == Some(hwnd))
+        .and_then(|(label, mirror)| {
+            mirror.visible = visible;
+            if !visible && !mirror.foregrounded_since_open {
+                version_to_bump = true;
+                Some(label.clone())
+            } else {
+                None
+            }
+        });
+    if version_to_bump {
+        let v = state.bump_version();
+        drift = Some(Event::HwndDriftDetected {
+            kind: HwndDriftKind::HiddenSinceOpen,
+            label: label_for_drift,
+            hwnd: Some(hwnd),
+            detail: "Window hidden without ever being foregrounded since open".to_string(),
+            severity: severity_for(HwndDriftKind::HiddenSinceOpen),
+            version: v,
+        });
+    }
+    drift.into_iter().collect()
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndForegroundChanged`.
+/// Updates the "has been seen" flag. Never emits drift directly
+/// — its role is to suppress future `HiddenSinceOpen` emissions.
+pub fn apply_hwnd_foreground_changed(state: &mut State, hwnd: u64, now_ms: u64) -> Vec<Event> {
+    if let Some((_, mirror)) = state.windows.iter_mut().find(|(_, m)| m.hwnd == Some(hwnd)) {
+        mirror.foregrounded_since_open = true;
+        mirror.last_foreground_at_ms = Some(now_ms);
+    }
+    vec![]
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndIconicChanged`. Updates
+/// state. No drift directly — operator can read steady state via
+/// `--diag wrr` (B.9.2) if they want to see who's minimized.
+pub fn apply_hwnd_iconic_changed(state: &mut State, hwnd: u64, iconic: bool) -> Vec<Event> {
+    if let Some((_, mirror)) = state.windows.iter_mut().find(|(_, m)| m.hwnd == Some(hwnd)) {
+        mirror.iconic = iconic;
+    }
+    vec![]
+}
+
+/// Phase B.9.1 — handle `Command::ReportHwndPositionChanged`.
+/// Compares the new rect against `state.monitors`; emits
+/// `OffMonitor` drift if it doesn't intersect any monitor.
+/// Suppressed when `state.monitors` is empty (we don't yet know
+/// the topology — first `ReportMonitorTopologyChanged` will
+/// reconcile every label's `last_rect` against fresh monitors).
+pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect) -> Vec<Event> {
+    let mut drift: Vec<Event> = Vec::new();
+    let monitors = state.monitors.clone();
+    let label_for_drift: Option<String> = state
+        .windows
+        .iter_mut()
+        .find(|(_, m)| m.hwnd == Some(hwnd))
+        .and_then(|(label, mirror)| {
+            mirror.last_rect = Some(new_rect);
+            if !monitors.is_empty() && !rect::intersects_any(&new_rect, &monitors) {
+                Some(label.clone())
+            } else {
+                None
+            }
+        });
+    if let Some(label) = label_for_drift {
+        let v = state.bump_version();
+        drift.push(Event::HwndDriftDetected {
+            kind: HwndDriftKind::OffMonitor,
+            label: Some(label),
+            hwnd: Some(hwnd),
+            detail: format!(
+                "Window rect ({},{})-({},{}) does not intersect any of {} monitors",
+                new_rect.left, new_rect.top, new_rect.right, new_rect.bottom,
+                monitors.len()
+            ),
+            severity: severity_for(HwndDriftKind::OffMonitor),
+            version: v,
+        });
+    }
+    drift
+}
+
+/// Phase B.9.1 — handle `Command::ReportMonitorTopologyChanged`.
+/// Replaces `state.monitors` wholesale, then re-evaluates every
+/// known mirror's `last_rect` against the new set. Emits
+/// `OffMonitor` for any window that newly falls off (e.g. user
+/// unplugged the external display where the window lived).
+pub fn apply_monitor_topology_changed(state: &mut State, rects: Vec<Rect>) -> Vec<Event> {
+    state.monitors = rects;
+    let monitors = state.monitors.clone();
+    if monitors.is_empty() {
+        // Headless / fully-disconnected — suppress drift; nothing
+        // is "off" if there's no "on".
+        return vec![];
+    }
+    let mut events: Vec<Event> = Vec::new();
+    let stranded: Vec<(String, u64, Rect)> = state
+        .windows
+        .iter()
+        .filter_map(|(label, mirror)| {
+            let r = mirror.last_rect?;
+            let h = mirror.hwnd?;
+            if rect::intersects_any(&r, &monitors) {
+                None
+            } else {
+                Some((label.clone(), h, r))
+            }
+        })
+        .collect();
+    for (label, hwnd, rect) in stranded {
+        let v = state.bump_version();
+        events.push(Event::HwndDriftDetected {
+            kind: HwndDriftKind::OffMonitor,
+            label: Some(label),
+            hwnd: Some(hwnd),
+            detail: format!(
+                "Monitor topology change stranded window at ({},{})-({},{})",
+                rect.left, rect.top, rect.right, rect.bottom
+            ),
+            severity: severity_for(HwndDriftKind::OffMonitor),
+            version: v,
+        });
+    }
+    events
+}
+
+/// Phase B.9.1 — per-kind severity classifier. The split is
+/// deliberate: `OrphanDestroy` and `HwndWithoutBrowser` indicate a
+/// real divergence between CEF identity and Win32 reality (a CEF
+/// bug or a missed report path) — ERROR. `OffMonitor`,
+/// `HiddenSinceOpen`, `LingeringHwnd` are operationally
+/// significant (user can't see / use the window) but don't
+/// indicate a state-machine bug — WARN. `BrowserWithoutHwnd` is
+/// commonly transient (race window between OS create and host
+/// link) — INFO; only meaningful if it doesn't reconcile.
+pub fn severity_for(kind: HwndDriftKind) -> Severity {
+    match kind {
+        HwndDriftKind::OrphanDestroy => Severity::Error,
+        HwndDriftKind::HwndWithoutBrowser => Severity::Error,
+        HwndDriftKind::OffMonitor => Severity::Warn,
+        HwndDriftKind::HiddenSinceOpen => Severity::Warn,
+        HwndDriftKind::LingeringHwnd => Severity::Warn,
+        HwndDriftKind::BrowserWithoutHwnd => Severity::Info,
+    }
+}

--- a/agentmux-launcher/src/wrr/rect.rs
+++ b/agentmux-launcher/src/wrr/rect.rs
@@ -1,0 +1,94 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.9.1 — rectangle math for monitor-membership classification.
+//
+// Win32 `RECT` semantics: `right` and `bottom` are one past the
+// last included pixel, so two rects intersect iff they overlap on
+// both axes after the half-open boundary check. Empty rects
+// (zero area) never intersect anything by definition.
+
+use agentmux_common::ipc::Rect;
+
+/// Phase B.9.1 — does `r` overlap with `m`? Half-open semantics.
+pub fn intersects(r: &Rect, m: &Rect) -> bool {
+    if r.left >= r.right || r.top >= r.bottom {
+        return false;
+    }
+    if m.left >= m.right || m.top >= m.bottom {
+        return false;
+    }
+    r.left < m.right && r.right > m.left && r.top < m.bottom && r.bottom > m.top
+}
+
+/// Phase B.9.1 — does `r` overlap with at least one monitor in
+/// `monitors`? Empty `monitors` returns `false` — no monitors,
+/// nothing to be "on".
+pub fn intersects_any(r: &Rect, monitors: &[Rect]) -> bool {
+    monitors.iter().any(|m| intersects(r, m))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(l: i32, t: i32, r: i32, b: i32) -> Rect {
+        Rect { left: l, top: t, right: r, bottom: b }
+    }
+
+    #[test]
+    fn fully_inside_intersects() {
+        let mon = rect(0, 0, 1920, 1080);
+        let win = rect(100, 100, 800, 600);
+        assert!(intersects(&win, &mon));
+    }
+
+    #[test]
+    fn touching_edge_does_not_intersect() {
+        // Half-open: `right == left` of the next means no overlap.
+        let mon = rect(0, 0, 1920, 1080);
+        let win = rect(1920, 100, 2920, 600);
+        assert!(!intersects(&win, &mon));
+    }
+
+    #[test]
+    fn fully_off_screen_no_intersect() {
+        let mon = rect(0, 0, 1920, 1080);
+        let off = rect(-9999, -9999, -9000, -9000);
+        assert!(!intersects(&off, &mon));
+    }
+
+    #[test]
+    fn intersects_any_picks_correct_monitor() {
+        let monitors = vec![
+            rect(0, 0, 1920, 1080),       // primary
+            rect(1920, 0, 3840, 1080),    // secondary right
+        ];
+        let win = rect(2000, 100, 2500, 600);
+        assert!(intersects_any(&win, &monitors));
+    }
+
+    #[test]
+    fn empty_monitors_returns_false() {
+        let win = rect(100, 100, 200, 200);
+        assert!(!intersects_any(&win, &[]));
+    }
+
+    #[test]
+    fn empty_rect_never_intersects() {
+        let mon = rect(0, 0, 1920, 1080);
+        let zero = rect(100, 100, 100, 100);
+        assert!(!intersects(&zero, &mon));
+    }
+
+    #[test]
+    fn cross_monitor_window_intersects_one() {
+        // Window straddling two monitors picks up at least one.
+        let monitors = vec![
+            rect(0, 0, 1920, 1080),
+            rect(1920, 0, 3840, 1080),
+        ];
+        let straddle = rect(1800, 100, 2200, 600);
+        assert!(intersects_any(&straddle, &monitors));
+    }
+}

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.487"
+version = "0.33.488"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.488"
+version = "0.33.489"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.485"
+version = "0.33.486"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.486"
+version = "0.33.487"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.482"
+version = "0.33.483"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.483"
+version = "0.33.484"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.484"
+version = "0.33.485"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -39,9 +39,12 @@ Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
                         │
                         ▼
               ✓ B.7.1 — entries-bearing window-instances-changed (#596)
-                        │
                         ▼
-              ◄── HERE. B.7.2 in flight: windowId-reemit.
+              ✓ B.7.2 — re-emit on BackendWindowId events (#597)
+                        ▼
+              ◄── HERE. B.9.1 in flight: WRR observation.
+                  (B.7.3 / B.8 deferred — B.9 jumped queue per
+                  user direction after stray-taskbar surface.)
               B.7  ──  frontend cutover (delete polling)
               B.8  ──  Phase B exit (delete obsolete defensive code,
                        add property tests, --diag tool, CI smoke)
@@ -72,10 +75,16 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 
 - Scaffolding-role comments added to `state.browsers`, `window_pool`, `unpromoted_pool_labels`, and `compute_and_report_host_counts` so future agents see why these fields don't follow the standard ratchet and where they head in Phase F.
 
-### B.6 — single-instance mutex (done — PR #595, fix in B.6.1)
+### B.6 — single-instance mutex (done — PRs #595 + #598 + #599 + direct-to-main 2ffa63c5)
 
 - Launcher synchronously binds `first_pipe_instance(true)` BEFORE spawning srv/host. The pipe bind is the AUTHORITATIVE single-instance signal.
-- **B.6.1 fix**: on `ERROR_ACCESS_DENIED`, the second launcher reads `<data-dir>/ipc-port` (still written by the host post-CEF-init) and forwards an `open_new_window` HTTP POST to the existing instance, then exits 0. Mirrors the status-bar version popup's "new window" UX. The MessageBox path is reserved for genuine bind failures (namespace misconfig). Stale-state defect (gap #8) is bounded because pipe-bind happens first: a stale port file is irrelevant on the first-instance path (overwritten); on the second-instance path the live first instance wrote a fresh port:token, so forwarding lands.
+- On `ERROR_ACCESS_DENIED`, the second launcher reads `<launcher-shared-data-dir>/ipc-port` (written by the host post-CEF-init) and forwards an `open_new_window` HTTP POST to the existing instance, then exits 0. Mirrors the status-bar version popup's "new window" UX.
+- Three iterations to land it:
+  - **#598**: initial forward implementation; transient classification.
+  - **2ffa63c5** (direct-to-main, mistake — should have been a PR): port-file path was at the cef cache dir but launcher reads at the launcher-shared data dir.
+  - **#599**: read response after POST so the launcher's process exit doesn't tear down the TCP connection before axum's async handler runs.
+- The MessageBox path is reserved for genuine bind failures (namespace misconfig). Stale-state defect (gap #8) is bounded because pipe-bind happens first: a stale port file is irrelevant on the first-instance path (overwritten); on the second-instance path the live first instance wrote a fresh port:token, so forwarding lands.
+- Smoke verified on v0.33.482: second `agentmux.exe` launch yields one new window in the existing instance, no dialog. Launcher log + host log both confirm.
 
 ### B.7 — frontend cutover (2-3 PRs)
 

--- a/docs/retro/wrr-design-2026-04-28.md
+++ b/docs/retro/wrr-design-2026-04-28.md
@@ -1,0 +1,273 @@
+# Window Reality Reconciliation (WRR) — design
+
+**Status:** Design draft. Awaiting answers to open questions before B.9.1 implementation.
+**Author:** AgentA.
+**Date:** 2026-04-28 (post-#599 / B.6.1 saga).
+
+---
+
+## TL;DR
+
+Make Win32 HWND state a first-class signal in the launcher's reducer, fed by Win32's own event-publishing mechanisms (`SetWinEventHook` + `WM_WINDOWPOSCHANGED` / `WM_DISPLAYCHANGE`). No polling, no heartbeats. Every drift between CEF browser identity (already tracked) and Win32 reality (newly tracked) is classified at the moment the offending state transition fires and emitted as a typed `Event::HwndDriftDetected`. Phase B.9 ships observation only; Phase F adds self-healing.
+
+---
+
+## Why this exists
+
+### The bug that motivated it
+
+During the B.6.1 smoke-test session on 2026-04-28, manual `curl` against the live host's IPC server invoked `open_new_window`, which created a `FullInstance` CEF browser and Win32 taskbar entry. The window was not visible to the user (off-screen, behind the main window, or otherwise non-foregrounded). When the user later closed the main window, the curl-created secondary remained alive — a stray taskbar entry attached to no user-visible window.
+
+### Why the current state machine missed it
+
+The reducer in its post-B.5 form tracks **identity** but not **observability**:
+
+- `state.windows` (launcher mirror) tracks `{label, kind, parent_label}`.
+- `state.browsers` (host scaffolding) tracks the live CEF `Browser` handles by label.
+- `report_window_opened` / `report_window_closed` keep both sides in lockstep.
+
+The drift sensor (B.4b) compares **counts**: `host.browsers.len() == launcher.windows.len()`. Both sides can be **identically wrong about Win32 reality** — the curl-created window IS in `state.browsers` and IS in `state.windows`, so no drift fires. The user just can't see it.
+
+The structural gap: the reducer never observes Win32 HWNDs. Visibility, foreground status, position, monitor membership are all invisible to it. So is the existence of HWNDs that the host didn't create through its own `OnAfterCreated` path (none currently, but a defense-in-depth sensor would catch a bug class we haven't enumerated).
+
+---
+
+## Design goal
+
+Treat Win32 HWND state as a **first-class projection** in the launcher reducer. The reducer learns:
+- Which HWNDs exist in the host process.
+- Which CEF browser label each HWND belongs to.
+- Each HWND's visibility, iconic-state, last-foreground time, last-known rect.
+- The current monitor topology.
+
+Every change to any of those is dispatched through the existing IPC pipe as a typed `Command`. Drift between CEF identity (the existing `state.windows`) and Win32 reality is classified per-transition in the reducer and emitted as `Event::HwndDriftDetected`. Phase B keeps it observation-only; Phase F gates corrective action behind config.
+
+**Non-goal:** polling. The reducer never wakes up to scan state. Every emission is in response to a specific OS event the reducer received as a Command.
+
+---
+
+## Event sources (zero polling)
+
+Every transition we care about already fires a Win32 event we can hook synchronously. One `SetWinEventHook(WINEVENT_OUTOFCONTEXT)` install at host startup, one teardown at shutdown. Each callback is a pre-existing OS notification — no thread-pool worker waking on an interval, no timer.
+
+| Transition | OS event | Subscription |
+|---|---|---|
+| HWND created | `EVENT_OBJECT_CREATE` (objid=`OBJID_WINDOW`) | `SetWinEventHook(WINEVENT_OUTOFCONTEXT)` — process-local, no DLL injection |
+| HWND destroyed | `EVENT_OBJECT_DESTROY` | same hook |
+| Visibility changed | `EVENT_OBJECT_SHOW` / `EVENT_OBJECT_HIDE` | same hook |
+| Foreground / focus | `EVENT_SYSTEM_FOREGROUND` | same hook |
+| Min / restore | `EVENT_SYSTEM_MINIMIZESTART` / `EVENT_SYSTEM_MINIMIZEEND` | same hook |
+| Move / resize | `WM_WINDOWPOSCHANGED` | wrap host's existing wndproc |
+| Monitor topology change | `WM_DISPLAYCHANGE` | wrap host's existing wndproc |
+| CEF browser create / close | `OnAfterCreated` / `OnBeforeClose` | already hooked (B.4) |
+
+`SetWinEventHook` with `WINEVENT_OUTOFCONTEXT` runs the callback on the calling thread of the hooking process — no DLL injection into other processes, no extra threads. We filter to the host process's PID via the `idProcess` parameter.
+
+---
+
+## State machine extension
+
+### New per-window state in the launcher
+
+```rust
+struct WindowState {
+    // Existing — identity
+    label: String,
+    kind: WindowKind,
+    parent_label: Option<String>,
+    // NEW — observability axis
+    hwnd: Option<u64>,                     // populated by HwndOpened
+    visible: bool,                         // last-known visibility
+    iconic: bool,                          // minimized?
+    last_rect: Option<Rect>,               // last-known position/size
+    last_foreground_at_ms: Option<u64>,    // ms since launcher start
+}
+```
+
+### New global state
+
+```rust
+struct State {
+    // ... existing fields ...
+    // NEW
+    monitors: Vec<Rect>,                   // updated on TopologyChanged
+    /// HWNDs the reducer has seen but couldn't yet associate with a
+    /// label (transient: race between OS create event and CEF
+    /// `OnAfterCreated` reaching the reducer). Drained on each
+    /// reconciliation.
+    pending_hwnds: HashMap<u64, HwndPending>,
+}
+```
+
+### New IPC commands
+
+One per OS event, no aggregation. Wire types live in `agentmux-common::ipc`:
+
+```rust
+Command::ReportHwndOpened {
+    hwnd: u64,
+    class_name: String,
+    title: String,                         // GetWindowTextW snapshot at create
+    label_hint: Option<String>,            // host's best guess from
+                                           // pending_window_creations,
+                                           // None if it can't tell yet
+}
+Command::ReportHwndDestroyed { hwnd: u64 }
+Command::ReportHwndVisibilityChanged { hwnd: u64, visible: bool }
+Command::ReportHwndForegroundChanged { hwnd: u64 }    // "this hwnd is now FG"
+Command::ReportHwndIconicChanged { hwnd: u64, iconic: bool }
+Command::ReportHwndPositionChanged { hwnd: u64, rect: Rect }
+Command::ReportMonitorTopologyChanged { rects: Vec<Rect> }
+```
+
+### New IPC events
+
+```rust
+Event::HwndDriftDetected {
+    kind: HwndDriftKind,
+    label: Option<String>,
+    hwnd: Option<u64>,
+    detail: String,
+    severity: Severity,
+    version: u64,
+}
+
+enum HwndDriftKind {
+    /// state.windows has a label whose `hwnd` field never got
+    /// populated, AND a follow-up event arrived that should have
+    /// reconciled it. CEF says open, Win32 has no matching HWND.
+    BrowserWithoutHwnd,
+    /// HWND in the snapshot doesn't map to any state.windows /
+    /// state.pool label. Win32 has it, CEF didn't open it. The
+    /// "stray taskbar" case.
+    HwndWithoutBrowser,
+    /// HWND for a known label was never SHOWN since open and another
+    /// event has elapsed. User can't see it.
+    HiddenSinceOpen,
+    /// Window rect doesn't intersect any monitor in state.monitors.
+    /// Off-screen orphan.
+    OffMonitor,
+    /// HWND destroy event arrived without a preceding
+    /// ReportWindowClosed for the matching label. Renderer crashed,
+    /// took the HWND with it.
+    OrphanDestroy,
+    /// ReportWindowClosed arrived, but subsequent OS events for the
+    /// HWND keep firing (it never went away on the Win32 side).
+    LingeringHwnd,
+}
+
+enum Severity { Info, Warn, Error }
+```
+
+---
+
+## Drift classification — at event time, no tick
+
+Each emission below is **emitted only when a specific OS-driven Command is dispatched through the reducer**. The reducer never wakes up to scan state. All comparisons happen synchronously inside `update()` for the command that just arrived.
+
+| Scenario | Triggering Command | Reducer action |
+|---|---|---|
+| **Stray HWND** | `ReportHwndOpened { hwnd, class_name, label_hint }` where `label_hint` is None and there is no pending `state.windows` entry awaiting an HWND | Emit `HwndDriftDetected { kind: HwndWithoutBrowser, hwnd }` |
+| **Browser-without-HWND** | Any later event whose dispatch finds a `state.windows[label]` with `hwnd == None` long after `ReportWindowOpened` arrived (the host should have followed up with `ReportHwndOpened` in the same dispatch cycle) | Emit `BrowserWithoutHwnd` once (de-duplicated by label) |
+| **Off-monitor** | `ReportHwndPositionChanged { hwnd, rect }` where `rect` does not intersect any rect in `state.monitors`, OR `ReportMonitorTopologyChanged` that strands an existing window's last rect | Emit `OffMonitor` synchronously in the same `update()` |
+| **Hidden after open** | `ReportHwndVisibilityChanged { hwnd, visible: false }` AND no `ReportHwndForegroundChanged` had arrived for that hwnd between `ReportHwndOpened` and now | Emit `HiddenSinceOpen` |
+| **Destroy without close** | `ReportHwndDestroyed { hwnd }` where the matching label in `state.windows` has `hwnd == this hwnd` AND no preceding `ReportWindowClosed { label }` was processed | Emit `OrphanDestroy`; clean the entry |
+| **Close without destroy** | Any subsequent OS event for an HWND that no longer has a matching `state.windows` label (its label was already removed via `ReportWindowClosed`) | Emit `LingeringHwnd` |
+
+### What pure event-driven gives up
+
+Pure event-driven catches **transitions**, not steady-state oddities. Specifically:
+
+- "Window has been minimized for 60 seconds" cannot fire spontaneously — there is no clock event to trigger evaluation.
+- The reducer **can** opportunistically evaluate at the next event from any source, using the timestamp it already gets in `Ctx::now_rfc3339`. If the user takes any action (clicks anything, opens any window, moves any window), the reducer re-evaluates all `state.windows` entries' staleness as a side effect of dispatching THAT command. That is not a heartbeat — it is free riding on whatever events naturally occur.
+- Truly idle, untouched windows don't get spontaneous drift events. That is correct: if nothing is happening and nothing is changing, nothing is wrong by definition.
+
+---
+
+## Module layout
+
+```
+agentmux-cef/src/wrr/
+    mod.rs          # public API: install_hooks(), uninstall_hooks()
+    win_event.rs    # SetWinEventHook callback; routes to launcher_ipc
+    wndproc.rs      # WM_WINDOWPOSCHANGED / WM_DISPLAYCHANGE hooks (wraps host's existing wndproc)
+    classify.rs     # is_app_class(class_name), rect-vs-monitor-set helpers
+
+agentmux-launcher/src/wrr/
+    mod.rs          # reducer arm + drift classification
+    rect.rs         # rect intersection / monitor membership math
+
+agentmux-common/src/ipc.rs
+    + Command::ReportHwnd* (7 variants)
+    + Command::ReportMonitorTopologyChanged
+    + Event::HwndDriftDetected
+    + HwndDriftKind, Severity, Rect
+```
+
+No sensor.rs. No 1-Hz loop. The WRR subsystem is (a) a thin Win32 hook layer in the host that turns OS events into IPC Commands, and (b) a reducer arm in the launcher that classifies state transitions.
+
+---
+
+## Phase mapping
+
+| Phase | Scope | Approx LoC | Behavior |
+|---|---|---|---|
+| **B.9.1** | `wrr/win_event.rs` + `wndproc.rs` hook installation in host; new IPC commands wired; reducer state additions + reducer arm + drift classification + emission | ~400 | OBSERVATION ONLY. Drift events logged at the configured severity floor. No corrective action. |
+| **B.9.2** | `agentmux.exe --diag wrr` Tool client. Subscribes as `ClientKind::Tool`, prints last N drift events with timestamps and current `state.windows` extended view. | ~80 | Operator visibility. "Did anything orphan in this session? Show me the table." |
+| **F.WRR** | `wrr/enforcer.rs` in host. Subscribes to `Event::HwndDriftDetected`. Gated on `enforce=true` config. Corrective UI tasks: auto-raise off-monitor windows, close stray HWNDs, surface "we lost a window" notification to user. | ~250 | SELF-HEALING. |
+
+### Why land B.9.1 first as observation only
+
+Without enforcement, B.9.1 is pure addition: no risk of self-healing logic doing the wrong thing. The drift events get logged; we run a session, smoke, and read the launcher log to see what bugs were lurking that we hadn't noticed. That data informs B.9.2's `--diag` output and Phase F's enforcement policy (which corrections are safe, which need user confirmation, which thresholds make sense).
+
+---
+
+## Configuration
+
+Operator-tunable, defined in `WrrConfig` in both crates and overridable via env vars (so portable users can tweak without rebuilding):
+
+| Knob | Default | Env var | Effect |
+|---|---|---|---|
+| `enabled` | `true` | `AGENTMUX_WRR` | Master switch. `false` skips hook installation entirely. |
+| `severity_floor` | `Warn` | `AGENTMUX_WRR_SEVERITY` | `Info` / `Warn` / `Error`. Events below the floor are not broadcast (still logged at DEBUG). |
+| `enforce` | `false` | `AGENTMUX_WRR_ENFORCE` | Phase F only. Default false through end of Phase B. |
+| `app_class_allowlist` | `["CefBrowserWindow", "Chrome_WidgetWin_*"]` | `AGENTMUX_WRR_APP_CLASSES` | Window classes the host hook considers candidate AgentMux windows. Filters out tooltips, IME hooks, CEF subprocess HWNDs, etc., at the hook callback (don't waste an IPC dispatch on noise). |
+| `dedup_window_ms` | `2000` | `AGENTMUX_WRR_DEDUP_MS` | Don't re-emit the same `HwndDriftKind` for the same `(label, hwnd)` pair within this window. Prevents log flooding when a transition oscillates. |
+
+---
+
+## Open questions
+
+1. **Naming.** Is `wrr` / "Window Reality Reconciliation" the right module name? Alternatives considered: `window_reality`, `hwnd_recon`, `hwnd_state`. Pick one before committing — renaming later is churn.
+2. **Sensor location.** All hooks live in the host (closest to CEF, no IPC for the OS events themselves — just for the resulting Commands). Alternative: separate small "wrr-sensor" process attached to the host's PID via `SetWinEventHook` with `idProcess`. Trade-off: the dedicated process survives a host crash long enough to report the destroy event, which could catch one extra failure mode (host crashes mid-window-create, no `ReportWindowClosed`, destroy event still flushes). Per the conversation, host-internal is the cheaper start.
+3. **CEF subprocess HWNDs filter.** Filter at the hook level (skip class names matching `Chrome_RenderWidget*`) or pass through and let the reducer ignore? Strong lean: filter at hook to keep the wire light and keep the reducer's `state.windows` semantics clean (only "user-meaningful" HWNDs).
+4. **Drift severity floor for B.9.1.** All-WARN, or split (`OrphanDestroy` / `HwndWithoutBrowser` = ERROR, `OffMonitor` / `HiddenSinceOpen` / `LingeringHwnd` = WARN, `BrowserWithoutHwnd` = INFO since it's transient by nature)?
+5. **Backpressure.** OS events can fire bursts (e.g. monitor topology change → all windows resize → many `WM_WINDOWPOSCHANGED`). Should the host coalesce on the way out (drop redundant `ReportHwndPositionChanged` for the same hwnd within a few ms) or send everything and let the reducer dedupe via `dedup_window_ms`? Lean: coalesce in the host, since the IPC pipe is the cheap-but-not-free bottleneck.
+
+---
+
+## Where this fits in the broader Phase mapping
+
+This addition does NOT change Phase B's existing sub-PR sequence. B.7.3 (CEF JS bridge for typed launcher events) and B.8 (Phase B exit: property tests, `--diag` tool, CI smoke) remain. WRR is **B.9** — added because the conversation surfaced a class of bug B.7/B.8 wouldn't catch.
+
+The Phase F multi-reducer destination is a natural fit for WRR's enforcement role: the host's `wrr/enforcer.rs` becomes part of the host-side reducer's saga set. Until Phase F, B.9.1 + B.9.2 deliver visibility; corrections stay manual.
+
+---
+
+## How to start B.9.1
+
+Concrete first PR plan, in commit order:
+
+1. `agentmux-common/src/ipc.rs` — add the new `Command` / `Event` variants + `HwndDriftKind` / `Severity` / `Rect`. No behavior change.
+2. `agentmux-cef/src/wrr/{mod.rs, win_event.rs, classify.rs}` — `SetWinEventHook` install / teardown, callback that turns OS events into IPC Commands, class-name filter.
+3. `agentmux-cef/src/wrr/wndproc.rs` — wrap the existing host window proc to capture `WM_WINDOWPOSCHANGED` and `WM_DISPLAYCHANGE`, dispatch as `ReportHwndPositionChanged` / `ReportMonitorTopologyChanged`.
+4. `agentmux-launcher/src/wrr/{mod.rs, rect.rs}` + reducer arm in `update()` — drift classification, emission. State additions (`hwnd`, `visible`, `iconic`, `last_rect`, `last_foreground_at_ms` per `WindowState`; `monitors` and `pending_hwnds` global).
+5. `WrrConfig` env-var parsing on both sides. Defaults gate B.9.1 to observation-only.
+6. **Smoke test before merge** (per `feedback_verify_before_push`):
+   - Open AgentMux portable.
+   - `curl` `open_new_window` (the bug we just had).
+   - Verify `Event::HwndDriftDetected { kind: HiddenSinceOpen | OffMonitor }` lands in the launcher log within one OS event tick.
+   - Move a window off all monitors → verify `OffMonitor` fires.
+   - Force-kill the host's main browser (renderer crash via Task Manager) → verify `OrphanDestroy` fires.
+
+Once 1–6 land, B.9.1 is done and we have visibility. B.9.2 is a small `--diag` follow-up. Phase F adds enforcement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.484",
+  "version": "0.33.485",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.484",
+      "version": "0.33.485",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.486",
+  "version": "0.33.487",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.486",
+      "version": "0.33.487",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.485",
+  "version": "0.33.486",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.485",
+      "version": "0.33.486",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.487",
+  "version": "0.33.488",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.487",
+      "version": "0.33.488",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.488",
+  "version": "0.33.489",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.488",
+      "version": "0.33.489",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.483",
+  "version": "0.33.484",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.483",
+      "version": "0.33.484",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.482",
+  "version": "0.33.483",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.482",
+      "version": "0.33.483",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.483",
+  "version": "0.33.484",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.484",
+  "version": "0.33.485",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.488",
+  "version": "0.33.489",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.487",
+  "version": "0.33.488",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.482",
+  "version": "0.33.483",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.485",
+  "version": "0.33.486",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.486",
+  "version": "0.33.487",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the bug class surfaced after #595 / B.6.1: a CEF browser opens, gets a Win32 HWND, and is then \"lost\" to the user (parked at CEF's hidden sentinel position, off all monitors, never foregrounded). Pre-B.9 the reducer tracked **identity** but not **observability** — the existing drift compare (\`host.browsers.len() == launcher.windows.len()\`) saw both sides agree about a window that didn't actually exist for the user. Now the reducer treats Win32 HWND state as a first-class projection, classifies divergences at event-dispatch time, and emits **corrective actions in the same reducer call**. **No timers, no heartbeats** — every emission is in response to a Win32 OS event the host hooks via \`SetWinEventHook\`.

Design at \`docs/retro/wrr-design-2026-04-28.md\`. The PR folds B.9.1 (observation) and B.9.2 (pure-reducer self-heal) into one cohesive change since they share the protocol surface.

## Architecture

\`\`\`
HOST (agentmux-cef/src/wrr/)
   SetWinEventHook(WINEVENT_OUTOFCONTEXT) for OBJECT_CREATE / DESTROY /
   SHOW / HIDE / FOREGROUND / MINIMIZESTART / MINIMIZEEND /
   LOCATIONCHANGE — filtered to host PID + OBJID_WINDOW + CHILDID_SELF
   - Each event becomes a typed Command on the launcher pipe
   - Position events debounced 50ms per HWND so drag bursts don't flood
   - on_after_created sends an EXPLICIT report_hwnd_opened with known
     label, eliminating the OS-event timing race against
     pending_window_creations
                          ▼  ReportHwnd* / ReportMonitorTopologyChanged
LAUNCHER REDUCER (agentmux-launcher/src/wrr/)
   Reducer arm classifies six divergences:
   - HwndWithoutBrowser, BrowserWithoutHwnd
   - HiddenSinceOpen, OffMonitor
   - OrphanDestroy, LingeringHwnd
   Emits Event::HwndDriftDetected per classification.
   For OffMonitor with foregrounded_since_open == false, ALSO emits
   Event::CorrectiveWindowMove { hwnd, target_rect, reason } in
   the SAME reducer call.
                          ▼  Event::CorrectiveWindowMove
HOST ENFORCER (agentmux-cef/src/ui_tasks.rs::CorrectiveWindowMoveTask)
   apply_event_to_shadow matches the event, posts a UI task that
   calls SetWindowPos(hwnd, NULL, x, y, w, h, SWP_NOZORDER |
   SWP_NOACTIVATE) on the next CEF UI tick.
\`\`\`

## Pure-reducer guarantee

Every \`HwndDriftDetected\` and every \`CorrectiveWindowMove\` is emitted **at the moment a Win32 OS event is dispatched through the reducer**. There is no clock task, no \"if N seconds elapsed do X\" — the trigger is always a state transition, never the passage of time.

The corrective guard is purely state-based: \`mirror.foregrounded_since_open == false\`. Once the user has interacted with a window (even one foreground event), the guard flips and **no auto-correction ever fires for that label** — we trust the user's position choices for the rest of that label's lifetime. This is the line between \"buggy state we should heal\" and \"legitimate user state we shouldn't touch\".

## Sentinel suppression

CEF Views briefly parks new top-level windows at the Win32 hidden sentinel positions (\`(-32000, -32000)\` and \`(-31970, -31970)\`-family) between \`CreateWindow\` and the first \`SetWindowPos\`. Naively firing \`OffMonitor\` drift on every legitimate window-open transient produces log noise. The reducer suppresses **drift logging** for these positions but **still emits the corrective move** — we want the window OFF the sentinel before the user notices.

## Smoke evidence (v0.33.489 portable)

\`\`\`
curl POST /ipc {\"cmd\":\"open_new_window\"} → status 200
[launcher] WRR-POS hwnd=0x22804ea rect=(-31970,-31970)-(-31340,-30871)
             linked=Some(\"window-fe8b1296...\") monitors=1
[launcher] WRR-DRIFT [Warn] HiddenSinceOpen — visibility classifier
                                              fired (no foreground event yet)
[host]     WARN [wrr] CorrectiveWindowMove hwnd=0x22804ea
             reason=OffMonitor target=(135,400)-(765,1200)
[host]     INFO [wrr] corrective SetWindowPos hwnd=0x22804ea
             -> (135,400) 630x800 ok=true
\`\`\`

The curl-window — which on v0.33.481 / v0.33.488 produced an unkillable orphan taskbar entry — now lands centered on the primary monitor on first paint. Confirmed visually: no orphan, real body, focusable.

## Tests

48 launcher tests pass (44 prior + 4 new):
- \`wrr_off_monitor_position_for_unseen_window_emits_drift_and_corrective\`
- \`wrr_sentinel_position_suppresses_drift_but_emits_corrective\`
- \`wrr_off_monitor_after_user_foregrounded_does_not_correct\`
- \`wrr_off_monitor_with_no_known_monitors_emits_neither\`
- 7 rect-math tests (intersects, half-open semantics, multi-monitor, empty cases)

## What this DOES NOT do

- **Phase F enforcer breadth**: only \`OffMonitor\` triggers a corrective. \`OrphanDestroy\`, \`HwndWithoutBrowser\`, \`LingeringHwnd\` are observation-only (logged, not auto-fixed). Adding correctives for those is straightforward (each gets its own \`Event::Corrective*\` variant) but deferred — the orphan-taskbar bug is the immediate user-visible one and the rest are rarer.
- **Mid-session monitor topology change**: \`WM_DISPLAYCHANGE\` wiring is a B.9 follow-up. Initial topology is enumerated at \`install_hooks\` time; if the user unplugs a monitor mid-session, drift won't re-evaluate stranded windows until the next position event from any source.
- **Source-side fix for *why* CEF Views parks windows at the sentinel**: the reducer self-heal is a safety net, not a substitute. A separate PR can investigate why \`open_window_with_kind\`'s requested position isn't being applied to the new CefWindow.

## Test plan

- [ ] \`task package\` builds clean.
- [ ] Launch portable, look for \`[wrr] installed 4 WinEventHook range(s)\` and \`[wrr] reported initial monitor topology: N monitor(s)\` in host log.
- [ ] Curl \`open_new_window\` → expect WRR-DRIFT \`HiddenSinceOpen\` + \`CorrectiveWindowMove\` in launcher log, \`SetWindowPos ok=true\` in host log, visible window centered on monitor (NOT a stray taskbar entry).
- [ ] Open a window through the UI normally → no drift, no corrective (the OS happy path).
- [ ] Open a window, focus it, drag it off-screen → drift fires (\`OffMonitor\`), corrective does NOT (foregrounded guard).
- [ ] Force-kill a render PID → \`OrphanDestroy\` drift fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)