### PR TITLE
feat(F.1): host reducer skeleton + pending_window_creations arm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.536"
+version = "0.33.537"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.536"
+version = "0.33.537"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.536"
+version = "0.33.537"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.536"
+version = "0.33.537"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.536"
+version = "0.33.537"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -153,7 +153,14 @@ impl AgentMuxHandler {
                 parent_instance_id: None,
             }
         } else {
-            self.state.pending_window_creations.lock().pop_front().unwrap_or_else(|| {
+            // Phase F.1 — dequeue via the host reducer. The reducer
+            // emits PendingWindowQueueEmpty on miss; the fallback
+            // (synthesize a UUID-labelled FullInstance entry) lives
+            // in the legacy code path it always has.
+            let out = self
+                .state
+                .host_dispatch(crate::reducer::HostCommand::DequeuePendingWindowCreation);
+            out.dequeued.unwrap_or_else(|| {
                 let lbl = format!("window-{}", uuid::Uuid::new_v4());
                 tracing::warn!(label = %lbl, "[on_after_created] no pending creation entry — defaulting to FullInstance");
                 crate::state::PendingWindowCreation {

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -360,11 +360,15 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
     // handoff (label + kind + parent). Tear-offs are FullInstance
     // with no parent. Replaces the previous parallel
     // `window_meta.insert` + `pending_window_labels.push` pair.
-    state.pending_window_creations.lock().push_back(
-        crate::state::PendingWindowCreation {
-            label: label.clone(),
-            kind: crate::state::WindowKind::FullInstance,
-            parent_instance_id: None,
+    //
+    // Phase F.1 — routed through the host reducer.
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: label.clone(),
+                kind: crate::state::WindowKind::FullInstance,
+                parent_instance_id: None,
+            },
         },
     );
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -618,11 +618,14 @@ fn open_window_with_kind(
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
 
-    state.pending_window_creations.lock().push_back(
-        crate::state::PendingWindowCreation {
-            label: label.clone(),
-            kind,
-            parent_instance_id,
+    // Phase F.1 — routed through the host reducer.
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: label.clone(),
+                kind,
+                parent_instance_id,
+            },
         },
     );
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -136,11 +136,15 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
     // Phase B.5 (window_meta step d) — combined pre-create handoff.
     // Pool windows graduate to tear-off destinations, which are
     // FullInstance from the user's perspective.
-    state.pending_window_creations.lock().push_back(
-        crate::state::PendingWindowCreation {
-            label: label.clone(),
-            kind: WindowKind::FullInstance,
-            parent_instance_id: None,
+    //
+    // Phase F.1 — routed through the host reducer.
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: label.clone(),
+                kind: WindowKind::FullInstance,
+                parent_instance_id: None,
+            },
         },
     );
 

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -35,6 +35,7 @@ mod srv_event_bridge;
 mod srv_ipc;
 mod memory_heartbeat;
 mod pane;
+mod reducer;
 mod sidecar;
 mod state;
 mod ui_tasks;

--- a/agentmux-cef/src/pane/creation.rs
+++ b/agentmux-cef/src/pane/creation.rs
@@ -57,11 +57,15 @@ wrap_task! {
             // Browser panes are not top-level windows; the kind
             // value here is irrelevant (on_after_created skips the
             // taskbar/report-open logic for browser-pane-* labels).
-            self.state.pending_window_creations.lock().push_back(
-                crate::state::PendingWindowCreation {
-                    label: self.label.clone(),
-                    kind: crate::state::WindowKind::FullInstance,
-                    parent_instance_id: None,
+            //
+            // Phase F.1 — routed through the host reducer.
+            self.state.host_dispatch(
+                crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+                    entry: crate::state::PendingWindowCreation {
+                        label: self.label.clone(),
+                        kind: crate::state::WindowKind::FullInstance,
+                        parent_instance_id: None,
+                    },
                 },
             );
 

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -1,0 +1,333 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase F.1 — host reducer.
+//
+// Third reducer in the multi-reducer architecture, after the launcher
+// (Phase B) and srv (Phase E). Same pure-functional shape as the
+// other two: `update(&mut HostState, HostCommand) -> Vec<HostEvent>`,
+// no I/O, no async, sub-millisecond mutex hold time.
+//
+// **Scope of F.1 (this PR):** skeleton + the `pending_window_creations`
+// arm. Per `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` §3.1,
+// pending_window_creations is the lowest-risk migration:
+// single-producer/single-consumer queue with a clean enqueue/dequeue
+// lifecycle and no FFI handles inside.
+//
+// **NOT in F.1:** drag arms (F.3), tear-off hook arms (F.4 — folds
+// into the tear-off spec). The CEF `browsers` map and warm pool stay
+// outside the reducer indefinitely (snapshot-and-drop discipline at
+// every read site, see spec §3.2 / §6).
+//
+// **Wire protocol:** F.1's `HostCommand` and `HostEvent` are
+// host-internal. They do NOT cross IPC. When a future PR adds a
+// command that needs frontend or launcher access, that PR promotes
+// the relevant variants to `agentmux-common::ipc::Command` /
+// `agentmux-common::ipc::Event` and adds the IPC plumbing. Keeping
+// F.1 in-process avoids serializing `PendingWindowCreation` over a
+// pipe just to satisfy a pattern that has no current consumer.
+
+use std::collections::VecDeque;
+
+use crate::state::PendingWindowCreation;
+
+/// Lifecycle phase of the host reducer. Mirrors the launcher and srv
+/// reducers' phase enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HostLifecyclePhase {
+    /// Pre-init: AppState exists, but no commands accepted yet.
+    Bootstrapping,
+    /// Normal operation: all commands accepted.
+    Running,
+    /// Shutting down: only cleanup commands accepted; producers
+    /// short-circuit with no-op events.
+    ShuttingDown,
+}
+
+/// State owned by the host reducer.
+///
+/// Held inside `AppState.host_state: parking_lot::Mutex<HostState>`.
+/// Locked briefly by `host_dispatch`; never held across CEF callbacks
+/// or `SendMessage` (snapshot-and-drop discipline — see spec §6).
+pub struct HostState {
+    /// FIFO queue of pre-create handoffs. Pushed by callers
+    /// (`pane/creation.rs`, `commands/window.rs::open_new_window`,
+    /// `commands/drag.rs::tear_off`, `commands/window_pool.rs::spawn_pool_window`)
+    /// before `post_create_window`. Popped by `client.rs::on_after_created`
+    /// when CEF reports a new browser. Peeked at the back by
+    /// `wrr/win_event.rs::handle_event` to label OS-level WM_CREATE
+    /// events with the upcoming label.
+    ///
+    /// Invariants:
+    /// - At most one entry per (in-flight) browser create.
+    /// - `on_after_created` always pops the head it expects to find.
+    /// - The "main" window is special-cased in `on_after_created` and
+    ///   never has a corresponding entry here.
+    pub pending_window_creations: VecDeque<PendingWindowCreation>,
+
+    /// Lifecycle phase. `Running` is the operating state; the others
+    /// gate command acceptance.
+    pub lifecycle: HostLifecyclePhase,
+
+    /// Monotonic event-version counter (per host-process run). Same
+    /// invariant as launcher / srv reducers.
+    pub event_version: u64,
+}
+
+impl Default for HostState {
+    fn default() -> Self {
+        Self {
+            pending_window_creations: VecDeque::new(),
+            // Boot directly into Running — nothing in F.1 needs the
+            // pre-init guard yet. Future PRs (drag, tear-off hooks)
+            // will move boot through Bootstrapping → Running.
+            lifecycle: HostLifecyclePhase::Running,
+            event_version: 0,
+        }
+    }
+}
+
+impl HostState {
+    /// Allocate the next event version. Called inside reducer arms
+    /// when emitting an event.
+    fn bump_version(&mut self) -> u64 {
+        self.event_version += 1;
+        self.event_version
+    }
+}
+
+/// Commands handled by the host reducer.
+#[derive(Debug, Clone)]
+pub enum HostCommand {
+    /// Append a pending-window-creation handoff. Producer side of the
+    /// `pending_window_creations` queue (replaces the four direct
+    /// `state.pending_window_creations.lock().push_back(...)` sites).
+    EnqueuePendingWindowCreation { entry: PendingWindowCreation },
+
+    /// Pop the head of `pending_window_creations`. Returns the popped
+    /// entry via `HostEvent::PendingWindowDequeued`, or
+    /// `HostEvent::PendingWindowQueueEmpty` if the queue was empty.
+    /// Consumer side of the queue (replaces
+    /// `client.rs::on_after_created`'s direct `pop_front`).
+    DequeuePendingWindowCreation,
+}
+
+/// Events emitted by the host reducer.
+///
+/// F.1 keeps these in-host: subscribers log them via tracing for
+/// observability, but no IPC propagation. When a future PR adds a
+/// wire-level consumer (host→launcher event for cross-process saga
+/// observability, frontend dispatcher in E.6), that PR promotes the
+/// relevant variants to `agentmux-common::ipc::Event`.
+#[derive(Debug, Clone)]
+pub enum HostEvent {
+    /// A `PendingWindowCreation` was enqueued. Carries a snapshot of
+    /// the current queue length so observers can spot pile-ups.
+    PendingWindowEnqueued {
+        label: String,
+        queue_len_after: usize,
+        version: u64,
+    },
+
+    /// A `PendingWindowCreation` was dequeued. The popped entry
+    /// travels back to the caller; observers see only the label and
+    /// post-pop queue length.
+    PendingWindowDequeued {
+        label: String,
+        queue_len_after: usize,
+        version: u64,
+    },
+
+    /// `DequeuePendingWindowCreation` ran on an empty queue. Caller
+    /// is responsible for the fallback (the legacy code paths
+    /// synthesize a UUID-labelled FullInstance entry).
+    PendingWindowQueueEmpty { version: u64 },
+
+    /// A command was rejected. Mirrors `Event::Error` in srv/launcher
+    /// reducers — kept generic for future arms.
+    Error { message: String, version: u64 },
+}
+
+/// Output bundle returned from the reducer for the dequeue arm.
+///
+/// The dequeue arm is the only F.1 command whose caller needs the
+/// popped value (an event is not sufficient — `client.rs::on_after_created`
+/// uses the popped `PendingWindowCreation`'s fields to drive
+/// `window_meta.insert` and `ReportWindowOpened`). Other arms can
+/// rely on events alone; this struct keeps the dispatch return type
+/// uniform.
+#[derive(Debug, Default)]
+pub struct DispatchOutput {
+    pub events: Vec<HostEvent>,
+    pub dequeued: Option<PendingWindowCreation>,
+}
+
+/// Pure functional core of the host reducer.
+///
+/// Returns the events emitted by the command. Side-effecting wiring
+/// (logging, future event broadcast) lives in `host_dispatch` — this
+/// function takes only `&mut HostState` and produces no I/O.
+pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
+    match cmd {
+        HostCommand::EnqueuePendingWindowCreation { entry } => {
+            handle_enqueue_pending_window_creation(state, entry)
+        }
+        HostCommand::DequeuePendingWindowCreation => {
+            handle_dequeue_pending_window_creation(state)
+        }
+    }
+}
+
+fn handle_enqueue_pending_window_creation(
+    state: &mut HostState,
+    entry: PendingWindowCreation,
+) -> DispatchOutput {
+    if state.lifecycle == HostLifecyclePhase::ShuttingDown {
+        // No new windows accepted during shutdown. Mirrors the
+        // launcher reducer's shutdown gating from B.9.3.
+        let v = state.bump_version();
+        return DispatchOutput {
+            events: vec![HostEvent::Error {
+                message: "enqueue_pending_window_creation: host is shutting down".to_string(),
+                version: v,
+            }],
+            dequeued: None,
+        };
+    }
+    let label = entry.label.clone();
+    state.pending_window_creations.push_back(entry);
+    let queue_len_after = state.pending_window_creations.len();
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PendingWindowEnqueued {
+            label,
+            queue_len_after,
+            version: v,
+        }],
+        dequeued: None,
+    }
+}
+
+fn handle_dequeue_pending_window_creation(state: &mut HostState) -> DispatchOutput {
+    match state.pending_window_creations.pop_front() {
+        Some(entry) => {
+            let queue_len_after = state.pending_window_creations.len();
+            let v = state.bump_version();
+            let label = entry.label.clone();
+            DispatchOutput {
+                events: vec![HostEvent::PendingWindowDequeued {
+                    label,
+                    queue_len_after,
+                    version: v,
+                }],
+                dequeued: Some(entry),
+            }
+        }
+        None => {
+            let v = state.bump_version();
+            DispatchOutput {
+                events: vec![HostEvent::PendingWindowQueueEmpty { version: v }],
+                dequeued: None,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::WindowKind;
+
+    fn entry(label: &str) -> PendingWindowCreation {
+        PendingWindowCreation {
+            label: label.to_string(),
+            kind: WindowKind::FullInstance,
+            parent_instance_id: None,
+        }
+    }
+
+    #[test]
+    fn enqueue_then_dequeue_round_trips() {
+        let mut state = HostState::default();
+        let out1 = update(
+            &mut state,
+            HostCommand::EnqueuePendingWindowCreation { entry: entry("w1") },
+        );
+        assert!(matches!(
+            out1.events.as_slice(),
+            [HostEvent::PendingWindowEnqueued { queue_len_after: 1, .. }]
+        ));
+        assert!(out1.dequeued.is_none());
+
+        let out2 = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+        assert!(matches!(
+            out2.events.as_slice(),
+            [HostEvent::PendingWindowDequeued { queue_len_after: 0, .. }]
+        ));
+        assert_eq!(out2.dequeued.as_ref().unwrap().label, "w1");
+    }
+
+    #[test]
+    fn dequeue_on_empty_returns_queue_empty_event() {
+        let mut state = HostState::default();
+        let out = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+        assert!(matches!(
+            out.events.as_slice(),
+            [HostEvent::PendingWindowQueueEmpty { .. }]
+        ));
+        assert!(out.dequeued.is_none());
+    }
+
+    #[test]
+    fn fifo_order_preserved() {
+        let mut state = HostState::default();
+        for label in ["w1", "w2", "w3"] {
+            update(
+                &mut state,
+                HostCommand::EnqueuePendingWindowCreation { entry: entry(label) },
+            );
+        }
+        for expected in ["w1", "w2", "w3"] {
+            let out = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+            assert_eq!(out.dequeued.as_ref().unwrap().label, expected);
+        }
+    }
+
+    #[test]
+    fn enqueue_during_shutdown_is_rejected() {
+        let mut state = HostState::default();
+        state.lifecycle = HostLifecyclePhase::ShuttingDown;
+        let out = update(
+            &mut state,
+            HostCommand::EnqueuePendingWindowCreation { entry: entry("w1") },
+        );
+        assert!(matches!(
+            out.events.as_slice(),
+            [HostEvent::Error { .. }]
+        ));
+        assert_eq!(state.pending_window_creations.len(), 0);
+    }
+
+    #[test]
+    fn version_increments_monotonically() {
+        let mut state = HostState::default();
+        let out1 = update(
+            &mut state,
+            HostCommand::EnqueuePendingWindowCreation { entry: entry("w1") },
+        );
+        let out2 = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+        let out3 = update(&mut state, HostCommand::DequeuePendingWindowCreation);
+
+        let extract_version = |events: &[HostEvent]| match &events[0] {
+            HostEvent::PendingWindowEnqueued { version, .. } => *version,
+            HostEvent::PendingWindowDequeued { version, .. } => *version,
+            HostEvent::PendingWindowQueueEmpty { version } => *version,
+            HostEvent::Error { version, .. } => *version,
+        };
+        let v1 = extract_version(&out1.events);
+        let v2 = extract_version(&out2.events);
+        let v3 = extract_version(&out3.events);
+        assert!(v1 < v2);
+        assert!(v2 < v3);
+    }
+}

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -222,19 +222,16 @@ pub struct AppState {
     /// for why step e ≠ delete here.
     pub window_meta: Mutex<HashMap<String, WindowMeta>>,
 
-    /// Phase B.5 (window_meta step d) — FIFO queue of pre-create
-    /// handoff entries. Pushed by callers
-    /// (`drag.rs::tear_off`, `commands/window.rs::open_new_window`,
-    /// `window_pool.rs::spawn_pool_window`, `pane/creation.rs`)
-    /// before `post_create_window`; popped by
-    /// `client.rs::on_after_created`. Each entry carries the label
-    /// AND the kind/parent so on_after_created can apply the
-    /// Subwindow taskbar-hide, emit `ReportWindowOpened`, and
-    /// populate the synchronous `window_meta` cache from a single
-    /// canonical site — replacing the pre-step-d parallel-channel
-    /// pattern (separate `window_meta.insert` from each caller +
-    /// label-only `pending_window_labels` queue).
-    pub pending_window_creations: Mutex<VecDeque<PendingWindowCreation>>,
+    /// Phase F.1 — host reducer state.
+    ///
+    /// Owns `pending_window_creations` (formerly a top-level
+    /// `Mutex<VecDeque<PendingWindowCreation>>` field on AppState).
+    /// All mutations go through `host_dispatch`; reads use the
+    /// `peek_back_pending_window_creation` snapshot helper.
+    /// Future PRs will migrate `active_drag` and tear-off-hook state
+    /// here too. See `agentmux-cef/src/reducer.rs` and
+    /// `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`.
+    pub host_state: Mutex<crate::reducer::HostState>,
 
     /// Tear-off Phase 6 — pre-warmed pool of hidden CEF windows ready for
     /// instant promotion on tear-off. Each entry is a label of a window
@@ -353,7 +350,7 @@ impl Default for AppState {
             ipc_token: uuid::Uuid::new_v4().to_string(),
             browsers: Mutex::new(HashMap::new()),
             window_meta: Mutex::new(HashMap::new()),
-            pending_window_creations: Mutex::new(VecDeque::new()),
+            host_state: Mutex::new(crate::reducer::HostState::default()),
             window_pool: Mutex::new(VecDeque::new()),
             unpromoted_pool_labels: Mutex::new(std::collections::HashSet::new()),
             window_pool_respawn_in_flight: std::sync::atomic::AtomicBool::new(false),
@@ -370,6 +367,44 @@ impl Default for AppState {
 }
 
 impl AppState {
+    /// Phase F.1 — dispatch a command through the host reducer.
+    ///
+    /// Locks `host_state`, applies the command via `reducer::update`,
+    /// logs emitted events via tracing, and returns the dispatch
+    /// output (which contains the events plus the dequeued entry for
+    /// `DequeuePendingWindowCreation`).
+    ///
+    /// Lock-hold time: pure-function reducer call, no I/O — typically
+    /// sub-microsecond. Never held across a `SendMessage`, CEF
+    /// callback, or any blocking call (snapshot-and-drop discipline,
+    /// see `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` §6).
+    pub fn host_dispatch(&self, cmd: crate::reducer::HostCommand) -> crate::reducer::DispatchOutput {
+        let out = {
+            let mut state = self.host_state.lock();
+            crate::reducer::update(&mut state, cmd)
+        };
+        for ev in &out.events {
+            log_host_event(ev);
+        }
+        out
+    }
+
+    /// Phase F.1 — non-mutating peek at the back of the
+    /// `pending_window_creations` queue.
+    ///
+    /// Used by `wrr/win_event.rs::handle_event` to label OS-level
+    /// `WM_CREATE` events with the upcoming window's label. CEF's
+    /// `OnAfterCreated` (which becomes the dequeue) fires AFTER this
+    /// OS event, but the host pushed the entry BEFORE calling
+    /// `post_create_window`, so back-of-queue is the right answer at
+    /// this moment.
+    ///
+    /// Snapshot-and-drop: takes the lock, clones the entry, drops
+    /// the lock. Callers never hold the lock past this call.
+    pub fn peek_back_pending_window_creation(&self) -> Option<PendingWindowCreation> {
+        self.host_state.lock().pending_window_creations.back().cloned()
+    }
+
     /// Phase B.5e — authoritative instance-number lookup. Reads
     /// the launcher-fed `shadow_instance_registry`, which is the
     /// sole source of truth post-B.5e (host's
@@ -447,5 +482,51 @@ impl AppState {
             }
         }
         out.into_iter().collect()
+    }
+}
+
+/// Phase F.1 — observability hook for host-reducer events.
+///
+/// Called by `AppState::host_dispatch` after every `update()` call.
+/// F.1 logs via tracing only; future PRs may add a broadcast channel
+/// here when an event consumer (cross-process saga, frontend
+/// dispatcher) appears.
+fn log_host_event(ev: &crate::reducer::HostEvent) {
+    use crate::reducer::HostEvent;
+    match ev {
+        HostEvent::PendingWindowEnqueued {
+            label,
+            queue_len_after,
+            version,
+        } => tracing::debug!(
+            target: "host-reducer",
+            event = "PendingWindowEnqueued",
+            label = %label,
+            queue_len_after,
+            version,
+        ),
+        HostEvent::PendingWindowDequeued {
+            label,
+            queue_len_after,
+            version,
+        } => tracing::debug!(
+            target: "host-reducer",
+            event = "PendingWindowDequeued",
+            label = %label,
+            queue_len_after,
+            version,
+        ),
+        HostEvent::PendingWindowQueueEmpty { version } => tracing::warn!(
+            target: "host-reducer",
+            event = "PendingWindowQueueEmpty",
+            version,
+            "[host-reducer] dequeue on empty queue — caller will fall back",
+        ),
+        HostEvent::Error { message, version } => tracing::warn!(
+            target: "host-reducer",
+            event = "Error",
+            version,
+            "[host-reducer] {}", message,
+        ),
     }
 }

--- a/agentmux-cef/src/wrr/win_event.rs
+++ b/agentmux-cef/src/wrr/win_event.rs
@@ -266,9 +266,12 @@ unsafe extern "system" fn win_event_callback(
             // window we're seeing. Pool windows that don't push a
             // pending entry get `None` and rely on the launcher
             // reducer's drain-on-WindowOpened fallback.
+            // Phase F.1 — peek through the host reducer's snapshot
+            // helper. Same back-of-queue read as before; lock is
+            // held only long enough to clone the back entry.
             let label_hint = app_state()
                 .get()
-                .and_then(|s| s.pending_window_creations.lock().back().cloned())
+                .and_then(|s| s.peek_back_pending_window_creation())
                 .map(|p| p.label);
             launcher_ipc::report_hwnd_opened(raw_hwnd, class, title, label_hint);
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.536"
+version = "0.33.537"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.536"
+version = "0.33.537"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.536"
+version = "0.33.537"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.536",
+  "version": "0.33.537",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.536",
+      "version": "0.33.537",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.536",
+  "version": "0.33.537",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First migration in **Phase F** (third reducer in the multi-reducer architecture, after launcher and srv). Skeleton + the lowest-risk arm: the pre-create handoff queue.

This PR closes part of [reducer-architecture-gaps §2](../blob/main/docs/retro/reducer-architecture-gaps-2026-05-01.md) — the Phase F implementation gap. It is **step 1** of [next-steps-architecture-completeness](../blob/main/docs/retro/next-steps-architecture-completeness-2026-05-01.md).

## What changed

- **New module `agentmux-cef/src/reducer.rs`** — `HostState`, `HostCommand`, `HostEvent`, pure-functional `update()`, 5 unit tests.
- **`AppState`** gains `host_state: Mutex<HostState>` + `host_dispatch()` + `peek_back_pending_window_creation()` snapshot helper. The standalone `pending_window_creations: Mutex<VecDeque<...>>` field is removed.
- **Producers (4 sites)** route through the reducer:
  - `pane/creation.rs` — browser pane handoff
  - `commands/window.rs::open_new_window` — top-level window
  - `commands/window_pool.rs::spawn_pool_window` — pool refill
  - `commands/drag.rs::tear_off` — tear-off destination
- **Consumers (2 sites)** route through the reducer:
  - `client.rs::on_after_created` — dispatches `DequeuePendingWindowCreation`, uses `DispatchOutput.dequeued`
  - `wrr/win_event.rs::handle_event` — uses `peek_back_pending_window_creation` snapshot helper
- **Observability**: `HostEvent` emissions logged via tracing under `target = "host-reducer"`. No broadcast subscriber yet (added when a wire consumer appears).

## Wire-format scoping

`HostCommand` / `HostEvent` are **host-internal** in F.1 — no IPC propagation. Per the spec, promotion to `agentmux-common::ipc::{Command, Event}` is deferred until a wire consumer appears (probably F.3 drag arms or step 6 cross-process sagas).

## Spec / plan refs

- Spec: `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` §3.1, §5
- Plan: `docs/retro/next-steps-architecture-completeness-2026-05-01.md` step 1 (PR 1 of 2 for step 1; PR 2 = drag arms / F.3)
- Gaps closed: §2 (partial — F.1+F.2 only), §3 (host pool-promote partial), §5 (host pipe foundation)

## Snapshot-and-drop discipline

The reducer mutex is held only for the `update()` call (pure function, sub-microsecond). All consumers take snapshots and drop the lock before any I/O / `SendMessage` / CEF callback.

## Test plan

- [x] `cargo test -p agentmux-cef reducer::` — 5/5 passing (round-trip, FIFO order, empty-queue fallback, shutdown rejection, version monotonicity)
- [x] `cargo check -p agentmux-cef` — clean (28 pre-existing warnings, none from this PR)
- [x] `task build:host` — green release build
- [ ] Smoke: open multiple top-level windows; verify each gets a unique label and the queue drains correctly
- [ ] Smoke: spawn pool window then promote on tear-off; verify pool refill enqueue/dequeue works
- [ ] Smoke: cross-window tab tear-off; verify destination window labeled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)