### PR TITLE
Phase D.1: GetSnapshot RPC + diag state-now view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.506"
+version = "0.33.507"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.506"
+version = "0.33.507"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.506"
+version = "0.33.507"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.506"
+version = "0.33.507"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,8 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.507 | 2026-04-29 | 160.3 MiB | 335.0 MiB | |
+| 0.33.507 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |
 | 0.33.506 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |
 | 0.33.505 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |
 | 0.33.504 | 2026-04-29 | 160.2 MiB | 334.7 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,7 +14,6 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
-| 0.33.507 | 2026-04-29 | 160.3 MiB | 335.0 MiB | |
 | 0.33.507 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |
 | 0.33.506 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |
 | 0.33.505 | 2026-04-29 | 160.3 MiB | 334.8 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.506"
+version = "0.33.507"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.506"
+version = "0.33.507"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -214,6 +214,16 @@ pub enum Command {
     ReportMonitorTopologyChanged {
         rects: Vec<Rect>,
     },
+    /// Phase D.1 — request a `Event::Snapshot` reply containing the
+    /// reducer's current canonical state. Used by `--diag wrr` for
+    /// state-now visibility, by the frontend reducer for mid-session
+    /// resync after disconnect, and by future Tool clients that need
+    /// to bootstrap without observing every prior event.
+    ///
+    /// Phase D.1 reply is a one-shot snapshot — no replay of
+    /// missed events. D.2 + D.3 add the persisted event log + the
+    /// `since: u64` parameter for delta replay.
+    GetSnapshot,
 }
 
 /// Phase B.9.1 — rectangle in Win32 screen coordinates (pixels).
@@ -437,6 +447,45 @@ pub enum Event {
     HostShouldQuit {
         version: u64,
     },
+    /// Phase D.1 — reply to `Command::GetSnapshot`. Carries the
+    /// reducer's current canonical state (the projections subscribers
+    /// most commonly need). The `version` field is the reducer's
+    /// `event_version` at the moment the snapshot was taken; events
+    /// the subscriber receives AFTER this snapshot have monotonically
+    /// greater version numbers, letting the subscriber apply them as
+    /// deltas without missing or duplicating updates.
+    ///
+    /// What's included: lifecycle, windows (label + kind + parent +
+    /// HWND-observation axis), pool labels, instance numbers,
+    /// backend window IDs, monitor topology. What's intentionally
+    /// excluded: `processes` (PID metadata is launcher-internal),
+    /// `pending_hwnds` (transient reconciliation state), event log
+    /// (Phase D.2 adds a separate snapshot-with-replay variant).
+    Snapshot {
+        version: u64,
+        lifecycle: LifecyclePhase,
+        windows: Vec<WindowSnapshot>,
+        pool: Vec<String>,
+        instance_registry: Vec<(String, u32)>,
+        backend_window_ids: Vec<(String, String)>,
+        monitors: Vec<Rect>,
+    },
+}
+
+/// Phase D.1 — serializable view of one window in the launcher
+/// reducer's canonical state. Maps 1:1 to the launcher's internal
+/// `WindowMirror` minus `opened_at` (which is launcher-local clock
+/// data not meaningful to subscribers).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WindowSnapshot {
+    pub label: String,
+    pub kind: WindowKind,
+    pub parent_label: Option<String>,
+    pub hwnd: Option<u64>,
+    pub visible: bool,
+    pub iconic: bool,
+    pub last_rect: Option<Rect>,
+    pub foregrounded_since_open: bool,
 }
 
 /// Phase B.9.1 — six classes of CEF↔Win32 disagreement the reducer

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.506"
+version = "0.33.507"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -70,6 +70,17 @@ pub async fn run_wrr_diag(launcher_exe_dir: &std::path::Path) -> Result<(), Stri
     write_half.flush().await
         .map_err(|e| format!("flush Register: {}", e))?;
 
+    // Phase D.1 — request a state snapshot. Reply arrives on the
+    // broadcast bus alongside the Register reply; we filter for it
+    // in the event collection below.
+    let mut buf = serde_json::to_vec(&Command::GetSnapshot)
+        .map_err(|e| format!("serialize GetSnapshot: {}", e))?;
+    buf.push(b'\n');
+    write_half.write_all(&buf).await
+        .map_err(|e| format!("send GetSnapshot: {}", e))?;
+    write_half.flush().await
+        .map_err(|e| format!("flush GetSnapshot: {}", e))?;
+
     // Read events for OBSERVATION_WINDOW. The launcher's IPC server
     // (post-B.8) broadcasts every reducer event on a server-wide
     // bus; this connection's fanout writes them to us. We collect
@@ -132,21 +143,65 @@ pub async fn run_wrr_diag(_launcher_exe_dir: &std::path::Path) -> Result<(), Str
 
 #[cfg(target_os = "windows")]
 fn print_summary(events: &[Event]) {
-    println!("Captured {} event(s) in {}s observation window:", events.len(), OBSERVATION_WINDOW.as_secs());
-    println!();
+    // Phase D.1 — pull the Snapshot out and print it first as the
+    // canonical "state now" view; remaining events are the live
+    // stream observed during the 2s window.
+    let (snapshot, stream): (Vec<_>, Vec<_>) = events
+        .iter()
+        .partition(|e| matches!(e, Event::Snapshot { .. }));
 
-    if events.is_empty() {
-        println!("(no events — running instance is idle. State observability via");
-        println!(" GetSnapshot RPC is Phase D scope; for now, perform a UI action");
-        println!(" on the running instance and re-run --diag wrr to capture the");
-        println!(" event stream.)");
-        return;
+    if let Some(Event::Snapshot {
+        version,
+        lifecycle,
+        windows,
+        pool,
+        instance_registry,
+        backend_window_ids,
+        monitors,
+    }) = snapshot.first().copied()
+    {
+        println!("=== Snapshot (event_version={}) ===", version);
+        println!("Lifecycle: {:?}", lifecycle);
+        println!("Monitors:  {} ({:?})", monitors.len(), monitors);
+        println!();
+        println!("Windows ({}):", windows.len());
+        if windows.is_empty() {
+            println!("  (none)");
+        } else {
+            for w in windows {
+                let inst = instance_registry
+                    .iter()
+                    .find(|(l, _)| l == &w.label)
+                    .map(|(_, n)| format!("#{}", n))
+                    .unwrap_or_else(|| "—".to_string());
+                let backend = backend_window_ids
+                    .iter()
+                    .find(|(l, _)| l == &w.label)
+                    .map(|(_, b)| b.as_str())
+                    .unwrap_or("—");
+                println!(
+                    "  {:>4} {:30} kind={:?} hwnd={:?} visible={} iconic={} fg_seen={} backend={}",
+                    inst, w.label, w.kind, w.hwnd, w.visible, w.iconic,
+                    w.foregrounded_since_open, backend
+                );
+            }
+        }
+        println!();
+        println!("Pool ({}): {:?}", pool.len(), pool);
+        println!();
+    } else {
+        println!("(snapshot not received — server may be older than D.1)");
+        println!();
     }
 
-    // Group by event kind for a quick at-a-glance view.
+    println!("=== Live stream observed in {}s ===", OBSERVATION_WINDOW.as_secs());
+    if stream.is_empty() {
+        println!("(no events — instance is idle.)");
+        return;
+    }
     use std::collections::BTreeMap;
     let mut counts: BTreeMap<&'static str, u32> = BTreeMap::new();
-    for evt in events {
+    for evt in &stream {
         *counts.entry(event_kind_name(evt)).or_insert(0) += 1;
     }
     println!("By kind:");
@@ -154,9 +209,8 @@ fn print_summary(events: &[Event]) {
         println!("  {:>4}× {}", count, kind);
     }
     println!();
-
     println!("Full stream (oldest first):");
-    for (i, evt) in events.iter().enumerate() {
+    for (i, evt) in stream.iter().enumerate() {
         println!("  [{}] {}", i, format_event(evt));
     }
 }
@@ -181,6 +235,7 @@ fn event_kind_name(e: &Event) -> &'static str {
         Event::HwndDriftDetected { .. } => "HwndDriftDetected",
         Event::CorrectiveWindowMove { .. } => "CorrectiveWindowMove",
         Event::HostShouldQuit { .. } => "HostShouldQuit",
+        Event::Snapshot { .. } => "Snapshot",
         _ => "Other",
     }
 }

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -16,10 +16,12 @@
 // gets all events broadcast on the pipe without affecting the
 // running instance.
 //
-// Phase D will add a `Command::GetSnapshot` RPC for a structured
-// reply (current windows + pool + drift state) — until then, this
-// captures the live event stream over a 2s window and infers
-// state from observed events.
+// Phase D.1 — `Command::GetSnapshot` is sent right after Register
+// to capture the launcher's canonical state in one round-trip; the
+// reply (`Event::Snapshot`) is printed prominently before the live
+// event stream. Phase D.2 + D.3 will add a persisted event log + a
+// `since: u64` parameter for delta replay; until then a snapshot is
+// "as-of-now" only.
 
 use std::time::Duration;
 

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -506,6 +506,10 @@ async fn enforce_register_first(
                 true,
             )
         }
+        // Phase D.1 — GetSnapshot before Register is non-fatal: any
+        // sane diagnostic client can fix it by retrying with Register
+        // first. (Same Ping-before-Register precedent — soft error.)
+        Command::GetSnapshot => ("GetSnapshot before Register".to_string(), false),
     };
     let mut state = ctx.state.lock().await;
     let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -187,6 +187,14 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }
             crate::wrr::apply_monitor_topology_changed(state, rects)
         }
+        // Phase D.1 — read-only snapshot of canonical state. Any
+        // registered client can ask; no host-only gate. Reducer state
+        // is unchanged by this command (it's a query, not a mutation),
+        // but we still bump `event_version` so the snapshot's version
+        // is monotonically distinct from prior events — a subscriber
+        // applying snapshot + delta events knows the snapshot's
+        // version is the "as-of" point.
+        Command::GetSnapshot => handle_get_snapshot(state),
     }
 }
 
@@ -497,6 +505,61 @@ fn host_is_running(state: &State) -> bool {
     })
 }
 
+/// Phase D.1 — clone the reducer's canonical state into a `Snapshot`
+/// event. Read-only; doesn't mutate state except for bumping
+/// `event_version` so the snapshot's version is monotonically
+/// distinct from prior events (subscribers applying snapshot + delta
+/// events know the snapshot is "as-of" this version).
+///
+/// Sorted-vec serialization (rather than HashMap-as-JSON-object) for:
+/// 1. Deterministic ordering across snapshots (idempotent diffs in
+///    operator output, easier test assertions).
+/// 2. Wire compatibility with `Vec<(K, V)>` decoders that don't
+///    require canonical-string-keyed JSON objects.
+fn handle_get_snapshot(state: &mut State) -> Vec<Event> {
+    let v = state.bump_version();
+
+    let mut windows: Vec<agentmux_common::ipc::WindowSnapshot> = state
+        .windows
+        .values()
+        .map(|w| agentmux_common::ipc::WindowSnapshot {
+            label: w.label.clone(),
+            kind: w.kind,
+            parent_label: w.parent_label.clone(),
+            hwnd: w.hwnd,
+            visible: w.visible,
+            iconic: w.iconic,
+            last_rect: w.last_rect,
+            foregrounded_since_open: w.foregrounded_since_open,
+        })
+        .collect();
+    windows.sort_by(|a, b| a.label.cmp(&b.label));
+
+    let mut pool: Vec<String> = state.pool.iter().cloned().collect();
+    pool.sort();
+
+    let mut instance_registry: Vec<(String, u32)> =
+        state.instance_registry.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    instance_registry.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut backend_window_ids: Vec<(String, String)> = state
+        .backend_window_ids
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    backend_window_ids.sort_by(|a, b| a.0.cmp(&b.0));
+
+    vec![Event::Snapshot {
+        version: v,
+        lifecycle: state.lifecycle,
+        windows,
+        pool,
+        instance_registry,
+        backend_window_ids,
+        monitors: state.monitors.clone(),
+    }]
+}
+
 fn handle_register(
     state: &mut State,
     ctx: &Ctx,
@@ -770,6 +833,7 @@ mod tests {
             | Event::HwndDriftDetected { version, .. }
             | Event::CorrectiveWindowMove { version, .. }
             | Event::HostShouldQuit { version, .. }
+            | Event::Snapshot { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -2515,5 +2579,106 @@ mod tests {
             );
         }
         assert!(state.pool.is_empty(), "pool must be empty after drain");
+    }
+
+    // -----------------------------------------------------------
+    // Phase D.1 — GetSnapshot tests
+    // -----------------------------------------------------------
+
+    #[test]
+    fn get_snapshot_returns_canonical_state_in_one_event() {
+        let (mut state, host_ctx) = registered_host_state();
+
+        // Drive some state into the reducer.
+        let _ = update(&mut state, Command::ReportWindowOpened {
+            label: "main".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        }, &host_ctx);
+        let _ = update(&mut state, Command::ReportWindowOpened {
+            label: "window-abc".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        }, &host_ctx);
+        let _ = update(&mut state, Command::ReportPoolWindowAdded {
+            label: "pool-x".into(),
+        }, &host_ctx);
+        let _ = update(&mut state, Command::ReportBackendWindowIdRegistered {
+            label: "main".into(),
+            window_id: "uuid-main".into(),
+        }, &host_ctx);
+
+        // Snapshot.
+        let evs = update(&mut state, Command::GetSnapshot, &host_ctx);
+        assert_eq!(evs.len(), 1, "expected exactly 1 Snapshot event, got {:?}", evs);
+
+        let Event::Snapshot {
+            version,
+            lifecycle: _,
+            windows,
+            pool,
+            instance_registry,
+            backend_window_ids,
+            monitors: _,
+        } = &evs[0] else {
+            panic!("expected Snapshot, got {:?}", evs[0]);
+        };
+
+        // Sorted ordering: "main" < "window-abc".
+        assert_eq!(windows.len(), 2);
+        assert_eq!(windows[0].label, "main");
+        assert_eq!(windows[1].label, "window-abc");
+        assert_eq!(pool, &vec!["pool-x".to_string()]);
+        // instance_registry has main=1 (pre-seed) + window-abc=2.
+        assert_eq!(instance_registry.len(), 2);
+        assert_eq!(instance_registry[0], ("main".to_string(), 1));
+        assert_eq!(backend_window_ids, &vec![("main".to_string(), "uuid-main".to_string())]);
+        // Snapshot's version is monotonic w.r.t. earlier events.
+        assert!(*version > 0, "snapshot version must be non-zero (was bump_version'd)");
+    }
+
+    #[test]
+    fn get_snapshot_does_not_mutate_canonical_state() {
+        let (mut state, host_ctx) = registered_host_state();
+        let _ = update(&mut state, Command::ReportWindowOpened {
+            label: "main".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        }, &host_ctx);
+
+        let pre_windows = state.windows.clone();
+        let pre_pool = state.pool.clone();
+        let pre_instance_registry = state.instance_registry.clone();
+        let pre_backend_window_ids = state.backend_window_ids.clone();
+        let pre_lifecycle = state.lifecycle;
+
+        let _ = update(&mut state, Command::GetSnapshot, &host_ctx);
+
+        assert_eq!(state.windows, pre_windows);
+        assert_eq!(state.pool, pre_pool);
+        assert_eq!(state.instance_registry, pre_instance_registry);
+        assert_eq!(state.backend_window_ids, pre_backend_window_ids);
+        assert_eq!(state.lifecycle, pre_lifecycle);
+    }
+
+    #[test]
+    fn get_snapshot_works_for_non_host_clients() {
+        // Tool clients (e.g. --diag wrr) should be able to query
+        // snapshots — host-only gate doesn't apply.
+        let mut state = State::default();
+        let _ = update(
+            &mut state,
+            Command::Register {
+                kind: ClientKind::Tool,
+                pid: 99,
+                version: "diag".into(),
+            },
+            &ctx(1),
+        );
+        let tool_ctx = ctx_with_pid(1, 99);
+
+        let evs = update(&mut state, Command::GetSnapshot, &tool_ctx);
+        assert_eq!(evs.len(), 1);
+        assert!(matches!(evs[0], Event::Snapshot { .. }));
     }
 }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.506"
+version = "0.33.507"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.506",
+  "version": "0.33.507",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.506",
+      "version": "0.33.507",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.506",
+  "version": "0.33.507",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase D.1 — adds the foundation for Phase D's durability/resync story. Subscribers can now ask the launcher reducer for its canonical state in a single round-trip via `Command::GetSnapshot`, instead of inferring state from the event stream that has flowed since they connected.

First piece of Phase D. D.2 adds a persisted event log (ring buffer); D.3 adds the `since: u64` parameter for delta replay.

## What changes

### Wire protocol (`agentmux-common/src/ipc.rs`)

- New `Command::GetSnapshot` (no args)
- New `Event::Snapshot { version, lifecycle, windows, pool, instance_registry, backend_window_ids, monitors }`
- New `WindowSnapshot` struct — serializable view of one window (label, kind, parent, plus the B.9 HWND-observation axis: hwnd, visible, iconic, last_rect, foregrounded_since_open)

### Reducer (`agentmux-launcher/src/reducer.rs`)

`handle_get_snapshot` clones canonical state into a Snapshot event. Sorted by label for deterministic ordering. The snapshot's `version` is `bump_version`'d so it's monotonically distinct from prior events — subscribers know the "as-of" point for applying subsequent events as deltas.

**Excluded by design:** `processes` (PID metadata is launcher-internal), `pending_hwnds` (transient), event log (D.2 adds that separately).

### Server (`agentmux-launcher/src/ipc/server.rs`)

`enforce_register_first` accepts `GetSnapshot` as a non-fatal pre-Register error (same precedent as `Ping`).

### Diag (`agentmux-launcher/src/diag.rs`)

`--diag wrr` now sends `GetSnapshot` right after Register and prints the snapshot before the 2s live-event observation window:

```
=== Snapshot (event_version=12) ===
Lifecycle: Running
Monitors:  1 ([Rect { left: 0, top: 0, right: 900, bottom: 1600 }])

Windows (1):
    #1 main                           kind=FullInstance hwnd=Some(2557122) visible=true iconic=false fg_seen=true backend=cc92f5e2-9245-4936-904d-f6ed29effe85

Pool (3): ["window-pool-149fb...", "window-pool-8178...", "window-pool-c598..."]

=== Live stream observed in 2s ===
...
```

Operator surface goes from "events-since-connect" to "what IS now + what's happening".

## Test plan

3 new launcher reducer tests (63 total, all passing):

- `get_snapshot_returns_canonical_state_in_one_event`: end-to-end populate state → snapshot → assert sorted Vec contents.
- `get_snapshot_does_not_mutate_canonical_state`: pre/post state equality (snapshot is read-only except for `bump_version`).
- `get_snapshot_works_for_non_host_clients`: Tool clients can query (no host-only gate).

Smoked locally on v0.33.507: snapshot output above is from a live diag run against a running instance.

## What this does NOT do

- No `since: u64` parameter or event replay — D.3 adds those.
- No persisted event log — D.2 adds that.
- No frontend resync wiring (renderer reducer doesn't consume snapshots yet) — natural follow-up after D.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)