### PR TITLE
B.7.3.1: launcher events to renderer via CEF JS bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.501"
+version = "0.33.502"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.501"
+version = "0.33.502"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.501"
+version = "0.33.502"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.501"
+version = "0.33.502"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.502 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.394 | 2026-04-25 | 159.8 MiB | 333.7 MiB | |
 | 0.33.372 | 2026-04-24 | 159.8 MiB | 333.6 MiB | |
 | 0.33.356 | 2026-04-24 | 159.8 MiB | 333.6 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.501"
+version = "0.33.502"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -1,0 +1,66 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.7.3.1 — host outbound JS bridge for launcher typed events.
+//
+// Single function `dispatch_to_renderers(state, event)` called from
+// `launcher_ipc::apply_event_to_shadow` after each event is applied
+// to host shadows. Iterates `state.browsers`, calls
+// `Frame::ExecuteJavaScript` per top-level browser to invoke
+// `window.__agentmux_launcher_event(<json>)` in the renderer.
+//
+// Filtering: pool windows (`window-pool-*`) and browser-pane child
+// HWNDs (`browser-pane-*`) are skipped. They have no UI to react.
+//
+// Cross-platform: `Frame::ExecuteJavaScript` is portable across
+// CEF's Windows / macOS / Linux backends. No platform specifics.
+//
+// Coexistence with the bespoke `window-instances-changed` event:
+// during B.7.3.1 both channels deliver overlapping data. The
+// renderer prefers typed events when seen and falls back to the
+// bespoke channel when not (see `frontend/util/launcher-events.ts`
+// + `frontend/app-init.ts`). B.7.3.2/.3 retire the bespoke path.
+//
+// See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::Event;
+use cef::{CefString, ImplBrowser, ImplFrame};
+
+/// Forward a launcher event to every top-level renderer.
+///
+/// Pool + browser-pane labels are excluded — they have no UI.
+/// The JSON payload uses `serde_json::to_string`, so any string
+/// content from the Event is escaped against quote / backtick
+/// injection at the JS-string boundary.
+pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event) {
+    let json = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                target: "launcher-event-bridge",
+                "[launcher-event-bridge] serialize failed: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    let script = format!(
+        "if (window.__agentmux_launcher_event) {{ try {{ window.__agentmux_launcher_event({}) }} catch(e) {{ console.error('[launcher-event] dispatch failed', e) }} }}",
+        json
+    );
+    let code = CefString::from(script.as_str());
+    let url = CefString::from("");
+
+    let browsers = state.browsers.lock();
+    for (label, browser) in browsers.iter() {
+        if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
+            continue;
+        }
+        if let Some(frame) = browser.main_frame() {
+            frame.execute_java_script(Some(&code), Some(&url), 0);
+        }
+    }
+}

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -242,6 +242,12 @@ pub async fn connect_to_launcher(
 /// add more shadow handlers as additional host maps migrate. Other
 /// event types are no-ops here (they're already logged at the call
 /// site).
+///
+/// Phase B.7.3.1 — after the match, fan the event out to every
+/// top-level renderer via the JS bridge. Shadows are updated FIRST
+/// so that any renderer-side code that reads host state via the IPC
+/// HTTP path (e.g. `listWindowInstances`) sees a consistent view at
+/// the moment the typed event lands.
 fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: &Event) {
     match event {
         Event::WindowInstanceAssigned { label, num, .. } => {
@@ -398,6 +404,12 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
         }
         _ => {}
     }
+
+    // Phase B.7.3.1 — broadcast the typed event to every top-level
+    // renderer. The renderer-side dispatcher (`window.__agentmux_launcher_event`,
+    // installed by `frontend/util/launcher-events.ts`) feeds the
+    // launcher-event-reducer signal that downstream UI subscribes to.
+    crate::launcher_event_bridge::dispatch_to_renderers(state, event);
 }
 
 /// Phase B.7.1 — emit `window-instances-changed` with a resolved

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -29,6 +29,7 @@ mod commands;
 mod dev_authfile;
 mod events;
 mod ipc;
+mod launcher_event_bridge;
 mod launcher_ipc;
 mod memory_heartbeat;
 mod pane;

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.501"
+version = "0.33.502"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.501"
+version = "0.33.502"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.501"
+version = "0.33.502"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/next-steps-2026-04-29.md
+++ b/docs/retro/next-steps-2026-04-29.md
@@ -1,0 +1,249 @@
+# Next steps — toward the full launcher reducer
+
+**Status:** Planning doc. Captures what's done, what's left, and the order I'd ship it in.
+**Author:** AgentA.
+**Date:** 2026-04-29 (post-#600 / B.9 merge).
+
+---
+
+## Where the launcher reducer is right now
+
+After this session's PRs (#594 + #595 + #596 + #597 + #598 + #599 + #600) the launcher's reducer **is the canonical mutator** for nine distinct state projections. Every state change goes through `agentmux-launcher::reducer::update(&mut state, cmd, &ctx) -> Vec<Event>`:
+
+| State | What it tracks | Authority |
+|---|---|---|
+| `lifecycle` | Starting → Running → Quitting → Dead | Reducer (B.3) |
+| `processes` | PID → kind / state / version | Reducer (B.3) |
+| `windows` | label → kind, parent, opened_at, **+ B.9: hwnd, visible, iconic, last_rect, last_foreground_at_ms, foregrounded_since_open** | Reducer (B.4 + B.5 + B.9) |
+| `pool` | pre-warmed pool labels | Reducer (B.4 follow-up) |
+| `instance_registry` | label → instance num | Reducer (B.5) |
+| `backend_window_ids` | label → backend window id | Reducer (B.5) |
+| `monitors` | Win32 monitor topology | Reducer (B.9) |
+| `pending_hwnds` | unlinked Win32 HWNDs awaiting reconciliation | Reducer (B.9) |
+| `event_version` / `next_client_id` | monotonic counters | Reducer (B.3) |
+
+**Pure functional core.** The reducer never blocks, never awaits, never does I/O. It runs synchronously inside a `Mutex<State>` lock for sub-millisecond duration. Side effects are emitted as `Vec<Event>` and applied by subscribers (host's `apply_event_to_shadow`, future Tool clients, future srv).
+
+**Pure event-driven.** Every reducer call is in response to an external Command. There is no clock task, no heartbeat, no timer. State transitions and corrective actions both fire on the same OS-event-driven dispatch.
+
+**59 tests** cover invariants:
+- Reducer-arm unit tests (44 pre-B.9 + 8 new B.9: idempotent dup, drift+corrective, sentinel suppress, post-foreground no-correct, no-monitors-known, orphan-destroy chain, dual-source race, double-link drift, rect math).
+- 1 proptest generates arbitrary command sequences and asserts mirror invariants hold.
+
+---
+
+## What "full" means
+
+The golden vision (per `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` and `docs/retro/multi-reducer-proposal-2026-04-28.md`) is:
+
+```
+                        ┌────────────────────────┐
+                        │  LAUNCHER REDUCER       │
+                        │  (canonical state)      │
+                        └─────────┬───────────────┘
+                                  │ Events
+              ┌───────────────────┼─────────────────────┐
+              ▼                   ▼                     ▼
+        HOST PROJECTION    SRV PROJECTION       RENDERER PROJECTION
+        (CEF, win32 ops)   (workspace data)     (frontend reducers)
+              │                   │                     │
+              └─→ Commands ←──────┴──────── Commands ←──┘
+```
+
+Three things make the model "full":
+
+1. **Authority**: every shared state mutation goes through the reducer. No subscriber writes to canonical state directly.
+2. **Subscription**: every subscriber receives the events it cares about, so the projection it maintains is provably consistent with the reducer's view (modulo the well-defined async lag between event emission and projection update).
+3. **Sagas / corrective events**: cross-process transitions (e.g., "user closed main → cascade-close children → reap pool") are encoded as reducer-emitted events that subscribers act on, NOT as ad-hoc cross-process synchronization in subscriber code.
+
+**Where we stand against this:**
+
+| Property | Status |
+|---|---|
+| (1) Authority over windows / pool / instance_registry / backend_window_ids / monitors / hwnd state | ✅ |
+| (1) Authority over `host.browsers` (CEF Browser handles) | ❌ Phase B "scaffolding" — host-only, retired in Phase F |
+| (1) Authority over `host.window_pool` + `host.unpromoted_pool_labels` | ❌ Phase B "scaffolding" — same |
+| (2) Host subscribes to launcher events | ✅ via `apply_event_to_shadow` |
+| (2) Renderer subscribes to launcher events | ❌ B.7.3 — currently goes through bespoke `window-instances-changed` |
+| (2) srv subscribes to launcher events | ❌ Phase D / E |
+| (3) Cross-process correctives via reducer events | ✅ (B.9.2 `CorrectiveWindowMove` proves the pattern) |
+| (3) Snapshot / replay for resync after disconnect | ❌ Phase D |
+
+---
+
+## What's left, concretely
+
+The work below is ordered as I'd ship it. Each row is independently shippable and reviewable.
+
+### Tier 1 — finish Phase B (small, well-scoped)
+
+#### 1.1 Source-side fix: CEF Views position bug
+
+**Why first**: B.9.2's self-heal masks a real underlying bug. `commands/window.rs::open_window_with_kind` computes a position via `get_offset_position()` and passes it to `post_create_window`. In practice the new top-level CefWindow lands at the Win32 hidden sentinel `(-31970, -31970)` instead of the requested offset. The corrective then snaps it onto the primary monitor, which works but is a band-aid. Fixing this means new windows appear where the user expects (offset from the active window) rather than centered.
+
+**Investigation hooks**: `agentmux-cef/src/ui_tasks.rs::CreateWindowTask` is what actually runs on the CEF UI thread. Either CefWindow's bounds are being overridden by Views' default placement, or the `set_bounds` call we make is racing the initial paint and getting overwritten. Likely fix: pass the position through `WindowDelegate::get_initial_bounds` instead of post-create `set_bounds`.
+
+**Estimate**: ~50 LoC, 1 PR.
+
+#### 1.2 B.7.3 — CEF JS bridge for typed launcher events
+
+**Why next**: closes (2) for the renderer subscription axis. After this lands, the renderer doesn't depend on the host's bespoke `window-instances-changed` event — it subscribes to typed launcher events directly. The synchronous count-only emits in `window.rs` / `drag.rs` / `window_pool.rs` / `client.rs` can finally be retired (they exist as fallbacks for the non-launcher-driven path).
+
+**Plan**:
+- `agentmux-cef/src/launcher_ipc.rs` adds an outbound JS-bridge fanout. When `apply_event_to_shadow` receives an event, it also serializes it to JSON and `Frame::ExecuteJavaScript("window.__launcher_event && window.__launcher_event(<json>)")` against every active CEF browser.
+- New module `frontend/app/store/launcher-events.ts`: registers `window.__launcher_event` as a dispatcher into a SolidJS signal that block-level subscribers can listen to.
+- Migrate `app-init.ts::initInstanceTracking` from `getApi().listen("window-instances-changed", ...)` to the new launcher-event subscription.
+- Sync emits in `window.rs:655`, `drag.rs:385`, `window_pool.rs:559`, `client.rs:475` get retired (verified-redundant via the launcher-event path).
+- `frontend` reducer fed by the typed event stream (the original B.7 vision).
+
+**Estimate**: ~3 PRs, ~500 LoC total. The JS bridge plumbing is the bulk; the migration is straightforward once the bridge works.
+
+#### 1.3 B.8.1 — `agentmux.exe --diag wrr`
+
+**Why**: gives operators read-only access to the reducer state without grepping the launcher log. Connects as `ClientKind::Tool`, sends a new `Command::GetSnapshot` (B.8 also lays the groundwork for Phase D's resync), pretty-prints the windows table + recent drift events.
+
+**Plan**:
+- New `Command::GetSnapshot` + `Event::Snapshot { windows, monitors, drift_log_tail, ... }`.
+- Reducer arm clones state into the snapshot.
+- New `agentmux.exe --diag wrr` CLI surface in launcher (a separate entry point that connects to its own pipe and asks for a snapshot).
+- Pretty-printer with a stable column layout.
+
+**Estimate**: 1 PR, ~250 LoC.
+
+#### 1.4 B.8.2 — property tests + CI smoke
+
+**Why**: the reducer is the canonical state surface; property-based tests across arbitrary command sequences guard against regressions in state-machine invariants. CI smoke (synthetic open-N-windows-then-close-all) catches integration regressions.
+
+**Plan**:
+- New `proptest` strategies for each command family. Existing `arb_window_cmd` is the template.
+- Invariants: every Open has exactly one matching Close; instance_registry numbers are monotonic; `windows.keys()` ⊆ instance_registry ∪ pool; etc.
+- CI smoke: `agentmux.exe --headless --smoke close-all` script that opens N windows, closes them, asserts state.windows is empty.
+- Delete obsolete defensive code (e.g., `app-init.ts::refreshLabels(retriesLeft)`'s retry loop — once B.7.3 lands, it's dead).
+
+**Estimate**: 1 PR, ~300 LoC.
+
+**Phase B exit criteria after 1.1–1.4**: the launcher reducer is the canonical authority for everything except the two scaffolding scratchpads (`browsers`, `window_pool`/`unpromoted_pool_labels`); subscribers (host, renderer) consume the typed event stream; operator surface (`--diag`) exists; CI catches regressions; the original spec's "delete all 13 host stores" goal is realized for the 11 maps that can move.
+
+#### 1.5 B.9.3 — `OrphanInstance` drift + reducer-driven quit signal
+
+**Why** (surfaced 2026-04-29 smoke of v0.33.490):
+
+Smoke sequence: open AgentMux → tear off a tab → close every visible window → expect the host process tree to exit cleanly.
+
+Actual: launcher tree (launcher + srv + 6 host PIDs) stays alive after close-all. Win32 enumeration shows two `Chrome_WidgetWin_1` HWNDs still owned by the host main thread, both parked at the `(-32000,-32000)` sentinel position. They're pool windows held warm for the next tear-off. The host's existing close path doesn't reap pool when the last user-visible window closes — so the process hangs around indefinitely with no UI.
+
+**Why B.9 didn't catch it**: pool windows are filtered from `ReportWindowOpened` by design (the launcher's `state.windows` mirrors user-meaningful labels only). When the last `state.windows` entry is removed, the reducer's invariant set says "everything's fine — zero windows is a valid state". It has no concept of "the host process should be alive only as long as it has at least one user-visible window".
+
+**The state machine ALREADY knows enough to detect this.** When `state.windows` is empty and the host's process record is in `Running` (per `state.processes`), and `pending_hwnds` only contains sentinel-positioned entries (= unpromoted pool inventory), that's the signature.
+
+**Pure-reducer fix design** (no timers, mirrors B.9.2's pattern):
+
+```rust
+// agentmux-common::ipc
+HwndDriftKind::OrphanInstance,    // Host alive, zero user-visible windows, only sentinel HWNDs remain
+Event::HostShouldQuit { version }  // saga-style corrective: host subscribes, reaps pool, quits
+```
+
+Reducer trigger: at the END of `handle_report_window_closed` (the existing path that drops a label from `state.windows`), check the post-mutation invariant:
+
+```rust
+fn check_orphan_instance(state: &State) -> bool {
+    state.windows.is_empty()
+        && !state.pool.is_empty()           // there ARE pool windows (host is "warm")
+        && state.processes.values().any(|p| {
+              matches!(p.state, ProcessState::Running) && p.kind == ClientKind::Host
+           })
+}
+```
+
+When the predicate flips from false → true on a `WindowClosed` transition, emit `Event::HwndDriftDetected { kind: OrphanInstance, severity: Warn, ... }` AND `Event::HostShouldQuit { version }`. Host subscriber in `apply_event_to_shadow` handles `HostShouldQuit` by:
+1. Reaping the warm pool (`window_pool::shutdown_all`).
+2. Calling `quit_message_loop()`.
+3. Tree exits cleanly via existing J0 reaping.
+
+**Pure-reducer guarantee preserved**: the trigger is a state transition (the last `state.windows` entry being removed), not the passage of time. No timer evaluates "host has been window-less for N seconds" — the moment the predicate flips, the saga fires.
+
+**Edge case — opt out for legitimate "headless"**: if a Tool client (`agentmux.exe --diag`) is the only registered client and there's no Host registered, the predicate is false (no Host process to quit). Tool sessions don't trigger `HostShouldQuit`.
+
+**Scope**:
+- New `Event::HostShouldQuit` + `HwndDriftKind::OrphanInstance` variant.
+- Reducer arm at end of `handle_report_window_closed` checking the predicate.
+- Host subscriber handling `HostShouldQuit` in `apply_event_to_shadow`.
+- Two unit tests: trigger fires on transition; doesn't fire if `state.windows` was already empty when host registered (e.g., headless Tool session).
+
+**Estimate**: 1 PR, ~150 LoC (mostly tests).
+
+**Where this fits**: this is B.9.3 — a follow-up to B.9 in the same WRR family, ships before Phase B exit (1.4). It's part of "completing observation" before adding the bigger Phase D / E / F machinery.
+
+---
+
+### Tier 2 — Phase D (snapshot + resync + persisted log)
+
+After Phase B exits, Phase D adds the durability story. The reducer's `event_version` counter is already monotonic — Phase D makes it useful.
+
+#### D.1 GetSnapshot RPC
+
+Lets a subscriber that disconnected and reconnected fetch the current state + the last N events, so it can rebuild its projection without missing anything between the snapshot and "now".
+
+#### D.2 Persisted event log (ring buffer)
+
+Fixed-size ring buffer of recent events on disk (`<data-dir>/launcher-events.log`). Survives launcher crash for forensics. After launcher restart, it's not authoritative state (state machine restarts fresh) but is invaluable for debugging.
+
+#### D.3 Subscriber-resync protocol
+
+Subscriber on (re)connect: `Register` → `GetSnapshot { since: 0 }` → reducer replies with `Snapshot { ... }` + `EventList { events: [...] }`. After applying, subscriber is caught up. Then it transitions to live event stream.
+
+**Estimate**: ~3 PRs.
+
+---
+
+### Tier 3 — multi-reducer (Phase E + F)
+
+Phase B ends with the **scaffolding model**: host owns `browsers` + pool maps directly (because they hold FFI handles + need synchronous lifecycle decisions). Phase E + F retire the scaffolding model in favor of multi-reducer, where each process has its own reducer over its own canonical state, and **sagas** — pure-reducer-emitted corrective events — handle cross-reducer transitions.
+
+#### Phase E — srv reducer
+
+`agentmux-srv` already has its own state (workspaces, tabs, blocks, layout, identity accounts). Promoting it to a Redux-style reducer is the **first validation point** for the multi-reducer model. If the srv reducer pattern works for tabs/panes/layout, the same pattern will work for host's CEF browsers in Phase F.
+
+**Why Phase E first**: srv's state is purer (no FFI handles, no Win32 sync constraints), so it's a lower-risk first migration.
+
+#### Phase F — host reducer
+
+After E proves the multi-reducer pattern, retrofit the host. `state.browsers` becomes part of the host-side reducer's canonical state. Host emits a domain command (`OpenBrowser { label, kind }`) into its own reducer, which authorizes the FFI call and emits the event. The launcher reducer subscribes (via the event stream) and updates `state.windows`.
+
+**Phase F deliverables**:
+- New `agentmux-cef::reducer` with arms for `OpenBrowser`, `CloseBrowser`, `PoolAdd`, `PoolPromote`, `PoolDestroy`.
+- Host-side reducer becomes the authority over `browsers` + pool maps.
+- Sagas: when launcher emits `Event::WindowClosed { label, .. }`, host's saga consumer fires `Command::CloseBrowser { label }` into its OWN reducer, which drives the FFI close synchronously.
+- WRR's `wrr/enforcer.rs` (the CorrectiveWindowMove apply path) generalizes to a saga consumer surface for ANY launcher-emitted corrective.
+
+**Estimate**: 5–8 PRs across both crates, the largest single architectural shift remaining.
+
+---
+
+## Recommended order
+
+1. **1.5 (B.9.3 — OrphanInstance + HostShouldQuit)** — small, surfaced by today's v0.33.490 smoke. Same WRR family; ships before the rest. ~1 day.
+2. **1.1 (CEF Views position fix)** — small, removes a known masking case for B.9. ~1 day.
+3. **1.3 (--diag wrr)** — small, gives us better visibility into 1.2's effect when we cut over. ~1 day.
+4. **1.2 (CEF JS bridge / B.7.3)** — completes Phase B's frontend story. ~2-3 days across multiple PRs.
+5. **1.4 (proptests + CI smoke)** — closes Phase B. ~1 day.
+6. **Tier 2 (Phase D)** — durability story. Sequence with Tier 3 by appetite — Phase D is independently useful even if multi-reducer is deferred.
+7. **Tier 3 (Phase E + F)** — multi-reducer. The biggest remaining architectural shift; only make sense after Phase D's resync protocol exists (multi-reducer makes the resync surface broader).
+
+## Cross-cutting notes
+
+- **Don't add timers**. The "no heartbeat" guarantee is load-bearing. If a corrective should fire, it should fire on the same dispatch as the transition that surfaces the bug. If a transition can't fire it, that's a missing event source, not a missing timer.
+- **Don't relitigate the 3-class taxonomy**. `browsers` and pool maps stay scaffolding through all of Phase B + D. Phase F is the only acceptable retirement path.
+- **Don't push code direct to main**. Per `feedback_pr_for_code_changes`. Even small fixes go through PR + reagent + codex.
+- **Smoke before push for bug fixes**. Per `feedback_verify_before_push`. Bot reviewers don't run the binary; the user-visible bug is what matters.
+
+## Reference
+
+- Roadmap: `docs/retro/phase-b-roadmap.md`
+- WRR design: `docs/retro/wrr-design-2026-04-28.md`
+- B.5 architecture analysis: `docs/retro/b5-migration-architecture-2026-04-28.md`
+- Multi-reducer proposal: `docs/retro/multi-reducer-proposal-2026-04-28.md`
+- a→b→c→d→e migration ratchet: `docs/retro/migration-pattern.md`
+- Spec: `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md`
+- Inventory + gaps: `specs/ANALYSIS_WINDOW_PROCESS_STATE_INVENTORY_2026_04_27.md`

--- a/docs/retro/phase-b-roadmap.md
+++ b/docs/retro/phase-b-roadmap.md
@@ -42,11 +42,13 @@ Pre-Phase-B  ──► host owns 13 HashMaps  ◄── started here
                         ▼
               ✓ B.7.2 — re-emit on BackendWindowId events (#597)
                         ▼
-              ◄── HERE. B.9.1 in flight: WRR observation.
-                  (B.7.3 / B.8 deferred — B.9 jumped queue per
-                  user direction after stray-taskbar surface.)
-              B.7  ──  frontend cutover (delete polling)
-              B.8  ──  Phase B exit (delete obsolete defensive code,
+              ✓ B.9 — WRR observation + pure-reducer self-heal (#600)
+                        ▼
+              ✓ B.9.3 — pool-refill drain + cefsimple-pattern quit (#601)
+                        ▼
+              ◄── HERE. B.7.3 / B.8 remaining for Phase B exit.
+              B.7.3 ──  CEF JS bridge for typed launcher events
+              B.8   ──  Phase B exit (delete obsolete defensive code,
                        add property tests, --diag tool, CI smoke)
                         │
                         ▼
@@ -125,6 +127,9 @@ See `b5-migration-architecture-2026-04-28.md` for why `browsers` and pool maps c
 | Multi-reducer is the long-term architecture | 2026-04-28 | Cleaner than "scaffolding outside the model"; deferred to Phase E + F to validate the pattern incrementally |
 | `docs/retro/*.md` files are local-only | 2026-04-28 | No review churn; future agents read them via `MEMORY.md` pointer |
 | Single-instance lives in launcher pipe bind, not host port-file | B.6 (#595) | Pipe handle is OS-owned → no stale-state path; ERROR_ACCESS_DENIED is the canonical second-instance signal; user-facing MessageBox replaces silent exit |
+| WRR uses event-driven Win32 hooks, no timers / heartbeats | B.9 (#600) | `SetWinEventHook` + `WM_WINDOWPOSCHANGED` deliver every needed transition synchronously; the reducer fires drift on the same dispatch tick |
+| Pool refill is suppressed during host drain via `is_quitting` flag | B.9.3 (#601) | CEF's `quit_message_loop` is QuitWhenIdle — without suppressing refill, pool windows keep state.browsers non-empty forever and idle is never reached |
+| Cross-thread "deliver work to UI thread" uses `cef::post_task` (or Win32 PostMessage as bypass) — NOT direct calls or PostThreadMessage | B.9.3 (#601) | Direct calls from worker thread are CEF UB; PostThreadMessage(WM_QUIT) is ignored by CEF's custom Windows pump; `cef::post_task` is the documented portable bridge — and Win32 `PostMessage(hwnd, WM_CLOSE)` bypasses CEF's task queue when needed |
 
 ## How to update this doc
 

--- a/docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md
+++ b/docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md
@@ -1,0 +1,290 @@
+# B.7.3 — launcher events to renderer via CEF JS bridge
+
+**Status:** Implementation spec. Written 2026-04-29 after B.9.3 merge (#601).
+**Author:** AgentA.
+**Parent spec:** `specs/SPEC_WINDOW_PROCESS_STATE_MACHINE_2026_04_27.md` §5.3 + §5.5 (renderer subscription, echo-loop guard).
+**Read after:** `docs/retro/phase-b-roadmap.md`, `docs/retro/next-steps-2026-04-29.md` §1.2.
+
+---
+
+## Why this exists
+
+After B.7.1 + B.7.2 (#596 + #597), the renderer subscribes to **one bespoke event** — `window-instances-changed` — emitted by the host. The launcher reducer emits a much richer typed-event stream (`Event::WindowOpened`, `Event::WindowClosed`, `Event::BackendWindowIdRegistered`, `Event::HwndDriftDetected`, `Event::CorrectiveWindowMove`, `Event::HostShouldQuit`, etc.) that **never reaches the renderer directly**. The host's `apply_event_to_shadow` translates SOME launcher events into the bespoke proxy event; most don't make it.
+
+This means:
+- Each new launcher event needs new host translation code to surface in the UI.
+- WRR drift events (`OffMonitor`, `HiddenSinceOpen`, `OrphanDestroy`, `OrphanInstance`) only land in launcher logs — the user never sees them in-app.
+- Frontend's reducer doesn't have a clean "all canonical state" feed; it patches together via a few proxy paths.
+
+**B.7.3 makes the renderer a first-class typed-event subscriber.** The host's CEF JS bridge forwards every launcher event to every active renderer; the renderer registers a single dispatcher that feeds a SolidJS signal; the frontend reducer / atoms / blocks consume the typed stream.
+
+---
+
+## Where the current state of the codebase is
+
+After B.9.3 (#601) merged, the relevant pieces are:
+
+```
+LAUNCHER (agentmux-launcher/src)
+  reducer.rs::update — emits Event variants per the agentmux-common::ipc::Event enum
+  ipc/server.rs::handle_connection — sends events back over the originating pipe
+                                     connection only (per-connection reply, no broadcast)
+
+HOST (agentmux-cef/src)
+  launcher_ipc.rs::connect_to_launcher — opens the pipe, reads events
+  launcher_ipc.rs::apply_event_to_shadow — host's projection layer; updates
+                                           shadow_window_meta, shadow_instance_registry,
+                                           shadow_backend_window_ids; ALSO re-emits
+                                           the bespoke window-instances-changed via
+                                           emit_event_all_windows for SOME events
+
+  events.rs::emit_event_all_windows(state, name, payload) — current proxy that
+    iterates state.browsers and calls Frame::ExecuteJavaScript on each;
+    delivers the bespoke event names
+
+RENDERER (frontend)
+  app-init.ts::initInstanceTracking subscribes via getApi().listen("window-instances-changed", ...)
+  cef-api.ts::listen wraps the host's bespoke event channel
+  app/store/global.ts atoms updated by app-init.ts payload handler
+```
+
+**Two reasons to leave most of this in place during the cutover:**
+1. The bespoke `window-instances-changed` is consumed by ≥3 frontend sites (`app-init.ts`, action-widgets, command-registry). Removing it requires migrating each.
+2. The `task dev` mode (no launcher) still emits the bespoke event directly from `commands::window`/`drag`/`window_pool`. Renderer needs to handle "no launcher" gracefully.
+
+---
+
+## Design
+
+### Wire format
+
+Reuse `agentmux_common::ipc::Event` directly. It's already `serde_json::Serialize`. The host's outbound JS bridge serializes to JSON and dispatches:
+
+```js
+// Renderer receives this via window.__agentmux_launcher_event(...)
+{
+  "event": "window_opened",
+  "label": "window-abc123...",
+  "kind": "full_instance",
+  "parent_label": null,
+  "version": 42
+}
+```
+
+The `event` discriminant matches the snake-case wire form (`#[serde(tag = "event", rename_all = "snake_case")]` already on `Event`). The `version` field carries the reducer's monotonic counter, useful for echo-loop deduping (per parent spec §5.5).
+
+### Host outbound bridge — new module `agentmux-cef/src/launcher_event_bridge.rs`
+
+Single function `dispatch_to_renderers(state, event)` called from `apply_event_to_shadow` after each event is applied to host shadows. Iterates `state.browsers`, calls `Frame::ExecuteJavaScript` per browser:
+
+```rust
+pub fn dispatch_to_renderers(state: &Arc<AppState>, event: &agentmux_common::ipc::Event) {
+    let json = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("[launcher-event-bridge] serialize failed: {}", e);
+            return;
+        }
+    };
+    // Note: the JS string interpolation uses serde_json's escaping —
+    // safe against quote/backtick injection from Event payloads.
+    let script = format!(
+        "if (window.__agentmux_launcher_event) {{ try {{ window.__agentmux_launcher_event({}) }} catch(e) {{ console.error('[launcher-event] dispatch failed', e) }} }}",
+        json
+    );
+    let browsers = state.browsers.lock();
+    for (label, b) in browsers.iter() {
+        // Skip pool + browser-pane — they have no UI to react.
+        if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
+            continue;
+        }
+        let mut b = b.clone();
+        if let Some(frame) = b.main_frame() {
+            frame.execute_java_script(
+                &cef::CefString::from(&script[..]),
+                &cef::CefString::from(""),
+                0,
+            );
+        }
+    }
+}
+```
+
+Filtering rationale:
+- **Pool windows skipped** — they're hidden, no user-visible UI. Sending events to them wastes a JS roundtrip per pool window per event; with 3+ pool windows that's 3× the cost.
+- **Browser-pane child HWNDs skipped** — same reason.
+- All other top-level browsers (main, full-instance tear-offs, sub-windows) get the event.
+
+Cross-platform: `Frame::ExecuteJavaScript` is portable; nothing Windows-specific in the dispatch.
+
+### Renderer subscription — `frontend/util/launcher-events.ts`
+
+New module. At init, registers `window.__agentmux_launcher_event` as the dispatcher. Pushes events into a `solid-js` signal that block-level subscribers can `effect()` over.
+
+```ts
+import { createSignal } from "solid-js";
+
+// Mirrors agentmux_common::ipc::Event enum on the wire.
+// Internally tagged: { event: "window_opened", label, kind, ..., version }
+export interface LauncherEvent {
+    event: string;
+    version: number;
+    [field: string]: any;
+}
+
+const [latestEvent, setLatestEvent] = createSignal<LauncherEvent | null>(null);
+const [eventVersion, setEventVersion] = createSignal<number>(0);
+
+/** Block subscribers read from this signal in createEffect. */
+export const launcherEvent = latestEvent;
+export const launcherEventVersion = eventVersion;
+
+let installed = false;
+export function installLauncherEventBridge() {
+    if (installed) return;
+    installed = true;
+    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => {
+        // Accept any event with a version; drift / lifecycle / corrective.
+        if (typeof evt?.version !== "number") {
+            console.warn("[launcher-events] received event without version", evt);
+            return;
+        }
+        setLatestEvent(evt);
+        setEventVersion(evt.version);
+    };
+    console.log("[launcher-events] bridge installed; window.__agentmux_launcher_event ready");
+}
+```
+
+Called once from `app-init.ts::initApp` BEFORE the first renderer-state-needing operation. Idempotent.
+
+### Frontend reducer — feeding atoms
+
+The renderer's existing atoms (`openWindowLabelsAtom`, `openWindowEntriesAtom`, `windowInstanceNumAtom`, `windowCountAtom`, etc.) currently get fed by `app-init.ts::applyEntries` which is called by the bespoke event listener. After B.7.3, those atoms are fed by typed events.
+
+New file `frontend/app/store/launcher-event-reducer.ts`:
+
+```ts
+import { createEffect } from "solid-js";
+import { launcherEvent, launcherEventVersion } from "@/util/launcher-events";
+import { setOpenWindowLabelsAtom, setOpenWindowEntriesAtom,
+         setWindowCountAtom, setWindowInstanceNumAtom } from "@/app/store/global";
+
+export function startLauncherEventReducer() {
+    createEffect(() => {
+        const evt = launcherEvent();
+        const v = launcherEventVersion();
+        if (!evt) return;
+        // Echo-loop guard (parent spec §5.5): if a local command
+        // dispatched this and we're applying it, skip the
+        // re-emission. Wire later when we have local commands
+        // that hit the launcher.
+        switch (evt.event) {
+            case "window_opened":
+                applyWindowOpened(evt);
+                break;
+            case "window_closed":
+                applyWindowClosed(evt);
+                break;
+            case "backend_window_id_registered":
+                applyBackendWindowIdRegistered(evt);
+                break;
+            // ... drift events: fire a notification or update a debug panel
+            case "hwnd_drift_detected":
+                applyHwndDrift(evt);
+                break;
+            // ... unhandled events are silently ignored (fwd-compat)
+        }
+    });
+}
+```
+
+Each `apply*` function reads-modify-writes the corresponding atoms.
+
+### Migration of `window-instances-changed`
+
+**Coexistence period (this PR)**: keep `window-instances-changed` working. Both event channels deliver overlapping data. Frontend prefers typed events when available, falls back to the bespoke event when not.
+
+**Detection**: at init time, if the launcher's bridge has installed itself (`window.__agentmux_launcher_event` is non-null and we've received any event with version > 0), the renderer treats typed events as authoritative. Otherwise (`task dev` mode, no launcher), it continues using the bespoke `window-instances-changed`.
+
+**Retirement (next PR)**: once typed events are validated to be authoritative across all variations (open/close/tear-off/pane), remove the bespoke listener from `app-init.ts` and the sync emit sites in `commands::window::open_window_with_kind`, `commands::drag::tear_off`, `commands::window_pool::*`, `client.rs`. Net delete ~40 LoC across those sites.
+
+### Echo-loop guard
+
+Per parent spec §5.5: when a renderer's local command (e.g. `getApi().openNewWindow()`) results in a launcher-emitted event flowing back to the same renderer, the renderer must not re-dispatch the local command.
+
+Initial design: track an `applying_remote` boolean in the reducer effect. When set, action handlers (e.g. atom-update side effects that would emit a command) check the flag and skip command emission. For B.7.3's first PR we don't have any frontend → launcher commands wired through this bridge yet (commands still go through the host IPC HTTP path), so the guard is a forward-compatibility hook — set it during `applyXxx` so future command emitters see it.
+
+---
+
+## Concretely, what changes — file-by-file
+
+| File | Change |
+|---|---|
+| **agentmux-cef/src/launcher_event_bridge.rs** (new) | `pub fn dispatch_to_renderers(state, event)` — JSON + ExecuteJavaScript fanout, filters pool/pane labels |
+| **agentmux-cef/src/launcher_ipc.rs::apply_event_to_shadow** | At end of every match arm, call `launcher_event_bridge::dispatch_to_renderers(state, event)` |
+| **agentmux-cef/src/main.rs** | `mod launcher_event_bridge;` |
+| **frontend/util/launcher-events.ts** (new) | Exports `installLauncherEventBridge()`, `launcherEvent` signal |
+| **frontend/app/store/launcher-event-reducer.ts** (new) | `startLauncherEventReducer()` — `createEffect` over `launcherEvent`, dispatches by `evt.event` |
+| **frontend/app-init.ts** | Call `installLauncherEventBridge()` early in `initApp`. Call `startLauncherEventReducer()` after `initWaveWrap`. Keep `window-instances-changed` listener as fallback when no typed events seen yet. |
+| **agentmux-launcher/src/wrr/mod.rs** (no change) | Drift events already typed and emitted; they'll just flow through the new bridge automatically |
+| **frontend/types/custom.d.ts** | Declare `window.__agentmux_launcher_event` for TS happiness |
+
+Estimated diff: ~300 LoC new, ~30 LoC modified, ~0 LoC deleted (deletion happens in B.7.3.2 follow-up).
+
+---
+
+## Sub-PR sequence
+
+This spec covers **B.7.3.1** (additive: bridge + renderer subscription + reducer scaffolding). Two follow-ups:
+
+- **B.7.3.2** — feed atoms from typed events as the authoritative path; demote `window-instances-changed` to fallback-only; verify no regressions across all variations.
+- **B.7.3.3** — retire `window-instances-changed` and the 4 sync-emit sites in `commands::window`, `drag`, `window_pool`, `client.rs`. Pure deletion. Delete the legacy `applyEntries` / `refreshLabelsViaRpc` paths.
+
+Each sub-PR is independently shippable. B.7.3.1 lands the cable; .2 makes the renderer prefer typed events; .3 burns the old bridge.
+
+---
+
+## Test plan
+
+**B.7.3.1 (this spec)**:
+- [ ] Launch portable, open DevTools (Ctrl+Shift+I), confirm `window.__agentmux_launcher_event` is a function.
+- [ ] Open a second window via status-bar button. Console should log incoming events: `window_opened`, `backend_window_id_registered`, etc. with valid `version`.
+- [ ] Tear off a tab. Same logging pattern; events arrive within ~5ms of close.
+- [ ] Close all windows. Process exits cleanly (B.9.3 invariant preserved).
+- [ ] `task dev` (no launcher) — renderer init succeeds, `window.__agentmux_launcher_event` is still installed (no events arrive, but no crash). Bespoke `window-instances-changed` fallback continues to drive the InstancePanel.
+- [ ] Force a drift event (curl `open_new_window`, see if `hwnd_drift_detected` arrives at the renderer console).
+
+**B.7.3.2**:
+- All atoms react correctly to typed events without the bespoke channel firing.
+- Event ordering preserved per pipe (B.7.3 inherits the parent spec's per-pipe ordering guarantee).
+- `applying_remote` flag set during apply (verify via debug print).
+
+**B.7.3.3**:
+- `task package` builds clean after deletion.
+- All InstancePanel / window-list UI behaves identically to v0.33.502 (the B.7.3.1 baseline).
+
+---
+
+## Open questions
+
+1. **Per-renderer subscription vs broadcast.** Current design broadcasts to every top-level browser. Should we let renderers register/deregister subscriptions (e.g., a renderer that doesn't show window state opts out)? B.7.3.1 broadcasts; refinement deferred — keep it simple.
+2. **Event volume.** Reducer can fire 10–50 events per user action (e.g., open window: WindowOpened + InstanceAssigned + BackendWindowIdRegistered + HwndOpened + HwndForegroundChanged + HwndPositionChanged + ...). Each costs one ExecuteJavaScript per top-level renderer. With 5 renderers and 10 events per action, that's 50 IPC roundtrips per user action. Profiling needed before B.7.3.3 retirement; if it shows up as jank, batch dispatch.
+3. **Drift event UX.** Drift events (`OffMonitor`, `HiddenSinceOpen`, etc.) currently only land in logs. Should the renderer surface them as toasts? B.7.3.1 makes them available at the renderer; UX wiring is a separate UX-design question.
+4. **`task dev` parity.** Without the launcher, no typed events flow. The renderer falls back to the bespoke channel. Long-term plan (Phase E srv reducer) makes the launcher unconditionally part of the loop, retiring `task dev`'s no-launcher mode. Until then, dual-path stays.
+
+---
+
+## Cross-platform notes
+
+- `Frame::ExecuteJavaScript` is portable across CEF's Windows / macOS / Linux backends. Same bridge code works everywhere.
+- The renderer-side dispatcher is plain JavaScript on a CEF V8 context; no platform specifics.
+- Phase 7 cross-platform parity work doesn't change anything in B.7.3 — the bridge is OS-agnostic.
+
+---
+
+## What this does NOT do
+
+- **No `GetSnapshot` resync protocol.** Parent spec §5.4. Required for proper reconnect, but B.7.3 assumes the host stays connected for its lifetime (current reality post-B.6). Phase D adds resync.
+- **No frontend → launcher commands via this channel.** Commands still flow renderer → host IPC HTTP → launcher pipe. The reverse channel (commands ON the JS bridge) is a Phase E concern.
+- **No event ordering across renderers.** Each renderer gets the same events in the same order, but the renderers' apply order isn't synchronized between each other. Per parent spec §5.3, ordering is per-pipe; broadcast doesn't preserve cross-subscriber ordering. Acceptable for AgentMux's use cases.

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -45,6 +45,8 @@ import { ContextMenuModel } from "@/app/store/contextmenu";
 import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
+import { installLauncherEventBridge } from "@/util/launcher-events";
+import { startLauncherEventReducer } from "@/app/store/launcher-event-reducer";
 
 // Deferred — assigned inside initApp() after window.api is ready.
 // Do NOT call getApi() at module level: this file is statically imported by
@@ -379,6 +381,12 @@ export async function initApp() {
     appVersion = getApi().getAboutModalDetails().version;
     document.title = `AgentMux ${appVersion}`;
 
+    // Phase B.7.3.1 — install `window.__agentmux_launcher_event` BEFORE
+    // any host-touching call. The host's `launcher_event_bridge` may
+    // start dispatching as soon as the renderer's V8 context is ready;
+    // registering early guarantees no events are dropped on the floor.
+    installLauncherEventBridge();
+
     // Register context menu click handler now that window.api exists.
     ContextMenuModel.init();
 
@@ -497,6 +505,10 @@ async function initWaveWrap(initOpts: AgentMuxInitOpts) {
         }
         savedInitOpts = initOpts;
         await initWave(initOpts);
+        // Phase B.7.3.1 — start the launcher-event reducer effect now
+        // that global state is wired. Idempotent: subsequent calls
+        // (e.g. via reinitWave path) are no-ops.
+        startLauncherEventReducer();
     } catch (e) {
         getApi().sendLog("Error in initWave " + e.message + "\n" + e.stack);
         console.error("Error in initWave", e);

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -1,0 +1,106 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.7.3.1 — frontend reducer for launcher typed events.
+//
+// Subscribes to the `launcherEvent` signal from
+// `frontend/util/launcher-events.ts` and dispatches by `event`
+// discriminant. In B.7.3.1 this is SCAFFOLDING: it logs every typed
+// event and, for the variants that already have a corresponding
+// bespoke `window-instances-changed` payload path, runs alongside
+// the bespoke channel (idempotent — both write the same atoms).
+//
+// B.7.3.2 promotes typed events to the authoritative path: when
+// `launcherEventsActive()` is true, atom-update side-effects flow
+// from here, not from the bespoke listener.
+// B.7.3.3 retires the bespoke channel and its 4 sync emit sites.
+//
+// Echo-loop guard (parent spec §5.5): an `applyingRemote` flag is
+// set during each apply so future renderer-emitted commands can
+// detect "this state change came from the launcher; don't re-emit."
+// Currently no commands flow through this bridge (commands still
+// take the host IPC HTTP path), so the flag is forward-compatibility
+// scaffolding.
+//
+// See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
+
+import { createEffect } from "solid-js";
+
+import { launcherEvent, launcherEventVersion, type LauncherEvent } from "@/util/launcher-events";
+
+let applyingRemote = false;
+
+/**
+ * True while the reducer is mid-apply for a launcher event. Future
+ * renderer-emitted commands should check this and skip re-emission
+ * to avoid echo loops with the launcher.
+ */
+export function isApplyingRemoteEvent(): boolean {
+    return applyingRemote;
+}
+
+let started = false;
+
+/**
+ * Start the reducer effect. Idempotent. Called once per renderer
+ * after `initWaveWrap` so global state is ready before the first
+ * apply touches atoms.
+ */
+export function startLauncherEventReducer(): void {
+    if (started) return;
+    started = true;
+
+    createEffect(() => {
+        const evt = launcherEvent();
+        // Read version too so SolidJS tracks the version signal as a
+        // dependency — guarantees the effect re-runs even when two
+        // consecutive events have referentially-equal payloads (e.g.
+        // a same-shape OffMonitor drift firing twice).
+        launcherEventVersion();
+        if (!evt) return;
+
+        applyingRemote = true;
+        try {
+            dispatch(evt);
+        } finally {
+            applyingRemote = false;
+        }
+    });
+}
+
+function dispatch(evt: LauncherEvent): void {
+    // B.7.3.1: log every event so smoke tests can verify the cable.
+    // B.7.3.2 promotes specific arms to atom-mutating handlers.
+    console.log("[launcher-event-reducer]", evt.event, "v=" + evt.version, evt);
+    switch (evt.event) {
+        case "window_opened":
+        case "window_closed":
+        case "window_instance_assigned":
+        case "window_instance_released":
+        case "backend_window_id_registered":
+        case "backend_window_id_unregistered":
+            // Lifecycle events — currently fed via the bespoke
+            // `window-instances-changed` payload's resolved entries.
+            // B.7.3.2 will swap that for an in-memory reduction
+            // here and demote the bespoke channel.
+            break;
+        case "hwnd_drift_detected":
+            // Drift events: WRR emits these when the launcher's
+            // pure-reducer detects an off-monitor / hidden / orphan
+            // window. Currently logged only; UX wiring (toast or
+            // debug panel) is a separate question (spec §Open
+            // questions #3).
+            break;
+        case "corrective_window_move":
+        case "host_should_quit":
+            // Saga events handled host-side via launcher_ipc.rs.
+            // Renderer just logs; no UI action.
+            break;
+        default:
+            // Forward-compat: unknown variants are silently ignored.
+            // The host bridge forwards every Event variant, so newly-
+            // added events (e.g. Phase D snapshot deltas) flow here
+            // without renderer code change until they need handling.
+            break;
+    }
+}

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -658,6 +658,12 @@ declare global {
         __WAVE_SERVER_WS_ENDPOINT__?: string;
         __WAVE_SERVER_WEB_ENDPOINT__?: string;
         __startupPerfStart?: number;
+
+        // Phase B.7.3.1 — launcher typed-event dispatcher.
+        // Installed by `frontend/util/launcher-events.ts`; called
+        // by the host's CEF JS bridge once per top-level renderer
+        // per launcher event.
+        __agentmux_launcher_event?: (evt: { event: string; version: number; [k: string]: unknown }) => void;
     }
 }
 

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -1,0 +1,85 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase B.7.3.1 — renderer-side subscriber for launcher typed events.
+//
+// Mirrors `agentmux_common::ipc::Event` on the wire. The host's CEF
+// JS bridge (`agentmux-cef/src/launcher_event_bridge.rs`) calls
+// `window.__agentmux_launcher_event(<json>)` once per top-level
+// renderer per launcher event. We feed those into a SolidJS signal
+// so block-level subscribers can `createEffect()` on them.
+//
+// During the cutover (B.7.3.1), the bespoke `window-instances-changed`
+// CEF event channel is still authoritative for the InstancePanel.
+// This module just installs the cable. B.7.3.2 makes typed events
+// the authoritative path for atom updates; B.7.3.3 retires the
+// bespoke channel.
+//
+// `task dev` mode: the launcher isn't in the loop, so no events
+// arrive. The dispatcher is still installed (idempotent, no
+// side-effects), and downstream subscribers see no signal updates.
+// The bespoke `window-instances-changed` channel continues to drive
+// the UI in that mode until Phase E retires the no-launcher path.
+//
+// See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
+
+import { createSignal } from "solid-js";
+
+/**
+ * Wire-format launcher event. Matches the JSON serialization of
+ * `agentmux_common::ipc::Event` (`#[serde(tag = "event", rename_all = "snake_case")]`).
+ *
+ * Every event carries `event` (discriminant, snake_case) and
+ * `version` (monotonic per launcher run, used for de-dup / echo-loop
+ * guard). Other fields are variant-specific; downstream subscribers
+ * narrow on `event` and read fields by name.
+ */
+export interface LauncherEvent {
+    event: string;
+    version: number;
+    [field: string]: unknown;
+}
+
+const [latestEvent, setLatestEvent] = createSignal<LauncherEvent | null>(null);
+const [eventVersion, setEventVersion] = createSignal<number>(0);
+const [seenAnyEvent, setSeenAnyEvent] = createSignal<boolean>(false);
+
+/** Latest typed event delivered by the launcher. Null until the first event. */
+export const launcherEvent = latestEvent;
+
+/** Monotonic version of the most recent event. 0 until the first event. */
+export const launcherEventVersion = eventVersion;
+
+/**
+ * True once we've received at least one typed event. The reducer uses
+ * this as the signal that typed events are flowing — the renderer
+ * can treat them as authoritative once this flips. Until then, the
+ * bespoke `window-instances-changed` channel remains the source of
+ * truth (covers `task dev` mode where no launcher is in the loop).
+ */
+export const launcherEventsActive = seenAnyEvent;
+
+let installed = false;
+
+/**
+ * Register `window.__agentmux_launcher_event` as the dispatcher.
+ * Idempotent — safe to call multiple times. Called once from
+ * `app-init.ts::initApp` BEFORE the first state-needing operation
+ * so events that arrive during init aren't dropped.
+ */
+export function installLauncherEventBridge(): void {
+    if (installed) return;
+    installed = true;
+    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => {
+        if (!evt || typeof evt.version !== "number" || typeof evt.event !== "string") {
+            console.warn("[launcher-events] received malformed event", evt);
+            return;
+        }
+        setLatestEvent(evt);
+        setEventVersion(evt.version);
+        if (!seenAnyEvent()) {
+            setSeenAnyEvent(true);
+        }
+    };
+    console.log("[launcher-events] bridge installed; window.__agentmux_launcher_event ready");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.501",
+  "version": "0.33.502",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.501",
+      "version": "0.33.502",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.501",
+  "version": "0.33.502",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase B.7.3.1 — adds the host outbound CEF JS bridge + renderer-side dispatcher + reducer scaffolding so launcher typed events reach the renderer without per-event host translation. This is the additive first step; B.7.3.2 promotes typed events to authoritative; B.7.3.3 retires the bespoke `window-instances-changed` channel.

## What changes

**Host (Rust)**
- `agentmux-cef/src/launcher_event_bridge.rs` (new) — `dispatch_to_renderers(state, event)` serializes the `agentmux_common::ipc::Event` JSON and calls `window.__agentmux_launcher_event` on every top-level browser via `Frame::ExecuteJavaScript`. Pool + browser-pane labels filtered out.
- `launcher_ipc.rs::apply_event_to_shadow` — invokes the bridge after every match arm. Shadows update FIRST so any IPC HTTP read sees consistent state at event-arrival time.

**Renderer (TypeScript / SolidJS)**
- `frontend/util/launcher-events.ts` (new) — `installLauncherEventBridge()` registers the dispatcher into a SolidJS signal pair (`latestEvent` + `version`). `launcherEventsActive` exposes a "have we seen any typed events" flag for B.7.3.2's prefer-typed-when-available cutover.
- `frontend/app/store/launcher-event-reducer.ts` (new) — `startLauncherEventReducer()` creates a `createEffect` over `launcherEvent`, dispatches by `evt.event`. B.7.3.1 logs only (scaffolding); B.7.3.2 promotes specific arms to atom-mutating handlers. `applyingRemote` flag is forward-compat scaffolding for the parent spec §5.5 echo-loop guard.
- `app-init.ts` — installs bridge BEFORE any host-touching call (no dropped events on first window); starts the reducer after `initWaveWrap` so global state is wired before atoms get touched.
- `types/custom.d.ts` — declares `window.__agentmux_launcher_event`.

## Coexistence with bespoke channel

The renderer still listens to `window-instances-changed` for InstancePanel (covers `task dev` / no-launcher mode where typed events don't flow). B.7.3.2 promotes typed events to authoritative; B.7.3.3 retires the bespoke channel and its 4 sync emit sites.

## Spec

`docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md` — wire format, design, file-by-file changes, sub-PR sequence, test plan, open questions.

## Test plan

Smoked locally on v0.33.502:

- [x] Console logs `[launcher-events] bridge installed; window.__agentmux_launcher_event ready` at init.
- [x] `window.__agentmux_launcher_event` is a function in DevTools.
- [x] Open second window via status-bar popup → typed events flow into console (`window_opened`, `backend_window_id_registered`, etc.) with valid `version`.
- [x] Tear off a tab → typed events flow.
- [x] Close all windows → process exits cleanly (B.9.3 invariant preserved).

## Cross-platform

`Frame::ExecuteJavaScript` is portable; nothing Windows-specific in the bridge or renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)