### PR TITLE
feat(E.2c.4 + E.2c.5a): block RPC migration + host bridge to srv pipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.518"
+version = "0.33.519"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.518"
+version = "0.33.519"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.518"
+version = "0.33.519"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.518"
+version = "0.33.519"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.518"
+version = "0.33.519"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -31,6 +31,8 @@ mod events;
 mod ipc;
 mod launcher_event_bridge;
 mod launcher_ipc;
+mod srv_event_bridge;
+mod srv_ipc;
 mod memory_heartbeat;
 mod pane;
 mod sidecar;
@@ -232,6 +234,15 @@ fn main() {
     // Failure to connect is non-fatal in B.2 (host can still run);
     // B.5+ will tighten when the host depends on IPC for state.
     let _launcher_ipc = runtime.block_on(launcher_ipc::connect_to_launcher(app_state.clone()));
+
+    // Phase E.2c.5a — connect to the srv reducer's pipe. Forwards
+    // srv events (workspace / tab / block lifecycle) to every
+    // top-level renderer via the JS bridge. Renderer-side handler
+    // (`window.__agentmux_srv_event`) lands in E.2c.5b. Non-fatal
+    // if absent: `task dev` mode doesn't run the launcher and so
+    // doesn't set `AGENTMUX_SRV_PIPE_PATH` — host runs without the
+    // bridge, frontend uses the legacy waveobj:update path.
+    let _srv_ipc = runtime.block_on(srv_ipc::connect_to_srv(app_state.clone()));
 
     // Phase B.1: if launcher already spawned srv (the normal portable
     // / installed path post-PR-#570 + B.1), populate state from the

--- a/agentmux-cef/src/srv_event_bridge.rs
+++ b/agentmux-cef/src/srv_event_bridge.rs
@@ -1,0 +1,53 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.2c.5a — host outbound JS bridge for srv typed events.
+//
+// Parallel to `launcher_event_bridge`, but for the srv reducer's
+// pipe (workspace / tab / block / layout lifecycle). Single function
+// `dispatch_to_renderers(state, event)` called from `srv_ipc`'s
+// read loop after each line is parsed.
+//
+// Renderer-side handler: `window.__agentmux_srv_event(<json>)`. The
+// renderer dispatcher (separate frontend PR — E.2c.5b) installs that
+// handler and routes events into atom domains.
+//
+// Filtering: pool windows (`window-pool-*`) and browser-pane child
+// HWNDs (`browser-pane-*`) are skipped — they have no UI.
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::Event;
+use cef::{CefString, ImplBrowser, ImplFrame};
+
+/// Forward an srv event to every top-level renderer.
+pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event) {
+    let json = match serde_json::to_string(event) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(
+                target: "srv-event-bridge",
+                "[srv-event-bridge] serialize failed: {}",
+                e
+            );
+            return;
+        }
+    };
+
+    let script = format!(
+        "if (window.__agentmux_srv_event) {{ try {{ window.__agentmux_srv_event({}) }} catch(e) {{ console.error('[srv-event] dispatch failed', e) }} }}",
+        json
+    );
+    let code = CefString::from(script.as_str());
+    let url = CefString::from("");
+
+    let browsers = state.browsers.lock();
+    for (label, browser) in browsers.iter() {
+        if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
+            continue;
+        }
+        if let Some(frame) = browser.main_frame() {
+            frame.execute_java_script(Some(&code), Some(&url), 0);
+        }
+    }
+}

--- a/agentmux-cef/src/srv_ipc.rs
+++ b/agentmux-cef/src/srv_ipc.rs
@@ -1,0 +1,162 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.2c.5a — host-side client for the srv reducer's named-pipe
+// IPC server. Connects on host startup, sends `Register`, and runs
+// a read loop that forwards every event to the renderer via
+// `srv_event_bridge::dispatch_to_renderers`.
+//
+// This is the host-bridge half of E.2c.5; the renderer dispatcher
+// half (the JS handler `window.__agentmux_srv_event`) lands as a
+// separate frontend PR (E.2c.5b).
+//
+// Activated only when `AGENTMUX_SRV_PIPE_PATH` is set — the env var
+// the launcher provides post-E.1b. Absent → host runs without the
+// srv bridge; renderer falls back to the bespoke
+// `waveobj:update` HTTP/WS path (still wired during the migration).
+//
+// Mirrors `launcher_ipc::connect_to_launcher` but slimmer:
+//   * No outbound command channel (host doesn't issue srv commands
+//     today; saga coordinator E.5+ adds the producer).
+//   * No shadow state tracking (host's existing state shadow the
+//     launcher reducer; srv events go straight through to the
+//     renderer).
+//
+// Reconnect / resync semantics: B.3 launcher pattern leaves them
+// for a follow-up; same here. If the srv pipe drops, we log and
+// stop forwarding. Renderer falls back to the legacy HTTP/WS path
+// until the host restarts. E.2c.5b/E.5 will tighten this once it
+// matters (saga consumers can't tolerate dropped events).
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::{ClientKind, Command, Event};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+#[cfg(target_os = "windows")]
+use tokio::net::windows::named_pipe::ClientOptions;
+
+/// Handle held by main.rs for the host's lifetime so the srv pipe
+/// connection stays open. Dropping it closes the pipe.
+#[cfg(target_os = "windows")]
+pub struct SrvIpcHandle {
+    #[allow(dead_code)]
+    reader_task: tokio::task::JoinHandle<()>,
+}
+
+#[cfg(not(target_os = "windows"))]
+pub struct SrvIpcHandle;
+
+/// If `AGENTMUX_SRV_PIPE_PATH` is set, connect, Register as Host,
+/// spawn a read loop that forwards srv events to all top-level
+/// renderers. Returns a handle to keep the connection alive.
+///
+/// Errors are logged but non-fatal: a srv-IPC failure should NOT
+/// prevent the host from running. The renderer continues using the
+/// legacy `waveobj:update` HTTP/WS path until the connection comes
+/// back at the next host start.
+#[cfg(target_os = "windows")]
+pub async fn connect_to_srv(
+    state: std::sync::Arc<crate::state::AppState>,
+) -> Option<SrvIpcHandle> {
+    let pipe_path = match std::env::var("AGENTMUX_SRV_PIPE_PATH") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            tracing::info!(
+                "AGENTMUX_SRV_PIPE_PATH unset — running without srv IPC bridge (dev mode)"
+            );
+            return None;
+        }
+    };
+
+    let client = match ClientOptions::new().open(&pipe_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                "[srv-ipc] failed to open {}: {} — continuing without srv bridge",
+                pipe_path,
+                e
+            );
+            return None;
+        }
+    };
+    tracing::info!("[srv-ipc] connected to {}", pipe_path);
+
+    let (read_half, mut write_half) = tokio::io::split(client);
+
+    // Send Register FIRST (server enforces register-first; violation
+    // is a fatal close).
+    let register = Command::Register {
+        kind: ClientKind::Host,
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+    let mut buf = match serde_json::to_vec(&register) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::error!("[srv-ipc] failed to serialize Register: {}", e);
+            return None;
+        }
+    };
+    buf.push(b'\n');
+    if let Err(e) = write_half.write_all(&buf).await {
+        tracing::error!("[srv-ipc] failed to send Register: {} — bailing", e);
+        return None;
+    }
+    if let Err(e) = write_half.flush().await {
+        tracing::error!("[srv-ipc] failed to flush Register: {} — bailing", e);
+        return None;
+    }
+
+    // Read loop: parse newline-delimited Events and forward each to
+    // every top-level renderer.
+    let state_for_reader = Arc::clone(&state);
+    let reader_task = tokio::spawn(async move {
+        let reader = BufReader::new(read_half);
+        let mut lines = reader.lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) if line.trim().is_empty() => continue,
+                Ok(Some(line)) => match serde_json::from_str::<Event>(&line) {
+                    Ok(event) => {
+                        crate::srv_event_bridge::dispatch_to_renderers(&state_for_reader, &event);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "[srv-ipc] could not parse event line ({}): {}",
+                            e,
+                            line
+                        );
+                    }
+                },
+                Ok(None) => {
+                    tracing::info!("[srv-ipc] srv pipe EOF — connection closed");
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("[srv-ipc] read error: {}", e);
+                    return;
+                }
+            }
+        }
+    });
+
+    // Keep the writer alive (Host doesn't send Commands today; saga
+    // coordinator E.5+ adds the producer). For now the writer is
+    // moved into a background task that just holds it open; dropping
+    // would close the pipe and trigger Goodbye on the server.
+    let _writer_keepalive = tokio::spawn(async move {
+        // No-op: just owns write_half so it isn't dropped.
+        let _ = write_half;
+        std::future::pending::<()>().await;
+    });
+
+    Some(SrvIpcHandle { reader_task })
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn connect_to_srv(
+    _state: std::sync::Arc<crate::state::AppState>,
+) -> Option<SrvIpcHandle> {
+    None
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.518"
+version = "0.33.519"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -287,6 +287,15 @@ pub enum Command {
     /// Session-only projection (no persist subscriber yet).
     CreateBlock {
         tab_id: String,
+        /// Phase E.2c.4 — block metadata (`view`, layout hints, etc.)
+        /// passed through to the persisted Block row. The reducer
+        /// itself doesn't track meta — it forwards it untouched into
+        /// `Event::BlockCreated` so the persist subscriber writes
+        /// the Block with the correct meta map. `#[serde(default)]`
+        /// for forward-compat with old log entries that pre-date the
+        /// meta field.
+        #[serde(default)]
+        meta: serde_json::Value,
     },
     /// Phase E.3 — delete a block from a tab. Idempotent silent no-op
     /// on missing tab or missing block.
@@ -707,6 +716,12 @@ pub enum Event {
     BlockCreated {
         tab_id: String,
         block_id: String,
+        /// Phase E.2c.4 — meta carried through from
+        /// `Command::CreateBlock`. The persist subscriber writes
+        /// the Block row with this meta map. `#[serde(default)]` for
+        /// forward-compat with pre-E.2c.4 log entries.
+        #[serde(default)]
+        meta: serde_json::Value,
         version: u64,
     },
     /// Phase E.3 — block was deleted from a tab.

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.518"
+version = "0.33.519"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.518"
+version = "0.33.519"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -214,8 +214,11 @@ pub(crate) fn apply_event_to_wstore(
             ..
         } => apply_tab_reordered(wstore, workspace_id, tab_id, *new_index),
         Event::BlockCreated {
-            tab_id, block_id, ..
-        } => apply_block_created(wstore, tab_id, block_id),
+            tab_id,
+            block_id,
+            meta,
+            ..
+        } => apply_block_created(wstore, tab_id, block_id, meta),
         Event::BlockDeleted {
             tab_id, block_id, ..
         } => apply_block_deleted(wstore, tab_id, block_id),
@@ -376,11 +379,23 @@ fn apply_block_created(
     wstore: &WaveStore,
     tab_id: &str,
     block_id: &str,
+    meta: &serde_json::Value,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if wstore.get::<Block>(block_id)?.is_none() {
+        // Phase E.2c.4 — write the meta map carried in the event
+        // (`view`, layout hints, etc.) so reducer-routed CreateBlock
+        // RPC produces blocks with valid view/meta in SQLite. Without
+        // this, the frontend sees a block with empty meta and renders
+        // a blank pane.
+        let meta_map: crate::backend::obj::MetaMapType = match meta {
+            serde_json::Value::Object(_) => serde_json::from_value(meta.clone())
+                .unwrap_or_default(),
+            _ => Default::default(),
+        };
         let mut block = Block {
             oid: block_id.to_string(),
             parentoref: format!("tab:{}", tab_id),
+            meta: meta_map,
             ..Default::default()
         };
         wstore.insert(&mut block)?;
@@ -693,11 +708,7 @@ mod tests {
         )
         .unwrap();
         apply_event_to_wstore(
-            &Event::BlockCreated {
-                tab_id: "tab-1".into(),
-                block_id: "block-1".into(),
-                version: 3,
-            },
+            &Event::BlockCreated { tab_id: "tab-1".into(), block_id: "block-1".into(), meta: serde_json::Value::Null, version: 3 },
             &s,
         )
         .unwrap();
@@ -730,11 +741,7 @@ mod tests {
         )
         .unwrap();
         apply_event_to_wstore(
-            &Event::BlockCreated {
-                tab_id: "tab-1".into(),
-                block_id: "block-1".into(),
-                version: 3,
-            },
+            &Event::BlockCreated { tab_id: "tab-1".into(), block_id: "block-1".into(), meta: serde_json::Value::Null, version: 3 },
             &s,
         )
         .unwrap();

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -55,7 +55,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             tab_id,
             new_index,
         } => handle_reorder_tab(state, workspace_id, tab_id, new_index),
-        Command::CreateBlock { tab_id } => handle_create_block(state, tab_id),
+        Command::CreateBlock { tab_id, meta } => handle_create_block(state, tab_id, meta),
         Command::DeleteBlock { tab_id, block_id } => handle_delete_block(state, tab_id, block_id),
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
@@ -467,7 +467,11 @@ fn handle_reorder_tab(
 ///
 /// NOT idempotent on retry (UUID assignment per call); saga-side
 /// dedup is responsible for at-most-once delivery in E.5+.
-fn handle_create_block(state: &mut State, tab_id: String) -> Vec<Event> {
+fn handle_create_block(
+    state: &mut State,
+    tab_id: String,
+    meta: serde_json::Value,
+) -> Vec<Event> {
     if !state.tabs.contains_key(&tab_id) {
         let v = state.bump_version();
         return vec![Event::Error {
@@ -491,6 +495,7 @@ fn handle_create_block(state: &mut State, tab_id: String) -> Vec<Event> {
     vec![Event::BlockCreated {
         tab_id,
         block_id,
+        meta,
         version: v,
     }]
 }
@@ -1266,9 +1271,7 @@ mod tests {
         let mut state = State::default();
         let events = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: "no-such-tab".into(),
-            },
+            Command::CreateBlock { tab_id: "no-such-tab".into(), meta: serde_json::Value::Null },
             &ctx(1),
         );
         assert!(matches!(&events[0], Event::Error { .. }));
@@ -1282,9 +1285,7 @@ mod tests {
         let tab_id = create_tab(&mut state, &ws_id, "t");
         let events = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: tab_id.clone(),
-            },
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
             &ctx(2),
         );
         assert!(matches!(&events[0], Event::BlockCreated { .. }));
@@ -1303,9 +1304,7 @@ mod tests {
         let tab_id = create_tab(&mut state, &ws_id, "t");
         let _ = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: tab_id.clone(),
-            },
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
             &ctx(2),
         );
         let block_id = state.tabs[&tab_id].block_ids[0].clone();
@@ -1345,16 +1344,12 @@ mod tests {
         let tab_id = create_tab(&mut state, &ws_id, "t");
         let _ = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: tab_id.clone(),
-            },
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
             &ctx(2),
         );
         let _ = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: tab_id.clone(),
-            },
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
             &ctx(3),
         );
         assert_eq!(state.blocks.len(), 2);
@@ -1376,14 +1371,12 @@ mod tests {
         let tab_id = create_tab(&mut state, &ws_id, "t");
         let _ = update(
             &mut state,
-            Command::CreateBlock {
-                tab_id: tab_id.clone(),
-            },
+            Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },
             &ctx(2),
         );
         let _ = update(
             &mut state,
-            Command::CreateBlock { tab_id },
+            Command::CreateBlock { tab_id, meta: serde_json::Value::Null },
             &ctx(3),
         );
         assert_eq!(state.blocks.len(), 2);
@@ -1403,7 +1396,7 @@ mod tests {
         let tab_id = create_tab(&mut state, &ws_id, "t");
         let _ = update(
             &mut state,
-            Command::CreateBlock { tab_id },
+            Command::CreateBlock { tab_id, meta: serde_json::Value::Null },
             &ctx(2),
         );
         let events = update(&mut state, Command::GetSrvSnapshot, &ctx(3));

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -117,32 +117,84 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     _ => return WebReturnType::error("missing uicontext.activetabid"),
                 },
             };
-            match wcore::create_block(store, &tab_id, block_def.meta) {
-                Ok(block) => {
-                    let block_oid = block.oid.clone();
-                    let block_update = WaveObjUpdate {
-                        updatetype: "update".into(),
-                        otype: OTYPE_BLOCK.to_string(),
-                        oid: block.oid.clone(),
-                        obj: Some(wave_obj_to_value(&block)),
-                    };
-                    let updates = match store.must_get::<Tab>(&tab_id) {
-                        Ok(tab) => {
-                            let tab_update = WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: OTYPE_TAB.to_string(),
-                                oid: tab_id.clone(),
-                                obj: Some(wave_obj_to_value(&tab)),
-                            };
-                            vec![block_update, tab_update]
-                        }
-                        Err(_) => vec![block_update],
-                    };
-                    WebReturnType::success_data_updates(serde_json::json!(block_oid), updates)
+            // Phase E.2c.4 — CreateBlock dispatches through the reducer
+            // (forward+compensate on SQLite failure). The reducer
+            // assigns the block_id; the persist subscriber's apply
+            // path writes the Block row with the caller's meta map.
+            let meta_value =
+                serde_json::to_value(&block_def.meta).unwrap_or(serde_json::Value::Null);
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::CreateBlock {
+                    tab_id: tab_id.clone(),
+                    meta: meta_value,
+                },
+            )
+            .await;
+            // Surface reducer Error events (tab not found).
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
+            }
+            let block_id = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::BlockCreated { block_id, .. } => {
+                    Some(block_id.clone())
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+                _ => None,
+            });
+            let mut apply_err: Option<String> = None;
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    apply_err = Some(e.to_string());
+                    break;
+                }
+            }
+            if let Some(err) = apply_err {
+                if let Some(bid) = block_id.as_ref() {
+                    compensate_via_reducer(
+                        state,
+                        agentmux_common::ipc::Command::DeleteBlock {
+                            tab_id: tab_id.clone(),
+                            block_id: bid.clone(),
+                        },
+                        store,
+                    )
+                    .await;
+                }
+                return WebReturnType::error(format!("CreateBlock: SQLite write failed: {}", err));
+            }
+            publish_events(state, &events);
+            match block_id {
+                Some(bid) => {
+                    let mut updates = vec![];
+                    if let Ok(block) = store.must_get::<Block>(&bid) {
+                        updates.push(WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: OTYPE_BLOCK.to_string(),
+                            oid: bid.clone(),
+                            obj: Some(wave_obj_to_value(&block)),
+                        });
+                    }
+                    if let Ok(tab) = store.must_get::<Tab>(&tab_id) {
+                        updates.push(WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: OTYPE_TAB.to_string(),
+                            oid: tab_id.clone(),
+                            obj: Some(wave_obj_to_value(&tab)),
+                        });
+                    }
+                    WebReturnType::success_data_updates(serde_json::json!(bid), updates)
+                }
+                None => WebReturnType::error(
+                    "CreateBlock: reducer did not emit BlockCreated".to_string(),
+                ),
             }
         }
+        // Phase E.2c.4 — DeleteBlock SQLite-first via wcore (cascades
+        // for PTY/controller already handled before the wcore call),
+        // then dispatch reducer's DeleteBlock to keep state in sync.
         ("object", "DeleteBlock") => {
             let tab_id = match call
                 .uicontext
@@ -160,10 +212,21 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             // and child process are torn down and the registry entry is cleared
             // regardless of DB outcome.
             blockcontroller::delete_controller(&block_id);
-            match wcore::delete_block(store, &tab_id, &block_id) {
-                Ok(()) => WebReturnType::success_empty(),
-                Err(e) => WebReturnType::error(e.to_string()),
+            if let Err(e) = wcore::delete_block(store, &tab_id, &block_id) {
+                return WebReturnType::error(e.to_string());
             }
+            // Reducer dispatch is silent on missing — safe to call
+            // unconditionally now that SQLite is consistent.
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::DeleteBlock {
+                    tab_id: tab_id.clone(),
+                    block_id: block_id.clone(),
+                },
+            )
+            .await;
+            publish_events(state, &events);
+            WebReturnType::success_empty()
         }
         ("object", "UpdateObject") => {
             let wave_obj_value: serde_json::Value = match service::get_arg(args, 0) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.518",
+  "version": "0.33.519",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Combines **E.2c.4 (Block RPC migration)** and the **Rust half of E.2c.5 (host bridge to srv pipe)** into one PR. The TypeScript renderer dispatcher half (E.2c.5b) lands as a separate frontend PR.

Per design report — finishes the reducer-authoritative migration for workspace/tab/block/active-tab + plumbs the host→renderer event channel for srv events.

Follow-up to #617.

## Block RPC migration (E.2c.4)

| Change | Detail |
|---|---|
| `Command::CreateBlock` | Gains `meta: serde_json::Value` (`#[serde(default)]` for forward-compat). Reducer forwards meta untouched into the event. |
| `Event::BlockCreated` | Gains `meta: serde_json::Value`. Subscriber deserializes to `MetaMapType` when writing the Block row. |
| `apply_block_created` | Writes Block with meta from event. Without this, reducer-routed blocks landed with empty meta → blank panes. |
| `(\"object\", \"CreateBlock\")` | Forward+compensate via reducer. DeleteBlock rollback on SQLite failure. |
| `(\"object\", \"DeleteBlock\")` | SQLite-first via `wcore::delete_block` (PTY cascade preserved), then reducer dispatch. |

## Host bridge (E.2c.5a)

Two new Rust modules in `agentmux-cef`:

- **`srv_event_bridge`** — parallel to existing `launcher_event_bridge`. Calls `window.__agentmux_srv_event(<json>)` on every top-level renderer for each srv event. Pool windows + browser-pane HWNDs skipped.
- **`srv_ipc`** — opens `AGENTMUX_SRV_PIPE_PATH` at host startup, sends `Register{kind: Host}`, runs a read loop that forwards each event to renderers via `srv_event_bridge`. Slimmer than `launcher_ipc`: no outbound command channel (host doesn't issue srv commands today; saga coordinator E.5+ adds the producer), no shadow state tracking.

Reconnect/resync deferred — if the pipe drops, log + stop forwarding; renderer falls back to the legacy `waveobj:update` HTTP/WS path until the host restarts. E.2c.5b/E.5 will tighten this when saga consumers can't tolerate dropped events.

`main.rs` wires `connect_to_srv` after `connect_to_launcher`.

## Out of scope (intentionally — E.2c.5b)

The renderer-side handler (`window.__agentmux_srv_event`) and the event router that dispatches srv events into atom domains lands as a separate frontend PR. Until then, the host bridge is **dead-code in production**: events arrive at the renderer but the JS-side handler isn't installed, so `if (window.__agentmux_srv_event)` short-circuits and the frontend keeps using the legacy `waveobj:update` HTTP/WS path.

This is a deliberate seam — Rust changes land first (testable in isolation), TypeScript follows.

## Test plan

- [x] 46/46 reducer + subscriber tests pass
- [x] `cargo build --release -p agentmux-srv -p agentmux-cef -p agentmux-launcher` clean
- [ ] Smoke (manual portable):
  - Create block via UI → SQLite has Block with correct view/meta (proves Block RPC migration)
  - Host log shows `[srv-ipc] connected to <pipe>` (proves host bridge connects)
  - Block creation triggers `dispatch_to_renderers` (visible in host log via tracing instrumentation if enabled, otherwise inferred from Block visible in UI)

## Status of E.2c

| | |
|---|---|
| E.2c.1 (#614) | Persist subscriber plumbing — ✅ |
| E.2c.2 (#615) | Workspace RPC migration — ✅ |
| E.2c.3 (#616) | CreateTab + SetActiveTab — ✅ |
| E.2c.3b (#617) | CloseTab + ReorderTab + pinned cleanup — ✅ |
| **E.2c.4 + E.2c.5a** (this PR) | Block RPC + host bridge |
| E.2c.5b | Renderer dispatcher (TypeScript) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)