### PR TITLE
feat(E.5.1+2): saga foundation — window state in reducer + design docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.520"
+version = "0.33.521"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.520"
+version = "0.33.521"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.520"
+version = "0.33.521"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.520"
+version = "0.33.521"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.520"
+version = "0.33.521"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.520"
+version = "0.33.521"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -281,6 +281,28 @@ pub enum Command {
         tab_id: String,
         new_index: u32,
     },
+    /// Phase E.5 — record a new window in the srv reducer's
+    /// `state.windows` map. Caller pre-assigns `window_id` (sagas
+    /// use a fresh UUID; RPC migration in PR 4 will likewise mint
+    /// the id at the RPC boundary). Validates the parent workspace
+    /// exists; errors otherwise. Used by CreateWindow + TearOff
+    /// sagas to track window↔workspace association.
+    CreateWindow {
+        window_id: String,
+        workspace_id: String,
+    },
+    /// Phase E.5 — remove a window's workspace mapping from the
+    /// reducer. Called by CloseWindow sagas after the host's CEF
+    /// window-close completes. Idempotent silent no-op on missing.
+    CloseWindowInternal {
+        window_id: String,
+    },
+    /// Phase E.5 — switch which workspace a window points at.
+    /// Errors if the window or destination workspace is unknown.
+    SwitchWorkspace {
+        window_id: String,
+        workspace_id: String,
+    },
     /// Phase E.3 — create a block inside an existing tab. Reducer
     /// validates parent tab exists, assigns the `block_id` (UUID),
     /// appends to the tab's `block_ids`, emits `Event::BlockCreated`.
@@ -710,6 +732,29 @@ pub enum Event {
         workspace_id: String,
         tab_id: String,
         new_index: u32,
+        version: u64,
+    },
+    /// Phase E.5 — srv-side window→workspace mapping established.
+    /// Distinct from launcher's `WindowOpened` (which tracks CEF
+    /// window lifecycle). Subscribers update their view of "which
+    /// workspace is each window showing."
+    SrvWindowOpened {
+        window_id: String,
+        workspace_id: String,
+        version: u64,
+    },
+    /// Phase E.5 — srv-side window mapping removed. Distinct from
+    /// launcher's `WindowClosed`.
+    SrvWindowClosed {
+        window_id: String,
+        version: u64,
+    },
+    /// Phase E.5 — a window now points at a different workspace
+    /// (used by the SwitchWorkspace command + the CloseWindow saga
+    /// when reassigning during cleanup).
+    SrvWindowWorkspaceChanged {
+        window_id: String,
+        workspace_id: String,
         version: u64,
     },
     /// Phase E.3 — block was created inside a tab.

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.520"
+version = "0.33.521"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -272,6 +272,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
         | Event::TabReordered { version, .. }
+        | Event::SrvWindowOpened { version, .. }
+        | Event::SrvWindowClosed { version, .. }
+        | Event::SrvWindowWorkspaceChanged { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -677,6 +677,19 @@ async fn enforce_register_first(
             "ReorderTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.5 — window↔workspace mapping commands are srv-pipe.
+        Command::CreateWindow { .. } => (
+            "CreateWindow is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::CloseWindowInternal { .. } => (
+            "CloseWindowInternal is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::SwitchWorkspace { .. } => (
+            "SwitchWorkspace is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => (
             "CreateBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -260,6 +260,34 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.5 — window↔workspace mapping commands are srv-pipe.
+        Command::CreateWindow { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "CreateWindow is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::CloseWindowInternal { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "CloseWindowInternal is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::SwitchWorkspace { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "SwitchWorkspace is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => {
             let v = state.bump_version();
@@ -944,6 +972,9 @@ mod tests {
             | Event::TabDeleted { version, .. }
             | Event::ActiveTabChanged { version, .. }
             | Event::TabReordered { version, .. }
+            | Event::SrvWindowOpened { version, .. }
+            | Event::SrvWindowClosed { version, .. }
+            | Event::SrvWindowWorkspaceChanged { version, .. }
             | Event::BlockCreated { version, .. }
             | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.520"
+version = "0.33.521"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -272,6 +272,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::TabDeleted { version, .. }
         | Event::ActiveTabChanged { version, .. }
         | Event::TabReordered { version, .. }
+        | Event::SrvWindowOpened { version, .. }
+        | Event::SrvWindowClosed { version, .. }
+        | Event::SrvWindowWorkspaceChanged { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -23,9 +23,9 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 
-use crate::backend::obj::{Block, Tab, Workspace};
+use crate::backend::obj::{Block, Tab, Window, Workspace};
 use crate::backend::storage::wstore::WaveStore;
-use crate::state::{BlockRecord, State, TabRecord, WorkspaceRecord};
+use crate::state::{BlockRecord, State, TabRecord, WindowRecord, WorkspaceRecord};
 
 /// Phase E.2 / E.2b — load workspaces and their tabs from SQLite
 /// into the reducer state. Called once at srv startup before the
@@ -164,11 +164,50 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
             },
         );
     }
+    // Phase E.5 — load Window→Workspace mappings. Used by sagas
+    // (TearOff/Restore/CreateWindow/CloseWindow) that coordinate
+    // window+workspace lifecycle. Skip windows whose `workspaceid`
+    // refers to a workspace that didn't load — those are dangling
+    // refs, same defensive treatment as orphan tabs/blocks.
+    let windows = wstore.get_all::<Window>().unwrap_or_else(|e| {
+        tracing::warn!(
+            target: "srv-persist",
+            "[srv-persist] bootstrap: failed to load windows from wstore: {} — windows start empty",
+            e
+        );
+        Vec::new()
+    });
+    for window in &windows {
+        if window.workspaceid.is_empty() {
+            tracing::warn!(
+                target: "srv-persist",
+                "[srv-persist] bootstrap: window {} has empty workspaceid — skipping",
+                window.oid
+            );
+            continue;
+        }
+        if !state.workspaces.contains_key(&window.workspaceid) {
+            tracing::warn!(
+                target: "srv-persist",
+                "[srv-persist] bootstrap: window {} points at unknown workspace {} — skipping",
+                window.oid, window.workspaceid
+            );
+            continue;
+        }
+        state.windows.insert(
+            window.oid.clone(),
+            WindowRecord {
+                window_id: window.oid.clone(),
+                workspace_id: window.workspaceid.clone(),
+            },
+        );
+    }
     tracing::info!(
         target: "srv-persist",
-        "[srv-persist] bootstrap loaded {} workspace(s) + {} tab(s) + {} block(s) from wstore",
+        "[srv-persist] bootstrap loaded {} workspace(s) + {} tab(s) + {} block(s) + {} window(s) from wstore",
         state.workspaces.len(),
         state.tabs.len(),
-        state.blocks.len()
+        state.blocks.len(),
+        state.windows.len()
     );
 }

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -438,17 +438,23 @@ fn apply_block_deleted(
 /// Phase E.5 — record/update a window's workspace pointer on the
 /// persisted Window row. Idempotent: inserts if missing, updates
 /// if `workspaceid` differs, no-ops if identical.
+///
+/// Also keeps `Client.windowids` in sync — appends the new window_id
+/// when the Window row is freshly created. The legacy
+/// `wcore::create_window_full` path does this too; without it, the
+/// Window row exists but `GetClientData` / focus-order logic can't
+/// see it. (codex P1 #619.)
 fn apply_srv_window_opened(
     wstore: &WaveStore,
     window_id: &str,
     workspace_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    match wstore.get::<Window>(window_id)? {
-        Some(existing) if existing.workspaceid == workspace_id => Ok(()),
+    let was_new = match wstore.get::<Window>(window_id)? {
+        Some(existing) if existing.workspaceid == workspace_id => false,
         Some(mut existing) => {
             existing.workspaceid = workspace_id.to_string();
             wstore.update(&mut existing)?;
-            Ok(())
+            false
         }
         None => {
             let mut window = Window {
@@ -457,18 +463,45 @@ fn apply_srv_window_opened(
                 ..Default::default()
             };
             wstore.insert(&mut window)?;
-            Ok(())
+            true
+        }
+    };
+    if was_new {
+        if let Ok(mut client) = wcore::get_client(wstore) {
+            if !client.windowids.iter().any(|id| id == window_id) {
+                client.windowids.push(window_id.to_string());
+                wstore.update(&mut client)?;
+            }
         }
     }
+    Ok(())
 }
 
-/// Phase E.5 — delete the persisted Window row.
+/// Phase E.5 — delete the persisted Window row + remove the id
+/// from `Client.windowids`. Mirrors `wcore::close_window`'s order:
+/// prune client.windowids FIRST (so any read between the two ops
+/// doesn't see a dangling id), then delete the Window row.
+/// (codex P1 #619.)
 fn apply_srv_window_closed(
     wstore: &WaveStore,
     window_id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if wstore.get::<Window>(window_id)?.is_none() {
-        return Ok(()); // already gone
+        // Window already gone, but the client list might still have
+        // the id from an earlier divergence — prune defensively.
+        if let Ok(mut client) = wcore::get_client(wstore) {
+            if client.windowids.iter().any(|id| id == window_id) {
+                client.windowids.retain(|id| id != window_id);
+                wstore.update(&mut client)?;
+            }
+        }
+        return Ok(());
+    }
+    if let Ok(mut client) = wcore::get_client(wstore) {
+        if client.windowids.iter().any(|id| id == window_id) {
+            client.windowids.retain(|id| id != window_id);
+            wstore.update(&mut client)?;
+        }
     }
     wstore.delete::<Window>(window_id)?;
     Ok(())

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 use agentmux_common::ipc::Event;
 use tokio::sync::{broadcast, Mutex};
 
-use crate::backend::obj::{Block, LayoutState as PersistedLayoutState, Tab, Workspace};
+use crate::backend::obj::{Block, LayoutState as PersistedLayoutState, Tab, Window, Workspace};
 use crate::backend::storage::wstore::WaveStore;
 use crate::backend::wcore;
 use crate::state::State;
@@ -222,6 +222,17 @@ pub(crate) fn apply_event_to_wstore(
         Event::BlockDeleted {
             tab_id, block_id, ..
         } => apply_block_deleted(wstore, tab_id, block_id),
+        Event::SrvWindowOpened {
+            window_id,
+            workspace_id,
+            ..
+        } => apply_srv_window_opened(wstore, window_id, workspace_id),
+        Event::SrvWindowClosed { window_id, .. } => apply_srv_window_closed(wstore, window_id),
+        Event::SrvWindowWorkspaceChanged {
+            window_id,
+            workspace_id,
+            ..
+        } => apply_srv_window_workspace_changed(wstore, window_id, workspace_id),
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -424,6 +435,56 @@ fn apply_block_deleted(
     }
 }
 
+/// Phase E.5 — record/update a window's workspace pointer on the
+/// persisted Window row. Idempotent: inserts if missing, updates
+/// if `workspaceid` differs, no-ops if identical.
+fn apply_srv_window_opened(
+    wstore: &WaveStore,
+    window_id: &str,
+    workspace_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match wstore.get::<Window>(window_id)? {
+        Some(existing) if existing.workspaceid == workspace_id => Ok(()),
+        Some(mut existing) => {
+            existing.workspaceid = workspace_id.to_string();
+            wstore.update(&mut existing)?;
+            Ok(())
+        }
+        None => {
+            let mut window = Window {
+                oid: window_id.to_string(),
+                workspaceid: workspace_id.to_string(),
+                ..Default::default()
+            };
+            wstore.insert(&mut window)?;
+            Ok(())
+        }
+    }
+}
+
+/// Phase E.5 — delete the persisted Window row.
+fn apply_srv_window_closed(
+    wstore: &WaveStore,
+    window_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if wstore.get::<Window>(window_id)?.is_none() {
+        return Ok(()); // already gone
+    }
+    wstore.delete::<Window>(window_id)?;
+    Ok(())
+}
+
+/// Phase E.5 — same shape as `apply_srv_window_opened` for the
+/// upsert behavior; separate function for log-clarity since the
+/// emitted event is distinct.
+fn apply_srv_window_workspace_changed(
+    wstore: &WaveStore,
+    window_id: &str,
+    workspace_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    apply_srv_window_opened(wstore, window_id, workspace_id)
+}
+
 /// Compact textual identifier for an event (debug logging only).
 fn event_kind(event: &Event) -> &'static str {
     match event {
@@ -433,6 +494,9 @@ fn event_kind(event: &Event) -> &'static str {
         Event::TabDeleted { .. } => "TabDeleted",
         Event::ActiveTabChanged { .. } => "ActiveTabChanged",
         Event::TabReordered { .. } => "TabReordered",
+        Event::SrvWindowOpened { .. } => "SrvWindowOpened",
+        Event::SrvWindowClosed { .. } => "SrvWindowClosed",
+        Event::SrvWindowWorkspaceChanged { .. } => "SrvWindowWorkspaceChanged",
         Event::BlockCreated { .. } => "BlockCreated",
         Event::BlockDeleted { .. } => "BlockDeleted",
         _ => "Other",

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -11,9 +11,12 @@
 // Arms by phase:
 //   * E.1b — Register / Goodbye / Ping / GetSrvSnapshot / GetEvents
 //   * E.2  — CreateWorkspace / DeleteWorkspace
-//   * E.2b — CreateTab / DeleteTab / SetActiveTab
+//   * E.2b — CreateTab / DeleteTab / SetActiveTab / ReorderTab
 //   * E.3  — CreateBlock / DeleteBlock
-//   * E.4+ — Layout commands (not yet present)
+//   * E.5  — CreateWindow / CloseWindowInternal / SwitchWorkspace
+//             (window↔workspace mapping for sagas)
+//   * E.5+ — saga-driven multi-step commands (TearOff/Restore/Move)
+//             land via the saga coordinator dispatching atomic arms
 //
 // `Command::GetEvents` is intercepted by the IPC server before
 // reaching the reducer (server queries the event log; reducer
@@ -22,7 +25,9 @@
 
 use agentmux_common::ipc::{ClientKind, Command, ErrorCode, Event, LifecyclePhase};
 
-use crate::state::{BlockRecord, ProcessRecord, ProcessState, State, TabRecord, WorkspaceRecord};
+use crate::state::{
+    BlockRecord, ProcessRecord, ProcessState, State, TabRecord, WindowRecord, WorkspaceRecord,
+};
 
 /// Per-dispatch context. Currently just an RFC3339 timestamp + the
 /// originating connection's `conn_id` for log correlation.
@@ -57,6 +62,17 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         } => handle_reorder_tab(state, workspace_id, tab_id, new_index),
         Command::CreateBlock { tab_id, meta } => handle_create_block(state, tab_id, meta),
         Command::DeleteBlock { tab_id, block_id } => handle_delete_block(state, tab_id, block_id),
+        Command::CreateWindow {
+            window_id,
+            workspace_id,
+        } => handle_create_window(state, window_id, workspace_id),
+        Command::CloseWindowInternal { window_id } => {
+            handle_close_window_internal(state, window_id)
+        }
+        Command::SwitchWorkspace {
+            window_id,
+            workspace_id,
+        } => handle_switch_workspace(state, window_id, workspace_id),
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
         // match by adding new arms above.
@@ -519,6 +535,99 @@ fn handle_delete_block(state: &mut State, tab_id: String, block_id: String) -> V
     }]
 }
 
+/// Phase E.5 — record a new window→workspace mapping. Validates
+/// the parent workspace exists; otherwise emits `Event::Error`
+/// (non-fatal). Idempotent on duplicate `window_id`: re-issuing
+/// for the same window updates the workspace pointer if it
+/// changed, or no-ops if identical.
+fn handle_create_window(
+    state: &mut State,
+    window_id: String,
+    workspace_id: String,
+) -> Vec<Event> {
+    if !state.workspaces.contains_key(&workspace_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("CreateWindow: workspace not found: {}", workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    if let Some(existing) = state.windows.get(&window_id) {
+        if existing.workspace_id == workspace_id {
+            return Vec::new();
+        }
+    }
+    state.windows.insert(
+        window_id.clone(),
+        WindowRecord {
+            window_id: window_id.clone(),
+            workspace_id: workspace_id.clone(),
+        },
+    );
+    let v = state.bump_version();
+    vec![Event::SrvWindowOpened {
+        window_id,
+        workspace_id,
+        version: v,
+    }]
+}
+
+/// Phase E.5 — remove a window's workspace mapping. Idempotent
+/// silent no-op on missing.
+fn handle_close_window_internal(state: &mut State, window_id: String) -> Vec<Event> {
+    if state.windows.remove(&window_id).is_none() {
+        return Vec::new();
+    }
+    let v = state.bump_version();
+    vec![Event::SrvWindowClosed {
+        window_id,
+        version: v,
+    }]
+}
+
+/// Phase E.5 — change which workspace a window points at. Errors
+/// (non-fatal) if the window or destination workspace is unknown.
+/// No-op if the window is already pointing at the destination.
+fn handle_switch_workspace(
+    state: &mut State,
+    window_id: String,
+    workspace_id: String,
+) -> Vec<Event> {
+    if !state.workspaces.contains_key(&workspace_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "SwitchWorkspace: destination workspace not found: {}",
+                workspace_id
+            ),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let Some(window) = state.windows.get_mut(&window_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("SwitchWorkspace: window not found: {}", window_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if window.workspace_id == workspace_id {
+        return Vec::new();
+    }
+    window.workspace_id = workspace_id.clone();
+    let v = state.bump_version();
+    vec![Event::SrvWindowWorkspaceChanged {
+        window_id,
+        workspace_id,
+        version: v,
+    }]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -572,6 +681,9 @@ mod tests {
             | Event::TabReordered { version, .. }
             | Event::BlockCreated { version, .. }
             | Event::BlockDeleted { version, .. }
+            | Event::SrvWindowOpened { version, .. }
+            | Event::SrvWindowClosed { version, .. }
+            | Event::SrvWindowWorkspaceChanged { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -1404,6 +1516,187 @@ mod tests {
             panic!("expected SrvSnapshot");
         };
         assert_eq!(blocks.len(), 1);
+    }
+
+    // ---- E.5: window↔workspace mapping arms ----
+
+    #[test]
+    fn create_window_validates_workspace_exists() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: "no-such-ws".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        assert!(state.windows.is_empty());
+    }
+
+    #[test]
+    fn create_window_inserts_record_and_emits_event() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let events = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id.clone(),
+            },
+            &ctx(2),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::SrvWindowOpened { window_id, workspace_id, .. }
+                if window_id == "win-1" && *workspace_id == ws_id
+        ));
+        assert_eq!(state.windows["win-1"].workspace_id, ws_id);
+    }
+
+    #[test]
+    fn create_window_idempotent_on_same_workspace() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id.clone(),
+            },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id,
+            },
+            &ctx(3),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn close_window_internal_removes_record() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id,
+            },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::CloseWindowInternal {
+                window_id: "win-1".into(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::SrvWindowClosed { .. }));
+        assert!(state.windows.is_empty());
+    }
+
+    #[test]
+    fn close_window_internal_silent_on_missing() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::CloseWindowInternal {
+                window_id: "ghost".into(),
+            },
+            &ctx(1),
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn switch_workspace_updates_window_pointer() {
+        let mut state = State::default();
+        let ws_a = create_workspace(&mut state, "a");
+        let ws_b = create_workspace(&mut state, "b");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_a.clone(),
+            },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::SwitchWorkspace {
+                window_id: "win-1".into(),
+                workspace_id: ws_b.clone(),
+            },
+            &ctx(3),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::SrvWindowWorkspaceChanged { workspace_id, .. } if *workspace_id == ws_b
+        ));
+        assert_eq!(state.windows["win-1"].workspace_id, ws_b);
+    }
+
+    #[test]
+    fn switch_workspace_validates_window_and_destination() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "a");
+        // Unknown window.
+        let events = update(
+            &mut state,
+            Command::SwitchWorkspace {
+                window_id: "ghost".into(),
+                workspace_id: ws_id.clone(),
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+        // Known window, unknown workspace.
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id,
+            },
+            &ctx(3),
+        );
+        let events = update(
+            &mut state,
+            Command::SwitchWorkspace {
+                window_id: "win-1".into(),
+                workspace_id: "no-such-ws".into(),
+            },
+            &ctx(4),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn switch_workspace_no_op_when_already_pointing() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "a");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-1".into(),
+                workspace_id: ws_id.clone(),
+            },
+            &ctx(2),
+        );
+        let events = update(
+            &mut state,
+            Command::SwitchWorkspace {
+                window_id: "win-1".into(),
+                workspace_id: ws_id,
+            },
+            &ctx(3),
+        );
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -268,6 +268,14 @@ fn handle_delete_workspace(state: &mut State, workspace_id: String) -> Vec<Event
             }
         }
     }
+    // Phase E.5 — also drop window mappings that point at the
+    // deleted workspace. Without this, `state.windows` keeps
+    // dangling refs and saga steps that inspect window→workspace
+    // membership make decisions from invalid state.
+    // (codex P1 #619.)
+    state
+        .windows
+        .retain(|_, record| record.workspace_id != workspace_id);
     let v = state.bump_version();
     vec![Event::WorkspaceDeleted {
         workspace_id,
@@ -1697,6 +1705,37 @@ mod tests {
             &ctx(3),
         );
         assert!(events.is_empty());
+    }
+
+    #[test]
+    fn delete_workspace_drops_pointing_windows() {
+        let mut state = State::default();
+        let ws_a = create_workspace(&mut state, "a");
+        let ws_b = create_workspace(&mut state, "b");
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-a".into(),
+                workspace_id: ws_a.clone(),
+            },
+            &ctx(2),
+        );
+        let _ = update(
+            &mut state,
+            Command::CreateWindow {
+                window_id: "win-b".into(),
+                workspace_id: ws_b.clone(),
+            },
+            &ctx(3),
+        );
+        // Delete workspace A; only win-a should be dropped, win-b survives.
+        let _ = update(
+            &mut state,
+            Command::DeleteWorkspace { workspace_id: ws_a },
+            &ctx(4),
+        );
+        assert!(!state.windows.contains_key("win-a"));
+        assert_eq!(state.windows["win-b"].workspace_id, ws_b);
     }
 
     #[test]

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -86,6 +86,23 @@ pub struct BlockRecord {
     pub tab_id: String,
 }
 
+/// Phase E.5 — window-to-workspace mapping as held by the srv
+/// reducer's canonical state. Mirrors the persistent
+/// `Window.workspaceid` field. Used by sagas (TearOff/Restore/
+/// CreateWindow/CloseWindow) that need to coordinate the
+/// window↔workspace lifecycle atomically.
+///
+/// Note: this is NOT the same as the launcher's `state::Window` —
+/// the launcher tracks CEF window ownership (label, kind, hwnd).
+/// The srv `WindowRecord` is purely "which workspace does this
+/// window currently point at." Both are valid orthogonal projections
+/// of the same on-disk Window row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowRecord {
+    pub window_id: String,
+    pub workspace_id: String,
+}
+
 #[derive(Debug)]
 pub struct State {
     pub lifecycle: LifecyclePhase,
@@ -110,6 +127,11 @@ pub struct State {
     /// `TabRecord.block_ids`. Bootstrap-loaded from SQLite at startup
     /// alongside workspaces and tabs.
     pub blocks: HashMap<String, BlockRecord>,
+    /// Phase E.5 — window→workspace mapping. Bootstrap-loaded from
+    /// SQLite Window rows. Mutated by the saga-driven CreateWindow/
+    /// CloseWindow/SwitchWorkspace commands; sagas use it to keep
+    /// window+workspace lifecycle coherent.
+    pub windows: HashMap<String, WindowRecord>,
     // `persistence_hwm` deferred to E.2c when the persist subscriber
     // lands and there's actually something to track.
 }
@@ -124,6 +146,7 @@ impl Default for State {
             workspaces: HashMap::new(),
             tabs: HashMap::new(),
             blocks: HashMap::new(),
+            windows: HashMap::new(),
         }
     }
 }

--- a/docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md
+++ b/docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md
@@ -1,0 +1,287 @@
+# Reducer/wcore Consistency During E.2 Migration — Analysis + Plan
+
+**Date:** 2026-04-30
+**Trigger:** Smoke regression in #618 (`agentmux-0.33.520`) — tear off tab to new window, click "+" tab, nothing happens. Same workspace's "+" works in the original window.
+
+---
+
+## 1. The bug
+
+**Repro:**
+1. Right-click an existing tab → "Tear Off" → new window opens with the torn tab.
+2. In the new window, click `+` to create another tab.
+3. **Expected:** new tab appears.
+   **Observed:** nothing — RPC returns an error from the reducer (`CreateTab: workspace not found: <uuid>`).
+
+The original window's `+` continues to work because its workspace was loaded into the reducer at bootstrap.
+
+## 2. Root cause
+
+The srv reducer's state is **bootstrap-loaded once at process startup** from SQLite. After that, the only way new workspaces enter `state.workspaces` is via `Command::CreateWorkspace` dispatched **through the reducer's pipe** by a migrated RPC handler.
+
+But several RPC handlers — including all the tear-off / move / window-create paths — still call `wcore::*` directly, writing SQLite without notifying the reducer. The reducer's view goes stale the moment any of those run:
+
+```
+       ┌──────────────────────┐
+       │  agentmux-srv        │
+       │                      │
+       │  ┌──────────────┐    │
+HTTP ──┼─→│ dispatch_svc │    │
+       │  └──┬───────┬───┘    │
+       │     │       │        │
+       │  reducer  wcore-direct│ ← writes SQLite,
+       │     ↓       ↓        │   reducer never sees it
+       │  state.    SQLite    │
+       │  workspaces  ▲       │
+       │     ▲        │       │
+       │     └────────┘       │
+       │  bootstrap ONCE      │
+       └──────────────────────┘
+```
+
+This is a fundamental inconsistency in the migration window: the reducer's claimed-authoritative state is actually a **partial projection** of SQLite. Any wcore-direct mutation creates a divergence that the reducer can't recover from on its own.
+
+## 3. Audit — every wcore-direct path that mutates reducer-relevant state
+
+Searched `agentmux-srv/src/server/service.rs` (handlers) and `agentmux-srv/src/backend/wcore/` (callees). Each row below is a code path that writes SQLite for a workspace/tab/block/layout WITHOUT dispatching through the reducer.
+
+| Handler / call site | wcore call | Mutates | Severity |
+|---|---|---|---|
+| `("workspace", "TearOffTab")` | `wcore::tear_off_tab` | creates new workspace + window; moves tab between workspaces | **HIGH** — direct cause of smoke regression |
+| `("workspace", "TearOffBlock")` | `wcore::tear_off_block` | creates new workspace + window + tab; moves block | **HIGH** — same root |
+| `("workspace", "RestoreTornOffTab")` | `wcore::restore_torn_off_tab` | moves tab back to source workspace; deletes torn-off workspace | HIGH |
+| `("workspace", "MoveTabToWorkspace")` | `wcore::move_tab_to_workspace` | moves tab between workspaces | HIGH |
+| `("workspace", "MoveBlockToTab")` | `wcore::move_block_to_tab` | moves block between tabs (potentially across workspaces) | HIGH |
+| `("workspace", "PromoteBlockToTab")` | `wcore::promote_block_to_tab` | block becomes new tab in same workspace | MEDIUM (workspace stays known) |
+| `("workspace", "UpdateTabIds")` | direct `store.update::<Workspace>` | reorders/replaces `tabids` wholesale | MEDIUM |
+| `("workspace", "UpdateWorkspace")` | direct `store.update::<Workspace>` | renames workspace | LOW (read-side only when stale) |
+| `("object", "UpdateObject")` | direct `store.update` | bulk wave-obj update | MEDIUM |
+| `("object", "UpdateObjectMeta")` | direct `store.update` | meta merge on workspace/tab/block | LOW |
+| `("object", "UpdateTabName")` | direct `store.update::<Tab>` | renames tab | LOW |
+| `("window", "CreateWindow")` | `wcore::create_window_full` | creates new workspace + window | **HIGH** |
+| `("window", "CloseWindow")` | `wcore::close_window` | may delete orphan workspace | HIGH |
+| `("window", "SwitchWorkspace")` | direct `store.update::<Window>` | window points at different workspace; could surface a workspace not in reducer | MEDIUM |
+| `wcore::ensure_initial_data` (startup, first launch only) | inserts Client/Window/Workspace/Tab/Block | creates the starter workspace | LOW (covered by bootstrap on next pass; but the FIRST run after first-launch races) |
+
+**Severity rubric:**
+- HIGH = produces the bug class the user just hit (CreateTab / SetActiveTab / ReorderTab on the new workspace fails).
+- MEDIUM = produces stale reads via reducer (currently masked because `GetWorkspace` / `ListWorkspaces` read wstore directly).
+- LOW = no immediate user-visible effect.
+
+**Count:** 14 paths bypass the reducer today. Tear-off and window flows are the biggest offenders for migration-window regressions.
+
+## 4. Design options
+
+### Option A — Lazy hot-load on demand
+
+Before dispatching any reducer command that takes a `workspace_id`, check if `state.workspaces` has it; if not, read from wstore and insert (along with referenced tabs/blocks). New helper:
+
+```rust
+async fn ensure_workspace_in_reducer(state: &AppState, workspace_id: &str) -> Result<(), String>
+```
+
+Called at the top of CreateTab, SetActiveTab, ReorderTab, CloseTab, CreateBlock, DeleteBlock.
+
+- **Pros**
+  - ~30 LoC, surgical, ships immediately
+  - Fixes the smoke regression cleanly
+  - Doesn't require touching tear-off / window code
+- **Cons**
+  - The inconsistency remains a footgun: when E.5 sagas run, they'll hit the same class of bug from different directions
+  - Requires every new reducer-dispatching handler to remember to call the helper (easy to forget)
+  - Doesn't solve UpdateTabIds / UpdateWorkspace causing stale reads through the reducer
+  - Saga coordinator (E.5) emits commands that might race with wcore-direct writes — lazy hot-load can't reconcile mid-flight
+
+### Option B — Migrate every wcore-direct path through the reducer
+
+Each handler in §3 becomes:
+1. Build a `Command::*` (existing or new) with the parameters
+2. Dispatch through reducer (gets event(s))
+3. Subscriber writes SQLite
+4. RPC returns
+
+For multi-step operations (tear-off, move) this means new compound reducer commands or — better — multi-step **sagas** orchestrated by the E.1a saga coordinator.
+
+- **Pros**
+  - Truly authoritative reducer; no inconsistency window
+  - Subscribers (renderer, future replication, --diag) see a coherent stream
+  - Testable: reducer unit tests cover the full surface
+- **Cons**
+  - ~500-800 LoC across 14 handlers
+  - Multi-step ops (tear-off, restore) are saga shape — depend on saga coordinator (E.5) being live
+  - Schema-level commands (`Command::TearOffTab`, etc.) bloat the wire protocol unless modelled as sagas
+  - Doesn't ship until E.5 lands; user UX broken for that long without a stopgap
+
+### Option C — Pure event publisher, drop reducer state
+
+Reducer no longer holds workspaces/tabs/blocks. `Command::CreateWorkspace` becomes "call wcore + emit event"; subscribers get the event and update their own state.
+
+- **Pros**
+  - No reducer/wcore divergence (reducer doesn't store anything to diverge)
+  - Simpler reducer state shape
+- **Cons**
+  - **Violates the spec's "pure functional core" invariant** — reducer becomes I/O-bound (calls wcore)
+  - Loses the ability to validate cross-entity invariants in-reducer (e.g., "tab must belong to a workspace") — those move to wcore
+  - Renderer-side state reconstruction needs every event since boot, no `GetSrvSnapshot` shortcut
+  - **Reject:** undoes the architectural choice that motivated Phase E
+
+### Option D — Synthetic register-existing events from wcore-direct paths
+
+New `Command::RegisterExistingWorkspace { workspace_id }` (and `RegisterExistingTab`, etc.). After every wcore-direct mutation, the handler emits the corresponding `Register*` command into the reducer so it picks up the new entity. Reducer's handler reads from wstore once and inserts the record.
+
+Equivalent to Option B but **single-step, no saga coordinator dependency**.
+
+- **Pros**
+  - Reducer stays authoritative for state queries (subscribers / renderer trust it)
+  - No multi-step saga shape needed; one extra dispatch per wcore-direct call
+  - Doesn't bloat the wire protocol with TearOff* commands — those stay local SQL, just with a register-after side-effect
+  - Bus event still emitted, so subscribers and the renderer dispatcher see the change
+- **Cons**
+  - Two-step pattern in every wcore-direct handler (call wcore, then register)
+  - If wcore succeeds but Register dispatch fails (e.g., reducer mutex briefly unavailable — but it's tokio Mutex so this doesn't happen): same divergence we have today, but now bounded to a known failure mode
+  - Slightly more wire traffic (one extra command per wcore-direct op)
+  - Doesn't fully migrate; reducer is still partly downstream of wcore. Phase F could finish the migration cleanly.
+
+### Hybrid recommendation
+
+**Ship Option A immediately as the smoke fix** (~30 LoC, ~1 review round, unblocks user testing today).
+
+**Plan Option D as a follow-up sweep** in E.2c.6 (or fold into E.5) (~200 LoC, touches every wcore-direct handler in §3 to add the register-after dispatch).
+
+**Defer Option B** to Phase F when the saga coordinator can absorb the multi-step ops cleanly.
+
+Why this layering:
+- **A right now** because the user is mid-smoke, the fix is small, and it's the bare minimum to unblock.
+- **D as the durable resolution** because it preserves the reducer's authoritative property without requiring sagas to land first.
+- **B is the long-term shape** because Phase F (host reducer) and Phase 7 (cross-platform) both benefit from "every state mutation goes through the reducer." But Phase F hasn't started; we shouldn't gate the smoke unblock on it.
+
+If A introduces inconsistencies under sustained tear-off/restore activity (e.g., the `tab_ids` snapshot in the reducer drifts from wstore), we accelerate D.
+
+## 5. Recommended Option-A implementation
+
+```rust
+// In service.rs, near the dispatch_to_reducer helper:
+
+/// Phase E.2c hot-fix — ensure the reducer knows about a workspace
+/// before dispatching commands that reference it. Wcore-direct paths
+/// (tear-off, window create, etc.) write SQLite without notifying
+/// the reducer; this helper picks up those workspaces on demand.
+///
+/// The proper fix is Option D in
+/// `docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md` — every
+/// wcore-direct path emits a Register* command after its write. This
+/// helper is a transitional patch.
+async fn ensure_workspace_in_reducer(
+    state: &AppState,
+    workspace_id: &str,
+) -> Result<(), String> {
+    {
+        let s = state.srv_state.lock().await;
+        if s.workspaces.contains_key(workspace_id) {
+            return Ok(());
+        }
+    }
+    let ws = match state.wstore.get::<Workspace>(workspace_id) {
+        Ok(Some(ws)) => ws,
+        Ok(None) => return Err(format!("workspace not found: {}", workspace_id)),
+        Err(e) => return Err(format!("SQLite read failed: {}", e)),
+    };
+    // Hot-load tabs that this workspace references so dispatches
+    // touching tab_ids work too (CreateBlock validates tab presence).
+    let mut tabs_to_load = Vec::new();
+    for tid in ws.tabids.iter().chain(ws.pinnedtabids.iter()) {
+        if let Ok(Some(tab)) = state.wstore.get::<Tab>(tid) {
+            tabs_to_load.push(tab);
+        }
+    }
+    let mut s = state.srv_state.lock().await;
+    s.workspaces.entry(workspace_id.to_string()).or_insert_with(|| {
+        crate::state::WorkspaceRecord {
+            workspace_id: ws.oid.clone(),
+            name: ws.name.clone(),
+            // Pinned-then-regular concat matches bootstrap convention.
+            tab_ids: ws.pinnedtabids.iter().chain(ws.tabids.iter()).cloned().collect(),
+            active_tab_id: if ws.activetabid.is_empty() {
+                None
+            } else {
+                Some(ws.activetabid.clone())
+            },
+        }
+    });
+    for tab in tabs_to_load {
+        s.tabs.entry(tab.oid.clone()).or_insert_with(|| {
+            crate::state::TabRecord {
+                tab_id: tab.oid.clone(),
+                workspace_id: workspace_id.to_string(),
+                name: tab.name.clone(),
+                block_ids: tab.blockids.clone(),
+            }
+        });
+    }
+    Ok(())
+}
+```
+
+Call sites — at the top of each handler, immediately after parsing `ws_id`:
+
+- `CreateTab`, `SetActiveTab`, `ReorderTab`, `CloseTab`
+- `CreateBlock` (gets `ws_id` indirectly via `tab_id`; needs a `ensure_tab_in_reducer` companion that walks back to the workspace if needed — simpler: just always call ensure_workspace if we can derive ws_id from the tab via wstore lookup)
+- `DeleteBlock` (same as CreateBlock)
+
+For CreateBlock/DeleteBlock the helper variant looks up the tab's parent workspace via `wstore.get::<Tab>` then ensures that workspace.
+
+**No new wire-protocol changes. No new commands. Pure RPC-layer patch.**
+
+## 6. Remaining Phase E work
+
+State of play after #618 merge (`agentmux-0.33.520`):
+
+| Sub-phase | Scope | Status |
+|---|---|---|
+| E.1a / E.1b | Saga coordinator + srv reducer skeleton | ✅ |
+| E.2 / E.2b / E.3 | Workspace + Tab + Block lifecycle arms | ✅ |
+| E.2c.1 — E.2c.5a | Persist subscriber + RPC migration (workspace + tab + block) + Rust host bridge | ✅ |
+| **E.2c.5b** | TypeScript renderer dispatcher — install `window.__agentmux_srv_event`, route events into atom domains | ⏸ next |
+| **E.2c.6 (NEW)** | Option D rollout — emit `RegisterExisting*` after every wcore-direct path enumerated in §3 | ⏸ proposed |
+| **E.4** | Layout state — minimal slice (focused/magnified node tracking only) | ⏸ deferred |
+| **E.5** | Drag/tear-off sagas (first concrete saga consumers; unblocks Option B path) | ⏸ deferred |
+| **E.6** | Renderer multi-source consumption + saga buffering | ⏸ depends on E.2c.5b |
+| **E.7 — exit** | Property tests + cross-reducer integration tests + `--diag srv` / `--diag sagas` | ⏸ exit |
+
+### Recommended sequencing post-#618
+
+1. **Hot-fix branch (this PR)** — Option A `ensure_workspace_in_reducer`. Unblocks smoke.
+2. **E.2c.5b** — TypeScript renderer dispatcher. Brings the host bridge live for renderer consumption. Expected: ~200-300 LoC TypeScript.
+3. **E.2c.6 (Option D rollout)** — Register-existing dispatch after every wcore-direct mutation in §3. Removes the inconsistency window. ~150-250 LoC.
+4. **E.4** — Layout minimal slice (focused/magnified). Unblocks E.6 renderer-side drift detection.
+5. **E.5** — Sagas. Tear-off / move become coordinated multi-reducer flows. Replaces parts of §3 that benefit from the saga shape.
+6. **E.6** — Renderer per-source version tracking + saga-buffer. Bespoke `WaveObjUpdate` retired or demoted.
+7. **E.7** — Property tests + integration tests + `--diag` Tools. Phase exit.
+
+### Carryovers from prior PRs
+
+Codex P3 from #617 (already addressed in #617): u32 clamp on reorder index — done.
+
+Codex P2 from #613 (post-merge): ambiguous block-parent during bootstrap (multi-tab block ownership). Defensive-repair concern; defer to next persist.rs PR (likely E.2c.6 or E.4).
+
+## 7. Open questions
+
+1. **Should `ensure_workspace_in_reducer` also hot-load blocks?** Currently the proposed helper only loads workspace + tabs. If a CreateBlock dispatch comes in for a tab in a tear-off workspace, the tab record gets loaded but the tab's existing blocks don't. Does the reducer's CreateBlock care? Looking at handle_create_block — it validates `state.tabs.contains_key(&tab_id)` and appends to `tab.block_ids`. It doesn't iterate `state.blocks`, so missing block records don't break Create. But DeleteBlock looks up by block_id — would silent-no-op on a block the reducer didn't load. That's idempotent-ish but means a block that exists in wstore can't be deleted via the reducer until something else loads it. **Decision: load blocks too** when ensuring a tab.
+
+2. **Race between `ensure_workspace_in_reducer` and a concurrent `CreateWorkspace`?** Two RPCs arrive simultaneously: one calls ensure (loads from wstore), one dispatches CreateWorkspace (assigns new uuid). Different workspaces, so no conflict. The lock is held only briefly by each. **Safe.**
+
+3. **What if wstore says "not found"?** The helper returns an error; the caller surfaces it. That's the correct behaviour — the user's CreateTab against a non-existent workspace should fail clearly.
+
+4. **When does Option A become a problem?** When the reducer's lazily-loaded `tab_ids` for a workspace falls behind a wcore-direct mutation that adds tabs to that workspace. E.g., a saga (E.5+) creates a tab via `wcore::create_tab_with_opts` and the reducer's hot-loaded snapshot is now stale. **Mitigation:** by E.5, Option D is shipped; saga producers always go through reducer → no wcore-direct writes for migrated entities.
+
+5. **Should the helper also reconcile reducer state with current wstore (overwrite)?** No — that's resync territory and would clobber legitimate reducer-only mutations between two RPC calls in the same workspace. The `or_insert_with` is intentional: only loads if missing.
+
+---
+
+## 8. Decision
+
+**Proceeding with Option A as the immediate fix** (this PR, hot-fix #619 or similar branch).
+
+**Option D rollout planned as E.2c.6** — one PR after E.2c.5b lands.
+
+This document committed to `docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md` so the analysis survives the next session.

--- a/docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md
+++ b/docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md
@@ -1,0 +1,335 @@
+# Phase E.5 Sagas — Execution Plan
+
+**Date:** 2026-04-30
+**Companion to:** `docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md` (the design spec)
+**Goal:** finish migrating every wcore-direct mutation through the srv reducer via saga or atomic command, removing the inconsistency window that produced the tear-off → CreateTab regression.
+
+---
+
+## 0. Decisions made
+
+- **Skip the Option-A hot-fix.** The robust solution (sagas) is what we're shipping. Smoke regression on tear-off → "+" tab persists until **PR 3** lands.
+- **No partial migration.** Every wcore-direct path in `phase-e-tear-off-and-remaining-2026-04-30.md` §3 either becomes an atomic reducer command (single-step) or a saga (multi-step). End state: reducer is sole writer of workspace/tab/block/window/layout state.
+- **PRs bundle aggressively** to match the established cadence (the E.2c series merged 7 PRs in one session).
+
+---
+
+## 1. PR sequence (4 PRs)
+
+| PR | Branch | Scope | Est LoC | Smoke regression fixed? |
+|---|---|---|---|---|
+| **PR 1: E.5.1+2** | `agenta/phase-e-5-foundation` | Saga trait + correlation IDs + window state in reducer | ~650 | No (foundation only) |
+| **PR 2: E.5.3+4** | `agenta/phase-e-5-atomic-commands` | New atomic commands + reducer arms + subscriber applies + RPC migration of all 7 single-step paths | ~900 | No (low-risk paths only) |
+| **PR 3: E.5.5+6** | `agenta/phase-e-5-tear-off-sagas` | TearOffTab + TearOffBlock + RestoreTornOffTab sagas | ~800 | **YES — tear-off → "+" tab works** |
+| **PR 4: E.5.7+8+9** | `agenta/phase-e-5-window-sagas-and-cleanup` | MoveTabToWorkspace + MoveBlockToTab + CreateWindow + CloseWindow sagas + helper retirement | ~750 | All wcore-direct migrations done |
+
+**Total: ~3100 LoC across 4 PRs.** Each individually shippable + smoke-testable.
+
+### Parallel work (not on the saga critical path)
+
+- **E.2c.5b** (TypeScript renderer dispatcher) — independent of saga work; can ship at any point. ~200-300 LoC frontend.
+- **E.4** (Layout minimal slice) — independent of saga work. ~250 LoC.
+- **E.6** (renderer per-source version + saga buffer) — depends on E.2c.5b and on saga lifecycle events.
+- **E.7** (proptests + integration tests + `--diag`) — phase exit; depends on all of above.
+
+---
+
+## 2. PR 1 — Foundation (E.5.1 + E.5.2)
+
+### Branch
+`agenta/phase-e-5-foundation`
+
+### Scope
+
+**E.5.1: Saga trait + correlation IDs + coordinator wiring**
+
+- Extend the `Saga` trait in `agentmux-launcher/src/saga.rs`:
+  - Add `fn compensate(&mut self) -> Vec<Command>` (default impl: empty Vec).
+  - Confirm/extend `on_event(&mut self, event: &Event) -> SagaStep` matches the spec §4.1 signature.
+  - Add `SagaStep::Continue / Completed / Failed` variants.
+- Add optional `saga_id: Option<u64>` to **every** `Command` and `Event` variant in `agentmux-common/src/ipc.rs`. `#[serde(default)]` on each so old log entries remain compatible.
+- Reducer (both launcher and srv) copies `saga_id` from incoming Command into emitted Events.
+- Coordinator changes:
+  - `register(saga: Box<dyn Saga>, completion_tx: oneshot::Sender<SagaOutcome>)` — RPC handlers register and await completion.
+  - On `SagaStep::Failed`, dispatch `compensate()` commands in reverse order; emit `SagaFailed`; resolve oneshot with `SagaOutcome::Failed(reason)`.
+  - On `SagaStep::Completed { result }`, emit `SagaCompleted`; resolve oneshot with `SagaOutcome::Completed(result)`.
+- Add `dispatch_saga<S: Saga + 'static>(state: &AppState, saga: S) -> Result<serde_json::Value, String>` helper in service.rs that wraps register + await + timeout (5s default).
+
+**E.5.2: Window state in reducer + bootstrap**
+
+- New `WindowRecord { window_id: String, workspace_id: String }` in `agentmux-srv/src/state.rs`.
+- New `windows: HashMap<String, WindowRecord>` field in State.
+- New `Command::CreateWindow { window_id, workspace_id }` and `Command::CloseWindowInternal { window_id }` and `Command::SwitchWorkspace { window_id, workspace_id }` (all atomic, dispatched by sagas in later PRs).
+  - **Note:** these are introduced here so PR 1 has full window-state plumbing without behavior change. PR 2 wires them into RPC handlers; PR 3-4 wire them into sagas.
+- New `Event::WindowOpened`, `Event::WindowClosed`, `Event::WindowWorkspaceChanged` (srv-side; the launcher already has its own WindowOpened — these are scoped to srv state).
+  - **Naming clash with launcher's `WindowOpened`:** rename srv's variants to `Event::SrvWindowOpened` etc. to avoid ambiguity.
+- Reducer arms for the three commands (validation, mutation, event emission).
+- Bootstrap (`persist::bootstrap_state_from_wstore`) loads windows from wstore alongside workspaces/tabs/blocks.
+- Persist subscriber gains `apply_srv_window_opened`, `apply_srv_window_closed`, `apply_srv_window_workspace_changed`.
+- `extract_version` updated in srv reducer + launcher reducer + both event_log files for the three new events.
+- Misrouted-srv arms in launcher reducer + ipc/server for the three new commands.
+
+### What stays the same in PR 1
+- No RPC handlers change behavior. `("window", "CreateWindow")` etc. still call `wcore::*` directly.
+- No sagas implemented yet — just the framework.
+- No tear-off behavior change.
+
+### Tests
+- Reducer tests for the three window commands: happy path + validation errors.
+- Saga trait property tests: `compensate` invoked on failure; correlation IDs propagate.
+- Bootstrap test: existing wstore Window rows load into `state.windows`.
+
+### Pre-merge smoke
+None practical — no behavior change. CI green is the only gate.
+
+---
+
+## 3. PR 2 — Atomic commands + RPC migration (E.5.3 + E.5.4)
+
+### Branch
+`agenta/phase-e-5-atomic-commands`
+
+### Scope
+
+**E.5.3: New atomic commands + reducer arms + subscriber applies**
+
+New commands (all atomic, no saga):
+```rust
+Command::PromoteBlockToTab { block_id, src_tab_id, workspace_id }
+Command::ReorderTabsBulk { workspace_id, tab_ids: Vec<String> }
+Command::RenameWorkspace { workspace_id, name }
+Command::RenameTab { tab_id, name }
+Command::UpdateBlockMeta { block_id, meta_patch: serde_json::Value }
+Command::UpdateWorkspaceMeta { workspace_id, meta_patch }
+Command::UpdateTabMeta { tab_id, meta_patch }
+Command::MoveTab { tab_id, src_workspace_id, dst_workspace_id, dst_index }
+Command::MoveBlock { block_id, src_tab_id, dst_tab_id, dst_index }
+Command::DeleteWorkspaceCascade { workspace_id }  // alias for DeleteWorkspace; explicit naming for sagas
+```
+
+Corresponding events:
+```rust
+Event::BlockPromotedToTab { block_id, new_tab_id, workspace_id, version }
+Event::TabsReorderedBulk { workspace_id, tab_ids, version }
+Event::WorkspaceRenamed { workspace_id, name, version }
+Event::TabRenamed { tab_id, name, version }
+Event::BlockMetaUpdated { block_id, meta, version }   // emits the resolved meta map, not the patch
+Event::WorkspaceMetaUpdated { workspace_id, meta, version }
+Event::TabMetaUpdated { tab_id, meta, version }
+Event::TabMoved { tab_id, src_workspace_id, dst_workspace_id, dst_index, version }
+Event::BlockMoved { block_id, src_tab_id, dst_tab_id, dst_index, version }
+```
+
+**Reducer state additions:** add `meta` field to `WorkspaceRecord`, `TabRecord`, `BlockRecord`. Bootstrap populates from wstore. All test usages of these structs need the new field.
+
+Reducer arm impl for each new command (validation + mutation + event emission). Tests for each.
+
+Subscriber apply functions for each new event. Tests for each.
+
+`extract_version` updated everywhere (srv reducer + event_log + launcher reducer + launcher event_log).
+
+Misrouted-srv arms in launcher for each new command.
+
+**E.5.4: RPC migration of single-step paths**
+
+In `agentmux-srv/src/server/service.rs`, migrate these handlers from wcore-direct to reducer-dispatch:
+
+| RPC handler | Old path | New path |
+|---|---|---|
+| `("workspace", "PromoteBlockToTab")` | `wcore::promote_block_to_tab` | dispatch `Command::PromoteBlockToTab` |
+| `("workspace", "UpdateTabIds")` | direct `store.update::<Workspace>` | dispatch `Command::ReorderTabsBulk` |
+| `("workspace", "UpdateWorkspace")` | direct `store.update::<Workspace>` | dispatch `Command::RenameWorkspace` (and/or `UpdateWorkspaceMeta` if meta-only) |
+| `("object", "UpdateTabName")` | direct `store.update::<Tab>` | dispatch `Command::RenameTab` |
+| `("object", "UpdateObjectMeta")` | dispatch helper that decomposes by otype | dispatch `Command::UpdateBlockMeta` / `UpdateTabMeta` / `UpdateWorkspaceMeta` |
+| `("object", "UpdateObject")` | generic deserialize + update | decompose at RPC layer to typed Update*Meta or Rename* commands |
+| `("window", "SwitchWorkspace")` | direct `store.update::<Window>` | dispatch `Command::SwitchWorkspace` |
+
+Each follows the now-established forward+compensate pattern (or SQLite-first for inverse-difficult paths). All migrated handlers exit forward+compensate territory because they only mutate existing entities, not create new ones — no compensation needed, just dispatch + apply + publish.
+
+### What stays the same in PR 2
+- Tear-off, restore, multi-step move paths still wcore-direct (saga-shape; saved for PR 3-4).
+- CreateWindow / CloseWindow still wcore-direct (saga-shape; PR 4).
+
+### Tests
+- Reducer tests for each new arm (10+ tests).
+- Subscriber tests for each new apply (10+ tests).
+- RPC handler smoke (manual): rename a workspace, rename a tab, reorder tabs (drag), edit tab meta — verify SQLite + reducer state in sync.
+
+### Pre-merge smoke
+- Rename workspace, rename tab → persists across restart.
+- Reorder tabs (drag) → order persists.
+- Block meta edits via UI → still works.
+- **No expected fixes for tear-off.**
+
+---
+
+## 4. PR 3 — Tear-off + Restore sagas (E.5.5 + E.5.6) **← FIXES SMOKE REGRESSION**
+
+### Branch
+`agenta/phase-e-5-tear-off-sagas`
+
+### Scope
+
+**Three saga implementations** in `agentmux-srv/src/sagas/` (new module):
+
+#### TearOffTab saga
+Per spec §6.1:
+1. `CreateWorkspace { name: <derived> }` → wait for `WorkspaceCreated`
+2. `MoveTab { tab_id, src_ws_id, new_ws_id, dst_index: 0 }` → wait for `TabMoved`
+3. `CreateWindow { window_id: <new uuid>, workspace_id: new_ws_id }` → wait for `SrvWindowOpened`
+4. `Completed { result: { new_workspace_id, new_window_id } }`
+
+Compensation: reverse `MoveTab` + `DeleteWorkspaceCascade` per step.
+
+#### TearOffBlock saga
+Per spec §6.2:
+1. `CreateWorkspace` → wait for `WorkspaceCreated`
+2. `CreateTab` → wait for `TabCreated`
+3. `MoveBlock` → wait for `BlockMoved`
+4. `CreateWindow` → wait for `SrvWindowOpened`
+5. `Completed { result: { new_workspace_id, new_tab_id, new_window_id } }`
+
+#### RestoreTornOffTab saga
+Per spec §6.3:
+1. `MoveTab { tab_id, src: torn_ws_id, dst: src_ws_id }` → wait for `TabMoved`
+2. Inspect post-move state: if `torn_ws_id` empty → step 3; else → `Completed`
+3. `DeleteWorkspaceCascade { torn_ws_id }` → wait for `WorkspaceDeleted`
+4. `Completed { result: {} }`
+
+### RPC handler migration
+
+| RPC handler | New impl |
+|---|---|
+| `("workspace", "TearOffTab")` | `dispatch_saga(state, TearOffTabSaga::new(...))` then return saga's result |
+| `("workspace", "TearOffBlock")` | `dispatch_saga(state, TearOffBlockSaga::new(...))` |
+| `("workspace", "RestoreTornOffTab")` | `dispatch_saga(state, RestoreTornOffTabSaga::new(...))` |
+
+### What stays the same in PR 3
+- `MoveTabToWorkspace`, `MoveBlockToTab`, `CreateWindow`, `CloseWindow` still wcore-direct (PR 4).
+
+### Tests
+- Saga property tests per spec §8.2:
+  - Happy path for each saga
+  - Step-N failure with correct compensation
+  - Out-of-order events ignored
+- Integration test: real coordinator + reducer + subscriber + in-memory wstore.
+- Reducer correctly emits `TabMoved` with all fields populated.
+
+### Pre-merge smoke (CRITICAL)
+
+The smoke regression from `agentmux-0.33.520` should be FIXED:
+1. Tear off a tab → new window opens with the tab.
+2. **In the new window, click `+` → new tab appears.** ← this is the regression
+3. Switch between tabs in the new window — works.
+4. Close one of the tabs in the new window — works.
+5. Drag-reorder tabs in the new window — works.
+6. Restore the torn-off tab (drag back, or "Restore" UI if exists) — tab returns to original window; torn-off window closes; torn-off workspace deleted.
+
+After this PR ships, the user can resume normal smoke testing of the entire app.
+
+---
+
+## 5. PR 4 — Window sagas + cleanup (E.5.7 + E.5.8 + E.5.9)
+
+### Branch
+`agenta/phase-e-5-window-sagas-and-cleanup`
+
+### Scope
+
+**E.5.7: MoveTab + MoveBlock cross-workspace sagas**
+
+These are single-step sagas (per spec §6.4 / §6.5). Could be plain reducer commands but using saga shape preserves correlation IDs for renderer buffering (E.6).
+
+```rust
+MoveTabSaga { tab_id, src_ws_id, dst_ws_id, insert_index }
+MoveBlockSaga { block_id, src_tab_id, dst_tab_id, dst_index }
+```
+
+RPC handlers migrated:
+- `("workspace", "MoveTabToWorkspace")` → `dispatch_saga(MoveTabSaga::new(...))`
+- `("workspace", "MoveBlockToTab")` → `dispatch_saga(MoveBlockSaga::new(...))`
+
+**E.5.8: CreateWindow + CloseWindow sagas**
+
+Per spec §6.6 / §6.7:
+- `CreateWindowSaga`: CreateWorkspace → CreateWindow → Completed
+- `CloseWindowSaga`: CloseWindowInternal → conditional DeleteWorkspaceCascade → Completed
+
+RPC handlers migrated:
+- `("window", "CreateWindow")` → `dispatch_saga(CreateWindowSaga::new(...))`
+- `("window", "CloseWindow")` → `dispatch_saga(CloseWindowSaga::new(...))`
+
+**E.5.9: Cleanup**
+
+- Audit `agentmux-srv/src/server/service.rs` for any remaining wcore-direct mutations of reducer-tracked state. Should be zero.
+- Remove the `ensure_workspace_in_reducer` helper (if Option-A hot-fix was ever shipped). **Per current plan: never shipped, so nothing to remove.**
+- Drop `wstore_workspace_exists` if no longer used (was added for DeleteWorkspace fallback in E.2c.2 / E.2c.3; now redundant).
+- Update `docs/retro/multi-reducer-status-2026-04-29.md` and `phase-e-status-2026-04-30.md` to mark E.5 complete.
+
+### What stays the same in PR 4
+- Phase E.6 + E.7 still ahead — renderer multi-source + saga buffering, then phase exit.
+
+### Tests
+- Saga tests for MoveTab, MoveBlock, CreateWindow, CloseWindow.
+- Property test: after E.5.9, no `service.rs` handler calls `wcore::create_*` / `wcore::delete_*` / `wcore::move_*` directly. (Could be a clippy lint or a grep-based CI check.)
+
+### Pre-merge smoke
+- Move tab between workspaces (drag) — works, persists.
+- Move block between tabs in different workspaces — works, persists.
+- Create new window via UI → workspace + window land in SQLite + reducer.
+- Close window → workspace deleted if last reference.
+- Full app exercise — every existing user-visible flow should work end-to-end.
+
+---
+
+## 6. Per-PR completion criteria
+
+Each PR ships when:
+
+1. All listed scope items implemented.
+2. All listed tests pass.
+3. `cargo build --release -p agentmux-srv -p agentmux-cef -p agentmux-launcher` clean.
+4. `cargo test -p agentmux-srv --release` passes.
+5. Reagent + Codex APPROVE the PR (or non-blocking only).
+6. Pre-merge smoke (where defined) verified manually on a portable build.
+7. Retro doc updated.
+
+---
+
+## 7. Risk register
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Tear-off remains broken in production through PRs 1-2 (3-5 days?) | Medium | User aware; smoke for non-tear-off paths still works. |
+| Saga timeout (5s default) too aggressive | Low | Tunable; raise to 30s if any saga shows latency in proptests. |
+| Adding meta to WorkspaceRecord/TabRecord/BlockRecord breaks ~30 existing tests | Medium | Mechanical fix (similar to Block meta in E.2c.4); budget half a session. |
+| New events break the launcher's `extract_version` exhaustive match | Low | Caught at compile time; mechanical fix per new variant. |
+| Compensation logic incorrect → state diverges on saga failure | High | Property tests cover every step's compensation; smoke each saga's failure path. |
+| `dispatch_saga` oneshot future leaks if the saga never terminates | Medium | Timeout wraps the await; coordinator force-fails the saga on timeout. |
+| Saga IDs collide across processes (counter not unique cross-instance) | Low | Each instance has its own counter; not shared; saga_id is per-instance scope. Cross-process correlation isn't a requirement until Phase F. |
+
+---
+
+## 8. Carry-forwards from prior PRs
+
+These are non-blocking but should fold into one of the PRs above when convenient:
+
+- Codex P2 from #613 — ambiguous block-parent during bootstrap. Fold into PR 2's bootstrap changes (PR 2 already touches bootstrap to load meta).
+- Whatever new codex notes appear on #618 post-merge — fold into PR 1 if compatible.
+
+---
+
+## 9. Out of scope for E.5
+
+- **TypeScript renderer dispatcher** (E.2c.5b) — separate frontend PR.
+- **Renderer per-source version tracking + saga buffer** (E.6) — depends on E.2c.5b + saga events.
+- **Property tests for full Phase E** (E.7) — phase exit; covers all of D, E, F.
+- **Layout state migration** (E.4) — separate; tracks focused/magnified node only in the minimal slice.
+- **Cross-process saga correlation** — Phase F or beyond.
+
+---
+
+## 10. Decision log
+
+- **2026-04-30:** plan written. 4-PR structure agreed. Hot-fix Option A skipped in favor of going straight to sagas.
+- Refer to `SPEC_PHASE_E_SAGAS_2026-04-30.md` for the design spec; this plan is the execution sequence.

--- a/docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md
+++ b/docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md
@@ -1,0 +1,465 @@
+# Phase E Sagas — Full Specification
+
+**Date:** 2026-04-30
+**Status:** Specification (not yet implemented)
+**Supersedes the "Option D register-after" plan in** `docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md`.
+**Replaces spec §7 of** `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` **with concrete per-saga state machines.**
+
+---
+
+## 1. Goal
+
+Eliminate the reducer/wcore inconsistency window by routing **every state mutation** through the srv reducer. The remaining offenders (audit table in `phase-e-tear-off-and-remaining-2026-04-30.md` §3) are mostly **multi-entity multi-step operations** — tear-off creates a workspace + window + moves a tab; restore moves a tab back + deletes the orphan workspace. These can't be modeled as single pure-functional reducer commands without compromising the reducer's "one mutation pass, no I/O" invariant.
+
+Sagas exist exactly for this shape. The E.1a saga coordinator is already in place (`agentmux-launcher::saga`); this spec describes the per-operation saga implementations and the RPC integration that sits in front of them.
+
+**End state when this spec ships:** the reducer is the sole writer of workspace / tab / block / layout state. Every wcore-direct path in service.rs §3 either becomes a reducer-dispatch handler (single-step) or a saga-driven RPC handler (multi-step). The persist subscriber writes SQLite for everything.
+
+## 2. Status quo
+
+Already shipped (Phase E up to #618):
+
+| | |
+|---|---|
+| E.1a | Saga coordinator framework: `Saga` trait, `SagaCoordinator` task, `SagaStarted`/`SagaCompleted`/`SagaFailed` events. **No saga implementations yet.** |
+| E.1b | Srv reducer skeleton + new srv pipe + broadcast bus + event log |
+| E.2 | Workspace lifecycle arms (CreateWorkspace / DeleteWorkspace) |
+| E.2b | Tab lifecycle arms (CreateTab / DeleteTab / SetActiveTab) |
+| E.3 | Block lifecycle arms (CreateBlock / DeleteBlock) |
+| E.2c.1 | Persist subscriber plumbing (idempotent SQLite write-back) |
+| E.2c.2 | Workspace RPC migrated through reducer; full-resync-on-lag |
+| E.2c.3 / E.2c.3b | Tab RPC migrated (CreateTab + SetActiveTab + CloseTab + ReorderTab) |
+| E.2c.4 | Block RPC migrated (CreateBlock + DeleteBlock with meta) |
+| E.2c.5a | Rust host bridge to srv pipe (forwards events to renderer) |
+
+What remains, ordered by dependency:
+
+| | |
+|---|---|
+| **E.2c.5b** | TypeScript renderer dispatcher (`window.__agentmux_srv_event` + atom routing) |
+| **E.2c.6 (hot-fix)** | Lazy-load (Option A) for the tear-off → CreateTab regression — ships in parallel as the smoke unblock |
+| **E.4** | Layout state — minimal slice (focused/magnified node tracking) |
+| **E.5 (this spec)** | Sagas + atomic single-step migrations for everything in audit §3 |
+| **E.6** | Renderer multi-source consumption + saga buffering |
+| **E.7** | Property tests + integration tests + `--diag` Tools |
+
+## 3. The remaining problem (recap)
+
+14 wcore-direct paths in `agentmux-srv/src/server/service.rs`. Categorized by shape:
+
+### 3a. Multi-step (saga shape)
+- `TearOffTab` — create new workspace + new window + move tab to new workspace
+- `TearOffBlock` — create new workspace + new window + new tab + move block to new tab
+- `RestoreTornOffTab` — move tab back to source workspace + delete now-orphan workspace + close torn-off window
+- `MoveTabToWorkspace` — remove tab from src workspace's tab_ids + add to dst workspace's tab_ids + update activetabid in both if affected
+- `MoveBlockToTab` (cross-workspace) — remove block from src tab's block_ids + add to dst tab's block_ids + update block.parentoref
+- `CreateWindow` — create new workspace + create window pointing at it
+- `CloseWindow` — close window + (conditionally) cascade-delete orphan workspace if no other window references it
+
+### 3b. Single-step (atomic command, no saga)
+- `PromoteBlockToTab` — within one workspace: create new tab + move block to it + update parents
+- `UpdateTabIds` — overwrite workspace.tabids wholesale
+- `UpdateWorkspace` — rename workspace
+- `UpdateTabName` — rename tab
+- `UpdateObjectMeta` — meta merge on workspace/tab/block
+- `UpdateObject` — generic wave-obj update (catch-all)
+- `SwitchWorkspace` — change which workspace a window points at
+
+### 3c. Already-saga (or trivially equivalent)
+None yet.
+
+---
+
+## 4. Saga design
+
+### 4.1 Coordinator contract (recap from E.1a)
+
+```rust
+pub trait Saga: Send + 'static {
+    /// Unique saga identity. Carried on all commands/events the
+    /// coordinator dispatches on behalf of this saga so subscribers
+    /// can correlate.
+    fn saga_id(&self) -> u64;
+
+    /// Called once when the coordinator starts the saga. Returns
+    /// the initial set of Commands to dispatch into the reducer.
+    /// Empty Vec means "wait for an external event before doing anything"
+    /// (rare; most sagas have an immediate first step).
+    fn start(&mut self) -> Vec<Command>;
+
+    /// Called by the coordinator for every Event the reducer emits
+    /// while this saga is in flight. Returns either:
+    ///   - Vec<Command> to dispatch next (continues the saga)
+    ///   - SagaStep::Completed { result } to mark success
+    ///   - SagaStep::Failed { reason } to mark failure (coordinator
+    ///     emits SagaFailed; sub-spec defines compensation)
+    ///
+    /// IMPORTANT: must NOT mutate reducer state directly; only
+    /// returns commands the coordinator will dispatch.
+    fn on_event(&mut self, event: &Event) -> SagaStep;
+}
+
+pub enum SagaStep {
+    Continue(Vec<Command>),
+    Completed { result: serde_json::Value },
+    Failed { reason: String },
+}
+```
+
+The coordinator:
+- Owns `Vec<Box<dyn Saga>>` — active sagas
+- Subscribes to the broadcast bus
+- For each Event, calls `saga.on_event(event)` for every active saga; processes each saga's returned commands (dispatches via `reducer::update`)
+- Emits `Event::SagaStarted { saga_id, kind }` when a saga is registered
+- Emits `Event::SagaCompleted { saga_id, result }` or `Event::SagaFailed { saga_id, reason }` when a saga's `on_event` returns a terminal `SagaStep`
+
+### 4.2 Saga correlation IDs on commands/events
+
+Every `Command` and every `Event` gains an optional `saga_id: Option<u64>` field. The coordinator sets this to `Some(saga.saga_id())` on commands it dispatches; the reducer copies it through to emitted events. Subscribers (renderer especially) use it to:
+
+- **Group events** belonging to the same logical operation.
+- **Buffer-until-complete** so the renderer applies cross-entity changes atomically rather than mid-flight (E.6).
+- **Filter `--diag` output** to see one saga's full lifecycle.
+
+`saga_id: None` = "not part of a saga" (the vast majority of events from RPC-direct dispatches).
+
+### 4.3 Compensation semantics
+
+When a saga's step N fails, the saga's `on_event` returns `SagaStep::Failed { reason }`. The coordinator emits `SagaFailed` and calls a separate `Saga::compensate(&mut self) -> Vec<Command>` method (see expanded trait below) to roll back already-applied steps. Compensating commands are dispatched in REVERSE order of the original steps.
+
+**Expanded trait:**
+```rust
+pub trait Saga: Send + 'static {
+    fn saga_id(&self) -> u64;
+    fn start(&mut self) -> Vec<Command>;
+    fn on_event(&mut self, event: &Event) -> SagaStep;
+    /// Called when a step fails. Returns commands that undo the
+    /// already-completed steps (in reverse order). Default: no-op.
+    /// Compensation is best-effort — if a compensating command itself
+    /// fails, the coordinator logs and continues.
+    fn compensate(&mut self) -> Vec<Command> { Vec::new() }
+}
+```
+
+### 4.4 Idempotency
+
+Every reducer command in a saga must be idempotent OR carry enough information to detect "already applied". Specifically:
+
+- `CreateWorkspace` is NOT idempotent on retry (UUID generated per call). Sagas avoid retry by tracking which steps have already started; the coordinator only re-invokes `start` once per saga registration.
+- `Move*` operations are idempotent if the target state matches (move block to tab where it already is = no-op).
+- `Delete*` are silently idempotent.
+
+Sagas should be designed so each step's success is observable from the events alone. If a saga state machine can't tell whether step N succeeded from the event stream, it can't safely compensate.
+
+### 4.5 RPC integration model
+
+For each saga-driven RPC, the handler:
+
+1. Generates a fresh `saga_id` (monotonic counter on `srv_state`).
+2. Constructs a `Saga` instance with the inputs.
+3. Registers it with the coordinator (`coordinator.register(Box::new(saga))`).
+4. Awaits `Event::SagaCompleted { saga_id }` OR `Event::SagaFailed { saga_id }` on the broadcast bus.
+5. Returns the saga's `result` to the HTTP caller (or surfaces the failure reason).
+
+Steps 4-5 happen via a tokio oneshot channel set up at registration: the coordinator sends the terminal event into the channel; the RPC handler awaits.
+
+```rust
+async fn dispatch_saga<S: Saga + 'static>(
+    state: &AppState,
+    saga: S,
+) -> Result<serde_json::Value, String> {
+    let saga_id = saga.saga_id();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    state.saga_coordinator.register(Box::new(saga), tx).await;
+    match rx.await {
+        Ok(SagaOutcome::Completed(result)) => Ok(result),
+        Ok(SagaOutcome::Failed(reason)) => Err(reason),
+        Err(_) => Err("saga channel closed before completion".into()),
+    }
+}
+```
+
+**Timeout:** RPC handler wraps `rx.await` in `tokio::time::timeout(SAGA_TIMEOUT, ...)`. Default 5 seconds. Timeout cancels the saga (coordinator marks it failed + dispatches compensation).
+
+---
+
+## 5. Wire protocol additions
+
+### 5.1 New single-step commands (no saga)
+
+Atomic commands the reducer supports directly. Each gets a corresponding event.
+
+```rust
+Command::PromoteBlockToTab { block_id, src_tab_id, workspace_id }
+Command::ReorderTabsBulk { workspace_id, tab_ids: Vec<String> }       // for UpdateTabIds
+Command::RenameWorkspace { workspace_id, name }                        // for UpdateWorkspace
+Command::RenameTab { tab_id, name }                                    // for UpdateTabName
+Command::UpdateBlockMeta { block_id, meta_patch: serde_json::Value }   // for UpdateObjectMeta on Block
+Command::UpdateWorkspaceMeta { workspace_id, meta_patch }
+Command::UpdateTabMeta { tab_id, meta_patch }
+Command::SwitchWorkspace { window_id, workspace_id }                   // window_id needs to be tracked in reducer
+```
+
+Note: `UpdateObject` (the catch-all generic update) deconstructs at the RPC layer into one of the typed commands above based on otype. No `Command::UpdateObject` in the reducer.
+
+### 5.2 Saga-internal commands (only used inside saga step machines)
+
+```rust
+Command::CreateWindow { window_id, workspace_id, pos, size }          // window_id pre-assigned
+Command::CloseWindowInternal { window_id }
+Command::MoveTab { tab_id, src_workspace_id, dst_workspace_id, dst_index }
+Command::MoveBlock { block_id, src_tab_id, dst_tab_id, dst_index }
+Command::DeleteWorkspaceCascade { workspace_id }                       // explicit cascade delete; same as current DeleteWorkspace but with explicit naming
+```
+
+### 5.3 Saga lifecycle events (already in E.1a)
+
+```rust
+Event::SagaStarted { saga_id, kind: String, version }
+Event::SagaCompleted { saga_id, result: serde_json::Value, version }
+Event::SagaFailed { saga_id, reason: String, version }
+```
+
+**`kind`** is a string discriminator: `"tear_off_tab"`, `"create_window"`, etc. Lets `--diag` filter by saga type.
+
+### 5.4 Window state in reducer (NEW)
+
+To support window-related sagas, the reducer needs a `windows: HashMap<String, WindowRecord>` map. Currently the reducer doesn't track windows; window state is wcore-direct via `Window` SQLite rows.
+
+```rust
+pub struct WindowRecord {
+    pub window_id: String,
+    pub workspace_id: String,
+    // Future: pos, size, focused — not needed for sagas in scope here.
+}
+```
+
+`Command::CreateWindow` inserts; `Command::CloseWindowInternal` removes; `Command::SwitchWorkspace` updates `workspace_id`.
+
+Bootstrap loads windows from wstore (alongside workspaces).
+
+---
+
+## 6. Per-saga specifications
+
+For each saga: trigger / steps / events watched / compensation / RPC return.
+
+### 6.1 TearOffTab
+
+**Trigger RPC:** `("workspace", "TearOffTab")` with `tab_id` and source `ws_id`.
+
+**Steps:**
+1. `CreateWorkspace { name: <derived from tab name> }` → wait for `WorkspaceCreated { workspace_id: new_ws_id }`
+2. `MoveTab { tab_id, src_workspace_id: src_ws_id, dst_workspace_id: new_ws_id, dst_index: 0 }` → wait for `TabMoved`
+3. `CreateWindow { window_id: <new uuid>, workspace_id: new_ws_id, pos: <derived>, size: <derived> }` → wait for `WindowOpened`
+4. `Completed { result: { new_workspace_id, new_window_id } }`
+
+**Compensation (reverse order on failure):**
+- After step 3 fail: `MoveTab { tab_id, src: new_ws_id, dst: src_ws_id }` then `DeleteWorkspaceCascade { new_ws_id }`
+- After step 2 fail: `DeleteWorkspaceCascade { new_ws_id }`
+- After step 1 fail: nothing to compensate; saga just fails
+
+**Subscriber side-effects:** `WorkspaceCreated` writes new workspace; `TabMoved` updates both workspaces' `tabids`; `WindowOpened` writes new Window row; `WorkspaceDeleted` (compensation) cascades.
+
+**RPC return:** `{ new_workspace_id, new_window_id }` — the host needs the window id to actually open the CEF window. Host bridge subscribes to `WindowOpened` and creates the CEF window; saga doesn't directly call CEF.
+
+### 6.2 TearOffBlock
+
+**Trigger RPC:** `("workspace", "TearOffBlock")` with `block_id`, `src_tab_id`, `src_ws_id`.
+
+**Steps:**
+1. `CreateWorkspace` → wait for `WorkspaceCreated { new_ws_id }`
+2. `CreateTab { workspace_id: new_ws_id, name: <derived> }` → wait for `TabCreated { new_tab_id }`
+3. `MoveBlock { block_id, src_tab_id, dst_tab_id: new_tab_id, dst_index: 0 }` → wait for `BlockMoved`
+4. `CreateWindow { workspace_id: new_ws_id, ... }` → wait for `WindowOpened { new_window_id }`
+5. `Completed { result: { new_workspace_id, new_tab_id, new_window_id } }`
+
+**Compensation:** reverse steps 4 → 1.
+
+### 6.3 RestoreTornOffTab
+
+**Trigger RPC:** `("workspace", "RestoreTornOffTab")` with `tab_id`, source `src_ws_id` (the original workspace), and the torn-off `torn_ws_id`.
+
+**Steps:**
+1. `MoveTab { tab_id, src_workspace_id: torn_ws_id, dst_workspace_id: src_ws_id, dst_index: <append> }` → wait for `TabMoved`
+2. Inspect `TabMoved` event: if `torn_ws_id` is now empty (no tabs left), proceed to step 3; otherwise complete.
+3. `DeleteWorkspaceCascade { torn_ws_id }` → wait for `WorkspaceDeleted`
+4. (Window close is host-side: host's existing CEF window-close logic fires when the workspace is gone. No saga step needed.)
+5. `Completed { result: {} }`
+
+**Compensation:** if step 1 fails, no rollback needed. If step 3 fails (e.g., the torn workspace has tabs again somehow), saga fails but step 1's MoveTab is already committed.
+
+### 6.4 MoveTabToWorkspace
+
+**Trigger RPC:** `("workspace", "MoveTabToWorkspace")` with `tab_id`, `src_ws_id`, `dst_ws_id`, `insert_index`.
+
+**Steps:**
+1. `MoveTab { tab_id, src_workspace_id: src_ws_id, dst_workspace_id: dst_ws_id, dst_index: insert_index }` → wait for `TabMoved`
+2. `Completed { result: {} }`
+
+Single-step saga (could also be modeled as a plain reducer command; using saga shape for uniformity with TearOff and to carry `saga_id` for renderer buffering).
+
+### 6.5 MoveBlockToTab (cross-workspace)
+
+**Trigger RPC:** `("workspace", "MoveBlockToTab")` with `block_id`, `src_tab_id`, `dst_tab_id`, `dst_index`.
+
+**Steps:**
+1. `MoveBlock { block_id, src_tab_id, dst_tab_id, dst_index }` → wait for `BlockMoved`
+2. `Completed { result: {} }`
+
+Same shape as 6.4. The "cross-workspace" detection is in the reducer's `handle_move_block` which adjusts both tabs' block_ids regardless of which workspace they belong to.
+
+### 6.6 CreateWindow
+
+**Trigger RPC:** `("window", "CreateWindow")`.
+
+**Steps:**
+1. `CreateWorkspace { name: "Workspace" }` → wait for `WorkspaceCreated { new_ws_id }`
+2. `CreateWindow { window_id: <new uuid>, workspace_id: new_ws_id, pos, size }` → wait for `WindowOpened { new_window_id }`
+3. `Completed { result: { new_window_id, new_workspace_id } }`
+
+**Compensation:** if step 2 fails, `DeleteWorkspaceCascade { new_ws_id }`.
+
+### 6.7 CloseWindow
+
+**Trigger RPC:** `("window", "CloseWindow")` with `window_id`.
+
+**Steps:**
+1. Read window's `workspace_id` from reducer state.
+2. `CloseWindowInternal { window_id }` → wait for `WindowClosed`
+3. Check if any other window in `state.windows` references the same `workspace_id`. If yes, `Completed`. If no:
+4. `DeleteWorkspaceCascade { workspace_id }` → wait for `WorkspaceDeleted`
+5. `Completed { result: {} }`
+
+**Compensation:** if step 4 fails, nothing to do (window's already closed).
+
+### 6.8 Single-step migrations (not sagas)
+
+Each becomes a direct reducer dispatch in the RPC handler. Pattern:
+
+```rust
+("workspace", "PromoteBlockToTab") => {
+    let events = dispatch_to_reducer(state, Command::PromoteBlockToTab { ... }).await;
+    // surface errors; apply synchronously to wstore; publish; return.
+}
+```
+
+Reducer handlers added:
+- `handle_promote_block_to_tab` — validates block + tab exist; assigns new tab UUID; mutates state.
+- `handle_reorder_tabs_bulk` — validates `tab_ids` is a permutation of workspace's current tab_ids; replaces.
+- `handle_rename_workspace` / `_tab` — trivial field update.
+- `handle_update_*_meta` — JSON merge on the appropriate record's meta map. **Note:** reducer's WorkspaceRecord/TabRecord/BlockRecord don't currently carry meta; needs adding.
+- `handle_switch_workspace` — updates `state.windows[window_id].workspace_id`.
+
+**Reducer state additions for meta:**
+```rust
+pub struct WorkspaceRecord {
+    // existing fields...
+    pub meta: serde_json::Map<String, serde_json::Value>,  // NEW
+}
+// similarly for TabRecord, BlockRecord
+```
+
+Bootstrap loads meta from wstore. Subscriber writes meta on each create/update event.
+
+---
+
+## 7. Persist subscriber changes
+
+Add apply handlers for the new events:
+
+| Event | Apply action |
+|---|---|
+| `Event::TabMoved { tab_id, src_ws, dst_ws, dst_index, .. }` | wcore::move_tab_to_workspace (or equivalent direct mutation) |
+| `Event::BlockMoved { block_id, src_tab, dst_tab, dst_index, .. }` | wcore::move_block_to_tab |
+| `Event::WindowOpened { window_id, workspace_id, .. }` | insert Window row |
+| `Event::WindowClosed { window_id, .. }` | delete Window row |
+| `Event::WorkspaceRenamed / TabRenamed / BlockMetaUpdated / etc.` | update appropriate row |
+
+All idempotent via "check current state, no-op if already match". Handles the same way the existing `apply_workspace_created` etc. do.
+
+Saga lifecycle events (`SagaStarted` / `SagaCompleted` / `SagaFailed`) are NOT persisted — they're transient. Subscribers ignore them.
+
+---
+
+## 8. Test plan
+
+### 8.1 Reducer property tests
+
+For each new reducer arm: unit tests covering happy path + invalid inputs + idempotency.
+
+### 8.2 Saga property tests
+
+Per saga, test:
+- Successful path: simulate happy-path event sequence; assert saga completes with expected result
+- Step-N failure: simulate failure event at each step boundary; assert correct compensation commands
+- Out-of-order events: feed unrelated events between saga's expected ones; assert saga ignores them
+
+### 8.3 Integration tests (Phase E.7)
+
+End-to-end: real srv reducer + real coordinator + real subscriber + in-memory wstore. RPC handler kicks off saga; assert wstore state matches expected after `SagaCompleted`. Crash mid-saga (kill subscriber after step N); assert bootstrap recovers correctly.
+
+### 8.4 Smoke
+
+Manual portable: tear off tab, restore tab, move tab between workspaces, create window via UI, close window. After each action: `--diag srv` should show coherent state matching the UI.
+
+---
+
+## 9. Sequencing & PR breakdown
+
+To keep PRs reviewable (~500-800 LoC each):
+
+| PR | Scope | Est LoC |
+|---|---|---|
+| **E.5.1** | Saga trait extension (compensate + on_event) + coordinator wiring + correlation IDs | ~350 |
+| **E.5.2** | Reducer state: windows map + bootstrap + extract_version + tests | ~300 |
+| **E.5.3** | New atomic commands: PromoteBlockToTab, ReorderTabsBulk, Rename*, Update*Meta, SwitchWorkspace + reducer arms + subscriber applies | ~600 |
+| **E.5.4** | RPC migration of single-step paths in §3b — they all become reducer-direct dispatches | ~300 |
+| **E.5.5** | TearOffTab saga (first concrete saga; proves the pattern) | ~400 |
+| **E.5.6** | TearOffBlock + RestoreTornOffTab sagas | ~400 |
+| **E.5.7** | MoveTabToWorkspace + MoveBlockToTab(cross-ws) sagas | ~300 |
+| **E.5.8** | CreateWindow + CloseWindow sagas (last because window state requires E.5.2 to land first) | ~400 |
+| **E.5.9** | Drop Option-A `ensure_workspace_in_reducer` helper (no longer needed; all paths reducer-routed) | ~50 (deletion) |
+
+**Total: ~3100 LoC across 9 PRs.** Each individually shippable + testable. The Option-A hot-fix from `phase-e-tear-off-and-remaining-2026-04-30.md` ships in parallel as the immediate smoke unblock; E.5.9 retires it.
+
+---
+
+## 10. Open questions
+
+1. **Does the renderer need to wait for `SagaCompleted` before applying any event?** E.6 specifies "saga buffer-until-complete" — but in practice the renderer is read-mostly and applying intermediate events shouldn't break the UI. Decision: **buffer optionally, default off in E.5; E.6 can flip to on with measurement.**
+
+2. **What happens if an RPC times out but the saga is still running?** The HTTP caller gets a timeout error; the saga keeps progressing. If it eventually completes, the resulting state changes still propagate (events still emit). UX: the user sees the change happen "after" the API said it failed. **Acceptable** — better than aborting mid-way and leaving inconsistent state.
+
+3. **Should saga registration be idempotent?** A double-fire from a flaky frontend could trigger two TearOffTab sagas for the same tab. Each generates its own saga_id; both run. The second's MoveTab might fail because the tab is no longer in src_workspace. Saga compensates. End state: one new workspace (from the first saga); the second's compensation cleans its own new workspace. **Acceptable but wasteful.** Future: the RPC layer could dedupe by hashing the input; out of scope for E.5.
+
+4. **How does the host bridge surface saga events to the renderer?** Same pipe, same dispatcher (E.2c.5b). The renderer's atom router treats `SagaStarted/Completed/Failed` as metadata events; only acts on the wrapped per-step events.
+
+5. **What about Layout state?** Sagas that touch tabs may need to update layouts (tear-off creates a new layout for the new workspace's tab). Layout migration is E.4, separate from sagas. Sagas in E.5 either skip layout updates (host catches up via existing wcore::heal_layout call paths) OR include `Command::CreateLayoutState` once E.4 lands. Decision: **defer layout integration to a follow-up E.5b once E.4 ships.**
+
+6. **CreateBlock with explicit tab_id arg (TOCTOU race)** — the existing CreateBlock handler accepts an optional explicit tab_id at args[2] to avoid the active-tab-changed race. Sagas that create blocks (TearOffBlock step 3) inherently know the destination tab_id. Direct saga dispatches bypass the TOCTOU concern. **No change needed.**
+
+---
+
+## 11. Decision
+
+This spec is the plan. Implementation proceeds via the 9-PR sequence in §9.
+
+**Immediate next steps:**
+
+1. **Ship the Option-A hot-fix** (already on `agenta/phase-e-2c-fix-tear-off-workspace`) — unblock smoke.
+2. **Open E.5.1** — saga trait extension + coordinator wiring + correlation IDs. Foundational; gates everything else.
+3. Iterate through E.5.2 → E.5.9 per the table.
+
+E.2c.5b (TypeScript renderer dispatcher) can ship in parallel with the E.5.x series — it doesn't depend on saga work.
+
+E.4 (Layout) can also ship in parallel; saga integration with layouts is deferred to E.5b.
+
+---
+
+## 12. Cross-references
+
+- `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §7 — original (sketchy) saga spec; this doc supersedes.
+- `docs/retro/phase-e-status-2026-04-30.md` — phase status snapshot
+- `docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md` — the bug analysis that motivated this spec
+- `docs/retro/multi-reducer-status-2026-04-29.md` — running phase progress

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.520",
+  "version": "0.33.521",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**PR 1 of 4** in the Phase E.5 saga rollout. Per the new [execution plan](https://github.com/agentmuxai/agentmux/blob/agenta/phase-e-5-foundation/docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md):

| PR | Scope | Smoke fix? |
|---|---|---|
| **PR 1 (this)** | Window state in reducer + design docs | No (foundation) |
| PR 2 | Atomic single-step commands + RPC migration | No |
| PR 3 | TearOff + Restore sagas | **YES — fixes tear-off → \"+\" tab regression** |
| PR 4 | Move + CreateWindow + CloseWindow sagas + cleanup | All migrations done |

## Window state in reducer

The reducer gains \`state.windows: HashMap<String, WindowRecord>\` to support sagas (TearOff/Restore/CreateWindow/CloseWindow) that coordinate window↔workspace lifecycle atomically.

\`\`\`rust
pub struct WindowRecord {
    pub window_id: String,
    pub workspace_id: String,
}
\`\`\`

Distinct from the launcher's CEF window state — that one tracks label/kind/hwnd; this one is purely about \"which workspace does each window point at.\"

Three new commands + matching events:

| Command | Event | Validation |
|---|---|---|
| \`CreateWindow { window_id, workspace_id }\` | \`SrvWindowOpened\` | workspace must exist; idempotent on duplicate window_id+workspace_id |
| \`CloseWindowInternal { window_id }\` | \`SrvWindowClosed\` | silent no-op if missing |
| \`SwitchWorkspace { window_id, workspace_id }\` | \`SrvWindowWorkspaceChanged\` | window + workspace must exist; no-op if already pointing |

## Design docs included

- \`docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md\` — analysis of the tear-off bug + 4 design options + audit of the 14 wcore-direct paths
- \`docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md\` — full saga design spec (trait contract, per-saga state machines, wire protocol)
- \`docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md\` — 4-PR execution plan with per-PR scope, completion criteria, risk register

## Out of scope (intentionally — later PRs)

- No saga implementations (PR 3)
- No saga trait extension (\`compensate\`, oneshot completion) — deferred to PR 3 where TearOffTab consumes them
- No \`saga_id\` correlation on events — deferred to PR 3
- No RPC handler migrations — PR 2 (single-step) and PR 3 (saga-driven)

The new window commands are **not yet dispatched by any RPC handler** — they're plumbing for sagas to use in PR 3-4.

## Test plan

- [x] \`cargo check -p agentmux-srv -p agentmux-launcher --release\` clean
- [x] 9 reducer tests added covering: validation (workspace not found, window not found), idempotency (same workspace = no-op), happy path, and switch with no-op detection
- [ ] **Full \`cargo test --release\`**: hit Windows linker stack-overrun (\`STATUS_STACK_BUFFER_OVERRUN\`) on this dev machine — environmental, not code-related. CI on fresh infra will validate.
- [ ] No smoke test possible — no behavior change in this PR.

## Carryovers (not addressed here)

- **Tear-off regression remains**: smoke fix lands in PR 3 alongside the TearOffTab saga.
- Codex P2 from #613 (ambiguous block-parent during bootstrap) — fold into PR 2 where bootstrap gains meta tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)