### PR TITLE
feat(E.2c.5b): renderer-side srv event dispatcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.533"
+version = "0.33.534"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.533"
+version = "0.33.534"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.533"
+version = "0.33.534"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.533"
+version = "0.33.534"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.533 | 2026-04-30 | 160.8 MiB | 336.4 MiB | |
 | 0.33.512 | 2026-04-29 | 160.5 MiB | 335.6 MiB | |
 | 0.33.511 | 2026-04-29 | 160.5 MiB | 335.5 MiB | |
 | 0.33.510 | 2026-04-29 | 160.5 MiB | 335.5 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.533"
+version = "0.33.534"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.533"
+version = "0.33.534"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.533"
+version = "0.33.534"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.533"
+version = "0.33.534"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -42,6 +42,7 @@ import { isHostApp } from "@/app/init/host-detect";
 import { showStartupError } from "@/app/init/error-display";
 import { withTimeout } from "@/app/init/timeout";
 import { installLauncherEventBridge } from "@/util/launcher-events";
+import { installSrvEventBridge } from "@/util/srv-events";
 import {
     seedKnownEntriesFromSnapshot,
     startLauncherEventReducer,
@@ -308,6 +309,11 @@ export async function initApp() {
     // start dispatching as soon as the renderer's V8 context is ready;
     // registering early guarantees no events are dropped on the floor.
     installLauncherEventBridge();
+    // Phase E.2c.5b — same discipline for srv events. The host's
+    // `srv_event_bridge.rs` (PR #618) starts forwarding srv reducer
+    // events as soon as the srv pipe is connected; install before
+    // any host-touching call so early events aren't dropped.
+    installSrvEventBridge();
 
     // Register context menu click handler now that window.api exists.
     ContextMenuModel.init();

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -663,6 +663,12 @@ declare global {
         // by the host's CEF JS bridge once per top-level renderer
         // per launcher event.
         __agentmux_launcher_event?: (evt: { event: string; version: number; [k: string]: unknown }) => void;
+
+        // Phase E.2c.5b — srv typed-event dispatcher.
+        // Installed by `frontend/util/srv-events.ts`; called by the
+        // host's CEF JS bridge (`agentmux-cef/src/srv_event_bridge.rs`)
+        // once per top-level renderer per srv event.
+        __agentmux_srv_event?: (evt: { event: string; version: number; [k: string]: unknown }) => void;
     }
 }
 

--- a/frontend/util/srv-events.ts
+++ b/frontend/util/srv-events.ts
@@ -1,0 +1,100 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.2c.5b — renderer-side subscriber for srv reducer typed events.
+//
+// Mirrors the `launcher-events.ts` pattern from Phase B.7.3.1, but
+// for the srv reducer's broadcast bus (workspace / tab / block / window
+// / saga lifecycle). The host's CEF JS bridge
+// (`agentmux-cef/src/srv_event_bridge.rs`, shipped in Phase E.2c.5a /
+// PR #618) calls `window.__agentmux_srv_event(<json>)` once per
+// top-level renderer per srv event. We feed those into a SolidJS
+// signal so block-level subscribers can `createEffect()` on them.
+//
+// **Initial scope (this PR — E.2c.5b):** scaffolding only. Install
+// the dispatcher, expose the latest event signal, log a one-line
+// debug summary on first event arrival. **No atom mutation** — the
+// existing RPC + WaveObjUpdate pipeline remains the authoritative
+// path for workspace/tab/block atom state. Atom-routing flips to
+// event-driven in a follow-up (likely E.6 alongside the per-source
+// version tracking + saga buffer).
+//
+// **Saga events** (`saga_started` / `saga_completed` / `saga_failed`)
+// arrive on this channel too. Future renderer-side correlation /
+// buffering (E.6 §9.2) consumes them via the same signal.
+//
+// See `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §6.6 + §9.
+
+import { createSignal } from "solid-js";
+
+/**
+ * Wire-format srv event. Matches the JSON serialization of
+ * `agentmux_common::ipc::Event`
+ * (`#[serde(tag = "event", rename_all = "snake_case")]`).
+ *
+ * Every event carries `event` (discriminant, snake_case) and
+ * `version` (monotonic per srv-process run, used for de-dup /
+ * resync ordering). Other fields are variant-specific; downstream
+ * subscribers narrow on `event` and read fields by name.
+ *
+ * Discriminator examples (non-exhaustive — see
+ * `agentmux-common/src/ipc.rs::Event`):
+ *   - `workspace_created` / `workspace_deleted` / `workspace_renamed`
+ *   - `tab_created` / `tab_deleted` / `tab_renamed` / `tab_moved` / `tab_reordered`
+ *   - `block_created` / `block_deleted` / `block_moved`
+ *   - `active_tab_changed`
+ *   - `srv_window_opened` / `srv_window_closed` / `srv_window_workspace_changed`
+ *   - `tabs_reordered_bulk`
+ *   - `workspace_meta_updated` / `tab_meta_updated` / `block_meta_updated`
+ *   - `saga_started` / `saga_completed` / `saga_failed`
+ */
+export interface SrvEvent {
+    event: string;
+    version: number;
+    [field: string]: unknown;
+}
+
+const [latestEvent, setLatestEvent] = createSignal<SrvEvent | null>(null);
+const [eventVersion, setEventVersion] = createSignal<number>(0);
+const [seenAnyEvent, setSeenAnyEvent] = createSignal<boolean>(false);
+
+/** Latest typed event delivered by the srv pipe. Null until the first event. */
+export const srvEvent = latestEvent;
+
+/** Monotonic version of the most recent event. 0 until the first event. */
+export const srvEventVersion = eventVersion;
+
+/**
+ * True once we've received at least one srv typed event. Mirrors
+ * `launcherEventsActive` — useful to E.6's resync flow to detect
+ * "have we seen at least one srv event?" vs "fresh srv pipe."
+ */
+export const srvEventsActive = seenAnyEvent;
+
+let installed = false;
+
+/**
+ * Register `window.__agentmux_srv_event` as the dispatcher.
+ * Idempotent — safe to call multiple times. Called once from
+ * `app-init.ts::initApp` BEFORE the first state-needing operation
+ * so events that arrive during init aren't dropped.
+ */
+export function installSrvEventBridge(): void {
+    if (installed) return;
+    installed = true;
+    (window as unknown as { __agentmux_srv_event?: (evt: SrvEvent) => void }).__agentmux_srv_event = (
+        evt: SrvEvent,
+    ) => {
+        if (!evt || typeof evt.version !== "number" || typeof evt.event !== "string") {
+            console.warn("[srv-events] received malformed event", evt);
+            return;
+        }
+        setLatestEvent(evt);
+        setEventVersion(evt.version);
+        if (!seenAnyEvent()) {
+            setSeenAnyEvent(true);
+            console.log("[srv-events] first event received", { event: evt.event, version: evt.version });
+        }
+    };
+    console.log("[srv-events] bridge installed; window.__agentmux_srv_event ready");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.533",
+  "version": "0.33.534",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.533",
+      "version": "0.33.534",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.533",
+  "version": "0.33.534",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes Phase E.2c.5b — installs the renderer half of the srv typed-event bridge that PR #618 shipped on the host side. The host's `srv_event_bridge.rs` calls `window.__agentmux_srv_event(json)` once per top-level renderer per srv event; this PR registers the handler + exposes the latest event as a SolidJS signal.

**Initial scope: scaffolding only.** Mirrors the B.7.3.1 launcher-event scaffolding pattern — no atom mutation yet. Atom-routing flips to event-driven in E.6 alongside the per-source version tracking + saga buffer.

## What this enables

- Saga lifecycle events (`saga_started`/`saga_completed`/`saga_failed`) are now reachable from renderer code via the `srvEvent()` signal.
- Future E.6 buffering subscribes to the same signal.
- Debugging: console gets a one-liner on first srv event arrival, confirming the bridge is working end-to-end.

## Files changed

- `frontend/util/srv-events.ts` — new, mirrors `launcher-events.ts`.
- `frontend/types/custom.d.ts` — adds `__agentmux_srv_event?` to the global `Window` interface.
- `frontend/app-init.ts` — calls `installSrvEventBridge()` right after the launcher bridge install.
- `VERSION_HISTORY.md` — auto-appended row from the 0.33.533 smoke build (housekeeping).
- `package-lock.json` — version sync to 0.33.534.

## Phase E status after this merges

- E.2c.5b ✅
- E.4 (layout) — open, design question
- E.6 (renderer multi-source + saga buffer) — open, depends on this
- E.7 (proptests + diag) — open, phase exit

See `docs/retro/next-steps-2026-05-01.md`.

## Test plan

- [x] `npm run build` clean.
- [ ] Live verify via smoke (deferred until E.6 lands and atom-routing becomes authoritative — same pattern as B.7.3.1's untested ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)