### PR TITLE
feat(E.7): --diag srv operator command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.534"
+version = "0.33.535"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.534"
+version = "0.33.535"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.534"
+version = "0.33.535"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.534"
+version = "0.33.535"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.534"
+version = "0.33.535"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.534"
+version = "0.33.535"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.534"
+version = "0.33.535"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -156,6 +156,362 @@ pub async fn run_wrr_diag(_launcher_exe_dir: &std::path::Path) -> Result<(), Str
     Err("--diag wrr is Windows-only (Phase 7 will add Unix domain socket parity)".to_string())
 }
 
+/// Phase E.7 — `agentmux.exe --diag srv` Tool client.
+///
+/// Connects to the srv pipe (`\\.\pipe\agentmux-{hash}\srv-command`),
+/// registers as a Tool client, sends `GetSrvSnapshot` + `GetEvents`,
+/// captures events for the same 2 s observation window as
+/// `--diag wrr`, prints a human-readable summary, exits.
+///
+/// Provides operator visibility into the srv reducer's canonical
+/// state (workspaces / tabs / blocks / windows / saga lifecycle) +
+/// recent event activity. Mirrors `run_wrr_diag` for the launcher;
+/// the differences are the pipe path, the snapshot variant
+/// (`Event::SrvSnapshot`), and the formatter for srv-specific event
+/// kinds.
+#[cfg(target_os = "windows")]
+pub async fn run_srv_diag(launcher_exe_dir: &std::path::Path) -> Result<(), String> {
+    let version = env!("CARGO_PKG_VERSION");
+    let is_dev = cfg!(debug_assertions);
+
+    let paths = crate::data_dir::resolve_paths(launcher_exe_dir, version, is_dev)
+        .map_err(|e| format!("path resolution failed: {}", e))?;
+    let dir_hash = crate::hash::data_dir_hash16(&paths.data_dir);
+    let pipe_path = crate::ipc::srv_pipe_name(&dir_hash);
+
+    println!("AgentMux srv diagnostic — connecting to {}", pipe_path);
+    println!("Data dir: {}", paths.data_dir.display());
+
+    let client = ClientOptions::new().open(&pipe_path).map_err(|e| {
+        format!(
+            "could not open srv pipe {}: {} (is AgentMux running for this data dir? \
+             srv may not be bound in `task dev` mode)",
+            pipe_path, e
+        )
+    })?;
+    println!("Connected. Registering as Tool client...\n");
+
+    let (read_half, mut write_half) = tokio::io::split(client);
+
+    let register = Command::Register {
+        kind: ClientKind::Tool,
+        pid: std::process::id(),
+        version: version.to_string(),
+    };
+    let mut buf = serde_json::to_vec(&register)
+        .map_err(|e| format!("serialize Register: {}", e))?;
+    buf.push(b'\n');
+    write_half
+        .write_all(&buf)
+        .await
+        .map_err(|e| format!("send Register: {}", e))?;
+    write_half
+        .flush()
+        .await
+        .map_err(|e| format!("flush Register: {}", e))?;
+
+    // Phase E.1b — request the srv reducer's canonical state.
+    let mut buf = serde_json::to_vec(&Command::GetSrvSnapshot)
+        .map_err(|e| format!("serialize GetSrvSnapshot: {}", e))?;
+    buf.push(b'\n');
+    write_half
+        .write_all(&buf)
+        .await
+        .map_err(|e| format!("send GetSrvSnapshot: {}", e))?;
+    write_half
+        .flush()
+        .await
+        .map_err(|e| format!("flush GetSrvSnapshot: {}", e))?;
+
+    // Phase D.3 / E.7 — request a replay of all retained events from
+    // the srv side's in-memory ring + on-disk event log. Useful for
+    // operators wanting recent srv reducer activity (saga lifecycle
+    // events, workspace/tab/block mutations) without having to wait
+    // for new activity.
+    let mut buf = serde_json::to_vec(&Command::GetEvents { since: 0 })
+        .map_err(|e| format!("serialize GetEvents: {}", e))?;
+    buf.push(b'\n');
+    write_half
+        .write_all(&buf)
+        .await
+        .map_err(|e| format!("send GetEvents: {}", e))?;
+    write_half
+        .flush()
+        .await
+        .map_err(|e| format!("flush GetEvents: {}", e))?;
+
+    let reader = BufReader::new(read_half);
+    let mut lines = reader.lines();
+    let mut events: Vec<Event> = Vec::new();
+    let deadline = tokio::time::Instant::now() + OBSERVATION_WINDOW;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, lines.next_line()).await {
+            Ok(Ok(Some(line))) if line.trim().is_empty() => continue,
+            Ok(Ok(Some(line))) => match serde_json::from_str::<Event>(&line) {
+                Ok(evt) => events.push(evt),
+                Err(e) => eprintln!("[warn] could not parse event: {} ({})", e, line),
+            },
+            Ok(Ok(None)) => {
+                eprintln!("[warn] srv pipe closed before observation window elapsed");
+                break;
+            }
+            Ok(Err(e)) => {
+                return Err(format!("read error: {}", e));
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Best-effort Goodbye so the srv server marks our PID Exited
+    // (same rationale as run_wrr_diag).
+    let goodbye = match serde_json::to_vec(&Command::Goodbye) {
+        Ok(mut b) => {
+            b.push(b'\n');
+            b
+        }
+        Err(_) => Vec::new(),
+    };
+    if !goodbye.is_empty() {
+        let _ = write_half.write_all(&goodbye).await;
+        let _ = write_half.flush().await;
+    }
+
+    print_srv_summary(&events);
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn run_srv_diag(_launcher_exe_dir: &std::path::Path) -> Result<(), String> {
+    Err("--diag srv is Windows-only (Phase 7 will add Unix domain socket parity)".to_string())
+}
+
+#[cfg(target_os = "windows")]
+fn print_srv_summary(events: &[Event]) {
+    let snapshot: Vec<&Event> = events
+        .iter()
+        .filter(|e| matches!(e, Event::SrvSnapshot { .. }))
+        .collect();
+    let replay: Vec<&Event> = events
+        .iter()
+        .filter(|e| matches!(e, Event::EventList { .. }))
+        .collect();
+    let stream: Vec<&Event> = events
+        .iter()
+        .filter(|e| !matches!(e, Event::SrvSnapshot { .. } | Event::EventList { .. }))
+        .collect();
+
+    if let Some(Event::SrvSnapshot {
+        version,
+        lifecycle,
+        workspaces,
+        tabs,
+        active_tabs,
+        blocks,
+    }) = snapshot.last().copied()
+    {
+        println!("=== SrvSnapshot (event_version={}) ===", version);
+        println!("Lifecycle: {:?}", lifecycle);
+        println!();
+        println!("Workspaces ({}):", workspaces.len());
+        if workspaces.is_empty() {
+            println!("  (none)");
+        } else {
+            for (id, name) in workspaces {
+                let active = active_tabs
+                    .iter()
+                    .find(|(ws, _)| ws == id)
+                    .map(|(_, t)| t.as_str())
+                    .unwrap_or("—");
+                let tab_count = tabs.iter().filter(|(_, ws, _)| ws == id).count();
+                println!(
+                    "  {:36} name={:<20} tabs={} active={}",
+                    id, name, tab_count, active
+                );
+            }
+        }
+        println!();
+        println!("Tabs ({}):", tabs.len());
+        if tabs.is_empty() {
+            println!("  (none)");
+        } else {
+            for (tab_id, ws_id, name) in tabs {
+                let block_count = blocks.iter().filter(|(_, t)| t == tab_id).count();
+                println!(
+                    "  {:36} ws={:36} name={:<16} blocks={}",
+                    tab_id, ws_id, name, block_count
+                );
+            }
+        }
+        println!();
+        println!("Blocks ({}):", blocks.len());
+        if blocks.is_empty() {
+            println!("  (none)");
+        } else {
+            for (block_id, tab_id) in blocks {
+                println!("  {:36} tab={}", block_id, tab_id);
+            }
+        }
+        println!();
+    } else {
+        println!("(SrvSnapshot not received — srv pipe may not be bound, or older srv build)");
+        println!();
+    }
+
+    if let Some(Event::EventList {
+        events: replay_events,
+        version,
+    }) = replay.last().copied()
+    {
+        println!(
+            "=== EventList replay (event_version={}, {} event(s)) ===",
+            version,
+            replay_events.len()
+        );
+        if replay_events.is_empty() {
+            println!("(empty — srv ring + event log contained no events)");
+        } else {
+            // Show the last 20 events to keep output manageable.
+            let to_show = replay_events.iter().rev().take(20).collect::<Vec<_>>();
+            let n = replay_events.len();
+            let skipped = n.saturating_sub(to_show.len());
+            if skipped > 0 {
+                println!("(showing last 20 of {})", n);
+            }
+            for (i, evt) in to_show.iter().rev().enumerate() {
+                println!("  [{}] {}", skipped + i, format_srv_event(evt));
+            }
+        }
+        println!();
+    }
+
+    // Saga activity is the most operator-relevant signal here.
+    use std::collections::BTreeMap;
+    let mut saga_counts: BTreeMap<&'static str, u32> = BTreeMap::new();
+    let stream_or_replay = events
+        .iter()
+        .filter(|e| !matches!(e, Event::SrvSnapshot { .. }))
+        .flat_map(|e| match e {
+            Event::EventList { events: inner, .. } => inner.iter().collect::<Vec<_>>(),
+            other => vec![other],
+        });
+    for evt in stream_or_replay {
+        match evt {
+            Event::SagaStarted { .. } => *saga_counts.entry("SagaStarted").or_insert(0) += 1,
+            Event::SagaCompleted { .. } => {
+                *saga_counts.entry("SagaCompleted").or_insert(0) += 1
+            }
+            Event::SagaFailed { .. } => *saga_counts.entry("SagaFailed").or_insert(0) += 1,
+            _ => {}
+        }
+    }
+    if !saga_counts.is_empty() {
+        println!("=== Saga lifecycle (across snapshot + replay + stream) ===");
+        for (kind, count) in &saga_counts {
+            println!("  {:>4}× {}", count, kind);
+        }
+        println!();
+    }
+
+    println!(
+        "=== Live stream observed in {}s ===",
+        OBSERVATION_WINDOW.as_secs()
+    );
+    if stream.is_empty() {
+        println!("(no events — srv reducer is idle.)");
+        return;
+    }
+    let mut counts: BTreeMap<&'static str, u32> = BTreeMap::new();
+    for evt in &stream {
+        *counts.entry(srv_event_kind_name(evt)).or_insert(0) += 1;
+    }
+    println!("By kind:");
+    for (kind, count) in &counts {
+        println!("  {:>4}× {}", count, kind);
+    }
+    println!();
+    println!("Full stream (oldest first):");
+    for (i, evt) in stream.iter().enumerate() {
+        println!("  [{}] {}", i, format_srv_event(evt));
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn srv_event_kind_name(e: &Event) -> &'static str {
+    match e {
+        Event::Registered { .. } => "Registered",
+        Event::ProcessSpawned { .. } => "ProcessSpawned",
+        Event::ProcessExited { .. } => "ProcessExited",
+        Event::LifecyclePhaseChanged { .. } => "LifecyclePhaseChanged",
+        Event::SagaStarted { .. } => "SagaStarted",
+        Event::SagaCompleted { .. } => "SagaCompleted",
+        Event::SagaFailed { .. } => "SagaFailed",
+        Event::WorkspaceCreated { .. } => "WorkspaceCreated",
+        Event::WorkspaceDeleted { .. } => "WorkspaceDeleted",
+        Event::WorkspaceRenamed { .. } => "WorkspaceRenamed",
+        Event::WorkspaceMetaUpdated { .. } => "WorkspaceMetaUpdated",
+        Event::TabCreated { .. } => "TabCreated",
+        Event::TabDeleted { .. } => "TabDeleted",
+        Event::TabRenamed { .. } => "TabRenamed",
+        Event::TabReordered { .. } => "TabReordered",
+        Event::TabsReorderedBulk { .. } => "TabsReorderedBulk",
+        Event::TabMoved { .. } => "TabMoved",
+        Event::TabMetaUpdated { .. } => "TabMetaUpdated",
+        Event::ActiveTabChanged { .. } => "ActiveTabChanged",
+        Event::BlockCreated { .. } => "BlockCreated",
+        Event::BlockDeleted { .. } => "BlockDeleted",
+        Event::BlockMoved { .. } => "BlockMoved",
+        Event::BlockMetaUpdated { .. } => "BlockMetaUpdated",
+        Event::SrvWindowOpened { .. } => "SrvWindowOpened",
+        Event::SrvWindowClosed { .. } => "SrvWindowClosed",
+        Event::SrvWindowWorkspaceChanged { .. } => "SrvWindowWorkspaceChanged",
+        Event::SrvSnapshot { .. } => "SrvSnapshot",
+        Event::EventList { .. } => "EventList",
+        Event::Error { .. } => "Error",
+        _ => "Other",
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn format_srv_event(e: &Event) -> String {
+    match e {
+        Event::SagaStarted { saga_id, name, version } => {
+            format!("v={:>3} SagaStarted        id={} name={}", version, saga_id, name)
+        }
+        Event::SagaCompleted { saga_id, version } => {
+            format!("v={:>3} SagaCompleted      id={}", version, saga_id)
+        }
+        Event::SagaFailed { saga_id, reason, version } => {
+            format!("v={:>3} SagaFailed         id={} reason={}", version, saga_id, reason)
+        }
+        Event::WorkspaceCreated { workspace_id, name, version } => {
+            format!("v={:>3} WorkspaceCreated   id={} name={}", version, workspace_id, name)
+        }
+        Event::WorkspaceDeleted { workspace_id, version } => {
+            format!("v={:>3} WorkspaceDeleted   id={}", version, workspace_id)
+        }
+        Event::TabCreated { workspace_id, tab_id, name, version } => {
+            format!("v={:>3} TabCreated         tab={} ws={} name={}", version, tab_id, workspace_id, name)
+        }
+        Event::TabMoved { tab_id, src_workspace_id, dst_workspace_id, dst_index, .. } => format!(
+            "v=??? TabMoved           tab={} {} → {} idx={}",
+            tab_id, src_workspace_id, dst_workspace_id, dst_index
+        ),
+        Event::BlockMoved { block_id, src_tab_id, dst_tab_id, dst_index, version } => format!(
+            "v={:>3} BlockMoved         blk={} {} → {} idx={}",
+            version, block_id, src_tab_id, dst_tab_id, dst_index
+        ),
+        Event::Error { code, message, version, .. } => {
+            format!("v={:>3} Error              code={:?} msg={}", version, code, message)
+        }
+        other => serde_json::to_string(other).unwrap_or_else(|_| format!("{:?}", other)),
+    }
+}
+
 #[cfg(target_os = "windows")]
 fn print_summary(events: &[Event]) {
     // Phase D.1 — pull the Snapshot out and print it first as the

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -497,9 +497,16 @@ fn format_srv_event(e: &Event) -> String {
         Event::TabCreated { workspace_id, tab_id, name, version } => {
             format!("v={:>3} TabCreated         tab={} ws={} name={}", version, tab_id, workspace_id, name)
         }
-        Event::TabMoved { tab_id, src_workspace_id, dst_workspace_id, dst_index, .. } => format!(
-            "v=??? TabMoved           tab={} {} → {} idx={}",
-            tab_id, src_workspace_id, dst_workspace_id, dst_index
+        Event::TabMoved {
+            tab_id,
+            src_workspace_id,
+            dst_workspace_id,
+            dst_index,
+            version,
+            ..
+        } => format!(
+            "v={:>3} TabMoved           tab={} {} → {} idx={}",
+            version, tab_id, src_workspace_id, dst_workspace_id, dst_index
         ),
         Event::BlockMoved { block_id, src_tab_id, dst_tab_id, dst_index, version } => format!(
             "v={:>3} BlockMoved         blk={} {} → {} idx={}",

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -86,21 +86,30 @@ async fn main() {
     if matches!(args.first().map(String::as_str), Some("--diag")) {
         let topic = args.get(1).map(String::as_str).unwrap_or("");
         match topic {
-            "wrr" => {
-                match diag::run_wrr_diag(exe_dir).await {
-                    Ok(()) => std::process::exit(0),
-                    Err(msg) => {
-                        eprintln!("--diag wrr failed: {}", msg);
-                        std::process::exit(1);
-                    }
+            "wrr" => match diag::run_wrr_diag(exe_dir).await {
+                Ok(()) => std::process::exit(0),
+                Err(msg) => {
+                    eprintln!("--diag wrr failed: {}", msg);
+                    std::process::exit(1);
                 }
-            }
+            },
+            // Phase E.7 — operator visibility into the srv reducer's
+            // canonical state (workspaces / tabs / blocks / sagas) +
+            // recent activity. Same `Tool` IPC pattern as `--diag wrr`,
+            // talks to the srv pipe instead of the launcher pipe.
+            "srv" => match diag::run_srv_diag(exe_dir).await {
+                Ok(()) => std::process::exit(0),
+                Err(msg) => {
+                    eprintln!("--diag srv failed: {}", msg);
+                    std::process::exit(1);
+                }
+            },
             "" => {
-                eprintln!("usage: agentmux.exe --diag <topic>\nknown topics: wrr");
+                eprintln!("usage: agentmux.exe --diag <topic>\nknown topics: wrr, srv");
                 std::process::exit(2);
             }
             other => {
-                eprintln!("unknown --diag topic: {} (known: wrr)", other);
+                eprintln!("unknown --diag topic: {} (known: wrr, srv)", other);
                 std::process::exit(2);
             }
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.534"
+version = "0.33.535"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.534",
+  "version": "0.33.535",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.534",
+      "version": "0.33.535",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.534",
+  "version": "0.33.535",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase E.7 partial — adds \`agentmux.exe --diag srv\` Tool client mirroring the existing \`--diag wrr\` for the srv reducer. Connects to the srv pipe, sends \`GetSrvSnapshot\` + \`GetEvents\`, observes for 2 s, prints a summary.

## Use cases

- "What does the srv reducer think the workspace tree looks like?" — vs SQLite, vs frontend atom state.
- "Did saga X complete or fail?" — Saga lifecycle counts surface this without scraping logs.
- "What recent srv activity has there been?" — EventList replay shows recent reducer events with compact one-liners.

## What's printed

- **SrvSnapshot** — Workspaces (id / name / tab count / active tab) → Tabs (id / parent ws / name / block count) → Blocks (id / parent tab).
- **EventList replay** — last 20 of N events from srv's in-memory ring + on-disk event log.
- **Saga lifecycle counts** across snapshot + replay + live stream.
- **Live stream** observed during the 2 s window.

## Implementation

- \`agentmux-launcher/src/diag.rs::run_srv_diag\` mirrors \`run_wrr_diag\` with srv pipe + SrvSnapshot variant.
- \`srv_event_kind_name\` / \`format_srv_event\` cover all srv-emitted Event variants.
- \`agentmux-launcher/src/main.rs\` dispatch table extended: \`--diag srv\` → \`run_srv_diag\`. Usage strings + unknown-topic error mention both topics.
- Non-Windows stub returns "Phase 7 will add Unix domain socket parity" — same pattern as \`run_wrr_diag\`.

## Phase E.7 status after this merges

| Item | Status |
|---|---|
| \`--diag srv\` | ✅ this PR |
| \`--diag sagas\` | 🟡 currently subsumed by \`--diag srv\`'s saga counts. Could split out if more saga-specific introspection is wanted later (in-flight registry doesn't exist — sagas run synchronously through \`run_saga\`). |
| Property tests for reducer arms | ❌ separate PR — independent test infrastructure work, no file overlap. |

## Test plan

- [x] \`cargo check -p agentmux-launcher\` clean.
- [ ] Live verify: \`agentmux.exe --diag srv\` against a running portable shows the workspace tree + recent events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)