### PR TITLE
feat(E.2c.1): persist subscriber (plumbing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.514"
+version = "0.33.515"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.514"
+version = "0.33.515"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.514"
+version = "0.33.515"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.514"
+version = "0.33.515"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.514"
+version = "0.33.515"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.514"
+version = "0.33.515"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.514"
+version = "0.33.515"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.514"
+version = "0.33.515"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -2,6 +2,7 @@ mod backend;
 mod config;
 mod event_log;
 mod persist;
+mod persist_subscriber;
 mod reducer;
 mod server;
 mod srv_ipc;
@@ -562,10 +563,24 @@ async fn main() {
                     // `update` and live only in this in-memory state
                     // until E.2c lands the persist subscriber.
                     persist::bootstrap_state_from_wstore(&srv_state, &wstore_for_persist).await;
-                    // Phase E.2 — no persist subscriber yet. RPC
-                    // continues writing to SQLite via wcore; pipe
-                    // commands only update reducer state. Persist
-                    // subscriber lands in E.2c with RPC migration.
+                    // Phase E.2c.1 — persist subscriber. Plumbing only:
+                    // the subscriber consumes Workspace/Tab/Block
+                    // events from the broadcast bus and mirrors them
+                    // back to SQLite via wcore. In E.2c.1 there are
+                    // no in-process producers (RPC still writes wcore
+                    // directly; saga coordinator empty), so this task
+                    // is dead-code in production. It exists so E.5
+                    // sagas + E.2c.2 RPC migration have a target to
+                    // write against. Lagged-bus recovery (full-resync
+                    // from reducer state) lands in E.2c.2 alongside
+                    // workspace RPC migration where resync is
+                    // non-destructive.
+                    let subscriber_rx = events_tx.subscribe();
+                    let subscriber_wstore = std::sync::Arc::clone(&wstore_for_persist);
+                    persist_subscriber::spawn_persist_subscriber(
+                        subscriber_rx,
+                        subscriber_wstore,
+                    );
 
                     let srv_ctx = srv_ipc::ServerCtx {
                         srv_pid: std::process::id(),

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -1,0 +1,544 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.2c.1 — persist subscriber. A tokio task that consumes the
+// srv reducer's broadcast bus and mirrors workspace/tab/block
+// lifecycle events back to SQLite via wcore.
+//
+// Status in E.2c.1: PLUMBING ONLY.
+//
+// The subscriber is dead-code in production today because no
+// in-process caller currently emits the Workspace/Tab/Block events
+// it consumes — RPC handlers still write SQLite directly via wcore;
+// the saga coordinator (E.5+) is empty. The subscriber's job in
+// E.2c.1 is to establish the persist-back pattern so the saga
+// coordinator and the future RPC migration (E.2c.2+) have a target
+// to write against. Idempotent applies are exercised by the unit
+// tests in this module.
+//
+// What this module does NOT do (intentionally):
+//   * Full-resync on broadcast `Lagged`. Resync would write the
+//     reducer's session-only state back to SQLite. That state is
+//     FROZEN at bootstrap for any entity the reducer doesn't
+//     mutate (i.e., everything RPC writes today). Doing a resync
+//     before RPC is migrated would clobber those RPC-driven writes.
+//     Resync lands in E.2c.2 alongside the workspace RPC migration,
+//     where reducer state actually tracks live changes.
+//   * Per-event ACK / sequence-number tracking. Bus is fire-and-
+//     forget; subscriber position is whatever tokio broadcast says.
+//   * Bus-lag recovery beyond a warning log. With no live event
+//     producers in E.2c.1, lag is impossible in practice — adding
+//     real recovery before producers exist is YAGNI. E.2c.2 brings
+//     the producer (RPC migration) AND the recovery (full-resync).
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::Event;
+use tokio::sync::broadcast;
+
+use crate::backend::obj::{Block, Tab, Workspace};
+use crate::backend::storage::wstore::WaveStore;
+use crate::backend::wcore;
+
+/// Spawn the persist subscriber task. Runs until the broadcast
+/// channel closes (i.e., the reducer's bus is dropped at process
+/// shutdown).
+pub fn spawn_persist_subscriber(
+    events_rx: broadcast::Receiver<Event>,
+    wstore: Arc<WaveStore>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(run_persist_subscriber(events_rx, wstore))
+}
+
+async fn run_persist_subscriber(
+    mut events_rx: broadcast::Receiver<Event>,
+    wstore: Arc<WaveStore>,
+) {
+    tracing::info!(target: "srv-persist-subscriber", "[srv-persist-subscriber] started");
+    loop {
+        match events_rx.recv().await {
+            Ok(event) => {
+                if let Err(e) = apply_event_to_wstore(&event, &wstore) {
+                    tracing::warn!(
+                        target: "srv-persist-subscriber",
+                        "[srv-persist-subscriber] apply failed for event {:?}: {}",
+                        event_kind(&event),
+                        e
+                    );
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                // E.2c.1 — log only. Real recovery (full-resync from
+                // reducer state) lands in E.2c.2 once the RPC
+                // migration makes resync non-destructive. With no
+                // live producers in E.2c.1 (saga coordinator empty,
+                // RPC still writes wcore directly), Lagged is
+                // unreachable — this arm exists only because the
+                // tokio API requires handling it.
+                tracing::warn!(
+                    target: "srv-persist-subscriber",
+                    "[srv-persist-subscriber] dropped {} event(s) — SQLite may diverge from reducer; resync lands in E.2c.2",
+                    n
+                );
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                tracing::info!(target: "srv-persist-subscriber", "[srv-persist-subscriber] bus closed — exiting");
+                return;
+            }
+        }
+    }
+}
+
+/// Apply one reducer event to the on-disk store. Idempotent: each
+/// arm checks for the entity's current SQLite state before writing
+/// so duplicate events (from at-least-once delivery semantics) don't
+/// produce duplicate rows or wcore errors.
+fn apply_event_to_wstore(
+    event: &Event,
+    wstore: &WaveStore,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match event {
+        Event::WorkspaceCreated {
+            workspace_id, name, ..
+        } => apply_workspace_created(wstore, workspace_id, name),
+        Event::WorkspaceDeleted { workspace_id, .. } => {
+            apply_workspace_deleted(wstore, workspace_id)
+        }
+        Event::TabCreated {
+            workspace_id,
+            tab_id,
+            name,
+            ..
+        } => apply_tab_created(wstore, workspace_id, tab_id, name),
+        Event::TabDeleted {
+            workspace_id,
+            tab_id,
+            ..
+        } => apply_tab_deleted(wstore, workspace_id, tab_id),
+        Event::ActiveTabChanged {
+            workspace_id,
+            tab_id,
+            ..
+        } => apply_active_tab_changed(wstore, workspace_id, tab_id.as_deref()),
+        Event::BlockCreated {
+            tab_id, block_id, ..
+        } => apply_block_created(wstore, tab_id, block_id),
+        Event::BlockDeleted {
+            tab_id, block_id, ..
+        } => apply_block_deleted(wstore, tab_id, block_id),
+        // All other event variants are not domain-state mutations
+        // (lifecycle, errors, snapshots). The subscriber ignores them.
+        _ => Ok(()),
+    }
+}
+
+fn apply_workspace_created(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Workspace>(workspace_id)?.is_some() {
+        return Ok(()); // already present
+    }
+    let mut ws = Workspace {
+        oid: workspace_id.to_string(),
+        name: name.to_string(),
+        ..Default::default()
+    };
+    wstore.insert(&mut ws)?;
+    Ok(())
+}
+
+fn apply_workspace_deleted(
+    wstore: &WaveStore,
+    workspace_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Workspace>(workspace_id)?.is_none() {
+        return Ok(()); // already gone
+    }
+    wcore::delete_workspace(wstore, workspace_id)?;
+    Ok(())
+}
+
+fn apply_tab_created(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    tab_id: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Tab>(tab_id)?.is_none() {
+        let mut tab = Tab {
+            oid: tab_id.to_string(),
+            name: name.to_string(),
+            ..Default::default()
+        };
+        wstore.insert(&mut tab)?;
+    }
+    // Idempotently link tab into the workspace's tabids.
+    if let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? {
+        let already_present =
+            ws.tabids.iter().any(|t| t == tab_id) || ws.pinnedtabids.iter().any(|t| t == tab_id);
+        if !already_present {
+            ws.tabids.push(tab_id.to_string());
+            wstore.update(&mut ws)?;
+        }
+    }
+    Ok(())
+}
+
+fn apply_tab_deleted(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    tab_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Tab>(tab_id)?.is_none() {
+        return Ok(()); // already gone (or never existed)
+    }
+    // wcore::delete_tab handles unlinking from the workspace's
+    // tabids, deleting the tab's blocks + layout, and the tab row
+    // itself. Returns NotFound errors if any of those don't exist —
+    // we surface those as the operation having already happened.
+    match wcore::delete_tab(wstore, workspace_id, tab_id) {
+        Ok(()) => Ok(()),
+        Err(crate::backend::storage::StoreError::NotFound) => Ok(()),
+        Err(e) => Err(Box::new(e)),
+    }
+}
+
+fn apply_active_tab_changed(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    tab_id: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
+        return Ok(()); // workspace already gone — nothing to update
+    };
+    let new = tab_id.unwrap_or("").to_string();
+    if ws.activetabid == new {
+        return Ok(());
+    }
+    ws.activetabid = new;
+    wstore.update(&mut ws)?;
+    Ok(())
+}
+
+fn apply_block_created(
+    wstore: &WaveStore,
+    tab_id: &str,
+    block_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Block>(block_id)?.is_none() {
+        let mut block = Block {
+            oid: block_id.to_string(),
+            parentoref: format!("tab:{}", tab_id),
+            ..Default::default()
+        };
+        wstore.insert(&mut block)?;
+    }
+    if let Some(mut tab) = wstore.get::<Tab>(tab_id)? {
+        if !tab.blockids.iter().any(|b| b == block_id) {
+            tab.blockids.push(block_id.to_string());
+            wstore.update(&mut tab)?;
+        }
+    }
+    Ok(())
+}
+
+fn apply_block_deleted(
+    wstore: &WaveStore,
+    tab_id: &str,
+    block_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Block>(block_id)?.is_none() {
+        return Ok(()); // already gone
+    }
+    match wcore::delete_block(wstore, tab_id, block_id) {
+        Ok(()) => Ok(()),
+        Err(crate::backend::storage::StoreError::NotFound) => Ok(()),
+        Err(e) => Err(Box::new(e)),
+    }
+}
+
+/// Compact textual identifier for an event (debug logging only).
+fn event_kind(event: &Event) -> &'static str {
+    match event {
+        Event::WorkspaceCreated { .. } => "WorkspaceCreated",
+        Event::WorkspaceDeleted { .. } => "WorkspaceDeleted",
+        Event::TabCreated { .. } => "TabCreated",
+        Event::TabDeleted { .. } => "TabDeleted",
+        Event::ActiveTabChanged { .. } => "ActiveTabChanged",
+        Event::BlockCreated { .. } => "BlockCreated",
+        Event::BlockDeleted { .. } => "BlockDeleted",
+        _ => "Other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::wstore::WaveStore;
+
+    fn store() -> Arc<WaveStore> {
+        // In-memory SQLite for tests (matches existing wstore test pattern).
+        let store = WaveStore::open_in_memory().expect("in-memory wstore");
+        Arc::new(store)
+    }
+
+    #[test]
+    fn workspace_created_inserts_row() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.name, "Alpha");
+    }
+
+    #[test]
+    fn workspace_created_idempotent_on_duplicate() {
+        let s = store();
+        let ev = Event::WorkspaceCreated {
+            workspace_id: "ws-1".into(),
+            name: "Alpha".into(),
+            version: 1,
+        };
+        apply_event_to_wstore(&ev, &s).unwrap();
+        // Second application should not error.
+        apply_event_to_wstore(&ev, &s).unwrap();
+        // Original name preserved (no overwrite).
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.name, "Alpha");
+    }
+
+    #[test]
+    fn workspace_deleted_silent_when_missing() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceDeleted {
+                workspace_id: "ghost".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn tab_created_links_into_workspace() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.tabids, vec!["tab-1".to_string()]);
+        let tab = s.get::<Tab>("tab-1").unwrap().unwrap();
+        assert_eq!(tab.name, "Tab");
+    }
+
+    #[test]
+    fn tab_created_idempotent_on_duplicate_link() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        let ev = Event::TabCreated {
+            workspace_id: "ws-1".into(),
+            tab_id: "tab-1".into(),
+            name: "Tab".into(),
+            version: 2,
+        };
+        apply_event_to_wstore(&ev, &s).unwrap();
+        apply_event_to_wstore(&ev, &s).unwrap();
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.tabids.len(), 1);
+    }
+
+    #[test]
+    fn active_tab_changed_updates_workspace() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::ActiveTabChanged {
+                workspace_id: "ws-1".into(),
+                tab_id: Some("tab-1".into()),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.activetabid, "tab-1");
+    }
+
+    #[test]
+    fn active_tab_changed_to_none_clears_activetabid() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::ActiveTabChanged {
+                workspace_id: "ws-1".into(),
+                tab_id: Some("tab-1".into()),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::ActiveTabChanged {
+                workspace_id: "ws-1".into(),
+                tab_id: None,
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        let ws = s.get::<Workspace>("ws-1").unwrap().unwrap();
+        assert_eq!(ws.activetabid, "");
+    }
+
+    #[test]
+    fn block_created_links_into_tab() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::BlockCreated {
+                tab_id: "tab-1".into(),
+                block_id: "block-1".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let tab = s.get::<Tab>("tab-1").unwrap().unwrap();
+        assert_eq!(tab.blockids, vec!["block-1".to_string()]);
+        let block = s.get::<Block>("block-1").unwrap().unwrap();
+        assert_eq!(block.parentoref, "tab:tab-1");
+    }
+
+    #[test]
+    fn block_deleted_unlinks_from_tab() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::BlockCreated {
+                tab_id: "tab-1".into(),
+                block_id: "block-1".into(),
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::BlockDeleted {
+                tab_id: "tab-1".into(),
+                block_id: "block-1".into(),
+                version: 4,
+            },
+            &s,
+        )
+        .unwrap();
+        assert!(s.get::<Block>("block-1").unwrap().is_none());
+        let tab = s.get::<Tab>("tab-1").unwrap().unwrap();
+        assert!(tab.blockids.is_empty());
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.514",
+  "version": "0.33.515",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.2c.1 — adds the persist subscriber task that consumes the srv reducer's broadcast bus and mirrors workspace/tab/block lifecycle events back to SQLite via wcore. Per the [design report](https://github.com/agentmuxai/agentmux/blob/main/docs/retro/phase-e-status-2026-04-30.md#31-e2c1--persist-subscriber-bus-laghwm-correctness), this PR scopes narrowly to the subscriber itself.

**Status: PLUMBING ONLY.** The subscriber is dead-code in production today — no in-process caller emits the events it consumes (RPC still writes wcore directly; saga coordinator empty). The subscriber's job is to establish the persist-back pattern so saga coordinator (E.5+) and RPC migration (E.2c.2+) have a target to write against.

## Design choices

Per the report, picked Option A (full-resync-on-lag) for E.2c. **But not in this PR.** Resync would write the reducer's session-only state back to SQLite. That state is FROZEN at bootstrap for any entity the reducer doesn't currently mutate (i.e., everything RPC writes today). Doing a resync before RPC is migrated would clobber RPC-driven writes. **Resync lands in E.2c.2 alongside the workspace RPC migration**, where reducer state actually tracks live changes.

In E.2c.1: on `RecvError::Lagged` → log warning, continue. With no live producers, lag is unreachable in practice; the arm exists only because the tokio API requires handling it.

## What's new

**New module** `agentmux-srv/src/persist_subscriber.rs`:
- `spawn_persist_subscriber(events_rx, wstore)` returns `JoinHandle`
- `run_persist_subscriber` loop: per-event idempotent apply
- Handles `RecvError::Lagged` (warn) and `RecvError::Closed` (clean exit)

**Idempotent apply handlers** (each checks SQLite state before writing):
| Event | Action |
|---|---|
| `WorkspaceCreated` | insert if missing |
| `WorkspaceDeleted` | `wcore::delete_workspace`, `NotFound` → ok |
| `TabCreated` | insert tab if missing; idempotently link into `workspace.tabids` (skip if already in `tabids` OR `pinnedtabids`) |
| `TabDeleted` | `wcore::delete_tab` (cascades to blocks + layout), `NotFound` → ok |
| `ActiveTabChanged` | update `workspace.activetabid` (None → empty string) |
| `BlockCreated` | insert block with `parentoref=\"tab:{tab_id}\"`; idempotently link into `tab.blockids` |
| `BlockDeleted` | `wcore::delete_block`, `NotFound` → ok |

**Wiring** in `main.rs`: subscriber spawned alongside the broadcast bus + event-log disk writer, after bootstrap loads state from SQLite.

## Test plan

- [x] 9 new unit tests in `persist_subscriber::tests` (in-memory wstore) — all pass.
  - Workspace insert + idempotent dedup
  - Silent delete-of-missing workspace
  - Tab create + workspace link + idempotent re-link
  - Active-tab change + clear-to-empty on None
  - Block create + tab link
  - Block delete + tab unlink
- [x] `cargo build --release -p agentmux-srv` clean.
- [x] `cargo check -p agentmux-srv --release` clean.
- [ ] Smoke (manual portable): startup logs the subscriber message; existing RPC paths still work (subscriber is dead-code so should be no functional change).

## Out of scope (intentionally, per design report)

- **Full-resync on Lagged** — lands in E.2c.2 with workspace RPC migration.
- **RPC migration** — separate PR(s) per entity (workspace → tab → block).
- **Host bridge + renderer dispatcher** — E.2c.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)