### PR TITLE
feat(E.2b): tab + active-tab reducer arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.512"
+version = "0.33.513"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.512"
+version = "0.33.513"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.512"
+version = "0.33.513"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.512"
+version = "0.33.513"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.512"
+version = "0.33.513"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.512"
+version = "0.33.513"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -246,6 +246,32 @@ pub enum Command {
     DeleteWorkspace {
         workspace_id: String,
     },
+    /// Phase E.2b — create a tab inside an existing workspace. The
+    /// reducer assigns the `tab_id` (UUID), appends to the workspace's
+    /// ordered tab list, and emits `Event::TabCreated`. Validates the
+    /// parent workspace exists; returns `Event::Error` if not.
+    /// Session-only projection (no persist subscriber yet).
+    CreateTab {
+        workspace_id: String,
+        name: String,
+    },
+    /// Phase E.2b — delete a tab from a workspace. Reducer removes the
+    /// tab from canonical state, removes its id from the workspace's
+    /// ordered tab list, and emits `Event::TabDeleted`. If the deleted
+    /// tab was the active tab, also emits `Event::ActiveTabChanged`
+    /// pointing at the new active (next-or-prev tab, or empty if the
+    /// workspace has no tabs left).
+    DeleteTab {
+        workspace_id: String,
+        tab_id: String,
+    },
+    /// Phase E.2b — set a workspace's active tab. No-op if already
+    /// active. Errors if the workspace doesn't exist or the tab isn't
+    /// in that workspace's tab list.
+    SetActiveTab {
+        workspace_id: String,
+        tab_id: String,
+    },
     /// Phase D.3 — request an `Event::EventList` reply containing the
     /// events the launcher has emitted with version > `since`. Used
     /// by subscribers that hold a snapshot at version V and want to
@@ -588,10 +614,20 @@ pub enum Event {
         /// written by E.1b (which had no `workspaces` field) still
         /// deserialize when later sub-phases add bootstrap-replay
         /// from the on-disk log. Same forward-compat treatment will
-        /// apply to E.2b's `tabs`, E.3's `blocks`, etc.
-        /// (reagent P2 #611.)
+        /// apply to E.3's `blocks`, etc. (reagent P2 #611.)
         #[serde(default)]
         workspaces: Vec<(String, String)>,
+        /// Phase E.2b — sorted list of tabs in the reducer's canonical
+        /// state. `(tab_id, workspace_id, name)` triples for
+        /// compactness. `#[serde(default)]` for forward-compat with
+        /// pre-E.2b log entries.
+        #[serde(default)]
+        tabs: Vec<(String, String, String)>,
+        /// Phase E.2b — sorted list of `(workspace_id, active_tab_id)`
+        /// pairs for workspaces that have an active tab set.
+        /// Workspaces with no active tab are omitted.
+        #[serde(default)]
+        active_tabs: Vec<(String, String)>,
     },
     /// Phase E.2 — workspace was created. Carries the assigned
     /// `oid` and `name` so subscribers (renderer, persist) can
@@ -604,6 +640,28 @@ pub enum Event {
     /// Phase E.2 — workspace was deleted.
     WorkspaceDeleted {
         workspace_id: String,
+        version: u64,
+    },
+    /// Phase E.2b — tab was created inside a workspace. Carries the
+    /// assigned `tab_id` and parent `workspace_id` so subscribers can
+    /// place it in the correct workspace's tab list.
+    TabCreated {
+        workspace_id: String,
+        tab_id: String,
+        name: String,
+        version: u64,
+    },
+    /// Phase E.2b — tab was deleted from a workspace.
+    TabDeleted {
+        workspace_id: String,
+        tab_id: String,
+        version: u64,
+    },
+    /// Phase E.2b — a workspace's active tab changed. `tab_id: None`
+    /// means the workspace has no active tab (e.g., last tab deleted).
+    ActiveTabChanged {
+        workspace_id: String,
+        tab_id: Option<String>,
         version: u64,
     },
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.512"
+version = "0.33.513"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -268,6 +268,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::SrvSnapshot { version, .. }
         | Event::WorkspaceCreated { version, .. }
         | Event::WorkspaceDeleted { version, .. }
+        | Event::TabCreated { version, .. }
+        | Event::TabDeleted { version, .. }
+        | Event::ActiveTabChanged { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -660,6 +660,19 @@ async fn enforce_register_first(
             "DeleteWorkspace is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.2b — Tab arms are also srv-pipe commands.
+        Command::CreateTab { .. } => (
+            "CreateTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::DeleteTab { .. } => (
+            "DeleteTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::SetActiveTab { .. } => (
+            "SetActiveTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
     };
     // Phase E.1b — connection-private error; sentinel version=0
     // (codex P2 #610). See parse-error path for rationale.

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -223,6 +223,34 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.2b — Tab arms are also srv-pipe commands.
+        Command::CreateTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "CreateTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::DeleteTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "DeleteTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::SetActiveTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "SetActiveTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.1b — `GetSrvSnapshot` is a srv-pipe command. If a
         // registered client misroutes it to the launcher pipe, return
         // an explicit error so the client knows the dispatch was
@@ -884,6 +912,9 @@ mod tests {
             | Event::SrvSnapshot { version, .. }
             | Event::WorkspaceCreated { version, .. }
             | Event::WorkspaceDeleted { version, .. }
+            | Event::TabCreated { version, .. }
+            | Event::TabDeleted { version, .. }
+            | Event::ActiveTabChanged { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.512"
+version = "0.33.513"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -268,6 +268,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::SrvSnapshot { version, .. }
         | Event::WorkspaceCreated { version, .. }
         | Event::WorkspaceDeleted { version, .. }
+        | Event::TabCreated { version, .. }
+        | Event::TabDeleted { version, .. }
+        | Event::ActiveTabChanged { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -3,9 +3,9 @@
 //
 // Phase E.2 — bootstrap helper: load SQLite-persistent state into
 // the srv reducer at startup. The reducer's state is a SESSION-only
-// projection in E.2 — it's populated from SQLite at boot, mutated
-// by pipe-originated commands during the session, and discarded on
-// restart (the next bootstrap re-reads SQLite).
+// projection in E.2/E.2b — it's populated from SQLite at boot,
+// mutated by pipe-originated commands during the session, and
+// discarded on restart (the next bootstrap re-reads SQLite).
 //
 // HTTP/WS RPC continues to write to SQLite directly via wcore. So
 // SQLite stays authoritative for the duration of the session even
@@ -23,42 +23,98 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::backend::obj::Workspace;
+use crate::backend::obj::{Tab, Workspace};
 use crate::backend::storage::wstore::WaveStore;
-use crate::state::{State, WorkspaceRecord};
+use crate::state::{State, TabRecord, WorkspaceRecord};
 
-/// Phase E.2 — load workspaces from SQLite into the reducer state.
-/// Called once at srv startup before the IPC server starts accepting
-/// commands. Async because we're inside the tokio runtime.
+/// Phase E.2 / E.2b — load workspaces and their tabs from SQLite
+/// into the reducer state. Called once at srv startup before the
+/// IPC server starts accepting commands. Async because we're inside
+/// the tokio runtime.
 ///
-/// Errors are logged but non-fatal: if SQLite read fails (fresh
-/// install, empty DB), the reducer starts with an empty workspace
-/// map. Subsequent reducer commands populate state as before.
+/// Errors are logged but non-fatal: if a SQLite read fails (fresh
+/// install, empty DB, transient I/O), the reducer starts with
+/// whatever loaded successfully. Workspace and tab loads are
+/// independent — a workspace-load failure does not prevent the tab
+/// load from being attempted (and vice versa), since pipe commands
+/// later in the session can populate either map.
 pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &WaveStore) {
-    let workspaces = match wstore.get_all::<Workspace>() {
-        Ok(ws) => ws,
-        Err(e) => {
-            tracing::warn!(
-                target: "srv-persist",
-                "[srv-persist] bootstrap: failed to load workspaces from wstore: {} — reducer starts empty",
-                e
-            );
-            return;
-        }
-    };
+    let workspaces = wstore.get_all::<Workspace>().unwrap_or_else(|e| {
+        tracing::warn!(
+            target: "srv-persist",
+            "[srv-persist] bootstrap: failed to load workspaces from wstore: {} — workspaces start empty",
+            e
+        );
+        Vec::new()
+    });
+    let tabs = wstore.get_all::<Tab>().unwrap_or_else(|e| {
+        tracing::warn!(
+            target: "srv-persist",
+            "[srv-persist] bootstrap: failed to load tabs from wstore: {} — tabs start empty",
+            e
+        );
+        Vec::new()
+    });
     let mut state = state.lock().await;
-    for ws in workspaces {
+    for ws in &workspaces {
+        // Filter the workspace's `tabids` against tabs we actually
+        // loaded — defensively drop dangling references rather than
+        // surface them to subscribers as fictional tabs. The active
+        // tab pointer is similarly only retained when it points at a
+        // tab present in the filtered list.
+        let tab_ids: Vec<String> = ws
+            .tabids
+            .iter()
+            .filter(|tid| tabs.iter().any(|t| &t.oid == *tid))
+            .cloned()
+            .collect();
+        let active_tab_id = if !ws.activetabid.is_empty()
+            && tab_ids.iter().any(|tid| tid == &ws.activetabid)
+        {
+            Some(ws.activetabid.clone())
+        } else {
+            None
+        };
         state.workspaces.insert(
             ws.oid.clone(),
             WorkspaceRecord {
-                workspace_id: ws.oid,
-                name: ws.name,
+                workspace_id: ws.oid.clone(),
+                name: ws.name.clone(),
+                tab_ids,
+                active_tab_id,
+            },
+        );
+    }
+    for tab in &tabs {
+        // Each tab needs to know its parent workspace_id, which the
+        // persistent `Tab` struct doesn't carry directly — we recover
+        // it from whichever workspace lists this tab in `tabids`.
+        // Tabs whose parent isn't loaded are skipped (orphans).
+        let Some(workspace_id) = workspaces
+            .iter()
+            .find(|ws| ws.tabids.iter().any(|tid| tid == &tab.oid))
+            .map(|ws| ws.oid.clone())
+        else {
+            tracing::warn!(
+                target: "srv-persist",
+                "[srv-persist] bootstrap: tab {} has no parent workspace — skipping",
+                tab.oid
+            );
+            continue;
+        };
+        state.tabs.insert(
+            tab.oid.clone(),
+            TabRecord {
+                tab_id: tab.oid.clone(),
+                workspace_id,
+                name: tab.name.clone(),
             },
         );
     }
     tracing::info!(
         target: "srv-persist",
-        "[srv-persist] bootstrap loaded {} workspace(s) from wstore",
-        state.workspaces.len()
+        "[srv-persist] bootstrap loaded {} workspace(s) + {} tab(s) from wstore",
+        state.workspaces.len(),
+        state.tabs.len()
     );
 }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -57,14 +57,17 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
     });
     let mut state = state.lock().await;
     for ws in &workspaces {
-        // Filter the workspace's `tabids` against tabs we actually
-        // loaded — defensively drop dangling references rather than
-        // surface them to subscribers as fictional tabs. The active
-        // tab pointer is similarly only retained when it points at a
-        // tab present in the filtered list.
+        // The persistent `Workspace` carries two ordered lists:
+        // `tabids` (regular tabs) and `pinnedtabids` (sticky tabs).
+        // Both are equally "owned by this workspace" for reducer
+        // purposes — only their UX semantics differ. Concatenate
+        // pinned-then-regular (pinning convention puts pinned tabs
+        // first), then filter against the tabs we actually loaded
+        // to drop dangling references defensively. (codex P1 #612.)
         let tab_ids: Vec<String> = ws
-            .tabids
+            .pinnedtabids
             .iter()
+            .chain(ws.tabids.iter())
             .filter(|tid| tabs.iter().any(|t| &t.oid == *tid))
             .cloned()
             .collect();
@@ -88,11 +91,17 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
     for tab in &tabs {
         // Each tab needs to know its parent workspace_id, which the
         // persistent `Tab` struct doesn't carry directly — we recover
-        // it from whichever workspace lists this tab in `tabids`.
-        // Tabs whose parent isn't loaded are skipped (orphans).
+        // it from whichever workspace lists this tab id in EITHER
+        // `tabids` OR `pinnedtabids`. Tabs whose parent isn't loaded
+        // are skipped (orphans). (codex P1 #612.)
         let Some(workspace_id) = workspaces
             .iter()
-            .find(|ws| ws.tabids.iter().any(|tid| tid == &tab.oid))
+            .find(|ws| {
+                ws.tabids
+                    .iter()
+                    .chain(ws.pinnedtabids.iter())
+                    .any(|tid| tid == &tab.oid)
+            })
             .map(|ws| ws.oid.clone())
         else {
             tracing::warn!(

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -11,7 +11,8 @@
 // Arms by phase:
 //   * E.1b — Register / Goodbye / Ping / GetSrvSnapshot / GetEvents
 //   * E.2  — CreateWorkspace / DeleteWorkspace
-//   * E.2b+ — Tab / Block / Layout commands (not yet present)
+//   * E.2b — CreateTab / DeleteTab / SetActiveTab
+//   * E.3+ — Block / Layout commands (not yet present)
 //
 // `Command::GetEvents` is intercepted by the IPC server before
 // reaching the reducer (server queries the event log; reducer
@@ -20,7 +21,7 @@
 
 use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event, LifecyclePhase};
 
-use crate::state::{ProcessRecord, ProcessState, State, WorkspaceRecord};
+use crate::state::{ProcessRecord, ProcessState, State, TabRecord, WorkspaceRecord};
 
 /// Per-dispatch context. Currently just an RFC3339 timestamp + the
 /// originating connection's `conn_id` for log correlation.
@@ -43,6 +44,11 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::GetEvents { .. } => Vec::new(), // intercepted by server; unreachable
         Command::CreateWorkspace { name } => handle_create_workspace(state, name),
         Command::DeleteWorkspace { workspace_id } => handle_delete_workspace(state, workspace_id),
+        Command::CreateTab { workspace_id, name } => handle_create_tab(state, workspace_id, name),
+        Command::DeleteTab { workspace_id, tab_id } => handle_delete_tab(state, workspace_id, tab_id),
+        Command::SetActiveTab { workspace_id, tab_id } => {
+            handle_set_active_tab(state, workspace_id, tab_id)
+        }
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
         // match by adding new arms above.
@@ -160,10 +166,28 @@ fn handle_get_srv_snapshot(state: &mut State) -> Vec<Event> {
     // Stable ordering for diffability — reducer state is HashMap so
     // iteration order is non-deterministic.
     workspaces.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut tabs: Vec<(String, String, String)> = state
+        .tabs
+        .values()
+        .map(|t| (t.tab_id.clone(), t.workspace_id.clone(), t.name.clone()))
+        .collect();
+    tabs.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut active_tabs: Vec<(String, String)> = state
+        .workspaces
+        .values()
+        .filter_map(|w| {
+            w.active_tab_id
+                .as_ref()
+                .map(|t| (w.workspace_id.clone(), t.clone()))
+        })
+        .collect();
+    active_tabs.sort_by(|a, b| a.0.cmp(&b.0));
     vec![Event::SrvSnapshot {
         version: v,
         lifecycle: state.lifecycle,
         workspaces,
+        tabs,
+        active_tabs,
     }]
 }
 
@@ -181,6 +205,8 @@ fn handle_create_workspace(state: &mut State, name: String) -> Vec<Event> {
         WorkspaceRecord {
             workspace_id: workspace_id.clone(),
             name: name.clone(),
+            tab_ids: Vec::new(),
+            active_tab_id: None,
         },
     );
     let v = state.bump_version();
@@ -192,15 +218,166 @@ fn handle_create_workspace(state: &mut State, name: String) -> Vec<Event> {
 }
 
 /// Phase E.2 — delete a workspace from canonical state. Idempotent:
-/// deleting a missing workspace is a silent no-op. Cascade to the
-/// workspace's tabs is E.2b territory (tab arms not yet present).
+/// deleting a missing workspace is a silent no-op. Cascades to the
+/// workspace's tabs (E.2b): every tab whose `workspace_id` matches
+/// is removed from `state.tabs` before the workspace itself goes
+/// away. Cascade events are NOT emitted individually — subscribers
+/// observing `WorkspaceDeleted` are expected to drop dependent state
+/// (mirrors how `wcore::delete_workspace` cascades in SQLite).
 fn handle_delete_workspace(state: &mut State, workspace_id: String) -> Vec<Event> {
-    if state.workspaces.remove(&workspace_id).is_none() {
+    let Some(removed) = state.workspaces.remove(&workspace_id) else {
         return Vec::new();
+    };
+    for tab_id in &removed.tab_ids {
+        state.tabs.remove(tab_id);
     }
     let v = state.bump_version();
     vec![Event::WorkspaceDeleted {
         workspace_id,
+        version: v,
+    }]
+}
+
+/// Phase E.2b — create a tab inside a workspace. Validates the
+/// parent exists; otherwise emits `Event::Error` (non-fatal). On
+/// success: assigns a UUID, appends to the workspace's `tab_ids`,
+/// inserts into `state.tabs`, emits `Event::TabCreated`. If the
+/// workspace had no active tab, the new tab also becomes active
+/// and an `Event::ActiveTabChanged` is emitted alongside.
+///
+/// NOT idempotent on retry (same UUID-assignment caveat as
+/// `handle_create_workspace`).
+fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> Vec<Event> {
+    if !state.workspaces.contains_key(&workspace_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("CreateTab: workspace not found: {}", workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let tab_id = uuid::Uuid::new_v4().to_string();
+    state.tabs.insert(
+        tab_id.clone(),
+        TabRecord {
+            tab_id: tab_id.clone(),
+            workspace_id: workspace_id.clone(),
+            name: name.clone(),
+        },
+    );
+    let workspace = state.workspaces.get_mut(&workspace_id).expect("checked");
+    workspace.tab_ids.push(tab_id.clone());
+    let activated = if workspace.active_tab_id.is_none() {
+        workspace.active_tab_id = Some(tab_id.clone());
+        true
+    } else {
+        false
+    };
+    let mut events = Vec::with_capacity(2);
+    let v = state.bump_version();
+    events.push(Event::TabCreated {
+        workspace_id: workspace_id.clone(),
+        tab_id: tab_id.clone(),
+        name,
+        version: v,
+    });
+    if activated {
+        let v2 = state.bump_version();
+        events.push(Event::ActiveTabChanged {
+            workspace_id,
+            tab_id: Some(tab_id),
+            version: v2,
+        });
+    }
+    events
+}
+
+/// Phase E.2b — delete a tab from a workspace. Idempotent: deleting
+/// a missing tab is a silent no-op. If the deleted tab was the
+/// active tab, the workspace's active tab becomes the next tab in
+/// `tab_ids` (or the previous one if the deleted was last; or None
+/// if the workspace is now empty), and an `Event::ActiveTabChanged`
+/// is emitted alongside `Event::TabDeleted`.
+fn handle_delete_tab(
+    state: &mut State,
+    workspace_id: String,
+    tab_id: String,
+) -> Vec<Event> {
+    let Some(workspace) = state.workspaces.get_mut(&workspace_id) else {
+        return Vec::new();
+    };
+    let Some(pos) = workspace.tab_ids.iter().position(|t| t == &tab_id) else {
+        return Vec::new();
+    };
+    workspace.tab_ids.remove(pos);
+    let active_changed = if workspace.active_tab_id.as_deref() == Some(tab_id.as_str()) {
+        let new_active = workspace
+            .tab_ids
+            .get(pos)
+            .or_else(|| pos.checked_sub(1).and_then(|i| workspace.tab_ids.get(i)))
+            .cloned();
+        workspace.active_tab_id = new_active.clone();
+        Some(new_active)
+    } else {
+        None
+    };
+    state.tabs.remove(&tab_id);
+    let mut events = Vec::with_capacity(2);
+    let v = state.bump_version();
+    events.push(Event::TabDeleted {
+        workspace_id: workspace_id.clone(),
+        tab_id,
+        version: v,
+    });
+    if let Some(new_active) = active_changed {
+        let v2 = state.bump_version();
+        events.push(Event::ActiveTabChanged {
+            workspace_id,
+            tab_id: new_active,
+            version: v2,
+        });
+    }
+    events
+}
+
+/// Phase E.2b — set a workspace's active tab. No-op if already
+/// active. Errors (non-fatal) if the workspace doesn't exist or the
+/// tab isn't in that workspace's tab list.
+fn handle_set_active_tab(
+    state: &mut State,
+    workspace_id: String,
+    tab_id: String,
+) -> Vec<Event> {
+    let Some(workspace) = state.workspaces.get_mut(&workspace_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("SetActiveTab: workspace not found: {}", workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if !workspace.tab_ids.iter().any(|t| t == &tab_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "SetActiveTab: tab {} not in workspace {}",
+                tab_id, workspace_id
+            ),
+            fatal: false,
+            version: v,
+        }];
+    }
+    if workspace.active_tab_id.as_deref() == Some(tab_id.as_str()) {
+        return Vec::new();
+    }
+    workspace.active_tab_id = Some(tab_id.clone());
+    let v = state.bump_version();
+    vec![Event::ActiveTabChanged {
+        workspace_id,
+        tab_id: Some(tab_id),
         version: v,
     }]
 }
@@ -252,6 +429,9 @@ mod tests {
             | Event::SagaFailed { version, .. }
             | Event::WorkspaceCreated { version, .. }
             | Event::WorkspaceDeleted { version, .. }
+            | Event::TabCreated { version, .. }
+            | Event::TabDeleted { version, .. }
+            | Event::ActiveTabChanged { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -519,6 +699,319 @@ mod tests {
         assert_eq!(workspaces.len(), 2);
         // Sorted by id; verify ordering deterministic (ascending).
         assert!(workspaces[0].0 < workspaces[1].0);
+    }
+
+    fn create_workspace(state: &mut State, name: &str) -> String {
+        let events = update(
+            state,
+            Command::CreateWorkspace { name: name.into() },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::WorkspaceCreated { workspace_id, .. } => workspace_id.clone(),
+            _ => panic!("expected WorkspaceCreated"),
+        }
+    }
+
+    #[test]
+    fn create_tab_validates_workspace_exists() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: "no-such-ws".into(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        assert!(state.tabs.is_empty());
+    }
+
+    #[test]
+    fn create_tab_first_tab_becomes_active() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        // First event: TabCreated; second: ActiveTabChanged.
+        assert!(matches!(&events[0], Event::TabCreated { .. }));
+        assert!(matches!(&events[1], Event::ActiveTabChanged { .. }));
+        let workspace = &state.workspaces[&ws_id];
+        assert_eq!(workspace.tab_ids.len(), 1);
+        assert_eq!(workspace.active_tab_id, Some(workspace.tab_ids[0].clone()));
+        assert_eq!(state.tabs.len(), 1);
+    }
+
+    #[test]
+    fn create_tab_second_tab_does_not_steal_active() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let first_active = state.workspaces[&ws_id].active_tab_id.clone();
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t2".into(),
+            },
+            &ctx(2),
+        );
+        // Only TabCreated — second tab does not become active.
+        assert!(matches!(&events[0], Event::TabCreated { .. }));
+        assert_eq!(events.len(), 1);
+        assert_eq!(state.workspaces[&ws_id].active_tab_id, first_active);
+        assert_eq!(state.workspaces[&ws_id].tab_ids.len(), 2);
+    }
+
+    #[test]
+    fn delete_tab_removes_from_state_and_workspace_list() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t2".into(),
+            },
+            &ctx(2),
+        );
+        let tab2_id = state.workspaces[&ws_id].tab_ids[1].clone();
+        let events = update(
+            &mut state,
+            Command::DeleteTab {
+                workspace_id: ws_id.clone(),
+                tab_id: tab2_id.clone(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::TabDeleted { .. }));
+        // tab2 wasn't active, so no ActiveTabChanged.
+        assert_eq!(events.len(), 1);
+        assert!(!state.tabs.contains_key(&tab2_id));
+        assert_eq!(state.workspaces[&ws_id].tab_ids.len(), 1);
+    }
+
+    #[test]
+    fn delete_active_tab_promotes_neighbor() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t2".into(),
+            },
+            &ctx(2),
+        );
+        let tab1_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        let tab2_id = state.workspaces[&ws_id].tab_ids[1].clone();
+        // tab1 was created first → it's active. Delete it.
+        let events = update(
+            &mut state,
+            Command::DeleteTab {
+                workspace_id: ws_id.clone(),
+                tab_id: tab1_id.clone(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::TabDeleted { .. }));
+        assert!(matches!(
+            &events[1],
+            Event::ActiveTabChanged { tab_id: Some(_), .. }
+        ));
+        // tab2 should now be active.
+        assert_eq!(state.workspaces[&ws_id].active_tab_id, Some(tab2_id));
+    }
+
+    #[test]
+    fn delete_last_tab_clears_active_to_none() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let tab1_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        let events = update(
+            &mut state,
+            Command::DeleteTab {
+                workspace_id: ws_id.clone(),
+                tab_id: tab1_id,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::TabDeleted { .. }));
+        assert!(matches!(
+            &events[1],
+            Event::ActiveTabChanged { tab_id: None, .. }
+        ));
+        assert_eq!(state.workspaces[&ws_id].active_tab_id, None);
+        assert!(state.tabs.is_empty());
+    }
+
+    #[test]
+    fn delete_unknown_tab_silent_no_op() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let events = update(
+            &mut state,
+            Command::DeleteTab {
+                workspace_id: ws_id,
+                tab_id: "ghost".into(),
+            },
+            &ctx(1),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn set_active_tab_validates_workspace_and_tab() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        // Wrong workspace.
+        let events = update(
+            &mut state,
+            Command::SetActiveTab {
+                workspace_id: "no-such".into(),
+                tab_id: "x".into(),
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        // Right workspace, wrong tab.
+        let events = update(
+            &mut state,
+            Command::SetActiveTab {
+                workspace_id: ws_id,
+                tab_id: "ghost".into(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn set_active_tab_idempotent_no_event_when_already_active() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let tab_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        // Already active (auto-activated on first tab create).
+        let events = update(
+            &mut state,
+            Command::SetActiveTab {
+                workspace_id: ws_id,
+                tab_id,
+            },
+            &ctx(2),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn delete_workspace_cascades_tabs() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t2".into(),
+            },
+            &ctx(2),
+        );
+        assert_eq!(state.tabs.len(), 2);
+        let events = update(
+            &mut state,
+            Command::DeleteWorkspace {
+                workspace_id: ws_id.clone(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::WorkspaceDeleted { .. }));
+        assert!(state.tabs.is_empty());
+        assert!(!state.workspaces.contains_key(&ws_id));
+    }
+
+    #[test]
+    fn snapshot_includes_tabs_and_active_tabs() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let events = update(&mut state, Command::GetSrvSnapshot, &ctx(2));
+        let Event::SrvSnapshot {
+            tabs, active_tabs, ..
+        } = &events[0]
+        else {
+            panic!("expected SrvSnapshot");
+        };
+        assert_eq!(tabs.len(), 1);
+        assert_eq!(active_tabs.len(), 1);
+        assert_eq!(active_tabs[0].0, ws_id);
     }
 
     #[test]

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -44,10 +44,30 @@ pub struct ProcessRecord {
 /// Phase E.2 — workspace as held by the srv reducer's canonical
 /// state. Mirrors the persistent `Workspace` struct in
 /// `agentmux_srv::backend::obj::Workspace` but with the reducer-
-/// canonical fields the cross-process events care about. Tabs
-/// are tracked separately in E.2b.
+/// canonical fields the cross-process events care about.
+///
+/// Phase E.2b extends the record with `tab_ids` (ordered) and
+/// `active_tab_id`. Tabs themselves live in `state.tabs` keyed by
+/// tab_id; the workspace owns the ordering.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceRecord {
+    pub workspace_id: String,
+    pub name: String,
+    /// Ordered list of tab ids in this workspace. Mirrors the
+    /// persistent `Workspace.tabids` field.
+    pub tab_ids: Vec<String>,
+    /// The active tab in this workspace, if any. `None` when the
+    /// workspace has no tabs or has not yet had one selected.
+    pub active_tab_id: Option<String>,
+}
+
+/// Phase E.2b — tab as held by the srv reducer's canonical state.
+/// Tabs are owned by exactly one workspace; the workspace's
+/// `tab_ids` field gives the ordering. Block-level state lands in
+/// E.3.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TabRecord {
+    pub tab_id: String,
     pub workspace_id: String,
     pub name: String,
 }
@@ -66,6 +86,11 @@ pub struct State {
     /// subscriber that mirrors changes back to SQLite (idempotent,
     /// version-gated) and migrates HTTP/WS RPC through the reducer.
     pub workspaces: HashMap<String, WorkspaceRecord>,
+    /// Phase E.2b — tabs canonical to the srv reducer. Keyed by
+    /// `tab_id`; ordering within a workspace is held in
+    /// `WorkspaceRecord.tab_ids`. Bootstrap-loaded from SQLite at
+    /// startup alongside workspaces.
+    pub tabs: HashMap<String, TabRecord>,
     // `persistence_hwm` deferred to E.2c when the persist subscriber
     // lands and there's actually something to track.
 }
@@ -78,6 +103,7 @@ impl Default for State {
             event_version: 0,
             next_client_id: 0,
             workspaces: HashMap::new(),
+            tabs: HashMap::new(),
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.512",
+  "version": "0.33.513",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.2b — adds tab lifecycle (`CreateTab` / `DeleteTab` / `SetActiveTab`) to the srv reducer, following the E.2 workspace pattern. **Reducer-only** — no persist subscriber yet (deferred to E.2c alongside RPC migration), so HTTP/WS RPC continues to write to SQLite via wcore today.

Follow-up to #611. Same scope-reduction discipline as E.2: ship the arms, defer the persist subscriber until E.2c where RPC migration makes it essential.

## What's new

**Commands** (`agentmux-common::ipc`):
- `CreateTab { workspace_id, name }`
- `DeleteTab { workspace_id, tab_id }`
- `SetActiveTab { workspace_id, tab_id }`

**Events**:
- `TabCreated { workspace_id, tab_id, name, version }`
- `TabDeleted { workspace_id, tab_id, version }`
- `ActiveTabChanged { workspace_id, tab_id: Option<String>, version }`

**State**: `WorkspaceRecord` gains `tab_ids: Vec<String>` + `active_tab_id: Option<String>`; new `TabRecord` in `state.tabs` map.

**Reducer behaviour**:
- `CreateTab` — validates parent workspace exists; first tab auto-activates (emits both `TabCreated` and `ActiveTabChanged`).
- `DeleteTab` — idempotent silent no-op on unknown tab/workspace. Active-tab deletion promotes next-then-prev-then-None.
- `SetActiveTab` — validates workspace + tab membership; no-op when already active (no event).
- `DeleteWorkspace` now cascades to tabs (matches `wcore::delete_workspace` cascade behaviour).

**Snapshot**: `Event::SrvSnapshot` extended with `tabs` (sorted) + `active_tabs` (sorted). Both `#[serde(default)]` for forward-compat with pre-E.2b log entries.

**Bootstrap** (`agentmux-srv::persist`): loads tabs alongside workspaces, filters dangling tab refs in `workspace.tabids`, recovers `tab.workspace_id` by reverse-lookup, skips orphan tabs with a warn.

## Test plan

- [x] `cargo test -p agentmux-srv` — 24 tests pass (11 new tab-arm tests + 13 carryovers from E.2)
- [x] `cargo test -p agentmux-launcher` — 71 tests pass
- [x] `cargo build --release -p agentmux-srv -p agentmux-launcher` — clean
- [ ] Smoke (manual portable): create workspace → create tab → switch tab → delete tab → delete workspace cascades

## Notes

- `handle_create_tab` and `handle_create_workspace` are NOT idempotent on retry (UUID assignment per call). Saga-side dedup is responsible for at-most-once delivery when sagas land in E.5+; this is documented on both handlers.
- Per the loop's scope-reduction rule from E.2: keep arms minimal, no persist subscriber, no RPC migration. Both land together in E.2c where they're mutually-required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)