### PR TITLE
feat(E.6): renderer multi-source dispatcher with saga buffering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.537"
+version = "0.33.538"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.537"
+version = "0.33.538"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.537"
+version = "0.33.538"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.537"
+version = "0.33.538"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.539"
+version = "0.33.540"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.539"
+version = "0.33.540"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.539"
+version = "0.33.540"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.539"
+version = "0.33.540"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.538"
+version = "0.33.539"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.538"
+version = "0.33.539"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.538"
+version = "0.33.539"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.538"
+version = "0.33.539"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.538"
+version = "0.33.539"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.539"
+version = "0.33.540"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.537"
+version = "0.33.538"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.537"
+version = "0.33.538"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.538"
+version = "0.33.539"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.539"
+version = "0.33.540"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.539"
+version = "0.33.540"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.538"
+version = "0.33.539"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.537"
+version = "0.33.538"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.538"
+version = "0.33.539"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.537"
+version = "0.33.538"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.539"
+version = "0.33.540"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/util/event-buffer.test.ts
+++ b/frontend/util/event-buffer.test.ts
@@ -221,19 +221,33 @@ describe("PerSourceTracker — saga buffering", () => {
         expect(onTerminal).not.toHaveBeenCalled();
     });
 
-    it("dispatches mismatched terminal directly even when another saga is in flight (reagent P1)", () => {
-        // Regression: terminal for saga 88 must NOT be buried inside
-        // saga 99's buffer when 99 is the in-flight saga.
-        const seen: string[] = [];
-        tracker.subscribe((e) => seen.push(`${e.event}@${e.saga_id ?? "?"}`));
+    it("flushes prior buffer before mismatched terminal (reagent P1 + codex P1 round 2)", () => {
+        // Regression — both P1s on PR #630:
+        //   1. Mismatched terminal must NOT be buried inside the
+        //      unrelated in-flight saga's buffer (reagent).
+        //   2. AND it must NOT be dispatched before the buffered
+        //      events (codex round 2: violates source ordering /
+        //      monotonic version contract).
+        // Resolution: flush prior buffer first, then dispatch
+        // mismatched terminal. Order preserved, nothing buried.
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const seen: { event: string; saga_id: unknown; version: number }[] = [];
+        tracker.subscribe((e) =>
+            seen.push({ event: e.event, saga_id: e.saga_id, version: e.version }),
+        );
         tracker.deliver(evt("saga_started", 1, { saga_id: 99 }));
-        // saga 88 terminal arrives mid-99 — must dispatch immediately,
-        // not get queued into 99's buffer.
-        tracker.deliver(evt("saga_completed", 2, { saga_id: 88 }));
-        expect(seen).toEqual(["saga_completed@88"]);
-        // 99's buffer still in flight, holding saga_started.
-        expect(tracker.stats().inSaga).toBe(99);
-        expect(tracker.stats().bufferedCount).toBe(1);
+        tracker.deliver(evt("step_a", 2)); // buffered
+        // Mismatched terminal at version 3 arrives mid-99
+        tracker.deliver(evt("saga_completed", 3, { saga_id: 88 }));
+
+        // Prior buffer flushed in source order, then mismatched
+        // terminal delivered last.
+        expect(seen.map((e) => e.event)).toEqual(["saga_started", "step_a", "saga_completed"]);
+        expect(seen.map((e) => e.version)).toEqual([1, 2, 3]); // monotonic
+        expect(seen[0].saga_id).toBe(99);
+        expect(seen[2].saga_id).toBe(88);
+        // Saga 99's buffer drained; tracker idle.
+        expect(tracker.stats().inSaga).toBeNull();
     });
 
     it("emergency-flushes on overflow", () => {

--- a/frontend/util/event-buffer.test.ts
+++ b/frontend/util/event-buffer.test.ts
@@ -1,0 +1,255 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.6 — tests for the per-source tracker.
+//
+// Covers: version monotonicity, gap detection, stale drop, saga
+// buffer round-trip, nested-saga flush, terminal-without-start
+// pass-through, malformed-event rejection, subscriber error
+// isolation, overflow safeguard.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PerSourceTracker, type VersionedEvent } from "./event-buffer";
+
+interface TestEvent extends VersionedEvent {}
+
+interface MockSetters {
+    setLatest: ReturnType<typeof vi.fn>;
+    setVersion: ReturnType<typeof vi.fn>;
+    setSawAny: ReturnType<typeof vi.fn>;
+}
+
+function mockSetters(): MockSetters {
+    return {
+        setLatest: vi.fn(),
+        setVersion: vi.fn(),
+        setSawAny: vi.fn(),
+    };
+}
+
+function evt(name: string, version: number, extra: Record<string, unknown> = {}): TestEvent {
+    return { event: name, version, ...extra };
+}
+
+describe("PerSourceTracker — basic delivery", () => {
+    let setters: MockSetters;
+    let tracker: PerSourceTracker<TestEvent>;
+    let onGap: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        setters = mockSetters();
+        onGap = vi.fn();
+        tracker = new PerSourceTracker<TestEvent>(
+            { source: "test", onVersionGap: onGap },
+            setters,
+        );
+    });
+
+    it("dispatches first event and flips sawAny", () => {
+        tracker.deliver(evt("workspace_created", 1));
+        expect(setters.setLatest).toHaveBeenCalledTimes(1);
+        expect(setters.setVersion).toHaveBeenCalledWith(1);
+        expect(setters.setSawAny).toHaveBeenCalledWith(true);
+    });
+
+    it("dispatches subsequent events in order with monotonic versions", () => {
+        tracker.deliver(evt("a", 1));
+        tracker.deliver(evt("b", 2));
+        tracker.deliver(evt("c", 3));
+        expect(setters.setLatest).toHaveBeenCalledTimes(3);
+        expect(setters.setVersion).toHaveBeenLastCalledWith(3);
+    });
+
+    it("invokes subscribers per event in order", () => {
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(`${e.event}@${e.version}`));
+        tracker.deliver(evt("a", 1));
+        tracker.deliver(evt("b", 2));
+        expect(seen).toEqual(["a@1", "b@2"]);
+    });
+
+    it("returns an unsubscribe function", () => {
+        const cb = vi.fn();
+        const unsub = tracker.subscribe(cb);
+        tracker.deliver(evt("a", 1));
+        unsub();
+        tracker.deliver(evt("b", 2));
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("PerSourceTracker — version checking", () => {
+    let setters: MockSetters;
+    let tracker: PerSourceTracker<TestEvent>;
+    let onGap: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        setters = mockSetters();
+        onGap = vi.fn();
+        tracker = new PerSourceTracker<TestEvent>(
+            { source: "test", onVersionGap: onGap },
+            setters,
+        );
+        // Silence the default console.warn for stale events. Other
+        // tests installed a custom onVersionGap so they don't need
+        // this; this stub covers the stale path.
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    it("logs a gap when version skips ahead", () => {
+        tracker.deliver(evt("a", 1));
+        tracker.deliver(evt("b", 5)); // gap of 3
+        expect(onGap).toHaveBeenCalledWith(3, 1, 5);
+        expect(tracker.stats().droppedCount).toBe(3);
+    });
+
+    it("does NOT log a gap on the very first event regardless of version", () => {
+        tracker.deliver(evt("a", 100));
+        expect(onGap).not.toHaveBeenCalled();
+        expect(tracker.stats().droppedCount).toBe(0);
+        expect(tracker.stats().lastVersion).toBe(100);
+    });
+
+    it("drops stale events (version <= last seen)", () => {
+        tracker.deliver(evt("a", 5));
+        tracker.deliver(evt("b", 5));
+        tracker.deliver(evt("c", 3));
+        expect(setters.setLatest).toHaveBeenCalledTimes(1);
+        expect(tracker.stats().lastVersion).toBe(5);
+    });
+});
+
+describe("PerSourceTracker — saga buffering", () => {
+    let setters: MockSetters;
+    let tracker: PerSourceTracker<TestEvent>;
+    let onTerminal: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        setters = mockSetters();
+        onTerminal = vi.fn();
+        tracker = new PerSourceTracker<TestEvent>(
+            { source: "test", onSagaTerminal: onTerminal },
+            setters,
+        );
+    });
+
+    it("buffers events between saga_started and saga_completed", () => {
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(`${e.event}@${e.version}`));
+        tracker.deliver(evt("saga_started", 1, { saga_id: 42, name: "tear_off_tab" }));
+        // Subscriber should NOT have been called yet (buffered).
+        expect(seen).toEqual([]);
+        tracker.deliver(evt("tab_moved", 2));
+        tracker.deliver(evt("block_moved", 3));
+        expect(seen).toEqual([]);
+        tracker.deliver(evt("saga_completed", 4, { saga_id: 42 }));
+        // All 4 events delivered in order, in one batch.
+        expect(seen).toEqual(["saga_started@1", "tab_moved@2", "block_moved@3", "saga_completed@4"]);
+        expect(onTerminal).toHaveBeenCalledWith(42, "completed");
+    });
+
+    it("buffers events on saga_failed and reports failed terminal", () => {
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(e.event));
+        tracker.deliver(evt("saga_started", 1, { saga_id: 7 }));
+        tracker.deliver(evt("tab_moved", 2));
+        tracker.deliver(evt("saga_failed", 3, { saga_id: 7, reason: "boom" }));
+        expect(seen).toEqual(["saga_started", "tab_moved", "saga_failed"]);
+        expect(onTerminal).toHaveBeenCalledWith(7, "failed");
+    });
+
+    it("flushes prior saga and opens new one on nested saga_started", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(`${e.event}@${e.saga_id ?? ""}`));
+        tracker.deliver(evt("saga_started", 1, { saga_id: 10 }));
+        tracker.deliver(evt("step_a", 2));
+        tracker.deliver(evt("saga_started", 3, { saga_id: 11 })); // nested → flush prior
+        // Prior saga 10 + step_a flushed (no terminal — partial)
+        expect(seen).toContain("saga_started@10");
+        expect(seen).toContain("step_a@");
+        // saga 11 NOT yet delivered (still buffering)
+        expect(seen).not.toContain("saga_started@11");
+        tracker.deliver(evt("saga_completed", 4, { saga_id: 11 }));
+        expect(seen).toContain("saga_started@11");
+        expect(seen).toContain("saga_completed@11");
+    });
+
+    it("passes through terminal that does not match an in-flight saga", () => {
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(e.event));
+        tracker.deliver(evt("saga_completed", 1, { saga_id: 99 })); // no matching start
+        expect(seen).toEqual(["saga_completed"]);
+        expect(onTerminal).not.toHaveBeenCalled();
+    });
+
+    it("emergency-flushes on overflow", () => {
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        const flushSize = 5;
+        const t = new PerSourceTracker<TestEvent>(
+            { source: "test", maxSagaBufferSize: flushSize },
+            setters,
+        );
+        const seen: string[] = [];
+        t.subscribe((e) => seen.push(e.event));
+        t.deliver(evt("saga_started", 1, { saga_id: 1 }));
+        for (let i = 2; i <= 10; i++) {
+            t.deliver(evt(`step_${i}`, i));
+        }
+        // After 6 events past saga_started (1 saga_started + 9 steps),
+        // overflow at the 7th queued (events length > 5) triggers flush.
+        // Subsequent steps deliver immediately.
+        expect(seen.length).toBeGreaterThan(0);
+        expect(t.stats().inSaga).toBeNull();
+    });
+});
+
+describe("PerSourceTracker — defensive paths", () => {
+    let setters: MockSetters;
+    let tracker: PerSourceTracker<TestEvent>;
+
+    beforeEach(() => {
+        setters = mockSetters();
+        tracker = new PerSourceTracker<TestEvent>(
+            { source: "test" },
+            setters,
+        );
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("rejects events missing required fields", () => {
+        // @ts-expect-error - intentional malformed event for test
+        tracker.deliver({ event: "a" });
+        // @ts-expect-error - intentional malformed event for test
+        tracker.deliver({ version: 1 });
+        tracker.deliver(null as unknown as TestEvent);
+        expect(setters.setLatest).not.toHaveBeenCalled();
+    });
+
+    it("isolates subscriber exceptions from later subscribers", () => {
+        const calls: string[] = [];
+        tracker.subscribe(() => {
+            throw new Error("subscriber A blew up");
+        });
+        tracker.subscribe((e) => calls.push(e.event));
+        tracker.deliver(evt("a", 1));
+        expect(calls).toEqual(["a"]);
+    });
+
+    it("treats saga_started without saga_id as a plain event", () => {
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(e.event));
+        tracker.deliver(evt("saga_started", 1)); // no saga_id
+        expect(seen).toEqual(["saga_started"]);
+        expect(tracker.stats().inSaga).toBeNull();
+    });
+
+    it("stats reflects ongoing saga state", () => {
+        tracker.deliver(evt("saga_started", 1, { saga_id: 5 }));
+        tracker.deliver(evt("step", 2));
+        const s = tracker.stats();
+        expect(s.inSaga).toBe(5);
+        expect(s.bufferedCount).toBe(2); // saga_started + step
+    });
+});

--- a/frontend/util/event-buffer.test.ts
+++ b/frontend/util/event-buffer.test.ts
@@ -117,6 +117,44 @@ describe("PerSourceTracker — version checking", () => {
         expect(setters.setLatest).toHaveBeenCalledTimes(1);
         expect(tracker.stats().lastVersion).toBe(5);
     });
+
+    it("resets state when source restarts (codex P1: version=1 after lastVersion>0)", () => {
+        // Regression: srv/launcher reset event_version=0 on process
+        // restart. After restart, version=1 events were being dropped
+        // as stale (1 <= lastVersion=42), permanently black-holing
+        // the stream until page reload.
+        tracker.deliver(evt("a", 40));
+        tracker.deliver(evt("b", 41));
+        tracker.deliver(evt("c", 42));
+        expect(tracker.stats().lastVersion).toBe(42);
+
+        // Source restart — first post-restart event is version=1.
+        tracker.deliver(evt("post_restart_first", 1));
+        expect(setters.setLatest).toHaveBeenCalledTimes(4);
+        expect(tracker.stats().lastVersion).toBe(1);
+        expect(tracker.stats().droppedCount).toBe(0); // reset by restart
+
+        // Subsequent events after restart should flow normally.
+        tracker.deliver(evt("post_restart_second", 2));
+        expect(setters.setLatest).toHaveBeenCalledTimes(5);
+        expect(tracker.stats().lastVersion).toBe(2);
+    });
+
+    it("drops stale saga buffer on source restart", () => {
+        // If we were buffering a saga when the source restarted, the
+        // buffer is part of the dead source's history. Drop it.
+        tracker.deliver(evt("a", 40));
+        tracker.deliver(evt("saga_started", 41, { saga_id: 7 }));
+        tracker.deliver(evt("step", 42));
+        expect(tracker.stats().inSaga).toBe(7);
+        expect(tracker.stats().bufferedCount).toBe(2);
+
+        // Source restart.
+        tracker.deliver(evt("fresh_event", 1));
+        expect(tracker.stats().inSaga).toBeNull();
+        expect(tracker.stats().bufferedCount).toBe(0);
+        expect(tracker.stats().lastVersion).toBe(1);
+    });
 });
 
 describe("PerSourceTracker — saga buffering", () => {
@@ -181,6 +219,21 @@ describe("PerSourceTracker — saga buffering", () => {
         tracker.deliver(evt("saga_completed", 1, { saga_id: 99 })); // no matching start
         expect(seen).toEqual(["saga_completed"]);
         expect(onTerminal).not.toHaveBeenCalled();
+    });
+
+    it("dispatches mismatched terminal directly even when another saga is in flight (reagent P1)", () => {
+        // Regression: terminal for saga 88 must NOT be buried inside
+        // saga 99's buffer when 99 is the in-flight saga.
+        const seen: string[] = [];
+        tracker.subscribe((e) => seen.push(`${e.event}@${e.saga_id ?? "?"}`));
+        tracker.deliver(evt("saga_started", 1, { saga_id: 99 }));
+        // saga 88 terminal arrives mid-99 — must dispatch immediately,
+        // not get queued into 99's buffer.
+        tracker.deliver(evt("saga_completed", 2, { saga_id: 88 }));
+        expect(seen).toEqual(["saga_completed@88"]);
+        // 99's buffer still in flight, holding saga_started.
+        expect(tracker.stats().inSaga).toBe(99);
+        expect(tracker.stats().bufferedCount).toBe(1);
     });
 
     it("emergency-flushes on overflow", () => {

--- a/frontend/util/event-buffer.ts
+++ b/frontend/util/event-buffer.ts
@@ -289,10 +289,28 @@ export class PerSourceTracker<E extends VersionedEvent = VersionedEvent> {
                 return;
             }
             // Terminal without matching start (resync mid-saga, or
-            // server-side bug). Dispatch directly — bypass
-            // routeIdleOrBuffered so the terminal isn't buried inside
-            // an unrelated in-flight saga's buffer waiting on its own
-            // terminal that may never come. (reagent P1, PR #630.)
+            // server-side bug). Two constraints to honor:
+            //   1. (reagent P1, PR #630) don't bury the terminal in
+            //      an unrelated in-flight saga's buffer — its own
+            //      terminal may never come.
+            //   2. (codex P1, PR #630 round 2) preserve source
+            //      ordering — the mismatched terminal carries a
+            //      higher version than the in-flight saga's buffered
+            //      events, so dispatching it first would make
+            //      `setVersion` go backwards when the buffer flushes.
+            // Resolution: flush the in-flight buffer first (treating
+            // the buffered saga as terminated-without-completion —
+            // that's the failure mode this case represents), THEN
+            // dispatch the mismatched terminal. Order preserved,
+            // nothing buried.
+            if (this.sagaBuffer) {
+                console.warn(
+                    `[${this.source}-events] terminal for saga ${sagaId} arrived while saga ${this.sagaBuffer.saga_id} was in flight; flushing prior buffer first to preserve ordering`,
+                );
+                const buf = this.sagaBuffer;
+                this.sagaBuffer = null;
+                this.flushSagaBuffer(buf);
+            }
             this.dispatch(evt);
             return;
         }

--- a/frontend/util/event-buffer.ts
+++ b/frontend/util/event-buffer.ts
@@ -1,0 +1,319 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.6 — renderer multi-source dispatcher with saga buffering.
+//
+// Shared infrastructure for `srv-events.ts` and `launcher-events.ts`.
+// Same per-source state machine drives both pipes. Phase F will add
+// a third (`host-events.ts`) when host events cross IPC; this module
+// is source-agnostic so adding the third bucket is a constructor
+// call away.
+//
+// **Three jobs:**
+//
+// 1. **Per-source version monotonicity.** Detect dropped events:
+//    each source's reducer emits a strictly-increasing `version`,
+//    so any gap means an event was lost on the wire. We log the gap
+//    and increment a `droppedCount`; recovery (force-push) is the
+//    consumer's responsibility — see "Force-push protocol" below.
+//
+// 2. **Saga buffering.** Between `SagaStarted { saga_id }` and the
+//    matching `SagaCompleted` / `SagaFailed`, all events from the
+//    same source are buffered. On terminal, the buffer is flushed
+//    inside `solid.batch(...)` so SolidJS-effect consumers (atom
+//    routers) see the saga as a single tick — no half-applied flicker.
+//    Per-event callback subscribers still receive every event
+//    individually, in order — they need that to drive correct atom
+//    state transitions; the batch only collapses the *signal* updates.
+//
+// 3. **Stale event drop.** If an event arrives with `version` <=
+//    last seen, it's a replay or out-of-order delivery. Drop it.
+//
+// **Saga correlation today is temporal.** Per-step events do NOT
+// carry `saga_id` (per-Event threading was deferred — see
+// `docs/retro/reducer-architecture-gaps-2026-05-01.md` §3). Sagas
+// run serially in the srv coordinator, so events between
+// `SagaStarted` and the terminal are reliably *this* saga's. If
+// concurrent sagas land in a future PR, this module will need
+// per-event `saga_id` tagging.
+//
+// **Resync ordering contract.** Snapshot replay must complete before
+// live-event application begins. The host-side bridge guarantees
+// this by holding the websocket reader paused until the snapshot
+// reply arrives; this module does not enforce — it would require
+// the snapshot to be fed through the same pipe, which is not the
+// design.
+//
+// **Force-push protocol.** When a renderer asks the source to
+// force-push (e.g. on detected gap), the source replies with a
+// snapshot followed by live events. Today `droppedCount > 0` is
+// observed but no automatic force-push is issued — the renderer
+// continues operating with potentially-stale state until manual
+// resync. Closing this is a future PR; for now, the spec contract
+// is: *gap detection is logged; recovery is operator-driven via
+// `--diag srv` followed by an explicit `Resync` command.*
+
+import { batch } from "solid-js";
+
+/**
+ * Wire-format event from any reducer source. Matches
+ * `agentmux_common::ipc::Event`'s JSON serialization
+ * (`#[serde(tag = "event", rename_all = "snake_case")]`).
+ *
+ * `event` = discriminant (snake_case), `version` = monotonic
+ * per-source counter. Saga lifecycle variants additionally carry
+ * `saga_id`. Per-step events MAY carry `saga_id` in a future PR
+ * (per-Event threading); today they do not.
+ */
+export interface VersionedEvent {
+    event: string;
+    version: number;
+    saga_id?: number;
+    [field: string]: unknown;
+}
+
+/** Subscriber callback — invoked once per event in source order. */
+export type EventCallback<E extends VersionedEvent> = (evt: E) => void;
+
+/**
+ * Solid signal setters the tracker drives on every dispatch.
+ * Kept as a tuple of plain functions so the tracker is unit-testable
+ * without a Solid runtime (tests pass mock setters).
+ */
+export interface SignalSetters<E extends VersionedEvent> {
+    setLatest: (evt: E) => void;
+    setVersion: (v: number) => void;
+    setSawAny: (b: boolean) => void;
+}
+
+export interface PerSourceTrackerOptions {
+    /** Source name for log prefixes — e.g. "srv", "launcher", "host". */
+    source: string;
+    /**
+     * Cap on how many events can pile up in a saga buffer before an
+     * emergency flush. Default 1000. The serial-saga server-side
+     * timeout is 5s, so 1000 events ≈ 200 events/sec — well past any
+     * realistic saga.
+     */
+    maxSagaBufferSize?: number;
+    /**
+     * Override the default gap warning. Useful in tests, or for
+     * future PRs that want to issue an automatic Resync request.
+     */
+    onVersionGap?: (gap: number, prevVersion: number, newVersion: number) => void;
+    /**
+     * Called on every saga terminal (success OR fail), AFTER the
+     * buffer has been flushed. Useful for telemetry / tests.
+     */
+    onSagaTerminal?: (sagaId: number, outcome: "completed" | "failed") => void;
+}
+
+export interface PerSourceStats {
+    lastVersion: number;
+    droppedCount: number;
+    sawAnyEvent: boolean;
+    /** Saga id of the in-flight saga, or null. */
+    inSaga: number | null;
+    /** Number of events currently sitting in the saga buffer. */
+    bufferedCount: number;
+    /** Number of registered subscribers. */
+    subscriberCount: number;
+}
+
+interface SagaBuffer {
+    saga_id: number;
+    events: VersionedEvent[];
+}
+
+/**
+ * Per-source event tracker. One instance per pipe (srv, launcher,
+ * host).
+ *
+ * Wire-up:
+ *   ```ts
+ *   const [latest, setLatest] = createSignal<SrvEvent | null>(null);
+ *   const [version, setVersion] = createSignal(0);
+ *   const [sawAny, setSawAny] = createSignal(false);
+ *   const tracker = new PerSourceTracker<SrvEvent>(
+ *       { source: "srv" },
+ *       { setLatest, setVersion, setSawAny },
+ *   );
+ *   window.__agentmux_srv_event = (evt) => tracker.deliver(evt);
+ *   ```
+ */
+export class PerSourceTracker<E extends VersionedEvent = VersionedEvent> {
+    private subscribers = new Set<EventCallback<E>>();
+    private lastVersion = 0;
+    private droppedCount = 0;
+    private sawAnyEvent = false;
+    private sagaBuffer: SagaBuffer | null = null;
+
+    private readonly source: string;
+    private readonly maxSagaBufferSize: number;
+    private readonly onVersionGap: NonNullable<PerSourceTrackerOptions["onVersionGap"]>;
+    private readonly onSagaTerminal: NonNullable<PerSourceTrackerOptions["onSagaTerminal"]>;
+
+    constructor(
+        opts: PerSourceTrackerOptions,
+        private readonly setters: SignalSetters<E>,
+    ) {
+        this.source = opts.source;
+        this.maxSagaBufferSize = opts.maxSagaBufferSize ?? 1000;
+        this.onVersionGap =
+            opts.onVersionGap ??
+            ((gap, prev, next) => {
+                console.warn(
+                    `[${this.source}-events] version gap: expected ${prev + 1}, got ${next} (${gap} event${gap === 1 ? "" : "s"} possibly dropped)`,
+                );
+            });
+        this.onSagaTerminal = opts.onSagaTerminal ?? (() => {});
+    }
+
+    /**
+     * Register a per-event callback. Called once per event in
+     * source order, including during saga flushes (where signals
+     * coalesce into the last-event-only via `solid.batch`, but
+     * subscribers see every step).
+     *
+     * Returns an unsubscribe function.
+     */
+    subscribe(cb: EventCallback<E>): () => void {
+        this.subscribers.add(cb);
+        return () => {
+            this.subscribers.delete(cb);
+        };
+    }
+
+    /**
+     * Process one event from the wire. The transport layer (host
+     * CEF JS bridge) calls this once per event.
+     */
+    deliver(evt: E): void {
+        // Defensive shape check — discard junk so a single malformed
+        // event can't tear down the dispatcher.
+        if (
+            evt == null ||
+            typeof evt !== "object" ||
+            typeof evt.version !== "number" ||
+            typeof evt.event !== "string"
+        ) {
+            console.warn(`[${this.source}-events] received malformed event`, evt);
+            return;
+        }
+
+        // Stale: lower-or-equal version than last seen. Drop.
+        if (this.lastVersion > 0 && evt.version <= this.lastVersion) {
+            console.warn(
+                `[${this.source}-events] stale event v=${evt.version} (last=${this.lastVersion}); dropping`,
+            );
+            return;
+        }
+
+        // Gap: version skipped one or more.
+        if (this.lastVersion > 0 && evt.version > this.lastVersion + 1) {
+            const gap = evt.version - this.lastVersion - 1;
+            this.droppedCount += gap;
+            this.onVersionGap(gap, this.lastVersion, evt.version);
+        }
+        this.lastVersion = evt.version;
+
+        if (!this.sawAnyEvent) {
+            this.sawAnyEvent = true;
+            this.setters.setSawAny(true);
+        }
+
+        // SagaStarted: open a new saga buffer.
+        if (evt.event === "saga_started") {
+            const sagaId = typeof evt.saga_id === "number" ? evt.saga_id : null;
+            if (sagaId === null) {
+                console.warn(`[${this.source}-events] saga_started without saga_id; treating as plain event`);
+                this.routeIdleOrBuffered(evt);
+                return;
+            }
+            if (this.sagaBuffer !== null) {
+                // Nested-saga not supported today (server-side
+                // coordinator runs sagas serially). Flush prior +
+                // open new — preserves observability without losing
+                // the prior saga's subscribers' state updates.
+                console.warn(
+                    `[${this.source}-events] nested saga: started ${sagaId} while ${this.sagaBuffer.saga_id} in flight; flushing prior`,
+                );
+                this.flushSagaBuffer(this.sagaBuffer);
+            }
+            this.sagaBuffer = { saga_id: sagaId, events: [evt] };
+            return;
+        }
+
+        // SagaCompleted / SagaFailed: close the matching buffer.
+        if (evt.event === "saga_completed" || evt.event === "saga_failed") {
+            const sagaId = typeof evt.saga_id === "number" ? evt.saga_id : null;
+            if (sagaId !== null && this.sagaBuffer && this.sagaBuffer.saga_id === sagaId) {
+                this.sagaBuffer.events.push(evt);
+                const buf = this.sagaBuffer;
+                this.sagaBuffer = null;
+                this.flushSagaBuffer(buf);
+                this.onSagaTerminal(
+                    sagaId,
+                    evt.event === "saga_completed" ? "completed" : "failed",
+                );
+                return;
+            }
+            // Terminal without matching start (resync mid-saga, or
+            // server-side bug). Pass through — better to deliver than
+            // silently swallow.
+        }
+
+        this.routeIdleOrBuffered(evt);
+    }
+
+    private routeIdleOrBuffered(evt: E): void {
+        if (this.sagaBuffer) {
+            this.sagaBuffer.events.push(evt);
+            if (this.sagaBuffer.events.length > this.maxSagaBufferSize) {
+                console.warn(
+                    `[${this.source}-events] saga buffer overflow at ${this.sagaBuffer.events.length}; emergency flush of saga ${this.sagaBuffer.saga_id}`,
+                );
+                const buf = this.sagaBuffer;
+                this.sagaBuffer = null;
+                this.flushSagaBuffer(buf);
+            }
+            return;
+        }
+        this.dispatch(evt);
+    }
+
+    private flushSagaBuffer(buf: SagaBuffer): void {
+        // `batch` coalesces signal updates: SolidJS effects on
+        // `latestEvent` see only the LAST event in this burst. Per-
+        // event subscriber callbacks still fire individually.
+        batch(() => {
+            for (const e of buf.events) {
+                this.dispatch(e as E);
+            }
+        });
+    }
+
+    private dispatch(evt: E): void {
+        this.setters.setLatest(evt);
+        this.setters.setVersion(evt.version);
+        for (const cb of this.subscribers) {
+            try {
+                cb(evt);
+            } catch (err) {
+                console.error(`[${this.source}-events] subscriber threw:`, err);
+            }
+        }
+    }
+
+    /** Diagnostic snapshot. Used by `--diag srv` / tests. */
+    stats(): PerSourceStats {
+        return {
+            lastVersion: this.lastVersion,
+            droppedCount: this.droppedCount,
+            sawAnyEvent: this.sawAnyEvent,
+            inSaga: this.sagaBuffer ? this.sagaBuffer.saga_id : null,
+            bufferedCount: this.sagaBuffer ? this.sagaBuffer.events.length : 0,
+            subscriberCount: this.subscribers.size,
+        };
+    }
+}

--- a/frontend/util/event-buffer.ts
+++ b/frontend/util/event-buffer.ts
@@ -201,6 +201,36 @@ export class PerSourceTracker<E extends VersionedEvent = VersionedEvent> {
             return;
         }
 
+        // Source-restart detection. Both srv and launcher reducers
+        // reset `event_version` to 0 on process restart (see
+        // `agentmux-srv/src/state.rs::default` and
+        // `agentmux-launcher/src/state.rs::default`); after a restart
+        // the next emitted event is `version=1`. Without resetting
+        // here, every post-restart event would fail the stale gate
+        // (`version <= lastVersion`) and be dropped permanently until
+        // a full page reload. (codex P1, PR #630.)
+        //
+        // Heuristic: `version === 1 && lastVersion > 0`. Version=1 is
+        // unambiguous — only the source's first event after start
+        // bumps the counter from 0 to 1, and we'd only see it now if
+        // we'd already processed events from a prior incarnation.
+        if (evt.version === 1 && this.lastVersion > 0) {
+            console.warn(
+                `[${this.source}-events] source restart detected (lastVersion=${this.lastVersion}, new event v=1); resetting tracker state`,
+            );
+            this.lastVersion = 0;
+            this.droppedCount = 0;
+            // Discard any in-flight saga buffer — the saga it was
+            // tracking is part of the dead source's history; the
+            // restart will re-emit fresh state via Snapshot+Resync.
+            if (this.sagaBuffer) {
+                console.warn(
+                    `[${this.source}-events] dropping stale saga buffer for saga ${this.sagaBuffer.saga_id} during restart`,
+                );
+                this.sagaBuffer = null;
+            }
+        }
+
         // Stale: lower-or-equal version than last seen. Drop.
         if (this.lastVersion > 0 && evt.version <= this.lastVersion) {
             console.warn(
@@ -259,8 +289,12 @@ export class PerSourceTracker<E extends VersionedEvent = VersionedEvent> {
                 return;
             }
             // Terminal without matching start (resync mid-saga, or
-            // server-side bug). Pass through — better to deliver than
-            // silently swallow.
+            // server-side bug). Dispatch directly — bypass
+            // routeIdleOrBuffered so the terminal isn't buried inside
+            // an unrelated in-flight saga's buffer waiting on its own
+            // terminal that may never come. (reagent P1, PR #630.)
+            this.dispatch(evt);
+            return;
         }
 
         this.routeIdleOrBuffered(evt);

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -2,39 +2,31 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Phase B.7.3.1 — renderer-side subscriber for launcher typed events.
+// Phase E.6 — multi-source dispatcher with version tracking + saga buffering.
 //
 // Mirrors `agentmux_common::ipc::Event` on the wire. The host's CEF
 // JS bridge (`agentmux-cef/src/launcher_event_bridge.rs`) calls
 // `window.__agentmux_launcher_event(<json>)` once per top-level
-// renderer per launcher event. We feed those into a SolidJS signal
-// so block-level subscribers can `createEffect()` on them.
+// renderer per launcher event.
 //
 // Phase B.7.3.3 — typed events are the SOLE path for InstancePanel
 // state. The bespoke `window-instances-changed` channel and its 4
-// sync emit sites in the host are gone. `task dev` mode (no
-// launcher in the loop) currently leaves the InstancePanel atoms
-// at their seeded values from the init RPC; live updates require
-// the launcher. Phase E folds srv into the same reducer pattern;
-// the no-launcher mode goes away then.
+// sync emit sites in the host are gone.
+//
+// Phase E.6 — dispatcher backed by the shared `PerSourceTracker`.
+// Same version-monotonicity + saga-buffer semantics as the srv pipe.
+// See `util/event-buffer.ts` for the contract.
 //
 // See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
 
 import { createSignal } from "solid-js";
+import { PerSourceTracker, type EventCallback, type VersionedEvent, type PerSourceStats } from "./event-buffer";
 
 /**
  * Wire-format launcher event. Matches the JSON serialization of
  * `agentmux_common::ipc::Event` (`#[serde(tag = "event", rename_all = "snake_case")]`).
- *
- * Every event carries `event` (discriminant, snake_case) and
- * `version` (monotonic per launcher run, used for de-dup / echo-loop
- * guard). Other fields are variant-specific; downstream subscribers
- * narrow on `event` and read fields by name.
  */
-export interface LauncherEvent {
-    event: string;
-    version: number;
-    [field: string]: unknown;
-}
+export type LauncherEvent = VersionedEvent;
 
 const [latestEvent, setLatestEvent] = createSignal<LauncherEvent | null>(null);
 const [eventVersion, setEventVersion] = createSignal<number>(0);
@@ -50,10 +42,32 @@ export const launcherEventVersion = eventVersion;
  * True once we've received at least one typed event. Kept as a
  * forward-compat utility — B.7.3.3 retired its only consumer (the
  * bespoke-channel gate in `app-init.ts`), but Phase D's `GetSnapshot`
- * resync flow may need it again to detect "have we resynced?" vs
- * "fresh launcher / first events not seen yet."
+ * resync flow may need it again.
  */
 export const launcherEventsActive = seenAnyEvent;
+
+const tracker = new PerSourceTracker<LauncherEvent>(
+    { source: "launcher" },
+    {
+        setLatest: setLatestEvent,
+        setVersion: setEventVersion,
+        setSawAny: setSeenAnyEvent,
+    },
+);
+
+/**
+ * Per-event subscriber for the launcher pipe. Same contract as
+ * `subscribeSrvEvent`: every event in source order, even during
+ * saga buffer flushes. Returns an unsubscribe function.
+ */
+export function subscribeLauncherEvent(cb: EventCallback<LauncherEvent>): () => void {
+    return tracker.subscribe(cb);
+}
+
+/** Diagnostic snapshot. Used by `--diag launcher` / tests. */
+export function launcherEventStats(): PerSourceStats {
+    return tracker.stats();
+}
 
 let installed = false;
 
@@ -66,16 +80,6 @@ let installed = false;
 export function installLauncherEventBridge(): void {
     if (installed) return;
     installed = true;
-    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => {
-        if (!evt || typeof evt.version !== "number" || typeof evt.event !== "string") {
-            console.warn("[launcher-events] received malformed event", evt);
-            return;
-        }
-        setLatestEvent(evt);
-        setEventVersion(evt.version);
-        if (!seenAnyEvent()) {
-            setSeenAnyEvent(true);
-        }
-    };
+    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => tracker.deliver(evt);
     console.log("[launcher-events] bridge installed; window.__agentmux_launcher_event ready");
 }

--- a/frontend/util/srv-events.ts
+++ b/frontend/util/srv-events.ts
@@ -2,40 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Phase E.2c.5b — renderer-side subscriber for srv reducer typed events.
+// Phase E.6 — multi-source dispatcher with version tracking + saga buffering.
 //
 // Mirrors the `launcher-events.ts` pattern from Phase B.7.3.1, but
 // for the srv reducer's broadcast bus (workspace / tab / block / window
 // / saga lifecycle). The host's CEF JS bridge
 // (`agentmux-cef/src/srv_event_bridge.rs`, shipped in Phase E.2c.5a /
 // PR #618) calls `window.__agentmux_srv_event(<json>)` once per
-// top-level renderer per srv event. We feed those into a SolidJS
-// signal so block-level subscribers can `createEffect()` on them.
+// top-level renderer per srv event.
 //
-// **Initial scope (this PR — E.2c.5b):** scaffolding only. Install
-// the dispatcher, expose the latest event signal, log a one-line
-// debug summary on first event arrival. **No atom mutation** — the
-// existing RPC + WaveObjUpdate pipeline remains the authoritative
-// path for workspace/tab/block atom state. Atom-routing flips to
-// event-driven in a follow-up (likely E.6 alongside the per-source
-// version tracking + saga buffer).
+// **Phase E.6 additions:** the dispatcher now lives in
+// `util/event-buffer.ts::PerSourceTracker`. Behavior:
+//   - Per-source version monotonicity check: gaps log a warning + bump
+//     `droppedCount` (visible via `srvEventStats()`).
+//   - Saga buffering: events between `saga_started`/`saga_completed`
+//     coalesce into a single SolidJS-effect tick (so atom-router
+//     consumers see the saga as one atomic update). Per-event
+//     subscriber callbacks still fire in source order.
+//   - Stale events (version <= last seen) are dropped.
 //
-// **Saga events** (`saga_started` / `saga_completed` / `saga_failed`)
-// arrive on this channel too. Future renderer-side correlation /
-// buffering (E.6 §9.2) consumes them via the same signal.
+// **Atom routing (still pending — TODO PR after E.6):** we expose a
+// `subscribeSrvEvent(cb)` API. The first atom-router consumer ships
+// in a follow-up; today the existing RPC + WaveObjUpdate pipeline
+// remains authoritative.
 //
-// See `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §6.6 + §9.
+// See `docs/specs/SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` §6.6 + §9
+// and `docs/retro/next-steps-architecture-completeness-2026-05-01.md`
+// step 2 for the broader plan.
 
 import { createSignal } from "solid-js";
+import { PerSourceTracker, type EventCallback, type VersionedEvent, type PerSourceStats } from "./event-buffer";
 
 /**
  * Wire-format srv event. Matches the JSON serialization of
  * `agentmux_common::ipc::Event`
  * (`#[serde(tag = "event", rename_all = "snake_case")]`).
- *
- * Every event carries `event` (discriminant, snake_case) and
- * `version` (monotonic per srv-process run, used for de-dup /
- * resync ordering). Other fields are variant-specific; downstream
- * subscribers narrow on `event` and read fields by name.
  *
  * Discriminator examples (non-exhaustive — see
  * `agentmux-common/src/ipc.rs::Event`):
@@ -48,11 +49,7 @@ import { createSignal } from "solid-js";
  *   - `workspace_meta_updated` / `tab_meta_updated` / `block_meta_updated`
  *   - `saga_started` / `saga_completed` / `saga_failed`
  */
-export interface SrvEvent {
-    event: string;
-    version: number;
-    [field: string]: unknown;
-}
+export type SrvEvent = VersionedEvent;
 
 const [latestEvent, setLatestEvent] = createSignal<SrvEvent | null>(null);
 const [eventVersion, setEventVersion] = createSignal<number>(0);
@@ -71,6 +68,36 @@ export const srvEventVersion = eventVersion;
  */
 export const srvEventsActive = seenAnyEvent;
 
+const tracker = new PerSourceTracker<SrvEvent>(
+    { source: "srv" },
+    {
+        setLatest: setLatestEvent,
+        setVersion: setEventVersion,
+        setSawAny: setSeenAnyEvent,
+    },
+);
+
+/**
+ * Per-event subscriber. Called once per srv event in source order,
+ * including events delivered as part of a saga buffer flush. Returns
+ * an unsubscribe function.
+ *
+ * Use this for atom routers — every event matters for correct atom
+ * state. Use the `srvEvent` signal for "what's the latest event?"
+ * style consumers (which see one tick per saga, not one per step).
+ */
+export function subscribeSrvEvent(cb: EventCallback<SrvEvent>): () => void {
+    return tracker.subscribe(cb);
+}
+
+/**
+ * Diagnostic snapshot of the srv pipe's tracker state. Used by
+ * `--diag srv` (renderer-side) and by tests.
+ */
+export function srvEventStats(): PerSourceStats {
+    return tracker.stats();
+}
+
 let installed = false;
 
 /**
@@ -84,17 +111,6 @@ export function installSrvEventBridge(): void {
     installed = true;
     (window as unknown as { __agentmux_srv_event?: (evt: SrvEvent) => void }).__agentmux_srv_event = (
         evt: SrvEvent,
-    ) => {
-        if (!evt || typeof evt.version !== "number" || typeof evt.event !== "string") {
-            console.warn("[srv-events] received malformed event", evt);
-            return;
-        }
-        setLatestEvent(evt);
-        setEventVersion(evt.version);
-        if (!seenAnyEvent()) {
-            setSeenAnyEvent(true);
-            console.log("[srv-events] first event received", { event: evt.event, version: evt.version });
-        }
-    };
+    ) => tracker.deliver(evt);
     console.log("[srv-events] bridge installed; window.__agentmux_srv_event ready");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.538",
+  "version": "0.33.539",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.538",
+      "version": "0.33.539",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.537",
+  "version": "0.33.538",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.537",
+      "version": "0.33.538",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.539",
+  "version": "0.33.540",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.539",
+      "version": "0.33.540",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.538",
+  "version": "0.33.539",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.537",
+  "version": "0.33.538",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.539",
+  "version": "0.33.540",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 2 of the architecture-completeness plan. Refactors the per-source event dispatchers (`srv-events`, `launcher-events`) onto a shared `PerSourceTracker` that adds three behaviors needed before F1 events are visible end-to-end.

Closes part of [reducer-architecture-gaps §1 E.6](../blob/main/docs/retro/reducer-architecture-gaps-2026-05-01.md) and §5 cross-pipe ordering. Plan: [next-steps-architecture-completeness step 2](../blob/main/docs/retro/next-steps-architecture-completeness-2026-05-01.md).

## What changed

### New: `frontend/util/event-buffer.ts`
Shared `PerSourceTracker<E>` class. Source-agnostic so adding the third pipe (`host-events.ts` when F1 events cross IPC) is a constructor call.

Three behaviors:

1. **Per-source version monotonicity.** Each source's reducer emits strictly-increasing `version`; gaps log a warning and bump `droppedCount`. Stale events (`version <= last seen`) are dropped.
2. **Saga buffering.** Events between `saga_started` and `saga_completed` / `saga_failed` coalesce via `solid.batch` — SolidJS effects on the latest signal see the saga as one atomic update; per-event subscriber callbacks still fire individually in source order.
3. **Defensive paths.** Malformed events rejected; subscriber exceptions isolated; nested-saga starts flush prior buffer; terminal-without-start passes through; overflow safeguard (default 1000 buffered).

### Refactored: `frontend/util/srv-events.ts` + `frontend/util/launcher-events.ts`
Both now delegate to a `PerSourceTracker` instance. Existing exports (`srvEvent`, `srvEventVersion`, `srvEventsActive`, `installSrvEventBridge`, and launcher equivalents) preserved — no consumer changes required.

New exports:
- `subscribeSrvEvent(cb)` / `subscribeLauncherEvent(cb)` → returns unsubscribe fn
- `srvEventStats()` / `launcherEventStats()` → diagnostic snapshot

### Tests: `frontend/util/event-buffer.test.ts`
16 new tests covering basic delivery, version checking (gaps + stale drop), saga buffering (round-trip, fail terminal, nested, terminal-without-start, overflow), defensive paths (malformed, subscriber-error isolation, missing saga_id, stats).

## Saga correlation today is temporal

Per-step events do NOT carry `saga_id` (per-Event threading was deferred per gaps doc §3). Sagas run serially in the srv coordinator, so events between `SagaStarted` and the terminal are reliably *this* saga's. If concurrent sagas land in a future PR, this module will need per-event `saga_id` tagging.

## Force-push protocol

Gap detection is logged but no automatic Resync issued — recovery is operator-driven via `--diag srv` followed by an explicit `Resync` command. A future PR closes this when a renderer-side resync request makes sense.

## Test plan

- [x] `npx vitest run frontend/util/event-buffer.test.ts` — 16/16 passing
- [x] `npx vitest run` — 255 pre-existing tests pass; only pre-existing `browser-model.test.ts` failure (unrelated, baseline)
- [x] `npx tsc --noEmit` — clean (only pre-existing `tab-presets.ts` + `tauri-api.ts` errors on baseline)
- [x] `task build:frontend` — green prod build
- [ ] Smoke: open AgentMux, verify console shows `[srv-events] bridge installed` and `[launcher-events] bridge installed`
- [ ] Smoke: tear-off a tab, verify `srvEventStats().droppedCount === 0` (no version gaps in normal flow)
- [ ] Smoke: trigger a saga (tear-off), verify atom updates from saga events apply atomically (no half-applied flicker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)