### PR TITLE
B.7.3.3: retire window-instances-changed bespoke channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.503"
+version = "0.33.504"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.503"
+version = "0.33.504"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.503"
+version = "0.33.504"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.503"
+version = "0.33.504"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.504 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.503 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.502 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |
 | 0.33.394 | 2026-04-25 | 159.8 MiB | 333.7 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.503"
+version = "0.33.504"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -683,13 +683,10 @@ impl AgentMuxHandler {
             quit_message_loop();
             tracing::warn!(target: "wrr", "[wrr] quit_message_loop returned");
         } else {
-            // Notify remaining windows of the new count.
-            let new_count = self.state.instance_count();
-            crate::events::emit_event_all_windows(
-                &self.state,
-                "window-instances-changed",
-                &serde_json::json!(new_count),
-            );
+            // Phase B.7.3.3 — `Event::WindowClosed` +
+            // `Event::WindowInstanceReleased` from the launcher
+            // drive remaining renderers' InstancePanel atoms via the
+            // CEF JS bridge; no sync emit here.
 
             // Tell the backend to clean up this window's workspace/tabs/shells.
             // This replaces the JavaScript `beforeunload` handler — running it here

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -375,14 +375,10 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
         true,
     );
 
-    // Phase B.5d — host no longer registers locally. The launcher
-    // assigns the instance number from `ReportWindowOpened`
-    // (triggered by on_after_created) and the shadow update emits
-    // a fresh `window-instances-changed` once it lands. The early
-    // emit below carries the pre-mutation count; frontend updates
-    // it again ~ms later when the shadow event arrives.
-    let count = state.instance_count();
-    events::emit_event_all_windows(state, "window-instances-changed", &serde_json::json!(count));
+    // Phase B.7.3.3 — the launcher's typed events
+    // (`Event::WindowOpened` + `Event::WindowInstanceAssigned` +
+    // `Event::BackendWindowIdRegistered`) flow through the CEF JS
+    // bridge to drive the InstancePanel atoms. No sync emit here.
 
     Ok(serde_json::json!(label))
 }

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -484,7 +484,7 @@ pub fn get_window_count(state: &Arc<AppState>) -> serde_json::Value {
 /// Register the backend window ID for a window label.
 /// Called by the frontend after it has initialized its backend Window object.
 /// Used by `on_before_close` to notify the backend when a secondary window closes.
-pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
+pub fn register_backend_window(_state: &Arc<AppState>, args: &serde_json::Value) -> serde_json::Value {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     let window_id = args.get("window_id").and_then(|v| v.as_str()).unwrap_or("");
     tracing::info!(label = %label, window_id = %window_id, "[window] register_backend_window received");
@@ -500,19 +500,10 @@ pub fn register_backend_window(state: &Arc<AppState>, args: &serde_json::Value) 
             label.to_string(),
             window_id.to_string(),
         );
-        // Notify listeners that the label→windowId mapping changed.
-        // The InstancePanel needs `windowId` to look up the backend
-        // Window record (display name in meta, workspace fallback).
-        // Without this emit, sibling windows would never re-fetch
-        // listWindowInstances after a freshly-opened window's
-        // windowId becomes available, leaving its row's name
-        // unresolvable and rename disabled. (codex PR #569 P2)
-        let count = state.instance_count();
-        crate::events::emit_event_all_windows(
-            state,
-            "window-instances-changed",
-            &serde_json::json!(count),
-        );
+        // Phase B.7.3.3 — the launcher's
+        // `Event::BackendWindowIdRegistered` (delivered via the CEF
+        // JS bridge) carries the label → windowId mapping change to
+        // every renderer's reducer. No sync emit here.
     } else {
         tracing::warn!(label = %label, "[window] register_backend_window called with empty window_id — skipped");
     }
@@ -650,9 +641,8 @@ fn open_window_with_kind(
         true,
     );
 
-    // Notify all windows of the count change
-    let count = state.instance_count();
-    crate::events::emit_event_all_windows(state, "window-instances-changed", &serde_json::json!(count));
+    // Phase B.7.3.3 — typed launcher events drive InstancePanel
+    // atoms via the CEF JS bridge; no sync emit here.
 
     Ok(serde_json::json!(label))
 }

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -559,19 +559,8 @@ pub fn promote_pool_window(
         let _ = ShowWindow(raw_hwnd, SW_SHOW);
     }
 
-    // Phase B.5d — host no longer registers locally on pool promote.
-    // The launcher assigns the instance number from
-    // `ReportWindowOpened` (sent immediately above this line in the
-    // promote path) and the shadow update emits a fresh
-    // `window-instances-changed` once it lands. The synchronous emit
-    // below carries the pre-mutation count; the shadow's later emit
-    // catches up.
-    let count = state.instance_count();
-    crate::events::emit_event_all_windows(
-        state,
-        "window-instances-changed",
-        &serde_json::json!(count),
-    );
+    // Phase B.7.3.3 — the launcher's typed events drive the
+    // InstancePanel atoms via the CEF JS bridge. No sync emit here.
 
     // Now tell the pool window's renderer to bootstrap the workspace.
     crate::events::emit_event_to_window(

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -15,11 +15,9 @@
 // Cross-platform: `Frame::ExecuteJavaScript` is portable across
 // CEF's Windows / macOS / Linux backends. No platform specifics.
 //
-// Coexistence with the bespoke `window-instances-changed` event:
-// during B.7.3.1 both channels deliver overlapping data. The
-// renderer prefers typed events when seen and falls back to the
-// bespoke channel when not (see `frontend/util/launcher-events.ts`
-// + `frontend/app-init.ts`). B.7.3.2/.3 retire the bespoke path.
+// Phase B.7.3.3 — typed events are the SOLE channel for
+// InstancePanel state. The bespoke `window-instances-changed`
+// event and its 4 sync emit sites in the host are retired.
 //
 // See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
 

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -237,17 +237,16 @@ pub async fn connect_to_launcher(
     None
 }
 
-/// Phase B.5e — apply launcher events to host's shadow projections.
-/// Currently handles instance-number events; future B.5 sub-PRs will
-/// add more shadow handlers as additional host maps migrate. Other
-/// event types are no-ops here (they're already logged at the call
-/// site).
+/// Apply a launcher event to host's shadow projections, then fan
+/// the event out to every top-level renderer via the JS bridge.
 ///
-/// Phase B.7.3.1 — after the match, fan the event out to every
-/// top-level renderer via the JS bridge. Shadows are updated FIRST
-/// so that any renderer-side code that reads host state via the IPC
-/// HTTP path (e.g. `listWindowInstances`) sees a consistent view at
-/// the moment the typed event lands.
+/// Shadows are updated FIRST so any renderer-side code that reads
+/// host state via the IPC HTTP path (e.g. `listWindowInstances`)
+/// sees a consistent view at the moment the typed event lands.
+///
+/// Phase B.7.3.3 — the bespoke `window-instances-changed` re-emit
+/// is gone; renderers now consume typed events directly via the
+/// CEF JS bridge dispatcher (`launcher_event_bridge`).
 fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: &Event) {
     match event {
         Event::WindowInstanceAssigned { label, num, .. } => {
@@ -259,22 +258,6 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 .shadow_instance_registry
                 .lock()
                 .insert(label.clone(), *num);
-            // Phase B.5d — re-emit `window-instances-changed` so the
-            // frontend's InstancePanel catches up after the brief
-            // race between the synchronous emit at the mutation site
-            // (which carries the pre-event count) and the launcher's
-            // `WindowInstanceAssigned` arrival here.
-            //
-            // Phase B.7.1 — payload now carries the resolved
-            // `entries` array (label + windowId pairs from launcher
-            // shadows), letting the frontend update its atoms
-            // directly without a follow-up `list_window_instances`
-            // RPC and without the retry-on-stale polling that
-            // existed only because the synchronous emit fired
-            // before state.browsers settled. Sync emits still
-            // ship count-only payloads; the frontend keeps the
-            // legacy refresh path as a fallback for those.
-            emit_window_instances_changed_with_entries(state);
         }
         Event::WindowOpened { label, kind, parent_label, .. } => {
             // Phase B.5 (window_meta step b) — shadow projection
@@ -331,34 +314,15 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
                 .shadow_backend_window_ids
                 .lock()
                 .insert(label.clone(), window_id.clone());
-            // Phase B.7.2 — windowId becoming available is the
-            // second half of an open: the entries array's windowId
-            // for `label` transitions from `null` to a real GUID
-            // here. Re-emit so the InstancePanel can resolve the
-            // backend Window record (display name, workspace) for
-            // a freshly-opened window without waiting for another
-            // unrelated event to fire. This was the codex PR #569
-            // P2 race that the now-removed `lastEntriesKey`
-            // polling existed to paper over.
-            emit_window_instances_changed_with_entries(state);
         }
         Event::BackendWindowIdUnregistered { label, .. } => {
             // Phase B.5 (window_id_map step e) — drift compare gone.
             state.shadow_backend_window_ids.lock().remove(label);
-            // Phase B.7.2 — symmetric re-emit so `windowId`
-            // becoming `null` (e.g. backend window record removed
-            // before the launcher's WindowClosed event arrives)
-            // surfaces in the InstancePanel immediately.
-            emit_window_instances_changed_with_entries(state);
         }
         Event::WindowInstanceReleased { label, .. } => {
             // Phase B.5e — host's `WindowInstanceRegistry` was
             // deleted; the drift compare is gone with it.
             state.shadow_instance_registry.lock().remove(label);
-            // Phase B.5d / B.7.1 — re-emit with the resolved
-            // entries array (see WindowInstanceAssigned arm above
-            // for rationale).
-            emit_window_instances_changed_with_entries(state);
         }
         Event::CorrectiveWindowMove { hwnd, target_rect, reason, .. } => {
             // Phase B.9.2 — pure-reducer self-heal. Reducer detected
@@ -410,53 +374,6 @@ fn apply_event_to_shadow(state: &std::sync::Arc<crate::state::AppState>, event: 
     // installed by `frontend/util/launcher-events.ts`) feeds the
     // launcher-event-reducer signal that downstream UI subscribes to.
     crate::launcher_event_bridge::dispatch_to_renderers(state, event);
-}
-
-/// Phase B.7.1 — emit `window-instances-changed` with a resolved
-/// `entries` array so the frontend can update its atoms directly,
-/// bypassing both the `list_window_instances` RPC round-trip and
-/// the historical retry-on-stale polling in `app-init.ts`.
-///
-/// Called from the launcher-driven re-emit sites (post-shadow
-/// update) where the `shadow_instance_registry` and
-/// `shadow_backend_window_ids` projections are guaranteed to
-/// reflect the launcher's view. Pool windows and `browser-pane-*`
-/// labels are filtered out here so the payload matches the
-/// `list_window_instances` shape the frontend already understands.
-///
-/// Sync emit sites (window.rs / drag.rs / window_pool.rs / client.rs)
-/// continue to ship count-only payloads in this PR — they fire
-/// before host state has settled and don't have access to the
-/// launcher's resolved view. B.7.2 retires them in favor of the
-/// launcher-driven path.
-fn emit_window_instances_changed_with_entries(state: &std::sync::Arc<crate::state::AppState>) {
-    let labels: Vec<String> = {
-        let pool_labels = state.unpromoted_pool_labels.lock();
-        let registry = state.shadow_instance_registry.lock();
-        registry
-            .keys()
-            .filter(|l| !pool_labels.contains(*l) && !l.starts_with("browser-pane-"))
-            .cloned()
-            .collect()
-    };
-    let entries: Vec<serde_json::Value> = labels
-        .iter()
-        .map(|l| {
-            serde_json::json!({
-                "label": l,
-                "windowId": state.backend_window_id(l),
-            })
-        })
-        .collect();
-    let count = entries.len();
-    crate::events::emit_event_all_windows(
-        state,
-        "window-instances-changed",
-        &serde_json::json!({
-            "count": count,
-            "entries": entries,
-        }),
-    );
 }
 
 /// Phase B.4 — sync API: report a window open to the launcher's

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -384,11 +384,11 @@ impl AppState {
     /// Phase B.5e — authoritative instance count. Returns the
     /// shadow's length (sole source of truth post-B.5e).
     ///
-    /// Synchronous emits at mutation sites still fire (carrying
-    /// the pre-launcher-event count, briefly off by one); a
-    /// subsequent `window-instances-changed` re-emit from
-    /// `apply_event_to_shadow` brings the InstancePanel current
-    /// once the launcher event arrives.
+    /// Phase B.7.3.3 — only remaining caller is the
+    /// `getWindowCount` IPC method. The InstancePanel-driving
+    /// path (sync emits + bespoke `window-instances-changed`
+    /// re-emit) is retired; typed launcher events delivered via
+    /// the CEF JS bridge update the renderer's atoms directly.
     pub fn instance_count(&self) -> usize {
         self.shadow_instance_registry.lock().len()
     }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.503"
+version = "0.33.504"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.503"
+version = "0.33.504"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.503"
+version = "0.33.504"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -25,11 +25,7 @@ import {
     pushNotification,
     removeNotificationById,
     subscribeToConnEvents,
-    windowInstanceNumAtom,
     setWindowInstanceNumAtom,
-    setWindowCountAtom,
-    setOpenWindowLabelsAtom,
-    setOpenWindowEntriesAtom,
     setReinitVersion,
     setUpdaterStatusAtom,
     setUpdaterVersionAtom,
@@ -45,9 +41,8 @@ import { ContextMenuModel } from "@/app/store/contextmenu";
 import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
-import { installLauncherEventBridge, launcherEventsActive } from "@/util/launcher-events";
+import { installLauncherEventBridge } from "@/util/launcher-events";
 import {
-    isInstanceLabel,
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
 } from "@/app/store/launcher-event-reducer";
@@ -74,109 +69,25 @@ window.modalsModel = modalsModel;
 const RPC_TIMEOUT = 5_000; // 5 seconds for individual RPC calls
 
 /**
- * Initialize the window instance number and count atoms, and subscribe to
- * the "window-instances-changed" Tauri event so the count stays reactive.
- * Called once per window after the wave UI is fully initialized.
+ * Initialize the window-instance-number atom and seed the reducer
+ * with the current snapshot. Subsequent updates to the panel atoms
+ * come from typed launcher events via `launcher-event-reducer.ts`.
+ *
+ * Phase B.7.3.3 — bespoke `window-instances-changed` channel and
+ * its retry/fallback paths are gone. The init RPC's only job is to
+ * give the reducer a starting set of entries (so a renderer joining
+ * mid-session sees existing windows before the first typed event
+ * arrives for one of them). Pre-seed close events are tombstoned
+ * inside the reducer and skipped at seed time. (codex P2 #603.)
  */
 async function initInstanceTracking(): Promise<void> {
-    // listWindows() returns ALL keys in state.browsers, which includes
-    // browser-pane child browsers (`browser-pane-*`) and pool labels
-    // (`window-pool-*`) — not just top-level app windows. The instance
-    // panel only wants the labels it can sensibly focus. The filter
-    // is imported from `launcher-event-reducer` so the bespoke
-    // fallback path uses the EXACT same rule as the typed-event
-    // reducer. (reagent P2 #603 — the two had diverged on pool
-    // labels, which leaked into the bespoke path's view.)
-
-    // Phase B.7.3.2 — typed launcher events are authoritative once
-    // they start flowing (`launcherEventsActive()` flips on the first
-    // event). The reducer in `launcher-event-reducer.ts` mutates the
-    // InstancePanel atoms from the typed stream.
-    //
-    // Two paths coexist as fallback during B.7.3.2:
-    //
-    //   1. Launcher-driven bespoke `window-instances-changed` re-emit
-    //      (`launcher_ipc.rs::apply_event_to_shadow`) ships
-    //      `{ count, entries: [{label, windowId}] }` — same data the
-    //      typed events derive from, but as a snapshot per event.
-    //      Used here ONLY when typed events haven't been seen yet
-    //      (covers the brief window between renderer-init and the
-    //      first typed event arriving).
-    //
-    //   2. Sync emits at the mutation sites (window.rs / drag.rs /
-    //      window_pool.rs / client.rs) still ship count-only
-    //      payloads. They fire BEFORE state.browsers settles, so a
-    //      single RPC read would see stale data. Also the sole
-    //      path during `task dev` (no launcher in the loop), so we
-    //      can't retire it yet — the 6×50ms retry-on-stale polling
-    //      stays as the no-launcher path. (codex PR #569 P2 +
-    //      reagent #596 P1.) B.7.3.3 retires the sync emits.
-    //
-    // The retry compares `entries-key` (label@windowId, joined) to
-    // detect a real change, including the `null → real` windowId
-    // transition that fires after the frontend's
-    // `register_backend_window` round-trip. Up to 6×50ms ≈ 300ms
-    // covers the empirical CEF on_after_created delay with margin.
-    let lastEntriesKey = "";
-
-    const applyEntries = (entries: Array<{ label: string; windowId: string | null }>): string => {
-        const filtered = entries.filter((e) => isInstanceLabel(e.label));
-        // Stable ordering: "main" pinned first, others alphabetical
-        // by label. Without this, panel rows can shuffle between
-        // refreshes (state.browsers is a Rust HashMap with
-        // non-deterministic iteration), and two windows could both
-        // display as "Window 1" because InstancePanel uses the
-        // array index for naming and special-cases "main".
-        filtered.sort((a, b) => {
-            if (a.label === "main") return -1;
-            if (b.label === "main") return 1;
-            return a.label.localeCompare(b.label);
-        });
-        setOpenWindowLabelsAtom(filtered.map((e) => e.label));
-        setOpenWindowEntriesAtom(filtered);
-        return filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
-    };
-
-    const refreshLabelsViaRpc = async (waitForChange = false, retriesLeft = 6): Promise<void> => {
-        try {
-            let entries: Array<{ label: string; windowId: string | null }>;
-            try {
-                const all = await getApi().listWindowInstances();
-                entries = Array.isArray(all) ? all : [];
-            } catch {
-                const all = await getApi().listWindows();
-                entries = (Array.isArray(all) ? all : []).map((label) => ({ label, windowId: null }));
-            }
-            const filtered = entries.filter((e) => isInstanceLabel(e.label));
-            filtered.sort((a, b) => {
-                if (a.label === "main") return -1;
-                if (b.label === "main") return 1;
-                return a.label.localeCompare(b.label);
-            });
-            const key = filtered.map((e) => `${e.label}@${e.windowId ?? ""}`).join("|");
-            if (waitForChange && key === lastEntriesKey && retriesLeft > 0) {
-                setTimeout(() => refreshLabelsViaRpc(true, retriesLeft - 1), 50);
-                return;
-            }
-            lastEntriesKey = key;
-            setOpenWindowLabelsAtom(filtered.map((e) => e.label));
-            setOpenWindowEntriesAtom(filtered);
-        } catch {
-            setOpenWindowLabelsAtom([]);
-            setOpenWindowEntriesAtom([]);
-        }
-    };
-
     try {
-        // Phase B.7.3.2 — fetch the snapshot once for the typed-event
-        // reducer to seed itself with. Each renderer's own instance
-        // number is fetched too (one-time, never updated by typed
-        // events — stable per-renderer-per-run). `getWindowCount`
-        // becomes derived state once typed events take over, but we
-        // keep the initial RPC for the no-launcher fallback path.
-        const [instanceNum, windowCount, snapshotEntries] = await Promise.all([
+        // Each renderer's own instance number is stable per-run —
+        // fetched once. The snapshot fetch primes the reducer for
+        // labels that exist before this renderer joined; thereafter
+        // typed events drive the panel.
+        const [instanceNum, snapshotEntries] = await Promise.all([
             getApi().getInstanceNumber(),
-            getApi().getWindowCount(),
             (async (): Promise<Array<{ label: string; windowId: string | null }>> => {
                 try {
                     const all = await getApi().listWindowInstances();
@@ -188,45 +99,7 @@ async function initInstanceTracking(): Promise<void> {
             })(),
         ]);
         setWindowInstanceNumAtom(instanceNum);
-        setWindowCountAtom(windowCount);
-        // Seed the reducer with the snapshot. Once the first typed
-        // event arrives, `launcherEventsActive()` flips and the
-        // reducer's atom-mutation path takes over from the bespoke
-        // listener below.
         seedKnownEntriesFromSnapshot(snapshotEntries);
-        // `lastEntriesKey` is used by the no-launcher retry path
-        // (`refreshLabelsViaRpc`); seed it from the snapshot so the
-        // first bespoke event compares against a real key.
-        lastEntriesKey = snapshotEntries
-            .filter((e) => isInstanceLabel(e.label))
-            .sort((a, b) => {
-                if (a.label === "main") return -1;
-                if (b.label === "main") return 1;
-                return a.label.localeCompare(b.label);
-            })
-            .map((e) => `${e.label}@${e.windowId ?? ""}`)
-            .join("|");
-
-        await getApi().listen("window-instances-changed", (event: any) => {
-            // B.7.3.2 — when typed events are flowing, the reducer
-            // is authoritative and this listener should NOT mutate
-            // atoms. Drop the payload silently. (`task dev` mode +
-            // the brief pre-first-typed-event window in portable
-            // mode are the only times this branch falls through.)
-            if (launcherEventsActive()) return;
-
-            const payload = event?.payload ?? event;
-            if (payload && typeof payload === "object" && Array.isArray(payload.entries)) {
-                if (typeof payload.count === "number") {
-                    setWindowCountAtom(payload.count);
-                }
-                lastEntriesKey = applyEntries(payload.entries);
-                return;
-            }
-            const count = typeof payload === "number" ? payload : 0;
-            setWindowCountAtom(count);
-            refreshLabelsViaRpc(true);
-        });
     } catch (e) {
         console.warn("[initInstanceTracking] failed:", e);
     }

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -208,8 +208,13 @@ function dispatch(evt: LauncherEvent): void {
                 // Pre-seed: record a tombstone so seed skips this
                 // label even if it appears in the snapshot (codex P2
                 // #603). The delete above handles the case where
-                // WindowOpened arrived first pre-seed.
+                // WindowOpened arrived first pre-seed — and if it
+                // did delete an existing entry, atoms must recompute
+                // here too, otherwise the ghost row persists until
+                // seed runs (or forever if seed fails). (codex P2
+                // #604.)
                 closedBeforeSeed.add(label);
+                if (deleted) recomputeAtoms();
                 return;
             }
             if (deleted) recomputeAtoms();
@@ -237,6 +242,7 @@ function dispatch(evt: LauncherEvent): void {
             const deleted = knownEntries.delete(label);
             if (!seedHasHappened && closedBeforeSeed) {
                 closedBeforeSeed.add(label);
+                if (deleted) recomputeAtoms();
                 return;
             }
             if (deleted) recomputeAtoms();

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -9,16 +9,15 @@
 //
 // Phase B.7.3.1 (PR #602): scaffolding only — logged every event,
 // no atom mutation.
-// Phase B.7.3.2 (this PR): typed events become AUTHORITATIVE for
+// Phase B.7.3.2 (PR #603): typed events became AUTHORITATIVE for
 // the InstancePanel atoms (`openWindowLabelsAtom`,
-// `openWindowEntriesAtom`, `windowCountAtom`). The reducer
-// maintains an in-memory `knownEntries` map of `label →
-// {label, windowId}`, applies deltas from typed events, and
-// recomputes the atoms after each apply. The bespoke
-// `window-instances-changed` listener in `app-init.ts` is gated
-// by `!launcherEventsActive()` — it only runs when the launcher
-// isn't in the loop (e.g. `task dev` mode).
-// Phase B.7.3.3: retire the bespoke channel + 4 sync emit sites.
+// `openWindowEntriesAtom`, `windowCountAtom`). Bespoke channel
+// demoted to fallback.
+// Phase B.7.3.3 (this PR): bespoke `window-instances-changed`
+// channel and its 4 sync emit sites in the host are RETIRED.
+// Typed events are the sole path. `task dev` mode (no launcher)
+// leaves the panel at its init-RPC-seeded values; live updates
+// require the launcher in the loop.
 //
 // State seed: at init, `app-init.ts::initInstanceTracking` calls
 // `seedKnownEntriesFromSnapshot` with the RPC `listWindowInstances`
@@ -64,6 +63,27 @@ export function isApplyingRemoteEvent(): boolean {
  * appear as `Event::WindowOpened`.
  */
 const knownEntries = new Map<string, WindowEntry>();
+
+/**
+ * Set to `true` once `seedKnownEntriesFromSnapshot` has run. Until
+ * then, close events are recorded as tombstones (see
+ * `closedBeforeSeed`) so the seed can skip labels that already
+ * closed pre-seed. (codex P2 #603.)
+ */
+let seedHasHappened = false;
+
+/**
+ * Tombstone set: labels for which a `WindowClosed` /
+ * `WindowInstanceReleased` arrived BEFORE seed ran. The reducer's
+ * close path on an empty `knownEntries` is a no-op delete, so
+ * without this set, the seed would re-add the label from the
+ * stale RPC snapshot and the InstancePanel would carry a ghost
+ * row (codex P2 #603 — the seed-vs-close race).
+ *
+ * Drained at seed time. Stays `null` after seed (close events
+ * apply directly to `knownEntries`).
+ */
+let closedBeforeSeed: Set<string> | null = new Set();
 
 /**
  * Filter for labels the InstancePanel surfaces. Sub-windows + main
@@ -119,15 +139,18 @@ function recomputeAtoms(): void {
  * entries are left as the typed-event stream wrote them.
  */
 export function seedKnownEntriesFromSnapshot(entries: ReadonlyArray<WindowEntry>): void {
+    const tombstones = closedBeforeSeed;
     for (const e of entries) {
         if (!isInstanceLabel(e.label)) continue;
         if (knownEntries.has(e.label)) continue;
+        // Pre-seed close tombstone — label closed between snapshot
+        // fetch and seed; the close arm couldn't delete from an
+        // empty map, so we skip the re-add here. (codex P2 #603.)
+        if (tombstones && tombstones.has(e.label)) continue;
         knownEntries.set(e.label, { label: e.label, windowId: e.windowId });
     }
-    // Always recompute — initial atoms were set from the bespoke
-    // channel before the reducer was promoted, so even a snapshot
-    // that adds nothing new still needs to publish the consolidated
-    // view (e.g. ordering / filter differences). Idempotent.
+    seedHasHappened = true;
+    closedBeforeSeed = null;
     recomputeAtoms();
 }
 
@@ -180,9 +203,16 @@ function dispatch(evt: LauncherEvent): void {
         case "window_closed": {
             const label = String(evt.label ?? "");
             if (!label) return;
-            if (knownEntries.delete(label)) {
-                recomputeAtoms();
+            const deleted = knownEntries.delete(label);
+            if (!seedHasHappened && closedBeforeSeed) {
+                // Pre-seed: record a tombstone so seed skips this
+                // label even if it appears in the snapshot (codex P2
+                // #603). The delete above handles the case where
+                // WindowOpened arrived first pre-seed.
+                closedBeforeSeed.add(label);
+                return;
             }
+            if (deleted) recomputeAtoms();
             return;
         }
         case "window_instance_assigned": {
@@ -204,9 +234,12 @@ function dispatch(evt: LauncherEvent): void {
             // deleted the entry; idempotent here.
             const label = String(evt.label ?? "");
             if (!label) return;
-            if (knownEntries.delete(label)) {
-                recomputeAtoms();
+            const deleted = knownEntries.delete(label);
+            if (!seedHasHappened && closedBeforeSeed) {
+                closedBeforeSeed.add(label);
+                return;
             }
+            if (deleted) recomputeAtoms();
             return;
         }
         case "backend_window_id_registered": {

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -9,17 +9,13 @@
 // renderer per launcher event. We feed those into a SolidJS signal
 // so block-level subscribers can `createEffect()` on them.
 //
-// During the cutover (B.7.3.1), the bespoke `window-instances-changed`
-// CEF event channel is still authoritative for the InstancePanel.
-// This module just installs the cable. B.7.3.2 makes typed events
-// the authoritative path for atom updates; B.7.3.3 retires the
-// bespoke channel.
-//
-// `task dev` mode: the launcher isn't in the loop, so no events
-// arrive. The dispatcher is still installed (idempotent, no
-// side-effects), and downstream subscribers see no signal updates.
-// The bespoke `window-instances-changed` channel continues to drive
-// the UI in that mode until Phase E retires the no-launcher path.
+// Phase B.7.3.3 — typed events are the SOLE path for InstancePanel
+// state. The bespoke `window-instances-changed` channel and its 4
+// sync emit sites in the host are gone. `task dev` mode (no
+// launcher in the loop) currently leaves the InstancePanel atoms
+// at their seeded values from the init RPC; live updates require
+// the launcher. Phase E folds srv into the same reducer pattern;
+// the no-launcher mode goes away then.
 //
 // See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
 
@@ -51,11 +47,11 @@ export const launcherEvent = latestEvent;
 export const launcherEventVersion = eventVersion;
 
 /**
- * True once we've received at least one typed event. The reducer uses
- * this as the signal that typed events are flowing — the renderer
- * can treat them as authoritative once this flips. Until then, the
- * bespoke `window-instances-changed` channel remains the source of
- * truth (covers `task dev` mode where no launcher is in the loop).
+ * True once we've received at least one typed event. Kept as a
+ * forward-compat utility — B.7.3.3 retired its only consumer (the
+ * bespoke-channel gate in `app-init.ts`), but Phase D's `GetSnapshot`
+ * resync flow may need it again to detect "have we resynced?" vs
+ * "fresh launcher / first events not seen yet."
  */
 export const launcherEventsActive = seenAnyEvent;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.503",
+  "version": "0.33.504",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.503",
+      "version": "0.33.504",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.503",
+  "version": "0.33.504",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase B.7.3.3 — pure deletion. The bespoke `window-instances-changed` CEF event channel and its 4 sync emit sites in the host are retired. Typed launcher events flowing through the CEF JS bridge (B.7.3.1 #602) are now the SOLE source of truth for the InstancePanel atoms.

Includes the codex P2 fix from PR #603 (seed-vs-close race) as a subitem.

Follow-up to #603. Closes the B.7.3 sub-PR sequence.

## What changes

**Host (Rust) deletions:**
- `launcher_ipc.rs::emit_window_instances_changed_with_entries` helper removed; the 4 callers in `apply_event_to_shadow` (`WindowInstanceAssigned`, `BackendWindowIdRegistered`, `BackendWindowIdUnregistered`, `WindowInstanceReleased`) no longer re-emit.
- `commands/window.rs::register_backend_window` — no sync emit.
- `commands/window.rs::open_window_with_kind` — no sync emit.
- `commands/drag.rs::tear_off` — no sync emit.
- `commands/window_pool.rs::promote_pool_window` — no sync emit.
- `client.rs::on_before_close` (non-quit branch) — no sync emit.

**Renderer deletions:**
- `app-init.ts::initInstanceTracking` shrinks from ~150 LoC to ~25. Removed: bespoke `window-instances-changed` listener, `applyEntries` helper, `refreshLabelsViaRpc` retry loop, `lastEntriesKey` state. Init RPC's only remaining job is seeding the reducer with a snapshot for renderers that join mid-session.
- Unused imports cleaned up in `app-init.ts` (`setWindowCountAtom`, `setOpenWindowLabelsAtom`, `setOpenWindowEntriesAtom`, `windowInstanceNumAtom`, `isInstanceLabel`, `launcherEventsActive`).

**Codex P2 fix from PR #603 (subitem)**:
- `launcher-event-reducer.ts::seedKnownEntriesFromSnapshot` had a race: a `WindowClosed` event arriving before seed ran was a no-op delete on empty `knownEntries`; subsequent seed re-added the label from the stale snapshot, leaving a ghost row in the InstancePanel. Fix: tombstone `Set<string>` populated by close arms pre-seed; seed skips labels in the set + clears it. `seedHasHappened` flag gates the tombstone path so close arms operate normally after seed.

## Test plan

Smoked locally on v0.33.504 with a wide variety of operations:

- [x] First-launch — InstancePanel shows main only.
- [x] Open second window via status-bar popup.
- [x] Tear off tabs (multiple times).
- [x] Tear off panes.
- [x] Close non-main windows.
- [x] Close main while secondaries exist.
- [x] Second exe launch while one running → forwards to existing instance.
- [x] Close all → process exits cleanly (B.9.3 invariant preserved, exit code 0 for both host + launcher).

Logs confirm: zero `window-instances-changed` references after the deletion, typed events flow correctly through the full lifecycle (open / tear-off / close-all), drift events fire for new windows, B.9.3 close cascade unchanged.

## What this does NOT do

- `getApi().getWindowCount()` host method still exists (unused now). Tagging for B.8 cleanup.
- `getApi().listWindowInstances()` still exists and is the snapshot source for `seedKnownEntriesFromSnapshot`. Phase D's `GetSnapshot` reply will replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)