### PR TITLE
fix(F1.B): restore tab on tear-off window-create failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.529"
+version = "0.33.530"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.529"
+version = "0.33.530"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.529"
+version = "0.33.530"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.529"
+version = "0.33.530"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.531"
+version = "0.33.532"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.531"
+version = "0.33.532"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.531"
+version = "0.33.532"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.531"
+version = "0.33.532"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.528"
+version = "0.33.529"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.528"
+version = "0.33.529"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.528"
+version = "0.33.529"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.528"
+version = "0.33.529"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.530"
+version = "0.33.531"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.530"
+version = "0.33.531"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.530"
+version = "0.33.531"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.530"
+version = "0.33.531"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.530"
+version = "0.33.531"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.528"
+version = "0.33.529"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.531"
+version = "0.33.532"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.529"
+version = "0.33.530"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.531"
+version = "0.33.532"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.529"
+version = "0.33.530"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.528"
+version = "0.33.529"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.530"
+version = "0.33.531"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.530"
+version = "0.33.531"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.528"
+version = "0.33.529"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.531"
+version = "0.33.532"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.529"
+version = "0.33.530"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.528"
+version = "0.33.529"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.531"
+version = "0.33.532"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.529"
+version = "0.33.530"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.530"
+version = "0.33.531"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -603,15 +603,23 @@ async function requestTearOff(
     wasPinned: boolean,
 ): Promise<void> {
     const t0 = performance.now();
-    // F1.B — track whether the destination window has actually been
-    // opened. If TearOffTab succeeded but window-creation later failed
-    // (both pool-promote AND cold-path open), the tab is stuck in an
-    // invisible new workspace. The catch below uses these flags to
-    // restore the tab to its original position (which also cascade-
-    // deletes the orphan workspace via RestoreTornOffTab's saga).
-    // Tracked OUTSIDE the try so the catch can read them.
+    // F1.B — track tear-off progress to drive the orphan-cleanup
+    // catch below. Three states:
+    // * newWsId unset            → TearOffTab hasn't succeeded;
+    //                              nothing to clean up.
+    // * windowCreateAttempted=false → no host window-create call has
+    //                              been issued; safe to restore.
+    // * windowCreateAttempted=true  → host's create-window API
+    //                              returned a label, but the window
+    //                              is created asynchronously and may
+    //                              or may not be live yet. The
+    //                              handshake below confirms HWND
+    //                              registration; only after handshake
+    //                              succeeds is the window definitively
+    //                              live. (codex P1 round-2 #624.)
     let newWsId: string | undefined;
-    let destWindowOpened = false;
+    let windowCreateAttempted = false;
+    let handshakeSucceeded = false;
     try {
         const sourceWindowLabel = await getApi().getWindowLabel();
         // Step 1 — sidecar transfers the tab into a new workspace.
@@ -637,16 +645,14 @@ async function requestTearOff(
                 newWsId,
             );
         }
-        // Note: `destWindowOpened` is NOT set here. Both
-        // tearOffPoolPromote and openWindowAtPosition return a label
-        // EAGERLY (the CEF command is posted asynchronously; the new
-        // window's HWND registration happens later). The handshake
-        // below is what waits for HWND registration; only AFTER it
-        // succeeds do we know the destination window is actually
-        // live. If the handshake fails because HWND never registers,
-        // there's no live window for the user to interact with and
-        // the orphan-cleanup catch below should restore the tab.
-        // (codex P1 #624.)
+        // Mark the create-window attempt. Both APIs return a label
+        // EAGERLY (the CEF command posts asynchronously; HWND
+        // registration happens later). After this point a window
+        // MAY exist; the catch below uses the handshake error
+        // message to distinguish "HWND never registered" (window
+        // doesn't exist) from "registered but post-registration
+        // failure" (window exists). (codex P1 round-2 #624.)
+        windowCreateAttempted = true;
         // Step 3 — Win32 SC_MOVE handshake. Host waits for the new
         // window's HWND to register, then transfers cursor capture
         // and posts WM_SYSCOMMAND/SC_MOVE so Windows enters its
@@ -671,12 +677,8 @@ async function requestTearOff(
             wasPinned,
         });
         // Handshake confirmed the destination window's HWND
-        // registered + Windows now owns the move loop. From here on
-        // the orphan-cleanup catch below skips RestoreTornOffTab.
-        // (codex P1 #624 — moved from immediately-after-create-window
-        // to here, since create-window APIs return eagerly before
-        // HWND registration.)
-        destWindowOpened = true;
+        // registered + Windows now owns the move loop.
+        handshakeSucceeded = true;
         // Clear the cross-window drag payload so the legacy dragend
         // pipeline (CrossWindowDragMonitor) doesn't double-process
         // this gesture when its dragend fires. Cleared HERE rather
@@ -692,18 +694,32 @@ async function requestTearOff(
         });
     } catch (e) {
         Logger.error("dnd", "tab tear-off failed", { tabId, error: String(e) });
-        // F1.B — orphan workspace cleanup. If TearOffTab succeeded
-        // (newWsId is set) but no destination window was ever opened
-        // (destWindowOpened is false), the tab is stuck in an
-        // invisible new workspace. Restore it to its original
-        // workspace + index — RestoreTornOffTab's saga also cascade-
-        // deletes the now-empty new workspace. Skip when the window
-        // WAS opened: a handshake-failure leaves the window live, so
-        // restoring would orphan the window pointing at a deleted
-        // workspace. Documented in
-        // docs/retro/saga-coordinator-location-analysis-2026-04-30.md
-        // §6.4.
-        if (newWsId && !destWindowOpened) {
+        // F1.B — orphan workspace cleanup. Only restore the tab when
+        // we're confident the destination window does NOT exist:
+        //
+        // 1. TearOffTab failed → newWsId unset → nothing to do.
+        // 2. TearOffTab succeeded, no window-create called → restore.
+        // 3. window-create returned a label, handshake threw with
+        //    "not registered within …s" → HWND never registered →
+        //    window doesn't exist → restore.
+        // 4. window-create returned a label, handshake threw any
+        //    other error (hook setup, PostMessageW, etc.) → HWND
+        //    DID register → window exists → SKIP restore. Restoring
+        //    would cascade-delete the workspace and orphan the live
+        //    window. (codex P1 round-2 #624.)
+        //
+        // Match-string is brittle but the host-side error is
+        // produced verbatim by `tear_off_sc_move_handshake` at
+        // `agentmux-cef/src/commands/drag.rs:491`. If that string
+        // changes, this guard becomes too conservative (skips
+        // restore where it could have safely fired) but never the
+        // other way (restore + orphan window). Acceptable failure mode.
+        const errStr = String(e);
+        const handshakeRegistrationTimeout = errStr.includes("not registered within");
+        const safeToRestore =
+            newWsId && !handshakeSucceeded
+            && (!windowCreateAttempted || handshakeRegistrationTimeout);
+        if (safeToRestore) {
             try {
                 await WorkspaceService.RestoreTornOffTab(
                     tabId,
@@ -715,6 +731,7 @@ async function requestTearOff(
                 Logger.info("dnd", "tab tear-off restored after window-create failure", {
                     tabId,
                     newWsId,
+                    handshakeRegistrationTimeout,
                 });
             } catch (restoreErr) {
                 Logger.error("dnd", "tab tear-off restore also failed — orphan workspace persists", {
@@ -723,6 +740,12 @@ async function requestTearOff(
                     error: String(restoreErr),
                 });
             }
+        } else if (newWsId && windowCreateAttempted && !handshakeSucceeded) {
+            // Window may exist; conservatively leave the orphan.
+            Logger.warn("dnd", "tab tear-off failed post-window-create — leaving workspace + window for user cleanup", {
+                tabId,
+                newWsId,
+            });
         }
     }
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -603,11 +603,20 @@ async function requestTearOff(
     wasPinned: boolean,
 ): Promise<void> {
     const t0 = performance.now();
+    // F1.B — track whether the destination window has actually been
+    // opened. If TearOffTab succeeded but window-creation later failed
+    // (both pool-promote AND cold-path open), the tab is stuck in an
+    // invisible new workspace. The catch below uses these flags to
+    // restore the tab to its original position (which also cascade-
+    // deletes the orphan workspace via RestoreTornOffTab's saga).
+    // Tracked OUTSIDE the try so the catch can read them.
+    let newWsId: string | undefined;
+    let destWindowOpened = false;
     try {
         const sourceWindowLabel = await getApi().getWindowLabel();
         // Step 1 — sidecar transfers the tab into a new workspace.
         // Returns the new workspace's ID.
-        const newWsId = await WorkspaceService.TearOffTab(tabId, workspaceId);
+        newWsId = await WorkspaceService.TearOffTab(tabId, workspaceId);
         // Step 2 — get the destination window. Phase 6 prefers the
         // pre-warmed pool (0 ms first-paint flash). On pool exhaustion
         // we fall back to the cold-path openWindowAtPosition (~150-300 ms
@@ -628,6 +637,12 @@ async function requestTearOff(
                 newWsId,
             );
         }
+        // Window has been opened (either pool or cold path). From here
+        // on the orphan-cleanup catch below skips the RestoreTornOffTab
+        // — the new window is live and pointing at the new workspace;
+        // restoring would empty + delete the workspace and leave the
+        // open window dangling.
+        destWindowOpened = true;
         // Step 3 — Win32 SC_MOVE handshake. Host waits for the new
         // window's HWND to register, then transfers cursor capture
         // and posts WM_SYSCOMMAND/SC_MOVE so Windows enters its
@@ -666,6 +681,38 @@ async function requestTearOff(
         });
     } catch (e) {
         Logger.error("dnd", "tab tear-off failed", { tabId, error: String(e) });
+        // F1.B — orphan workspace cleanup. If TearOffTab succeeded
+        // (newWsId is set) but no destination window was ever opened
+        // (destWindowOpened is false), the tab is stuck in an
+        // invisible new workspace. Restore it to its original
+        // workspace + index — RestoreTornOffTab's saga also cascade-
+        // deletes the now-empty new workspace. Skip when the window
+        // WAS opened: a handshake-failure leaves the window live, so
+        // restoring would orphan the window pointing at a deleted
+        // workspace. Documented in
+        // docs/retro/saga-coordinator-location-analysis-2026-04-30.md
+        // §6.4.
+        if (newWsId && !destWindowOpened) {
+            try {
+                await WorkspaceService.RestoreTornOffTab(
+                    tabId,
+                    newWsId,
+                    workspaceId,
+                    originalTabIndex,
+                    wasPinned,
+                );
+                Logger.info("dnd", "tab tear-off restored after window-create failure", {
+                    tabId,
+                    newWsId,
+                });
+            } catch (restoreErr) {
+                Logger.error("dnd", "tab tear-off restore also failed — orphan workspace persists", {
+                    tabId,
+                    newWsId,
+                    error: String(restoreErr),
+                });
+            }
+        }
     }
 }
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -603,23 +603,28 @@ async function requestTearOff(
     wasPinned: boolean,
 ): Promise<void> {
     const t0 = performance.now();
-    // F1.B — track tear-off progress to drive the orphan-cleanup
-    // catch below. Three states:
-    // * newWsId unset            → TearOffTab hasn't succeeded;
-    //                              nothing to clean up.
-    // * windowCreateAttempted=false → no host window-create call has
-    //                              been issued; safe to restore.
-    // * windowCreateAttempted=true  → host's create-window API
-    //                              returned a label, but the window
-    //                              is created asynchronously and may
-    //                              or may not be live yet. The
-    //                              handshake below confirms HWND
-    //                              registration; only after handshake
-    //                              succeeds is the window definitively
-    //                              live. (codex P1 round-2 #624.)
+    // F1.B — orphan-cleanup state. We only restore the tab when we
+    // can PROVE the destination window doesn't exist: the
+    // create-window APIs (pool-promote and openWindowAtPosition) post
+    // window creation asynchronously, so neither a successful return
+    // nor a handshake error proves the window won't materialize.
+    //
+    // The single safe signal: `openWindowAtPosition` itself threw.
+    // That means the host couldn't even post the create command —
+    // no window will ever materialize for this tear-off. (Pool-
+    // promote being exhausted is also a host-side rejection, but
+    // we then attempt cold-path; only when cold-path ALSO throws do
+    // we know no create was posted.)
+    //
+    // Anything else (pool-promote succeeded; cold-path returned a
+    // label and the create posted but never registered; handshake
+    // failed for any reason post-create) leaves the window in an
+    // unknown state. Conservatively skip restore in those cases —
+    // the orphan workspace is a smaller harm than the risk of
+    // cascade-deleting a workspace that a delayed window is about
+    // to register against. (codex P1 round-3 #624.)
     let newWsId: string | undefined;
-    let windowCreateAttempted = false;
-    let handshakeSucceeded = false;
+    let coldPathFailed = false;
     try {
         const sourceWindowLabel = await getApi().getWindowLabel();
         // Step 1 — sidecar transfers the tab into a new workspace.
@@ -639,20 +644,21 @@ async function requestTearOff(
             Logger.warn("dnd", "tear-off pool exhausted, falling back to cold path", {
                 error: String(poolErr),
             });
-            destWindowLabel = await getApi().openWindowAtPosition(
-                cursorX,
-                cursorY,
-                newWsId,
-            );
+            try {
+                destWindowLabel = await getApi().openWindowAtPosition(
+                    cursorX,
+                    cursorY,
+                    newWsId,
+                );
+            } catch (coldErr) {
+                // F1.B safe-restore signal: cold-path API itself
+                // threw. The host couldn't post the create command,
+                // so no window will materialize. Re-throw to outer
+                // catch which will dispatch RestoreTornOffTab.
+                coldPathFailed = true;
+                throw coldErr;
+            }
         }
-        // Mark the create-window attempt. Both APIs return a label
-        // EAGERLY (the CEF command posts asynchronously; HWND
-        // registration happens later). After this point a window
-        // MAY exist; the catch below uses the handshake error
-        // message to distinguish "HWND never registered" (window
-        // doesn't exist) from "registered but post-registration
-        // failure" (window exists). (codex P1 round-2 #624.)
-        windowCreateAttempted = true;
         // Step 3 — Win32 SC_MOVE handshake. Host waits for the new
         // window's HWND to register, then transfers cursor capture
         // and posts WM_SYSCOMMAND/SC_MOVE so Windows enters its
@@ -678,7 +684,6 @@ async function requestTearOff(
         });
         // Handshake confirmed the destination window's HWND
         // registered + Windows now owns the move loop.
-        handshakeSucceeded = true;
         // Clear the cross-window drag payload so the legacy dragend
         // pipeline (CrossWindowDragMonitor) doesn't double-process
         // this gesture when its dragend fires. Cleared HERE rather
@@ -695,31 +700,13 @@ async function requestTearOff(
     } catch (e) {
         Logger.error("dnd", "tab tear-off failed", { tabId, error: String(e) });
         // F1.B — orphan workspace cleanup. Only restore the tab when
-        // we're confident the destination window does NOT exist:
-        //
-        // 1. TearOffTab failed → newWsId unset → nothing to do.
-        // 2. TearOffTab succeeded, no window-create called → restore.
-        // 3. window-create returned a label, handshake threw with
-        //    "not registered within …s" → HWND never registered →
-        //    window doesn't exist → restore.
-        // 4. window-create returned a label, handshake threw any
-        //    other error (hook setup, PostMessageW, etc.) → HWND
-        //    DID register → window exists → SKIP restore. Restoring
-        //    would cascade-delete the workspace and orphan the live
-        //    window. (codex P1 round-2 #624.)
-        //
-        // Match-string is brittle but the host-side error is
-        // produced verbatim by `tear_off_sc_move_handshake` at
-        // `agentmux-cef/src/commands/drag.rs:491`. If that string
-        // changes, this guard becomes too conservative (skips
-        // restore where it could have safely fired) but never the
-        // other way (restore + orphan window). Acceptable failure mode.
-        const errStr = String(e);
-        const handshakeRegistrationTimeout = errStr.includes("not registered within");
-        const safeToRestore =
-            newWsId && !handshakeSucceeded
-            && (!windowCreateAttempted || handshakeRegistrationTimeout);
-        if (safeToRestore) {
+        // we're PROVABLY safe: cold-path window-create threw (no
+        // window will materialize). Any other failure path leaves
+        // the destination window in an unknown state and we
+        // conservatively keep the orphan workspace rather than risk
+        // cascade-deleting a workspace a delayed window is about
+        // to register against. (codex P1 round-3 #624.)
+        if (newWsId && coldPathFailed) {
             try {
                 await WorkspaceService.RestoreTornOffTab(
                     tabId,
@@ -731,7 +718,6 @@ async function requestTearOff(
                 Logger.info("dnd", "tab tear-off restored after window-create failure", {
                     tabId,
                     newWsId,
-                    handshakeRegistrationTimeout,
                 });
             } catch (restoreErr) {
                 Logger.error("dnd", "tab tear-off restore also failed — orphan workspace persists", {
@@ -740,9 +726,13 @@ async function requestTearOff(
                     error: String(restoreErr),
                 });
             }
-        } else if (newWsId && windowCreateAttempted && !handshakeSucceeded) {
-            // Window may exist; conservatively leave the orphan.
-            Logger.warn("dnd", "tab tear-off failed post-window-create — leaving workspace + window for user cleanup", {
+        } else if (newWsId) {
+            // TearOffTab succeeded but we hit a failure mode where
+            // we can't safely restore (handshake error, post-window-
+            // create timing, etc.). Leave the orphan workspace; the
+            // user will see it in the workspace list and can close
+            // it via the UI.
+            Logger.warn("dnd", "tab tear-off failed post-create — orphan workspace left for user cleanup", {
                 tabId,
                 newWsId,
             });

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -637,12 +637,16 @@ async function requestTearOff(
                 newWsId,
             );
         }
-        // Window has been opened (either pool or cold path). From here
-        // on the orphan-cleanup catch below skips the RestoreTornOffTab
-        // — the new window is live and pointing at the new workspace;
-        // restoring would empty + delete the workspace and leave the
-        // open window dangling.
-        destWindowOpened = true;
+        // Note: `destWindowOpened` is NOT set here. Both
+        // tearOffPoolPromote and openWindowAtPosition return a label
+        // EAGERLY (the CEF command is posted asynchronously; the new
+        // window's HWND registration happens later). The handshake
+        // below is what waits for HWND registration; only AFTER it
+        // succeeds do we know the destination window is actually
+        // live. If the handshake fails because HWND never registers,
+        // there's no live window for the user to interact with and
+        // the orphan-cleanup catch below should restore the tab.
+        // (codex P1 #624.)
         // Step 3 — Win32 SC_MOVE handshake. Host waits for the new
         // window's HWND to register, then transfers cursor capture
         // and posts WM_SYSCOMMAND/SC_MOVE so Windows enters its
@@ -666,12 +670,19 @@ async function requestTearOff(
             originalTabIndex,
             wasPinned,
         });
-        // Handshake succeeded — Windows now owns the move loop. Clear
-        // the cross-window drag payload so the legacy dragend pipeline
-        // (CrossWindowDragMonitor) doesn't double-process this gesture
-        // when its dragend fires. Cleared HERE rather than in onDrag so
-        // a failure mid-pipeline (TearOffTab, openWindowAtPosition, or
-        // the handshake itself) leaves the legacy fallback intact.
+        // Handshake confirmed the destination window's HWND
+        // registered + Windows now owns the move loop. From here on
+        // the orphan-cleanup catch below skips RestoreTornOffTab.
+        // (codex P1 #624 — moved from immediately-after-create-window
+        // to here, since create-window APIs return eagerly before
+        // HWND registration.)
+        destWindowOpened = true;
+        // Clear the cross-window drag payload so the legacy dragend
+        // pipeline (CrossWindowDragMonitor) doesn't double-process
+        // this gesture when its dragend fires. Cleared HERE rather
+        // than in onDrag so a failure mid-pipeline (TearOffTab,
+        // openWindowAtPosition, or the handshake itself) leaves the
+        // legacy fallback intact.
         setCurrentDragPayload(null);
         Logger.info("dnd", "tab tear-off complete", {
             tabId,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.530",
+  "version": "0.33.531",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.530",
+      "version": "0.33.531",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.528",
+  "version": "0.33.529",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.528",
+      "version": "0.33.529",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.529",
+  "version": "0.33.530",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.529",
+      "version": "0.33.530",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.531",
+  "version": "0.33.532",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.531",
+      "version": "0.33.532",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.529",
+  "version": "0.33.530",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.530",
+  "version": "0.33.531",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.531",
+  "version": "0.33.532",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.528",
+  "version": "0.33.529",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the orphan-workspace gap from:
- `docs/retro/saga-coordinator-location-analysis-2026-04-30.md` §6.4
- `docs/specs/PHASE_E_SAGAS_EXECUTION_PLAN_2026-04-30.md` §9b (F1.B)

Before this PR, if \`WorkspaceService.TearOffTab\` succeeded but both the warm-pool promote AND the cold-path \`open_window_at_position\` then failed, the tab was stuck in an invisible new workspace with no window pointing at it. The catch block just logged the error.

## What changed

In \`requestTearOff\`:
- Track whether the destination window was opened (\`destWindowOpened\` flag).
- In the catch:
  - If TearOffTab succeeded AND no window was opened → dispatch \`WorkspaceService.RestoreTornOffTab\` to put the tab back at its original index. The saga (shipped in #621) also cascade-deletes the empty new workspace.
  - If a window WAS opened (handshake-failure case) → skip restore. Restoring would empty + delete the new workspace and leave the open window dangling.

## Test plan

- [x] Frontend builds clean (\`npm run build\`).
- [x] Code review: catch path only fires on already-broken state; uses existing RestoreTornOffTab saga.
- [ ] Failure-injection smoke is hard from the existing harness — change is small and well-scoped.

## Phase E.5 + follow-ups status

After this PR merges:
- Phase E.5 ✅ (PRs #619-#622)
- F1.A ✅ (#623)
- F1.B ✅ (#this)

Remaining Phase E sub-phases (E.2c.5b, E.4, E.6, E.7) are scoped separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)