### PR TITLE
B.9.3: fix host-doesn't-quit-on-close-all (pool-refill cascade)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.490"
+version = "0.33.491"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.490"
+version = "0.33.491"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.490"
+version = "0.33.491"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.490"
+version = "0.33.491"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.491"
+version = "0.33.492"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.491"
+version = "0.33.492"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.491"
+version = "0.33.492"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.491"
+version = "0.33.492"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.500"
+version = "0.33.501"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.500"
+version = "0.33.501"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.500"
+version = "0.33.501"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.500"
+version = "0.33.501"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.495"
+version = "0.33.496"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.495"
+version = "0.33.496"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.495"
+version = "0.33.496"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.495"
+version = "0.33.496"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.493"
+version = "0.33.494"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.493"
+version = "0.33.494"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.493"
+version = "0.33.494"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.493"
+version = "0.33.494"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.489"
+version = "0.33.490"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.489"
+version = "0.33.490"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.489"
+version = "0.33.490"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.489"
+version = "0.33.490"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.497"
+version = "0.33.498"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.497"
+version = "0.33.498"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.497"
+version = "0.33.498"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.497"
+version = "0.33.498"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.499"
+version = "0.33.500"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.499"
+version = "0.33.500"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.499"
+version = "0.33.500"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.499"
+version = "0.33.500"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.496"
+version = "0.33.497"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.496"
+version = "0.33.497"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.496"
+version = "0.33.497"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.496"
+version = "0.33.497"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.494"
+version = "0.33.495"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.494"
+version = "0.33.495"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.494"
+version = "0.33.495"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.494"
+version = "0.33.495"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.498"
+version = "0.33.499"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.498"
+version = "0.33.499"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.498"
+version = "0.33.499"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.498"
+version = "0.33.499"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.492"
+version = "0.33.493"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.492"
+version = "0.33.493"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.492"
+version = "0.33.493"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.492"
+version = "0.33.493"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.493"
+version = "0.33.494"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.492"
+version = "0.33.493"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.496"
+version = "0.33.497"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.498"
+version = "0.33.499"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.491"
+version = "0.33.492"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.489"
+version = "0.33.490"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.494"
+version = "0.33.495"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.497"
+version = "0.33.498"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.499"
+version = "0.33.500"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.495"
+version = "0.33.496"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.500"
+version = "0.33.501"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.490"
+version = "0.33.491"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -12,15 +12,24 @@ use parking_lot::Mutex;
 
 use crate::state::{AppState, WindowKind};
 
-// Phase B.9.3 — non-Windows close-pool-browser task. Built only on
-// non-Windows because Windows uses Win32 PostMessage(WM_CLOSE)
-// directly (bypasses CEF task queue). On macOS/Linux we defer
-// close_browser via the canonical cef::post_task(TID_UI, ...) so
-// the call lands on the UI thread AFTER the current
-// on_before_close unwinds (close_browser inline from another
-// browser's close callback re-enters CEF and hangs).
-// (reagent #601 P1 — non-Windows had no close path.)
-#[cfg(not(target_os = "windows"))]
+// Phase B.9.3 — close-pool-browser task. Used by Stage 1 to defer
+// `close_browser` onto the CEF UI thread via `cef::post_task`, so
+// the call runs AFTER the current `on_before_close` unwinds.
+// `close_browser` called inline from inside another browser's
+// close callback re-enters CEF and hangs the UI thread (smoke
+// v0.33.497 confirmed).
+//
+// Two callers:
+// - Windows: HWND lookup fallback. Stage 1 prefers Win32
+//   `PostMessage(hwnd, WM_CLOSE)` (bypasses CEF's task queue —
+//   useful as a belt-and-suspenders mechanism), but if the
+//   window handle is null (early/late lifecycle, e.g. browser
+//   created without a Views top-level yet), fall through to this
+//   task so the close still happens. Otherwise self.browser_list
+//   never empties and Stage 2 never fires. (codex #601 P1.)
+// - Non-Windows: canonical path. macOS/Linux don't have
+//   `PostMessage(WM_CLOSE)`; defer close_browser via post_task
+//   for both correctness and portability. (reagent #601 P1.)
 wrap_task! {
     pub struct ClosePoolBrowserTask {
         browser: Browser,
@@ -596,8 +605,13 @@ impl AgentMuxHandler {
                 pool_browsers.len()
             );
 
-            // Windows path: Win32 PostMessage(WM_CLOSE) — bypasses
-            // CEF's task queue (proven reliable; smoke v0.33.500+).
+            // Windows path: prefer Win32 PostMessage(WM_CLOSE) —
+            // bypasses CEF's task queue (proven reliable; smoke
+            // v0.33.500+). When window_handle() returns null
+            // (early/late lifecycle), fall through to the
+            // post_task path so the close still happens — without
+            // the fallback, self.browser_list never empties and
+            // Stage 2 never fires. (codex #601 P1.)
             #[cfg(target_os = "windows")]
             {
                 use windows_sys::Win32::Foundation::HWND;
@@ -619,9 +633,15 @@ impl AgentMuxHandler {
                             i, hwnd, ok != 0
                         );
                     } else {
-                        tracing::debug!(
-                            target: "wrr-trace",
-                            "[trace] stage1[{}] no hwnd available", i
+                        // Fallback: defer close_browser via UI task.
+                        // Same path as non-Windows so the cascade
+                        // still drains.
+                        let mut task = ClosePoolBrowserTask::new(b);
+                        let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                        tracing::warn!(
+                            target: "wrr",
+                            "[wrr] stage1[{}] hwnd=null; fell back to post_task(close_browser) posted={}",
+                            i, posted != 0
                         );
                     }
                 }
@@ -632,14 +652,10 @@ impl AgentMuxHandler {
             // inline from inside another browser's on_before_close
             // hangs the UI thread (CEF re-entrance, smoke
             // v0.33.497 confirmed on Windows; same constraint on
-            // macOS / Linux per CEF docs). The post_task posts the
-            // call onto the UI thread's task queue; it runs after
-            // the current on_before_close unwinds. This is the
-            // canonical cross-platform path; Windows uses
-            // PostMessage(WM_CLOSE) instead because it's the OS-
-            // native idiom and bypasses CEF's task queue (which
-            // proved unreliable in similar-shaped late-teardown
-            // windows during B.9.3 saga investigation —
+            // macOS / Linux per CEF docs). Windows prefers
+            // PostMessage(WM_CLOSE) as the primary path (bypasses
+            // CEF's task queue, which proved unreliable in
+            // late-teardown windows — see
             // `docs/retro/b9-3-quit-thread-analysis.md`).
             // (reagent #601 P1.)
             #[cfg(not(target_os = "windows"))]

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -369,6 +369,15 @@ impl AgentMuxHandler {
     fn on_before_close(&mut self, browser: Option<&mut Browser>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
+        // Phase B.9.3 — diagnostic trace at debug level. Filtered
+        // out in production (default RUST_LOG=info). Enable via
+        // RUST_LOG="info,wrr-trace=debug" when investigating
+        // close-cascade issues.
+        tracing::debug!(
+            target: "wrr-trace",
+            "[trace] on_before_close ENTER; self.browser_list.len()={} is_pane={}",
+            self.browser_list.len(), self.is_pane
+        );
         dlog(&format!("on_before_close fired; browser_list.len()={}", self.browser_list.len()));
 
         let mut browser = browser.cloned().expect("Browser is None");
@@ -490,29 +499,118 @@ impl AgentMuxHandler {
         //
         // Promoted pool windows ARE counted: they're removed from
         // `unpromoted_pool_labels` at promote time.
-        let user_browser_count = {
+        let (user_browser_count, browsers_keys, pool_keys) = {
             let pool_labels = self.state.unpromoted_pool_labels.lock().clone();
             let browsers = self.state.browsers.lock();
-            browsers
+            let count = browsers
                 .iter()
                 .filter(|(label, _)| {
                     !pool_labels.contains(*label) && !label.starts_with("browser-pane-")
                 })
-                .count()
+                .count();
+            let keys: Vec<String> = browsers.keys().cloned().collect();
+            let pool: Vec<String> = pool_labels.iter().cloned().collect();
+            (count, keys, pool)
         };
 
+        // Phase B.9.3 diagnostic — fires for every close (incl.
+        // pane closes). Demoted to debug for production. Enable
+        // via RUST_LOG="info,wrr-trace=debug" to see per-close
+        // gate input when investigating close-cascade issues.
+        tracing::debug!(
+            target: "wrr-trace",
+            "[trace] app-exit gate: closing_label={:?} user_count={} is_pane={} browsers={:?} unpromoted_pool={:?}",
+            label, user_browser_count, self.is_pane, browsers_keys, pool_keys
+        );
+
+        // ── Phase B.9.3 — two-stage close cascade ─────────────────
+        //
+        // Stage 1: If user_browser_count just dropped to 0 (last
+        // user-visible window closed), POST WM_CLOSE to every pool
+        // browser. Async — the message loop processes the closes on
+        // subsequent iterations. We do NOT call quit_message_loop
+        // here. Calling it from inside on_before_close DEADLOCKS the
+        // UI thread (smoke v0.33.498 confirmed: log line "calling
+        // quit_message_loop now" was last; loop never returned).
+        //
+        // Stage 2: When self.browser_list becomes empty AFTER
+        // removing this browser (i.e. every browser this handler
+        // ever managed has closed), THEN call quit_message_loop.
+        // Matches the canonical cefsimple pattern. By then there
+        // are no other in-flight CEF lifecycle events to deadlock
+        // against. The MAIN client's handler is the only one that
+        // owns top-level windows + pool windows, so this fires
+        // exactly when the entire app's CEF browser inventory is
+        // gone.
+        //
+        // Cross-platform note: the Stage 1 PostMessage is the
+        // Windows path. macOS uses NSWindow.performClose:; Linux
+        // uses X11 WM_DELETE_WINDOW. Same async-close-cascade
+        // semantics on all platforms; only the OS API differs.
         if user_browser_count == 0 && !self.is_pane {
-            dlog(&format!(
-                "last user-facing window closed (browser_list.len()={}) — calling quit_message_loop",
-                self.browser_list.len()
-            ));
-            // Last user-facing window — quit the message loop.
-            // The Job Object kills agentmux-srv which kills all shell processes,
-            // and CEF tears down any remaining pool windows during shutdown.
-            // Only the MAIN client's handler should trigger app exit — pane
-            // clients own only their own pane browser and their list emptying
-            // just means the user closed the pane, not the whole app.
+            // Phase B.9.3 — set the drain flag BEFORE collecting
+            // pool browsers. spawn_pool_window will see this and
+            // skip refill on every subsequent on_pool_window_destroyed
+            // → no new pool browsers added → state.browsers can
+            // actually drain.
+            self.state
+                .is_quitting
+                .store(true, std::sync::atomic::Ordering::Release);
+            tracing::warn!(target: "wrr", "[wrr] is_quitting=true (drain mode)");
+
+            let pool_browsers: Vec<cef::Browser> = {
+                let browsers = self.state.browsers.lock();
+                browsers
+                    .iter()
+                    .filter(|(label, _)| label.starts_with("window-pool-"))
+                    .map(|(_, b)| b.clone())
+                    .collect()
+            };
+            tracing::warn!(
+                target: "wrr",
+                "[wrr] stage 1: user_count==0; PostMessage WM_CLOSE on {} pool browser(s)",
+                pool_browsers.len()
+            );
+            #[cfg(target_os = "windows")]
+            {
+                use windows_sys::Win32::Foundation::HWND;
+                use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
+                for (i, mut b) in pool_browsers.into_iter().enumerate() {
+                    let hwnd_opt = b.host().and_then(|h| {
+                        let wh = h.window_handle();
+                        if wh.0.is_null() {
+                            None
+                        } else {
+                            Some(wh.0 as HWND)
+                        }
+                    });
+                    if let Some(hwnd) = hwnd_opt {
+                        let ok = unsafe { PostMessageW(hwnd, WM_CLOSE, 0, 0) };
+                        tracing::debug!(
+                            target: "wrr-trace",
+                            "[trace] stage1[{}] PostMessage(hwnd={:p}, WM_CLOSE) ok={}",
+                            i, hwnd, ok != 0
+                        );
+                    } else {
+                        tracing::debug!(
+                            target: "wrr-trace",
+                            "[trace] stage1[{}] no hwnd available", i
+                        );
+                    }
+                }
+            }
+        }
+
+        // Stage 2: every browser this handler ever managed is now
+        // gone. Safe to call quit_message_loop — no other CEF
+        // lifecycle is in flight that could deadlock with it.
+        if self.browser_list.is_empty() && !self.is_pane {
+            tracing::warn!(
+                target: "wrr",
+                "[wrr] stage 2: self.browser_list.is_empty() — calling quit_message_loop"
+            );
             quit_message_loop();
+            tracing::warn!(target: "wrr", "[wrr] quit_message_loop returned");
         } else {
             // Notify remaining windows of the new count.
             let new_count = self.state.instance_count();
@@ -542,6 +640,12 @@ impl AgentMuxHandler {
                 tracing::warn!("{}", warn);
             }
         }
+
+        tracing::debug!(
+            target: "wrr-trace",
+            "[trace] on_before_close EXIT label={:?} self.browser_list.len()={}",
+            label, self.browser_list.len()
+        );
     }
 
     /// CEF fires this whenever the browser's loading/history state changes

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -12,6 +12,30 @@ use parking_lot::Mutex;
 
 use crate::state::{AppState, WindowKind};
 
+// Phase B.9.3 — non-Windows close-pool-browser task. Built only on
+// non-Windows because Windows uses Win32 PostMessage(WM_CLOSE)
+// directly (bypasses CEF task queue). On macOS/Linux we defer
+// close_browser via the canonical cef::post_task(TID_UI, ...) so
+// the call lands on the UI thread AFTER the current
+// on_before_close unwinds (close_browser inline from another
+// browser's close callback re-enters CEF and hangs).
+// (reagent #601 P1 — non-Windows had no close path.)
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct ClosePoolBrowserTask {
+        browser: Browser,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            let mut b = self.browser.clone();
+            if let Some(host) = b.host() {
+                host.close_browser(1); // force_close = true
+            }
+        }
+    }
+}
+
 /// Write a debug line to `%TEMP%\agentmux-close-debug.txt`.
 ///
 /// Only active when `AGENTMUX_DEBUG_CLOSE=1` is set in the environment.
@@ -568,9 +592,12 @@ impl AgentMuxHandler {
             };
             tracing::warn!(
                 target: "wrr",
-                "[wrr] stage 1: user_count==0; PostMessage WM_CLOSE on {} pool browser(s)",
+                "[wrr] stage 1: user_count==0; closing {} pool browser(s)",
                 pool_browsers.len()
             );
+
+            // Windows path: Win32 PostMessage(WM_CLOSE) — bypasses
+            // CEF's task queue (proven reliable; smoke v0.33.500+).
             #[cfg(target_os = "windows")]
             {
                 use windows_sys::Win32::Foundation::HWND;
@@ -597,6 +624,34 @@ impl AgentMuxHandler {
                             "[trace] stage1[{}] no hwnd available", i
                         );
                     }
+                }
+            }
+
+            // Non-Windows path: defer `close_browser` to the UI
+            // thread via `cef::post_task`. Calling close_browser
+            // inline from inside another browser's on_before_close
+            // hangs the UI thread (CEF re-entrance, smoke
+            // v0.33.497 confirmed on Windows; same constraint on
+            // macOS / Linux per CEF docs). The post_task posts the
+            // call onto the UI thread's task queue; it runs after
+            // the current on_before_close unwinds. This is the
+            // canonical cross-platform path; Windows uses
+            // PostMessage(WM_CLOSE) instead because it's the OS-
+            // native idiom and bypasses CEF's task queue (which
+            // proved unreliable in similar-shaped late-teardown
+            // windows during B.9.3 saga investigation —
+            // `docs/retro/b9-3-quit-thread-analysis.md`).
+            // (reagent #601 P1.)
+            #[cfg(not(target_os = "windows"))]
+            {
+                for (i, b) in pool_browsers.into_iter().enumerate() {
+                    let mut task = ClosePoolBrowserTask::new(b);
+                    let posted = cef::post_task(cef::ThreadId::UI, Some(&mut task));
+                    tracing::debug!(
+                        target: "wrr-trace",
+                        "[trace] stage1[{}] post_task(close_browser) posted={}",
+                        i, posted != 0
+                    );
                 }
             }
         }

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -54,6 +54,19 @@ const TITLE_BAR_OFFSET_PX: i32 = 16;
 /// in-flight semaphore — concurrent calls collapse to one spawn
 /// in flight at a time.
 pub fn spawn_pool_window(state: &Arc<AppState>) {
+    // Phase B.9.3 — if the host has decided to quit (last user-
+    // visible window closed, draining pool), skip refill. Without
+    // this guard, every pool close triggers a refill, keeping
+    // state.browsers non-empty forever and quit_message_loop's
+    // QuitWhenIdle never reaches idle.
+    if state.is_quitting.load(Ordering::Acquire) {
+        tracing::warn!(
+            target: "wrr",
+            "[wrr] spawn_pool_window skipped — is_quitting=true (drain mode)"
+        );
+        return;
+    }
+
     // Single-flight: skip if a respawn is already pending. The
     // pending one will catch up to TARGET_SIZE; we don't need
     // to stack spawns.

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -378,6 +378,24 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 target_rect.bottom - target_rect.top,
             );
         }
+        Event::HostShouldQuit { .. } => {
+            // Phase B.9.3 — diagnostic only. The actual close
+            // cascade is now driven host-side by the
+            // `is_quitting` drain flag in `client.rs::on_before_close`
+            // (Cause A fix). This event remains as a launcher-side
+            // observability signal: when it fires, the host's
+            // close-path SHOULD have already started draining, so
+            // we just log and trust the host to exit. Three smoke
+            // sessions in v0.33.491–v0.33.494 attempted to make
+            // this saga deliver work to the host's UI thread; all
+            // failed (CEF post_task drops, direct call is UB,
+            // PostThreadMessage(WM_QUIT) ignored by CEF's pump).
+            // See `docs/retro/b9-3-lifecycle-analysis.md`.
+            tracing::warn!(
+                target: "wrr",
+                "[wrr] HostShouldQuit received — host close cascade should be in flight"
+            );
+        }
         _ => {}
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -274,6 +274,15 @@ pub struct AppState {
     /// **Phase B status**: host-only sync primitive; not migrate-able.
     pub window_pool_respawn_in_flight: std::sync::atomic::AtomicBool,
 
+    /// Phase B.9.3 — set true once `on_before_close` decides
+    /// "this is the last user-visible window closing". Tells
+    /// `spawn_pool_window` to skip refill so the existing pool
+    /// can drain. Without this, every pool close triggers a
+    /// refill that adds a new pool browser, keeping
+    /// `state.browsers` non-empty forever and preventing
+    /// `quit_message_loop` from ever reaching idle.
+    pub is_quitting: std::sync::atomic::AtomicBool,
+
     /// Version-specific data directory (e.g. ai.agentmux.cef.v0-32-111/)
     pub version_data_dir: Mutex<Option<String>>,
 
@@ -348,6 +357,7 @@ impl Default for AppState {
             window_pool: Mutex::new(VecDeque::new()),
             unpromoted_pool_labels: Mutex::new(std::collections::HashSet::new()),
             window_pool_respawn_in_flight: std::sync::atomic::AtomicBool::new(false),
+            is_quitting: std::sync::atomic::AtomicBool::new(false),
             version_data_dir: Mutex::new(None),
             version_config_dir: Mutex::new(None),
             user_home_dir: Mutex::new(None),

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -240,6 +240,16 @@ pub fn post_corrective_window_move(state: &Arc<AppState>, hwnd: u64, x: i32, y: 
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// Phase B.9.3 (WRR) — `Event::HostShouldQuit` handling lives in
+// `launcher_ipc::apply_event_to_shadow`. After three smoke
+// iterations (v0.33.491–v0.33.493) confirmed `cef::post_task`
+// silently drops new tasks during the last-window-closed
+// teardown window — even when previously-posted tasks still
+// run — we bypass CEF entirely and use Win32
+// `PostThreadMessage(host_main_tid, WM_QUIT, 0, 0)` via
+// `wrr::win_event::post_thread_quit_message`. The UI thread's
+// captured TID is stored at `install_hooks` time.
+
 // ── Create new window (CEF Views) ───────────────────────────────────────
 
 wrap_task! {

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -53,6 +53,7 @@ fn app_state() -> &'static OnceLock<Arc<AppState>> {
     &S
 }
 
+
 /// Phase B.9.1 — handles to the installed hooks. Held in a
 /// `OnceLock<Mutex<Option<...>>>` so install_hooks is idempotent
 /// (no-op on second call) and uninstall can drop them on shutdown.

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.498"
+version = "0.33.499"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.495"
+version = "0.33.496"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.490"
+version = "0.33.491"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.492"
+version = "0.33.493"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.500"
+version = "0.33.501"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.489"
+version = "0.33.490"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.497"
+version = "0.33.498"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.496"
+version = "0.33.497"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.493"
+version = "0.33.494"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.491"
+version = "0.33.492"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.499"
+version = "0.33.500"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.494"
+version = "0.33.495"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -424,6 +424,19 @@ pub enum Event {
         reason: HwndDriftKind,
         version: u64,
     },
+    /// Phase B.9.3 — saga-style corrective. Reducer detected the
+    /// `OrphanInstance` transition (last user-visible label
+    /// removed from `state.windows`, host still Running). Host
+    /// subscriber handles by reaping the warm pool and calling
+    /// `quit_message_loop()`. ADVISORY, not a hard command —
+    /// the host's handler should re-check `state.browsers`
+    /// before actually quitting (the user could open a new
+    /// window in the same dispatch tick race window). Event is
+    /// idempotent: multiple emissions are safe; reaping pool +
+    /// quit are themselves idempotent.
+    HostShouldQuit {
+        version: u64,
+    },
 }
 
 /// Phase B.9.1 — six classes of CEF↔Win32 disagreement the reducer
@@ -454,6 +467,16 @@ pub enum HwndDriftKind {
     /// `ReportWindowClosed` arrived, but subsequent OS events for
     /// the HWND keep firing (it never went away on the Win32 side).
     LingeringHwnd,
+    /// Phase B.9.3 — host process is alive and registered, but
+    /// `state.windows` just transitioned to empty. The host's own
+    /// close path doesn't reap the warm pool when the last
+    /// user-visible window closes (pool windows hold
+    /// `state.browsers` non-empty, so `quit_message_loop` never
+    /// fires). The launcher's reducer is the only place that knows
+    /// "all user-meaningful labels are gone" cleanly, so we
+    /// surface the signal here. Paired with `Event::HostShouldQuit`
+    /// emitted in the same reducer call (see B.9.3 saga).
+    OrphanInstance,
 }
 
 /// Phase B.9.1 — drift severity. Operator-tunable severity floor

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.493"
+version = "0.33.494"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.498"
+version = "0.33.499"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.495"
+version = "0.33.496"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.497"
+version = "0.33.498"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.494"
+version = "0.33.495"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.492"
+version = "0.33.493"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.490"
+version = "0.33.491"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.499"
+version = "0.33.500"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.496"
+version = "0.33.497"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.489"
+version = "0.33.490"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.500"
+version = "0.33.501"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.491"
+version = "0.33.492"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -41,7 +41,7 @@
 //     register. Running → Quitting on Quit (B.3 placeholder).
 //     Quitting → Dead on cleanup-done (B.3 placeholder). No skipping.
 
-use agentmux_common::ipc::{ClientKind, Command, DriftKind, ErrorCode, Event, WindowKind};
+use agentmux_common::ipc::{ClientKind, Command, DriftKind, ErrorCode, Event, HwndDriftKind, WindowKind};
 
 use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State, WindowMirror};
 
@@ -448,7 +448,7 @@ fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
         // Silent: only emit when the close pairs with a known open.
         return vec![];
     }
-    let mut out = Vec::with_capacity(2);
+    let mut out = Vec::with_capacity(4);
     let v = state.bump_version();
     out.push(Event::WindowClosed {
         label: label.clone(),
@@ -456,9 +456,45 @@ fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
     });
     if let Some(num) = state.instance_registry.remove(&label) {
         let v = state.bump_version();
-        out.push(Event::WindowInstanceReleased { label, num, version: v });
+        out.push(Event::WindowInstanceReleased { label: label.clone(), num, version: v });
+    }
+
+    // Phase B.9.3 — OrphanInstance transition. The label we just
+    // removed was the LAST user-visible window (state.windows is
+    // now empty). If a Host is still registered as Running, its
+    // own close path won't quit_message_loop because the warm
+    // pool is keeping state.browsers non-empty. Emit drift +
+    // saga-style HostShouldQuit so the host can reap pool and
+    // quit cleanly. See B.9.3 in
+    // docs/retro/next-steps-2026-04-29.md.
+    if state.windows.is_empty() && host_is_running(state) {
+        let v_drift = state.bump_version();
+        out.push(Event::HwndDriftDetected {
+            kind: HwndDriftKind::OrphanInstance,
+            label: Some(label),
+            hwnd: None,
+            detail: "Last user-visible window closed; host still alive (likely holding warm pool)"
+                .to_string(),
+            severity: agentmux_common::ipc::Severity::Warn,
+            version: v_drift,
+        });
+        let v_quit = state.bump_version();
+        out.push(Event::HostShouldQuit { version: v_quit });
     }
     out
+}
+
+/// Phase B.9.3 — does state.processes contain a Host in the
+/// `Running` lifecycle? Used by the OrphanInstance transition
+/// check; without this guard, a stale Exited record would fire
+/// HostShouldQuit on every benign close. Tool-only sessions
+/// (`agentmux.exe --diag`) also correctly skip the saga because
+/// they never register a Host.
+fn host_is_running(state: &State) -> bool {
+    use crate::state::ProcessState;
+    state.processes.values().any(|r| {
+        r.kind == ClientKind::Host && matches!(r.state, ProcessState::Running)
+    })
 }
 
 fn handle_register(
@@ -733,6 +769,7 @@ mod tests {
             | Event::DriftDetected { version, .. }
             | Event::HwndDriftDetected { version, .. }
             | Event::CorrectiveWindowMove { version, .. }
+            | Event::HostShouldQuit { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -855,7 +892,10 @@ mod tests {
         );
         assert!(!state.windows.contains_key("main"));
         // B.5 — close emits WindowClosed + WindowInstanceReleased.
-        assert_eq!(events.len(), 2);
+        // B.9.3 — closing the last window with a Host registered
+        // also emits OrphanInstance drift + HostShouldQuit saga,
+        // so the total is 4 events on the last-window-close path.
+        assert_eq!(events.len(), 4);
         assert!(matches!(
             &events[0],
             Event::WindowClosed { label, .. } if label == "main"
@@ -864,6 +904,11 @@ mod tests {
             &events[1],
             Event::WindowInstanceReleased { label, num: 1, .. } if label == "main"
         ));
+        assert!(matches!(
+            &events[2],
+            Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. }
+        ));
+        assert!(matches!(&events[3], Event::HostShouldQuit { .. }));
     }
 
     #[test]
@@ -1931,6 +1976,122 @@ mod tests {
                 Event::HwndDriftDetected { kind: HwndDriftKind::HwndWithoutBrowser, .. }
             )),
             "different HWND for same label must fire drift, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn b9_3_orphan_instance_fires_when_last_window_closes_and_host_running() {
+        // The smoke-test scenario: open a window, close it; with a
+        // Host registered, the reducer should emit OrphanInstance
+        // drift + HostShouldQuit on the same dispatch tick.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        // Sanity: window opened, no orphan signal yet.
+        let evs = update(
+            &mut state,
+            Command::ReportWindowClosed { label: "w1".into() },
+            &c,
+        );
+        assert!(
+            evs.iter()
+                .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. })),
+            "expected OrphanInstance drift on last-window-close, got {:?}", evs
+        );
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::HostShouldQuit { .. })),
+            "expected HostShouldQuit saga on last-window-close, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn b9_3_orphan_instance_does_not_fire_on_non_terminal_close() {
+        // Closing one of N windows when N > 1 must NOT fire — the
+        // host has more user-visible windows alive, so it shouldn't
+        // quit. Predicate: state.windows still non-empty after
+        // remove → no signal.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w2".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        let evs = update(
+            &mut state,
+            Command::ReportWindowClosed { label: "w1".into() },
+            &c,
+        );
+        assert!(
+            !evs.iter()
+                .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. })),
+            "OrphanInstance must NOT fire while other windows are open, got {:?}", evs
+        );
+        assert!(
+            !evs.iter().any(|e| matches!(e, Event::HostShouldQuit { .. })),
+            "HostShouldQuit must NOT fire while other windows are open, got {:?}", evs
+        );
+    }
+
+    #[test]
+    fn b9_3_orphan_instance_does_not_fire_after_host_goodbye() {
+        // Realistic scenario for the no-Host predicate guard:
+        // Host registers, opens a window, then sends Goodbye
+        // (clean shutdown), which marks its ProcessRecord as
+        // Exited. A subsequent ReportWindowClosed arriving from
+        // the host's pipe (e.g. a queued event flushed during
+        // shutdown) MUST NOT fire HostShouldQuit — there's no
+        // Running Host left to quit.
+        let (mut state, c) = registered_host_state();
+        let _ = update(
+            &mut state,
+            Command::ReportWindowOpened {
+                label: "w1".into(),
+                kind: WindowKind::FullInstance,
+                parent_label: None,
+            },
+            &c,
+        );
+        // Host says Goodbye — record transitions to Exited.
+        let _ = update(&mut state, Command::Goodbye, &c);
+        // Force the close path to actually run by calling the
+        // private handler directly. (The public path's
+        // enforce_host_only would reject because the Host record
+        // is no longer Running, but that rejection happens
+        // BEFORE reaching the predicate; we want to prove the
+        // predicate itself is correct.)
+        let evs = handle_report_window_closed(&mut state, "w1".into());
+        assert!(
+            evs.iter().any(|e| matches!(e, Event::WindowClosed { .. })),
+            "WindowClosed should still emit, got {:?}", evs
+        );
+        assert!(
+            !evs.iter()
+                .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::OrphanInstance, .. })),
+            "OrphanInstance must NOT fire after host has Goodbye'd, got {:?}", evs
+        );
+        assert!(
+            !evs.iter().any(|e| matches!(e, Event::HostShouldQuit { .. })),
+            "HostShouldQuit must NOT fire after host has Goodbye'd, got {:?}", evs
         );
     }
 

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -490,5 +490,10 @@ pub fn severity_for(kind: HwndDriftKind) -> Severity {
         HwndDriftKind::HiddenSinceOpen => Severity::Warn,
         HwndDriftKind::LingeringHwnd => Severity::Warn,
         HwndDriftKind::BrowserWithoutHwnd => Severity::Info,
+        // Phase B.9.3 — OrphanInstance is operationally significant
+        // (process tree won't quit) but isn't a state-machine bug
+        // per se; it's an observation about cross-process lifecycle.
+        // WARN matches the other "user can't see / use this" kinds.
+        HwndDriftKind::OrphanInstance => Severity::Warn,
     }
 }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.497"
+version = "0.33.498"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.492"
+version = "0.33.493"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.494"
+version = "0.33.495"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.493"
+version = "0.33.494"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.500"
+version = "0.33.501"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.499"
+version = "0.33.500"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.489"
+version = "0.33.490"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.496"
+version = "0.33.497"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.495"
+version = "0.33.496"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.491"
+version = "0.33.492"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.490"
+version = "0.33.491"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.498"
+version = "0.33.499"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/b9-3-lifecycle-analysis.md
+++ b/docs/retro/b9-3-lifecycle-analysis.md
@@ -1,0 +1,412 @@
+# Why does AgentMux need a "host should quit" saga?
+
+**Status:** Architectural analysis. Written 2026-04-29 after multiple smoke iterations on B.9.3.
+**Author:** AgentA.
+**Goal:** zoom out far enough that the design choices become obvious. Diagrams from launch → tab tear → close → quit.
+
+---
+
+## The core invariant
+
+> When the user closes every visible AgentMux window, the host process tree should exit.
+
+This is the basic user contract. They closed everything, the app should be gone. CPU should be free, memory should be free, the taskbar should be clean.
+
+**Why this is non-trivial in our architecture**: AgentMux is not "one process per window". The host process owns multiple CEF browsers — visible top-level windows AND a hidden warm pool of pre-spawned browsers (so tear-off is instantaneous). The OS has no concept of "user-meaningful windows vs hidden infrastructure". When all visible windows close, the host process is still busy maintaining the pool, so it doesn't exit on its own.
+
+Something has to **decide** that the user is done and tell the host process to terminate. That decision needs to be:
+
+1. **Correct**: only fire when the user is truly done (not when they're between windows).
+2. **Reliable**: fire deterministically, not based on heuristics or timers.
+3. **Cross-platform**: same logic works on Windows / macOS / Linux.
+
+---
+
+## The full lifecycle
+
+### 1. Launch
+
+```
+USER double-clicks agentmux.exe
+       │
+       ▼
+LAUNCHER (one process)
+       │ creates J0 Job Object (KILL_ON_JOB_CLOSE)
+       │ binds \\.\pipe\agentmux-{hash}\command (single-instance lock)
+       │ spawns IPC server on tokio runtime  ←─── reducer lives here
+       │ spawns srv (assigned to J0)
+       │ spawns host (assigned to J0)
+       │
+       ▼
+HOST process boots
+       │ CEF init: creates main process + helper subprocesses
+       │ launcher_ipc connects to pipe → Register → reducer marks Host=Running
+       │ WRR install_hooks: captures UI thread id, SetWinEventHook installed
+       │ creates "main" CEF Browser
+       │   → on_after_created fires:
+       │       state.browsers["main"] = Browser
+       │       launcher_ipc.report_window_opened("main", FullInstance, None)
+       │   → launcher reducer:
+       │       state.windows["main"] = WindowMirror{...}
+       │       Event::WindowOpened broadcast to subscribers
+       │ pool warming: spawn 3 hidden pool windows
+       │   for each: state.browsers["window-pool-N"] = Browser
+       │             state.unpromoted_pool_labels.insert("window-pool-N")
+       │             launcher_ipc.report_pool_window_added(...)
+       │
+       ▼
+RUN_MESSAGE_LOOP (blocking call on host's main thread)
+       │ This thread is now "the UI thread" — what CEF docs call
+       │ "the main application thread". From here forward:
+       │   - cef::quit_message_loop must be called HERE
+       │   - on_before_close, on_after_created, etc., all run HERE
+       │   - cef::post_task(TID_UI, ...) targets THIS thread
+```
+
+State after launch is steady:
+
+```
+LAUNCHER reducer state              HOST AppState
+state.windows = { "main" }          state.browsers = {
+state.pool = {                          "main": Browser,
+    "window-pool-1",                    "window-pool-1": Browser,
+    "window-pool-2",                    "window-pool-2": Browser,
+    "window-pool-3",                    "window-pool-3": Browser,
+}                                   }
+state.processes = { Host: Running   state.unpromoted_pool_labels = {
+                  , Srv:  Running       "window-pool-1",
+                  }                     "window-pool-2",
+                                        "window-pool-3",
+                                    }
+```
+
+### 2. Tab tear-off
+
+User drags a tab out of the main window past the threshold. The host's `commands::drag::tear_off` runs on the UI thread:
+
+```
+                user finishes drag
+                       │
+                       ▼
+HOST (UI thread):
+  promote_pool_window("workspace_id", x, y)
+       │
+       │ 1. pop "window-pool-1" from pool queue
+       │ 2. unpromoted_pool_labels.remove("window-pool-1")
+       │ 3. rename to "window-{uuid}" — but: state.browsers KEY stays
+       │    "window-pool-1" until on_after_created creates a new entry?
+       │    (this is the part that's actually delicate; see real source)
+       │ 4. position the window where the user dropped
+       │ 5. spawn a new pool window to refill: "window-pool-N+1"
+       │
+       ▼ (per CEF Views creating a fresh top-level)
+  on_after_created fires for the freshly-promoted window:
+       │ state.browsers["window-{uuid}"] = Browser
+       │ launcher_ipc.report_pool_window_removed("window-pool-1")
+       │ launcher_ipc.report_window_opened("window-{uuid}", FullInstance, None)
+       │
+       ▼
+LAUNCHER reducer:
+  state.pool.remove("window-pool-1")
+  state.windows.insert("window-{uuid}", ...)
+  Event::PoolWindowRemoved + Event::WindowOpened broadcast
+```
+
+After one tear-off:
+
+```
+state.windows = { "main", "window-abc123..." }
+state.pool = { "window-pool-2", "window-pool-3", "window-pool-4" }  ← refilled
+state.browsers = { "main", "window-abc123...", "window-pool-2", ..., "window-pool-4" }
+```
+
+### 3. Close all visible windows — what's SUPPOSED to happen
+
+User clicks X on the torn-off window first, then on main.
+
+```
+3a. Close torn-off window
+────────────────────────
+  user clicks X
+       │
+       ▼
+CEF lifecycle (UI thread):
+  on_before_close("window-abc123...") fires
+       │
+       │ host's client.rs::on_before_close:
+       │   browsers.remove("window-abc123...")
+       │   launcher_ipc.report_window_closed("window-abc123...")
+       │
+       │   ── compute user_browser_count ──────────────
+       │   filter state.browsers excluding:
+       │     - keys in unpromoted_pool_labels
+       │     - keys starting with "browser-pane-"
+       │   = { "main" } → count = 1
+       │   ────────────────────────────────────────────
+       │
+       │   if count == 0 && !is_pane → quit_message_loop()
+       │   ELSE → emit window-instances-changed, continue
+       │
+       ▼
+LAUNCHER reducer:
+  state.windows.remove("window-abc123...")
+  state.windows = { "main" }                  ← still has main
+  Event::WindowClosed broadcast
+  (B.9.3) check: state.windows.is_empty()? NO → no saga
+
+3b. Close main window
+─────────────────────
+  user clicks X on main
+       │
+       ▼
+CEF lifecycle (UI thread):
+  on_before_close("main") fires
+       │
+       │ host's client.rs::on_before_close:
+       │   browsers.remove("main")
+       │   launcher_ipc.report_window_closed("main")
+       │
+       │   ── compute user_browser_count ──────────────
+       │   filter state.browsers excluding:
+       │     - keys in unpromoted_pool_labels
+       │     - keys starting with "browser-pane-"
+       │   browsers = { "window-pool-2", "window-pool-3", "window-pool-4" }
+       │   pool      = { "window-pool-2", "window-pool-3", "window-pool-4" }
+       │   = { } → count = 0 ✓
+       │   ────────────────────────────────────────────
+       │
+       │   if count == 0 && !is_pane:
+       │     quit_message_loop()  ✓ ← CALLED HERE on UI thread
+       │
+       ▼
+CEF run_message_loop sees the quit signal, returns
+       │
+       ▼
+HOST main() falls out of run_message_loop, drops handles, exits
+       │
+       ▼
+J0's KILL_ON_JOB_CLOSE reaps srv + render workers
+       │
+       ▼
+Tree exits ✓
+```
+
+**This is the design. It works on paper. It does NOT work in our smoke.**
+
+### 4. What's actually happening — the bug
+
+Smoke evidence from v0.33.491–v0.33.494 (each: tear off + close all):
+
+```
+[host]  Unregistered browser: label=window-{tear-off} (remaining: 4)
+[host]  Unregistered browser: label=main (remaining: 3)
+[host]  ?? "last user-facing window closed (...) — calling quit_message_loop"
+        ── this log line is MISSING ──
+
+[launcher] reducer: state.windows.remove("window-{tear-off}") → still {main}
+[launcher] reducer: state.windows.remove("main") → state.windows.is_empty() ✓
+[launcher] (B.9.3) emits Event::HostShouldQuit
+[host]  receives HostShouldQuit on tokio thread
+[host]  ?? "QuitMessageLoopTask running on UI thread"
+        ── this log line is MISSING (saga delivery failed) ──
+
+[host process tree stays alive forever]
+```
+
+**Two independent bugs were uncovered, both labeled in `b9-3-quit-thread-analysis.md`:**
+
+```
+                               ┌──────────────────────────────────────┐
+                               │  CLOSE-ALL TIMELINE (broken state)   │
+                               └──────────────────────────────────────┘
+
+main window closes
+       │
+       ▼
+on_before_close("main") fires on UI thread
+       │
+       │ ┌─── CAUSE A ──────────────────────────────────────────────┐
+       │ │ user_browser_count == 0 && !is_pane gate doesn't fire.  │
+       │ │ Possible reasons (unverified):                           │
+       │ │   (a) is_pane is true — closing browser is on a          │
+       │ │       pane-client, gate's "main client only" skip kicks. │
+       │ │   (b) pool refill races: a new "window-pool-N+1" lands   │
+       │ │       in state.browsers before unpromoted_pool_labels    │
+       │ │       is updated, so it counts as user-facing.           │
+       │ │   (c) something else.                                    │
+       │ │                                                          │
+       │ │ Whichever it is, quit_message_loop is NOT called here.   │
+       │ │ This is a host-local bug. Cross-platform — same code on  │
+       │ │ Windows / macOS / Linux. One fix covers all.             │
+       │ └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+launcher_ipc.report_window_closed("main") sent
+       │
+       ▼
+LAUNCHER reducer (tokio thread):
+       │ state.windows.remove("main") → empty
+       │ B.9.3 transition check: empty? yes. host running? yes. → fire saga
+       │
+       │ Event::HostShouldQuit emitted
+       │
+       ▼
+HOST receives Event::HostShouldQuit on its tokio thread
+       │
+       │ ┌─── CAUSE B ──────────────────────────────────────────────┐
+       │ │ Need to deliver "call quit_message_loop" to UI thread,   │
+       │ │ from the tokio thread that received the event.           │
+       │ │                                                          │
+       │ │ Tried & failed:                                          │
+       │ │   v.491  cef::post_task(TID_UI, task) — task never runs. │
+       │ │          Earlier post_tasks DID run; this one is dropped.│
+       │ │   v.492  call quit_message_loop directly from tokio —    │
+       │ │          UB per CEF docs; no-op in practice.             │
+       │ │   v.493  minimal post_task with only quit_message_loop — │
+       │ │          still dropped. Confirmed Cause B is post_task,  │
+       │ │          not anything we did.                            │
+       │ │   v.494  Win32 PostThreadMessage(WM_QUIT) — accepted by  │
+       │ │          OS (ok=true) but CEF's run_message_loop on      │
+       │ │          Windows uses a custom pump that doesn't honor   │
+       │ │          WM_QUIT to terminate. (Cross-platform: this     │
+       │ │          workaround is Windows-only anyway.)             │
+       │ │                                                          │
+       │ │ Cross-platform implication: cef::post_task is the only   │
+       │ │ portable abstraction for "deliver work to UI thread".    │
+       │ │ If it's broken in this state, the bug is in CEF — not    │
+       │ │ something we should paper over with three platform-      │
+       │ │ specific bridges.                                        │
+       │ └──────────────────────────────────────────────────────────┘
+       │
+       ▼
+[no quit happens]
+[host process tree stays alive forever]
+```
+
+---
+
+## Why both paths exist (and why both should be fixed)
+
+The reducer-driven saga (B.9.3) was added on the assumption that Cause A might never get diagnosed cheaply, and the launcher's view of "the user is done" is cleaner than the host's view (no pool / pane filtering needed — the launcher only ever sees user-meaningful labels via `report_window_opened`).
+
+This is sound — the launcher's reducer is the canonical state. **But** the saga has to deliver work back to the host's UI thread to actually quit, and we ran into Cause B trying to do that.
+
+So we have:
+
+| Path | Detection | Delivery | Status |
+|---|---|---|---|
+| Host-local gate (pre-B.9) | `client.rs:515` count check | runs on UI thread already (in `on_before_close`) → direct call | **Cause A: detection broken** |
+| Reducer-driven saga (B.9.3) | `apply_hwnd_destroyed` / `handle_report_window_closed` post-mutation check | tokio → ??? → UI thread | **Cause B: delivery broken** |
+
+Both should work. Both eventually call the same `cef::quit_message_loop()` from the UI thread. The difference is who decides.
+
+---
+
+## Cross-platform implications
+
+```
+                         CROSS-PLATFORM PORTABILITY MATRIX
+
+LAYER                              | Windows | macOS  | Linux  | Verdict
+───────────────────────────────────|─────────|────────|────────|──────────
+state.windows reducer mutation     |    ✓    |   ✓    |   ✓    | portable
+Event::HostShouldQuit emission     |    ✓    |   ✓    |   ✓    | portable
+host receives event on tokio thrd  |    ✓    |   ✓    |   ✓    | portable
+client.rs:515 gate logic           |    ✓    |   ✓    |   ✓    | portable (Cause A)
+cef::post_task delivery to UI      |    ✗    |   ?    |   ?    | CEF binding
+cef::quit_message_loop on UI thrd  |    ✓    |   ✓    |   ✓    | portable
+PostThreadMessage(WM_QUIT)         |    ✗    |   N/A  |   N/A  | win32 only,
+                                   |         |        |        | doesn't work
+Hidden message-only window         |    ?    |   N/A  |   N/A  | win32 only
+WinEventHook (the WRR sensor)      |    ✓    |   N/A  |   N/A  | win32 only —
+                                   |         |        |        | macOS/Linux
+                                   |         |        |        | needs
+                                   |         |        |        | NSWindow
+                                   |         |        |        | / X11
+                                   |         |        |        | equivalent
+```
+
+**Key insight**: WRR's *sensor* (the WinEventHook) is already Windows-only by necessity — there's no portable abstraction over OS window events. macOS / Linux ports will replace it with platform-specific equivalents.
+
+But WRR's *signal* (the events flowing into the reducer) is portable. So is the saga emission. Only the **delivery** of the saga's resulting work back to the UI thread is platform-specific — and `cef::post_task` is supposed to abstract that.
+
+If `cef::post_task` is unreliable, then either:
+- It's a CEF bug — file upstream, accept current behavior, document the workaround per-platform.
+- We're using it wrong — figure out the right idiom (e.g., post on a different thread first, or use post_delayed_task with 0).
+
+The right thing is NOT to build three platform-specific bridges. That's how cross-platform code rots.
+
+---
+
+## Recommended path forward
+
+**Primary fix — Cause A (cross-platform)**:
+- Land v0.33.495's gate diagnostic.
+- Run one smoke (tear off + close all) and read the `[wrr] app-exit gate: ...` log line.
+- The diagnostic will print `user_count`, `is_pane`, the browsers map, and the unpromoted pool labels at the moment of decision. We will know IMMEDIATELY which of (a)/(b)/(c) is the culprit.
+- Fix in client.rs (likely 1–5 lines). Cross-platform.
+
+**Secondary — keep the saga, leave Cause B for later**:
+- B.9.3's reducer arm + saga emission stays. They're cross-platform and useful even if the delivery is currently unreliable.
+- Strip the v0.33.494 Win32 PostThreadMessage code (single-OS, doesn't work, dead end).
+- Saga delivery: keep `cef::post_task`. When Cause A is fixed, the saga rarely fires; when it does, accept that it might be unreliable in the teardown window and treat it as a diagnostic / "should not be load-bearing" path.
+- If we later determine `cef::post_task` is genuinely broken, file upstream + revisit with a CEF-binding-level fix that ALL platforms benefit from.
+
+**What stays in the codebase**:
+- WRR sensor (Windows-only, by design — macOS/Linux port adds equivalents)
+- WRR reducer arms (cross-platform)
+- `Event::HostShouldQuit` (cross-platform)
+- `OrphanInstance` drift (cross-platform diagnostic, fires whenever Cause A regression-tests itself even if Cause A is fixed)
+
+**What gets removed**:
+- `wrr::win_event::post_thread_quit_message` (Win32 PostThreadMessage)
+- `ui_tasks::post_quit_message_loop` if it was added (Win32-specific wrapper)
+- TID capture in install_hooks (no longer needed)
+- The `cfg(windows)` block in launcher_ipc that calls into post_thread_quit_message
+
+---
+
+## TL;DR diagram
+
+```
+                    THE BUG, IN ONE PICTURE
+                    
+        ┌─────────────────────────┐
+        │  user closes everything │
+        └──────────┬──────────────┘
+                   │
+                   ▼
+       ┌─────────────────────┐
+       │ on_before_close fires│
+       │  on UI thread       │
+       └──────────┬──────────┘
+                  │
+                  ▼
+         ┌──────────────────┐         ┌────────────────────┐
+         │  CAUSE A: gate   │   ──┐   │ launcher reducer   │
+         │  silently fails  │     │   │ sees windows=∅      │
+         │  to fire quit    │     │   └─────────┬──────────┘
+         └──────────────────┘     │             │
+                                  │             ▼
+                                  │   ┌──────────────────┐
+                                  │   │ saga:            │
+                                  │   │ HostShouldQuit   │
+                                  │   └─────────┬────────┘
+                                  │             │
+                                  │             ▼
+                                  │   ┌──────────────────┐
+                                  │   │ CAUSE B: delivery│
+                                  │   │ to UI thread     │
+                                  │   │ silently fails   │
+                                  │   └──────────────────┘
+                                  │
+                                  ▼
+                       ┌─────────────────────┐
+                       │ host process        │
+                       │ stays alive forever │
+                       └─────────────────────┘
+
+Fix Cause A (cross-platform, diagnostic data already in our pocket).
+Saga stays as defense-in-depth (cross-platform).
+Don't ship the Win32-only delivery hacks (single-OS, also doesn't work).
+```

--- a/docs/retro/b9-3-quit-thread-analysis.md
+++ b/docs/retro/b9-3-quit-thread-analysis.md
@@ -1,0 +1,102 @@
+# B.9.3 — analysis of the "host won't quit" loop
+
+**Status:** Analysis, written 2026-04-29 after v0.33.491–v0.33.493 smoke iterations all left the host process tree alive.
+**Author:** AgentA.
+**Goal:** stop oscillating; establish the real constraints, the real failure mode, and the right fix.
+
+---
+
+## What's actually happening
+
+### Smoke results (each test: open AgentMux → tear off → close all visible windows)
+
+| Build | Approach | Observed |
+|---|---|---|
+| v0.33.491 | tokio handler posts a UI task that reaps pool + calls `quit_message_loop` | Task body **never executed**. `[wrr] HostShouldQuit received` logs from tokio handler; nothing from inside the task. Host stays alive. |
+| v0.33.492 | tokio handler calls `cef::quit_message_loop()` directly | Call **returns immediately, no effect**. Host stays alive. |
+| v0.33.493 | tokio handler posts a minimal UI task that does ONLY `quit_message_loop` | Same as 491. Task body never logs. Host stays alive. |
+
+### Two independent things are broken — naming them precisely
+
+1. **Cause A: the host's own close path (`client.rs:515`) doesn't fire `quit_message_loop` when it should.** This existed before B.9. The whole reason B.9.3 was added is that this gate fails to trigger reliably. Specifically: when the user closes the last visible window, `on_before_close` runs and counts user-facing browsers (filtering pool + browser-pane). The gate is `user_browser_count == 0 && !self.is_pane`. We have evidence that this path never logs `last user-facing window closed` despite the user-visible state being "all closed". Possible reasons (ranked by likelihood, unverified):
+   - The closing browser's client has `self.is_pane == true` (the gate skips non-main-clients deliberately, per "only the main client should trigger app exit"). If the close happens to land on a pane-client, the quit is silently skipped.
+   - Pool refill races the count check: a new pool window has been added to `state.browsers` but not yet to `unpromoted_pool_labels`, so it counts as user-facing.
+   - The user-facing count is correctly 0 but `quit_message_loop` is somehow itself a no-op in this state (less likely; this is the function CEF supplies for exactly this purpose).
+
+2. **Cause B: `cef::post_task(ThreadId::UI, ...)` silently drops tasks during the post-close-cascade window.** This is what made the B.9.3 fix attempts fail. We confirmed empirically that:
+   - Earlier in the same session, tasks posted via `post_task` DO run (e.g. `MainFocusReclaimTask` ran 1–4 seconds before HostShouldQuit fired).
+   - After the close cascade, our newly-posted task — even a one-line task — never executes, never logs.
+   - The post call itself doesn't return an error or panic. The task is enqueued but the queue is not drained.
+
+These are SEPARATE bugs. B.9.3's fix was supposed to work around Cause A, but my fix attempts ran into Cause B.
+
+---
+
+## What CEF actually requires (the "thread" question)
+
+I oscillated between "must be on UI thread" and "thread-safe, call from anywhere" over three iterations. Here is the actual answer.
+
+CEF C API doc for `cef_quit_message_loop`:
+
+> Quit the CEF message loop that was started by calling `cef_run_message_loop()`. This function should only be called on the main application thread and only if `cef_run_message_loop()` was used.
+
+This is unambiguous: **UI thread only**. The function called from any other thread is undefined behavior — in practice, on Windows, it's a silent no-op (the v0.33.492 evidence).
+
+So calling from the tokio thread (v0.33.492) was wrong. I knew it was wrong; I tried it anyway hoping the binding might shim. It doesn't.
+
+The right pattern is: **the work runs on the UI thread; the trigger is delivered from any thread via a thread-safe bridge.**
+
+CEF provides one such bridge: `cef::post_task(ThreadId::UI, task)`. It IS thread-safe to call. But it requires CEF's task queue to be functional, and our smoke evidence shows it isn't functional in the specific window between "last visible browser closed" and "host process exits". That's Cause B.
+
+Win32 provides a different bridge: `PostThreadMessage(thread_id, msg, ...)`. Documented thread-safe. Goes through Windows' message queue (NOT CEF's task queue). `WM_QUIT` posted via this terminates `GetMessage` → `run_message_loop` returns → host falls out of `main()` → process tree exits via J0.
+
+So the choice isn't "UI thread vs not UI thread". Both bridges DELIVER the work to the UI thread. The choice is "CEF's task queue (proven unreliable here) vs Windows' message queue (proven reliable)".
+
+**`PostThreadMessage(WM_QUIT)` is the correct bridge** for this specific state because:
+- Win32's message queue is at a layer below CEF's task queue
+- `cef_run_message_loop`'s implementation on Windows is a `GetMessage` loop; `WM_QUIT` is the canonical termination signal
+- Even if CEF stops draining its own task queue during teardown, `GetMessage` continues to run until it sees `WM_QUIT`
+
+---
+
+## Recommended path forward
+
+### B.9.3.1 (current iteration, building as v0.33.494)
+
+Land the Win32 `PostThreadMessage(WM_QUIT)` approach. It's:
+- The right fix for Cause B (CEF task queue unreliable in this window)
+- A defensible permanent design (Win32 message-pump is more fundamental than CEF's task queue; we're not papering over a CEF bug, we're using a lower-level primitive that's appropriate for "tell the message loop to exit")
+- Independent of Cause A (the host's broken gate)
+
+Specifically:
+- `wrr/win_event.rs::install_hooks` captures `GetCurrentThreadId()` (this runs on the host's main thread = UI thread)
+- `wrr/win_event.rs::post_thread_quit_message()` reads the captured TID and calls `PostThreadMessageW(tid, WM_QUIT, 0, 0)` from any thread
+- `launcher_ipc::apply_event_to_shadow` for `Event::HostShouldQuit` calls this (post race-window check)
+
+### B.9.3.2 (separate, defensive, follow-up)
+
+Investigate Cause A — why `client.rs:515 quit_message_loop()` doesn't fire on the existing close path.
+
+Hypotheses to test:
+1. Add a log line right before the `user_browser_count == 0 && !self.is_pane` check showing `user_browser_count`, `is_pane`, the browsers map keys, and the filtered set. Re-smoke and read the log.
+2. If `is_pane == true` is the culprit: the gate's "only main client triggers exit" assumption is wrong; the LAST-CLOSE check should run on whichever client owns the last user-visible browser, regardless of `is_pane`.
+3. If `user_browser_count != 0` due to pool refill: the count needs to use a different snapshot of `unpromoted_pool_labels` — perhaps "pool labels we've EVER seen, minus those promoted" rather than the current set after refill.
+
+This is host-internal cleanup and should happen anyway. B.9.3.1 already provides safety from the launcher-side, so the host fix can be unhurried.
+
+---
+
+## Decision rules going forward (so the oscillation stops)
+
+1. **The destination is the UI thread.** Always. CEF docs are right.
+2. **The bridge is the choice.** `cef::post_task(TID_UI, ...)` is the default; switch to Win32 `PostThreadMessage`/`PostMessage` when (a) there's evidence the CEF task queue isn't draining, or (b) we need the work to happen below CEF's abstraction (e.g., to terminate the message loop itself).
+3. **Don't call CEF UI-thread-only APIs from a worker thread directly.** It's not "thread-safe in our binding"; it's silent UB. The v0.33.492 attempt was wrong on first principles and shouldn't have been tried.
+4. **When a UI task doesn't execute, log a stable signal in the task body.** Then we can tell "task ran but I'm misreading the log" from "task never ran" — which is what cost us iteration 491→493. (Done in v0.33.493 by stripping the task to one log line; the silence was the answer.)
+
+---
+
+## What we actually learned
+
+- The `OrphanInstance` reducer arm + `HostShouldQuit` saga are correct. The reducer detects the transition cleanly. The host receives the event cleanly. The IPC + reducer + saga emission all work end-to-end.
+- The failure is purely in "how does the launcher-side saga deliver work to the host's UI thread when CEF's task queue is unreliable in this window".
+- Win32 `PostThreadMessage` is the answer; not because it bypasses the UI thread (it doesn't — it lands on it via the OS message queue), but because it bypasses CEF's task queue (which is the thing actually broken here).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.498",
+  "version": "0.33.499",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.498",
+      "version": "0.33.499",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.492",
+  "version": "0.33.493",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.492",
+      "version": "0.33.493",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.489",
+  "version": "0.33.490",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.489",
+      "version": "0.33.490",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.496",
+  "version": "0.33.497",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.496",
+      "version": "0.33.497",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.500",
+  "version": "0.33.501",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.500",
+      "version": "0.33.501",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.497",
+  "version": "0.33.498",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.497",
+      "version": "0.33.498",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.493",
+  "version": "0.33.494",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.493",
+      "version": "0.33.494",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.490",
+  "version": "0.33.491",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.490",
+      "version": "0.33.491",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.491",
+  "version": "0.33.492",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.491",
+      "version": "0.33.492",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.495",
+  "version": "0.33.496",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.495",
+      "version": "0.33.496",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.499",
+  "version": "0.33.500",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.499",
+      "version": "0.33.500",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.494",
+  "version": "0.33.495",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.494",
+      "version": "0.33.495",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.494",
+  "version": "0.33.495",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.500",
+  "version": "0.33.501",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.498",
+  "version": "0.33.499",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.492",
+  "version": "0.33.493",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.497",
+  "version": "0.33.498",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.491",
+  "version": "0.33.492",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.495",
+  "version": "0.33.496",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.493",
+  "version": "0.33.494",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.489",
+  "version": "0.33.490",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.499",
+  "version": "0.33.500",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.490",
+  "version": "0.33.491",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.496",
+  "version": "0.33.497",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the regression introduced by #566 (warm pool feature, 2026-04-27): closing all visible AgentMux windows used to leave the host process tree alive forever, accumulating zombie instances. After this PR, host exits cleanly within ~30ms of the last close.

## Root cause (one sentence)

CEF's \`quit_message_loop\` is documented as **QuitWhenIdle** — it sets a flag that fires when all CefBrowsers close, but the warm pool's auto-refill kept replacing every closed pool browser with a new one, so idle was never reached.

## Fix

Three coordinated changes, all host-side, all cross-platform:

1. **\`AppState::is_quitting: AtomicBool\`** — new flag, default false.
2. **\`spawn_pool_window\` early-return on \`is_quitting=true\`** — suppresses refill during drain.
3. **Two-stage \`on_before_close\` cascade**:
   - Stage 1 (\`user_count==0 && !is_pane\`): set \`is_quitting=true\`, async \`PostMessage(hwnd, WM_CLOSE)\` on every remaining pool browser. Lets the current \`on_before_close\` unwind without re-entering CEF.
   - Stage 2 (\`self.browser_list.is_empty() && !is_pane\`): canonical cefsimple pattern — call \`quit_message_loop\`. Fires only on the absolute last close.

Only the \`PostMessage\` step is Windows-specific (macOS uses \`NSWindow.performClose:\`, Linux uses X11 \`WM_DELETE_WINDOW\` ClientMessage). Same semantics.

## Smoke evidence

v0.33.501 portable, multiple sessions including:
- single tear-off close-tear-off-first
- single tear-off close-main-first
- multiple tear-offs with variations
- pane tear-offs included

Every session: process tree empty after close-all. Cascade timeline (~30ms):

\`\`\`
[wrr] is_quitting=true (drain mode)
[wrr] stage 1: user_count==0; PostMessage WM_CLOSE on 3 pool browser(s)
[wrr] stage 1: ... on 2 pool browser(s)
[wrr] spawn_pool_window skipped — is_quitting=true (drain mode)   ← refill suppressed
[wrr] stage 1: ... on 1 pool browser(s)
[wrr] stage 1: ... on 0 pool browser(s)
[wrr] stage 2: self.browser_list.is_empty() — calling quit_message_loop
[wrr] quit_message_loop returned
\`\`\`

Process tree confirmed empty via \`tasklist\`.

## What's NOT in this PR (reverted from earlier iterations)

The earlier B.9.3 design proposed a launcher-reducer-driven saga (\`Event::HostShouldQuit\` emitted when \`state.windows\` becomes empty). I built it across v0.33.491–v0.33.494, then learned empirically that delivering ANY work to the host's UI thread during the close-cascade window is unsolvable:
- \`cef::post_task(TID_UI, ...)\` silently drops new tasks
- Direct \`cef::quit_message_loop()\` from worker thread is UB
- Win32 \`PostThreadMessage(WM_QUIT)\` is ignored by CEF's custom pump

So the saga's delivery side was a dead-end. With the host-side fix in this PR, the saga is unnecessary — the host quits naturally. The IPC type additions (\`Event::HostShouldQuit\`, \`HwndDriftKind::OrphanInstance\`) remain in \`agentmux-common\` for any future observability use, with the host-side handler reduced to a single tracing line.

Full reasoning in \`docs/retro/b9-3-lifecycle-analysis.md\` and \`docs/retro/b9-3-quit-thread-analysis.md\`.

## Diagnostic logs

Structural signals (drain start, per-stage cascade, refill suppression, stage 2 quit) at \`tracing::warn!\` — operator visible in production. Verbose per-browser ENTER/EXIT trace at \`tracing::debug!\` with target \`wrr-trace\` — filtered out by default. Enable when investigating:

\`\`\`
RUST_LOG=\"info,wrr-trace=debug\"
\`\`\`

## Tests

- 55 launcher reducer tests pass (4 new B.9.3 cases for OrphanInstance signal — kept since the IPC types are kept; reducer-side observability without the saga delivery)
- Manual smoke confirmed across 4+ variations + pane tear-offs

## Test plan

- [ ] \`task package\` builds clean
- [ ] Launch portable, tear off any tab, close every visible window → process tree exits within seconds
- [ ] Repeat with multiple tear-offs (3+) → still exits cleanly
- [ ] Repeat with pane tear-offs → still exits cleanly
- [ ] \`task dev\` (no launcher) regression check — host exits when last visible window closes
- [ ] After close-all and clean exit, double-clicking exe again starts a fresh instance (no zombie blocking the named-pipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)