### PR TITLE
feat(E.5.3+4): atomic single-step commands + RPC migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.521"
+version = "0.33.522"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.521"
+version = "0.33.522"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.521"
+version = "0.33.522"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.521"
+version = "0.33.522"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.521"
+version = "0.33.522"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.521"
+version = "0.33.522"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -303,6 +303,50 @@ pub enum Command {
         window_id: String,
         workspace_id: String,
     },
+    /// Phase E.5.3 — replace a workspace's `tab_ids` with the given
+    /// list. The new list must be a permutation of the current set
+    /// (same elements, possibly different order); reducer errors
+    /// otherwise. Used by the drag-reorder UI's bulk-reorder path
+    /// (replaces wcore-direct `UpdateTabIds`).
+    ReorderTabsBulk {
+        workspace_id: String,
+        tab_ids: Vec<String>,
+    },
+    /// Phase E.5.3 — rename a workspace. Errors if the workspace
+    /// doesn't exist; no-op if the name is identical.
+    RenameWorkspace {
+        workspace_id: String,
+        name: String,
+    },
+    /// Phase E.5.3 — rename a tab. Errors if the tab doesn't exist;
+    /// no-op if identical.
+    RenameTab {
+        tab_id: String,
+        name: String,
+    },
+    /// Phase E.5.3 — apply a meta-patch to a workspace. The reducer
+    /// validates the entity exists and emits `Event::WorkspaceMetaUpdated`
+    /// with the patch payload; the persist subscriber performs the
+    /// actual merge against wstore. Reducer state does NOT track meta
+    /// in E.5.3 — pass-through preserves the reducer's small footprint
+    /// without losing the migration property (every mutation goes
+    /// through the reducer's broadcast bus).
+    UpdateWorkspaceMeta {
+        workspace_id: String,
+        meta_patch: serde_json::Value,
+    },
+    /// Phase E.5.3 — apply a meta-patch to a tab. Same pass-through
+    /// shape as `UpdateWorkspaceMeta`.
+    UpdateTabMeta {
+        tab_id: String,
+        meta_patch: serde_json::Value,
+    },
+    /// Phase E.5.3 — apply a meta-patch to a block. Same pass-through
+    /// shape as `UpdateWorkspaceMeta`.
+    UpdateBlockMeta {
+        block_id: String,
+        meta_patch: serde_json::Value,
+    },
     /// Phase E.3 — create a block inside an existing tab. Reducer
     /// validates parent tab exists, assigns the `block_id` (UUID),
     /// appends to the tab's `block_ids`, emits `Event::BlockCreated`.
@@ -755,6 +799,48 @@ pub enum Event {
     SrvWindowWorkspaceChanged {
         window_id: String,
         workspace_id: String,
+        version: u64,
+    },
+    /// Phase E.5.3 — workspace's `tab_ids` was replaced wholesale.
+    /// Subscribers should rewrite the persistent `Workspace.tabids`
+    /// to match the new list (preserving `pinnedtabids` separately —
+    /// pinning is a Waveterm legacy and not in scope here).
+    TabsReorderedBulk {
+        workspace_id: String,
+        tab_ids: Vec<String>,
+        version: u64,
+    },
+    /// Phase E.5.3 — workspace was renamed.
+    WorkspaceRenamed {
+        workspace_id: String,
+        name: String,
+        version: u64,
+    },
+    /// Phase E.5.3 — tab was renamed.
+    TabRenamed {
+        tab_id: String,
+        name: String,
+        version: u64,
+    },
+    /// Phase E.5.3 — meta-patch applied to a workspace. Carries the
+    /// patch (NOT the resolved meta map); subscribers merge against
+    /// the workspace's existing meta. This shape lets sagas inspect
+    /// what changed without needing the prior state.
+    WorkspaceMetaUpdated {
+        workspace_id: String,
+        meta_patch: serde_json::Value,
+        version: u64,
+    },
+    /// Phase E.5.3 — meta-patch applied to a tab.
+    TabMetaUpdated {
+        tab_id: String,
+        meta_patch: serde_json::Value,
+        version: u64,
+    },
+    /// Phase E.5.3 — meta-patch applied to a block.
+    BlockMetaUpdated {
+        block_id: String,
+        meta_patch: serde_json::Value,
         version: u64,
     },
     /// Phase E.3 — block was created inside a tab.

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.521"
+version = "0.33.522"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -275,6 +275,12 @@ fn event_version(e: &Event) -> u64 {
         | Event::SrvWindowOpened { version, .. }
         | Event::SrvWindowClosed { version, .. }
         | Event::SrvWindowWorkspaceChanged { version, .. }
+        | Event::TabsReorderedBulk { version, .. }
+        | Event::WorkspaceRenamed { version, .. }
+        | Event::TabRenamed { version, .. }
+        | Event::WorkspaceMetaUpdated { version, .. }
+        | Event::TabMetaUpdated { version, .. }
+        | Event::BlockMetaUpdated { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -690,6 +690,31 @@ async fn enforce_register_first(
             "SwitchWorkspace is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.5.3 — atomic single-step domain commands are srv-pipe.
+        Command::ReorderTabsBulk { .. } => (
+            "ReorderTabsBulk is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::RenameWorkspace { .. } => (
+            "RenameWorkspace is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::RenameTab { .. } => (
+            "RenameTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::UpdateWorkspaceMeta { .. } => (
+            "UpdateWorkspaceMeta is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::UpdateTabMeta { .. } => (
+            "UpdateTabMeta is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::UpdateBlockMeta { .. } => (
+            "UpdateBlockMeta is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => (
             "CreateBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -288,6 +288,61 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.5.3 — atomic single-step domain commands are srv-pipe.
+        Command::ReorderTabsBulk { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "ReorderTabsBulk is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::RenameWorkspace { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "RenameWorkspace is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::RenameTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "RenameTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::UpdateWorkspaceMeta { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "UpdateWorkspaceMeta is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::UpdateTabMeta { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "UpdateTabMeta is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::UpdateBlockMeta { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "UpdateBlockMeta is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.3 — Block arms are also srv-pipe commands.
         Command::CreateBlock { .. } => {
             let v = state.bump_version();
@@ -975,6 +1030,12 @@ mod tests {
             | Event::SrvWindowOpened { version, .. }
             | Event::SrvWindowClosed { version, .. }
             | Event::SrvWindowWorkspaceChanged { version, .. }
+            | Event::TabsReorderedBulk { version, .. }
+            | Event::WorkspaceRenamed { version, .. }
+            | Event::TabRenamed { version, .. }
+            | Event::WorkspaceMetaUpdated { version, .. }
+            | Event::TabMetaUpdated { version, .. }
+            | Event::BlockMetaUpdated { version, .. }
             | Event::BlockCreated { version, .. }
             | Event::BlockDeleted { version, .. }
             | Event::Error { version, .. } => *version,

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.521"
+version = "0.33.522"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -275,6 +275,12 @@ fn event_version(e: &Event) -> u64 {
         | Event::SrvWindowOpened { version, .. }
         | Event::SrvWindowClosed { version, .. }
         | Event::SrvWindowWorkspaceChanged { version, .. }
+        | Event::TabsReorderedBulk { version, .. }
+        | Event::WorkspaceRenamed { version, .. }
+        | Event::TabRenamed { version, .. }
+        | Event::WorkspaceMetaUpdated { version, .. }
+        | Event::TabMetaUpdated { version, .. }
+        | Event::BlockMetaUpdated { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -233,6 +233,30 @@ pub(crate) fn apply_event_to_wstore(
             workspace_id,
             ..
         } => apply_srv_window_workspace_changed(wstore, window_id, workspace_id),
+        Event::TabsReorderedBulk {
+            workspace_id,
+            tab_ids,
+            ..
+        } => apply_tabs_reordered_bulk(wstore, workspace_id, tab_ids),
+        Event::WorkspaceRenamed {
+            workspace_id, name, ..
+        } => apply_workspace_renamed(wstore, workspace_id, name),
+        Event::TabRenamed { tab_id, name, .. } => apply_tab_renamed(wstore, tab_id, name),
+        Event::WorkspaceMetaUpdated {
+            workspace_id,
+            meta_patch,
+            ..
+        } => apply_workspace_meta_updated(wstore, workspace_id, meta_patch),
+        Event::TabMetaUpdated {
+            tab_id,
+            meta_patch,
+            ..
+        } => apply_tab_meta_updated(wstore, tab_id, meta_patch),
+        Event::BlockMetaUpdated {
+            block_id,
+            meta_patch,
+            ..
+        } => apply_block_meta_updated(wstore, block_id, meta_patch),
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -518,6 +542,137 @@ fn apply_srv_window_workspace_changed(
     apply_srv_window_opened(wstore, window_id, workspace_id)
 }
 
+/// Phase E.5.3 — replace the workspace's `tabids` with the new
+/// list. `pinnedtabids` is left alone (pinning is Waveterm legacy
+/// and not in the reorder scope). No-op if already matching.
+fn apply_tabs_reordered_bulk(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    tab_ids: &[String],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
+        return Ok(());
+    };
+    if ws.tabids == tab_ids {
+        return Ok(());
+    }
+    ws.tabids = tab_ids.to_vec();
+    wstore.update(&mut ws)?;
+    Ok(())
+}
+
+/// Phase E.5.3 — rename a persisted workspace.
+fn apply_workspace_renamed(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
+        return Ok(());
+    };
+    if ws.name == name {
+        return Ok(());
+    }
+    ws.name = name.to_string();
+    wstore.update(&mut ws)?;
+    Ok(())
+}
+
+/// Phase E.5.3 — rename a persisted tab.
+fn apply_tab_renamed(
+    wstore: &WaveStore,
+    tab_id: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.name == name {
+        return Ok(());
+    }
+    tab.name = name.to_string();
+    wstore.update(&mut tab)?;
+    Ok(())
+}
+
+/// Phase E.5.3 — apply a meta-patch to a workspace's `meta` map.
+/// Reducer doesn't track meta in `WorkspaceRecord`; this subscriber
+/// is the sole authority that mutates persisted meta. Patch is a
+/// JSON object that merges shallow-key-by-shallow-key on top of the
+/// existing meta. `null` values in the patch delete the key.
+fn apply_workspace_meta_updated(
+    wstore: &WaveStore,
+    workspace_id: &str,
+    meta_patch: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
+        return Ok(());
+    };
+    if merge_meta_patch(&mut ws.meta, meta_patch) {
+        wstore.update(&mut ws)?;
+    }
+    Ok(())
+}
+
+/// Phase E.5.3 — apply a meta-patch to a tab's `meta` map.
+fn apply_tab_meta_updated(
+    wstore: &WaveStore,
+    tab_id: &str,
+    meta_patch: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if merge_meta_patch(&mut tab.meta, meta_patch) {
+        wstore.update(&mut tab)?;
+    }
+    Ok(())
+}
+
+/// Phase E.5.3 — apply a meta-patch to a block's `meta` map.
+fn apply_block_meta_updated(
+    wstore: &WaveStore,
+    block_id: &str,
+    meta_patch: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut block) = wstore.get::<Block>(block_id)? else {
+        return Ok(());
+    };
+    if merge_meta_patch(&mut block.meta, meta_patch) {
+        wstore.update(&mut block)?;
+    }
+    Ok(())
+}
+
+/// Phase E.5.3 — shallow merge a JSON object patch into a
+/// `MetaMapType`. `null` patch values delete the corresponding key.
+/// Returns `true` if anything actually changed.
+fn merge_meta_patch(
+    meta: &mut crate::backend::obj::MetaMapType,
+    patch: &serde_json::Value,
+) -> bool {
+    let serde_json::Value::Object(patch_map) = patch else {
+        return false;
+    };
+    let mut changed = false;
+    for (k, v) in patch_map {
+        if v.is_null() {
+            if meta.remove(k).is_some() {
+                changed = true;
+            }
+        } else {
+            match meta.get(k) {
+                Some(existing) if existing == v => {}
+                _ => {
+                    meta.insert(k.clone(), v.clone());
+                    changed = true;
+                }
+            }
+        }
+    }
+    changed
+}
+
 /// Compact textual identifier for an event (debug logging only).
 fn event_kind(event: &Event) -> &'static str {
     match event {
@@ -530,6 +685,12 @@ fn event_kind(event: &Event) -> &'static str {
         Event::SrvWindowOpened { .. } => "SrvWindowOpened",
         Event::SrvWindowClosed { .. } => "SrvWindowClosed",
         Event::SrvWindowWorkspaceChanged { .. } => "SrvWindowWorkspaceChanged",
+        Event::TabsReorderedBulk { .. } => "TabsReorderedBulk",
+        Event::WorkspaceRenamed { .. } => "WorkspaceRenamed",
+        Event::TabRenamed { .. } => "TabRenamed",
+        Event::WorkspaceMetaUpdated { .. } => "WorkspaceMetaUpdated",
+        Event::TabMetaUpdated { .. } => "TabMetaUpdated",
+        Event::BlockMetaUpdated { .. } => "BlockMetaUpdated",
         Event::BlockCreated { .. } => "BlockCreated",
         Event::BlockDeleted { .. } => "BlockDeleted",
         _ => "Other",

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -543,8 +543,12 @@ fn apply_srv_window_workspace_changed(
 }
 
 /// Phase E.5.3 — replace the workspace's `tabids` with the new
-/// list. `pinnedtabids` is left alone (pinning is Waveterm legacy
-/// and not in the reorder scope). No-op if already matching.
+/// list and drain any legacy `pinnedtabids` rows. Pinning was a
+/// Waveterm feature removed from AgentMux; bootstrap merges legacy
+/// pinned tabs into the reducer's `tab_ids`, so the next reorder
+/// is the canonical full ordering. Leaving stale `pinnedtabids`
+/// in SQLite would cause UI double-insertion (`workspace.tsx`
+/// builds the displayed tab list as `[...pinnedtabids, ...tabids]`).
 fn apply_tabs_reordered_bulk(
     wstore: &WaveStore,
     workspace_id: &str,
@@ -553,10 +557,13 @@ fn apply_tabs_reordered_bulk(
     let Some(mut ws) = wstore.get::<Workspace>(workspace_id)? else {
         return Ok(());
     };
-    if ws.tabids == tab_ids {
+    let tabids_match = ws.tabids == tab_ids;
+    let pinned_clear = ws.pinnedtabids.is_empty();
+    if tabids_match && pinned_clear {
         return Ok(());
     }
     ws.tabids = tab_ids.to_vec();
+    ws.pinnedtabids.clear();
     wstore.update(&mut ws)?;
     Ok(())
 }
@@ -645,7 +652,14 @@ fn apply_block_meta_updated(
 }
 
 /// Phase E.5.3 — shallow merge a JSON object patch into a
-/// `MetaMapType`. `null` patch values delete the corresponding key.
+/// `MetaMapType`. Mirrors `backend::obj::merge_meta` semantics so
+/// `UpdateObjectMeta` keeps behaving the same way after the reducer
+/// migration:
+/// - Keys ending in `:*` with a `true` value clear all keys with
+///   that prefix (e.g. `{"term:*": true}` removes every `term*`
+///   key) before regular merging.
+/// - `null` patch values delete the corresponding key.
+/// - Other values replace the key.
 /// Returns `true` if anything actually changed.
 fn merge_meta_patch(
     meta: &mut crate::backend::obj::MetaMapType,
@@ -655,18 +669,41 @@ fn merge_meta_patch(
         return false;
     };
     let mut changed = false;
+    // First pass: section-clear keys (`prefix:*` with `true`).
     for (k, v) in patch_map {
+        if !k.ends_with(":*") {
+            continue;
+        }
+        if !matches!(v, serde_json::Value::Bool(true)) {
+            continue;
+        }
+        let prefix = k.trim_end_matches(":*");
+        if prefix.is_empty() {
+            continue;
+        }
+        let prefix_colon = format!("{prefix}:");
+        let before = meta.len();
+        meta.retain(|k2, _| k2 != prefix && !k2.starts_with(&prefix_colon));
+        if meta.len() != before {
+            changed = true;
+        }
+    }
+    // Second pass: regular merges and null deletes.
+    for (k, v) in patch_map {
+        if k.ends_with(":*") {
+            continue;
+        }
         if v.is_null() {
             if meta.remove(k).is_some() {
                 changed = true;
             }
-        } else {
-            match meta.get(k) {
-                Some(existing) if existing == v => {}
-                _ => {
-                    meta.insert(k.clone(), v.clone());
-                    changed = true;
-                }
+            continue;
+        }
+        match meta.get(k) {
+            Some(existing) if existing == v => {}
+            _ => {
+                meta.insert(k.clone(), v.clone());
+                changed = true;
             }
         }
     }
@@ -1015,5 +1052,103 @@ mod tests {
         assert!(s.get::<Block>("block-1").unwrap().is_none());
         let tab = s.get::<Tab>("tab-1").unwrap().unwrap();
         assert!(tab.blockids.is_empty());
+    }
+
+    /// codex P1 #620: a workspace with legacy `pinnedtabids` rows must
+    /// have those drained the first time `TabsReorderedBulk` writes
+    /// the workspace; otherwise the UI's
+    /// `[...pinnedtabids, ...tabids]` combine duplicates the pinned
+    /// tab IDs once they have been merged into the reducer's
+    /// `tab_ids` at bootstrap.
+    #[test]
+    fn tabs_reordered_bulk_drains_legacy_pinned_tabids() {
+        let s = store();
+        let ws = wcore::create_workspace(&s, "Alpha").unwrap();
+        let pinned_tab =
+            wcore::create_tab_with_opts(&s, &ws.oid, "Pinned", true).unwrap();
+        let regular_tab =
+            wcore::create_tab_with_opts(&s, &ws.oid, "Regular", false).unwrap();
+        // Sanity: pinned tab is in `pinnedtabids` on disk.
+        let ws_before = s.get::<Workspace>(&ws.oid).unwrap().unwrap();
+        assert!(ws_before.pinnedtabids.contains(&pinned_tab.oid));
+
+        // Reducer-driven bulk reorder treating the pinned tab as a
+        // regular tab (mirrors what bootstrap-merge produces).
+        apply_event_to_wstore(
+            &Event::TabsReorderedBulk {
+                workspace_id: ws.oid.clone(),
+                tab_ids: vec![pinned_tab.oid.clone(), regular_tab.oid.clone()],
+                version: ws_before.version as u64 + 1,
+            },
+            &s,
+        )
+        .unwrap();
+        let ws_after = s.get::<Workspace>(&ws.oid).unwrap().unwrap();
+        assert_eq!(
+            ws_after.tabids,
+            vec![pinned_tab.oid.clone(), regular_tab.oid.clone()]
+        );
+        assert!(
+            ws_after.pinnedtabids.is_empty(),
+            "pinnedtabids must be drained, was {:?}",
+            ws_after.pinnedtabids
+        );
+    }
+
+    /// codex P2 #620: `merge_meta_patch` must honour the existing
+    /// `section:*` clear-prefix semantics so `UpdateObjectMeta`
+    /// behaviour stays the same after the reducer migration.
+    #[test]
+    fn meta_updated_clears_section_prefix() {
+        let s = store();
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "ws-1".into(),
+                tab_id: "tab-1".into(),
+                name: "Tab".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        apply_event_to_wstore(
+            &Event::WorkspaceCreated {
+                workspace_id: "ws-1".into(),
+                name: "Alpha".into(),
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        // Seed the tab with grouped meta entries.
+        let mut tab = s.get::<Tab>("tab-1").unwrap().unwrap();
+        tab.meta
+            .insert("term:fontsize".into(), serde_json::json!(14));
+        tab.meta
+            .insert("term:theme".into(), serde_json::json!("solarized"));
+        tab.meta.insert("name".into(), serde_json::json!("keep"));
+        s.update(&mut tab).unwrap();
+        // Patch with `term:*` clear plus a single replacement key.
+        apply_event_to_wstore(
+            &Event::TabMetaUpdated {
+                tab_id: "tab-1".into(),
+                meta_patch: serde_json::json!({
+                    "term:*": true,
+                    "term:fontsize": 18,
+                }),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let after = s.get::<Tab>("tab-1").unwrap().unwrap();
+        assert!(!after.meta.contains_key("term:theme"),
+            "term:theme should be cleared by `term:*` patch");
+        assert_eq!(
+            after.meta.get("term:fontsize"),
+            Some(&serde_json::json!(18)),
+            "term:fontsize replacement must take effect after the section clear"
+        );
+        assert_eq!(after.meta.get("name"), Some(&serde_json::json!("keep")));
     }
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -73,6 +73,26 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             window_id,
             workspace_id,
         } => handle_switch_workspace(state, window_id, workspace_id),
+        Command::ReorderTabsBulk {
+            workspace_id,
+            tab_ids,
+        } => handle_reorder_tabs_bulk(state, workspace_id, tab_ids),
+        Command::RenameWorkspace { workspace_id, name } => {
+            handle_rename_workspace(state, workspace_id, name)
+        }
+        Command::RenameTab { tab_id, name } => handle_rename_tab(state, tab_id, name),
+        Command::UpdateWorkspaceMeta {
+            workspace_id,
+            meta_patch,
+        } => handle_update_workspace_meta(state, workspace_id, meta_patch),
+        Command::UpdateTabMeta {
+            tab_id,
+            meta_patch,
+        } => handle_update_tab_meta(state, tab_id, meta_patch),
+        Command::UpdateBlockMeta {
+            block_id,
+            meta_patch,
+        } => handle_update_block_meta(state, block_id, meta_patch),
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
         // match by adding new arms above.
@@ -268,19 +288,31 @@ fn handle_delete_workspace(state: &mut State, workspace_id: String) -> Vec<Event
             }
         }
     }
-    // Phase E.5 — also drop window mappings that point at the
-    // deleted workspace. Without this, `state.windows` keeps
-    // dangling refs and saga steps that inspect window→workspace
-    // membership make decisions from invalid state.
-    // (codex P1 #619.)
-    state
+    // Phase E.5 — drop window mappings that point at the deleted
+    // workspace AND emit `SrvWindowClosed` for each so the persist
+    // subscriber prunes the SQLite Window row + Client.windowids.
+    // The original cascade (E.5.1+2) was silent, leaving downstream
+    // projections out of sync. (codex P1 follow-up to #619.)
+    let dropped_window_ids: Vec<String> = state
         .windows
-        .retain(|_, record| record.workspace_id != workspace_id);
+        .iter()
+        .filter(|(_, w)| w.workspace_id == workspace_id)
+        .map(|(id, _)| id.clone())
+        .collect();
+    for id in &dropped_window_ids {
+        state.windows.remove(id);
+    }
+    let mut events = Vec::with_capacity(1 + dropped_window_ids.len());
     let v = state.bump_version();
-    vec![Event::WorkspaceDeleted {
+    events.push(Event::WorkspaceDeleted {
         workspace_id,
         version: v,
-    }]
+    });
+    for window_id in dropped_window_ids {
+        let v = state.bump_version();
+        events.push(Event::SrvWindowClosed { window_id, version: v });
+    }
+    events
 }
 
 /// Phase E.2b — create a tab inside a workspace. Validates the
@@ -636,6 +668,194 @@ fn handle_switch_workspace(
     }]
 }
 
+/// Phase E.5.3 — replace a workspace's `tab_ids` with the given
+/// list. Validates the workspace exists and the new list is a
+/// permutation of the current set (same elements, possibly
+/// different order). No-op if identical.
+fn handle_reorder_tabs_bulk(
+    state: &mut State,
+    workspace_id: String,
+    tab_ids: Vec<String>,
+) -> Vec<Event> {
+    // Validate using `&` borrow first so we can call `bump_version`
+    // (which needs `&mut state`) on error paths without borrow conflict.
+    let validation_error: Option<String> = {
+        let Some(workspace) = state.workspaces.get(&workspace_id) else {
+            let v = state.bump_version();
+            return vec![Event::Error {
+                code: ErrorCode::InvalidCommand,
+                message: format!("ReorderTabsBulk: workspace not found: {}", workspace_id),
+                fatal: false,
+                version: v,
+            }];
+        };
+        if workspace.tab_ids == tab_ids {
+            return Vec::new();
+        }
+        if workspace.tab_ids.len() != tab_ids.len() {
+            Some(format!(
+                "ReorderTabsBulk: new tab_ids has {} entries; workspace has {}",
+                tab_ids.len(),
+                workspace.tab_ids.len()
+            ))
+        } else {
+            let current_set: std::collections::HashSet<&String> =
+                workspace.tab_ids.iter().collect();
+            let new_set: std::collections::HashSet<&String> = tab_ids.iter().collect();
+            if current_set != new_set {
+                Some(
+                    "ReorderTabsBulk: new tab_ids must be a permutation of the workspace's current set"
+                        .to_string(),
+                )
+            } else {
+                None
+            }
+        }
+    };
+    if let Some(message) = validation_error {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message,
+            fatal: false,
+            version: v,
+        }];
+    }
+    state.workspaces.get_mut(&workspace_id).expect("checked").tab_ids = tab_ids.clone();
+    let v = state.bump_version();
+    vec![Event::TabsReorderedBulk {
+        workspace_id,
+        tab_ids,
+        version: v,
+    }]
+}
+
+/// Phase E.5.3 — rename a workspace. Errors if missing; no-op if
+/// the name is unchanged.
+fn handle_rename_workspace(state: &mut State, workspace_id: String, name: String) -> Vec<Event> {
+    let Some(workspace) = state.workspaces.get_mut(&workspace_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("RenameWorkspace: workspace not found: {}", workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if workspace.name == name {
+        return Vec::new();
+    }
+    workspace.name = name.clone();
+    let v = state.bump_version();
+    vec![Event::WorkspaceRenamed {
+        workspace_id,
+        name,
+        version: v,
+    }]
+}
+
+/// Phase E.5.3 — rename a tab. Errors if missing; no-op if the
+/// name is unchanged.
+fn handle_rename_tab(state: &mut State, tab_id: String, name: String) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("RenameTab: tab not found: {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if tab.name == name {
+        return Vec::new();
+    }
+    tab.name = name.clone();
+    let v = state.bump_version();
+    vec![Event::TabRenamed {
+        tab_id,
+        name,
+        version: v,
+    }]
+}
+
+/// Phase E.5.3 — pass-through validation + emit for workspace
+/// meta updates. The reducer does NOT mutate meta in state (it
+/// doesn't track meta in WorkspaceRecord); the persist subscriber
+/// applies the patch directly to wstore. This keeps the reducer's
+/// state shape unchanged while still routing every meta mutation
+/// through the broadcast bus for observers.
+fn handle_update_workspace_meta(
+    state: &mut State,
+    workspace_id: String,
+    meta_patch: serde_json::Value,
+) -> Vec<Event> {
+    if !state.workspaces.contains_key(&workspace_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "UpdateWorkspaceMeta: workspace not found: {}",
+                workspace_id
+            ),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let v = state.bump_version();
+    vec![Event::WorkspaceMetaUpdated {
+        workspace_id,
+        meta_patch,
+        version: v,
+    }]
+}
+
+/// Phase E.5.3 — pass-through for tab meta updates. Same shape as
+/// `handle_update_workspace_meta`.
+fn handle_update_tab_meta(
+    state: &mut State,
+    tab_id: String,
+    meta_patch: serde_json::Value,
+) -> Vec<Event> {
+    if !state.tabs.contains_key(&tab_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("UpdateTabMeta: tab not found: {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let v = state.bump_version();
+    vec![Event::TabMetaUpdated {
+        tab_id,
+        meta_patch,
+        version: v,
+    }]
+}
+
+/// Phase E.5.3 — pass-through for block meta updates. Same shape.
+fn handle_update_block_meta(
+    state: &mut State,
+    block_id: String,
+    meta_patch: serde_json::Value,
+) -> Vec<Event> {
+    if !state.blocks.contains_key(&block_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("UpdateBlockMeta: block not found: {}", block_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    let v = state.bump_version();
+    vec![Event::BlockMetaUpdated {
+        block_id,
+        meta_patch,
+        version: v,
+    }]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -692,6 +912,12 @@ mod tests {
             | Event::SrvWindowOpened { version, .. }
             | Event::SrvWindowClosed { version, .. }
             | Event::SrvWindowWorkspaceChanged { version, .. }
+            | Event::TabsReorderedBulk { version, .. }
+            | Event::WorkspaceRenamed { version, .. }
+            | Event::TabRenamed { version, .. }
+            | Event::WorkspaceMetaUpdated { version, .. }
+            | Event::TabMetaUpdated { version, .. }
+            | Event::BlockMetaUpdated { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -1708,7 +1934,7 @@ mod tests {
     }
 
     #[test]
-    fn delete_workspace_drops_pointing_windows() {
+    fn delete_workspace_drops_pointing_windows_and_emits_events() {
         let mut state = State::default();
         let ws_a = create_workspace(&mut state, "a");
         let ws_b = create_workspace(&mut state, "b");
@@ -1728,12 +1954,23 @@ mod tests {
             },
             &ctx(3),
         );
-        // Delete workspace A; only win-a should be dropped, win-b survives.
-        let _ = update(
+        // Delete workspace A; only win-a should be dropped + emit
+        // SrvWindowClosed; win-b survives.
+        let events = update(
             &mut state,
             Command::DeleteWorkspace { workspace_id: ws_a },
             &ctx(4),
         );
+        assert!(matches!(&events[0], Event::WorkspaceDeleted { .. }));
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::SrvWindowClosed { window_id, .. } if window_id == "win-a"
+        )));
+        // Verify win-b was NOT closed.
+        assert!(!events.iter().any(|e| matches!(
+            e,
+            Event::SrvWindowClosed { window_id, .. } if window_id == "win-b"
+        )));
         assert!(!state.windows.contains_key("win-a"));
         assert_eq!(state.windows["win-b"].workspace_id, ws_b);
     }

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -958,9 +958,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
         // Phase E.5.3 — UpdateTabIds migrated to ReorderTabsBulk
         // through the reducer. The legacy `pinned_tab_ids` arg is
         // ignored: pinning was a Waveterm feature removed from
-        // AgentMux. Bootstrap merged any legacy pinnedtabids into
-        // the reducer's tab_ids; the subscriber's apply will also
-        // clear `Workspace.pinnedtabids` in wstore on this path.
+        // AgentMux. Bootstrap merged any legacy `pinnedtabids` into
+        // the reducer's `tab_ids`. The subscriber's
+        // `apply_tabs_reordered_bulk` rewrites `Workspace.tabids`
+        // only — leaves any pre-existing `pinnedtabids` rows alone
+        // (legacy data persists harmlessly until the next user-driven
+        // workspace mutation that touches that field).
         ("workspace", "UpdateTabIds") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -246,9 +246,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => WebReturnType::error(e),
             }
         }
+        // Phase E.5.3 — UpdateObjectMeta migrated through the
+        // reducer. Decomposes by otype to the typed Update*Meta
+        // command. Reducer is pass-through (validates entity exists;
+        // emits event); subscriber's apply_*_meta_updated does the
+        // shallow merge against wstore.
         ("object", "UpdateObjectMeta") => {
-            // args[0] = oref string, args[1] = meta map
-            // (Go dispatcher strips UIContext from args; TS sends [oref, meta])
             let oref_str: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
@@ -257,39 +260,76 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            match update_object_meta(store, &oref_str, &meta_update) {
-                Ok(()) => {
-                    // Return the updated object so the frontend WOS cache stays in sync.
-                    // (Without this, atoms like cmd:cwd never update after OSC 7 fires.)
-                    let oref = match crate::backend::ORef::parse(&oref_str) {
-                        Ok(v) => v,
-                        Err(e) => return WebReturnType::error(e.to_string()),
+            let oref = match crate::backend::ORef::parse(&oref_str) {
+                Ok(v) => v,
+                Err(e) => return WebReturnType::error(e.to_string()),
+            };
+            let meta_value = serde_json::to_value(&meta_update).unwrap_or(serde_json::Value::Null);
+            let cmd = match oref.otype.as_str() {
+                t if t == OTYPE_WORKSPACE => agentmux_common::ipc::Command::UpdateWorkspaceMeta {
+                    workspace_id: oref.oid.clone(),
+                    meta_patch: meta_value,
+                },
+                t if t == OTYPE_TAB => agentmux_common::ipc::Command::UpdateTabMeta {
+                    tab_id: oref.oid.clone(),
+                    meta_patch: meta_value,
+                },
+                t if t == OTYPE_BLOCK => agentmux_common::ipc::Command::UpdateBlockMeta {
+                    block_id: oref.oid.clone(),
+                    meta_patch: meta_value,
+                },
+                other => {
+                    // Layouts + Windows aren't meta-mutated via this path
+                    // today; fall back to wcore for forward-compat.
+                    return match update_object_meta(store, &oref_str, &meta_update) {
+                        Ok(()) => WebReturnType::success_empty(),
+                        Err(e) => WebReturnType::error(format!(
+                            "UpdateObjectMeta: unsupported otype {} via reducer; wcore fallback failed: {}",
+                            other, e
+                        )),
                     };
-                    if oref.otype == OTYPE_BLOCK {
-                        if let Ok(block) = store.must_get::<Block>(&oref.oid) {
-                            return WebReturnType::success_with_updates(vec![WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: OTYPE_BLOCK.to_string(),
-                                oid: oref.oid.clone(),
-                                obj: Some(wave_obj_to_value(&block)),
-                            }]);
-                        }
-                    }
-                    if oref.otype == OTYPE_TAB {
-                        if let Ok(tab) = store.must_get::<Tab>(&oref.oid) {
-                            return WebReturnType::success_with_updates(vec![WaveObjUpdate {
-                                updatetype: "update".into(),
-                                otype: OTYPE_TAB.to_string(),
-                                oid: oref.oid.clone(),
-                                obj: Some(wave_obj_to_value(&tab)),
-                            }]);
-                        }
-                    }
-                    WebReturnType::success_empty()
                 }
-                Err(e) => WebReturnType::error(e),
+            };
+            let events = dispatch_to_reducer(state, cmd).await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "UpdateObjectMeta: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            // Return the updated object so the frontend WOS cache stays in sync.
+            if oref.otype == OTYPE_BLOCK {
+                if let Ok(block) = store.must_get::<Block>(&oref.oid) {
+                    return WebReturnType::success_with_updates(vec![WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: OTYPE_BLOCK.to_string(),
+                        oid: oref.oid.clone(),
+                        obj: Some(wave_obj_to_value(&block)),
+                    }]);
+                }
+            }
+            if oref.otype == OTYPE_TAB {
+                if let Ok(tab) = store.must_get::<Tab>(&oref.oid) {
+                    return WebReturnType::success_with_updates(vec![WaveObjUpdate {
+                        updatetype: "update".into(),
+                        otype: OTYPE_TAB.to_string(),
+                        oid: oref.oid.clone(),
+                        obj: Some(wave_obj_to_value(&tab)),
+                    }]);
+                }
+            }
+            WebReturnType::success_empty()
         }
+        // Phase E.5.3 — UpdateTabName migrated through the reducer.
         ("object", "UpdateTabName") => {
             let tab_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -299,31 +339,40 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            match store.must_get::<Tab>(&tab_id) {
-                Ok(mut tab) => {
-                    tab.name = name;
-                    match store.update(&mut tab) {
-                        Ok(_) => {
-                            // Return updated tab so frontend WOS cache stays in sync
-                            if let Ok(updated_tab) = store.must_get::<Tab>(&tab_id) {
-                                let update = WaveObjUpdate {
-                                    updatetype: "update".into(),
-                                    otype: OTYPE_TAB.to_string(),
-                                    oid: tab_id.clone(),
-                                    obj: Some(wave_obj_to_value(&updated_tab)),
-                                };
-                                WebReturnType::success_with_updates(vec![update])
-                            } else {
-                                WebReturnType::success_empty()
-                            }
-                        }
-                        Err(e) => WebReturnType::error(e.to_string()),
-                    }
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::RenameTab {
+                    tab_id: tab_id.clone(),
+                    name,
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "UpdateTabName: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            if let Ok(updated_tab) = store.must_get::<Tab>(&tab_id) {
+                let update = WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&updated_tab)),
+                };
+                return WebReturnType::success_with_updates(vec![update]);
+            }
+            WebReturnType::success_empty()
         }
-
         // ---- ClientService ----
         ("client", "GetClientData") => match wcore::get_client(store) {
             Ok(client) => {
@@ -868,25 +917,50 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 updates,
             )
         }
+        // Phase E.5.3 — UpdateWorkspace migrated through the reducer.
+        // Currently only handles rename (the only field this RPC ever
+        // mutated). Meta-only updates are dispatched as
+        // UpdateWorkspaceMeta separately by frontends.
         ("workspace", "UpdateWorkspace") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
             let name: Option<String> = service::get_optional_arg(args, 1).unwrap_or(None);
-            match store.must_get::<Workspace>(&ws_id) {
-                Ok(mut ws) => {
-                    if let Some(n) = name {
-                        ws.name = n;
-                    }
-                    match store.update(&mut ws) {
-                        Ok(_) => WebReturnType::success_empty(),
-                        Err(e) => WebReturnType::error(e.to_string()),
-                    }
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            let Some(name) = name else {
+                return WebReturnType::success_empty();
+            };
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::RenameWorkspace {
+                    workspace_id: ws_id.clone(),
+                    name,
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "UpdateWorkspace: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            WebReturnType::success_empty()
         }
+        // Phase E.5.3 — UpdateTabIds migrated to ReorderTabsBulk
+        // through the reducer. The legacy `pinned_tab_ids` arg is
+        // ignored: pinning was a Waveterm feature removed from
+        // AgentMux. Bootstrap merged any legacy pinnedtabids into
+        // the reducer's tab_ids; the subscriber's apply will also
+        // clear `Workspace.pinnedtabids` in wstore on this path.
         ("workspace", "UpdateTabIds") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -896,30 +970,40 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            let pinned_tab_ids: Vec<String> = service::get_arg(args, 2).unwrap_or_default();
-            match store.must_get::<Workspace>(&ws_id) {
-                Ok(mut ws) => {
-                    ws.tabids = tab_ids;
-                    ws.pinnedtabids = pinned_tab_ids;
-                    match store.update(&mut ws) {
-                        Ok(_) => {
-                            if let Ok(updated_ws) = store.must_get::<Workspace>(&ws_id) {
-                                let update = WaveObjUpdate {
-                                    updatetype: "update".into(),
-                                    otype: OTYPE_WORKSPACE.to_string(),
-                                    oid: ws_id.clone(),
-                                    obj: Some(wave_obj_to_value(&updated_ws)),
-                                };
-                                WebReturnType::success_with_updates(vec![update])
-                            } else {
-                                WebReturnType::success_empty()
-                            }
-                        }
-                        Err(e) => WebReturnType::error(e.to_string()),
-                    }
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            // args[2] (pinned_tab_ids) intentionally ignored.
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::ReorderTabsBulk {
+                    workspace_id: ws_id.clone(),
+                    tab_ids,
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "UpdateTabIds: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            if let Ok(updated_ws) = store.must_get::<Workspace>(&ws_id) {
+                let update = WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&updated_ws)),
+                };
+                return WebReturnType::success_with_updates(vec![update]);
+            }
+            WebReturnType::success_empty()
         }
         ("workspace", "MoveBlockToTab") => {
             let ws_id: String = match service::get_arg(args, 0) {

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -961,9 +961,10 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
         // AgentMux. Bootstrap merged any legacy `pinnedtabids` into
         // the reducer's `tab_ids`. The subscriber's
         // `apply_tabs_reordered_bulk` rewrites `Workspace.tabids`
-        // only — leaves any pre-existing `pinnedtabids` rows alone
-        // (legacy data persists harmlessly until the next user-driven
-        // workspace mutation that touches that field).
+        // and drains any leftover `Workspace.pinnedtabids` so the
+        // UI's `[...pinnedtabids, ...tabids]` combine never
+        // double-counts a tab once a workspace's tabs are
+        // reordered through the reducer.
         ("workspace", "UpdateTabIds") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.521",
+  "version": "0.33.522",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**PR 2 of 4** in the Phase E.5 saga rollout. Closes most of the wcore-direct paths in audit §3b — workspace rename, tab rename, bulk tab reorder, meta updates on workspace/tab/block. Multi-step ops (PromoteBlockToTab, MoveTab, MoveBlock) deferred to PR 3 sagas.

| PR | Status |
|---|---|
| PR 1 (#619) | ✅ merged |
| **PR 2 (this)** | foundation + RPC migration of single-step paths |
| PR 3 | TearOff + Restore sagas — fixes tear-off → \"+\" tab smoke regression |
| PR 4 | Move + CreateWindow + CloseWindow sagas + cleanup |

## What's new

### 6 new atomic commands

- `Command::ReorderTabsBulk { workspace_id, tab_ids }`
- `Command::RenameWorkspace { workspace_id, name }`
- `Command::RenameTab { tab_id, name }`
- `Command::UpdateWorkspaceMeta { workspace_id, meta_patch }`
- `Command::UpdateTabMeta { tab_id, meta_patch }`
- `Command::UpdateBlockMeta { block_id, meta_patch }`

Plus 6 matching events.

### Reducer

- `handle_reorder_tabs_bulk` validates the new list is a permutation of current tab_ids.
- `handle_rename_*` updates the field directly with no-op detection.
- `handle_update_*_meta` is **pass-through** — reducer doesn't track meta in `WorkspaceRecord`/`TabRecord`/`BlockRecord` (would bloat state and break dozens of existing tests). Subscriber applies the merge against wstore directly.

### Persist subscriber

- `apply_tabs_reordered_bulk` — replaces `Workspace.tabids`.
- `apply_workspace_renamed` / `_tab_renamed` — direct field update.
- `apply_*_meta_updated` — shallow merge via new `merge_meta_patch` helper. `null` values in the patch delete the key. Returns true only if anything changed.

### RPC migration

Five HTTP/WS handlers migrated:

| Handler | Before | After |
|---|---|---|
| `(\"workspace\", \"UpdateWorkspace\")` | direct `store.update` | dispatch `RenameWorkspace` |
| `(\"workspace\", \"UpdateTabIds\")` | direct `store.update` | dispatch `ReorderTabsBulk`; legacy `pinned_tab_ids` arg **ignored** |
| `(\"object\", \"UpdateTabName\")` | direct `store.update` | dispatch `RenameTab` |
| `(\"object\", \"UpdateObjectMeta\")` | `wcore::update_object_meta` | decompose by otype → `Update{Workspace,Tab,Block}Meta`. Layout/Window otypes fall back to wcore for forward-compat. |
| `(\"object\", \"UpdateObject\")` | unchanged | unchanged (catch-all; not in scope for E.5.3) |

### Carryover from #619 (codex P1)

`handle_delete_workspace` was silently retaining-out windows pointing at the deleted workspace — no `SrvWindowClosed` events emitted, so SQLite Window rows + Client.windowids stayed stale. Now emits `SrvWindowClosed` for each cascade-removed window so the subscriber's existing `apply_srv_window_closed` handler prunes the persisted state.

## Out of scope (intentionally — later PRs)

- `PromoteBlockToTab` (multi-step → saga in PR 3 or follow-up)
- `MoveTab` / `MoveBlock` (saga-internal in PR 3)
- TearOff / Restore / CreateWindow / CloseWindow sagas (PR 3-4)
- `(\"object\", \"UpdateObject\")` decompose — defer; rarely invoked

## Test plan

- [x] 55/55 reducer + subscriber tests pass
- [x] `cargo build --release -p agentmux-srv -p agentmux-launcher` clean
- [ ] Smoke (manual portable):
  - Rename workspace → persists across restart, frontend WOS cache updates
  - Rename tab → same
  - Drag-reorder tabs → order persists
  - Edit block meta (e.g., \"view\") via right-click → applies, frontend reflects
  - **Tear-off → \"+\" tab still broken until PR 3 lands** — known regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)