### PR TITLE
feat(E.2c.3b): CloseTab + ReorderTab migration; remove pinned-tab handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.517"
+version = "0.33.518"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.517"
+version = "0.33.518"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.517"
+version = "0.33.518"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.517"
+version = "0.33.518"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.517"
+version = "0.33.518"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.517"
+version = "0.33.518"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -272,6 +272,15 @@ pub enum Command {
         workspace_id: String,
         tab_id: String,
     },
+    /// Phase E.2c.3b — reorder a tab within its workspace's
+    /// `tab_ids`. `new_index` is clamped to the list length; no-op
+    /// if the tab is already at that position. Errors if the
+    /// workspace doesn't exist or the tab isn't in its tab list.
+    ReorderTab {
+        workspace_id: String,
+        tab_id: String,
+        new_index: u32,
+    },
     /// Phase E.3 — create a block inside an existing tab. Reducer
     /// validates parent tab exists, assigns the `block_id` (UUID),
     /// appends to the tab's `block_ids`, emits `Event::BlockCreated`.
@@ -681,6 +690,17 @@ pub enum Event {
     ActiveTabChanged {
         workspace_id: String,
         tab_id: Option<String>,
+        version: u64,
+    },
+    /// Phase E.2c.3b — a tab was reordered within its workspace's
+    /// `tab_ids`. Subscribers should rewrite the workspace's tab
+    /// order to match the reducer's authoritative list (which lives
+    /// in the snapshot's `tabs` field; subscribers can also recompute
+    /// from `tab_id` + `new_index` against their last-known order).
+    TabReordered {
+        workspace_id: String,
+        tab_id: String,
+        new_index: u32,
         version: u64,
     },
     /// Phase E.3 — block was created inside a tab.

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.517"
+version = "0.33.518"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -271,6 +271,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabCreated { version, .. }
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
+        | Event::TabReordered { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -673,6 +673,10 @@ async fn enforce_register_first(
             "SetActiveTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        Command::ReorderTab { .. } => (
+            "ReorderTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => (
             "CreateBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -251,6 +251,15 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        Command::ReorderTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "ReorderTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => {
             let v = state.bump_version();
@@ -934,6 +943,7 @@ mod tests {
             | Event::TabCreated { version, .. }
             | Event::TabDeleted { version, .. }
             | Event::ActiveTabChanged { version, .. }
+            | Event::TabReordered { version, .. }
             | Event::BlockCreated { version, .. }
             | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.517"
+version = "0.33.518"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -271,6 +271,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabCreated { version, .. }
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
+        | Event::TabReordered { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -207,6 +207,12 @@ pub(crate) fn apply_event_to_wstore(
             tab_id,
             ..
         } => apply_active_tab_changed(wstore, workspace_id, tab_id.as_deref()),
+        Event::TabReordered {
+            workspace_id,
+            tab_id,
+            new_index,
+            ..
+        } => apply_tab_reordered(wstore, workspace_id, tab_id, *new_index),
         Event::BlockCreated {
             tab_id, block_id, ..
         } => apply_block_created(wstore, tab_id, block_id),
@@ -327,6 +333,31 @@ fn apply_active_tab_changed(
     Ok(())
 }
 
+fn apply_tab_reordered(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    tab_id: &str,
+    new_index: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
+        return Ok(());
+    };
+    let Some(current_pos) = ws.tabids.iter().position(|t| t == tab_id) else {
+        // Tab might have been a legacy pinned entry, or already
+        // gone — silent no-op (idempotent).
+        return Ok(());
+    };
+    let len = ws.tabids.len();
+    let target = (new_index as usize).min(len.saturating_sub(1));
+    if current_pos == target {
+        return Ok(());
+    }
+    let id = ws.tabids.remove(current_pos);
+    ws.tabids.insert(target, id);
+    wstore.update(&mut ws)?;
+    Ok(())
+}
+
 fn apply_block_created(
     wstore: &WaveStore,
     tab_id: &str,
@@ -372,6 +403,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::TabCreated { .. } => "TabCreated",
         Event::TabDeleted { .. } => "TabDeleted",
         Event::ActiveTabChanged { .. } => "ActiveTabChanged",
+        Event::TabReordered { .. } => "TabReordered",
         Event::BlockCreated { .. } => "BlockCreated",
         Event::BlockDeleted { .. } => "BlockDeleted",
         _ => "Other",

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -342,19 +342,33 @@ fn apply_tab_reordered(
     let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
         return Ok(());
     };
-    let Some(current_pos) = ws.tabids.iter().position(|t| t == tab_id) else {
-        // Tab might have been a legacy pinned entry, or already
-        // gone — silent no-op (idempotent).
-        return Ok(());
-    };
-    let len = ws.tabids.len();
-    let target = (new_index as usize).min(len.saturating_sub(1));
-    if current_pos == target {
-        return Ok(());
+    // Pinning was removed from AgentMux but legacy SQLite databases
+    // can still have entries in `Workspace.pinnedtabids`; bootstrap
+    // surfaces those as regular tabs in the reducer's `tab_ids`. The
+    // reducer can therefore emit a TabReordered for a tab that on
+    // disk still lives in `pinnedtabids`. Search both lists so the
+    // reorder lands wherever the tab actually is. (codex P2 #617.)
+    let target_index = (new_index as usize);
+    if let Some(current_pos) = ws.tabids.iter().position(|t| t == tab_id) {
+        let len = ws.tabids.len();
+        let target = target_index.min(len.saturating_sub(1));
+        if current_pos == target {
+            return Ok(());
+        }
+        let id = ws.tabids.remove(current_pos);
+        ws.tabids.insert(target, id);
+        wstore.update(&mut ws)?;
+    } else if let Some(current_pos) = ws.pinnedtabids.iter().position(|t| t == tab_id) {
+        let len = ws.pinnedtabids.len();
+        let target = target_index.min(len.saturating_sub(1));
+        if current_pos == target {
+            return Ok(());
+        }
+        let id = ws.pinnedtabids.remove(current_pos);
+        ws.pinnedtabids.insert(target, id);
+        wstore.update(&mut ws)?;
     }
-    let id = ws.tabids.remove(current_pos);
-    ws.tabids.insert(target, id);
-    wstore.update(&mut ws)?;
+    // Tab not in either list — silent no-op (idempotent).
     Ok(())
 }
 

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -50,6 +50,11 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::SetActiveTab { workspace_id, tab_id } => {
             handle_set_active_tab(state, workspace_id, tab_id)
         }
+        Command::ReorderTab {
+            workspace_id,
+            tab_id,
+            new_index,
+        } => handle_reorder_tab(state, workspace_id, tab_id, new_index),
         Command::CreateBlock { tab_id } => handle_create_block(state, tab_id),
         Command::DeleteBlock { tab_id, block_id } => handle_delete_block(state, tab_id, block_id),
         // Anything else is a non-fatal protocol error. Future
@@ -408,6 +413,53 @@ fn handle_set_active_tab(
     }]
 }
 
+/// Phase E.2c.3b — reorder a tab within its workspace's
+/// `tab_ids`. `new_index` is clamped to `tab_ids.len()`. No-op
+/// if the tab is already at that position. Errors (non-fatal) if
+/// the workspace doesn't exist or the tab isn't in its tab list.
+fn handle_reorder_tab(
+    state: &mut State,
+    workspace_id: String,
+    tab_id: String,
+    new_index: u32,
+) -> Vec<Event> {
+    let Some(workspace) = state.workspaces.get_mut(&workspace_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("ReorderTab: workspace not found: {}", workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    let Some(current_pos) = workspace.tab_ids.iter().position(|t| t == &tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "ReorderTab: tab {} not in workspace {}",
+                tab_id, workspace_id
+            ),
+            fatal: false,
+            version: v,
+        }];
+    };
+    let len = workspace.tab_ids.len();
+    let target = (new_index as usize).min(len.saturating_sub(1));
+    if current_pos == target {
+        return Vec::new();
+    }
+    let id = workspace.tab_ids.remove(current_pos);
+    workspace.tab_ids.insert(target, id);
+    let v = state.bump_version();
+    vec![Event::TabReordered {
+        workspace_id,
+        tab_id,
+        new_index: target as u32,
+        version: v,
+    }]
+}
+
 /// Phase E.3 — create a block inside a tab. Validates parent tab
 /// exists; otherwise emits `Event::Error` (non-fatal). On success:
 /// assigns a UUID, appends to the tab's `block_ids`, inserts into
@@ -512,6 +564,7 @@ mod tests {
             | Event::TabCreated { version, .. }
             | Event::TabDeleted { version, .. }
             | Event::ActiveTabChanged { version, .. }
+            | Event::TabReordered { version, .. }
             | Event::BlockCreated { version, .. }
             | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,
@@ -1037,6 +1090,127 @@ mod tests {
             &ctx(2),
         );
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn reorder_tab_moves_to_new_index() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        for i in 1..=3 {
+            let _ = update(
+                &mut state,
+                Command::CreateTab {
+                    workspace_id: ws_id.clone(),
+                    name: format!("t{}", i),
+                },
+                &ctx(i),
+            );
+        }
+        let original = state.workspaces[&ws_id].tab_ids.clone();
+        // Move first tab to index 2 (last).
+        let events = update(
+            &mut state,
+            Command::ReorderTab {
+                workspace_id: ws_id.clone(),
+                tab_id: original[0].clone(),
+                new_index: 2,
+            },
+            &ctx(10),
+        );
+        assert!(matches!(&events[0], Event::TabReordered { .. }));
+        let after = &state.workspaces[&ws_id].tab_ids;
+        assert_eq!(after[0], original[1]);
+        assert_eq!(after[1], original[2]);
+        assert_eq!(after[2], original[0]);
+    }
+
+    #[test]
+    fn reorder_tab_clamps_to_last_index() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t2".into(),
+            },
+            &ctx(2),
+        );
+        let original = state.workspaces[&ws_id].tab_ids.clone();
+        // Asking for index 99 should clamp to 1 (len-1).
+        let events = update(
+            &mut state,
+            Command::ReorderTab {
+                workspace_id: ws_id.clone(),
+                tab_id: original[0].clone(),
+                new_index: 99,
+            },
+            &ctx(3),
+        );
+        if let Event::TabReordered { new_index, .. } = &events[0] {
+            assert_eq!(*new_index, 1);
+        } else {
+            panic!("expected TabReordered");
+        }
+    }
+
+    #[test]
+    fn reorder_tab_already_at_position_no_op() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t1".into(),
+            },
+            &ctx(1),
+        );
+        let tab_id = state.workspaces[&ws_id].tab_ids[0].clone();
+        let events = update(
+            &mut state,
+            Command::ReorderTab {
+                workspace_id: ws_id,
+                tab_id,
+                new_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn reorder_tab_validates_workspace_and_tab() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::ReorderTab {
+                workspace_id: "no-such-ws".into(),
+                tab_id: "x".into(),
+                new_index: 0,
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        let ws_id = create_workspace(&mut state, "w");
+        let events = update(
+            &mut state,
+            Command::ReorderTab {
+                workspace_id: ws_id,
+                tab_id: "ghost".into(),
+                new_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
     }
 
     #[test]

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -541,14 +541,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             Ok(list) => WebReturnType::success(serde_json::to_value(&list).unwrap_or_default()),
             Err(e) => WebReturnType::error(e.to_string()),
         },
-        // Phase E.2c.3 — CreateTab routes through the reducer for
-        // regular (unpinned) tabs. Pinned tabs (`pinned=true` in
-        // args[3]) stay on the wcore-direct path until E.2c.3b adds
-        // pinned-tab support to the reducer. The split is necessary
-        // because the reducer's WorkspaceRecord doesn't yet track
-        // `pinned_tab_ids` separately — adding that is structural
-        // (state shape + bootstrap split + subscriber routing) and
-        // doesn't fit cleanly into this PR.
+        // Phase E.2c.3b — CreateTab dispatches through the reducer.
+        // The `pinned` argument from older clients is ignored:
+        // pinning was a Waveterm feature removed from AgentMux.
+        // Legacy SQLite databases may still have entries in
+        // `Workspace.pinnedtabids`; bootstrap merges them into
+        // `tab_ids` so they behave as regular tabs.
         ("workspace", "CreateTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -556,45 +554,13 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             };
             let tab_name: String = service::get_arg(args, 1).unwrap_or_default();
             let activate: bool = service::get_arg(args, 2).unwrap_or(true);
-            let pinned: bool = service::get_arg(args, 3).unwrap_or(false);
-            if pinned {
-                // Pinned-tab path: wcore-direct (unchanged from E.2c.2).
-                match wcore::create_tab_with_opts(store, &ws_id, &tab_name, true) {
-                    Ok(tab) => {
-                        if activate {
-                            let _ = wcore::set_active_tab(store, &ws_id, &tab.oid);
-                        }
-                        let tab_oid = tab.oid.clone();
-                        let mut updates = vec![WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_TAB.to_string(),
-                            oid: tab.oid.clone(),
-                            obj: Some(wave_obj_to_value(&tab)),
-                        }];
-                        if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                            updates.push(WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: OTYPE_WORKSPACE.to_string(),
-                                oid: ws_id.clone(),
-                                obj: Some(wave_obj_to_value(&ws)),
-                            });
-                        }
-                        return WebReturnType::success_data_updates(
-                            serde_json::to_value(&tab_oid).unwrap_or_default(),
-                            updates,
-                        );
-                    }
-                    Err(e) => return WebReturnType::error(e.to_string()),
-                }
-            }
-            // Regular tab: dispatch through reducer. Auto-generate
-            // a `tab{N}` name when the caller passed empty so the
-            // reducer path matches the wcore behaviour
-            // (wcore::create_tab_with_opts auto-names empties from
-            // `ws.tabids.len() + ws.pinnedtabids.len()`). Without
-            // this, regular reducer-routed tabs got blank titles
-            // while pinned wcore-routed tabs auto-named — UX
-            // inconsistency. (reagent + codex P1 #616.)
+            // args[3] (`pinned`) intentionally ignored.
+            // Auto-generate a `tab{N}` name when the caller passed
+            // empty so behaviour matches the prior wcore path. Counts
+            // both `tabids` and any leftover `pinnedtabids` from
+            // legacy data so the numbering doesn't collide with
+            // pre-removal entries that bootstrap will surface as
+            // regular tabs.
             let resolved_name = if tab_name.is_empty() {
                 match store.get::<Workspace>(&ws_id) {
                     Ok(Some(ws)) => {
@@ -737,50 +703,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             // orphaned block nodes that would render as blank panes.
             let _ = wcore::heal_layout(store, &tab_id);
 
-            // Pinned tabs aren't tracked in the reducer yet — dispatch
-            // would emit Error("tab not in workspace's tab list").
-            // Detect and fall through to wcore for those.
-            let is_pinned = match store.get::<Workspace>(&ws_id) {
-                Ok(Some(ws)) => ws.pinnedtabids.iter().any(|t| t == &tab_id),
-                _ => false,
-            };
-            if is_pinned {
-                return match wcore::set_active_tab(store, &ws_id, &tab_id) {
-                    Ok(()) => {
-                        // Pinned tabs aren't in the reducer's
-                        // WorkspaceRecord.tab_ids (E.2c.3 doesn't yet
-                        // model them). Clear the reducer's
-                        // active_tab_id so the next SetActiveTab on a
-                        // regular tab isn't a no-op (would happen if
-                        // the reducer still pointed at a previously-
-                        // active regular tab — bouncing between
-                        // pinned and regular would lose user switch
-                        // requests). Direct mutation outside the
-                        // reducer is a transitional hack; E.2c.3b
-                        // adds pinned-tab support and unifies the
-                        // path. (codex P1 #616.)
-                        {
-                            let mut s = state.srv_state.lock().await;
-                            if let Some(ws_record) = s.workspaces.get_mut(&ws_id) {
-                                ws_record.active_tab_id = None;
-                            }
-                        }
-                        if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                            let update = WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: OTYPE_WORKSPACE.to_string(),
-                                oid: ws_id.clone(),
-                                obj: Some(wave_obj_to_value(&ws)),
-                            };
-                            WebReturnType::success_with_updates(vec![update])
-                        } else {
-                            WebReturnType::success_empty()
-                        }
-                    }
-                    Err(e) => WebReturnType::error(e.to_string()),
-                };
-            }
-
+            // Phase E.2c.3b — pinning was removed from AgentMux
+            // (Waveterm legacy). All tabs are regular; dispatch
+            // straight through the reducer. Bootstrap merges any
+            // legacy `pinnedtabids` into the reducer's `tab_ids` so
+            // tabs from older databases are reachable as normal tabs.
             let events = dispatch_to_reducer(
                 state,
                 agentmux_common::ipc::Command::SetActiveTab {
@@ -826,6 +753,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 WebReturnType::success_empty()
             }
         }
+        // Phase E.2c.3b — CloseTab applies SQLite first via wcore
+        // (cascades to blocks + layouts), then dispatches the
+        // reducer's DeleteTab to keep state in sync. Same SQLite-
+        // first pattern as DeleteWorkspace — Delete cascades touch
+        // many records and rolling back the reducer on a partial
+        // wcore failure is impractical.
         ("workspace", "CloseTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -835,35 +768,42 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            match wcore::delete_tab(store, &ws_id, &tab_id) {
-                Ok(()) => {
-                    let rtn = CloseTabRtnType {
-                        closewindow: false,
-                        newactivetabid: String::new(),
-                    };
-                    let mut updates = vec![];
-                    // Include deleted tab update so frontend removes it from cache
-                    updates.push(WaveObjUpdate {
-                        updatetype: "delete".into(),
-                        otype: OTYPE_TAB.to_string(),
-                        oid: tab_id.clone(),
-                        obj: None,
-                    });
-                    if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&ws)),
-                        });
-                    }
-                    WebReturnType::success_data_updates(
-                        serde_json::to_value(&rtn).unwrap_or_default(),
-                        updates,
-                    )
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            if let Err(e) = wcore::delete_tab(store, &ws_id, &tab_id) {
+                return WebReturnType::error(e.to_string());
             }
+            // Reducer dispatch is silent on missing — safe to call
+            // unconditionally now that SQLite is consistent.
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::DeleteTab {
+                    workspace_id: ws_id.clone(),
+                    tab_id: tab_id.clone(),
+                },
+            )
+            .await;
+            publish_events(state, &events);
+            let rtn = CloseTabRtnType {
+                closewindow: false,
+                newactivetabid: String::new(),
+            };
+            let mut updates = vec![WaveObjUpdate {
+                updatetype: "delete".into(),
+                otype: OTYPE_TAB.to_string(),
+                oid: tab_id.clone(),
+                obj: None,
+            }];
+            if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                });
+            }
+            WebReturnType::success_data_updates(
+                serde_json::to_value(&rtn).unwrap_or_default(),
+                updates,
+            )
         }
         ("workspace", "UpdateWorkspace") => {
             let ws_id: String = match service::get_arg(args, 0) {
@@ -1018,6 +958,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        // Phase E.2c.3b — ReorderTab dispatches through the reducer.
+        // Forward+compensate isn't useful here (reorder is its own
+        // inverse), so on SQLite apply failure we just surface the
+        // error and the reducer state ends up ahead of disk for the
+        // remainder of the session — converges back at next restart
+        // via bootstrap.
         ("workspace", "ReorderTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1032,21 +978,43 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => return WebReturnType::error(e),
             };
             tracing::info!(ws_id = %ws_id, tab_id = %tab_id, new_index = %new_index, "[dnd:svc] ReorderTab");
-            match wcore::reorder_tab(store, &ws_id, &tab_id, new_index) {
-                Ok(()) => {
-                    if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                        let update = WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&ws)),
-                        };
-                        WebReturnType::success_with_updates(vec![update])
-                    } else {
-                        WebReturnType::success_empty()
-                    }
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::ReorderTab {
+                    workspace_id: ws_id.clone(),
+                    tab_id: tab_id.clone(),
+                    new_index: new_index as u32,
+                },
+            )
+            .await;
+            // Surface reducer Error events.
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
+            }
+            let mut apply_err: Option<String> = None;
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    apply_err = Some(e.to_string());
+                    break;
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+            }
+            if let Some(err) = apply_err {
+                return WebReturnType::error(format!("ReorderTab: SQLite write failed: {}", err));
+            }
+            publish_events(state, &events);
+            if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
+                let update = WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                };
+                WebReturnType::success_with_updates(vec![update])
+            } else {
+                WebReturnType::success_empty()
             }
         }
         ("workspace", "MoveTabToWorkspace") => {

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -978,12 +978,18 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => return WebReturnType::error(e),
             };
             tracing::info!(ws_id = %ws_id, tab_id = %tab_id, new_index = %new_index, "[dnd:svc] ReorderTab");
+            // Clamp to u32::MAX rather than truncating via `as u32`.
+            // The reducer further clamps to `tab_ids.len() - 1` so an
+            // absurd usize ends up at the last position — matching
+            // the prior `wcore::reorder_tab` behaviour where any
+            // out-of-range usize clamped to the end. (codex P3 #617.)
+            let new_index_u32 = u32::try_from(new_index).unwrap_or(u32::MAX);
             let events = dispatch_to_reducer(
                 state,
                 agentmux_common::ipc::Command::ReorderTab {
                     workspace_id: ws_id.clone(),
                     tab_id: tab_id.clone(),
-                    new_index: new_index as u32,
+                    new_index: new_index_u32,
                 },
             )
             .await;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.517",
+  "version": "0.33.518",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.2c.3b — completes the tab RPC migration. CloseTab + ReorderTab now route through the reducer. Pinned-tab handling is **removed** (Waveterm legacy; pinning was removed from AgentMux). Legacy SQLite databases with leftover `Workspace.pinnedtabids` entries continue to work — bootstrap surfaces them as regular tabs.

Follow-up to #616.

## What's new

### CloseTab — SQLite-first

Same pattern as DeleteWorkspace: `wcore::delete_tab` first (cascades to blocks + layouts), then dispatch reducer's `DeleteTab` to keep state in sync. If wcore fails, reducer is untouched.

### ReorderTab — new reducer arm + RPC migration

- `Command::ReorderTab { workspace_id, tab_id, new_index }`
- `Event::TabReordered { workspace_id, tab_id, new_index, version }`
- Reducer's `handle_reorder_tab` validates ws + tab membership, clamps `new_index` to `tab_ids.len() - 1`, no-op when already at target. Emits the clamped index in the event so subscribers don't recompute.
- Subscriber's `apply_tab_reordered` updates `Workspace.tabids`. Silent no-op when the tab isn't found (handles legacy pinnedtabids entries that the reducer surfaced as regular tabs but SQLite still tracks separately).
- RPC handler dispatches through reducer; surfaces reducer `Error` events as RPC errors; applies synchronously (no compensation — reorder is its own inverse).

### Pinned-tab branches removed

Per user directive, pinning is gone:
- `CreateTab`: no more `pinned=true` wcore-direct path. `args[3]` is ignored.
- `SetActiveTab`: no more pinned-detection / `active_tab_id=Some(pinned_id)` direct-mutation hack.

The carryover fixes I had queued for this PR (StoreError propagation in pinned-detect, `Some(pinned_id)` instead of `None`) are no longer needed — the code paths they guarded don't exist.

### Misrouted-srv-command arms

Launcher reducer + ipc/server gain `ReorderTab` arms returning the expected soft errors.

## Test plan

- [x] 4 new reducer tests for ReorderTab: move-to-new-index, clamp-to-last-index, already-at-position no-op, validates ws/tab
- [x] 46/46 reducer + subscriber tests pass
- [x] `cargo build --release -p agentmux-srv -p agentmux-launcher` clean
- [ ] Smoke (manual portable):
  - Create + close tab → SQLite + reducer in sync
  - Drag-reorder tabs → ordering matches in both reducer state and SQLite

## Status of E.2c

| | |
|---|---|
| E.2c.1 (#614) | Persist subscriber plumbing — ✅ |
| E.2c.2 (#615) | Workspace RPC migration — ✅ |
| E.2c.3 (#616) | CreateTab + SetActiveTab — ✅ |
| **E.2c.3b** (this PR) | CloseTab + ReorderTab + pinned-tab cleanup |
| E.2c.4 | Block RPC migration |
| E.2c.5 | Host bridge + renderer dispatcher |

🤖 Generated with [Claude Code](https://claude.com/claude-code)