### PR TITLE
feat(E.5.7+8+9): finish saga RPC migration + cleanup — closes Phase E.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.525"
+version = "0.33.526"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.525"
+version = "0.33.526"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.525"
+version = "0.33.526"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.525"
+version = "0.33.526"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.526"
+version = "0.33.527"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.526"
+version = "0.33.527"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.526"
+version = "0.33.527"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.526"
+version = "0.33.527"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.526"
+version = "0.33.527"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.525"
+version = "0.33.526"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.526"
+version = "0.33.527"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.525"
+version = "0.33.526"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.526"
+version = "0.33.527"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.525"
+version = "0.33.526"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.526"
+version = "0.33.527"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.525"
+version = "0.33.526"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -337,7 +337,7 @@ fn handle_delete_workspace(state: &mut State, workspace_id: String) -> Vec<Event
 /// NOT idempotent on retry (same UUID-assignment caveat as
 /// `handle_create_workspace`).
 fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> Vec<Event> {
-    if !state.workspaces.contains_key(&workspace_id) {
+    let Some(workspace_record) = state.workspaces.get(&workspace_id) else {
         let v = state.bump_version();
         return vec![Event::Error {
             code: ErrorCode::InvalidCommand,
@@ -345,14 +345,25 @@ fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> V
             fatal: false,
             version: v,
         }];
-    }
+    };
+    // codex P2 #622: auto-generate `tabN` when name is empty,
+    // matching `wcore::create_tab`'s default-naming behaviour. The
+    // counter uses the reducer's tab_ids length + 1 (matching the
+    // old SQLite-side count: tabids.len() + pinnedtabids.len() + 1
+    // — pinnedtabids stays at zero in production since pinning
+    // was removed in E.2c.3b, so reducer-only counting matches).
+    let resolved_name = if name.is_empty() {
+        format!("tab{}", workspace_record.tab_ids.len() + 1)
+    } else {
+        name
+    };
     let tab_id = uuid::Uuid::new_v4().to_string();
     state.tabs.insert(
         tab_id.clone(),
         TabRecord {
             tab_id: tab_id.clone(),
             workspace_id: workspace_id.clone(),
-            name: name.clone(),
+            name: resolved_name.clone(),
             block_ids: Vec::new(),
         },
     );
@@ -369,7 +380,7 @@ fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> V
     events.push(Event::TabCreated {
         workspace_id: workspace_id.clone(),
         tab_id: tab_id.clone(),
-        name,
+        name: resolved_name,
         version: v,
     });
     if activated {
@@ -1905,6 +1916,57 @@ mod tests {
         match &events[0] {
             Event::TabCreated { tab_id, .. } => tab_id.clone(),
             _ => panic!("expected TabCreated"),
+        }
+    }
+
+    /// codex P2 #622: empty name auto-generates `tabN`, mirroring
+    /// `wcore::create_tab`'s default-naming behaviour. Without this,
+    /// CreateWindow's "fresh workspace" path + TearOffBlock's new tab
+    /// would land with blank titles — a user-visible regression.
+    #[test]
+    fn create_tab_auto_generates_tabN_when_name_empty() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: String::new(),
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::TabCreated { name, tab_id, .. } => {
+                assert_eq!(name, "tab1", "first tab in fresh workspace");
+                assert_eq!(state.tabs[tab_id].name, "tab1");
+            }
+            other => panic!("expected TabCreated, got {:?}", other),
+        }
+        // Second empty-name CreateTab → "tab2".
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: String::new(),
+            },
+            &ctx(3),
+        );
+        match &events[0] {
+            Event::TabCreated { name, .. } => assert_eq!(name, "tab2"),
+            other => panic!("expected TabCreated, got {:?}", other),
+        }
+        // Explicit non-empty name passes through verbatim.
+        let events = update(
+            &mut state,
+            Command::CreateTab {
+                workspace_id: ws_id,
+                name: "my custom tab".into(),
+            },
+            &ctx(4),
+        );
+        match &events[0] {
+            Event::TabCreated { name, .. } => assert_eq!(name, "my custom tab"),
+            other => panic!("expected TabCreated, got {:?}", other),
         }
     }
 

--- a/agentmux-srv/src/sagas/mod.rs
+++ b/agentmux-srv/src/sagas/mod.rs
@@ -41,6 +41,7 @@
 //   (gap; Phase F).
 // * Saga state across srv restart (gap; Phase F+).
 
+pub mod promote_block_to_tab;
 pub mod restore_torn_off_tab;
 pub mod tear_off_block;
 pub mod tear_off_tab;

--- a/agentmux-srv/src/sagas/promote_block_to_tab.rs
+++ b/agentmux-srv/src/sagas/promote_block_to_tab.rs
@@ -1,0 +1,230 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.7 — PromoteBlockToTab saga.
+//
+// Migrates the reducer-state portion of `wcore::promote_block_to_tab`
+// to a reducer-driven multi-step. The original wcore function does
+// substantial layout work + sets the new tab as active; that work
+// stays wcore-direct in the RPC handler that wraps this saga.
+//
+// **Steps:**
+// 1. `CreateTab { workspace_id, name: "" }` — new tab in the same
+//    workspace.
+// 2. `MoveBlock { block_id, src=source_tab, dst=new_tab, dst_index: 0 }`.
+//
+// **Compensation:**
+// * Step 2 fails after step 1 → `DeleteTab { workspace_id, new_tab_id }`
+//   (cascades through any blocks; new tab has no blocks at this
+//   point since step 2 failed).
+// * Step 1 fails → nothing to compensate.
+//
+// Layout setup (rootnode + leaforder for the new tab) and SetActiveTab
+// stay in the RPC handler post-saga; auto-close empty source tab too.
+
+use agentmux_common::ipc::{Command, Event};
+use serde_json::{json, Value};
+
+use super::{alloc_saga_id, emit_saga_started, emit_terminal, run_saga, SagaCtx};
+use crate::server::AppState;
+
+/// Run the PromoteBlockToTab saga. On success, returns
+/// `{"new_tab_id": "..."}`.
+pub async fn run(
+    state: &AppState,
+    block_id: String,
+    source_tab_id: String,
+    workspace_id: String,
+) -> Result<Value, String> {
+    // Pre-condition: read SQLite (source of truth during migration
+    // window — wcore-direct paths can leave reducer state stale).
+    {
+        let block = match state.wstore.get::<crate::backend::obj::Block>(&block_id) {
+            Ok(Some(b)) => b,
+            Ok(None) => {
+                return Err(format!("PromoteBlockToTab: block not found: {}", block_id));
+            }
+            Err(e) => return Err(format!("PromoteBlockToTab: block read failed: {}", e)),
+        };
+        let expected_parent = format!("tab:{}", source_tab_id);
+        if block.parentoref != expected_parent {
+            return Err(format!(
+                "PromoteBlockToTab: block {} is in {}, not tab:{}",
+                block_id, block.parentoref, source_tab_id
+            ));
+        }
+        if state
+            .wstore
+            .get::<crate::backend::obj::Workspace>(&workspace_id)
+            .map(|w| w.is_none())
+            .unwrap_or(true)
+        {
+            return Err(format!(
+                "PromoteBlockToTab: workspace not found: {}",
+                workspace_id
+            ));
+        }
+    }
+
+    let saga_id = alloc_saga_id(state);
+    emit_saga_started(state, saga_id, "promote_block_to_tab").await;
+    let ctx = SagaCtx { state, saga_id };
+    let result = run_saga(
+        "promote_block_to_tab",
+        run_inner(ctx, block_id, source_tab_id, workspace_id),
+    )
+    .await;
+    emit_terminal(
+        state,
+        saga_id,
+        match &result {
+            Ok(_) => Ok(()),
+            Err(r) => Err(r.as_str()),
+        },
+    )
+    .await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    block_id: String,
+    source_tab_id: String,
+    workspace_id: String,
+) -> Result<Value, String> {
+    // Step 1: create the new tab in the same workspace.
+    let create_tab_events = ctx
+        .dispatch(Command::CreateTab {
+            workspace_id: workspace_id.clone(),
+            name: String::new(),
+        })
+        .await
+        .map_err(|e| format!("PromoteBlockToTab step 1 (CreateTab): {}", e))?;
+    let new_tab_id = create_tab_events
+        .iter()
+        .find_map(|e| match e {
+            Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            "PromoteBlockToTab: CreateTab did not emit TabCreated".to_string()
+        })?;
+
+    // Step 2: move the block into the new tab.
+    if let Err(reason) = ctx
+        .dispatch(Command::MoveBlock {
+            block_id: block_id.clone(),
+            src_tab_id: source_tab_id.clone(),
+            dst_tab_id: new_tab_id.clone(),
+            dst_index: 0,
+        })
+        .await
+    {
+        // Compensate: delete the empty new tab.
+        ctx.compensate(Command::DeleteTab {
+            workspace_id: workspace_id.clone(),
+            tab_id: new_tab_id.clone(),
+        })
+        .await;
+        return Err(format!("PromoteBlockToTab step 2 (MoveBlock): {}", reason));
+    }
+
+    Ok(json!({ "new_tab_id": new_tab_id }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::tests::test_state;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    #[tokio::test]
+    async fn happy_path_creates_tab_and_moves_block() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "src".into(),
+            },
+        )
+        .await;
+        let src_tab = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateBlock {
+                tab_id: src_tab.clone(),
+                meta: serde_json::Value::Null,
+            },
+        )
+        .await;
+        let block_id = blk_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        let result = run(&state, block_id.clone(), src_tab.clone(), ws_id.clone())
+            .await
+            .unwrap();
+        let new_tab_id = result["new_tab_id"].as_str().unwrap();
+
+        // Reducer: src_tab has no blocks; new_tab has the block.
+        let s = state.srv_state.lock().await;
+        assert!(s.tabs[&src_tab].block_ids.is_empty());
+        assert_eq!(s.tabs[new_tab_id].block_ids, vec![block_id.clone()]);
+        assert_eq!(s.blocks[&block_id].tab_id, new_tab_id);
+        assert!(s.workspaces[&ws_id].tab_ids.contains(&new_tab_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn rejects_when_block_in_different_tab() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let err = run(&state, "ghost-block".into(), "ghost-tab".into(), ws_id)
+            .await
+            .unwrap_err();
+        assert!(err.contains("not found") || err.contains("not in"), "got: {}", err);
+    }
+}

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -639,6 +639,15 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 },
             )
             .await;
+            // reagent P1 #622: surface reducer rejection before
+            // applying / publishing. Every other primary dispatch in
+            // this PR follows this pattern; CloseWindow was missing it.
+            if let Some(err_msg) = close_events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
+            }
             for ev in &close_events {
                 if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
                     return WebReturnType::error(format!(
@@ -1285,6 +1294,17 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             };
             let auto_close: bool = service::get_arg(args, 4).unwrap_or(true);
             tracing::info!(ws_id = %ws_id, block_id = %block_id, source_tab = %source_tab_id, dest_tab = %dest_tab_id, "[dnd:svc] MoveBlockToTab via reducer");
+            // codex P2 #622: same-tab requests were no-ops in the
+            // prior wcore handler. The reducer's MoveBlock treats
+            // same source = dest as an in-tab reorder; with
+            // `dst_index: u32::MAX` it would silently move the block
+            // to the end of the list. Short-circuit to preserve the
+            // prior contract — a `MoveBlockToTab` whose dest equals
+            // the source is a UI quirk (e.g. drop on origin tab),
+            // not an intentional reorder.
+            if source_tab_id == dest_tab_id {
+                return WebReturnType::success_empty();
+            }
             // Move the block via the reducer. dst_index 0 to mirror
             // wcore::move_block_to_tab which appended at end... wait,
             // wcore appends, so end-of-list. The reducer's MoveBlock

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -431,28 +431,260 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => WebReturnType::error(e.to_string()),
             }
         }
+        // Phase E.5.8 — CreateWindow migrated through the reducer.
+        // Two paths: (1) empty workspace_id → CreateWorkspace +
+        // CreateTab + CreateWindow as a multi-step dispatch (mirrors
+        // wcore::create_window_full's "fresh workspace" path); (2)
+        // existing workspace_id → just CreateWindow. The subscriber's
+        // apply_srv_window_opened handles `Client.windowids` updates
+        // and Window-row creation. Layout setup for the new tab uses
+        // the apply_tab_created provisioning (E.4 layout migration is
+        // separate; default rootnode = None matches wcore behaviour).
         ("window", "CreateWindow") => {
-            let ws_id: String = match service::get_arg(args, 1) {
-                Ok(v) => v,
-                Err(e) => return WebReturnType::error(e),
-            };
-            match wcore::create_window_full(store, &ws_id) {
-                Ok(win) => {
-                    WebReturnType::success(serde_json::to_value(&win).unwrap_or_default())
+            let requested_ws_id: String = service::get_arg(args, 1).unwrap_or_default();
+            // Resolve / create the workspace.
+            let (ws_id, fresh_workspace_events): (String, Vec<agentmux_common::ipc::Event>) =
+                if requested_ws_id.is_empty() {
+                    // Step 1: create workspace.
+                    let ws_events = dispatch_to_reducer(
+                        state,
+                        agentmux_common::ipc::Command::CreateWorkspace {
+                            name: String::new(),
+                        },
+                    )
+                    .await;
+                    if let Some(err_msg) = ws_events.iter().find_map(|e| match e {
+                        agentmux_common::ipc::Event::Error { message, .. } => {
+                            Some(message.clone())
+                        }
+                        _ => None,
+                    }) {
+                        return WebReturnType::error(err_msg);
+                    }
+                    for ev in &ws_events {
+                        if let Err(e) =
+                            crate::persist_subscriber::apply_event_to_wstore(ev, store)
+                        {
+                            return WebReturnType::error(format!(
+                                "CreateWindow: SQLite write failed: {}",
+                                e
+                            ));
+                        }
+                    }
+                    let new_ws_id = ws_events
+                        .iter()
+                        .find_map(|e| match e {
+                            agentmux_common::ipc::Event::WorkspaceCreated {
+                                workspace_id, ..
+                            } => Some(workspace_id.clone()),
+                            _ => None,
+                        })
+                        .unwrap_or_default();
+                    // Step 2: create tab.
+                    let tab_events = dispatch_to_reducer(
+                        state,
+                        agentmux_common::ipc::Command::CreateTab {
+                            workspace_id: new_ws_id.clone(),
+                            name: String::new(),
+                        },
+                    )
+                    .await;
+                    if let Some(err_msg) = tab_events.iter().find_map(|e| match e {
+                        agentmux_common::ipc::Event::Error { message, .. } => {
+                            Some(message.clone())
+                        }
+                        _ => None,
+                    }) {
+                        // Compensate: delete the empty workspace.
+                        let comp = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::DeleteWorkspace {
+                                workspace_id: new_ws_id.clone(),
+                            },
+                        )
+                        .await;
+                        for ev in &comp {
+                            let _ = crate::persist_subscriber::apply_event_to_wstore(ev, store);
+                        }
+                        publish_events(state, &comp);
+                        return WebReturnType::error(err_msg);
+                    }
+                    for ev in &tab_events {
+                        if let Err(e) =
+                            crate::persist_subscriber::apply_event_to_wstore(ev, store)
+                        {
+                            return WebReturnType::error(format!(
+                                "CreateWindow: SQLite write failed: {}",
+                                e
+                            ));
+                        }
+                    }
+                    let mut combined = ws_events;
+                    combined.extend(tab_events);
+                    (new_ws_id, combined)
+                } else {
+                    // Existing workspace — verify it's in the reducer
+                    // (or SQLite), but no creation needed.
+                    let exists_in_sqlite = match store.get::<Workspace>(&requested_ws_id) {
+                        Ok(opt) => opt.is_some(),
+                        Err(e) => {
+                            return WebReturnType::error(format!(
+                                "CreateWindow: workspace lookup failed: {}",
+                                e
+                            ));
+                        }
+                    };
+                    if !exists_in_sqlite {
+                        return WebReturnType::error(format!(
+                            "CreateWindow: workspace not found: {}",
+                            requested_ws_id
+                        ));
+                    }
+                    (requested_ws_id, Vec::new())
+                };
+
+            // Step 3: register the window in the reducer.
+            let window_id = uuid::Uuid::new_v4().to_string();
+            let win_events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::CreateWindow {
+                    window_id: window_id.clone(),
+                    workspace_id: ws_id.clone(),
+                },
+            )
+            .await;
+            if let Some(err_msg) = win_events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                // Compensate the fresh workspace if we created one.
+                if !fresh_workspace_events.is_empty() {
+                    let comp = dispatch_to_reducer(
+                        state,
+                        agentmux_common::ipc::Command::DeleteWorkspace {
+                            workspace_id: ws_id.clone(),
+                        },
+                    )
+                    .await;
+                    for ev in &comp {
+                        let _ = crate::persist_subscriber::apply_event_to_wstore(ev, store);
+                    }
+                    publish_events(state, &comp);
                 }
-                Err(e) => WebReturnType::error(e.to_string()),
+                return WebReturnType::error(err_msg);
+            }
+            for ev in &win_events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "CreateWindow: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            // Mark the window as `isnew` so the host's first-paint
+            // signaling logic still applies — wcore::create_window_full
+            // set this; the subscriber's default is `isnew: false`.
+            if let Ok(mut win) = store.must_get::<Window>(&window_id) {
+                if !win.isnew {
+                    win.isnew = true;
+                    let _ = store.update(&mut win);
+                }
+            }
+            // Publish all events from this multi-step (workspace + tab + window).
+            let mut all_events = fresh_workspace_events;
+            all_events.extend(win_events);
+            publish_events(state, &all_events);
+            // Return the Window struct (matches the prior RPC contract).
+            match store.must_get::<Window>(&window_id) {
+                Ok(win) => WebReturnType::success(serde_json::to_value(&win).unwrap_or_default()),
+                Err(e) => WebReturnType::error(format!(
+                    "CreateWindow: window read-back failed: {}",
+                    e
+                )),
             }
         }
+        // Phase E.5.8 — CloseWindow migrated through the reducer.
+        // Sequence:
+        //   1. Look up the window's workspace (for cascade decision).
+        //   2. Dispatch Command::CloseWindowInternal — emits
+        //      SrvWindowClosed; subscriber prunes Client.windowids.
+        //   3. If no other window points at the same workspace, dispatch
+        //      Command::DeleteWorkspace which cascades through tabs+blocks.
+        // Mirrors `wcore::close_window` behaviour where each window
+        // owns one workspace, but uses the reducer-routed conditional
+        // pattern so future multi-window-on-same-workspace flows
+        // don't accidentally drop user state.
         ("window", "CloseWindow") => {
             let window_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            match wcore::close_window(store, &window_id) {
-                Ok(()) => WebReturnType::success_empty(),
-                Err(e) => WebReturnType::error(e.to_string()),
+            // Look up the window's workspace before we close it.
+            // Read SQLite (source of truth during migration).
+            let ws_id: Option<String> = match store.get::<Window>(&window_id) {
+                Ok(Some(w)) => Some(w.workspaceid.clone()),
+                Ok(None) => None,
+                Err(e) => {
+                    return WebReturnType::error(format!(
+                        "CloseWindow: window lookup failed: {}",
+                        e
+                    ));
+                }
+            };
+            // Step 1: drop the window mapping in reducer.
+            let close_events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::CloseWindowInternal {
+                    window_id: window_id.clone(),
+                },
+            )
+            .await;
+            for ev in &close_events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "CloseWindow: SQLite write failed: {}",
+                        e
+                    ));
+                }
             }
+            publish_events(state, &close_events);
+            // Step 2: cascade delete the workspace if no other window
+            // points at it. The reducer keeps state.windows updated;
+            // check there.
+            if let Some(ws_id) = ws_id {
+                let any_other_window = {
+                    let s = state.srv_state.lock().await;
+                    s.windows.values().any(|w| w.workspace_id == ws_id)
+                };
+                if !any_other_window {
+                    let del_events = dispatch_to_reducer(
+                        state,
+                        agentmux_common::ipc::Command::DeleteWorkspace {
+                            workspace_id: ws_id.clone(),
+                        },
+                    )
+                    .await;
+                    for ev in &del_events {
+                        if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store)
+                        {
+                            tracing::warn!(
+                                "CloseWindow: workspace cascade SQLite write failed: {}",
+                                e
+                            );
+                        }
+                    }
+                    publish_events(state, &del_events);
+                }
+            }
+            // Subscriber's apply_srv_window_closed already pruned
+            // Client.windowids and deleted the Window row; nothing
+            // more for the handler to do.
+            WebReturnType::success_empty()
         }
+        // Phase E.5.8 — SwitchWorkspace migrated to single-step
+        // reducer dispatch. The reducer validates window + workspace
+        // both exist + emits SrvWindowWorkspaceChanged; subscriber
+        // writes Window.workspaceid in SQLite.
         ("window", "SwitchWorkspace") => {
             let window_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -462,10 +694,30 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            match wcore::switch_workspace(store, &window_id, &ws_id) {
-                Ok(()) => WebReturnType::success_empty(),
-                Err(e) => WebReturnType::error(e.to_string()),
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::SwitchWorkspace {
+                    window_id: window_id.clone(),
+                    workspace_id: ws_id.clone(),
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "SwitchWorkspace: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            WebReturnType::success_empty()
         }
         ("window", "SetWindowPosAndSize") => {
             let window_id: String = match service::get_arg(args, 0) {
@@ -1009,6 +1261,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             }
             WebReturnType::success_empty()
         }
+        // Phase E.5.7 — MoveBlockToTab migrated to dispatch
+        // Command::MoveBlock through the reducer. Auto-close empty
+        // source tab still uses Command::DeleteTab. ws_id arg kept
+        // for backward compat — used only for the post-op SQLite
+        // refresh + auto-close workspace check.
         ("workspace", "MoveBlockToTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1027,39 +1284,95 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => return WebReturnType::error(e),
             };
             let auto_close: bool = service::get_arg(args, 4).unwrap_or(true);
-            tracing::info!(ws_id = %ws_id, block_id = %block_id, source_tab = %source_tab_id, dest_tab = %dest_tab_id, "[dnd:svc] MoveBlockToTab");
-            match wcore::move_block_to_tab(store, &block_id, &source_tab_id, &dest_tab_id, &ws_id, auto_close) {
-                Ok(()) => {
-                    let mut updates = vec![];
-                    if let Ok(src) = store.must_get::<Tab>(&source_tab_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_TAB.to_string(),
-                            oid: source_tab_id.clone(),
-                            obj: Some(wave_obj_to_value(&src)),
-                        });
-                    }
-                    if let Ok(dst) = store.must_get::<Tab>(&dest_tab_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_TAB.to_string(),
-                            oid: dest_tab_id.clone(),
-                            obj: Some(wave_obj_to_value(&dst)),
-                        });
-                    }
-                    if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&ws)),
-                        });
-                    }
-                    WebReturnType::success_with_updates(updates)
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            tracing::info!(ws_id = %ws_id, block_id = %block_id, source_tab = %source_tab_id, dest_tab = %dest_tab_id, "[dnd:svc] MoveBlockToTab via reducer");
+            // Move the block via the reducer. dst_index 0 to mirror
+            // wcore::move_block_to_tab which appended at end... wait,
+            // wcore appends, so end-of-list. The reducer's MoveBlock
+            // clamps dst_index to dst.block_ids.len(); use u32::MAX
+            // to land at the end.
+            let events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::MoveBlock {
+                    block_id: block_id.clone(),
+                    src_tab_id: source_tab_id.clone(),
+                    dst_tab_id: dest_tab_id.clone(),
+                    dst_index: u32::MAX,
+                },
+            )
+            .await;
+            if let Some(err_msg) = events.iter().find_map(|e| match e {
+                agentmux_common::ipc::Event::Error { message, .. } => Some(message.clone()),
+                _ => None,
+            }) {
+                return WebReturnType::error(err_msg);
             }
+            for ev in &events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    return WebReturnType::error(format!(
+                        "MoveBlockToTab: SQLite write failed: {}",
+                        e
+                    ));
+                }
+            }
+            publish_events(state, &events);
+            // Auto-close empty source tab (mirrors wcore::move_block_to_tab).
+            if auto_close {
+                let should_close = match store.must_get::<Tab>(&source_tab_id) {
+                    Ok(t) => t.blockids.is_empty(),
+                    Err(_) => false,
+                };
+                if should_close {
+                    let total_tabs = match store.must_get::<Workspace>(&ws_id) {
+                        Ok(ws) => ws.tabids.len() + ws.pinnedtabids.len(),
+                        Err(_) => 0,
+                    };
+                    if total_tabs > 1 {
+                        let close_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::DeleteTab {
+                                workspace_id: ws_id.clone(),
+                                tab_id: source_tab_id.clone(),
+                            },
+                        )
+                        .await;
+                        for ev in &close_events {
+                            let _ = crate::persist_subscriber::apply_event_to_wstore(ev, store);
+                        }
+                        publish_events(state, &close_events);
+                    }
+                }
+            }
+            let mut updates = vec![];
+            if let Ok(src) = store.must_get::<Tab>(&source_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: source_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&src)),
+                });
+            }
+            if let Ok(dst) = store.must_get::<Tab>(&dest_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: dest_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&dst)),
+                });
+            }
+            if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                });
+            }
+            WebReturnType::success_with_updates(updates)
         }
+        // Phase E.5.7 — PromoteBlockToTab migrated to saga
+        // (CreateTab + MoveBlock). Layout setup + SetActiveTab +
+        // auto-close source tab stay wcore-direct here (E.4 layout
+        // territory). Same shape as TearOffBlock's RPC handler.
         ("workspace", "PromoteBlockToTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1074,40 +1387,106 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Err(e) => return WebReturnType::error(e),
             };
             let auto_close: bool = service::get_arg(args, 3).unwrap_or(true);
-            tracing::info!(ws_id = %ws_id, block_id = %block_id, source_tab = %source_tab_id, "[dnd:svc] PromoteBlockToTab");
-            match wcore::promote_block_to_tab(store, &block_id, &source_tab_id, &ws_id, auto_close) {
-                Ok(new_tab) => {
-                    let new_tab_oid = new_tab.oid.clone();
-                    let mut updates = vec![];
-                    updates.push(WaveObjUpdate {
-                        updatetype: "update".into(),
-                        otype: OTYPE_TAB.to_string(),
-                        oid: new_tab.oid.clone(),
-                        obj: Some(wave_obj_to_value(&new_tab)),
-                    });
-                    if let Ok(src) = store.must_get::<Tab>(&source_tab_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_TAB.to_string(),
-                            oid: source_tab_id.clone(),
-                            obj: Some(wave_obj_to_value(&src)),
-                        });
-                    }
-                    if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
-                        updates.push(WaveObjUpdate {
-                            updatetype: "update".into(),
-                            otype: OTYPE_WORKSPACE.to_string(),
-                            oid: ws_id.clone(),
-                            obj: Some(wave_obj_to_value(&ws)),
-                        });
-                    }
-                    WebReturnType::success_data_updates(
-                        serde_json::to_value(&new_tab_oid).unwrap_or_default(),
-                        updates,
-                    )
-                }
-                Err(e) => WebReturnType::error(e.to_string()),
+            tracing::info!(ws_id = %ws_id, block_id = %block_id, source_tab = %source_tab_id, "[dnd:svc] PromoteBlockToTab via saga");
+            let saga_result = crate::sagas::promote_block_to_tab::run(
+                state,
+                block_id.clone(),
+                source_tab_id.clone(),
+                ws_id.clone(),
+            )
+            .await;
+            let new_tab_oid = match saga_result {
+                Ok(v) => v
+                    .get("new_tab_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string(),
+                Err(reason) => return WebReturnType::error(reason),
+            };
+
+            // Layout setup: rootnode + leaforder for the new tab so
+            // the frontend renders the moved block correctly. Same
+            // helper TearOffBlock uses.
+            if let Err(e) = setup_torn_off_block_layout(store, &new_tab_oid, &block_id) {
+                tracing::warn!(new_tab = %new_tab_oid, "PromoteBlockToTab: layout setup failed: {}", e);
             }
+            // Source tab: queue layout-delete action.
+            if let Err(e) = queue_source_layout_delete(store, &source_tab_id, &block_id) {
+                tracing::warn!(source_tab = %source_tab_id, "PromoteBlockToTab: source layout delete-action enqueue failed: {}", e);
+            }
+            // Set the new tab as active in the workspace via reducer.
+            let active_events = dispatch_to_reducer(
+                state,
+                agentmux_common::ipc::Command::SetActiveTab {
+                    workspace_id: ws_id.clone(),
+                    tab_id: new_tab_oid.clone(),
+                },
+            )
+            .await;
+            for ev in &active_events {
+                if let Err(e) = crate::persist_subscriber::apply_event_to_wstore(ev, store) {
+                    tracing::warn!("PromoteBlockToTab: SetActiveTab apply failed: {}", e);
+                }
+            }
+            publish_events(state, &active_events);
+
+            // Auto-close empty source tab (mirrors wcore behaviour).
+            if auto_close {
+                let should_close = match store.must_get::<Tab>(&source_tab_id) {
+                    Ok(t) => t.blockids.is_empty(),
+                    Err(_) => false,
+                };
+                if should_close {
+                    let total_tabs = match store.must_get::<Workspace>(&ws_id) {
+                        Ok(ws) => ws.tabids.len() + ws.pinnedtabids.len(),
+                        Err(_) => 0,
+                    };
+                    if total_tabs > 1 {
+                        let close_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::DeleteTab {
+                                workspace_id: ws_id.clone(),
+                                tab_id: source_tab_id.clone(),
+                            },
+                        )
+                        .await;
+                        for ev in &close_events {
+                            let _ = crate::persist_subscriber::apply_event_to_wstore(ev, store);
+                        }
+                        publish_events(state, &close_events);
+                    }
+                }
+            }
+
+            let mut updates = vec![];
+            if let Ok(new_tab) = store.must_get::<Tab>(&new_tab_oid) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: new_tab_oid.clone(),
+                    obj: Some(wave_obj_to_value(&new_tab)),
+                });
+            }
+            if let Ok(src) = store.must_get::<Tab>(&source_tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_TAB.to_string(),
+                    oid: source_tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&src)),
+                });
+            }
+            if let Ok(ws) = store.must_get::<Workspace>(&ws_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.to_string(),
+                    oid: ws_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                });
+            }
+            WebReturnType::success_data_updates(
+                serde_json::to_value(&new_tab_oid).unwrap_or_default(),
+                updates,
+            )
         }
         // Phase E.2c.3b — ReorderTab dispatches through the reducer.
         // Forward+compensate isn't useful here (reorder is its own

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.526",
+  "version": "0.33.527",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.526",
+      "version": "0.33.527",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.525",
+  "version": "0.33.526",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.525",
+      "version": "0.33.526",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.525",
+  "version": "0.33.526",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.526",
+  "version": "0.33.527",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.5 closeout — final batch of wcore-direct → reducer-routed migrations in service.rs.

## What changed

**E.5.7 — tab/block move migrations:**
- `MoveBlockToTab` → `Command::MoveBlock` + auto-close via `Command::DeleteTab`.
- `PromoteBlockToTab` → new `sagas::promote_block_to_tab` (CreateTab + MoveBlock + compensation). Layout setup / SetActiveTab / auto-close stay wcore-direct / reducer-direct in the handler (E.4 layout territory).
- `MoveTabToWorkspace` was already migrated in #621 (codex P1 carryover).

**E.5.8 — window operations:**
- `CreateWindow` → multi-step inline reducer dispatch (CreateWorkspace + CreateTab + CreateWindow when empty workspace_id; just CreateWindow when provided). Compensation: if step 2 fails, deletes the empty workspace.
- `CloseWindow` → CloseWindowInternal + conditional DeleteWorkspaceCascade if no other window points at the workspace.
- `SwitchWorkspace` → single-step `Command::SwitchWorkspace` dispatch.

**E.5.9 — cleanup:**
- Audit confirms no remaining wcore-direct mutations of reducer-tracked state (only SQLite-first deletes remain, intentional from earlier sub-phases).
- 1 new saga module + 2 new saga tests.

## What this PR does NOT close

Same gaps as documented in `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §4.2:
- Per-step SQLite transactions in subscriber (F1.A follow-up).
- Host pool-promote outside saga (F1.B / Phase F).
- Renderer registration outside saga (Phase F).
- Saga state across srv restart (Phase F+).

After this PR, **Phase E.5 is complete**. Phase E remaining:
- E.2c.5b: TypeScript renderer dispatcher.
- E.4: Layout state migration.
- E.6: Renderer multi-source consumption + saga buffering.
- E.7: Property tests + integration tests + `--diag` Tools.

## Test plan

- [x] 719 unit tests pass (+9 saga tests, +2 new for PromoteBlockToTab).
- [x] cargo build clean across all crates.
- [ ] Pre-merge smoke: drag tab between workspaces; promote block to tab; create + close window; switch workspaces.
- [ ] Reagent + codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)