### PR TITLE
feat(E.3): block lifecycle reducer arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.513"
+version = "0.33.514"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.513"
+version = "0.33.514"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.513"
+version = "0.33.514"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.513"
+version = "0.33.514"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.513"
+version = "0.33.514"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.513"
+version = "0.33.514"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -272,6 +272,19 @@ pub enum Command {
         workspace_id: String,
         tab_id: String,
     },
+    /// Phase E.3 — create a block inside an existing tab. Reducer
+    /// validates parent tab exists, assigns the `block_id` (UUID),
+    /// appends to the tab's `block_ids`, emits `Event::BlockCreated`.
+    /// Session-only projection (no persist subscriber yet).
+    CreateBlock {
+        tab_id: String,
+    },
+    /// Phase E.3 — delete a block from a tab. Idempotent silent no-op
+    /// on missing tab or missing block.
+    DeleteBlock {
+        tab_id: String,
+        block_id: String,
+    },
     /// Phase D.3 — request an `Event::EventList` reply containing the
     /// events the launcher has emitted with version > `since`. Used
     /// by subscribers that hold a snapshot at version V and want to
@@ -628,6 +641,12 @@ pub enum Event {
         /// Workspaces with no active tab are omitted.
         #[serde(default)]
         active_tabs: Vec<(String, String)>,
+        /// Phase E.3 — sorted list of blocks in the reducer's
+        /// canonical state. `(block_id, tab_id)` pairs for
+        /// compactness. `#[serde(default)]` for forward-compat with
+        /// pre-E.3 log entries.
+        #[serde(default)]
+        blocks: Vec<(String, String)>,
     },
     /// Phase E.2 — workspace was created. Carries the assigned
     /// `oid` and `name` so subscribers (renderer, persist) can
@@ -662,6 +681,18 @@ pub enum Event {
     ActiveTabChanged {
         workspace_id: String,
         tab_id: Option<String>,
+        version: u64,
+    },
+    /// Phase E.3 — block was created inside a tab.
+    BlockCreated {
+        tab_id: String,
+        block_id: String,
+        version: u64,
+    },
+    /// Phase E.3 — block was deleted from a tab.
+    BlockDeleted {
+        tab_id: String,
+        block_id: String,
         version: u64,
     },
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.513"
+version = "0.33.514"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -271,6 +271,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabCreated { version, .. }
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
+        | Event::BlockCreated { version, .. }
+        | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -673,6 +673,15 @@ async fn enforce_register_first(
             "SetActiveTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.3 — Block arms are also srv-pipe commands.
+        Command::CreateBlock { .. } => (
+            "CreateBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::DeleteBlock { .. } => (
+            "DeleteBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
     };
     // Phase E.1b — connection-private error; sentinel version=0
     // (codex P2 #610). See parse-error path for rationale.

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -251,6 +251,25 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.3 — Block arms are also srv-pipe commands.
+        Command::CreateBlock { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "CreateBlock is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::DeleteBlock { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "DeleteBlock is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.1b — `GetSrvSnapshot` is a srv-pipe command. If a
         // registered client misroutes it to the launcher pipe, return
         // an explicit error so the client knows the dispatch was
@@ -915,6 +934,8 @@ mod tests {
             | Event::TabCreated { version, .. }
             | Event::TabDeleted { version, .. }
             | Event::ActiveTabChanged { version, .. }
+            | Event::BlockCreated { version, .. }
+            | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.513"
+version = "0.33.514"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -271,6 +271,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabCreated { version, .. }
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
+        | Event::BlockCreated { version, .. }
+        | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -23,9 +23,9 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::backend::obj::{Tab, Workspace};
+use crate::backend::obj::{Block, Tab, Workspace};
 use crate::backend::storage::wstore::WaveStore;
-use crate::state::{State, TabRecord, WorkspaceRecord};
+use crate::state::{BlockRecord, State, TabRecord, WorkspaceRecord};
 
 /// Phase E.2 / E.2b — load workspaces and their tabs from SQLite
 /// into the reducer state. Called once at srv startup before the
@@ -51,6 +51,14 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
         tracing::warn!(
             target: "srv-persist",
             "[srv-persist] bootstrap: failed to load tabs from wstore: {} — tabs start empty",
+            e
+        );
+        Vec::new()
+    });
+    let blocks = wstore.get_all::<Block>().unwrap_or_else(|e| {
+        tracing::warn!(
+            target: "srv-persist",
+            "[srv-persist] bootstrap: failed to load blocks from wstore: {} — blocks start empty",
             e
         );
         Vec::new()
@@ -111,19 +119,53 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
             );
             continue;
         };
+        // Phase E.3 — filter dangling block ids on the same defensive
+        // basis we apply to tabs above.
+        let block_ids: Vec<String> = tab
+            .blockids
+            .iter()
+            .filter(|bid| blocks.iter().any(|b| &b.oid == *bid))
+            .cloned()
+            .collect();
         state.tabs.insert(
             tab.oid.clone(),
             TabRecord {
                 tab_id: tab.oid.clone(),
                 workspace_id,
                 name: tab.name.clone(),
+                block_ids,
+            },
+        );
+    }
+    for block in &blocks {
+        // Phase E.3 — recover each block's parent tab via reverse
+        // lookup against `Tab.blockids`. Blocks without a known
+        // parent are skipped (orphans).
+        let Some(tab_id) = tabs
+            .iter()
+            .find(|t| t.blockids.iter().any(|bid| bid == &block.oid))
+            .map(|t| t.oid.clone())
+        else {
+            tracing::warn!(
+                target: "srv-persist",
+                "[srv-persist] bootstrap: block {} has no parent tab — skipping",
+                block.oid
+            );
+            continue;
+        };
+        state.blocks.insert(
+            block.oid.clone(),
+            BlockRecord {
+                block_id: block.oid.clone(),
+                tab_id,
             },
         );
     }
     tracing::info!(
         target: "srv-persist",
-        "[srv-persist] bootstrap loaded {} workspace(s) + {} tab(s) from wstore",
+        "[srv-persist] bootstrap loaded {} workspace(s) + {} tab(s) + {} block(s) from wstore",
         state.workspaces.len(),
-        state.tabs.len()
+        state.tabs.len(),
+        state.blocks.len()
     );
 }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -139,16 +139,19 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
     }
     for block in &blocks {
         // Phase E.3 — recover each block's parent tab via reverse
-        // lookup against `Tab.blockids`. Blocks without a known
-        // parent are skipped (orphans).
-        let Some(tab_id) = tabs
-            .iter()
-            .find(|t| t.blockids.iter().any(|bid| bid == &block.oid))
-            .map(|t| t.oid.clone())
+        // lookup against `state.tabs` (NOT raw `tabs` from SQLite):
+        // tabs orphaned in the prior loop (no parent workspace) are
+        // not in `state.tabs`, so blocks under them must also be
+        // dropped to keep reducer state consistent. (reagent P1 #613.)
+        let Some(tab_id) = state
+            .tabs
+            .values()
+            .find(|t| t.block_ids.iter().any(|bid| bid == &block.oid))
+            .map(|t| t.tab_id.clone())
         else {
             tracing::warn!(
                 target: "srv-persist",
-                "[srv-persist] bootstrap: block {} has no parent tab — skipping",
+                "[srv-persist] bootstrap: block {} has no parent tab in reducer state — skipping",
                 block.oid
             );
             continue;

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -12,7 +12,8 @@
 //   * E.1b — Register / Goodbye / Ping / GetSrvSnapshot / GetEvents
 //   * E.2  — CreateWorkspace / DeleteWorkspace
 //   * E.2b — CreateTab / DeleteTab / SetActiveTab
-//   * E.3+ — Block / Layout commands (not yet present)
+//   * E.3  — CreateBlock / DeleteBlock
+//   * E.4+ — Layout commands (not yet present)
 //
 // `Command::GetEvents` is intercepted by the IPC server before
 // reaching the reducer (server queries the event log; reducer
@@ -21,7 +22,7 @@
 
 use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event, LifecyclePhase};
 
-use crate::state::{ProcessRecord, ProcessState, State, TabRecord, WorkspaceRecord};
+use crate::state::{BlockRecord, ProcessRecord, ProcessState, State, TabRecord, WorkspaceRecord};
 
 /// Per-dispatch context. Currently just an RFC3339 timestamp + the
 /// originating connection's `conn_id` for log correlation.
@@ -49,6 +50,8 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::SetActiveTab { workspace_id, tab_id } => {
             handle_set_active_tab(state, workspace_id, tab_id)
         }
+        Command::CreateBlock { tab_id } => handle_create_block(state, tab_id),
+        Command::DeleteBlock { tab_id, block_id } => handle_delete_block(state, tab_id, block_id),
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
         // match by adding new arms above.
@@ -182,12 +185,19 @@ fn handle_get_srv_snapshot(state: &mut State) -> Vec<Event> {
         })
         .collect();
     active_tabs.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut blocks: Vec<(String, String)> = state
+        .blocks
+        .values()
+        .map(|b| (b.block_id.clone(), b.tab_id.clone()))
+        .collect();
+    blocks.sort_by(|a, b| a.0.cmp(&b.0));
     vec![Event::SrvSnapshot {
         version: v,
         lifecycle: state.lifecycle,
         workspaces,
         tabs,
         active_tabs,
+        blocks,
     }]
 }
 
@@ -219,17 +229,23 @@ fn handle_create_workspace(state: &mut State, name: String) -> Vec<Event> {
 
 /// Phase E.2 — delete a workspace from canonical state. Idempotent:
 /// deleting a missing workspace is a silent no-op. Cascades to the
-/// workspace's tabs (E.2b): every tab whose `workspace_id` matches
-/// is removed from `state.tabs` before the workspace itself goes
-/// away. Cascade events are NOT emitted individually — subscribers
-/// observing `WorkspaceDeleted` are expected to drop dependent state
-/// (mirrors how `wcore::delete_workspace` cascades in SQLite).
+/// workspace's tabs (E.2b) and through to each tab's blocks (E.3):
+/// every tab whose `workspace_id` matches is removed from
+/// `state.tabs`, and each block in those tabs is removed from
+/// `state.blocks`, before the workspace itself goes away. Cascade
+/// events are NOT emitted individually — subscribers observing
+/// `WorkspaceDeleted` are expected to drop dependent state (mirrors
+/// how `wcore::delete_workspace` cascades in SQLite).
 fn handle_delete_workspace(state: &mut State, workspace_id: String) -> Vec<Event> {
     let Some(removed) = state.workspaces.remove(&workspace_id) else {
         return Vec::new();
     };
     for tab_id in &removed.tab_ids {
-        state.tabs.remove(tab_id);
+        if let Some(tab) = state.tabs.remove(tab_id) {
+            for block_id in &tab.block_ids {
+                state.blocks.remove(block_id);
+            }
+        }
     }
     let v = state.bump_version();
     vec![Event::WorkspaceDeleted {
@@ -264,6 +280,7 @@ fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> V
             tab_id: tab_id.clone(),
             workspace_id: workspace_id.clone(),
             name: name.clone(),
+            block_ids: Vec::new(),
         },
     );
     let workspace = state.workspaces.get_mut(&workspace_id).expect("checked");
@@ -322,7 +339,16 @@ fn handle_delete_tab(
     } else {
         None
     };
-    state.tabs.remove(&tab_id);
+    let removed_tab = state.tabs.remove(&tab_id);
+    // Phase E.3 — cascade to blocks. Subscribers observing TabDeleted
+    // are expected to drop dependent block state (no per-block
+    // BlockDeleted events emitted; mirrors workspace→tabs cascade
+    // semantics).
+    if let Some(tab) = &removed_tab {
+        for block_id in &tab.block_ids {
+            state.blocks.remove(block_id);
+        }
+    }
     let mut events = Vec::with_capacity(2);
     let v = state.bump_version();
     events.push(Event::TabDeleted {
@@ -382,6 +408,60 @@ fn handle_set_active_tab(
     }]
 }
 
+/// Phase E.3 — create a block inside a tab. Validates parent tab
+/// exists; otherwise emits `Event::Error` (non-fatal). On success:
+/// assigns a UUID, appends to the tab's `block_ids`, inserts into
+/// `state.blocks`, emits `Event::BlockCreated`.
+///
+/// NOT idempotent on retry (UUID assignment per call); saga-side
+/// dedup is responsible for at-most-once delivery in E.5+.
+fn handle_create_block(state: &mut State, tab_id: String) -> Vec<Event> {
+    if !state.tabs.contains_key(&tab_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("CreateBlock: tab not found: {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let block_id = uuid::Uuid::new_v4().to_string();
+    state.blocks.insert(
+        block_id.clone(),
+        BlockRecord {
+            block_id: block_id.clone(),
+            tab_id: tab_id.clone(),
+        },
+    );
+    let tab = state.tabs.get_mut(&tab_id).expect("checked");
+    tab.block_ids.push(block_id.clone());
+    let v = state.bump_version();
+    vec![Event::BlockCreated {
+        tab_id,
+        block_id,
+        version: v,
+    }]
+}
+
+/// Phase E.3 — delete a block from a tab. Idempotent: deleting a
+/// missing tab or missing block is a silent no-op.
+fn handle_delete_block(state: &mut State, tab_id: String, block_id: String) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        return Vec::new();
+    };
+    let Some(pos) = tab.block_ids.iter().position(|b| b == &block_id) else {
+        return Vec::new();
+    };
+    tab.block_ids.remove(pos);
+    state.blocks.remove(&block_id);
+    let v = state.bump_version();
+    vec![Event::BlockDeleted {
+        tab_id,
+        block_id,
+        version: v,
+    }]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -432,6 +512,8 @@ mod tests {
             | Event::TabCreated { version, .. }
             | Event::TabDeleted { version, .. }
             | Event::ActiveTabChanged { version, .. }
+            | Event::BlockCreated { version, .. }
+            | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -988,6 +1070,173 @@ mod tests {
         assert!(matches!(&events[0], Event::WorkspaceDeleted { .. }));
         assert!(state.tabs.is_empty());
         assert!(!state.workspaces.contains_key(&ws_id));
+    }
+
+    fn create_tab(state: &mut State, workspace_id: &str, name: &str) -> String {
+        let events = update(
+            state,
+            Command::CreateTab {
+                workspace_id: workspace_id.into(),
+                name: name.into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::TabCreated { tab_id, .. } => tab_id.clone(),
+            _ => panic!("expected TabCreated"),
+        }
+    }
+
+    #[test]
+    fn create_block_validates_tab_exists() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: "no-such-tab".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        assert!(state.blocks.is_empty());
+    }
+
+    #[test]
+    fn create_block_appends_to_tab_block_ids() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let events = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::BlockCreated { .. }));
+        let block_id = match &events[0] {
+            Event::BlockCreated { block_id, .. } => block_id.clone(),
+            _ => panic!(),
+        };
+        assert_eq!(state.tabs[&tab_id].block_ids, vec![block_id.clone()]);
+        assert_eq!(state.blocks[&block_id].tab_id, tab_id);
+    }
+
+    #[test]
+    fn delete_block_removes_from_state_and_tab() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let _ = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+            },
+            &ctx(2),
+        );
+        let block_id = state.tabs[&tab_id].block_ids[0].clone();
+        let events = update(
+            &mut state,
+            Command::DeleteBlock {
+                tab_id: tab_id.clone(),
+                block_id: block_id.clone(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::BlockDeleted { .. }));
+        assert!(!state.blocks.contains_key(&block_id));
+        assert!(state.tabs[&tab_id].block_ids.is_empty());
+    }
+
+    #[test]
+    fn delete_block_unknown_silent_no_op() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let events = update(
+            &mut state,
+            Command::DeleteBlock {
+                tab_id,
+                block_id: "ghost".into(),
+            },
+            &ctx(2),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn delete_tab_cascades_blocks() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let _ = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+            },
+            &ctx(2),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+            },
+            &ctx(3),
+        );
+        assert_eq!(state.blocks.len(), 2);
+        let _ = update(
+            &mut state,
+            Command::DeleteTab {
+                workspace_id: ws_id,
+                tab_id,
+            },
+            &ctx(4),
+        );
+        assert!(state.blocks.is_empty());
+    }
+
+    #[test]
+    fn delete_workspace_cascades_through_tabs_to_blocks() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let _ = update(
+            &mut state,
+            Command::CreateBlock {
+                tab_id: tab_id.clone(),
+            },
+            &ctx(2),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateBlock { tab_id },
+            &ctx(3),
+        );
+        assert_eq!(state.blocks.len(), 2);
+        let _ = update(
+            &mut state,
+            Command::DeleteWorkspace { workspace_id: ws_id },
+            &ctx(4),
+        );
+        assert!(state.blocks.is_empty());
+        assert!(state.tabs.is_empty());
+    }
+
+    #[test]
+    fn snapshot_includes_blocks() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t");
+        let _ = update(
+            &mut state,
+            Command::CreateBlock { tab_id },
+            &ctx(2),
+        );
+        let events = update(&mut state, Command::GetSrvSnapshot, &ctx(3));
+        let Event::SrvSnapshot { blocks, .. } = &events[0] else {
+            panic!("expected SrvSnapshot");
+        };
+        assert_eq!(blocks.len(), 1);
     }
 
     #[test]

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -63,13 +63,27 @@ pub struct WorkspaceRecord {
 
 /// Phase E.2b — tab as held by the srv reducer's canonical state.
 /// Tabs are owned by exactly one workspace; the workspace's
-/// `tab_ids` field gives the ordering. Block-level state lands in
-/// E.3.
+/// `tab_ids` field gives the ordering. E.3 adds `block_ids` so the
+/// tab tracks which blocks live inside it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TabRecord {
     pub tab_id: String,
     pub workspace_id: String,
     pub name: String,
+    /// Phase E.3 — ordered list of block ids in this tab. Mirrors
+    /// the persistent `Tab.blockids` field.
+    pub block_ids: Vec<String>,
+}
+
+/// Phase E.3 — block as held by the srv reducer's canonical state.
+/// Blocks are owned by exactly one tab; the tab's `block_ids`
+/// field gives the ordering. Block content (view, meta, runtimeopts)
+/// is intentionally not yet tracked — E.3 ships block lifecycle
+/// only; metadata + view land in a follow-up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlockRecord {
+    pub block_id: String,
+    pub tab_id: String,
 }
 
 #[derive(Debug)]
@@ -91,6 +105,11 @@ pub struct State {
     /// `WorkspaceRecord.tab_ids`. Bootstrap-loaded from SQLite at
     /// startup alongside workspaces.
     pub tabs: HashMap<String, TabRecord>,
+    /// Phase E.3 — blocks canonical to the srv reducer. Keyed by
+    /// `block_id`; ordering within a tab is held in
+    /// `TabRecord.block_ids`. Bootstrap-loaded from SQLite at startup
+    /// alongside workspaces and tabs.
+    pub blocks: HashMap<String, BlockRecord>,
     // `persistence_hwm` deferred to E.2c when the persist subscriber
     // lands and there's actually something to track.
 }
@@ -104,6 +123,7 @@ impl Default for State {
             next_client_id: 0,
             workspaces: HashMap::new(),
             tabs: HashMap::new(),
+            blocks: HashMap::new(),
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.513",
+  "version": "0.33.514",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.3 — adds block lifecycle (`CreateBlock` / `DeleteBlock`) to the srv reducer, following the E.2b tab pattern. **Reducer-only** — persist subscriber and RPC migration deferred (same scope-reduction discipline as E.2 + E.2b).

Note on phase ordering: spec §8 lists E.2c (persist subscriber + RPC migration + host bridge + renderer) before E.3, but E.2c needs design input on bus-lag/HWM correctness (carryover from codex P1s in E.2). Skipping ahead to E.3 keeps the reducer-arms train moving while the E.2c design settles. E.2c will land as a "make the reducer authoritative" PR after all the lifecycle arms are in place.

## What's new

**Commands** (`agentmux-common::ipc`):
- `CreateBlock { tab_id }`
- `DeleteBlock { tab_id, block_id }`

**Events**:
- `BlockCreated { tab_id, block_id, version }`
- `BlockDeleted { tab_id, block_id, version }`

**State**: `TabRecord` gains `block_ids: Vec<String>`; new `BlockRecord { block_id, tab_id }` in `state.blocks` map.

**Reducer behaviour**:
- `CreateBlock` — validates parent tab exists; assigns UUID; appends to `tab.block_ids`.
- `DeleteBlock` — idempotent silent no-op on unknown tab or block.
- `DeleteTab` now cascades to blocks (no per-block events emitted; subscribers observing `TabDeleted` drop dependent state).
- `DeleteWorkspace` now cascades through tabs to blocks (two-level cascade; one `WorkspaceDeleted` event).

**Snapshot**: `Event::SrvSnapshot` extended with `blocks` (sorted, `#[serde(default)]` for forward-compat with pre-E.3 log entries).

**Bootstrap** (`agentmux-srv::persist`): loads blocks alongside workspaces and tabs; filters dangling block refs in `tab.blockids`; recovers `block.tab_id` by reverse-lookup against `Tab.blockids`; skips orphan blocks with a warn.

## Out of scope (intentionally)

- **Block content** (`view`, `meta`, `runtimeopts`) — tracked nowhere in the reducer yet. Pre-existing wcore CRUD remains authoritative for SQLite. A follow-up sub-phase adds `UpdateBlockMeta` and view tracking once the persist subscriber lands.
- **Persist subscriber + RPC migration** — see E.2c notes above.

## Test plan

- [x] `cargo test -p agentmux-srv` — 31 reducer tests pass (7 new block tests + 24 carryovers).
- [x] `cargo build --release -p agentmux-srv -p agentmux-launcher` — clean.
- [ ] Smoke (manual portable): create workspace → create tab → create block → delete block → delete tab cascades → delete workspace double-cascades.

## Notes

- `handle_create_block` is NOT idempotent on retry (UUID assignment per call); saga-side dedup is responsible for at-most-once delivery in E.5+.
- Block content fields (view, meta, runtimeopts) intentionally absent from the reducer state. The reducer only tracks lifecycle (which block belongs to which tab) — content stays in wcore until the persist-subscriber migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)