### PR TITLE
B.7.3.2: typed events authoritative for InstancePanel atoms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.502"
+version = "0.33.503"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.502"
+version = "0.33.503"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.502"
+version = "0.33.503"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.502"
+version = "0.33.503"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.503 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.502 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.394 | 2026-04-25 | 159.8 MiB | 333.7 MiB | |
 | 0.33.372 | 2026-04-24 | 159.8 MiB | 333.6 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.502"
+version = "0.33.503"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.502"
+version = "0.33.503"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.502"
+version = "0.33.503"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.502"
+version = "0.33.503"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -45,8 +45,8 @@ import { ContextMenuModel } from "@/app/store/contextmenu";
 import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
-import { installLauncherEventBridge } from "@/util/launcher-events";
-import { startLauncherEventReducer } from "@/app/store/launcher-event-reducer";
+import { installLauncherEventBridge, launcherEventsActive } from "@/util/launcher-events";
+import { seedKnownEntriesFromSnapshot, startLauncherEventReducer } from "@/app/store/launcher-event-reducer";
 
 // Deferred — assigned inside initApp() after window.api is ready.
 // Do NOT call getApi() at module level: this file is statically imported by
@@ -83,23 +83,29 @@ async function initInstanceTracking(): Promise<void> {
     const isInstanceLabel = (l: string): boolean =>
         l === "main" || /^window-/.test(l);
 
-    // Phase B.7.1 — two payload shapes coexist during the cutover:
+    // Phase B.7.3.2 — typed launcher events are authoritative once
+    // they start flowing (`launcherEventsActive()` flips on the first
+    // event). The reducer in `launcher-event-reducer.ts` mutates the
+    // InstancePanel atoms from the typed stream.
     //
-    //   1. Launcher-driven re-emit (`launcher_ipc.rs::apply_event_to_shadow`)
-    //      ships `{ count, entries: [{label, windowId}] }`. The
-    //      shadows + state.browsers are both populated by the time
-    //      this fires, so a single application is authoritative —
-    //      no RPC, no polling. This is the path B.7 is migrating
-    //      everything to.
+    // Two paths coexist as fallback during B.7.3.2:
+    //
+    //   1. Launcher-driven bespoke `window-instances-changed` re-emit
+    //      (`launcher_ipc.rs::apply_event_to_shadow`) ships
+    //      `{ count, entries: [{label, windowId}] }` — same data the
+    //      typed events derive from, but as a snapshot per event.
+    //      Used here ONLY when typed events haven't been seen yet
+    //      (covers the brief window between renderer-init and the
+    //      first typed event arriving).
     //
     //   2. Sync emits at the mutation sites (window.rs / drag.rs /
     //      window_pool.rs / client.rs) still ship count-only
     //      payloads. They fire BEFORE state.browsers settles, so a
-    //      single RPC read would see stale data. This is also the
-    //      sole path during `task dev` (no launcher in the loop),
-    //      so we can't retire it yet — keep the historic 6×50ms
-    //      retry-on-stale polling here. (codex PR #569 P2 +
-    //      reagent #596 P1.) B.7.2 retires the sync emits.
+    //      single RPC read would see stale data. Also the sole
+    //      path during `task dev` (no launcher in the loop), so we
+    //      can't retire it yet — the 6×50ms retry-on-stale polling
+    //      stays as the no-launcher path. (codex PR #569 P2 +
+    //      reagent #596 P1.) B.7.3.3 retires the sync emits.
     //
     // The retry compares `entries-key` (label@windowId, joined) to
     // detect a real change, including the `null → real` windowId
@@ -157,15 +163,53 @@ async function initInstanceTracking(): Promise<void> {
     };
 
     try {
-        const [instanceNum, windowCount] = await Promise.all([
+        // Phase B.7.3.2 — fetch the snapshot once for the typed-event
+        // reducer to seed itself with. Each renderer's own instance
+        // number is fetched too (one-time, never updated by typed
+        // events — stable per-renderer-per-run). `getWindowCount`
+        // becomes derived state once typed events take over, but we
+        // keep the initial RPC for the no-launcher fallback path.
+        const [instanceNum, windowCount, snapshotEntries] = await Promise.all([
             getApi().getInstanceNumber(),
             getApi().getWindowCount(),
-            refreshLabelsViaRpc(),
+            (async (): Promise<Array<{ label: string; windowId: string | null }>> => {
+                try {
+                    const all = await getApi().listWindowInstances();
+                    return Array.isArray(all) ? all : [];
+                } catch {
+                    const all = await getApi().listWindows();
+                    return (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
+                }
+            })(),
         ]);
         setWindowInstanceNumAtom(instanceNum);
         setWindowCountAtom(windowCount);
+        // Seed the reducer with the snapshot. Once the first typed
+        // event arrives, `launcherEventsActive()` flips and the
+        // reducer's atom-mutation path takes over from the bespoke
+        // listener below.
+        seedKnownEntriesFromSnapshot(snapshotEntries);
+        // `lastEntriesKey` is used by the no-launcher retry path
+        // (`refreshLabelsViaRpc`); seed it from the snapshot so the
+        // first bespoke event compares against a real key.
+        lastEntriesKey = snapshotEntries
+            .filter((e) => isInstanceLabel(e.label))
+            .sort((a, b) => {
+                if (a.label === "main") return -1;
+                if (b.label === "main") return 1;
+                return a.label.localeCompare(b.label);
+            })
+            .map((e) => `${e.label}@${e.windowId ?? ""}`)
+            .join("|");
 
         await getApi().listen("window-instances-changed", (event: any) => {
+            // B.7.3.2 — when typed events are flowing, the reducer
+            // is authoritative and this listener should NOT mutate
+            // atoms. Drop the payload silently. (`task dev` mode +
+            // the brief pre-first-typed-event window in portable
+            // mode are the only times this branch falls through.)
+            if (launcherEventsActive()) return;
+
             const payload = event?.payload ?? event;
             if (payload && typeof payload === "object" && Array.isArray(payload.entries)) {
                 if (typeof payload.count === "number") {

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -46,7 +46,11 @@ import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
 import { installLauncherEventBridge, launcherEventsActive } from "@/util/launcher-events";
-import { seedKnownEntriesFromSnapshot, startLauncherEventReducer } from "@/app/store/launcher-event-reducer";
+import {
+    isInstanceLabel,
+    seedKnownEntriesFromSnapshot,
+    startLauncherEventReducer,
+} from "@/app/store/launcher-event-reducer";
 
 // Deferred — assigned inside initApp() after window.api is ready.
 // Do NOT call getApi() at module level: this file is statically imported by
@@ -76,12 +80,13 @@ const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
  */
 async function initInstanceTracking(): Promise<void> {
     // listWindows() returns ALL keys in state.browsers, which includes
-    // browser-pane child browsers (`browser-pane-*`) and other internal
-    // labels — not just top-level app windows. The instance panel only
-    // wants the labels it can sensibly focus, so filter here. Top-level
-    // window labels are either "main" or "window-<uuid>".
-    const isInstanceLabel = (l: string): boolean =>
-        l === "main" || /^window-/.test(l);
+    // browser-pane child browsers (`browser-pane-*`) and pool labels
+    // (`window-pool-*`) — not just top-level app windows. The instance
+    // panel only wants the labels it can sensibly focus. The filter
+    // is imported from `launcher-event-reducer` so the bespoke
+    // fallback path uses the EXACT same rule as the typed-event
+    // reducer. (reagent P2 #603 — the two had diverged on pool
+    // labels, which leaked into the bespoke path's view.)
 
     // Phase B.7.3.2 — typed launcher events are authoritative once
     // they start flowing (`launcherEventsActive()` flips on the first

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -1,19 +1,30 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Phase B.7.3.1 — frontend reducer for launcher typed events.
+// Phase B.7.3 — frontend reducer for launcher typed events.
 //
 // Subscribes to the `launcherEvent` signal from
 // `frontend/util/launcher-events.ts` and dispatches by `event`
-// discriminant. In B.7.3.1 this is SCAFFOLDING: it logs every typed
-// event and, for the variants that already have a corresponding
-// bespoke `window-instances-changed` payload path, runs alongside
-// the bespoke channel (idempotent — both write the same atoms).
+// discriminant.
 //
-// B.7.3.2 promotes typed events to the authoritative path: when
-// `launcherEventsActive()` is true, atom-update side-effects flow
-// from here, not from the bespoke listener.
-// B.7.3.3 retires the bespoke channel and its 4 sync emit sites.
+// Phase B.7.3.1 (PR #602): scaffolding only — logged every event,
+// no atom mutation.
+// Phase B.7.3.2 (this PR): typed events become AUTHORITATIVE for
+// the InstancePanel atoms (`openWindowLabelsAtom`,
+// `openWindowEntriesAtom`, `windowCountAtom`). The reducer
+// maintains an in-memory `knownEntries` map of `label →
+// {label, windowId}`, applies deltas from typed events, and
+// recomputes the atoms after each apply. The bespoke
+// `window-instances-changed` listener in `app-init.ts` is gated
+// by `!launcherEventsActive()` — it only runs when the launcher
+// isn't in the loop (e.g. `task dev` mode).
+// Phase B.7.3.3: retire the bespoke channel + 4 sync emit sites.
+//
+// State seed: at init, `app-init.ts::initInstanceTracking` calls
+// `seedKnownEntriesFromSnapshot` with the RPC `listWindowInstances`
+// result. This populates `knownEntries` so a renderer that joins
+// mid-session sees the existing windows. Subsequent typed events
+// apply deltas on top.
 //
 // Echo-loop guard (parent spec §5.5): an `applyingRemote` flag is
 // set during each apply so future renderer-emitted commands can
@@ -27,6 +38,12 @@
 import { createEffect } from "solid-js";
 
 import { launcherEvent, launcherEventVersion, type LauncherEvent } from "@/util/launcher-events";
+import {
+    setOpenWindowEntriesAtom,
+    setOpenWindowLabelsAtom,
+    setWindowCountAtom,
+    type WindowEntry,
+} from "@/app/store/global";
 
 let applyingRemote = false;
 
@@ -37,6 +54,66 @@ let applyingRemote = false;
  */
 export function isApplyingRemoteEvent(): boolean {
     return applyingRemote;
+}
+
+/**
+ * In-memory mirror of label → windowId for top-level + sub windows.
+ * Pool labels (`window-pool-*`) and browser-pane labels are excluded —
+ * pool windows fire `Event::PoolWindowAdded/Removed` (different
+ * event variants we ignore here), and browser-pane HWNDs never
+ * appear as `Event::WindowOpened`.
+ */
+const knownEntries = new Map<string, WindowEntry>();
+
+/**
+ * `isInstanceLabel` mirrors the legacy filter in
+ * `app-init.ts::initInstanceTracking`. Sub-windows + main + full
+ * instances all match `/^window-/` or === "main". `window-pool-*`
+ * also matches, but pool windows don't fire `WindowOpened`, so
+ * they never enter `knownEntries`. Defensive belt anyway: filter
+ * out `window-pool-` here too in case the host's launcher
+ * implementation ever changes.
+ */
+function isInstanceLabel(label: string): boolean {
+    if (label === "main") return true;
+    if (label.startsWith("window-pool-")) return false;
+    if (label.startsWith("browser-pane-")) return false;
+    return label.startsWith("window-");
+}
+
+function recomputeAtoms(): void {
+    const filtered = Array.from(knownEntries.values()).filter((e) => isInstanceLabel(e.label));
+    // Stable ordering: "main" pinned first, others alphabetical.
+    // Without this, panel rows shuffle across recomputes (Map
+    // iteration is insertion-ordered, but the InstancePanel uses
+    // array index for naming and special-cases "main").
+    filtered.sort((a, b) => {
+        if (a.label === "main") return -1;
+        if (b.label === "main") return 1;
+        return a.label.localeCompare(b.label);
+    });
+    setOpenWindowLabelsAtom(filtered.map((e) => e.label));
+    setOpenWindowEntriesAtom(filtered);
+    setWindowCountAtom(filtered.length);
+}
+
+/**
+ * Seed `knownEntries` from the init RPC snapshot. Called once from
+ * `app-init.ts::initInstanceTracking` after `listWindowInstances`
+ * returns. Subsequent typed events apply deltas on top.
+ *
+ * Idempotent w.r.t. repeated calls: each call clears + re-seeds.
+ * Repeated typed-event apply on the same label is also idempotent
+ * (`Map.set` overwrites; `Map.delete` of a missing key is a no-op).
+ */
+export function seedKnownEntriesFromSnapshot(entries: ReadonlyArray<WindowEntry>): void {
+    knownEntries.clear();
+    for (const e of entries) {
+        if (isInstanceLabel(e.label)) {
+            knownEntries.set(e.label, { label: e.label, windowId: e.windowId });
+        }
+    }
+    recomputeAtoms();
 }
 
 let started = false;
@@ -69,38 +146,89 @@ export function startLauncherEventReducer(): void {
 }
 
 function dispatch(evt: LauncherEvent): void {
-    // B.7.3.1: log every event so smoke tests can verify the cable.
-    // B.7.3.2 promotes specific arms to atom-mutating handlers.
-    console.log("[launcher-event-reducer]", evt.event, "v=" + evt.version, evt);
     switch (evt.event) {
-        case "window_opened":
-        case "window_closed":
-        case "window_instance_assigned":
-        case "window_instance_released":
-        case "backend_window_id_registered":
-        case "backend_window_id_unregistered":
-            // Lifecycle events — currently fed via the bespoke
-            // `window-instances-changed` payload's resolved entries.
-            // B.7.3.2 will swap that for an in-memory reduction
-            // here and demote the bespoke channel.
-            break;
+        case "window_opened": {
+            const label = String(evt.label ?? "");
+            if (!label || !isInstanceLabel(label)) return;
+            // Preserve existing windowId if a BackendWindowIdRegistered
+            // arrived before WindowOpened (rare, but the launcher's
+            // event ordering between separate Commands isn't
+            // synchronized w.r.t. renderer apply order — the per-pipe
+            // ordering guarantee is the host → renderer hop, not
+            // host's emission order across distinct host-side
+            // mutations).
+            const existing = knownEntries.get(label);
+            knownEntries.set(label, { label, windowId: existing?.windowId ?? null });
+            recomputeAtoms();
+            return;
+        }
+        case "window_closed": {
+            const label = String(evt.label ?? "");
+            if (!label) return;
+            if (knownEntries.delete(label)) {
+                recomputeAtoms();
+            }
+            return;
+        }
+        case "window_instance_assigned": {
+            // The reducer doesn't track instance numbers — the host's
+            // bespoke channel previously carried `count`, but the
+            // count is now derived from `knownEntries.size`. We still
+            // ensure the entry is in the map (defensive — should
+            // already be from WindowOpened).
+            const label = String(evt.label ?? "");
+            if (!label || !isInstanceLabel(label)) return;
+            if (!knownEntries.has(label)) {
+                knownEntries.set(label, { label, windowId: null });
+                recomputeAtoms();
+            }
+            return;
+        }
+        case "window_instance_released": {
+            // Released usually pairs with WindowClosed which already
+            // deleted the entry; idempotent here.
+            const label = String(evt.label ?? "");
+            if (!label) return;
+            if (knownEntries.delete(label)) {
+                recomputeAtoms();
+            }
+            return;
+        }
+        case "backend_window_id_registered": {
+            const label = String(evt.label ?? "");
+            const windowId = typeof evt.window_id === "string" ? evt.window_id : null;
+            if (!label || !isInstanceLabel(label)) return;
+            const existing = knownEntries.get(label);
+            // If the entry doesn't exist yet, create it — out-of-order
+            // arrival path. WindowOpened, when it lands, preserves
+            // this windowId (see preserve-existing-windowId branch
+            // in `window_opened` arm).
+            knownEntries.set(label, { label, windowId });
+            // Skip recompute if windowId actually didn't change AND
+            // the entry was already present — avoids a redundant
+            // atom write (SolidJS would treat a referentially-new
+            // array as a change and re-run subscribers).
+            if (existing && existing.windowId === windowId) return;
+            recomputeAtoms();
+            return;
+        }
+        case "backend_window_id_unregistered": {
+            const label = String(evt.label ?? "");
+            if (!label || !isInstanceLabel(label)) return;
+            const existing = knownEntries.get(label);
+            if (!existing) return;
+            if (existing.windowId === null) return;
+            knownEntries.set(label, { label, windowId: null });
+            recomputeAtoms();
+            return;
+        }
         case "hwnd_drift_detected":
-            // Drift events: WRR emits these when the launcher's
-            // pure-reducer detects an off-monitor / hidden / orphan
-            // window. Currently logged only; UX wiring (toast or
-            // debug panel) is a separate question (spec §Open
-            // questions #3).
-            break;
         case "corrective_window_move":
         case "host_should_quit":
-            // Saga events handled host-side via launcher_ipc.rs.
-            // Renderer just logs; no UI action.
-            break;
+            // WRR / saga events. Logged only — UX wiring deferred.
+            return;
         default:
-            // Forward-compat: unknown variants are silently ignored.
-            // The host bridge forwards every Event variant, so newly-
-            // added events (e.g. Phase D snapshot deltas) flow here
-            // without renderer code change until they need handling.
-            break;
+            // Forward-compat: unknown variants silently ignored.
+            return;
     }
 }

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -66,15 +66,19 @@ export function isApplyingRemoteEvent(): boolean {
 const knownEntries = new Map<string, WindowEntry>();
 
 /**
- * `isInstanceLabel` mirrors the legacy filter in
- * `app-init.ts::initInstanceTracking`. Sub-windows + main + full
- * instances all match `/^window-/` or === "main". `window-pool-*`
- * also matches, but pool windows don't fire `WindowOpened`, so
- * they never enter `knownEntries`. Defensive belt anyway: filter
- * out `window-pool-` here too in case the host's launcher
- * implementation ever changes.
+ * Filter for labels the InstancePanel surfaces. Sub-windows + main
+ * + full instances all match `/^window-/` or === "main". Pool
+ * (`window-pool-*`) and browser-pane child HWNDs are excluded —
+ * pool windows fire `Event::PoolWindowAdded/Removed` (different
+ * event variants we don't subscribe to), and browser-pane HWNDs
+ * never appear as `Event::WindowOpened`. Defensive filter even so.
+ *
+ * Exported so `app-init.ts::initInstanceTracking` (the bespoke
+ * fallback path + the snapshot-key seed) uses the SAME filter as
+ * the typed-event reducer. (reagent P2 #603 — the two filters
+ * had diverged on `window-pool-*`.)
  */
-function isInstanceLabel(label: string): boolean {
+export function isInstanceLabel(label: string): boolean {
     if (label === "main") return true;
     if (label.startsWith("window-pool-")) return false;
     if (label.startsWith("browser-pane-")) return false;
@@ -102,17 +106,28 @@ function recomputeAtoms(): void {
  * `app-init.ts::initInstanceTracking` after `listWindowInstances`
  * returns. Subsequent typed events apply deltas on top.
  *
- * Idempotent w.r.t. repeated calls: each call clears + re-seeds.
- * Repeated typed-event apply on the same label is also idempotent
- * (`Map.set` overwrites; `Map.delete` of a missing key is a no-op).
+ * **Important — does NOT clobber existing entries.** The reducer
+ * effect is started earlier (in `initWaveWrap`, before
+ * `initInstanceTracking` runs the RPC), so typed events can arrive
+ * between snapshot-fetch and this seed call. A `BackendWindowIdRegistered`
+ * that landed first would have updated `windowEntries[label].windowId`
+ * to a real value; the snapshot — taken at an earlier moment — may
+ * still show `null` for that label. Clobbering would roll the
+ * windowId back to stale `null`, and since `launcherEventsActive()`
+ * is now true, the bespoke fallback channel won't recover it. (codex
+ * P1 #603.) So this function fills in MISSING labels only; existing
+ * entries are left as the typed-event stream wrote them.
  */
 export function seedKnownEntriesFromSnapshot(entries: ReadonlyArray<WindowEntry>): void {
-    knownEntries.clear();
     for (const e of entries) {
-        if (isInstanceLabel(e.label)) {
-            knownEntries.set(e.label, { label: e.label, windowId: e.windowId });
-        }
+        if (!isInstanceLabel(e.label)) continue;
+        if (knownEntries.has(e.label)) continue;
+        knownEntries.set(e.label, { label: e.label, windowId: e.windowId });
     }
+    // Always recompute — initial atoms were set from the bespoke
+    // channel before the reducer was promoted, so even a snapshot
+    // that adds nothing new still needs to publish the consolidated
+    // view (e.g. ordering / filter differences). Idempotent.
     recomputeAtoms();
 }
 
@@ -223,9 +238,20 @@ function dispatch(evt: LauncherEvent): void {
             return;
         }
         case "hwnd_drift_detected":
+            // Drift events fire when the launcher's pure reducer
+            // detects an off-monitor / hidden / orphan window.
+            // Currently logged at warn so they surface in the
+            // backend-forwarded `[fe]` log without being silent on
+            // the user side. UX wiring (toast / debug panel) is a
+            // separate question — see spec §Open questions #3.
+            // (reagent P2 #603.)
+            console.warn("[launcher-event] drift", evt);
+            return;
         case "corrective_window_move":
         case "host_should_quit":
-            // WRR / saga events. Logged only — UX wiring deferred.
+            // Saga events handled host-side. Renderer logs at info
+            // for observability — these are rare and meaningful.
+            console.info("[launcher-event]", evt.event, evt);
             return;
         default:
             // Forward-compat: unknown variants silently ignored.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.502",
+  "version": "0.33.503",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.502",
+      "version": "0.33.503",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.502",
+  "version": "0.33.503",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase B.7.3.2 — promotes the launcher's typed event stream to the authoritative source for the InstancePanel atoms (`openWindowLabelsAtom`, `openWindowEntriesAtom`, `windowCountAtom`). The bespoke `window-instances-changed` channel is demoted to fallback-only (covers `task dev` / no-launcher mode).

Follow-up to #602 (B.7.3.1, which landed the bridge cable) — see `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.

## What changes

**Reducer (`frontend/app/store/launcher-event-reducer.ts`)**
- Maintains an in-memory `knownEntries: Map<string, WindowEntry>`.
- `seedKnownEntriesFromSnapshot(entries)` populates the map from the init RPC.
- Real dispatch arms for `window_opened`, `window_closed`, `window_instance_assigned`, `window_instance_released`, `backend_window_id_registered`, `backend_window_id_unregistered`. Each mutates the map and calls `recomputeAtoms()`.
- `recomputeAtoms()` filters with the same `isInstanceLabel` rule (excludes pool + browser-pane), sorts main-first alphabetical, writes atoms + count.
- Out-of-order arrival defenses: `WindowOpened` preserves an existing `windowId` (in case `BackendWindowIdRegistered` arrived first); `BackendWindowIdRegistered` skips recompute when the windowId didn't change.

**Init wiring (`frontend/app-init.ts`)**
- Init RPC's `listWindowInstances` result feeds `seedKnownEntriesFromSnapshot`.
- Bespoke `window-instances-changed` listener now short-circuits on `launcherEventsActive()` — only mutates atoms when launcher isn't flowing typed events.
- `lastEntriesKey` seeded from the same snapshot for the no-launcher retry path.

## Test plan

Smoked locally on v0.33.503:

- [x] InstancePanel renders correctly at startup.
- [x] Open new window via status-bar popup → InstancePanel adds row (typed-event path).
- [x] Tear off a tab → InstancePanel adds row.
- [x] Close non-main → row removed.
- [x] Close all → process exits cleanly (B.9.3 invariant preserved, exit code 0).

Logs confirm: typed `WindowOpened` / `WindowInstanceAssigned` / `BackendWindowIdRegistered` / `WindowClosed` / `WindowInstanceReleased` / `BackendWindowIdUnregistered` flowed through the full lifecycle for both main + tear-off. WRR drift fired (`HiddenSinceOpen`, `OrphanInstance`). HostShouldQuit cascade exited cleanly.

## What this does NOT do

- Bespoke `window-instances-changed` channel still emitted by the host's `apply_event_to_shadow` and the 4 sync emit sites — kept as fallback for `task dev`. Retired in B.7.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)