### PR TITLE
feat(E.4-A): layout reducer focused/magnified arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.540"
+version = "0.33.541"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.540"
+version = "0.33.541"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.540"
+version = "0.33.541"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.540"
+version = "0.33.541"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.541"
+version = "0.33.542"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.541"
+version = "0.33.542"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.541"
+version = "0.33.542"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.541"
+version = "0.33.542"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.542"
+version = "0.33.543"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.542"
+version = "0.33.543"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.542"
+version = "0.33.543"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.542"
+version = "0.33.543"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.541"
+version = "0.33.542"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.542"
+version = "0.33.543"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.540"
+version = "0.33.541"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.541"
+version = "0.33.542"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.540"
+version = "0.33.541"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.542"
+version = "0.33.543"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -408,6 +408,23 @@ pub enum Command {
         tab_id: String,
         block_id: String,
     },
+    /// Phase E.4 (Option A) — set a tab's `focusednodeid`. Errors if
+    /// the tab is unknown to the reducer; no-op short-circuit when the
+    /// value is already current. Empty `node_id` clears the field.
+    /// Routes through the reducer so the persist subscriber writes the
+    /// new value into `LayoutState.focusednodeid` for the tab. The
+    /// rest of `LayoutState` (rootnode/leaforder/pendingbackendactions)
+    /// keeps its existing wcore-direct path until Option B lands.
+    SetFocusedNode {
+        tab_id: String,
+        node_id: String,
+    },
+    /// Phase E.4 (Option A) — set a tab's `magnifiednodeid`. Same
+    /// shape as `SetFocusedNode`; empty `node_id` clears (toggle-off).
+    SetMagnifiedNode {
+        tab_id: String,
+        node_id: String,
+    },
     /// Phase D.3 — request an `Event::EventList` reply containing the
     /// events the launcher has emitted with version > `since`. Used
     /// by subscribers that hold a snapshot at version V and want to
@@ -939,6 +956,22 @@ pub enum Event {
     BlockDeleted {
         tab_id: String,
         block_id: String,
+        version: u64,
+    },
+    /// Phase E.4 (Option A) — a tab's `focusednodeid` changed via the
+    /// reducer. Subscribers (persist, eventually the renderer's E.6
+    /// dispatcher) update the tab's layout view. Empty `node_id`
+    /// reflects a clear.
+    FocusedNodeChanged {
+        tab_id: String,
+        node_id: String,
+        version: u64,
+    },
+    /// Phase E.4 (Option A) — a tab's `magnifiednodeid` changed via
+    /// the reducer. Empty `node_id` reflects a clear (toggle-off).
+    MagnifiedNodeChanged {
+        tab_id: String,
+        node_id: String,
         version: u64,
     },
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.542"
+version = "0.33.543"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.540"
+version = "0.33.541"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.541"
+version = "0.33.542"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -285,6 +285,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::BlockMoved { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
+        | Event::FocusedNodeChanged { version, .. }
+        | Event::MagnifiedNodeChanged { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -733,6 +733,15 @@ async fn enforce_register_first(
             "MoveBlock is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        // Phase E.4 (Option A) — layout focused/magnified setters are srv-pipe.
+        Command::SetFocusedNode { .. } => (
+            "SetFocusedNode is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
+        Command::SetMagnifiedNode { .. } => (
+            "SetMagnifiedNode is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
     };
     // Phase E.1b — connection-private error; sentinel version=0
     // (codex P2 #610). See parse-error path for rationale.

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -381,6 +381,27 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase E.4 (Option A) — layout-focused/magnified setters are
+        // srv-pipe commands. Misrouted to the launcher pipe, return
+        // a non-fatal error so the client knows the dispatch was wrong.
+        Command::SetFocusedNode { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "SetFocusedNode is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::SetMagnifiedNode { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "SetMagnifiedNode is a srv-pipe command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         // Phase E.1b — `GetSrvSnapshot` is a srv-pipe command. If a
         // registered client misroutes it to the launcher pipe, return
         // an explicit error so the client knows the dispatch was

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.542"
+version = "0.33.543"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.540"
+version = "0.33.541"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.541"
+version = "0.33.542"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -285,6 +285,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::BlockMoved { version, .. }
         | Event::BlockCreated { version, .. }
         | Event::BlockDeleted { version, .. }
+        | Event::FocusedNodeChanged { version, .. }
+        | Event::MagnifiedNodeChanged { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -127,6 +127,18 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
             .filter(|bid| blocks.iter().any(|b| &b.oid == *bid))
             .cloned()
             .collect();
+        // Phase E.4 (Option A) — bootstrap focused/magnified node from
+        // the tab's LayoutState row so the reducer's view matches what
+        // the user last saw on disk. Empty when the layout row isn't
+        // found or has no value (matches `LayoutState` defaults).
+        let (focused_node_id, magnified_node_id) = if tab.layoutstate.is_empty() {
+            (String::new(), String::new())
+        } else {
+            match wstore.get::<crate::backend::obj::LayoutState>(&tab.layoutstate) {
+                Ok(Some(layout)) => (layout.focusednodeid, layout.magnifiednodeid),
+                _ => (String::new(), String::new()),
+            }
+        };
         state.tabs.insert(
             tab.oid.clone(),
             TabRecord {
@@ -134,6 +146,8 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
                 workspace_id,
                 name: tab.name.clone(),
                 block_ids,
+                focused_node_id,
+                magnified_node_id,
             },
         );
     }

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -281,6 +281,12 @@ pub(crate) fn apply_event_to_wstore(
             dst_index,
             ..
         } => apply_block_moved(wstore, block_id, src_tab_id, dst_tab_id, *dst_index),
+        Event::FocusedNodeChanged { tab_id, node_id, .. } => {
+            apply_focused_node_changed(wstore, tab_id, node_id)
+        }
+        Event::MagnifiedNodeChanged { tab_id, node_id, .. } => {
+            apply_magnified_node_changed(wstore, tab_id, node_id)
+        }
         // All other event variants are not domain-state mutations
         // (lifecycle, errors, snapshots). The subscriber ignores them.
         _ => Ok(()),
@@ -650,6 +656,60 @@ fn apply_tab_renamed(
     Ok(())
 }
 
+/// Phase E.4 (Option A) — write the reducer-emitted focused node id
+/// onto the tab's `LayoutState.focusednodeid` column. Tab→layout is
+/// a join through `Tab.layoutstate`. Idempotent: silent no-op when the
+/// tab is unknown (deleted concurrently), the layout row is missing
+/// (legacy tab without one), or the value already matches. Other
+/// `LayoutState` fields stay on their existing wcore-direct path until
+/// Option B lands.
+fn apply_focused_node_changed(
+    wstore: &WaveStore,
+    tab_id: &str,
+    node_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.layoutstate.is_empty() {
+        return Ok(());
+    }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else {
+        return Ok(());
+    };
+    if layout.focusednodeid == node_id {
+        return Ok(());
+    }
+    layout.focusednodeid = node_id.to_string();
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+
+/// Phase E.4 (Option A) — write the reducer-emitted magnified node id
+/// onto the tab's `LayoutState.magnifiednodeid` column. Same shape as
+/// `apply_focused_node_changed`.
+fn apply_magnified_node_changed(
+    wstore: &WaveStore,
+    tab_id: &str,
+    node_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else {
+        return Ok(());
+    };
+    if tab.layoutstate.is_empty() {
+        return Ok(());
+    }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else {
+        return Ok(());
+    };
+    if layout.magnifiednodeid == node_id {
+        return Ok(());
+    }
+    layout.magnifiednodeid = node_id.to_string();
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+
 /// Phase E.5.3 — apply a meta-patch to a workspace's `meta` map.
 /// Reducer doesn't track meta in `WorkspaceRecord`; this subscriber
 /// is the sole authority that mutates persisted meta. Patch is a
@@ -911,6 +971,8 @@ fn event_kind(event: &Event) -> &'static str {
         Event::BlockMoved { .. } => "BlockMoved",
         Event::BlockCreated { .. } => "BlockCreated",
         Event::BlockDeleted { .. } => "BlockDeleted",
+        Event::FocusedNodeChanged { .. } => "FocusedNodeChanged",
+        Event::MagnifiedNodeChanged { .. } => "MagnifiedNodeChanged",
         _ => "Other",
     }
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -62,6 +62,12 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         } => handle_reorder_tab(state, workspace_id, tab_id, new_index),
         Command::CreateBlock { tab_id, meta } => handle_create_block(state, tab_id, meta),
         Command::DeleteBlock { tab_id, block_id } => handle_delete_block(state, tab_id, block_id),
+        Command::SetFocusedNode { tab_id, node_id } => {
+            handle_set_focused_node(state, tab_id, node_id)
+        }
+        Command::SetMagnifiedNode { tab_id, node_id } => {
+            handle_set_magnified_node(state, tab_id, node_id)
+        }
         Command::CreateWindow {
             window_id,
             workspace_id,
@@ -365,6 +371,8 @@ fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> V
             workspace_id: workspace_id.clone(),
             name: resolved_name.clone(),
             block_ids: Vec::new(),
+            focused_node_id: String::new(),
+            magnified_node_id: String::new(),
         },
     );
     let workspace = state.workspaces.get_mut(&workspace_id).expect("checked");
@@ -594,6 +602,58 @@ fn handle_delete_block(state: &mut State, tab_id: String, block_id: String) -> V
     vec![Event::BlockDeleted {
         tab_id,
         block_id,
+        version: v,
+    }]
+}
+
+/// Phase E.4 (Option A) — set the focused layout-node id on a tab.
+/// Errors (non-fatal) if the tab is unknown to the reducer; no-op
+/// short-circuit when the value is already current. Empty `node_id`
+/// clears the field. Bumps the version only on real changes so a
+/// burst of identical sets doesn't churn the event stream.
+fn handle_set_focused_node(state: &mut State, tab_id: String, node_id: String) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("SetFocusedNode: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if tab.focused_node_id == node_id {
+        return Vec::new();
+    }
+    tab.focused_node_id = node_id.clone();
+    let v = state.bump_version();
+    vec![Event::FocusedNodeChanged {
+        tab_id,
+        node_id,
+        version: v,
+    }]
+}
+
+/// Phase E.4 (Option A) — set the magnified layout-node id on a tab.
+/// Same shape as `handle_set_focused_node`. Empty `node_id` is the
+/// toggle-off / clear case.
+fn handle_set_magnified_node(state: &mut State, tab_id: String, node_id: String) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("SetMagnifiedNode: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    if tab.magnified_node_id == node_id {
+        return Vec::new();
+    }
+    tab.magnified_node_id = node_id.clone();
+    let v = state.bump_version();
+    vec![Event::MagnifiedNodeChanged {
+        tab_id,
+        node_id,
         version: v,
     }]
 }
@@ -863,6 +923,8 @@ fn handle_move_tab(
                     workspace_id: dst_workspace_id.clone(),
                     name: String::new(),
                     block_ids: Vec::new(),
+                    focused_node_id: String::new(),
+                    magnified_node_id: String::new(),
                 },
             );
         }
@@ -1147,6 +1209,8 @@ mod tests {
             | Event::BlockMetaUpdated { version, .. }
             | Event::TabMoved { version, .. }
             | Event::BlockMoved { version, .. }
+            | Event::FocusedNodeChanged { version, .. }
+            | Event::MagnifiedNodeChanged { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -2039,6 +2103,177 @@ mod tests {
             &ctx(2),
         );
         assert!(events.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // Phase E.4 (Option A) — SetFocusedNode / SetMagnifiedNode
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn set_focused_node_round_trip_emits_event_and_updates_state() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t1");
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "");
+        let events = update(
+            &mut state,
+            Command::SetFocusedNode {
+                tab_id: tab_id.clone(),
+                node_id: "node-7".into(),
+            },
+            &ctx(2),
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::FocusedNodeChanged { tab_id: t, node_id, .. } => {
+                assert_eq!(t, &tab_id);
+                assert_eq!(node_id, "node-7");
+            }
+            other => panic!("expected FocusedNodeChanged, got {:?}", other),
+        }
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "node-7");
+    }
+
+    #[test]
+    fn set_focused_node_no_op_when_value_unchanged() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t1");
+        let _ = update(
+            &mut state,
+            Command::SetFocusedNode {
+                tab_id: tab_id.clone(),
+                node_id: "node-1".into(),
+            },
+            &ctx(2),
+        );
+        let version_before = state.event_version;
+        let events = update(
+            &mut state,
+            Command::SetFocusedNode {
+                tab_id,
+                node_id: "node-1".into(),
+            },
+            &ctx(3),
+        );
+        assert!(events.is_empty(), "no-op should emit no events");
+        assert_eq!(state.event_version, version_before, "no version bump on no-op");
+    }
+
+    #[test]
+    fn set_focused_node_unknown_tab_emits_error() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::SetFocusedNode {
+                tab_id: "ghost-tab".into(),
+                node_id: "node-1".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], Event::Error { .. }),
+            "expected Event::Error, got {:?}",
+            events[0]
+        );
+    }
+
+    #[test]
+    fn set_magnified_node_round_trip_emits_event_and_updates_state() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t1");
+        let events = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id: tab_id.clone(),
+                node_id: "node-9".into(),
+            },
+            &ctx(2),
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::MagnifiedNodeChanged { tab_id: t, node_id, .. } => {
+                assert_eq!(t, &tab_id);
+                assert_eq!(node_id, "node-9");
+            }
+            other => panic!("expected MagnifiedNodeChanged, got {:?}", other),
+        }
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "node-9");
+    }
+
+    #[test]
+    fn set_magnified_node_no_op_when_value_unchanged() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t1");
+        let _ = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id: tab_id.clone(),
+                node_id: "node-2".into(),
+            },
+            &ctx(2),
+        );
+        let version_before = state.event_version;
+        let events = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id,
+                node_id: "node-2".into(),
+            },
+            &ctx(3),
+        );
+        assert!(events.is_empty());
+        assert_eq!(state.event_version, version_before);
+    }
+
+    #[test]
+    fn set_magnified_node_clear_with_empty_node_id() {
+        let mut state = State::default();
+        let ws_id = create_workspace(&mut state, "w");
+        let tab_id = create_tab(&mut state, &ws_id, "t1");
+        // Magnify a node first.
+        let _ = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id: tab_id.clone(),
+                node_id: "node-3".into(),
+            },
+            &ctx(2),
+        );
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "node-3");
+        // Now clear with empty node_id (toggle-off semantics).
+        let events = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id: tab_id.clone(),
+                node_id: String::new(),
+            },
+            &ctx(3),
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::MagnifiedNodeChanged { node_id, .. } => assert_eq!(node_id, ""),
+            other => panic!("expected MagnifiedNodeChanged with empty node_id, got {:?}", other),
+        }
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "");
+    }
+
+    #[test]
+    fn set_magnified_node_unknown_tab_emits_error() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::SetMagnifiedNode {
+                tab_id: "ghost-tab".into(),
+                node_id: "node-1".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], Event::Error { .. }));
     }
 
     #[test]

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1140,7 +1140,40 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             };
             // Self-heal the layout before activating — remove any
             // orphaned block nodes that would render as blank panes.
-            let _ = wcore::heal_layout(store, &tab_id);
+            // (codex P1 PR #632 round 2) heal_layout clears
+            // focusednodeid in SQLite when rootnode drops to empty,
+            // bypassing the reducer. Sync the post-heal state through
+            // the reducer so its tabs[tab_id].focused_node_id mirror
+            // matches SQLite.
+            let healed = wcore::heal_layout(store, &tab_id).unwrap_or(false);
+            if healed {
+                if let Ok(tab) = store.must_get::<Tab>(&tab_id) {
+                    if !tab.layoutstate.is_empty() {
+                        if let Ok(Some(layout)) = store.get::<LayoutState>(&tab.layoutstate) {
+                            // Best-effort dispatch — failures here
+                            // don't block SetActiveTab.
+                            let focus_events = dispatch_to_reducer(
+                                state,
+                                agentmux_common::ipc::Command::SetFocusedNode {
+                                    tab_id: tab_id.clone(),
+                                    node_id: layout.focusednodeid.clone(),
+                                },
+                            )
+                            .await;
+                            publish_events(state, &focus_events);
+                            let mag_events = dispatch_to_reducer(
+                                state,
+                                agentmux_common::ipc::Command::SetMagnifiedNode {
+                                    tab_id: tab_id.clone(),
+                                    node_id: layout.magnifiednodeid.clone(),
+                                },
+                            )
+                            .await;
+                            publish_events(state, &mag_events);
+                        }
+                    }
+                }
+            }
 
             // Phase E.2c.3b — pinning was removed from AgentMux
             // (Waveterm legacy). All tabs are regular; dispatch

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -233,6 +233,57 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
+            // Phase E.4 (Option A) — when a LayoutState update lands,
+            // route the focused/magnified slice through the srv reducer
+            // so its canonical state matches what the frontend just
+            // pushed and the persist subscriber emits the new
+            // FocusedNodeChanged / MagnifiedNodeChanged events for E.6
+            // dispatcher consumption. The remaining LayoutState fields
+            // (rootnode/leaforder/pendingbackendactions) keep the
+            // wcore-direct write below per the deferred Option B
+            // decision in `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`.
+            // Best-effort: dispatch failures here do NOT block the
+            // wcore write — wstore stays the durable source until the
+            // full layout migration ships.
+            if wave_obj_value
+                .get("otype")
+                .and_then(|v| v.as_str())
+                == Some(OTYPE_LAYOUT)
+            {
+                if let Some(layout_oid) = wave_obj_value.get("oid").and_then(|v| v.as_str()) {
+                    let owning_tab_id = find_tab_for_layout(store, layout_oid);
+                    if let Some(tab_id) = owning_tab_id {
+                        let new_focused = wave_obj_value
+                            .get("focusednodeid")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let new_magnified = wave_obj_value
+                            .get("magnifiednodeid")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let focus_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::SetFocusedNode {
+                                tab_id: tab_id.clone(),
+                                node_id: new_focused,
+                            },
+                        )
+                        .await;
+                        publish_events(state, &focus_events);
+                        let mag_events = dispatch_to_reducer(
+                            state,
+                            agentmux_common::ipc::Command::SetMagnifiedNode {
+                                tab_id,
+                                node_id: new_magnified,
+                            },
+                        )
+                        .await;
+                        publish_events(state, &mag_events);
+                    }
+                }
+            }
             match update_object(store, wave_obj_value) {
                 Ok((otype, oid, obj_val)) => {
                     let update = WaveObjUpdate {
@@ -2012,6 +2063,21 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             call.service, call.method
         )),
     }
+}
+
+/// Phase E.4 (Option A) — reverse lookup: given a `LayoutState.oid`,
+/// find the `Tab.oid` that owns it (i.e., the tab whose `layoutstate`
+/// field matches). Returns `None` when the layout is unowned (legacy
+/// or partially-migrated row) or the wstore read fails — caller treats
+/// either as "skip the reducer dispatch and fall through to the wcore
+/// write." Linear scan over all tabs; acceptable here because the
+/// layout-update path is low-frequency relative to drag-resize and
+/// the reducer mutex itself is held for sub-millisecond intervals.
+fn find_tab_for_layout(store: &WaveStore, layout_oid: &str) -> Option<String> {
+    let tabs = store.get_all::<Tab>().ok()?;
+    tabs.into_iter()
+        .find(|t| t.layoutstate == layout_oid)
+        .map(|t| t.oid)
 }
 
 /// Resolve an "otype:oid" string to the corresponding wave object JSON.

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -242,17 +242,24 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
             // (rootnode/leaforder/pendingbackendactions) keep the
             // wcore-direct write below per the deferred Option B
             // decision in `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`.
-            // Best-effort: dispatch failures here do NOT block the
-            // wcore write — wstore stays the durable source until the
-            // full layout migration ships.
-            if wave_obj_value
+            //
+            // (codex P2 PR #632) Capture the slice now but DO NOT
+            // dispatch yet — reducer + subscriber updates must happen
+            // ONLY AFTER update_object succeeds. Otherwise an
+            // UpdateObject failure would leave reducer state and
+            // FocusedNodeChanged/MagnifiedNodeChanged events fired for
+            // a request that returned an error, breaking failure
+            // atomicity.
+            let layout_slice: Option<(String, String, String)> = if wave_obj_value
                 .get("otype")
                 .and_then(|v| v.as_str())
                 == Some(OTYPE_LAYOUT)
             {
-                if let Some(layout_oid) = wave_obj_value.get("oid").and_then(|v| v.as_str()) {
-                    let owning_tab_id = find_tab_for_layout(store, layout_oid);
-                    if let Some(tab_id) = owning_tab_id {
+                wave_obj_value
+                    .get("oid")
+                    .and_then(|v| v.as_str())
+                    .and_then(|layout_oid| find_tab_for_layout(store, layout_oid))
+                    .map(|tab_id| {
                         let new_focused = wave_obj_value
                             .get("focusednodeid")
                             .and_then(|v| v.as_str())
@@ -263,6 +270,18 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                             .and_then(|v| v.as_str())
                             .unwrap_or("")
                             .to_string();
+                        (tab_id, new_focused, new_magnified)
+                    })
+            } else {
+                None
+            };
+            match update_object(store, wave_obj_value) {
+                Ok((otype, oid, obj_val)) => {
+                    // DB write succeeded — now dispatch the layout
+                    // reducer updates so reducer state and persist-
+                    // subscriber events stay aligned with the
+                    // committed wstore state. (codex P2 PR #632)
+                    if let Some((tab_id, new_focused, new_magnified)) = layout_slice {
                         let focus_events = dispatch_to_reducer(
                             state,
                             agentmux_common::ipc::Command::SetFocusedNode {
@@ -282,10 +301,6 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                         .await;
                         publish_events(state, &mag_events);
                     }
-                }
-            }
-            match update_object(store, wave_obj_value) {
-                Ok((otype, oid, obj_val)) => {
                     let update = WaveObjUpdate {
                         updatetype: "update".into(),
                         otype,

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -65,7 +65,7 @@ pub struct WorkspaceRecord {
 /// Tabs are owned by exactly one workspace; the workspace's
 /// `tab_ids` field gives the ordering. E.3 adds `block_ids` so the
 /// tab tracks which blocks live inside it.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TabRecord {
     pub tab_id: String,
     pub workspace_id: String,
@@ -73,6 +73,18 @@ pub struct TabRecord {
     /// Phase E.3 — ordered list of block ids in this tab. Mirrors
     /// the persistent `Tab.blockids` field.
     pub block_ids: Vec<String>,
+    /// Phase E.4 (Option A) — focused layout node id. Empty when no
+    /// pane in this tab is focused. Mirrors
+    /// `LayoutState.focusednodeid` for the tab's layout row. Mutated
+    /// by `Command::SetFocusedNode` and bootstrap-loaded from the
+    /// LayoutState row at startup. The remaining LayoutState fields
+    /// (rootnode/leaforder/pendingbackendactions) stay on the
+    /// existing wcore-direct path until Option B.
+    pub focused_node_id: String,
+    /// Phase E.4 (Option A) — magnified layout node id. Empty when
+    /// no pane is magnified (toggle-off). Mirrors
+    /// `LayoutState.magnifiednodeid`.
+    pub magnified_node_id: String,
 }
 
 /// Phase E.3 — block as held by the srv reducer's canonical state.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.542",
+  "version": "0.33.543",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.542",
+      "version": "0.33.543",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.540",
+  "version": "0.33.541",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.540",
+      "version": "0.33.541",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.541",
+  "version": "0.33.542",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.541",
+      "version": "0.33.542",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.540",
+  "version": "0.33.541",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.542",
+  "version": "0.33.543",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.541",
+  "version": "0.33.542",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 3 (Option A) of the architecture-completeness plan. Migrates the focused/magnified layout fields onto the srv reducer; rootnode / leaforder / pendingbackendactions stay on the existing wcore-direct paths per the deferred Option B decision.

Closes (partial): [reducer-architecture-gaps §1 E.4](../blob/main/docs/retro/reducer-architecture-gaps-2026-05-01.md). The `handle_move_tab` strict-mode flip (gap §4) ships as PR 2 of this step after Option A soaks.

Spec: `docs/specs/SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`
Plan: `docs/retro/next-steps-architecture-completeness-2026-05-01.md` step 3

## What changed

- Wire format: `Command::{SetFocusedNode,SetMagnifiedNode}` + `Event::{FocusedNodeChanged,MagnifiedNodeChanged}`.
- Reducer arms with no-op short-circuit + unknown-tab error path; `TabRecord` gains `focused_node_id` + `magnified_node_id` (bootstrap-loaded from each tab's `LayoutState` row).
- Persist subscriber writes the field within the existing layout transaction via the `Tab.layoutstate` join (`apply_focused_node_changed` / `apply_magnified_node_changed`).
- RPC routing: `("object", "UpdateObject")` for `OTYPE_LAYOUT` extracts focusednodeid/magnifiednodeid and dispatches the new reducer commands before the existing wcore write. Other LayoutState fields (rootnode/leaforder/pendingbackendactions) keep flowing through wcore unchanged. Frontend send-sites untouched.
- Launcher reducer / event_log / ipc-server: match-arm wiring for the new srv-pipe-only commands and events.
- Unit tests for round-trip, no-op, unknown-tab, magnify-clear (7 new tests).

## What's NOT in this PR

- Option B (rootnode / leaforder migration) — deferred per spec §3.
- `handle_move_tab` strict-mode flip — PR 2 of step 3.

## Test plan

- [x] `cargo check -p agentmux-srv` clean
- [x] `cargo check -p agentmux-launcher` clean
- [x] `cargo check -p agentmux-cef` clean
- [x] `cargo test -p agentmux-srv reducer::` — 68 passing (7 new)
- [ ] Smoke: switch tabs, click panes, verify focused-pane state preserved per-tab
- [ ] Smoke: toggle magnify on a pane, verify magnification flows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)