### PR TITLE
feat(E.5.5+6): tear-off sagas — fixes new-window-+-tab smoke regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.522"
+version = "0.33.523"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.522"
+version = "0.33.523"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.522"
+version = "0.33.523"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.522"
+version = "0.33.523"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.523"
+version = "0.33.524"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.523"
+version = "0.33.524"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.523"
+version = "0.33.524"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.523"
+version = "0.33.524"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.524"
+version = "0.33.525"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.524"
+version = "0.33.525"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.524"
+version = "0.33.525"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.524"
+version = "0.33.525"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.523"
+version = "0.33.524"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.524"
+version = "0.33.525"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.522"
+version = "0.33.523"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.523"
+version = "0.33.524"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.524"
+version = "0.33.525"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.522"
+version = "0.33.523"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -347,6 +347,45 @@ pub enum Command {
         block_id: String,
         meta_patch: serde_json::Value,
     },
+    /// Phase E.5.5 — move a tab from one workspace to another.
+    /// Reducer:
+    /// * Removes `tab_id` from `src_workspace_id.tab_ids`.
+    /// * Updates `tab.workspace_id = dst_workspace_id`.
+    /// * Inserts `tab_id` at `dst_index` in `dst_workspace_id.tab_ids`,
+    ///   clamping to the dst list length.
+    /// * If `tab_id` was the source workspace's `active_tab_id`, the
+    ///   source's active reverts to its first remaining tab (or
+    ///   `None` if the source becomes empty).
+    /// Errors if any of: source workspace, dest workspace, or tab is
+    /// missing; if `tab.workspace_id != src_workspace_id`; or if
+    /// the tab is the source workspace's last tab AND no caller has
+    /// arranged a fallback (callers like tear-off should reject the
+    /// move at the saga layer if removing the tab would empty the
+    /// source — preserving the "workspaces have at least one tab"
+    /// invariant most UI paths assume). Used by the TearOffTab,
+    /// MoveTabToWorkspace, and RestoreTornOffTab sagas.
+    MoveTab {
+        tab_id: String,
+        src_workspace_id: String,
+        dst_workspace_id: String,
+        dst_index: u32,
+    },
+    /// Phase E.5.5 — move a block from one tab to another (or to a
+    /// different position in the same tab).
+    /// Reducer:
+    /// * Removes `block_id` from `src_tab_id.block_ids`.
+    /// * Updates `block.tab_id = dst_tab_id`.
+    /// * Inserts `block_id` at `dst_index` in `dst_tab_id.block_ids`,
+    ///   clamping to the dst list length.
+    /// Errors if source tab, dest tab, or block is missing, or if
+    /// `block.tab_id != src_tab_id`. Used by TearOffBlock and the
+    /// MoveBlockToTab saga.
+    MoveBlock {
+        block_id: String,
+        src_tab_id: String,
+        dst_tab_id: String,
+        dst_index: u32,
+    },
     /// Phase E.3 — create a block inside an existing tab. Reducer
     /// validates parent tab exists, assigns the `block_id` (UUID),
     /// appends to the tab's `block_ids`, emits `Event::BlockCreated`.
@@ -841,6 +880,35 @@ pub enum Event {
     BlockMetaUpdated {
         block_id: String,
         meta_patch: serde_json::Value,
+        version: u64,
+    },
+    /// Phase E.5.5 — a tab was moved from one workspace to another.
+    /// Subscribers should rewrite both workspaces' `tabids` and the
+    /// tab's `parentoref`/`workspaceid` to match the reducer's view.
+    /// `dst_index` reflects the position in `dst_workspace_id.tab_ids`
+    /// AFTER insertion (already clamped by the reducer).
+    /// Carries enough information to re-derive the new state without
+    /// reading the reducer (subscribers replay events post-Lagged).
+    TabMoved {
+        tab_id: String,
+        src_workspace_id: String,
+        dst_workspace_id: String,
+        dst_index: u32,
+        /// The source workspace's new `active_tab_id` after the move,
+        /// or `None` if the source has no remaining tabs. Subscribers
+        /// rewrite the source's `activetabid` to match.
+        new_src_active_tab_id: Option<String>,
+        version: u64,
+    },
+    /// Phase E.5.5 — a block was moved from one tab to another (or
+    /// repositioned within the same tab). Subscribers update both
+    /// tabs' `blockids` and the block's `parentoref`. `dst_index`
+    /// reflects post-insertion position.
+    BlockMoved {
+        block_id: String,
+        src_tab_id: String,
+        dst_tab_id: String,
+        dst_index: u32,
         version: u64,
     },
     /// Phase E.3 — block was created inside a tab.

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -898,6 +898,18 @@ pub enum Event {
         /// or `None` if the source has no remaining tabs. Subscribers
         /// rewrite the source's `activetabid` to match.
         new_src_active_tab_id: Option<String>,
+        /// The destination workspace's new `active_tab_id` after the
+        /// move. Wcore behavior (`move_tab_to_workspace`) was to
+        /// always set the moved tab as dst's active; the reducer
+        /// mirrors that. `None` means "do not change dst.active_tab_id"
+        /// — reserved for future flows where the moved tab shouldn't
+        /// steal focus. Codex P2 #621.
+        ///
+        /// `#[serde(default)]` for forward-compat with pre-PR3
+        /// `srv-events.log` entries (none in production yet, but the
+        /// pattern is established).
+        #[serde(default)]
+        new_dst_active_tab_id: Option<String>,
         version: u64,
     },
     /// Phase E.5.5 — a block was moved from one tab to another (or

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.524"
+version = "0.33.525"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.522"
+version = "0.33.523"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.523"
+version = "0.33.524"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -281,6 +281,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::WorkspaceMetaUpdated { version, .. }
         | Event::TabMetaUpdated { version, .. }
         | Event::BlockMetaUpdated { version, .. }
+        | Event::TabMoved { version, .. }
+        | Event::BlockMoved { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -724,6 +724,15 @@ async fn enforce_register_first(
             "DeleteBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.5.5 — saga-driven move commands are srv-pipe.
+        Command::MoveTab { .. } => (
+            "MoveTab is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::MoveBlock { .. } => (
+            "MoveBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
     };
     // Phase E.1b — connection-private error; sentinel version=0
     // (codex P2 #610). See parse-error path for rationale.

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -362,6 +362,25 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.5.5 — saga-driven move commands are srv-pipe.
+        Command::MoveTab { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "MoveTab is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::MoveBlock { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "MoveBlock is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.1b — `GetSrvSnapshot` is a srv-pipe command. If a
         // registered client misroutes it to the launcher pipe, return
         // an explicit error so the client knows the dispatch was

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.522"
+version = "0.33.523"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.523"
+version = "0.33.524"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.524"
+version = "0.33.525"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -281,6 +281,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::WorkspaceMetaUpdated { version, .. }
         | Event::TabMetaUpdated { version, .. }
         | Event::BlockMetaUpdated { version, .. }
+        | Event::TabMoved { version, .. }
+        | Event::BlockMoved { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
         | Event::Error { version, .. } => *version,

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -4,6 +4,7 @@ mod event_log;
 mod persist;
 mod persist_subscriber;
 mod reducer;
+mod sagas;
 mod server;
 mod srv_ipc;
 mod state;
@@ -552,6 +553,10 @@ async fn main() {
         // subscriber writes back to SQLite asynchronously.
         srv_state: std::sync::Arc::clone(&srv_state),
         srv_events_tx: srv_events_tx.clone(),
+        // Phase E.5.5 — saga-id allocator. Starts at 0; every
+        // `sagas::run_saga` invocation `fetch_add(1)`s. First
+        // saga gets id 1.
+        saga_id_alloc: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
     };
 
     // Phase E.1b — srv pipe IPC server. Bound when launcher passes

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -257,6 +257,28 @@ pub(crate) fn apply_event_to_wstore(
             meta_patch,
             ..
         } => apply_block_meta_updated(wstore, block_id, meta_patch),
+        Event::TabMoved {
+            tab_id,
+            src_workspace_id,
+            dst_workspace_id,
+            dst_index,
+            new_src_active_tab_id,
+            ..
+        } => apply_tab_moved(
+            wstore,
+            tab_id,
+            src_workspace_id,
+            dst_workspace_id,
+            *dst_index,
+            new_src_active_tab_id.as_deref(),
+        ),
+        Event::BlockMoved {
+            block_id,
+            src_tab_id,
+            dst_tab_id,
+            dst_index,
+            ..
+        } => apply_block_moved(wstore, block_id, src_tab_id, dst_tab_id, *dst_index),
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -651,6 +673,115 @@ fn apply_block_meta_updated(
     Ok(())
 }
 
+/// Phase E.5.5 — apply a `TabMoved` event to SQLite.
+/// Idempotent: detects already-moved state (tab in dst, not in src)
+/// and returns `Ok(())` without re-mutating.
+///
+/// What this writes:
+/// * Removes `tab_id` from `src_workspace.tabids` (and `pinnedtabids`
+///   for legacy rows — bootstrap merges them into reducer state, so
+///   any leftover here is a stray legacy entry that should be drained).
+/// * Updates `src_workspace.activetabid` to `new_src_active_tab_id`
+///   (which may be empty when the source emptied).
+/// * Inserts `tab_id` at `dst_index` in `dst_workspace.tabids`,
+///   clamping to the dst list length.
+/// * Updates the `Tab` row's parent ref so loaders find it under
+///   the new workspace.
+fn apply_tab_moved(
+    wstore: &WaveStore,
+    tab_id: &str,
+    src_workspace_id: &str,
+    dst_workspace_id: &str,
+    dst_index: u32,
+    new_src_active_tab_id: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Source workspace: remove the tab and update activetabid.
+    if let Some(mut src_ws) = wstore.get::<Workspace>(src_workspace_id)? {
+        let len_before_tabids = src_ws.tabids.len();
+        let len_before_pinned = src_ws.pinnedtabids.len();
+        src_ws.tabids.retain(|id| id != tab_id);
+        src_ws.pinnedtabids.retain(|id| id != tab_id);
+        let new_active = new_src_active_tab_id.unwrap_or("").to_string();
+        let active_changed = src_ws.activetabid != new_active;
+        if src_ws.tabids.len() != len_before_tabids
+            || src_ws.pinnedtabids.len() != len_before_pinned
+            || active_changed
+        {
+            src_ws.activetabid = new_active;
+            wstore.update(&mut src_ws)?;
+        }
+    }
+
+    // Dest workspace: insert at clamped index. Skip if already there
+    // (idempotent on duplicate event delivery).
+    if let Some(mut dst_ws) = wstore.get::<Workspace>(dst_workspace_id)? {
+        if !dst_ws.tabids.iter().any(|id| id == tab_id) {
+            let clamped = (dst_index as usize).min(dst_ws.tabids.len());
+            dst_ws.tabids.insert(clamped, tab_id.to_string());
+            wstore.update(&mut dst_ws)?;
+        }
+    }
+
+    // No per-Tab parent ref to update — the workspace owns the
+    // parentage relationship via its `tabids` list (no `Tab.workspaceid`
+    // or `Tab.parentoref` field exists). Removing from the source
+    // workspace's `tabids` and inserting into the dest's is the
+    // entirety of the parent change.
+
+    Ok(())
+}
+
+/// Phase E.5.5 — apply a `BlockMoved` event to SQLite.
+/// Handles both cross-tab moves and intra-tab repositioning.
+/// Idempotent on re-delivery (checks current parent before mutating).
+fn apply_block_moved(
+    wstore: &WaveStore,
+    block_id: &str,
+    src_tab_id: &str,
+    dst_tab_id: &str,
+    dst_index: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if src_tab_id == dst_tab_id {
+        // Intra-tab reposition: remove + re-insert in the same tab.
+        if let Some(mut tab) = wstore.get::<Tab>(src_tab_id)? {
+            tab.blockids.retain(|id| id != block_id);
+            let clamped = (dst_index as usize).min(tab.blockids.len());
+            tab.blockids.insert(clamped, block_id.to_string());
+            wstore.update(&mut tab)?;
+        }
+        return Ok(());
+    }
+
+    // Cross-tab: remove from src.
+    if let Some(mut src_tab) = wstore.get::<Tab>(src_tab_id)? {
+        let before = src_tab.blockids.len();
+        src_tab.blockids.retain(|id| id != block_id);
+        if src_tab.blockids.len() != before {
+            wstore.update(&mut src_tab)?;
+        }
+    }
+
+    // Insert into dst (skip if already there).
+    if let Some(mut dst_tab) = wstore.get::<Tab>(dst_tab_id)? {
+        if !dst_tab.blockids.iter().any(|id| id == block_id) {
+            let clamped = (dst_index as usize).min(dst_tab.blockids.len());
+            dst_tab.blockids.insert(clamped, block_id.to_string());
+            wstore.update(&mut dst_tab)?;
+        }
+    }
+
+    // Block row: update parent.
+    if let Some(mut block) = wstore.get::<Block>(block_id)? {
+        let new_parent = format!("tab:{}", dst_tab_id);
+        if block.parentoref != new_parent {
+            block.parentoref = new_parent;
+            wstore.update(&mut block)?;
+        }
+    }
+
+    Ok(())
+}
+
 /// Phase E.5.3 — shallow merge a JSON object patch into a
 /// `MetaMapType`. Mirrors `backend::obj::merge_meta` semantics so
 /// `UpdateObjectMeta` keeps behaving the same way after the reducer
@@ -728,6 +859,8 @@ fn event_kind(event: &Event) -> &'static str {
         Event::WorkspaceMetaUpdated { .. } => "WorkspaceMetaUpdated",
         Event::TabMetaUpdated { .. } => "TabMetaUpdated",
         Event::BlockMetaUpdated { .. } => "BlockMetaUpdated",
+        Event::TabMoved { .. } => "TabMoved",
+        Event::BlockMoved { .. } => "BlockMoved",
         Event::BlockCreated { .. } => "BlockCreated",
         Event::BlockDeleted { .. } => "BlockDeleted",
         _ => "Other",
@@ -1150,5 +1283,168 @@ mod tests {
             "term:fontsize replacement must take effect after the section clear"
         );
         assert_eq!(after.meta.get("name"), Some(&serde_json::json!("keep")));
+    }
+
+    // ---- Phase E.5.5 — TabMoved / BlockMoved subscriber tests ----
+
+    #[test]
+    fn tab_moved_cross_workspace_rewrites_both_tabids() {
+        let s = store();
+        // Two workspaces, each pre-existing in SQLite.
+        for (id, name) in &[("src-ws", "Src"), ("dst-ws", "Dst")] {
+            apply_event_to_wstore(
+                &Event::WorkspaceCreated {
+                    workspace_id: id.to_string(),
+                    name: name.to_string(),
+                    version: 1,
+                },
+                &s,
+            )
+            .unwrap();
+        }
+        // Tab in src.
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "src-ws".into(),
+                tab_id: "tab-1".into(),
+                name: "T".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let src = s.get::<Workspace>("src-ws").unwrap().unwrap();
+        assert_eq!(src.tabids, vec!["tab-1".to_string()]);
+
+        // Move it.
+        apply_event_to_wstore(
+            &Event::TabMoved {
+                tab_id: "tab-1".into(),
+                src_workspace_id: "src-ws".into(),
+                dst_workspace_id: "dst-ws".into(),
+                dst_index: 0,
+                new_src_active_tab_id: None,
+                version: 3,
+            },
+            &s,
+        )
+        .unwrap();
+        let src = s.get::<Workspace>("src-ws").unwrap().unwrap();
+        let dst = s.get::<Workspace>("dst-ws").unwrap().unwrap();
+        assert!(src.tabids.is_empty());
+        assert_eq!(src.activetabid, "");
+        assert_eq!(dst.tabids, vec!["tab-1".to_string()]);
+    }
+
+    #[test]
+    fn tab_moved_idempotent_on_re_delivery() {
+        let s = store();
+        for (id, name) in &[("src-ws", "Src"), ("dst-ws", "Dst")] {
+            apply_event_to_wstore(
+                &Event::WorkspaceCreated {
+                    workspace_id: id.to_string(),
+                    name: name.to_string(),
+                    version: 1,
+                },
+                &s,
+            )
+            .unwrap();
+        }
+        apply_event_to_wstore(
+            &Event::TabCreated {
+                workspace_id: "src-ws".into(),
+                tab_id: "tab-1".into(),
+                name: "T".into(),
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let ev = Event::TabMoved {
+            tab_id: "tab-1".into(),
+            src_workspace_id: "src-ws".into(),
+            dst_workspace_id: "dst-ws".into(),
+            dst_index: 0,
+            new_src_active_tab_id: None,
+            version: 3,
+        };
+        apply_event_to_wstore(&ev, &s).unwrap();
+        // Re-deliver the same event.
+        apply_event_to_wstore(&ev, &s).unwrap();
+        let dst = s.get::<Workspace>("dst-ws").unwrap().unwrap();
+        // Still exactly one entry — no duplicate insert.
+        assert_eq!(dst.tabids, vec!["tab-1".to_string()]);
+    }
+
+    #[test]
+    fn block_moved_cross_tab_updates_block_lists_and_parent() {
+        let s = store();
+        let ws = wcore::create_workspace(&s, "W").unwrap();
+        let src_tab = wcore::create_tab_with_opts(&s, &ws.oid, "src", false).unwrap();
+        let dst_tab = wcore::create_tab_with_opts(&s, &ws.oid, "dst", false).unwrap();
+        // Create a block in src via the subscriber path.
+        apply_event_to_wstore(
+            &Event::BlockCreated {
+                tab_id: src_tab.oid.clone(),
+                block_id: "blk-1".into(),
+                meta: serde_json::Value::Null,
+                version: 1,
+            },
+            &s,
+        )
+        .unwrap();
+        let src_before = s.get::<Tab>(&src_tab.oid).unwrap().unwrap();
+        assert_eq!(src_before.blockids, vec!["blk-1".to_string()]);
+
+        apply_event_to_wstore(
+            &Event::BlockMoved {
+                block_id: "blk-1".into(),
+                src_tab_id: src_tab.oid.clone(),
+                dst_tab_id: dst_tab.oid.clone(),
+                dst_index: 0,
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let src_after = s.get::<Tab>(&src_tab.oid).unwrap().unwrap();
+        let dst_after = s.get::<Tab>(&dst_tab.oid).unwrap().unwrap();
+        let block = s.get::<Block>("blk-1").unwrap().unwrap();
+        assert!(src_after.blockids.is_empty());
+        assert_eq!(dst_after.blockids, vec!["blk-1".to_string()]);
+        assert_eq!(block.parentoref, format!("tab:{}", dst_tab.oid));
+    }
+
+    #[test]
+    fn block_moved_intra_tab_repositions() {
+        let s = store();
+        let ws = wcore::create_workspace(&s, "W").unwrap();
+        let tab = wcore::create_tab_with_opts(&s, &ws.oid, "t", false).unwrap();
+        for id in &["b1", "b2", "b3"] {
+            apply_event_to_wstore(
+                &Event::BlockCreated {
+                    tab_id: tab.oid.clone(),
+                    block_id: id.to_string(),
+                    meta: serde_json::Value::Null,
+                    version: 1,
+                },
+                &s,
+            )
+            .unwrap();
+        }
+        // Move b1 to position 2 (post-removal end).
+        apply_event_to_wstore(
+            &Event::BlockMoved {
+                block_id: "b1".into(),
+                src_tab_id: tab.oid.clone(),
+                dst_tab_id: tab.oid.clone(),
+                dst_index: 2,
+                version: 2,
+            },
+            &s,
+        )
+        .unwrap();
+        let tab_after = s.get::<Tab>(&tab.oid).unwrap().unwrap();
+        assert_eq!(tab_after.blockids, vec!["b2".to_string(), "b3".to_string(), "b1".to_string()]);
     }
 }

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -263,6 +263,7 @@ pub(crate) fn apply_event_to_wstore(
             dst_workspace_id,
             dst_index,
             new_src_active_tab_id,
+            new_dst_active_tab_id,
             ..
         } => apply_tab_moved(
             wstore,
@@ -271,6 +272,7 @@ pub(crate) fn apply_event_to_wstore(
             dst_workspace_id,
             *dst_index,
             new_src_active_tab_id.as_deref(),
+            new_dst_active_tab_id.as_deref(),
         ),
         Event::BlockMoved {
             block_id,
@@ -694,6 +696,7 @@ fn apply_tab_moved(
     dst_workspace_id: &str,
     dst_index: u32,
     new_src_active_tab_id: Option<&str>,
+    new_dst_active_tab_id: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Source workspace: remove the tab and update activetabid.
     if let Some(mut src_ws) = wstore.get::<Workspace>(src_workspace_id)? {
@@ -712,12 +715,23 @@ fn apply_tab_moved(
         }
     }
 
-    // Dest workspace: insert at clamped index. Skip if already there
-    // (idempotent on duplicate event delivery).
+    // Dest workspace: insert at clamped index + update active_tab_id
+    // if the event carries one (codex P2 #621). Skip insert if the
+    // tab is already present (idempotent on duplicate delivery).
     if let Some(mut dst_ws) = wstore.get::<Workspace>(dst_workspace_id)? {
+        let mut changed = false;
         if !dst_ws.tabids.iter().any(|id| id == tab_id) {
             let clamped = (dst_index as usize).min(dst_ws.tabids.len());
             dst_ws.tabids.insert(clamped, tab_id.to_string());
+            changed = true;
+        }
+        if let Some(new_active) = new_dst_active_tab_id {
+            if dst_ws.activetabid != new_active {
+                dst_ws.activetabid = new_active.to_string();
+                changed = true;
+            }
+        }
+        if changed {
             wstore.update(&mut dst_ws)?;
         }
     }
@@ -1316,7 +1330,8 @@ mod tests {
         let src = s.get::<Workspace>("src-ws").unwrap().unwrap();
         assert_eq!(src.tabids, vec!["tab-1".to_string()]);
 
-        // Move it.
+        // Move it. Set dst active to the moved tab (per reducer
+        // semantics + codex P2 #621).
         apply_event_to_wstore(
             &Event::TabMoved {
                 tab_id: "tab-1".into(),
@@ -1324,6 +1339,7 @@ mod tests {
                 dst_workspace_id: "dst-ws".into(),
                 dst_index: 0,
                 new_src_active_tab_id: None,
+                new_dst_active_tab_id: Some("tab-1".into()),
                 version: 3,
             },
             &s,
@@ -1334,6 +1350,7 @@ mod tests {
         assert!(src.tabids.is_empty());
         assert_eq!(src.activetabid, "");
         assert_eq!(dst.tabids, vec!["tab-1".to_string()]);
+        assert_eq!(dst.activetabid, "tab-1", "dst active should be the moved tab");
     }
 
     #[test]
@@ -1366,6 +1383,7 @@ mod tests {
             dst_workspace_id: "dst-ws".into(),
             dst_index: 0,
             new_src_active_tab_id: None,
+            new_dst_active_tab_id: Some("tab-1".into()),
             version: 3,
         };
         apply_event_to_wstore(&ev, &s).unwrap();

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -677,49 +677,52 @@ fn handle_reorder_tabs_bulk(
     workspace_id: String,
     tab_ids: Vec<String>,
 ) -> Vec<Event> {
-    // Validate using `&` borrow first so we can call `bump_version`
-    // (which needs `&mut state`) on error paths without borrow conflict.
-    let validation_error: Option<String> = {
-        let Some(workspace) = state.workspaces.get(&workspace_id) else {
-            let v = state.bump_version();
-            return vec![Event::Error {
-                code: ErrorCode::InvalidCommand,
-                message: format!("ReorderTabsBulk: workspace not found: {}", workspace_id),
-                fatal: false,
-                version: v,
-            }];
-        };
-        if workspace.tab_ids == tab_ids {
-            return Vec::new();
-        }
-        if workspace.tab_ids.len() != tab_ids.len() {
-            Some(format!(
-                "ReorderTabsBulk: new tab_ids has {} entries; workspace has {}",
-                tab_ids.len(),
-                workspace.tab_ids.len()
-            ))
-        } else {
-            let current_set: std::collections::HashSet<&String> =
-                workspace.tab_ids.iter().collect();
-            let new_set: std::collections::HashSet<&String> = tab_ids.iter().collect();
-            if current_set != new_set {
-                Some(
-                    "ReorderTabsBulk: new tab_ids must be a permutation of the workspace's current set"
-                        .to_string(),
-                )
-            } else {
-                None
-            }
-        }
-    };
-    if let Some(message) = validation_error {
+    // codex P1 #620 carryover: relax membership validation until tab
+    // moves are migrated through the reducer. `MoveTabToWorkspace`
+    // and `PromoteBlockToTab` (planned for PR 4) still write through
+    // wcore without dispatching reducer commands, so the reducer's
+    // view of `workspace.tab_ids` can be stale relative to SQLite.
+    // A subsequent `UpdateTabIds` (now routed through this command)
+    // must not refuse the canonical order just because the reducer
+    // hasn't seen the upstream move yet — that would be a
+    // user-visible regression vs. the prior wcore-direct path.
+    //
+    // Treat the caller's `tab_ids` as authoritative. The remaining
+    // checks are basic sanity: the workspace must exist in the
+    // reducer, and `tab_ids` must not contain duplicates (which would
+    // produce a corrupt persisted ordering with no way for the
+    // subscriber to recover). Length / set comparison against the
+    // reducer's stale view is dropped here; PR 4 reinstates strict
+    // validation once tab moves go through the reducer.
+    if !state.workspaces.contains_key(&workspace_id) {
         let v = state.bump_version();
         return vec![Event::Error {
             code: ErrorCode::InvalidCommand,
-            message,
+            message: format!("ReorderTabsBulk: workspace not found: {}", workspace_id),
             fatal: false,
             version: v,
         }];
+    }
+    {
+        let mut seen: std::collections::HashSet<&String> =
+            std::collections::HashSet::with_capacity(tab_ids.len());
+        for id in &tab_ids {
+            if !seen.insert(id) {
+                let v = state.bump_version();
+                return vec![Event::Error {
+                    code: ErrorCode::InvalidCommand,
+                    message: format!(
+                        "ReorderTabsBulk: tab_ids contains duplicate entry: {}",
+                        id
+                    ),
+                    fatal: false,
+                    version: v,
+                }];
+            }
+        }
+    }
+    if state.workspaces.get(&workspace_id).expect("checked").tab_ids == tab_ids {
+        return Vec::new();
     }
     state.workspaces.get_mut(&workspace_id).expect("checked").tab_ids = tab_ids.clone();
     let v = state.bump_version();
@@ -1560,6 +1563,84 @@ mod tests {
                 new_index: 0,
             },
             &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    /// codex P1 #620 carryover: `ReorderTabsBulk` must accept a list
+    /// containing tab_ids the reducer hasn't seen yet (because they
+    /// arrived via wcore-direct paths like `MoveTabToWorkspace`).
+    /// Strict permutation validation against the reducer's stale view
+    /// would falsely reject the canonical SQLite ordering during the
+    /// migration window.
+    #[test]
+    fn reorder_tabs_bulk_accepts_unknown_ids_during_migration() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let known = create_tab(&mut state, &ws_id, "known");
+        // Simulate a wcore-direct move that landed a new tab in this
+        // workspace's SQLite list without going through the reducer.
+        // The reducer's `workspace.tab_ids` is now stale: it knows
+        // about `known` only, but SQLite has both `known` and
+        // `imported` (and the latter belongs to an entirely different
+        // workspace from the reducer's perspective).
+        let imported = "imported-tab".to_string();
+        let events = update(
+            &mut state,
+            Command::ReorderTabsBulk {
+                workspace_id: ws_id.clone(),
+                tab_ids: vec![imported.clone(), known.clone()],
+            },
+            &ctx(99),
+        );
+        assert!(
+            matches!(&events[0], Event::TabsReorderedBulk { .. }),
+            "expected TabsReorderedBulk, got {:?}",
+            events.first()
+        );
+        let ws = state.workspaces.get(&ws_id).expect("ws still present");
+        assert_eq!(ws.tab_ids, vec![imported, known]);
+    }
+
+    /// codex P1 #620 carryover: a duplicate tab_id in the new list
+    /// is still rejected — that would corrupt the persisted ordering
+    /// in a way the subscriber can't recover from.
+    #[test]
+    fn reorder_tabs_bulk_rejects_duplicates() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let t1 = create_tab(&mut state, &ws_id, "t1");
+        let events = update(
+            &mut state,
+            Command::ReorderTabsBulk {
+                workspace_id: ws_id,
+                tab_ids: vec![t1.clone(), t1.clone()],
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::Error { code, message, .. } => {
+                assert_eq!(*code, ErrorCode::InvalidCommand);
+                assert!(
+                    message.contains("duplicate"),
+                    "error should mention duplicate, got: {}",
+                    message
+                );
+            }
+            other => panic!("expected Error event, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reorder_tabs_bulk_validates_workspace() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::ReorderTabsBulk {
+                workspace_id: "no-such-ws".into(),
+                tab_ids: vec!["a".into()],
+            },
+            &ctx(1),
         );
         assert!(matches!(&events[0], Event::Error { .. }));
     }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -813,11 +813,16 @@ fn handle_move_tab(
         src.active_tab_id.clone()
     };
 
-    // Insert into dst at clamped index.
+    // Insert into dst at clamped index. Set the moved tab as dst's
+    // new active tab — mirrors wcore::move_tab_to_workspace
+    // behaviour and addresses codex P2 #621 (dst.active_tab_id was
+    // previously left untouched, so a saga-driven tear-off could
+    // produce a destination workspace with no active tab selected).
     let final_dst_index: u32 = {
         let dst = state.workspaces.get_mut(&dst_workspace_id).expect("checked");
         let clamped = (dst_index as usize).min(dst.tab_ids.len());
         dst.tab_ids.insert(clamped, tab_id.clone());
+        dst.active_tab_id = Some(tab_id.clone());
         clamped as u32
     };
 
@@ -830,11 +835,12 @@ fn handle_move_tab(
 
     let v = state.bump_version();
     vec![Event::TabMoved {
-        tab_id,
+        tab_id: tab_id.clone(),
         src_workspace_id,
         dst_workspace_id,
         dst_index: final_dst_index,
         new_src_active_tab_id,
+        new_dst_active_tab_id: Some(tab_id),
         version: v,
     }]
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -775,35 +775,43 @@ fn handle_move_tab(
             version: v,
         }];
     }
-    // Validate the three entities up-front using `&` borrows so we
-    // can `bump_version` on error paths without borrow conflicts.
-    let validation_error: Option<String> = {
-        if !state.workspaces.contains_key(&src_workspace_id) {
-            Some(format!("MoveTab: src workspace not found: {}", src_workspace_id))
-        } else if !state.workspaces.contains_key(&dst_workspace_id) {
-            Some(format!("MoveTab: dst workspace not found: {}", dst_workspace_id))
-        } else {
-            match state.tabs.get(&tab_id) {
-                None => Some(format!("MoveTab: tab not found: {}", tab_id)),
-                Some(tab) if tab.workspace_id != src_workspace_id => Some(format!(
-                    "MoveTab: tab {} belongs to workspace {}, not {}",
-                    tab_id, tab.workspace_id, src_workspace_id
-                )),
-                _ => None,
-            }
-        }
-    };
-    if let Some(message) = validation_error {
+    // **Migration-tolerant validation** (codex P1 round-2 #621):
+    // tab existence + workspace_id checks are dropped during the
+    // migration window. Some tab-creating/moving paths
+    // (`PromoteBlockToTab`, etc.) are still wcore-direct — their
+    // writes don't flow into reducer state, so `state.tabs` and
+    // `state.workspaces[*].tab_ids` can lag SQLite. The saga / RPC
+    // handler that called us has already validated against SQLite
+    // (the source of truth); here we only enforce that both
+    // workspaces exist in the reducer (so we can mutate them) and
+    // trust the caller for the tab. If the tab isn't in
+    // `state.tabs`, lazy-insert a synthetic record stamped with the
+    // dst workspace_id (name unset — refilled when later events
+    // touch the tab). PR 4 reinstates strict validation once the
+    // remaining wcore-direct paths migrate.
+    if !state.workspaces.contains_key(&src_workspace_id) {
         let v = state.bump_version();
         return vec![Event::Error {
             code: ErrorCode::InvalidCommand,
-            message,
+            message: format!("MoveTab: src workspace not found: {}", src_workspace_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    if !state.workspaces.contains_key(&dst_workspace_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("MoveTab: dst workspace not found: {}", dst_workspace_id),
             fatal: false,
             version: v,
         }];
     }
 
-    // Remove from src.
+    // Remove from src. Even if the reducer's view shows the tab
+    // isn't in src.tab_ids (stale state), the persist subscriber's
+    // apply_tab_moved reads SQLite and removes from there, so the
+    // disk-side ordering ends up correct.
     let new_src_active_tab_id: Option<String> = {
         let src = state.workspaces.get_mut(&src_workspace_id).expect("checked");
         src.tab_ids.retain(|id| id != &tab_id);
@@ -826,12 +834,28 @@ fn handle_move_tab(
         clamped as u32
     };
 
-    // Update the tab's parent.
-    state
-        .tabs
-        .get_mut(&tab_id)
-        .expect("checked")
-        .workspace_id = dst_workspace_id.clone();
+    // Update the tab's parent. If the reducer's view didn't have
+    // this tab (a wcore-direct creation/move slipped past), lazy-
+    // insert a TabRecord. Name is left empty — subsequent events
+    // (TabRenamed, etc.) will refill it. The launcher's snapshot
+    // view tolerates empty names (renderer reads names from SQLite
+    // -sourced events).
+    match state.tabs.get_mut(&tab_id) {
+        Some(tab) => {
+            tab.workspace_id = dst_workspace_id.clone();
+        }
+        None => {
+            state.tabs.insert(
+                tab_id.clone(),
+                crate::state::TabRecord {
+                    tab_id: tab_id.clone(),
+                    workspace_id: dst_workspace_id.clone(),
+                    name: String::new(),
+                    block_ids: Vec::new(),
+                },
+            );
+        }
+    }
 
     let v = state.bump_version();
     vec![Event::TabMoved {
@@ -2437,6 +2461,11 @@ mod tests {
         );
         assert!(matches!(&events[0], Event::Error { .. }));
 
+        // codex P1 round-2 #621: unknown tabs are now ACCEPTED
+        // (lazy-imported into state.tabs), since wcore-direct paths
+        // can create tabs the reducer hasn't seen. Pre-checks live
+        // in the saga / RPC layer (against SQLite). The reducer
+        // here only validates that both workspaces exist.
         let events = update(
             &mut state,
             Command::MoveTab {
@@ -2447,33 +2476,71 @@ mod tests {
             },
             &ctx(4),
         );
-        assert!(matches!(&events[0], Event::Error { .. }));
+        assert!(
+            matches!(&events[0], Event::TabMoved { .. }),
+            "unknown tab should be lazy-imported, got {:?}",
+            events.first()
+        );
     }
 
+    /// codex P1 round-2 #621: handle_move_tab tolerates a tab whose
+    /// reducer-state workspace_id mismatches `src_workspace_id`. The
+    /// reducer's view can lag SQLite during the migration window
+    /// (wcore-direct paths create/move tabs without dispatching),
+    /// so a strict check would reject valid moves. The saga/RPC
+    /// reads SQLite (the source of truth) for the membership check;
+    /// the reducer here just performs the move.
     #[test]
-    fn move_tab_rejects_when_tab_belongs_to_different_workspace() {
+    fn move_tab_tolerates_workspace_id_mismatch_during_migration() {
         let mut state = State::default();
         let real_src = create_workspace(&mut state, "src");
         let dst = create_workspace(&mut state, "dst");
         let t1 = create_tab(&mut state, &real_src, "t1");
         let other = create_workspace(&mut state, "other");
-        let _ = create_tab(&mut state, &other, "filler"); // make `other` non-empty
+        let _ = create_tab(&mut state, &other, "filler");
+        // Move with src_workspace_id = "other" even though the tab
+        // technically belongs to real_src per reducer state.
         let events = update(
             &mut state,
             Command::MoveTab {
-                tab_id: t1,
+                tab_id: t1.clone(),
                 src_workspace_id: other,
-                dst_workspace_id: dst,
+                dst_workspace_id: dst.clone(),
                 dst_index: 0,
             },
             &ctx(2),
         );
-        match &events[0] {
-            Event::Error { message, .. } => {
-                assert!(message.contains("belongs to workspace"), "got: {}", message);
-            }
-            other => panic!("expected Error, got {:?}", other),
-        }
+        assert!(matches!(&events[0], Event::TabMoved { .. }));
+        // Tab's workspace_id should now point at dst.
+        assert_eq!(state.tabs[&t1].workspace_id, dst);
+    }
+
+    /// codex P1 round-2 #621: lazy-import populates state.tabs for
+    /// a tab the reducer hadn't seen. After the move, state.tabs
+    /// has an entry with workspace_id = dst.
+    #[test]
+    fn move_tab_lazy_imports_unknown_tab() {
+        let mut state = State::default();
+        let src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let unknown_id = "unknown-tab-xyz".to_string();
+        assert!(!state.tabs.contains_key(&unknown_id));
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: unknown_id.clone(),
+                src_workspace_id: src,
+                dst_workspace_id: dst.clone(),
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::TabMoved { .. }));
+        let tab = state
+            .tabs
+            .get(&unknown_id)
+            .expect("unknown tab should be lazy-imported");
+        assert_eq!(tab.workspace_id, dst);
     }
 
     // ---- Phase E.5.5 — MoveBlock tests ----

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -93,6 +93,18 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             block_id,
             meta_patch,
         } => handle_update_block_meta(state, block_id, meta_patch),
+        Command::MoveTab {
+            tab_id,
+            src_workspace_id,
+            dst_workspace_id,
+            dst_index,
+        } => handle_move_tab(state, tab_id, src_workspace_id, dst_workspace_id, dst_index),
+        Command::MoveBlock {
+            block_id,
+            src_tab_id,
+            dst_tab_id,
+            dst_index,
+        } => handle_move_block(state, block_id, src_tab_id, dst_tab_id, dst_index),
         // Anything else is a non-fatal protocol error. Future
         // phases (E.2b tabs, E.3 blocks, E.4 layouts) extend this
         // match by adding new arms above.
@@ -733,6 +745,177 @@ fn handle_reorder_tabs_bulk(
     }]
 }
 
+/// Phase E.5.5 — move a tab from `src_workspace_id` to
+/// `dst_workspace_id`, inserting at `dst_index` (clamped to dst's
+/// length). Updates the tab's `workspace_id`, removes it from src's
+/// `tab_ids`, inserts into dst's `tab_ids`. If the tab was src's
+/// `active_tab_id`, src's active reverts to its first remaining
+/// tab (or `None` when empty).
+///
+/// Errors when:
+/// * source / dest workspace not found,
+/// * tab not found,
+/// * `tab.workspace_id != src_workspace_id` (caller-side bug),
+/// * `src_workspace_id == dst_workspace_id` (use `ReorderTab` for
+///   intra-workspace reorders — same-workspace moves through this
+///   path would create ambiguity around `dst_index` semantics).
+fn handle_move_tab(
+    state: &mut State,
+    tab_id: String,
+    src_workspace_id: String,
+    dst_workspace_id: String,
+    dst_index: u32,
+) -> Vec<Event> {
+    if src_workspace_id == dst_workspace_id {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: "MoveTab: src and dst workspaces are identical; use ReorderTab".into(),
+            fatal: false,
+            version: v,
+        }];
+    }
+    // Validate the three entities up-front using `&` borrows so we
+    // can `bump_version` on error paths without borrow conflicts.
+    let validation_error: Option<String> = {
+        if !state.workspaces.contains_key(&src_workspace_id) {
+            Some(format!("MoveTab: src workspace not found: {}", src_workspace_id))
+        } else if !state.workspaces.contains_key(&dst_workspace_id) {
+            Some(format!("MoveTab: dst workspace not found: {}", dst_workspace_id))
+        } else {
+            match state.tabs.get(&tab_id) {
+                None => Some(format!("MoveTab: tab not found: {}", tab_id)),
+                Some(tab) if tab.workspace_id != src_workspace_id => Some(format!(
+                    "MoveTab: tab {} belongs to workspace {}, not {}",
+                    tab_id, tab.workspace_id, src_workspace_id
+                )),
+                _ => None,
+            }
+        }
+    };
+    if let Some(message) = validation_error {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message,
+            fatal: false,
+            version: v,
+        }];
+    }
+
+    // Remove from src.
+    let new_src_active_tab_id: Option<String> = {
+        let src = state.workspaces.get_mut(&src_workspace_id).expect("checked");
+        src.tab_ids.retain(|id| id != &tab_id);
+        if src.active_tab_id.as_deref() == Some(tab_id.as_str()) {
+            src.active_tab_id = src.tab_ids.first().cloned();
+        }
+        src.active_tab_id.clone()
+    };
+
+    // Insert into dst at clamped index.
+    let final_dst_index: u32 = {
+        let dst = state.workspaces.get_mut(&dst_workspace_id).expect("checked");
+        let clamped = (dst_index as usize).min(dst.tab_ids.len());
+        dst.tab_ids.insert(clamped, tab_id.clone());
+        clamped as u32
+    };
+
+    // Update the tab's parent.
+    state
+        .tabs
+        .get_mut(&tab_id)
+        .expect("checked")
+        .workspace_id = dst_workspace_id.clone();
+
+    let v = state.bump_version();
+    vec![Event::TabMoved {
+        tab_id,
+        src_workspace_id,
+        dst_workspace_id,
+        dst_index: final_dst_index,
+        new_src_active_tab_id,
+        version: v,
+    }]
+}
+
+/// Phase E.5.5 — move a block from `src_tab_id` to `dst_tab_id` at
+/// `dst_index` (clamped). Updates `block.tab_id`. Cross-tab moves
+/// AND intra-tab repositioning both go through this command (the
+/// caller specifies the destination index regardless).
+///
+/// Errors when source / dest tab missing, block missing, or
+/// `block.tab_id != src_tab_id`.
+fn handle_move_block(
+    state: &mut State,
+    block_id: String,
+    src_tab_id: String,
+    dst_tab_id: String,
+    dst_index: u32,
+) -> Vec<Event> {
+    let validation_error: Option<String> = {
+        if !state.tabs.contains_key(&src_tab_id) {
+            Some(format!("MoveBlock: src tab not found: {}", src_tab_id))
+        } else if !state.tabs.contains_key(&dst_tab_id) {
+            Some(format!("MoveBlock: dst tab not found: {}", dst_tab_id))
+        } else {
+            match state.blocks.get(&block_id) {
+                None => Some(format!("MoveBlock: block not found: {}", block_id)),
+                Some(block) if block.tab_id != src_tab_id => Some(format!(
+                    "MoveBlock: block {} belongs to tab {}, not {}",
+                    block_id, block.tab_id, src_tab_id
+                )),
+                _ => None,
+            }
+        }
+    };
+    if let Some(message) = validation_error {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message,
+            fatal: false,
+            version: v,
+        }];
+    }
+
+    // Special-case intra-tab move: remove and re-insert in the same
+    // tab. The clamp is computed AFTER the removal so dst_index
+    // refers to the post-removal list (matches the spec's "position
+    // in dst.tab_ids AFTER insertion" semantics for cross-tab moves).
+    let final_dst_index: u32 = if src_tab_id == dst_tab_id {
+        let tab = state.tabs.get_mut(&src_tab_id).expect("checked");
+        tab.block_ids.retain(|id| id != &block_id);
+        let clamped = (dst_index as usize).min(tab.block_ids.len());
+        tab.block_ids.insert(clamped, block_id.clone());
+        clamped as u32
+    } else {
+        // Remove from src.
+        state
+            .tabs
+            .get_mut(&src_tab_id)
+            .expect("checked")
+            .block_ids
+            .retain(|id| id != &block_id);
+        // Insert into dst.
+        let dst = state.tabs.get_mut(&dst_tab_id).expect("checked");
+        let clamped = (dst_index as usize).min(dst.block_ids.len());
+        dst.block_ids.insert(clamped, block_id.clone());
+        // Update parent.
+        state.blocks.get_mut(&block_id).expect("checked").tab_id = dst_tab_id.clone();
+        clamped as u32
+    };
+
+    let v = state.bump_version();
+    vec![Event::BlockMoved {
+        block_id,
+        src_tab_id,
+        dst_tab_id,
+        dst_index: final_dst_index,
+        version: v,
+    }]
+}
+
 /// Phase E.5.3 — rename a workspace. Errors if missing; no-op if
 /// the name is unchanged.
 fn handle_rename_workspace(state: &mut State, workspace_id: String, name: String) -> Vec<Event> {
@@ -921,6 +1104,8 @@ mod tests {
             | Event::WorkspaceMetaUpdated { version, .. }
             | Event::TabMetaUpdated { version, .. }
             | Event::BlockMetaUpdated { version, .. }
+            | Event::TabMoved { version, .. }
+            | Event::BlockMoved { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -2101,5 +2286,325 @@ mod tests {
             state.processes[&100].state,
             ProcessState::Exited { code: 0 }
         ));
+    }
+
+    // ---- Phase E.5.5 — MoveTab tests ----
+
+    #[test]
+    fn move_tab_cross_workspace_updates_lists_and_parent() {
+        let mut state = State::default();
+        let src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let t1 = create_tab(&mut state, &src, "t1");
+        let t2 = create_tab(&mut state, &src, "t2");
+        let dst_existing = create_tab(&mut state, &dst, "existing");
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1.clone(),
+                src_workspace_id: src.clone(),
+                dst_workspace_id: dst.clone(),
+                dst_index: 0,
+            },
+            &ctx(99),
+        );
+        match &events[0] {
+            Event::TabMoved {
+                tab_id,
+                src_workspace_id,
+                dst_workspace_id,
+                dst_index,
+                new_src_active_tab_id,
+                ..
+            } => {
+                assert_eq!(tab_id, &t1);
+                assert_eq!(src_workspace_id, &src);
+                assert_eq!(dst_workspace_id, &dst);
+                assert_eq!(*dst_index, 0);
+                assert_eq!(new_src_active_tab_id, &Some(t2.clone()));
+            }
+            other => panic!("expected TabMoved, got {:?}", other),
+        }
+        assert_eq!(state.workspaces[&src].tab_ids, vec![t2.clone()]);
+        assert_eq!(state.workspaces[&dst].tab_ids, vec![t1.clone(), dst_existing]);
+        assert_eq!(state.tabs[&t1].workspace_id, dst);
+        assert_eq!(state.workspaces[&src].active_tab_id, Some(t2));
+    }
+
+    #[test]
+    fn move_tab_clamps_dst_index_to_dst_length() {
+        let mut state = State::default();
+        let src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let t1 = create_tab(&mut state, &src, "t1");
+        let _ = create_tab(&mut state, &src, "filler");
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1.clone(),
+                src_workspace_id: src,
+                dst_workspace_id: dst.clone(),
+                dst_index: 999,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::TabMoved { dst_index, .. } => assert_eq!(*dst_index, 0),
+            other => panic!("expected TabMoved, got {:?}", other),
+        }
+        assert_eq!(state.workspaces[&dst].tab_ids, vec![t1]);
+    }
+
+    #[test]
+    fn move_tab_src_active_clears_when_workspace_empties() {
+        let mut state = State::default();
+        let src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let only_tab = create_tab(&mut state, &src, "only");
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: only_tab,
+                src_workspace_id: src.clone(),
+                dst_workspace_id: dst,
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::TabMoved {
+                new_src_active_tab_id,
+                ..
+            } => assert_eq!(new_src_active_tab_id, &None),
+            other => panic!("expected TabMoved, got {:?}", other),
+        }
+        assert_eq!(state.workspaces[&src].active_tab_id, None);
+        assert!(state.workspaces[&src].tab_ids.is_empty());
+    }
+
+    #[test]
+    fn move_tab_rejects_same_workspace() {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let t1 = create_tab(&mut state, &ws, "t1");
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1,
+                src_workspace_id: ws.clone(),
+                dst_workspace_id: ws,
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn move_tab_rejects_unknown_src_or_dst_or_tab() {
+        let mut state = State::default();
+        let src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let t1 = create_tab(&mut state, &src, "t1");
+
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1.clone(),
+                src_workspace_id: "no-such-src".into(),
+                dst_workspace_id: dst.clone(),
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1.clone(),
+                src_workspace_id: src.clone(),
+                dst_workspace_id: "no-such-dst".into(),
+                dst_index: 0,
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: "ghost-tab".into(),
+                src_workspace_id: src.clone(),
+                dst_workspace_id: dst,
+                dst_index: 0,
+            },
+            &ctx(4),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn move_tab_rejects_when_tab_belongs_to_different_workspace() {
+        let mut state = State::default();
+        let real_src = create_workspace(&mut state, "src");
+        let dst = create_workspace(&mut state, "dst");
+        let t1 = create_tab(&mut state, &real_src, "t1");
+        let other = create_workspace(&mut state, "other");
+        let _ = create_tab(&mut state, &other, "filler"); // make `other` non-empty
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1,
+                src_workspace_id: other,
+                dst_workspace_id: dst,
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::Error { message, .. } => {
+                assert!(message.contains("belongs to workspace"), "got: {}", message);
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    // ---- Phase E.5.5 — MoveBlock tests ----
+
+    fn create_block(state: &mut State, tab_id: &str) -> String {
+        let events = update(
+            state,
+            Command::CreateBlock {
+                tab_id: tab_id.into(),
+                meta: serde_json::Value::Null,
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::BlockCreated { block_id, .. } => block_id.clone(),
+            _ => panic!("expected BlockCreated"),
+        }
+    }
+
+    #[test]
+    fn move_block_cross_tab_updates_lists_and_parent() {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let src_tab = create_tab(&mut state, &ws, "src");
+        let dst_tab = create_tab(&mut state, &ws, "dst");
+        let block = create_block(&mut state, &src_tab);
+        let dst_existing = create_block(&mut state, &dst_tab);
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: block.clone(),
+                src_tab_id: src_tab.clone(),
+                dst_tab_id: dst_tab.clone(),
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::BlockMoved { .. }));
+        assert_eq!(state.tabs[&src_tab].block_ids, Vec::<String>::new());
+        assert_eq!(state.tabs[&dst_tab].block_ids, vec![block.clone(), dst_existing]);
+        assert_eq!(state.blocks[&block].tab_id, dst_tab);
+    }
+
+    #[test]
+    fn move_block_intra_tab_repositions() {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let tab = create_tab(&mut state, &ws, "t");
+        let b1 = create_block(&mut state, &tab);
+        let b2 = create_block(&mut state, &tab);
+        let b3 = create_block(&mut state, &tab);
+        // Move b1 to position 2 (end after removal).
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: b1.clone(),
+                src_tab_id: tab.clone(),
+                dst_tab_id: tab.clone(),
+                dst_index: 2,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::BlockMoved { dst_index, .. } => assert_eq!(*dst_index, 2),
+            other => panic!("expected BlockMoved, got {:?}", other),
+        }
+        assert_eq!(state.tabs[&tab].block_ids, vec![b2, b3, b1]);
+    }
+
+    #[test]
+    fn move_block_rejects_unknown_src_or_dst_or_block() {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let tab = create_tab(&mut state, &ws, "t");
+        let other_tab = create_tab(&mut state, &ws, "other");
+        let block = create_block(&mut state, &tab);
+
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: block.clone(),
+                src_tab_id: "ghost-src".into(),
+                dst_tab_id: other_tab.clone(),
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: block.clone(),
+                src_tab_id: tab.clone(),
+                dst_tab_id: "ghost-dst".into(),
+                dst_index: 0,
+            },
+            &ctx(3),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: "ghost-block".into(),
+                src_tab_id: tab,
+                dst_tab_id: other_tab,
+                dst_index: 0,
+            },
+            &ctx(4),
+        );
+        assert!(matches!(&events[0], Event::Error { .. }));
+    }
+
+    #[test]
+    fn move_block_rejects_when_block_belongs_to_different_tab() {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let real_src = create_tab(&mut state, &ws, "real");
+        let other = create_tab(&mut state, &ws, "other");
+        let dst = create_tab(&mut state, &ws, "dst");
+        let block = create_block(&mut state, &real_src);
+        let events = update(
+            &mut state,
+            Command::MoveBlock {
+                block_id: block,
+                src_tab_id: other,
+                dst_tab_id: dst,
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::Error { message, .. } => {
+                assert!(message.contains("belongs to tab"), "got: {}", message);
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
     }
 }

--- a/agentmux-srv/src/sagas/mod.rs
+++ b/agentmux-srv/src/sagas/mod.rs
@@ -1,0 +1,208 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.5 — srv-side saga coordinator.
+//
+// **Why srv, not launcher:** the existing E.1a coordinator
+// framework lives in `agentmux-launcher::saga` (which still does
+// nothing — no consumers). The original Phase E spec assumed
+// sagas would fan out across host/launcher/srv via cross-process
+// IPC; the actual implementation kept that fan-out in the frontend
+// (`requestTearOff` calls srv-rpc and host-rpc directly), so every
+// saga in the E.5 plan mutates only srv state. In-process oneshot
+// dispatch beats an IPC round-trip on every saga step. See
+// `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` for
+// the full reasoning, including the robustness trade-offs (which
+// are the same for both placements).
+//
+// **Shape:** sagas are async functions that:
+//   1. allocate a fresh saga_id via `alloc_saga_id`,
+//   2. emit `Event::SagaStarted` via `emit_saga_started`,
+//   3. drive their state machine via `SagaCtx::dispatch` /
+//      `SagaCtx::compensate`,
+//   4. emit `Event::SagaCompleted` or `Event::SagaFailed` via
+//      `emit_terminal` once the inner work returns.
+//
+// `run_saga(state, name, future)` is a thin wrapper that does
+// 1+2+4 + applies a 5 s timeout. Sagas pass the future directly
+// (not a closure), avoiding the lifetime-of-SagaCtx complication
+// that closure-style coordinators run into.
+//
+// **Compensation:** the saga's inner future is responsible for
+// driving compensation before returning `Err`. `SagaCtx::compensate`
+// is a best-effort dispatch that swallows errors (the saga is
+// already failing; secondary failures get logged). Idempotency of
+// compensating commands (`MoveTab` back to source, `DeleteWorkspace`,
+// etc.) keeps the cleanup safe even if a step partially applied.
+//
+// What this module does NOT close (per the location analysis §4.2):
+// * Per-step SQLite transactions in the subscriber (gap; F1.A).
+// * Host pool-promote and renderer registration outside the saga
+//   (gap; Phase F).
+// * Saga state across srv restart (gap; Phase F+).
+
+pub mod restore_torn_off_tab;
+pub mod tear_off_block;
+pub mod tear_off_tab;
+
+use std::sync::atomic::Ordering;
+
+use agentmux_common::ipc::{Command, Event};
+use serde_json::Value;
+
+use crate::server::AppState;
+
+/// Maximum wall-clock time a saga is allowed to run before the
+/// coordinator force-fails it. Tear-off sagas should complete in
+/// tens of milliseconds; the budget is generous to absorb SQLite
+/// write spikes without flapping in CI.
+const SAGA_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Read-only context passed to a saga's inner async function.
+/// Wraps the AppState handle and the saga's allocated id.
+pub struct SagaCtx<'a> {
+    pub(crate) state: &'a AppState,
+    pub(crate) saga_id: u64,
+}
+
+impl<'a> SagaCtx<'a> {
+    /// Saga-id this context belongs to. Used by sagas that need to
+    /// log progress with the saga prefix.
+    #[allow(dead_code)]
+    pub fn saga_id(&self) -> u64 {
+        self.saga_id
+    }
+
+    /// Acquire the reducer's state lock for read-only inspection.
+    /// Used by sagas that need to inspect post-step state to decide
+    /// the next step (e.g. RestoreTornOffTab checking whether the
+    /// source workspace is now empty before issuing the cascade
+    /// delete). Hold briefly — the reducer is single-mutex.
+    pub async fn state_lock(&self) -> tokio::sync::MutexGuard<'_, crate::state::State> {
+        self.state.srv_state.lock().await
+    }
+
+    /// Dispatch `cmd` through the srv reducer and apply the emitted
+    /// events to SQLite + the broadcast bus, exactly like the
+    /// in-handler reducer-dispatch helpers.
+    ///
+    /// Returns the emitted event vec on success. If the reducer
+    /// emits any `Event::Error`, the error message is returned and
+    /// SQLite/bus side-effects are skipped — the caller must then
+    /// dispatch compensation for the saga's already-applied steps.
+    pub async fn dispatch(&self, cmd: Command) -> Result<Vec<Event>, String> {
+        let events = crate::server::service::dispatch_to_reducer(self.state, cmd).await;
+        if let Some(message) = events.iter().find_map(|e| match e {
+            Event::Error { message, .. } => Some(message.clone()),
+            _ => None,
+        }) {
+            return Err(message);
+        }
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &self.state.wstore)
+                .map_err(|e| e.to_string())?;
+        }
+        crate::server::service::publish_events(self.state, &events);
+        Ok(events)
+    }
+
+    /// Best-effort compensating dispatch. Same as `dispatch` but
+    /// SQLite-write failures are logged and swallowed. Intended for
+    /// the unwind path: the saga is already returning an error to
+    /// the caller; throwing on cleanup hides the original cause and
+    /// prevents subsequent compensating commands from running.
+    pub async fn compensate(&self, cmd: Command) {
+        let events =
+            crate::server::service::dispatch_to_reducer(self.state, cmd.clone()).await;
+        if let Some(message) = events.iter().find_map(|e| match e {
+            Event::Error { message, .. } => Some(message.clone()),
+            _ => None,
+        }) {
+            tracing::warn!(
+                saga_id = self.saga_id,
+                "[saga] compensation rejected by reducer: {} (cmd discriminant: {:?})",
+                message,
+                std::mem::discriminant(&cmd),
+            );
+            return;
+        }
+        for ev in &events {
+            if let Err(e) =
+                crate::persist_subscriber::apply_event_to_wstore(ev, &self.state.wstore)
+            {
+                tracing::warn!(
+                    saga_id = self.saga_id,
+                    "[saga] compensation: SQLite write failed: {}",
+                    e
+                );
+            }
+        }
+        crate::server::service::publish_events(self.state, &events);
+    }
+}
+
+/// Allocate the next saga_id. Monotonic per srv-process run.
+pub fn alloc_saga_id(state: &AppState) -> u64 {
+    state.saga_id_alloc.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+/// Emit `Event::SagaStarted` for a freshly-allocated saga_id.
+/// Sagas call this immediately after `alloc_saga_id` so subscribers
+/// see the start record before any per-step events.
+pub async fn emit_saga_started(state: &AppState, saga_id: u64, name: &'static str) {
+    let v = state.srv_state.lock().await.bump_version();
+    let _ = state.srv_events_tx.send(Event::SagaStarted {
+        saga_id,
+        name: name.to_string(),
+        version: v,
+    });
+}
+
+/// Emit the saga's terminal lifecycle event. Pass `Ok(())` for
+/// success (emits `SagaCompleted`) or `Err(reason)` for failure
+/// (emits `SagaFailed`).
+pub async fn emit_terminal(state: &AppState, saga_id: u64, outcome: Result<(), &str>) {
+    let v = state.srv_state.lock().await.bump_version();
+    let event = match outcome {
+        Ok(()) => Event::SagaCompleted {
+            saga_id,
+            version: v,
+        },
+        Err(reason) => Event::SagaFailed {
+            saga_id,
+            reason: reason.to_string(),
+            version: v,
+        },
+    };
+    let _ = state.srv_events_tx.send(event);
+}
+
+/// Run a saga's inner future under a 5 s timeout. The inner future
+/// is responsible for emitting `SagaStarted` (the saga itself, since
+/// it owns the saga_id allocation) and any compensation it needs;
+/// `run_saga` only enforces the timeout and emits the terminal
+/// `SagaCompleted` / `SagaFailed`.
+///
+/// Concrete usage (per saga):
+/// ```ignore
+/// pub async fn run(state: &AppState, ...) -> Result<Value, String> {
+///     let saga_id = alloc_saga_id(state);
+///     emit_saga_started(state, saga_id, "tear_off_tab").await;
+///     let ctx = SagaCtx { state, saga_id };
+///     let result = run_saga(run_inner(ctx, ...)).await;
+///     emit_terminal(state, saga_id, match &result {
+///         Ok(_) => Ok(()),
+///         Err(r) => Err(r.as_str()),
+///     }).await;
+///     result
+/// }
+/// ```
+pub async fn run_saga<Fut>(name: &'static str, fut: Fut) -> Result<Value, String>
+where
+    Fut: std::future::Future<Output = Result<Value, String>>,
+{
+    match tokio::time::timeout(SAGA_TIMEOUT, fut).await {
+        Ok(r) => r,
+        Err(_) => Err(format!("saga '{}' timed out after {:?}", name, SAGA_TIMEOUT)),
+    }
+}

--- a/agentmux-srv/src/sagas/restore_torn_off_tab.rs
+++ b/agentmux-srv/src/sagas/restore_torn_off_tab.rs
@@ -1,0 +1,257 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.6 — RestoreTornOffTab saga.
+//
+// Drops the torn-off tab back into the destination workspace and,
+// if the source workspace became empty, deletes it (cascade).
+//
+// **Steps:**
+// 1. `MoveTab { tab_id, src=source_ws, dst=dest_ws, dst_index }`
+// 2. If post-move state shows source workspace's `tab_ids` is
+//    empty → `DeleteWorkspace { source_ws }` (cascade is built in;
+//    no surviving tabs to handle).
+//    Otherwise → done.
+//
+// **Compensation:**
+// * Step 1 fails → nothing to compensate (reducer rejected without
+//   mutating; tab is still in source).
+// * Step 2 fails → tab is already restored to dest; the orphan
+//   source workspace persists. Log the failure but return success
+//   (the user-visible operation succeeded; the orphan is a soft
+//   cleanup gap that the next user action — close window, etc. —
+//   will catch).
+//
+// **Pinning note:** the legacy `was_pinned` arg of `RestoreTornOffTab`
+// is ignored. Pinning was a Waveterm feature removed from AgentMux
+// (per E.2c.3b). Restored tabs always land in `tab_ids`.
+
+use agentmux_common::ipc::Command;
+use serde_json::{json, Value};
+
+use super::{alloc_saga_id, emit_saga_started, emit_terminal, run_saga, SagaCtx};
+use crate::server::AppState;
+
+/// Run the RestoreTornOffTab saga. On success, returns
+/// `{"source_workspace_deleted": <bool>}`.
+pub async fn run(
+    state: &AppState,
+    tab_id: String,
+    source_workspace_id: String,
+    dest_workspace_id: String,
+    insert_index: Option<u32>,
+) -> Result<Value, String> {
+    // Pre-condition checks read state under the reducer lock so we
+    // don't allocate a saga_id for an obviously-invalid request.
+    {
+        let s = state.srv_state.lock().await;
+        if !s.workspaces.contains_key(&source_workspace_id) {
+            return Err(format!(
+                "RestoreTornOffTab: source workspace not found: {}",
+                source_workspace_id
+            ));
+        }
+        if !s.workspaces.contains_key(&dest_workspace_id) {
+            return Err(format!(
+                "RestoreTornOffTab: dest workspace not found: {}",
+                dest_workspace_id
+            ));
+        }
+        match s.tabs.get(&tab_id) {
+            None => {
+                return Err(format!("RestoreTornOffTab: tab not found: {}", tab_id));
+            }
+            Some(tab) if tab.workspace_id != source_workspace_id => {
+                return Err(format!(
+                    "RestoreTornOffTab: tab {} is in workspace {}, not {}",
+                    tab_id, tab.workspace_id, source_workspace_id
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let dst_index = insert_index.unwrap_or(u32::MAX);
+
+    let saga_id = alloc_saga_id(state);
+    emit_saga_started(state, saga_id, "restore_torn_off_tab").await;
+    let ctx = SagaCtx { state, saga_id };
+    let result = run_saga(
+        "restore_torn_off_tab",
+        run_inner(ctx, tab_id, source_workspace_id, dest_workspace_id, dst_index),
+    )
+    .await;
+    emit_terminal(
+        state,
+        saga_id,
+        match &result {
+            Ok(_) => Ok(()),
+            Err(r) => Err(r.as_str()),
+        },
+    )
+    .await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    tab_id: String,
+    source_workspace_id: String,
+    dest_workspace_id: String,
+    dst_index: u32,
+) -> Result<Value, String> {
+    // Step 1: move the tab.
+    ctx.dispatch(Command::MoveTab {
+        tab_id: tab_id.clone(),
+        src_workspace_id: source_workspace_id.clone(),
+        dst_workspace_id: dest_workspace_id.clone(),
+        dst_index,
+    })
+    .await
+    .map_err(|e| format!("RestoreTornOffTab step 1 (MoveTab): {}", e))?;
+
+    // Step 2: check post-move state, conditionally delete source.
+    let source_now_empty = {
+        let s = ctx.state_lock().await;
+        s.workspaces
+            .get(&source_workspace_id)
+            .map(|ws| ws.tab_ids.is_empty())
+            .unwrap_or(true)
+    };
+
+    let mut source_deleted = false;
+    if source_now_empty {
+        // Best-effort delete; log + soft-fail on reducer rejection
+        // (tab is already restored, which is what the user asked for).
+        match ctx
+            .dispatch(Command::DeleteWorkspace {
+                workspace_id: source_workspace_id.clone(),
+            })
+            .await
+        {
+            Ok(_) => source_deleted = true,
+            Err(e) => {
+                tracing::warn!(
+                    saga_id = ctx.saga_id(),
+                    "[saga] RestoreTornOffTab: source workspace cleanup failed: {} (orphan workspace {})",
+                    e,
+                    source_workspace_id
+                );
+            }
+        }
+    }
+
+    Ok(json!({ "source_workspace_deleted": source_deleted }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentmux_common::ipc::Event;
+    use crate::backend::obj::Workspace;
+    use crate::server::tests::test_state;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    /// Seeds a "torn-off" workspace (single tab) and a destination
+    /// workspace (its own tab). Returns (state, torn_ws, torn_tab,
+    /// dest_ws, dest_tab).
+    async fn seed_torn_off_state() -> (crate::server::AppState, String, String, String, String) {
+        let state = test_state();
+        let mut ws_ids = Vec::new();
+        let mut tab_ids = Vec::new();
+        for ws_name in &["torn", "dest"] {
+            let ws_evs = dispatch_apply(
+                &state,
+                agentmux_common::ipc::Command::CreateWorkspace {
+                    name: ws_name.to_string(),
+                },
+            )
+            .await;
+            let ws_id = ws_evs
+                .iter()
+                .find_map(|e| match e {
+                    Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                    _ => None,
+                })
+                .unwrap();
+            let tab_evs = dispatch_apply(
+                &state,
+                agentmux_common::ipc::Command::CreateTab {
+                    workspace_id: ws_id.clone(),
+                    name: format!("{}-tab", ws_name),
+                },
+            )
+            .await;
+            let tab_id = tab_evs
+                .iter()
+                .find_map(|e| match e {
+                    Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                    _ => None,
+                })
+                .unwrap();
+            ws_ids.push(ws_id);
+            tab_ids.push(tab_id);
+        }
+        (
+            state,
+            ws_ids[0].clone(),
+            tab_ids[0].clone(),
+            ws_ids[1].clone(),
+            tab_ids[1].clone(),
+        )
+    }
+
+    #[tokio::test]
+    async fn happy_path_moves_tab_back_and_deletes_empty_source() {
+        let (state, torn_ws, torn_tab, dest_ws, _dest_tab) = seed_torn_off_state().await;
+        let result = run(&state, torn_tab.clone(), torn_ws.clone(), dest_ws.clone(), Some(0))
+            .await
+            .unwrap();
+        assert_eq!(result["source_workspace_deleted"], true);
+
+        // Reducer: source workspace gone; tab is in dest.
+        let s = state.srv_state.lock().await;
+        assert!(!s.workspaces.contains_key(&torn_ws));
+        assert!(s.workspaces[&dest_ws].tab_ids.contains(&torn_tab));
+        assert_eq!(s.tabs[&torn_tab].workspace_id, dest_ws);
+        drop(s);
+
+        // SQLite: source workspace row gone too.
+        assert!(state.wstore.get::<Workspace>(&torn_ws).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn skips_delete_when_source_still_has_tabs() {
+        let (state, torn_ws, torn_tab, dest_ws, _) = seed_torn_off_state().await;
+        // Add a second tab to torn so it doesn't become empty.
+        let _ = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: torn_ws.clone(),
+                name: "extra".into(),
+            },
+        )
+        .await;
+
+        let result = run(&state, torn_tab, torn_ws.clone(), dest_ws, Some(0))
+            .await
+            .unwrap();
+        assert_eq!(
+            result["source_workspace_deleted"], false,
+            "source ws should survive when it still has tabs"
+        );
+        // Source still in reducer.
+        let s = state.srv_state.lock().await;
+        assert!(s.workspaces.contains_key(&torn_ws));
+    }
+}

--- a/agentmux-srv/src/sagas/restore_torn_off_tab.rs
+++ b/agentmux-srv/src/sagas/restore_torn_off_tab.rs
@@ -41,33 +41,45 @@ pub async fn run(
     dest_workspace_id: String,
     insert_index: Option<u32>,
 ) -> Result<Value, String> {
-    // Pre-condition checks read state under the reducer lock so we
-    // don't allocate a saga_id for an obviously-invalid request.
+    // Pre-condition checks read SQLite, not reducer state. During
+    // the migration window, wcore-direct paths (PromoteBlockToTab,
+    // etc.) leave reducer.tabs / workspaces stale relative to disk;
+    // a reducer-state pre-check would falsely reject valid restores
+    // (codex P1 round-2 #621).
     {
-        let s = state.srv_state.lock().await;
-        if !s.workspaces.contains_key(&source_workspace_id) {
-            return Err(format!(
-                "RestoreTornOffTab: source workspace not found: {}",
-                source_workspace_id
-            ));
-        }
-        if !s.workspaces.contains_key(&dest_workspace_id) {
+        let src_ws = match state.wstore.get::<crate::backend::obj::Workspace>(&source_workspace_id) {
+            Ok(Some(ws)) => ws,
+            Ok(None) => {
+                return Err(format!(
+                    "RestoreTornOffTab: source workspace not found: {}",
+                    source_workspace_id
+                ));
+            }
+            Err(e) => {
+                return Err(format!(
+                    "RestoreTornOffTab: workspace read failed: {}",
+                    e
+                ));
+            }
+        };
+        if state
+            .wstore
+            .get::<crate::backend::obj::Workspace>(&dest_workspace_id)
+            .map(|w| w.is_none())
+            .unwrap_or(true)
+        {
             return Err(format!(
                 "RestoreTornOffTab: dest workspace not found: {}",
                 dest_workspace_id
             ));
         }
-        match s.tabs.get(&tab_id) {
-            None => {
-                return Err(format!("RestoreTornOffTab: tab not found: {}", tab_id));
-            }
-            Some(tab) if tab.workspace_id != source_workspace_id => {
-                return Err(format!(
-                    "RestoreTornOffTab: tab {} is in workspace {}, not {}",
-                    tab_id, tab.workspace_id, source_workspace_id
-                ));
-            }
-            _ => {}
+        let in_workspace = src_ws.tabids.iter().any(|id| id == &tab_id)
+            || src_ws.pinnedtabids.iter().any(|id| id == &tab_id);
+        if !in_workspace {
+            return Err(format!(
+                "RestoreTornOffTab: tab {} is not in workspace {}",
+                tab_id, source_workspace_id
+            ));
         }
     }
 

--- a/agentmux-srv/src/sagas/tear_off_block.rs
+++ b/agentmux-srv/src/sagas/tear_off_block.rs
@@ -1,0 +1,291 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.5 — TearOffBlock saga.
+//
+// Migrates the reducer-state portion of `wcore::tear_off_block` to
+// a reducer-driven multi-step. The original wcore function does
+// substantial layout work (rebuilds the new tab's `LayoutState`
+// rootnode + leaforder, queues a layout-delete action on the source
+// tab's pendingbackendactions) — that's E.4 territory and stays
+// wcore-direct in the RPC handler that wraps this saga. The
+// reducer/SQLite portion is what fixes the smoke regression
+// (the new workspace was invisible to the reducer because wcore
+// bypassed it).
+//
+// **Steps:**
+// 1. `CreateWorkspace { name: "" }`
+// 2. `CreateTab { workspace_id: new_ws_id, name: "" }`
+// 3. `MoveBlock { block_id, src=source_tab, dst=new_tab, dst_index: 0 }`
+//
+// Auto-close-source-tab and layout setup are NOT here — see the
+// RPC handler in `service.rs` for those steps.
+//
+// **Compensation:**
+// * Step 3 fails after step 1+2 → `DeleteWorkspace { new_ws_id }`
+//   (cascades through tabs to blocks; no blocks landed in the new
+//   tab at this point).
+// * Step 2 fails after step 1 → `DeleteWorkspace { new_ws_id }`.
+// * Step 1 fails → nothing to compensate.
+
+use agentmux_common::ipc::{Command, Event};
+use serde_json::{json, Value};
+
+use super::{alloc_saga_id, emit_saga_started, emit_terminal, run_saga, SagaCtx};
+use crate::server::AppState;
+
+/// Run the TearOffBlock saga. On success, returns
+/// `{"new_workspace_id": "...", "new_tab_id": "..."}`.
+pub async fn run(
+    state: &AppState,
+    block_id: String,
+    source_tab_id: String,
+    source_workspace_id: String,
+) -> Result<Value, String> {
+    // Pre-condition: block exists and belongs to source_tab; source
+    // tab is in source_workspace. Reducer would catch the structural
+    // mismatch via MoveBlock validation, but check up-front so we
+    // don't allocate a workspace + tab and then have to compensate.
+    {
+        let s = state.srv_state.lock().await;
+        match s.blocks.get(&block_id) {
+            None => {
+                return Err(format!("TearOffBlock: block not found: {}", block_id));
+            }
+            Some(block) if block.tab_id != source_tab_id => {
+                return Err(format!(
+                    "TearOffBlock: block {} is in tab {}, not {}",
+                    block_id, block.tab_id, source_tab_id
+                ));
+            }
+            _ => {}
+        }
+        match s.tabs.get(&source_tab_id) {
+            None => {
+                return Err(format!(
+                    "TearOffBlock: source tab not found: {}",
+                    source_tab_id
+                ));
+            }
+            Some(tab) if tab.workspace_id != source_workspace_id => {
+                return Err(format!(
+                    "TearOffBlock: tab {} is in workspace {}, not {}",
+                    source_tab_id, tab.workspace_id, source_workspace_id
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    let saga_id = alloc_saga_id(state);
+    emit_saga_started(state, saga_id, "tear_off_block").await;
+    let ctx = SagaCtx { state, saga_id };
+    let result = run_saga("tear_off_block", run_inner(ctx, block_id, source_tab_id)).await;
+    emit_terminal(
+        state,
+        saga_id,
+        match &result {
+            Ok(_) => Ok(()),
+            Err(r) => Err(r.as_str()),
+        },
+    )
+    .await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    block_id: String,
+    source_tab_id: String,
+) -> Result<Value, String> {
+    // Step 1: new workspace.
+    let create_ws_events = ctx
+        .dispatch(Command::CreateWorkspace {
+            name: String::new(),
+        })
+        .await
+        .map_err(|e| format!("TearOffBlock step 1 (CreateWorkspace): {}", e))?;
+    let new_workspace_id = create_ws_events
+        .iter()
+        .find_map(|e| match e {
+            Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            "TearOffBlock: CreateWorkspace did not emit WorkspaceCreated".to_string()
+        })?;
+
+    // Step 2: new tab in the new workspace.
+    let create_tab_events = match ctx
+        .dispatch(Command::CreateTab {
+            workspace_id: new_workspace_id.clone(),
+            name: String::new(),
+        })
+        .await
+    {
+        Ok(evs) => evs,
+        Err(reason) => {
+            ctx.compensate(Command::DeleteWorkspace {
+                workspace_id: new_workspace_id.clone(),
+            })
+            .await;
+            return Err(format!("TearOffBlock step 2 (CreateTab): {}", reason));
+        }
+    };
+    let new_tab_id = create_tab_events
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            "TearOffBlock: CreateTab did not emit TabCreated".to_string()
+        })?;
+
+    // Step 3: move the block.
+    if let Err(reason) = ctx
+        .dispatch(Command::MoveBlock {
+            block_id: block_id.clone(),
+            src_tab_id: source_tab_id.clone(),
+            dst_tab_id: new_tab_id.clone(),
+            dst_index: 0,
+        })
+        .await
+    {
+        // Compensate: delete the workspace (cascades the empty tab).
+        ctx.compensate(Command::DeleteWorkspace {
+            workspace_id: new_workspace_id.clone(),
+        })
+        .await;
+        return Err(format!("TearOffBlock step 3 (MoveBlock): {}", reason));
+    }
+
+    Ok(json!({
+        "new_workspace_id": new_workspace_id,
+        "new_tab_id": new_tab_id,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::{Block, Tab};
+    use crate::server::tests::test_state;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<agentmux_common::ipc::Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn happy_path_creates_workspace_tab_and_moves_block() {
+        let state = test_state();
+        // Seed: workspace with one tab containing a block.
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "src".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t".into(),
+            },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateBlock {
+                tab_id: tab_id.clone(),
+                meta: serde_json::Value::Null,
+            },
+        )
+        .await;
+        let block_id = blk_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        let result = run(&state, block_id.clone(), tab_id.clone(), ws_id.clone())
+            .await
+            .unwrap();
+        let new_ws_id = result["new_workspace_id"].as_str().unwrap();
+        let new_tab_id = result["new_tab_id"].as_str().unwrap();
+
+        // Reducer: source tab has no blocks; new tab has the block.
+        let s = state.srv_state.lock().await;
+        assert!(s.tabs[&tab_id].block_ids.is_empty());
+        assert_eq!(
+            s.tabs[new_tab_id].block_ids,
+            vec![block_id.clone()],
+            "block should be in new tab"
+        );
+        assert_eq!(s.blocks[&block_id].tab_id, new_tab_id);
+        assert_eq!(s.workspaces[new_ws_id].tab_ids, vec![new_tab_id.to_string()]);
+
+        // SQLite: matches.
+        drop(s);
+        let new_tab = state.wstore.get::<Tab>(new_tab_id).unwrap().unwrap();
+        assert_eq!(new_tab.blockids, vec![block_id.clone()]);
+        let block = state.wstore.get::<Block>(&block_id).unwrap().unwrap();
+        assert_eq!(block.parentoref, format!("tab:{}", new_tab_id));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_block_not_in_source_tab() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let _ = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t".into(),
+            },
+        )
+        .await;
+        let err = run(
+            &state,
+            "ghost-block".into(),
+            "ghost-tab".into(),
+            ws_id,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.contains("block not found") || err.contains("source tab not found"), "got: {}", err);
+    }
+}

--- a/agentmux-srv/src/sagas/tear_off_tab.rs
+++ b/agentmux-srv/src/sagas/tear_off_tab.rs
@@ -58,32 +58,42 @@ pub async fn run(
     // We're about to move one out; if it's the only tab, we'd leave
     // an empty workspace behind, which the UI doesn't represent
     // gracefully. Mirrors `wcore::tear_off_tab`'s "cannot tear off
-    // last tab" guard. Read the reducer state under its lock
-    // (sub-millisecond) before allocating saga_id — no point starting
-    // the saga if the precondition fails.
+    // last tab" guard.
+    //
+    // **Read SQLite, not reducer state.** During the migration
+    // window, some tab-creating/moving paths (e.g.
+    // `PromoteBlockToTab`) are still wcore-direct — their writes
+    // don't flow through the reducer, so `state.workspaces[ws].tab_ids`
+    // can lag SQLite. A reducer-state pre-check would falsely reject
+    // valid tear-off requests (codex P1 round-2 #621). SQLite is the
+    // source of truth; check there. Also include `pinnedtabids` in
+    // the membership check — bootstrap merges them into the reducer's
+    // `tab_ids`, but legacy SQLite rows may still carry the entry.
     {
-        let s = state.srv_state.lock().await;
-        match s.workspaces.get(&source_workspace_id) {
-            None => {
+        let src_ws = match state.wstore.get::<crate::backend::obj::Workspace>(&source_workspace_id) {
+            Ok(Some(ws)) => ws,
+            Ok(None) => {
                 return Err(format!(
                     "TearOffTab: source workspace not found: {}",
                     source_workspace_id
                 ));
             }
-            Some(ws) => {
-                if !ws.tab_ids.iter().any(|id| id == &tab_id) {
-                    return Err(format!(
-                        "TearOffTab: tab {} is not in workspace {}",
-                        tab_id, source_workspace_id
-                    ));
-                }
-                if ws.tab_ids.len() <= 1 {
-                    return Err(format!(
-                        "TearOffTab: cannot tear off last tab from workspace {}",
-                        source_workspace_id
-                    ));
-                }
-            }
+            Err(e) => return Err(format!("TearOffTab: workspace read failed: {}", e)),
+        };
+        let in_workspace = src_ws.tabids.iter().any(|id| id == &tab_id)
+            || src_ws.pinnedtabids.iter().any(|id| id == &tab_id);
+        if !in_workspace {
+            return Err(format!(
+                "TearOffTab: tab {} is not in workspace {}",
+                tab_id, source_workspace_id
+            ));
+        }
+        let total_tabs = src_ws.tabids.len() + src_ws.pinnedtabids.len();
+        if total_tabs <= 1 {
+            return Err(format!(
+                "TearOffTab: cannot tear off last tab from workspace {}",
+                source_workspace_id
+            ));
         }
     }
 

--- a/agentmux-srv/src/sagas/tear_off_tab.rs
+++ b/agentmux-srv/src/sagas/tear_off_tab.rs
@@ -1,0 +1,274 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.5 — TearOffTab saga.
+//
+// Migrates the tear-off-tab flow from `wcore::tear_off_tab` (which
+// did two non-transactional SQLite writes outside the reducer) to a
+// reducer-driven multi-step that the persist subscriber writes to
+// SQLite event-by-event. Closes the smoke regression where the new
+// workspace existed in SQLite but the reducer didn't know about it,
+// so the new window's `CreateTab` call would fail.
+//
+// **Steps (mirrors `wcore::tear_off_tab`'s behaviour, NOT the
+// `SPEC_PHASE_E_SAGAS_2026-04-30.md` §6.1 step 3 `CreateWindow`):**
+//
+// 1. `CreateWorkspace { name: "" }` — empty-name matches wcore's
+//    behaviour; user renames after.
+// 2. `MoveTab { tab_id, src=source_ws, dst=new_ws, dst_index: 0 }`.
+//
+// The frontend separately calls the host's `tear_off_pool_promote`
+// to open the CEF window, then the new window's renderer registers
+// the (window_id, workspace_id) mapping via `WindowService.CreateWindow`.
+// Including `Command::CreateWindow` in the saga (per spec §6.1) is
+// deferred — it would require pre-assigning the window_id before
+// the CEF window opens, which the existing host pool-promote and
+// app-init.ts flow doesn't accommodate. See
+// `docs/retro/saga-coordinator-location-analysis-2026-04-30.md`
+// §4.2 — host CEF window creation stays outside the saga.
+//
+// **Pre-condition:** the source workspace has more than one tab.
+// `wcore::tear_off_tab` enforced this; the reducer's `MoveTab`
+// doesn't (intentionally — the same command supports legitimate
+// "drain workspace" flows). The saga checks before issuing any
+// commands so the user-visible error is clear.
+//
+// **Compensation:**
+// * Step 2 fails after step 1 succeeded → `DeleteWorkspace { new_ws_id }`
+//   (the reducer cascades any tabs in it; the new workspace will be
+//   empty here since step 2 failed before moving the tab).
+// * Step 1 fails → nothing to compensate (reducer rejected without
+//   mutating).
+
+use agentmux_common::ipc::{Command, Event};
+use serde_json::{json, Value};
+
+use super::{alloc_saga_id, emit_saga_started, emit_terminal, run_saga, SagaCtx};
+use crate::server::AppState;
+
+/// Run the TearOffTab saga. On success, returns
+/// `{"new_workspace_id": "..."}`. On failure, the source workspace
+/// is unchanged (compensation has reverted any partial state).
+pub async fn run(
+    state: &AppState,
+    tab_id: String,
+    source_workspace_id: String,
+) -> Result<Value, String> {
+    // Pre-condition: source workspace must have more than one tab.
+    // We're about to move one out; if it's the only tab, we'd leave
+    // an empty workspace behind, which the UI doesn't represent
+    // gracefully. Mirrors `wcore::tear_off_tab`'s "cannot tear off
+    // last tab" guard. Read the reducer state under its lock
+    // (sub-millisecond) before allocating saga_id — no point starting
+    // the saga if the precondition fails.
+    {
+        let s = state.srv_state.lock().await;
+        match s.workspaces.get(&source_workspace_id) {
+            None => {
+                return Err(format!(
+                    "TearOffTab: source workspace not found: {}",
+                    source_workspace_id
+                ));
+            }
+            Some(ws) => {
+                if !ws.tab_ids.iter().any(|id| id == &tab_id) {
+                    return Err(format!(
+                        "TearOffTab: tab {} is not in workspace {}",
+                        tab_id, source_workspace_id
+                    ));
+                }
+                if ws.tab_ids.len() <= 1 {
+                    return Err(format!(
+                        "TearOffTab: cannot tear off last tab from workspace {}",
+                        source_workspace_id
+                    ));
+                }
+            }
+        }
+    }
+
+    let saga_id = alloc_saga_id(state);
+    emit_saga_started(state, saga_id, "tear_off_tab").await;
+    let ctx = SagaCtx { state, saga_id };
+    let result = run_saga("tear_off_tab", run_inner(ctx, tab_id, source_workspace_id)).await;
+    emit_terminal(
+        state,
+        saga_id,
+        match &result {
+            Ok(_) => Ok(()),
+            Err(r) => Err(r.as_str()),
+        },
+    )
+    .await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    tab_id: String,
+    source_workspace_id: String,
+) -> Result<Value, String> {
+    // Step 1: create the new workspace.
+    let create_events = ctx
+        .dispatch(Command::CreateWorkspace {
+            name: String::new(),
+        })
+        .await
+        .map_err(|e| format!("TearOffTab step 1 (CreateWorkspace): {}", e))?;
+    let new_workspace_id = create_events
+        .iter()
+        .find_map(|e| match e {
+            Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            "TearOffTab: CreateWorkspace did not emit WorkspaceCreated".to_string()
+        })?;
+
+    // Step 2: move the tab.
+    if let Err(reason) = ctx
+        .dispatch(Command::MoveTab {
+            tab_id: tab_id.clone(),
+            src_workspace_id: source_workspace_id.clone(),
+            dst_workspace_id: new_workspace_id.clone(),
+            dst_index: 0,
+        })
+        .await
+    {
+        // Compensate: delete the empty workspace we just created.
+        ctx.compensate(Command::DeleteWorkspace {
+            workspace_id: new_workspace_id.clone(),
+        })
+        .await;
+        return Err(format!("TearOffTab step 2 (MoveTab): {}", reason));
+    }
+
+    Ok(json!({ "new_workspace_id": new_workspace_id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::Workspace;
+    use crate::server::tests::test_state;
+
+    /// Boot a workspace + 2 tabs in the reducer + SQLite, mirroring
+    /// what bootstrap would do at startup. Returns `(state, ws_id,
+    /// tab_a_id, tab_b_id)`.
+    async fn seed_workspace_with_two_tabs() -> (
+        crate::server::AppState,
+        String,
+        String,
+        String,
+    ) {
+        let state = test_state();
+        // Use the reducer to create a workspace + 2 tabs so they end
+        // up in both reducer state and SQLite (the saga's pre-condition
+        // checks read reducer state).
+        let ws_events = crate::server::service::dispatch_to_reducer(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "src".into() },
+        )
+        .await;
+        for ev in &ws_events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        let ws_id = ws_events
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let mut tab_ids = Vec::new();
+        for name in &["tab-a", "tab-b"] {
+            let tab_events = crate::server::service::dispatch_to_reducer(
+                &state,
+                agentmux_common::ipc::Command::CreateTab {
+                    workspace_id: ws_id.clone(),
+                    name: name.to_string(),
+                },
+            )
+            .await;
+            for ev in &tab_events {
+                crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+            }
+            tab_ids.push(
+                tab_events
+                    .iter()
+                    .find_map(|e| match e {
+                        Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                        _ => None,
+                    })
+                    .unwrap(),
+            );
+        }
+        (state, ws_id, tab_ids[0].clone(), tab_ids[1].clone())
+    }
+
+    #[tokio::test]
+    async fn happy_path_creates_new_workspace_and_moves_tab() {
+        let (state, src_ws, tab_a, tab_b) = seed_workspace_with_two_tabs().await;
+        let result = run(&state, tab_a.clone(), src_ws.clone()).await.unwrap();
+        let new_ws_id = result["new_workspace_id"].as_str().unwrap();
+
+        // Reducer view: src has just tab_b; new_ws has tab_a.
+        let s = state.srv_state.lock().await;
+        assert_eq!(s.workspaces[&src_ws].tab_ids, vec![tab_b.clone()]);
+        assert_eq!(s.workspaces[new_ws_id].tab_ids, vec![tab_a.clone()]);
+        assert_eq!(s.tabs[&tab_a].workspace_id, new_ws_id);
+
+        // SQLite view: same.
+        let src_persist = state.wstore.get::<Workspace>(&src_ws).unwrap().unwrap();
+        let new_persist = state.wstore.get::<Workspace>(new_ws_id).unwrap().unwrap();
+        assert_eq!(src_persist.tabids, vec![tab_b]);
+        assert_eq!(new_persist.tabids, vec![tab_a]);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_source_workspace_missing() {
+        let state = test_state();
+        let err = run(&state, "tab-1".into(), "no-such-ws".into()).await.unwrap_err();
+        assert!(err.contains("source workspace not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn rejects_last_tab() {
+        let state = test_state();
+        let ws_events = crate::server::service::dispatch_to_reducer(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "src".into() },
+        )
+        .await;
+        for ev in &ws_events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        let ws_id = ws_events
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_events = crate::server::service::dispatch_to_reducer(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "only".into(),
+            },
+        )
+        .await;
+        for ev in &tab_events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        let only_tab = tab_events
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let err = run(&state, only_tab, ws_id).await.unwrap_err();
+        assert!(err.contains("last tab"), "got: {}", err);
+    }
+}

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -9,7 +9,7 @@ mod tool_handlers;
 mod websocket;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;
 
 use std::sync::Arc;
 
@@ -77,6 +77,13 @@ pub struct AppState {
     /// subscriber writes them back to SQLite. Pipe IPC server (when
     /// bound) shares the same bus.
     pub srv_events_tx: tokio::sync::broadcast::Sender<agentmux_common::ipc::Event>,
+    /// Phase E.5.5 — monotonic saga-id allocator. Each saga
+    /// (TearOffTab, TearOffBlock, RestoreTornOffTab, etc.) calls
+    /// `fetch_add` to claim a unique id; the id is stamped onto
+    /// `Event::SagaStarted/Completed/Failed` so subscribers can
+    /// correlate. Per-instance scope (no cross-process sharing — see
+    /// `docs/retro/saga-coordinator-location-analysis-2026-04-30.md`).
+    pub saga_id_alloc: std::sync::Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1213,6 +1213,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        // Phase E.5.6 — RestoreTornOffTab migrated to saga (MoveTab
+        // back + conditional DeleteWorkspaceCascade if source becomes
+        // empty). The legacy `was_pinned` arg is ignored — pinning
+        // was removed from AgentMux in E.2c.3b; restored tabs always
+        // land in `tab_ids`.
         ("workspace", "RestoreTornOffTab") => {
             let tab_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1226,20 +1231,21 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            let insert_index: Option<usize> = service::get_arg(args, 3).ok();
-            // arg 4 is `wasPinned: bool`. Default false — older clients
-            // and the merge path (which always restores into the target's
-            // tabids regardless of source pin status) don't need to pass
-            // it. Pinned-status preservation is a cancel-back-only feature.
-            let was_pinned: bool = service::get_arg(args, 4).unwrap_or(false);
-            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, was_pinned = %was_pinned, "[dnd:svc] RestoreTornOffTab");
-            match wcore::restore_torn_off_tab(store, &tab_id, &source_ws_id, &dest_ws_id, insert_index, was_pinned) {
-                Ok(()) => {
+            let insert_index: Option<u32> = service::get_arg::<usize>(args, 3)
+                .ok()
+                .map(|v| v.try_into().unwrap_or(u32::MAX));
+            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, "[dnd:svc] RestoreTornOffTab via saga");
+            let saga_result = crate::sagas::restore_torn_off_tab::run(
+                state,
+                tab_id,
+                source_ws_id.clone(),
+                dest_ws_id.clone(),
+                insert_index,
+            )
+            .await;
+            match saga_result {
+                Ok(_) => {
                     let mut updates = Vec::new();
-                    // Source workspace: emit a delete update if we deleted
-                    // it; otherwise an update with current state. Frontends
-                    // listening on the dragged window's workspace can react
-                    // to either.
                     match store.get::<Workspace>(&source_ws_id) {
                         Ok(Some(src_ws)) => {
                             updates.push(WaveObjUpdate {
@@ -1269,9 +1275,20 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     }
                     WebReturnType::success_with_updates(updates)
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+                Err(reason) => WebReturnType::error(reason),
             }
         }
+        // Phase E.5.5 — TearOffBlock migrated to saga (reducer-state
+        // portion: CreateWorkspace + CreateTab + MoveBlock). Layout
+        // tree setup on the new tab + queueing the source tab's
+        // layout-delete action stay wcore-direct here — layout state
+        // is E.4 work, separately scoped. The saga's atomicity is
+        // limited to the reducer-state portion; layout writes are
+        // best-effort and can leave a torn-off block with a malformed
+        // layout if the post-saga step fails. Acceptable trade-off
+        // for the smoke regression fix; full atomicity is a Phase F+
+        // gap (see saga-coordinator-location-analysis-2026-04-30.md
+        // §4.2).
         ("workspace", "TearOffBlock") => {
             let block_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1286,44 +1303,111 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => return WebReturnType::error(e),
             };
             let auto_close: bool = service::get_arg(args, 3).unwrap_or(true);
-            tracing::info!(block_id = %block_id, source_tab = %source_tab_id, source_ws = %source_ws_id, "[dnd:svc] TearOffBlock");
-            match wcore::tear_off_block(store, &block_id, &source_tab_id, &source_ws_id, auto_close) {
-                Ok(new_ws) => {
-                    let new_ws_oid = new_ws.oid.clone();
-                    let mut updates = Vec::new();
-                    // Source tab update
-                    if let Ok(src_tab) = store.must_get::<Tab>(&source_tab_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_TAB.to_string(),
-                            oid: source_tab_id.clone(),
-                            obj: Some(wave_obj_to_value(&src_tab)),
-                        });
-                    }
-                    // Source workspace update
-                    if let Ok(src_ws) = store.must_get::<Workspace>(&source_ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: source_ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&src_ws)),
-                        });
-                    }
-                    // New workspace update
-                    updates.push(WaveObjUpdate {
-                        updatetype: "update".into(),
-                        otype: OTYPE_WORKSPACE.to_string(),
-                        oid: new_ws_oid.clone(),
-                        obj: Some(wave_obj_to_value(&new_ws)),
-                    });
-                    WebReturnType::success_data_updates(
-                        serde_json::to_value(&new_ws_oid).unwrap_or_default(),
-                        updates,
-                    )
+            tracing::info!(block_id = %block_id, source_tab = %source_tab_id, source_ws = %source_ws_id, "[dnd:svc] TearOffBlock via saga");
+            let saga_result = crate::sagas::tear_off_block::run(
+                state,
+                block_id.clone(),
+                source_tab_id.clone(),
+                source_ws_id.clone(),
+            )
+            .await;
+            let (new_ws_oid, new_tab_oid) = match saga_result {
+                Ok(value) => {
+                    let new_ws_oid = value
+                        .get("new_workspace_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    let new_tab_oid = value
+                        .get("new_tab_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    (new_ws_oid, new_tab_oid)
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+                Err(reason) => return WebReturnType::error(reason),
+            };
+
+            // Layout setup for the new tab — make the moved block its
+            // single root node so the frontend renders it. Mirrors
+            // wcore::tear_off_block. Best-effort; layout migration is
+            // E.4 territory and not yet reducer-routed.
+            if let Err(e) = setup_torn_off_block_layout(store, &new_tab_oid, &block_id) {
+                tracing::warn!(new_tab = %new_tab_oid, "TearOffBlock: layout setup failed: {} (block in tab but layout malformed)", e);
             }
+            // Source tab: queue a layout-delete action so the source
+            // window's frontend removes the node from its tree.
+            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+                tracing::warn!(source_tab = %source_tab_id, "TearOffBlock: source layout delete-action enqueue failed: {}", e);
+            }
+
+            // Auto-close empty source tab. Route through the reducer
+            // (DeleteTab cascade is built in; the tab has no blocks
+            // at this point — we just moved the only one out). Skip
+            // when source workspace would become empty.
+            if auto_close {
+                let should_close = match store.must_get::<Tab>(&source_tab_id) {
+                    Ok(t) => t.blockids.is_empty(),
+                    Err(_) => false,
+                };
+                if should_close {
+                    let total_tabs = match store.must_get::<Workspace>(&source_ws_id) {
+                        Ok(ws) => ws.tabids.len() + ws.pinnedtabids.len(),
+                        Err(_) => 0,
+                    };
+                    if total_tabs > 1 {
+                        tracing::info!(source_tab = %source_tab_id, "[dnd:svc] auto-closing empty source tab after TearOffBlock");
+                        let close_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::DeleteTab {
+                                workspace_id: source_ws_id.clone(),
+                                tab_id: source_tab_id.clone(),
+                            },
+                        )
+                        .await;
+                        for ev in &close_events {
+                            let _ = crate::persist_subscriber::apply_event_to_wstore(ev, store);
+                        }
+                        publish_events(state, &close_events);
+                    }
+                }
+            }
+
+            let mut updates = Vec::new();
+            if let Ok(src_tab) = store.must_get::<Tab>(&source_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: source_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&src_tab)),
+                });
+            }
+            if let Ok(src_ws) = store.must_get::<Workspace>(&source_ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: source_ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&src_ws)),
+                });
+            }
+            if let Ok(new_ws) = store.must_get::<Workspace>(&new_ws_oid) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: new_ws_oid.clone(),
+                    obj: Some(wave_obj_to_value(&new_ws)),
+                });
+            }
+            WebReturnType::success_data_updates(
+                serde_json::to_value(&new_ws_oid).unwrap_or_default(),
+                updates,
+            )
         }
+        // Phase E.5.5 — TearOffTab migrated to saga. Closes the
+        // smoke regression where wcore::tear_off_tab created the new
+        // workspace bypassing the reducer, leaving the new window's
+        // CreateTab/etc. calls failing on "workspace not found"
+        // checks against the reducer's stale view.
         ("workspace", "TearOffTab") => {
             let tab_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1333,12 +1417,15 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, "[dnd:svc] TearOffTab");
-            match wcore::tear_off_tab(store, &tab_id, &source_ws_id) {
-                Ok(new_ws) => {
-                    let new_ws_oid = new_ws.oid.clone();
+            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, "[dnd:svc] TearOffTab via saga");
+            match crate::sagas::tear_off_tab::run(state, tab_id, source_ws_id.clone()).await {
+                Ok(saga_result) => {
+                    let new_ws_oid = saga_result
+                        .get("new_workspace_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string();
                     let mut updates = Vec::new();
-                    // Source workspace update
                     if let Ok(src_ws) = store.must_get::<Workspace>(&source_ws_id) {
                         updates.push(WaveObjUpdate {
                             updatetype: "update".into(),
@@ -1347,19 +1434,20 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                             obj: Some(wave_obj_to_value(&src_ws)),
                         });
                     }
-                    // New workspace update
-                    updates.push(WaveObjUpdate {
-                        updatetype: "update".into(),
-                        otype: OTYPE_WORKSPACE.to_string(),
-                        oid: new_ws_oid.clone(),
-                        obj: Some(wave_obj_to_value(&new_ws)),
-                    });
+                    if let Ok(new_ws) = store.must_get::<Workspace>(&new_ws_oid) {
+                        updates.push(WaveObjUpdate {
+                            updatetype: "update".into(),
+                            otype: OTYPE_WORKSPACE.to_string(),
+                            oid: new_ws_oid.clone(),
+                            obj: Some(wave_obj_to_value(&new_ws)),
+                        });
+                    }
                     WebReturnType::success_data_updates(
                         serde_json::to_value(&new_ws_oid).unwrap_or_default(),
                         updates,
                     )
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+                Err(reason) => WebReturnType::error(reason),
             }
         }
         // ---- UserInputService ----
@@ -1564,7 +1652,7 @@ pub(crate) fn update_object_meta(
 /// events. Locks the reducer mutex briefly; the lock is released
 /// before any I/O (caller is responsible for publishing the events
 /// to the broadcast bus).
-async fn dispatch_to_reducer(
+pub(crate) async fn dispatch_to_reducer(
     state: &AppState,
     cmd: agentmux_common::ipc::Command,
 ) -> Vec<agentmux_common::ipc::Event> {
@@ -1581,7 +1669,7 @@ async fn dispatch_to_reducer(
 
 /// Publish each event on the srv broadcast bus. Failures (no
 /// subscribers) are non-fatal.
-fn publish_events(state: &AppState, events: &[agentmux_common::ipc::Event]) {
+pub(crate) fn publish_events(state: &AppState, events: &[agentmux_common::ipc::Event]) {
     for event in events {
         let _ = state.srv_events_tx.send(event.clone());
     }
@@ -1609,6 +1697,69 @@ async fn compensate_via_reducer(
             );
         }
     }
+}
+
+/// Phase E.5.5 — set up the layout tree for a tab that just received
+/// its first block via the TearOffBlock saga. Called from the
+/// TearOffBlock RPC handler after the saga's reducer-state portion
+/// (CreateTab + MoveBlock) completes. Mirrors the layout-rootnode
+/// + leaforder construction that `wcore::tear_off_block` previously
+/// embedded in its single function.
+///
+/// Layout state migration is E.4 — until then layout writes are
+/// wcore-direct and not reducer-routed. Best-effort: a failure here
+/// leaves the new tab with the moved block but a malformed layout;
+/// the user-visible symptom is an empty render in the new window.
+fn setup_torn_off_block_layout(
+    store: &WaveStore,
+    new_tab_id: &str,
+    block_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let new_tab = store.must_get::<Tab>(new_tab_id)?;
+    let mut layout = store.must_get::<LayoutState>(&new_tab.layoutstate)?;
+    let node_id = uuid::Uuid::new_v4().to_string();
+    layout.rootnode = Some(serde_json::json!({
+        "id": node_id,
+        "data": { "blockId": block_id },
+        "flexDirection": "row",
+        "size": 1
+    }));
+    layout.leaforder = Some(vec![LeafOrderEntry {
+        nodeid: node_id,
+        blockid: block_id.to_string(),
+    }]);
+    store.update(&mut layout)?;
+    Ok(())
+}
+
+/// Phase E.5.5 — append a layout-delete action to the source tab's
+/// `LayoutState.pendingbackendactions` so the source window's
+/// frontend tears the moved block out of its layout tree on next
+/// poll. Mirrors the action-queueing portion of
+/// `wcore::tear_off_block`. Layout migration is E.4.
+fn queue_source_layout_delete(
+    store: &WaveStore,
+    source_tab_id: &str,
+    block_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source_tab = store.must_get::<Tab>(source_tab_id)?;
+    let mut source_layout = store.must_get::<LayoutState>(&source_tab.layoutstate)?;
+    let mut actions = source_layout.pendingbackendactions.take().unwrap_or_default();
+    actions.push(LayoutActionData {
+        actiontype: "delete".to_string(),
+        actionid: uuid::Uuid::new_v4().to_string(),
+        blockid: block_id.to_string(),
+        nodesize: None,
+        indexarr: None,
+        focused: false,
+        magnified: false,
+        ephemeral: false,
+        targetblockid: String::new(),
+        position: String::new(),
+    });
+    source_layout.pendingbackendactions = Some(actions);
+    store.update(&mut source_layout)?;
+    Ok(())
 }
 
 /// Existence check used by `DeleteWorkspace` to decide whether to

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1174,6 +1174,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 WebReturnType::success_empty()
             }
         }
+        // Phase E.5.5 — MoveTabToWorkspace migrated to dispatch
+        // Command::MoveTab through the reducer. Closes codex P1 #621
+        // (the saga's reducer-state pre-check rejected tear-off after
+        // a wcore-direct cross-window drag had left state.tabs stale)
+        // by routing all tab moves through the reducer so its view
+        // always matches SQLite.
         ("workspace", "MoveTabToWorkspace") => {
             let tab_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1187,31 +1193,77 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            let insert_index: Option<usize> = service::get_arg(args, 3).ok();
-            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, "[dnd:svc] MoveTabToWorkspace");
-            match wcore::move_tab_to_workspace(store, &tab_id, &source_ws_id, &dest_ws_id, insert_index) {
-                Ok(()) => {
-                    let mut updates = Vec::new();
-                    if let Ok(src_ws) = store.must_get::<Workspace>(&source_ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: source_ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&src_ws)),
-                        });
-                    }
-                    if let Ok(dst_ws) = store.must_get::<Workspace>(&dest_ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: dest_ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&dst_ws)),
-                        });
-                    }
-                    WebReturnType::success_with_updates(updates)
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            let insert_index: Option<u32> = service::get_arg::<usize>(args, 3)
+                .ok()
+                .map(|v| v.try_into().unwrap_or(u32::MAX));
+            tracing::info!(tab_id = %tab_id, source_ws = %source_ws_id, dest_ws = %dest_ws_id, insert_index = ?insert_index, "[dnd:svc] MoveTabToWorkspace via reducer");
+            // Same-workspace short-circuit matches wcore behaviour.
+            // The reducer rejects same-workspace moves outright (use
+            // ReorderTab instead); for the RPC contract, treat it as
+            // a no-op success so existing callers don't see a
+            // behavioural regression.
+            if source_ws_id == dest_ws_id {
+                return WebReturnType::success_empty();
             }
+            // Last-tab guard mirrors wcore::move_tab_to_workspace —
+            // the reducer's MoveTab doesn't enforce this (intentionally,
+            // for sagas that legitimately drain a workspace to delete
+            // it). Keep the guard at the RPC layer where the policy
+            // belongs.
+            {
+                let s = state.srv_state.lock().await;
+                if let Some(src_ws) = s.workspaces.get(&source_ws_id) {
+                    if src_ws.tab_ids.len() <= 1 {
+                        return WebReturnType::error(
+                            "cannot move last tab out of workspace".to_string(),
+                        );
+                    }
+                }
+            }
+            let dst_index = insert_index.unwrap_or(u32::MAX);
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::MoveTab {
+                    tab_id: tab_id.clone(),
+                    src_workspace_id: source_ws_id.clone(),
+                    dst_workspace_id: dest_ws_id.clone(),
+                    dst_index,
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
+            }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "MoveTabToWorkspace: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            let mut updates = Vec::new();
+            if let Ok(src_ws) = store.must_get::<Workspace>(&source_ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: source_ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&src_ws)),
+                });
+            }
+            if let Ok(dst_ws) = store.must_get::<Workspace>(&dest_ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: dest_ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&dst_ws)),
+                });
+            }
+            WebReturnType::success_with_updates(updates)
         }
         // Phase E.5.6 — RestoreTornOffTab migrated to saga (MoveTab
         // back + conditional DeleteWorkspaceCascade if source becomes

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1209,15 +1209,32 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             // the reducer's MoveTab doesn't enforce this (intentionally,
             // for sagas that legitimately drain a workspace to delete
             // it). Keep the guard at the RPC layer where the policy
-            // belongs.
-            {
-                let s = state.srv_state.lock().await;
-                if let Some(src_ws) = s.workspaces.get(&source_ws_id) {
-                    if src_ws.tab_ids.len() <= 1 {
+            // belongs. **Read SQLite, not reducer state** — during the
+            // migration window, wcore-direct tab paths
+            // (PromoteBlockToTab, etc.) leave reducer.tab_ids stale,
+            // so a reducer-state guard would falsely reject valid
+            // moves. SQLite is the source of truth (codex P1 round-2
+            // #621).
+            match store.get::<Workspace>(&source_ws_id) {
+                Ok(Some(src_ws)) => {
+                    let total_tabs = src_ws.tabids.len() + src_ws.pinnedtabids.len();
+                    if total_tabs <= 1 {
                         return WebReturnType::error(
                             "cannot move last tab out of workspace".to_string(),
                         );
                     }
+                }
+                Ok(None) => {
+                    return WebReturnType::error(format!(
+                        "MoveTabToWorkspace: source workspace not found: {}",
+                        source_ws_id
+                    ));
+                }
+                Err(e) => {
+                    return WebReturnType::error(format!(
+                        "MoveTabToWorkspace: workspace read failed: {}",
+                        e
+                    ));
                 }
             }
             let dst_index = insert_index.unwrap_or(u32::MAX);

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -7,7 +7,7 @@ use crate::backend::reactive as backend_reactive;
 use crate::backend::wconfig;
 use crate::backend::wcore;
 
-fn test_state() -> AppState {
+pub(crate) fn test_state() -> AppState {
     let wstore = Arc::new(WaveStore::open_in_memory().unwrap());
     let filestore = Arc::new(FileStore::open_in_memory().unwrap());
     let event_bus = Arc::new(EventBus::new());
@@ -53,6 +53,7 @@ fn test_state() -> AppState {
         // Tests get fresh state + a dummy broadcast bus.
         srv_state: Arc::new(tokio::sync::Mutex::new(crate::state::State::default())),
         srv_events_tx: tokio::sync::broadcast::channel::<agentmux_common::ipc::Event>(64).0,
+        saga_id_alloc: Arc::new(std::sync::atomic::AtomicU64::new(0)),
     }
 }
 

--- a/docs/retro/saga-coordinator-location-analysis-2026-04-30.md
+++ b/docs/retro/saga-coordinator-location-analysis-2026-04-30.md
@@ -1,0 +1,324 @@
+# Saga coordinator — location decision and robustness audit
+
+**Date:** 2026-04-30
+**Status:** Decision input for PR 3 (E.5.5+6 tear-off sagas).
+**Audience:** anyone implementing or reviewing PR 3 / PR 4, or scoping Phase F.
+
+---
+
+## 0. TL;DR
+
+1. **The original spec put the saga coordinator in the launcher.** That call was correct at the time — the original tear-off saga genuinely fanned out across host pool + launcher windows + srv state.
+2. **The actual implementation took a different cross-process orchestration path.** `Command::PromotePoolWindow` was never wired into `agentmux-common::ipc`; instead the frontend was wired to call CEF host's pool-promote IPC handler directly. The pool itself is alive — only the launcher↔host orchestration wire was never built.
+3. **Combined with PR #619's srv-level Window concept**, every saga in the E.5 plan (7 of them) now mutates only srv state. Cross-process work is frontend-orchestrated.
+4. **Recommended: build the saga coordinator in srv (Path A).** In-process dispatch via oneshot channel; the new saga spec already assumes this. The launcher coordinator stays as a labeled stub for hypothetical future cross-process sagas.
+5. **E.5 closes the smoke regression but is a partial robustness improvement.** Four robustness gaps remain: per-step SQLite transactions (no plan), host pool-promote outside saga (Phase F stub), renderer registration outside saga (no plan), saga persistence (Phase F stub). Two of them (#1 and frontend orphan-cleanup on host failure) are cheap follow-up PRs that should be filed.
+
+---
+
+## 1. Why the launcher was the original answer
+
+The original Phase E spec (`SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §7.1) was unambiguous:
+
+> "Phase E adds a **centralized saga coordinator in the launcher** that owns saga lifecycle."
+
+The reasoning shows up in the worked example (§7.2 — TearOffBlock):
+
+| Step | Target pipe | Operation |
+|---|---|---|
+| 1 | **Host** | `Command::PromotePoolWindow{}` — promote a pool CEF window |
+| 2 | **Srv**  | `Command::CreateWorkspace{name}` |
+| 3 | **Srv**  | `Command::CreateTab{workspace_id, ...}` |
+| 4 | **Srv**  | `Command::MoveBlockToTab{...}` |
+| 5 | **Launcher** | `Command::AssignWorkspaceToWindow{...}` |
+
+A saga that genuinely fans out across three reducers in three processes can really only live in the central pipe-routing process — the launcher. The `PipeTarget` enum in `agentmux-launcher::saga` (`LauncherSelf | Host | Srv`) baked that in.
+
+The original answer wasn't arbitrary. It tracked the actual data flow.
+
+---
+
+## 2. What changed
+
+### 2.1 `Command::PromotePoolWindow` was never wired through the launcher
+
+For step 1 to flow through a saga, the wire protocol between launcher and host had to carry `PromotePoolWindow` as an IPC command. **That command was never added to `agentmux-common::ipc`** — a grep for `PromotePoolWindow` in `agentmux-common/src/` and `agentmux-launcher/src/` returns nothing.
+
+What was built instead: the frontend calls the CEF host's IPC handler directly. Per `agentmux-cef/src/commands/drag.rs:394`:
+
+```
+requestTearOff (tabbar.tsx):
+  1. WorkspaceService.TearOffTab        ← srv RPC (frontend → srv pipe)
+  2. tear_off_pool_promote               ← host IPC (frontend → CEF host
+                                           Tauri-style handler, NOT via
+                                           the launcher pipe)
+  3. tear_off_sc_move_handshake          ← host IPC (Win32 SC_MOVE)
+```
+
+The pool itself is still in use (`agentmux-cef/src/commands/window_pool.rs` is alive — pre-warmed CEF windows promote in ~0 ms vs ~150-300 ms cold). What's gone is the **orchestration shape** that would have made it a saga step. The frontend is the cross-process orchestrator today, holding both `srv-rpc` and `host-rpc` clients in the same call site.
+
+### 2.2 PR #619 added a srv-level `Window` concept
+
+E.5.1+2 introduced `WindowRecord` + `state.windows: HashMap<window_id, WindowRecord>` in the srv reducer, plus `Command::CreateWindow{window_id, workspace_id}` and `Event::SrvWindowOpened{...}`. These track the AgentMux-level "which workspace is this window viewing" — distinct from the launcher's notion of "which Win32 HWND has this label."
+
+That collapsed step 5 of the original saga. Workspace-to-window assignment is now a srv reducer mutation, not a launcher one.
+
+### 2.3 Result
+
+Every saga in the E.5 plan now mutates only srv state:
+
+| Saga | Steps | Pipes touched |
+|---|---|---|
+| TearOffTab | CreateWorkspace → MoveTab → CreateWindow | srv only |
+| TearOffBlock | CreateWorkspace → CreateTab → MoveBlock → CreateWindow | srv only |
+| RestoreTornOffTab | MoveTab → DeleteWorkspaceCascade | srv only |
+| MoveTabSaga (PR 4) | MoveTab | srv only |
+| MoveBlockSaga (PR 4) | MoveBlock | srv only |
+| CreateWindowSaga (PR 4) | CreateWorkspace → CreateWindow | srv only |
+| CloseWindowSaga (PR 4) | CloseWindowInternal → cond. DeleteWorkspaceCascade | srv only |
+
+Not because cross-process work has gone away — it's still there, as the frontend's two-step `srv-rpc + host-rpc`. But the **piece** that needs *coordinated state-machine retries with compensation* (the saga's value proposition) is contained entirely within srv state. Pool-promote isn't transactional with anything; the frontend can retry it on its own without saga ceremony. The srv-side multi-step is what needs atomicity.
+
+---
+
+## 3. Path comparison
+
+### Path A — coordinator in srv
+
+Build a saga coordinator inside `agentmux-srv` (`agentmux-srv/src/sagas/`). It owns:
+- `next_saga_id: AtomicU64`
+- `in_flight: HashMap<u64, (Box<dyn Saga>, oneshot::Sender<SagaOutcome>)>`
+- A handle to the srv reducer for in-process dispatch
+- A subscription to the srv broadcast bus
+
+RPC handlers register sagas via `dispatch_saga(state, saga).await`. The launcher coordinator becomes a labeled stub.
+
+This is what `SPEC_PHASE_E_SAGAS_2026-04-30.md` §4.5 already assumes (the spec literally writes `state.saga_coordinator.register(...)` — `state` here is srv state).
+
+### Path B — coordinator in launcher (per original spec)
+
+Keep the coordinator in `agentmux-launcher::saga`. Srv RPC handlers reach it via cross-process IPC: srv sends a new `Command::StartSaga{kind, args}` up the launcher pipe; launcher routes events back over the broadcast bus; srv RPC handler awaits a saga-correlated event over the bus.
+
+Requires:
+- A new `Command::StartSaga` over IPC.
+- Either launcher knowing about every saga shape (kind/args) — coupling launcher to srv-specific commands — or a generic "execute this serialized saga state" mechanism (more abstract, more code).
+- Saga-driven commands flowing srv → launcher → srv (round-trip latency on every step).
+
+### Path C — both coordinators
+
+Srv coordinator handles srv-only sagas. Launcher coordinator stays available for genuine cross-reducer sagas. Adds duplicated infrastructure for unclear future benefit.
+
+### Trade-off table
+
+| Concern | Path A (srv) | Path B (launcher) | Path C (both) |
+|---|---|---|---|
+| Lines of new code (PR 3) | ~600 (coordinator + 3 sagas) | ~900 (coord + sagas + IPC + wire types) | ~700 |
+| Existing E.1a code | becomes labeled stub | becomes the real implementation | both used |
+| Latency per saga step | in-process oneshot | IPC round-trip | depends |
+| Failure modes | reducer mutex contention | IPC pipe failures × 2 | both |
+| Future cross-reducer saga | needs coord wiring (build later) | already supported | already supported |
+| Faithfulness to original spec | low | high | high |
+| Faithfulness to current saga spec (4-30) | high | low | mixed |
+
+**Recommendation: Path A.**
+
+Rationale:
+1. **Every saga in the E.5 plan is srv-only.** Building cross-process coordination machinery for zero cross-process consumers is YAGNI.
+2. **The architectural justification for the original launcher placement no longer holds.** `Command::PromotePoolWindow` was never wired; PR #619 collapsed step 5 into srv. What remains is purely srv-side multi-step state.
+3. **In-process dispatch is materially simpler.** A oneshot channel beats an IPC round-trip per saga step.
+4. **The new spec already says srv.** Building where the spec lives is the faithful execution.
+5. **The launcher coordinator is reversible.** If Phase F surfaces a saga that genuinely spans processes, we revive `agentmux-launcher::saga` then. Today it's framework-only — leaving it as a stub costs nothing.
+
+---
+
+## 4. Robustness audit
+
+### 4.1 Failure modes during a tear-off
+
+| # | Step | What can fail | Today (wcore-direct) | Path A (srv coordinator) |
+|---|---|---|---|---|
+| 1 | Source workspace lookup | tab/workspace not found | Errors before mutating; safe | Reducer rejects with `Error` event; safe |
+| 2 | Update source workspace (remove tab, reassign active) | SQLite write error | **Bug today**: wcore has no transaction wrapping; partial state can survive | Reducer in-memory mutation is atomic; subscriber's SQLite write is a single `update`. If it fails, saga compensates by re-adding tab to source |
+| 3 | Create new workspace | UUID collision (impossible), SQLite insert error | If this fails after step 2, the tab is gone from source — **state is corrupted: tab orphaned**. wcore returns error but partial state survives | Saga sees `Error` event from reducer/subscriber; runs compensate → MoveTab back to source. Atomic from caller's perspective |
+| 4 | Frontend opens CEF window | pool exhausted (handled via cold path), cold-path window-create fails | Srv state already mutated; host failure leaves orphan workspace nobody can see | **Same as today.** Saga doesn't include host. Frontend handles fallback or surfaces error; orphan workspace persists |
+| 5 | Renderer registers `(window_id, workspace_id)` mapping | network/IPC error after CEF window opened | Srv has workspace + tab; host has CEF window; mapping missing → orphan window pointing nowhere | Mapping registration is its own RPC; saga doesn't span it. Same outcome as today |
+| 6 | Mid-saga srv crash | SIGSEGV, panic | Partial state survives in SQLite; reducer rebuilds from bootstrap | In-flight saga is lost; reducer rebuilds from event log + SQLite. **Compensation not run**: partial state survives. Phase F adds saga persistence |
+
+### 4.2 What Path A guarantees vs not
+
+**Guarantees:**
+- ✅ Srv reducer state and SQLite stay consistent at the boundary of each saga step (subscriber's idempotent apply).
+- ✅ Saga compensation runs on srv-side step failure (rows 1-3 above).
+- ✅ The reducer/wcore-divergence smoke regression is fixed (the actual user-visible bug).
+- ✅ saga_id correlation lets the renderer (E.6) buffer events atomically.
+
+**Does NOT guarantee:**
+- ❌ Each saga step's SQLite writes are in a single transaction. Today's wcore code isn't either (e.g., `tear_off_tab` does two `store.update`/`store.insert` calls non-transactionally). Mitigation: subscriber arms are idempotent and bootstrap tolerates partial state. Strict atomicity per step needs explicit `wstore` transactions — orthogonal to coordinator placement.
+- ❌ Host pool-promote is included in the saga. If the CEF window fails to open, srv-side state was already mutated and isn't rolled back. Frontend must compensate (call `DeleteWorkspaceCascade`) or accept the orphan.
+- ❌ Renderer-side `(window_id, workspace_id)` registration is included. If the new window's renderer dies before calling that RPC, srv has no mapping for the window.
+- ❌ Saga state is durable. Mid-saga srv restart abandons in-flight work and runs no compensation.
+
+### 4.3 Tab vs pane (block) tear-off
+
+Identical failure structure, only the step count differs:
+
+| Saga | Steps | Compensation chain (max length) |
+|---|---|---|
+| TearOffTab | CreateWorkspace → MoveTab → CreateWindow | 3 reverse commands |
+| TearOffBlock | CreateWorkspace → CreateTab → MoveBlock → CreateWindow | 4 reverse commands |
+
+Both fully covered by Path A's srv-only compensation. Both have the same gap at steps 4-5 (host pool-promote + renderer registration outside the saga).
+
+### 4.4 Robustness gradient
+
+```
+today (wcore-direct, non-transactional, no compensation)
+  → Path A (or Path B) — fixes the smoke regression; same robustness ceiling
+  → above + per-step SQLite txns in subscriber  ← cheap follow-up
+  → above + frontend orphan-cleanup on host failure  ← cheap follow-up
+  → above + Command::PromotePoolWindow wired into saga  ← cross-process saga
+  → above + persisted saga state  ← Phase F+ target
+```
+
+Choosing between A and B for E.5 is a question about **dispatch mechanics, code locality, and future extensibility**, not about state preservation. Path A and Path B have the same end-to-end robustness ceiling.
+
+---
+
+## 5. Are the gaps planned for?
+
+Honest audit. §4.4 names six robustness levels; here's whether each beyond Path A is actually planned:
+
+| Gap | Plan? | Where it's discussed | Concrete spec? |
+|---|---|---|---|
+| Per-step SQLite transactions in subscriber | ❌ **No plan** | Not mentioned in `SPEC_PHASE_E_SAGAS_2026-04-30.md`, `SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md`, or the execution plan. Grep for `transaction\|BEGIN\|COMMIT` in saga/reducer specs returns zero hits. | None |
+| Frontend orphan-cleanup on host failure | ❌ **No plan** | Not mentioned. `drag.rs:394` comment treats the two RPCs as independent; there's no error-recovery design. | None |
+| Host pool-promote as saga step | ⚠️ **Stub deferral** | `PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md` §9: "Cross-process saga correlation — Phase F or beyond." | **No Phase F spec exists.** |
+| Renderer registration as saga step | ❌ **No plan** | Not mentioned anywhere. | None |
+| Persistent saga state across restart | ⚠️ **Stub deferral** | `SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §15 mentions it once: "revisit if Phase F's pool-respawn sagas need it." | None |
+| Saga timeout / retry | ✅ Planned | `SPEC_PHASE_E_SAGAS_2026-04-30.md` §4.5: 5s default, tunable. | Yes — implemented in PR 3. |
+
+### 5.1 What "Phase F or beyond" actually means
+
+Phase F has **no written spec**. It's sketched in three places:
+
+1. `SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §13 — "Phase F preview" — frames Phase F's job as the **host reducer**, with explicit caveats that `browsers` (CEF FFI) and pool maps "resist the reducer pattern":
+   > Phase F's outcome is likely "host reducer for the easy parts, scaffolding stays for the hard parts."
+
+2. `multi-reducer-proposal-2026-04-28.md` — high-level "third reducer, retire scaffolding model" intent only.
+
+3. The phrase "Phase F or beyond" appears 5+ times in the saga spec as a deferral cookie.
+
+**No spec schedules or scopes the cross-process saga work, the per-step transaction work, the renderer-registration work, or saga persistence.**
+
+### 5.2 Honest characterization of the current arc
+
+```
+PR 1+2 (#619, #620) — done
+PR 3+4 (E.5)        — fixes the smoke regression by routing srv-state
+                      through reducer + sagas
+                      ↓
+                      leaves four gaps documented in §4.2
+                      ↓
+[no concrete plan for items 1-4 below]
+                      ↓
+some future phase   — closes them
+```
+
+E.5 is a **partial** robustness improvement, not a complete one. Anyone who reads the plan and infers "tear-off becomes transactional after E.5" is mistaken: tear-off becomes srv-side-atomic. Cross-process orphans (CEF window opens but srv state is broken; or srv state succeeds but renderer fails to register) remain possible.
+
+The actual user-visible value of E.5 is:
+1. Fixing the smoke regression (reducer/wcore divergence).
+2. The saga_id correlation infrastructure that unblocks E.6 (renderer multi-source buffering).
+
+---
+
+## 6. Plan forward
+
+### 6.1 PR 3 (E.5.5+6) — proceed with Path A
+
+Build the saga coordinator in `agentmux-srv/src/sagas/`. Implementation sketch:
+
+**Module layout:**
+```
+agentmux-srv/src/sagas/
+  mod.rs                     // Saga trait + SagaStep + dispatch_saga()
+  coordinator.rs             // SagaCoordinator (registry + bus subscription)
+  tear_off_tab.rs            // TearOffTabSaga state machine + tests
+  tear_off_block.rs          // TearOffBlockSaga state machine + tests
+  restore_torn_off_tab.rs    // RestoreTornOffTabSaga state machine + tests
+```
+
+**Trait shape** (per `SPEC_PHASE_E_SAGAS_2026-04-30.md` §4.3):
+```rust
+pub trait Saga: Send + 'static {
+    fn saga_id(&self) -> u64;
+    fn name(&self) -> &'static str;
+    fn start(&mut self) -> Vec<Command>;
+    fn on_event(&mut self, event: &Event) -> SagaStep;
+    fn compensate(&mut self) -> Vec<Command> { Vec::new() }
+}
+```
+
+**Coordinator** subscribes to srv broadcast bus, maintains in-flight registry, dispatches commands via reducer in-process, emits `SagaStarted/Completed/Failed` lifecycle events.
+
+**Dispatch from RPC handler** uses oneshot + 5s `tokio::time::timeout`.
+
+**Wire-up:** `AppState` gains `saga_coordinator: Arc<SagaCoordinator>`. `main.rs` constructs after reducer+bus exist; spawns run-loop. RPC handlers in `service.rs` (TearOffTab, TearOffBlock, RestoreTornOffTab) replace `wcore::tear_off_*` calls with `dispatch_saga(...)`.
+
+**`saga_id` threading:** add `saga_id: Option<u64>` to every Command and Event. Reducer copies through. Coordinator sets on outgoing commands.
+
+**Existing launcher coordinator:** add a comment pointing to this doc, leave the code in place. PR 4 cleanup may delete it; safer to keep through E.5.
+
+### 6.2 PR 4 (E.5.7+8+9) — finish saga RPC migration + cleanup
+
+Per existing execution plan §5. No design changes needed.
+
+### 6.3 Follow-up PR — subscriber SQLite transactions
+
+**Scope:** wrap each `apply_*_event` arm's writes in a `wstore` transaction. Subscriber currently uses sequential `store.update`/`store.insert` calls; if the second of two writes fails, partial state survives.
+
+**Estimate:** ~200 LOC, 1 PR, no architectural risk.
+
+**When:** opportunistic — could ship inside PR 4 (low extra LOC) or as a focused follow-up. Not blocking E.5.
+
+**Why now:** this is a real correctness gap that already exists (predates E.5). Cheapest robustness win on the table.
+
+### 6.4 Follow-up PR — frontend orphan-cleanup on host failure
+
+**Scope:** in `tabbar.tsx::requestTearOff` (and equivalents for block tear-off), if `tear_off_pool_promote` returns `pool_exhausted` AND `open_window_at_position` then fails, dispatch `WorkspaceService.DeleteWorkspaceCascade` to clean up the orphan workspace just created via `TearOffTab`. Show a user-facing error toast.
+
+**Estimate:** ~50 LOC TS, 1 PR.
+
+**When:** post-E.5. Doesn't block anything.
+
+**Why now:** trivial fix for a real failure mode that produces visible junk in the workspace list.
+
+### 6.5 Phase F-sized — defer until Phase F has a spec
+
+Three items need spec work before they can be scheduled:
+
+1. **Cross-process saga (`Command::PromotePoolWindow` wired)** — wires host pool-promote into the saga. Closes most of gap 4.4-#4.
+2. **Renderer-registration as saga step** — closes gap 4.4-#5.
+3. **Persistent saga state** — closes gap 4.4-#6 (mid-saga crash). Probably the right answer is to wait until Phase G's event-sourced model lands and let the journal subsume saga persistence.
+
+Action: when Phase F is scheduled, write its spec first; reference §4 of this doc for the gap analysis and proposed shape.
+
+---
+
+## 7. Open questions (carried from earlier draft)
+
+1. **Saga timeout.** Spec says 5s default. Reasonable for local in-process flows; a tear-off should complete in tens of milliseconds. Keep 5s.
+2. **Saga restart on srv crash.** Spec defers persistence to Phase F. In-flight sagas die on srv restart; renderer-side timeout handles it. PR 3 doesn't need to solve this.
+3. **Multiple in-flight sagas same saga_id.** Coordinator allocates monotonically; collisions impossible within one srv run.
+4. **Saga events arriving before SagaStarted is published.** The coordinator emits SagaStarted FIRST (synchronously, holding the registry lock), THEN dispatches start()'s commands. So step-1 events always have a corresponding SagaStarted ahead of them on the bus.
+
+---
+
+## 8. Decision
+
+**Pending user confirmation. Default proceed: Path A + file follow-ups §6.3 and §6.4 as separate PRs after E.5 closes.**
+
+History of this doc:
+- Initial draft claimed "the pool was removed" — corrected; the pool is alive, only the launcher↔host orchestration wire was never built.
+- Initial draft claimed Path A vs B was a robustness question — corrected; both have the same end-to-end robustness ceiling.
+- Initial draft claimed the gaps were "Phase F territory" — corrected; that's a deferral cookie, not a plan. Phase F has no spec.

--- a/docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md
+++ b/docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md
@@ -329,7 +329,22 @@ These are non-blocking but should fold into one of the PRs above when convenient
 
 ---
 
+## 9b. Post-E.5 follow-up PRs (small, scheduled)
+
+Two cheap correctness gaps worth filing now so they don't get lost. Both are documented in `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §6.3-§6.4.
+
+| ID | Scope | LoC | When | Why |
+|---|---|---|---|---|
+| **F1.A** | Wrap each `apply_*_event` arm in the persist subscriber in a `wstore` BEGIN/COMMIT transaction. Today's subscriber does sequential `store.update`/`store.insert` calls non-transactionally; partial failures can leave half-written rows. | ~200 | Inside PR 4 (low extra LOC) or standalone | Cheapest robustness win. Real correctness gap that exists today, not a Phase F problem. |
+| **F1.B** | Frontend cleanup on host pool-promote failure: in `tabbar.tsx::requestTearOff` (and block-tear-off equivalents), if `tear_off_pool_promote` returns `pool_exhausted` AND `open_window_at_position` then fails, dispatch `WorkspaceService.DeleteWorkspaceCascade` to clean up the orphan workspace just created via `TearOffTab`. Show a user-facing error toast. | ~50 TS | Standalone, post-E.5 | Trivial fix for a real failure mode that produces visible junk in the workspace list. |
+
+The other three robustness gaps (host as saga step, renderer registration as saga step, persistent saga state) are deferred until Phase F has a written spec. They are not currently scoped or scheduled.
+
+---
+
 ## 10. Decision log
 
 - **2026-04-30:** plan written. 4-PR structure agreed. Hot-fix Option A skipped in favor of going straight to sagas.
+- **2026-04-30:** coordinator location decided as srv-side (Path A). See `docs/retro/saga-coordinator-location-analysis-2026-04-30.md`.
+- **2026-04-30:** post-E.5 follow-ups F1.A (subscriber transactions) and F1.B (frontend orphan cleanup) added to plan §9b.
 - Refer to `SPEC_PHASE_E_SAGAS_2026-04-30.md` for the design spec; this plan is the execution sequence.

--- a/docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md
+++ b/docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md
@@ -11,7 +11,9 @@
 
 Eliminate the reducer/wcore inconsistency window by routing **every state mutation** through the srv reducer. The remaining offenders (audit table in `phase-e-tear-off-and-remaining-2026-04-30.md` §3) are mostly **multi-entity multi-step operations** — tear-off creates a workspace + window + moves a tab; restore moves a tab back + deletes the orphan workspace. These can't be modeled as single pure-functional reducer commands without compromising the reducer's "one mutation pass, no I/O" invariant.
 
-Sagas exist exactly for this shape. The E.1a saga coordinator is already in place (`agentmux-launcher::saga`); this spec describes the per-operation saga implementations and the RPC integration that sits in front of them.
+Sagas exist exactly for this shape. This spec describes the per-operation saga implementations and the RPC integration that sits in front of them.
+
+> **Coordinator location update (2026-04-30):** the existing E.1a coordinator framework (`agentmux-launcher::saga`) is **not** what E.5 will use. Every saga in this spec mutates only srv state — see `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` for the full reasoning. PR 3 builds a srv-side coordinator at `agentmux-srv/src/sagas/`; the launcher coordinator stays as a labeled stub for hypothetical future cross-process sagas.
 
 **End state when this spec ships:** the reducer is the sole writer of workspace / tab / block / layout state. Every wcore-direct path in service.rs §3 either becomes a reducer-dispatch handler (single-step) or a saga-driven RPC handler (multi-step). The persist subscriber writes SQLite for everything.
 
@@ -72,7 +74,10 @@ None yet.
 
 ## 4. Saga design
 
-### 4.1 Coordinator contract (recap from E.1a)
+### 4.1 Coordinator contract
+
+> **Note:** the trait shape below is similar to E.1a's `agentmux-launcher::saga::Saga` but is **not** the same type. PR 3 introduces `agentmux-srv::sagas::Saga` with the trait below. The E.1a launcher coordinator stays in place as a labeled stub. See `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §3 for why.
+
 
 ```rust
 pub trait Saga: Send + 'static {
@@ -460,6 +465,25 @@ E.4 (Layout) can also ship in parallel; saga integration with layouts is deferre
 ## 12. Cross-references
 
 - `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §7 — original (sketchy) saga spec; this doc supersedes.
+- `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` — coordinator-location decision (Path A: srv) + full robustness audit + gap analysis. Read this before implementing PR 3.
 - `docs/retro/phase-e-status-2026-04-30.md` — phase status snapshot
 - `docs/retro/phase-e-tear-off-and-remaining-2026-04-30.md` — the bug analysis that motivated this spec
+
+---
+
+## 13. What this spec does NOT close (honest scope)
+
+E.5 fixes the reducer/wcore divergence (the smoke regression cause) and adds saga_id correlation infrastructure for E.6. It is a **partial** robustness improvement, not a complete one.
+
+Four robustness gaps remain after E.5 ships. They are documented in `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §4-§5, summarized here so anyone scoping future work doesn't miss them:
+
+| Gap | Status | Cheapest fix |
+|---|---|---|
+| Subscriber writes are not in SQLite transactions | No plan | ~200 LOC: wrap each `apply_*_event` arm in `wstore` BEGIN/COMMIT. Could ship in PR 4 or as standalone follow-up. |
+| Frontend doesn't clean up orphan workspace if host pool-promote fails | No plan | ~50 LOC TS: dispatch `DeleteWorkspaceCascade` on host RPC failure. Standalone follow-up. |
+| Host pool-promote sits outside the saga | "Phase F or beyond" stub deferral | Wire `Command::PromotePoolWindow` into `agentmux-common::ipc`; revive launcher coordinator. ~800-1200 LOC, multi-PR. Needs Phase F spec first. |
+| Renderer-side `(window_id, workspace_id)` registration sits outside the saga | No plan | New-window bootstrap protocol so renderer phones home with `saga_id`. Phase F territory. |
+| Saga state lost on srv crash mid-saga | "Phase F or beyond" stub deferral | Disk-backed saga journal. Probably wait for Phase G's event-sourced model to subsume it. |
+
+Anyone reading this spec and inferring "tear-off becomes transactional after E.5" is mistaken: tear-off becomes srv-side-atomic. Cross-process orphans remain possible.
 - `docs/retro/multi-reducer-status-2026-04-29.md` — running phase progress

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.524",
+  "version": "0.33.525",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.524",
+      "version": "0.33.525",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.520",
+  "version": "0.33.523",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.520",
+      "version": "0.33.523",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.523",
+  "version": "0.33.524",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.523",
+      "version": "0.33.524",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.524",
+  "version": "0.33.525",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.522",
+  "version": "0.33.523",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.523",
+  "version": "0.33.524",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.5.5 + E.5.6 — fixes the tear-off → "+" tab smoke regression by routing the multi-step tear-off / restore operations through the srv reducer via a saga coordinator. The reducer's session-only projection now sees the new workspace + tab + block immediately after tear-off, so the new window's subsequent CreateTab / etc. calls succeed instead of erroring on "workspace not found".

Plus carry-forward fix: codex P1 #620 — relaxes ReorderTabsBulk validation since wcore-direct tab moves leave the reducer's tab_ids stale during the migration window.

## What changed

**Wire types (agentmux-common::ipc):**
- `Command::MoveTab { tab_id, src_workspace_id, dst_workspace_id, dst_index }`
- `Command::MoveBlock { block_id, src_tab_id, dst_tab_id, dst_index }`
- `Event::TabMoved { ..., new_src_active_tab_id, version }`
- `Event::BlockMoved { ..., version }`

**Reducer arms (agentmux-srv::reducer):**
- `handle_move_tab` — cross-workspace move; updates both workspaces' tab_ids; updates tab.workspace_id; reassigns src.active_tab_id if needed. Rejects same-workspace moves.
- `handle_move_block` — cross-tab + intra-tab; clamps dst_index; updates block.tab_id on cross-tab.

**Subscriber arms (persist_subscriber):**
- `apply_tab_moved` — drains tab from src.tabids/pinnedtabids, inserts at clamped dst_index in dst, updates src.activetabid. Idempotent on re-delivery.
- `apply_block_moved` — handles intra + cross-tab; updates block.parentoref.

**Saga coordinator (agentmux-srv/src/sagas/, new module ~1030 LOC):**
- `SagaCtx` — dispatch / compensate / state_lock helpers.
- `run_saga(name, fut)` — 5 s timeout wrapper.
- Per-saga lifecycle event emission (SagaStarted / SagaCompleted / SagaFailed).
- 3 sagas: TearOffTab, TearOffBlock, RestoreTornOffTab.

**RPC migrations (service.rs):**
- TearOffTab handler → `sagas::tear_off_tab::run`.
- TearOffBlock handler → `sagas::tear_off_block::run` + post-saga layout setup (E.4 stays wcore-direct).
- RestoreTornOffTab handler → `sagas::restore_torn_off_tab::run`. Legacy `was_pinned` arg ignored.

**Carry-forward from #620 (codex P1):**
- Relaxed `ReorderTabsBulk` validation. Strict permutation check rejected canonical orderings whenever a wcore-direct tab move had just landed (planned for migration in PR 4); now accepts the caller's list as authoritative, still rejects duplicates and unknown workspaces.

**Docs:**
- `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` — coordinator-location decision (Path A: srv) + full robustness audit + gap analysis.
- `SPEC_PHASE_E_SAGAS_2026-04-30.md` §13 — list of robustness gaps E.5 explicitly does NOT close.
- `PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md` §9b — two cheap follow-up PRs (F1.A subscriber transactions, F1.B frontend orphan-cleanup).

## What this PR does NOT close

Documented in detail at `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §4.2 + §5:

- ❌ Per-step SQLite transactions in the subscriber (gap; F1.A follow-up planned).
- ❌ Host pool-promote outside the saga — frontend orchestrates this; failures leave srv-side orphans (Phase F gap; F1.B follow-up adds frontend cleanup).
- ❌ Renderer-side `(window_id, workspace_id)` registration outside the saga (Phase F gap).
- ❌ Saga persistence across srv restart (Phase F+).

E.5 is a **partial** robustness improvement, not a complete one. The user-visible value is fixing the smoke regression and unblocking E.6 (renderer multi-source buffering via saga_id correlation).

## Test plan

- [x] 715 unit tests pass (+7 saga tests, +14 move-related reducer/subscriber tests in this PR's earlier commits).
- [x] `cargo build -p agentmux-srv -p agentmux-launcher -p agentmux-cef` clean.
- [ ] Pre-merge smoke (after build): tear off tab → new window opens → click "+" → new tab appears (THE regression fix). Restore torn-off tab → workspace cleaned up. Tear off block → new window with single block.
- [ ] Reagent + codex review.

## Commits

1. `0b3c6de3` — fix(E.5.5+6): relax ReorderTabsBulk validation during migration window
2. `7f49499e` — docs(E.5): coordinator-location analysis + honest scope of E.5 sagas
3. `4e82b14b` — feat(E.5.5): MoveTab + MoveBlock commands + reducer arms + subscriber arms
4. `f9c0a39b` — feat(E.5.5+6): srv-side saga coordinator + 3 sagas + RPC migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)