### PR TITLE
feat(step5): DeleteBlock + DeleteTab sagas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.543"
+version = "0.33.544"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.543"
+version = "0.33.544"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.543"
+version = "0.33.544"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.543"
+version = "0.33.544"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.545"
+version = "0.33.546"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.545"
+version = "0.33.546"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.545"
+version = "0.33.546"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.545"
+version = "0.33.546"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.544"
+version = "0.33.545"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.544"
+version = "0.33.545"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.544"
+version = "0.33.545"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.544"
+version = "0.33.545"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.546"
+version = "0.33.547"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.546"
+version = "0.33.547"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.546"
+version = "0.33.547"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.546"
+version = "0.33.547"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.547"
+version = "0.33.548"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.547"
+version = "0.33.548"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.547"
+version = "0.33.548"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.547"
+version = "0.33.548"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.543"
+version = "0.33.544"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.547"
+version = "0.33.548"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.545"
+version = "0.33.546"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.546"
+version = "0.33.547"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.544"
+version = "0.33.545"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.546"
+version = "0.33.547"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.543"
+version = "0.33.544"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.545"
+version = "0.33.546"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.544"
+version = "0.33.545"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.547"
+version = "0.33.548"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -264,6 +264,19 @@ pub enum Command {
     DeleteTab {
         workspace_id: String,
         tab_id: String,
+        /// (codex P2 PR #633 round 4 + codex P1 round 2.) Bypass the
+        /// reducer's atomic last-tab guard. `false` for user-facing
+        /// flows (close button, keyboard shortcut) — reducer rejects
+        /// last-tab deletes to keep workspaces non-empty. `true` for
+        /// internal compensation paths (`CreateTab` rollback,
+        /// `PromoteBlockToTab` compensation) where rolling back a
+        /// just-created tab requires deleting the only tab.
+        ///
+        /// Defaults to `false` via `#[serde(default)]` for backwards
+        /// compatibility — pre-existing producers that don't set the
+        /// field get the safe (guarded) behavior.
+        #[serde(default)]
+        force: bool,
     },
     /// Phase E.2b — set a workspace's active tab. No-op if already
     /// active. Errors if the workspace doesn't exist or the tab isn't

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.543"
+version = "0.33.544"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.547"
+version = "0.33.548"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.544"
+version = "0.33.545"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.545"
+version = "0.33.546"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.546"
+version = "0.33.547"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.546"
+version = "0.33.547"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.544"
+version = "0.33.545"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.547"
+version = "0.33.548"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.545"
+version = "0.33.546"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.543"
+version = "0.33.544"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -51,7 +51,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::CreateWorkspace { name } => handle_create_workspace(state, name),
         Command::DeleteWorkspace { workspace_id } => handle_delete_workspace(state, workspace_id),
         Command::CreateTab { workspace_id, name } => handle_create_tab(state, workspace_id, name),
-        Command::DeleteTab { workspace_id, tab_id } => handle_delete_tab(state, workspace_id, tab_id),
+        Command::DeleteTab { workspace_id, tab_id, force } => handle_delete_tab(state, workspace_id, tab_id, force),
         Command::SetActiveTab { workspace_id, tab_id } => {
             handle_set_active_tab(state, workspace_id, tab_id)
         }
@@ -412,6 +412,7 @@ fn handle_delete_tab(
     state: &mut State,
     workspace_id: String,
     tab_id: String,
+    force: bool,
 ) -> Vec<Event> {
     let Some(workspace) = state.workspaces.get_mut(&workspace_id) else {
         return Vec::new();
@@ -419,26 +420,33 @@ fn handle_delete_tab(
     let Some(pos) = workspace.tab_ids.iter().position(|t| t == &tab_id) else {
         return Vec::new();
     };
-    // No last-tab guard at the reducer level. (Round 2 of PR #633.)
-    // The first round added a saga-level pre-check (TOCTOU race);
-    // round 2 moved it to the reducer (atomic). Both regressed
-    // legitimate flows:
-    //   * codex P1 round 1: Cmd+Shift+W on a 1-tab workspace silently
-    //     fails while frontend's `simpleCloseStaticTab` still calls
-    //     `deleteLayoutModelForTab`, leaving client/server divergence.
-    //     (reagent P1 round 2 explicitly notes the tabbar close button
-    //     already gates with `if (allTabs.length <= 1) return`; the
-    //     keyboard path needs the same gate.)
-    //   * codex P1 round 2: the guard rejects `CreateTab` rollback
-    //     compensation — when creating the *first* tab in a workspace
-    //     fails to persist, the compensating `DeleteTab` is now
-    //     refused, leaving state/DB divergence.
-    // Resolution: the reducer accepts last-tab deletes. User-facing
-    // flows (close button, keyboard) gate at the call site. Internal
-    // compensation paths work as intended. The TOCTOU race that
-    // motivated the guard is a tiny window only reachable by
-    // automated test harnesses; frontend gating prevents user-driven
-    // concurrent CloseTabs.
+    // Last-tab guard with `force` bypass (round 4 of PR #633).
+    // History:
+    //   * Round 1: saga pre-check → reagent flagged TOCTOU race.
+    //   * Round 2: moved guard to reducer (atomic) → broke CreateTab
+    //     compensation (codex P1 round 2) and Cmd+W keyboard flow
+    //     (codex P1 round 1).
+    //   * Round 3: removed guard entirely; saga keeps soft pre-check
+    //     → codex P2 round 4 re-flagged the TOCTOU race.
+    //   * Round 4 (this): atomic guard with `force: bool` bypass.
+    //     User-facing flows (CloseTab RPC → DeleteTab saga) pass
+    //     `force: false`; compensation paths (`CreateTab` rollback,
+    //     `PromoteBlockToTab.ctx.compensate`) pass `force: true`.
+    //     Frontend keyboard handler `simpleCloseStaticTab` already
+    //     gates pre-RPC, so the reducer rejection is a defense-in-
+    //     depth backstop that catches automation/race paths.
+    if !force && workspace.tab_ids.len() <= 1 {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "DeleteTab: refusing to delete the last tab in workspace {} (would leave empty workspace; pass force=true for compensation paths)",
+                workspace_id,
+            ),
+            fatal: false,
+            version: v,
+        }];
+    }
     workspace.tab_ids.remove(pos);
     let active_changed = if workspace.active_tab_id.as_deref() == Some(tab_id.as_str()) {
         let new_active = workspace
@@ -1602,6 +1610,7 @@ mod tests {
             Command::DeleteTab {
                 workspace_id: ws_id.clone(),
                 tab_id: tab2_id.clone(),
+                force: false,
             },
             &ctx(3),
         );
@@ -1640,6 +1649,7 @@ mod tests {
             Command::DeleteTab {
                 workspace_id: ws_id.clone(),
                 tab_id: tab1_id.clone(),
+                force: false,
             },
             &ctx(3),
         );
@@ -1675,6 +1685,11 @@ mod tests {
             Command::DeleteTab {
                 workspace_id: ws_id.clone(),
                 tab_id: tab1_id,
+                // Last-tab delete needs force=true post-round-4
+                // (codex P2 #633). Test asserts the
+                // ActiveTabChanged-to-None behavior still works
+                // when compensation paths force a last-tab delete.
+                force: true,
             },
             &ctx(2),
         );
@@ -1696,6 +1711,7 @@ mod tests {
             Command::DeleteTab {
                 workspace_id: ws_id,
                 tab_id: "ghost".into(),
+                force: false,
             },
             &ctx(1),
         );
@@ -2322,6 +2338,9 @@ mod tests {
             Command::DeleteTab {
                 workspace_id: ws_id,
                 tab_id,
+                // Single-tab workspace; force=true bypasses last-tab
+                // guard so we can test the block cascade.
+                force: true,
             },
             &ctx(4),
         );
@@ -3097,6 +3116,11 @@ mod tests {
                     let cmd = Command::DeleteTab {
                         workspace_id: tab.workspace_id.clone(),
                         tab_id: tab_id.clone(),
+                        // Proptest exercises both guarded + unguarded
+                        // paths; force=true here ensures cascade
+                        // invariants are tested without the guard
+                        // short-circuiting the operation.
+                        force: true,
                     };
                     update(state, cmd, &ctx(conn_id))
                 } else {

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -419,6 +419,30 @@ fn handle_delete_tab(
     let Some(pos) = workspace.tab_ids.iter().position(|t| t == &tab_id) else {
         return Vec::new();
     };
+    // Last-tab guard. (reagent P1 PR #633.) The DeleteTabSaga used
+    // to enforce this in a pre-check that read state under a lock,
+    // dropped the lock, then re-acquired it via dispatch — a TOCTOU
+    // window where two concurrent CloseTab RPCs on different tabs in
+    // a 2-tab workspace could both pass the pre-check and both
+    // succeed, leaving an empty workspace. Enforcing here makes the
+    // check + remove atomic with the reducer's state lock.
+    //
+    // Internal cascade paths (workspace delete, tab cascade from
+    // block delete) come through `handle_delete_workspace` /
+    // implicit cascade — they don't dispatch DeleteTab directly per
+    // tab, so they're unaffected.
+    if workspace.tab_ids.len() <= 1 {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!(
+                "DeleteTab: refusing to delete the last tab in workspace {} (would leave empty workspace)",
+                workspace_id,
+            ),
+            fatal: false,
+            version: v,
+        }];
+    }
     workspace.tab_ids.remove(pos);
     let active_changed = if workspace.active_tab_id.as_deref() == Some(tab_id.as_str()) {
         let new_active = workspace
@@ -1633,7 +1657,11 @@ mod tests {
     }
 
     #[test]
-    fn delete_last_tab_clears_active_to_none() {
+    fn delete_last_tab_rejected_with_error_event() {
+        // (reagent P1 PR #633.) Reducer rejects last-tab deletes
+        // atomically — refusing to leave workspaces empty. Workspace
+        // cleanup happens via DeleteWorkspace cascade (which removes
+        // tabs inline without dispatching DeleteTab per tab).
         let mut state = State::default();
         let ws_id = create_workspace(&mut state, "w");
         let _ = update(
@@ -1649,17 +1677,18 @@ mod tests {
             &mut state,
             Command::DeleteTab {
                 workspace_id: ws_id.clone(),
-                tab_id: tab1_id,
+                tab_id: tab1_id.clone(),
             },
             &ctx(2),
         );
-        assert!(matches!(&events[0], Event::TabDeleted { .. }));
-        assert!(matches!(
-            &events[1],
-            Event::ActiveTabChanged { tab_id: None, .. }
-        ));
-        assert_eq!(state.workspaces[&ws_id].active_tab_id, None);
-        assert!(state.tabs.is_empty());
+        assert!(
+            matches!(&events[0], Event::Error { message, .. } if message.contains("last tab")),
+            "expected last-tab Error, got: {:?}",
+            events
+        );
+        // Tab is still present; state unchanged.
+        assert_eq!(state.workspaces[&ws_id].tab_ids, vec![tab1_id.clone()]);
+        assert!(state.tabs.contains_key(&tab1_id));
     }
 
     #[test]
@@ -2281,6 +2310,9 @@ mod tests {
         let mut state = State::default();
         let ws_id = create_workspace(&mut state, "w");
         let tab_id = create_tab(&mut state, &ws_id, "t");
+        // Last-tab guard: create a second tab so the test tab isn't
+        // the only one. (reagent P1 PR #633.)
+        let _keep_tab = create_tab(&mut state, &ws_id, "keep");
         let _ = update(
             &mut state,
             Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -419,30 +419,26 @@ fn handle_delete_tab(
     let Some(pos) = workspace.tab_ids.iter().position(|t| t == &tab_id) else {
         return Vec::new();
     };
-    // Last-tab guard. (reagent P1 PR #633.) The DeleteTabSaga used
-    // to enforce this in a pre-check that read state under a lock,
-    // dropped the lock, then re-acquired it via dispatch — a TOCTOU
-    // window where two concurrent CloseTab RPCs on different tabs in
-    // a 2-tab workspace could both pass the pre-check and both
-    // succeed, leaving an empty workspace. Enforcing here makes the
-    // check + remove atomic with the reducer's state lock.
-    //
-    // Internal cascade paths (workspace delete, tab cascade from
-    // block delete) come through `handle_delete_workspace` /
-    // implicit cascade — they don't dispatch DeleteTab directly per
-    // tab, so they're unaffected.
-    if workspace.tab_ids.len() <= 1 {
-        let v = state.bump_version();
-        return vec![Event::Error {
-            code: ErrorCode::InvalidCommand,
-            message: format!(
-                "DeleteTab: refusing to delete the last tab in workspace {} (would leave empty workspace)",
-                workspace_id,
-            ),
-            fatal: false,
-            version: v,
-        }];
-    }
+    // No last-tab guard at the reducer level. (Round 2 of PR #633.)
+    // The first round added a saga-level pre-check (TOCTOU race);
+    // round 2 moved it to the reducer (atomic). Both regressed
+    // legitimate flows:
+    //   * codex P1 round 1: Cmd+Shift+W on a 1-tab workspace silently
+    //     fails while frontend's `simpleCloseStaticTab` still calls
+    //     `deleteLayoutModelForTab`, leaving client/server divergence.
+    //     (reagent P1 round 2 explicitly notes the tabbar close button
+    //     already gates with `if (allTabs.length <= 1) return`; the
+    //     keyboard path needs the same gate.)
+    //   * codex P1 round 2: the guard rejects `CreateTab` rollback
+    //     compensation — when creating the *first* tab in a workspace
+    //     fails to persist, the compensating `DeleteTab` is now
+    //     refused, leaving state/DB divergence.
+    // Resolution: the reducer accepts last-tab deletes. User-facing
+    // flows (close button, keyboard) gate at the call site. Internal
+    // compensation paths work as intended. The TOCTOU race that
+    // motivated the guard is a tiny window only reachable by
+    // automated test harnesses; frontend gating prevents user-driven
+    // concurrent CloseTabs.
     workspace.tab_ids.remove(pos);
     let active_changed = if workspace.active_tab_id.as_deref() == Some(tab_id.as_str()) {
         let new_active = workspace
@@ -1657,11 +1653,12 @@ mod tests {
     }
 
     #[test]
-    fn delete_last_tab_rejected_with_error_event() {
-        // (reagent P1 PR #633.) Reducer rejects last-tab deletes
-        // atomically — refusing to leave workspaces empty. Workspace
-        // cleanup happens via DeleteWorkspace cascade (which removes
-        // tabs inline without dispatching DeleteTab per tab).
+    fn delete_last_tab_clears_active_to_none() {
+        // Reducer accepts last-tab delete (round 2 of PR #633 walked
+        // back the guard). User-facing flows gate at the call site
+        // (close button + keymodel both check `tab_ids.len() <= 1`);
+        // internal compensation paths rely on this acceptance to
+        // roll back failed CreateTab persists.
         let mut state = State::default();
         let ws_id = create_workspace(&mut state, "w");
         let _ = update(
@@ -1677,18 +1674,17 @@ mod tests {
             &mut state,
             Command::DeleteTab {
                 workspace_id: ws_id.clone(),
-                tab_id: tab1_id.clone(),
+                tab_id: tab1_id,
             },
             &ctx(2),
         );
-        assert!(
-            matches!(&events[0], Event::Error { message, .. } if message.contains("last tab")),
-            "expected last-tab Error, got: {:?}",
-            events
-        );
-        // Tab is still present; state unchanged.
-        assert_eq!(state.workspaces[&ws_id].tab_ids, vec![tab1_id.clone()]);
-        assert!(state.tabs.contains_key(&tab1_id));
+        assert!(matches!(&events[0], Event::TabDeleted { .. }));
+        assert!(matches!(
+            &events[1],
+            Event::ActiveTabChanged { tab_id: None, .. }
+        ));
+        assert_eq!(state.workspaces[&ws_id].active_tab_id, None);
+        assert!(state.tabs.is_empty());
     }
 
     #[test]
@@ -2310,9 +2306,6 @@ mod tests {
         let mut state = State::default();
         let ws_id = create_workspace(&mut state, "w");
         let tab_id = create_tab(&mut state, &ws_id, "t");
-        // Last-tab guard: create a second tab so the test tab isn't
-        // the only one. (reagent P1 PR #633.)
-        let _keep_tab = create_tab(&mut state, &ws_id, "keep");
         let _ = update(
             &mut state,
             Command::CreateBlock { tab_id: tab_id.clone(), meta: serde_json::Value::Null },

--- a/agentmux-srv/src/sagas/delete_block.rs
+++ b/agentmux-srv/src/sagas/delete_block.rs
@@ -87,13 +87,6 @@ pub async fn run(
         }
     }
 
-    // Drop the controller BEFORE reducer dispatch. The persist
-    // subscriber's `wcore::delete_block` doesn't touch the controller
-    // registry — that was a side-effect of the old RPC handler, and
-    // we preserve it here so the PTY/child process is gone before
-    // SQLite stops referring to the block. Idempotent on missing.
-    crate::backend::blockcontroller::delete_controller(&block_id);
-
     let saga_id = alloc_saga_id(state);
     if let Err(e) = emit_saga_started(
         state,
@@ -109,7 +102,19 @@ pub async fn run(
         return Err(e);
     }
     let ctx = SagaCtx::new(state, saga_id);
-    let result = run_saga("delete_block", run_inner(ctx, tab_id, block_id)).await;
+    let result = run_saga("delete_block", run_inner(ctx, tab_id, block_id.clone())).await;
+    // Kill the controller AFTER the saga's reducer + SQLite writes
+    // succeed. (reagent P2 PR #633.) The earlier round killed the
+    // controller before emit_saga_started, which left an
+    // unrecoverable side-effect leak if start_saga rejected a
+    // collision: PTY dead, block still in reducer + SQLite. Doing
+    // it here means: success → controller gone, block gone, all
+    // consistent; saga failure → controller still alive (we don't
+    // touch it), block stays — also consistent. Idempotent on
+    // missing controller.
+    if result.is_ok() {
+        crate::backend::blockcontroller::delete_controller(&block_id);
+    }
     emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
     result
 }

--- a/agentmux-srv/src/sagas/delete_block.rs
+++ b/agentmux-srv/src/sagas/delete_block.rs
@@ -103,17 +103,28 @@ pub async fn run(
     }
     let ctx = SagaCtx::new(state, saga_id);
     let result = run_saga("delete_block", run_inner(ctx, tab_id, block_id.clone())).await;
-    // Kill the controller AFTER the saga's reducer + SQLite writes
-    // succeed. (reagent P2 PR #633.) The earlier round killed the
-    // controller before emit_saga_started, which left an
-    // unrecoverable side-effect leak if start_saga rejected a
-    // collision: PTY dead, block still in reducer + SQLite. Doing
-    // it here means: success → controller gone, block gone, all
-    // consistent; saga failure → controller still alive (we don't
-    // touch it), block stays — also consistent. Idempotent on
-    // missing controller.
-    if result.is_ok() {
-        crate::backend::blockcontroller::delete_controller(&block_id);
+    // Controller-kill ordering. Three rounds of bot review:
+    //   * Round 1 (agent): killed BEFORE emit_saga_started → reagent
+    //     P2: side-effect leak if start_saga collides.
+    //   * Round 2 (this PR): conditional on result.is_ok() → codex P2
+    //     round 2: leaks PTY when reducer succeeds but
+    //     `apply_event_to_wstore` fails inside `SagaCtx::dispatch`
+    //     (block already removed from reducer state, RPC returns
+    //     error, retry pre-check sees "block not found" → controller
+    //     never cleaned up).
+    //   * Round 3 (this fix): kill controller whenever the reducer
+    //     dispatched DeleteBlock — i.e., whenever block was removed
+    //     from reducer state. This includes both success and the
+    //     reducer-succeeded-wstore-failed cases. We approximate this
+    //     by checking reducer state for the block: if it's gone, the
+    //     reducer dispatched (regardless of wstore outcome), so kill
+    //     the controller. Idempotent on missing controller.
+    {
+        let block_still_in_reducer =
+            state.srv_state.lock().await.blocks.contains_key(&block_id);
+        if !block_still_in_reducer {
+            crate::backend::blockcontroller::delete_controller(&block_id);
+        }
     }
     emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
     result

--- a/agentmux-srv/src/sagas/delete_block.rs
+++ b/agentmux-srv/src/sagas/delete_block.rs
@@ -1,0 +1,284 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.7 (Step 5 PR 1) — DeleteBlock saga.
+//
+// Replaces the SQLite-first delete pattern in `service.rs`'s
+// `("object", "DeleteBlock")` handler with a reducer-driven saga.
+// The legacy handler called `wcore::delete_block` first and then
+// dispatched `Command::DeleteBlock` to keep the reducer in sync — a
+// short-circuit that pre-dates the saga coordinator + persist
+// subscriber pattern (closes gap §4 in
+// `docs/retro/reducer-architecture-gaps-2026-05-01.md`).
+//
+// **Steps:**
+// 1. `DeleteBlock { tab_id, block_id }` — reducer removes the block
+//    from canonical state and emits `Event::BlockDeleted`. The
+//    persist subscriber writes SQLite via `wcore::delete_block`
+//    (cascades to layout pruning).
+//
+// **Block controller side-effect:** the legacy RPC handler killed
+// the block's PTY/controller via `blockcontroller::delete_controller`
+// BEFORE the wcore SQLite delete. The saga preserves that ordering
+// — controller-kill happens in this function before the reducer
+// dispatch, since the persist subscriber's `wcore::delete_block`
+// only handles SQLite and layout pruning, not process teardown. We
+// still drop the controller even if the saga later short-circuits
+// (block-not-found): the controller registry is a process-local
+// map, idempotent on missing keys.
+//
+// **Compensation:** delete sagas are awkward to compensate — once
+// the block row + controller are gone, "un-delete" requires
+// reconstructing both the SQLite row and the PTY/process subtree,
+// neither of which is meaningful from saga state. We follow the
+// brief's pragma: log a warning on dispatch failure, no automatic
+// re-create. The reducer's `DeleteBlock` is silent-no-op on missing
+// inputs (see reducer.rs handle_delete_block), so the only failure
+// path is wstore write errors surfaced by the persist subscriber —
+// in which case the controller is already gone (intentional; the
+// PTY can't be partially-killed) and the SQLite row may or may not
+// have been written. PR 2's `compensate_unresolved` resume scan
+// surfaces these via the durable saga log for operator follow-up.
+//
+// **Pre-condition:** the block must exist in the reducer state.
+// Without this, the reducer would silently no-op (handle_delete_block
+// returns an empty event vec on missing tab/block) and the user
+// would see "delete succeeded" while nothing happened. The saga
+// surfaces a clear "block not found" error instead. We check the
+// reducer state (not SQLite) because `Command::DeleteBlock` carries
+// `tab_id` from the RPC's `uicontext.activetabid` and we want to
+// validate against the reducer's view of (tab → blocks) — that's
+// what the dispatch will mutate.
+
+use agentmux_common::ipc::Command;
+use serde_json::{json, Value};
+
+use super::{
+    alloc_saga_id, classify_run_saga_result, emit_saga_started, emit_terminal, run_saga, SagaCtx,
+};
+use crate::server::AppState;
+
+/// Run the DeleteBlock saga. On success returns
+/// `{"block_id": "...", "tab_id": "..."}`.
+pub async fn run(
+    state: &AppState,
+    tab_id: String,
+    block_id: String,
+) -> Result<Value, String> {
+    // Pre-condition: block exists and is in the named tab. Reducer
+    // would silent-no-op otherwise (see handle_delete_block); the
+    // saga surfaces a clear error instead.
+    {
+        let s = state.srv_state.lock().await;
+        match s.blocks.get(&block_id) {
+            None => {
+                return Err(format!("DeleteBlock: block not found: {}", block_id));
+            }
+            Some(block) if block.tab_id != tab_id => {
+                return Err(format!(
+                    "DeleteBlock: block {} is in tab {}, not {}",
+                    block_id, block.tab_id, tab_id
+                ));
+            }
+            _ => {}
+        }
+        if !s.tabs.contains_key(&tab_id) {
+            return Err(format!("DeleteBlock: tab not found: {}", tab_id));
+        }
+    }
+
+    // Drop the controller BEFORE reducer dispatch. The persist
+    // subscriber's `wcore::delete_block` doesn't touch the controller
+    // registry — that was a side-effect of the old RPC handler, and
+    // we preserve it here so the PTY/child process is gone before
+    // SQLite stops referring to the block. Idempotent on missing.
+    crate::backend::blockcontroller::delete_controller(&block_id);
+
+    let saga_id = alloc_saga_id(state);
+    if let Err(e) = emit_saga_started(
+        state,
+        saga_id,
+        "delete_block",
+        json!({
+            "tab_id": &tab_id,
+            "block_id": &block_id,
+        }),
+    )
+    .await
+    {
+        return Err(e);
+    }
+    let ctx = SagaCtx::new(state, saga_id);
+    let result = run_saga("delete_block", run_inner(ctx, tab_id, block_id)).await;
+    emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    tab_id: String,
+    block_id: String,
+) -> Result<Value, String> {
+    // Step 1: dispatch DeleteBlock through the reducer. The persist
+    // subscriber sees the BlockDeleted event and runs
+    // `wcore::delete_block` (SQLite delete + layout prune).
+    if let Err(reason) = ctx
+        .dispatch(Command::DeleteBlock {
+            tab_id: tab_id.clone(),
+            block_id: block_id.clone(),
+        })
+        .await
+    {
+        // No automatic compensation — un-deleting a block requires
+        // reconstructing both SQLite + PTY which we cannot do from
+        // saga state. Surface the failure; PR 2's restart-recovery
+        // scan picks up the durable log row for operator review.
+        tracing::warn!(
+            tab_id = %tab_id,
+            block_id = %block_id,
+            "[saga] DeleteBlock dispatch failed (no automatic compensation): {}",
+            reason
+        );
+        return Err(format!("DeleteBlock: {}", reason));
+    }
+
+    Ok(json!({
+        "tab_id": tab_id,
+        "block_id": block_id,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::Block;
+    use crate::server::tests::test_state;
+    use agentmux_common::ipc::Event;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<agentmux_common::ipc::Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    /// Seed a workspace + tab + block and return their ids.
+    async fn seed() -> (
+        crate::server::AppState,
+        String, // workspace_id
+        String, // tab_id
+        String, // block_id
+    ) {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "t".into(),
+            },
+        )
+        .await;
+        let tab_id = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let blk_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateBlock {
+                tab_id: tab_id.clone(),
+                meta: serde_json::Value::Null,
+            },
+        )
+        .await;
+        let block_id = blk_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::BlockCreated { block_id, .. } => Some(block_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        (state, ws_id, tab_id, block_id)
+    }
+
+    #[tokio::test]
+    async fn happy_path_removes_block_from_reducer_and_sqlite() {
+        let (state, _ws_id, tab_id, block_id) = seed().await;
+
+        // Sanity: block is present pre-delete.
+        {
+            let s = state.srv_state.lock().await;
+            assert!(s.blocks.contains_key(&block_id));
+            assert_eq!(s.tabs[&tab_id].block_ids, vec![block_id.clone()]);
+        }
+        assert!(state.wstore.get::<Block>(&block_id).unwrap().is_some());
+
+        let result = run(&state, tab_id.clone(), block_id.clone()).await.unwrap();
+        assert_eq!(result["block_id"], block_id);
+        assert_eq!(result["tab_id"], tab_id);
+
+        // Reducer: block gone, tab's block_ids empty.
+        let s = state.srv_state.lock().await;
+        assert!(!s.blocks.contains_key(&block_id));
+        assert!(s.tabs[&tab_id].block_ids.is_empty());
+        drop(s);
+
+        // SQLite: block gone.
+        assert!(state.wstore.get::<Block>(&block_id).unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn rejects_when_block_not_found() {
+        let (state, _ws_id, tab_id, _block_id) = seed().await;
+        let err = run(&state, tab_id, "ghost-block".into()).await.unwrap_err();
+        assert!(err.contains("block not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_block_in_different_tab() {
+        let (state, _ws_id, tab_id, block_id) = seed().await;
+        // Create a second tab; ask to delete block via that tab's id.
+        let tab_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: _ws_id.clone(),
+                name: "other".into(),
+            },
+        )
+        .await;
+        let other_tab = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let err = run(&state, other_tab, block_id.clone()).await.unwrap_err();
+        assert!(
+            err.contains("is in tab") && err.contains(&tab_id),
+            "got: {}",
+            err
+        );
+        // Block must still be present (saga rejected pre-dispatch).
+        let s = state.srv_state.lock().await;
+        assert!(s.blocks.contains_key(&block_id));
+    }
+}

--- a/agentmux-srv/src/sagas/delete_tab.rs
+++ b/agentmux-srv/src/sagas/delete_tab.rs
@@ -66,7 +66,16 @@ pub async fn run(
     workspace_id: String,
     tab_id: String,
 ) -> Result<Value, String> {
-    // Pre-conditions: tab exists in workspace; not the last tab.
+    // Pre-conditions: tab exists in workspace.
+    //
+    // (reagent P1 PR #633.) The last-tab guard is now ENFORCED IN
+    // THE REDUCER (`reducer::handle_delete_tab`) so check + delete
+    // is atomic with the state lock. The earlier pre-check version
+    // had a TOCTOU window: read state under lock, drop lock,
+    // dispatch re-acquires — two concurrent CloseTab RPCs in a
+    // 2-tab workspace could both pass and both succeed. The reducer
+    // now rejects with `Event::Error` if `tab_ids.len() <= 1`, and
+    // `SagaCtx::dispatch` surfaces that as the saga's Err return.
     {
         let s = state.srv_state.lock().await;
         let Some(workspace) = s.workspaces.get(&workspace_id) else {
@@ -79,12 +88,6 @@ pub async fn run(
             return Err(format!(
                 "DeleteTab: tab {} is not in workspace {}",
                 tab_id, workspace_id
-            ));
-        }
-        if workspace.tab_ids.len() <= 1 {
-            return Err(format!(
-                "DeleteTab: cannot delete last tab in workspace {}",
-                workspace_id
             ));
         }
         if !s.tabs.contains_key(&tab_id) {

--- a/agentmux-srv/src/sagas/delete_tab.rs
+++ b/agentmux-srv/src/sagas/delete_tab.rs
@@ -1,0 +1,290 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase E.5.7 (Step 5 PR 1) — DeleteTab saga.
+//
+// Replaces the SQLite-first delete pattern in `service.rs`'s
+// `("workspace", "CloseTab")` handler with a reducer-driven saga.
+// The legacy handler called `wcore::delete_tab` first and then
+// dispatched `Command::DeleteTab` to keep the reducer in sync — a
+// short-circuit that pre-dates the saga coordinator + persist
+// subscriber pattern (closes gap §4 in
+// `docs/retro/reducer-architecture-gaps-2026-05-01.md`).
+//
+// **Steps:**
+// 1. `DeleteTab { workspace_id, tab_id }` — reducer removes the tab
+//    from canonical state (cascading to its blocks in-state) and
+//    emits `Event::TabDeleted` plus optional `Event::ActiveTabChanged`
+//    if the removed tab was active. The persist subscriber writes
+//    SQLite via `wcore::delete_tab` (cascades to blocks + layout +
+//    PTY controllers).
+//
+// **Pre-conditions:**
+// 1. Tab must exist in the reducer state and be in the named
+//    workspace.
+// 2. Tab must NOT be the workspace's last tab. Mirrors `TearOffTab`'s
+//    "cannot tear off last tab" guard. Removing the last tab leaves
+//    an empty workspace whose UI representation is awkward — callers
+//    that want full-workspace teardown should issue
+//    `DeleteWorkspace` (which is its own saga in Step 5 PR 2).
+//
+// **Block controller cascade:** the persist subscriber's
+// `apply_tab_deleted` invokes `wcore::delete_tab` which calls
+// `delete_tab_inner` → `delete_controller(block_id)` for each block.
+// The saga therefore does not need to do explicit controller-kill
+// like `delete_block.rs` does (DeleteBlock's persist path is
+// `wcore::delete_block` which only handles the SQLite + layout
+// prune, not controller teardown).
+//
+// **Compensation:** like DeleteBlock, un-deleting a tab requires
+// reconstructing SQLite rows (Tab + LayoutState + cascaded Blocks)
+// AND re-spawning the PTY controllers — neither feasible from saga
+// state. Pragma per the brief: log warning on failure, no automatic
+// re-create. PR 2's restart-recovery scan will surface partial
+// failures from the durable saga log.
+//
+// **Pre-condition source — reducer vs SQLite:** check reducer state.
+// The legacy CloseTab path was SQLite-first which made SQLite
+// authoritative; the saga inverts this — the reducer's `tab_ids` is
+// the source of truth, with the persist subscriber writing SQLite
+// in response. Tabs that exist in SQLite but not in the reducer
+// indicate a bootstrap-mismatch (separate bug); the saga rejecting
+// them is the correct conservative behaviour.
+
+use agentmux_common::ipc::Command;
+use serde_json::{json, Value};
+
+use super::{
+    alloc_saga_id, classify_run_saga_result, emit_saga_started, emit_terminal, run_saga, SagaCtx,
+};
+use crate::server::AppState;
+
+/// Run the DeleteTab saga. On success returns
+/// `{"workspace_id": "...", "tab_id": "..."}`.
+pub async fn run(
+    state: &AppState,
+    workspace_id: String,
+    tab_id: String,
+) -> Result<Value, String> {
+    // Pre-conditions: tab exists in workspace; not the last tab.
+    {
+        let s = state.srv_state.lock().await;
+        let Some(workspace) = s.workspaces.get(&workspace_id) else {
+            return Err(format!(
+                "DeleteTab: workspace not found: {}",
+                workspace_id
+            ));
+        };
+        if !workspace.tab_ids.iter().any(|t| t == &tab_id) {
+            return Err(format!(
+                "DeleteTab: tab {} is not in workspace {}",
+                tab_id, workspace_id
+            ));
+        }
+        if workspace.tab_ids.len() <= 1 {
+            return Err(format!(
+                "DeleteTab: cannot delete last tab in workspace {}",
+                workspace_id
+            ));
+        }
+        if !s.tabs.contains_key(&tab_id) {
+            // Inconsistent state — workspace.tab_ids references a
+            // tab that's not in state.tabs. Reject; bootstrap-rebuild
+            // gap is a separate concern.
+            return Err(format!("DeleteTab: tab record missing: {}", tab_id));
+        }
+    }
+
+    let saga_id = alloc_saga_id(state);
+    if let Err(e) = emit_saga_started(
+        state,
+        saga_id,
+        "delete_tab",
+        json!({
+            "workspace_id": &workspace_id,
+            "tab_id": &tab_id,
+        }),
+    )
+    .await
+    {
+        return Err(e);
+    }
+    let ctx = SagaCtx::new(state, saga_id);
+    let result = run_saga("delete_tab", run_inner(ctx, workspace_id, tab_id)).await;
+    emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
+    result
+}
+
+async fn run_inner(
+    ctx: SagaCtx<'_>,
+    workspace_id: String,
+    tab_id: String,
+) -> Result<Value, String> {
+    // Step 1: dispatch DeleteTab through the reducer. The persist
+    // subscriber sees TabDeleted (and optional ActiveTabChanged) and
+    // runs `wcore::delete_tab` which cascades to blocks + layout +
+    // PTY controllers.
+    if let Err(reason) = ctx
+        .dispatch(Command::DeleteTab {
+            workspace_id: workspace_id.clone(),
+            tab_id: tab_id.clone(),
+        })
+        .await
+    {
+        // No automatic compensation. See module doc-comment for
+        // rationale.
+        tracing::warn!(
+            workspace_id = %workspace_id,
+            tab_id = %tab_id,
+            "[saga] DeleteTab dispatch failed (no automatic compensation): {}",
+            reason
+        );
+        return Err(format!("DeleteTab: {}", reason));
+    }
+
+    Ok(json!({
+        "workspace_id": workspace_id,
+        "tab_id": tab_id,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::obj::{Tab, Workspace};
+    use crate::server::tests::test_state;
+    use agentmux_common::ipc::Event;
+
+    async fn dispatch_apply(
+        state: &crate::server::AppState,
+        cmd: agentmux_common::ipc::Command,
+    ) -> Vec<agentmux_common::ipc::Event> {
+        let events = crate::server::service::dispatch_to_reducer(state, cmd).await;
+        for ev in &events {
+            crate::persist_subscriber::apply_event_to_wstore(ev, &state.wstore).unwrap();
+        }
+        events
+    }
+
+    /// Seed: a workspace with two tabs (last-tab guard requires >1).
+    /// Returns `(state, ws_id, tab_a_id, tab_b_id)`.
+    async fn seed_workspace_with_two_tabs() -> (
+        crate::server::AppState,
+        String,
+        String,
+        String,
+    ) {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let mut tab_ids = Vec::new();
+        for name in &["tab-a", "tab-b"] {
+            let tab_evs = dispatch_apply(
+                &state,
+                agentmux_common::ipc::Command::CreateTab {
+                    workspace_id: ws_id.clone(),
+                    name: name.to_string(),
+                },
+            )
+            .await;
+            tab_ids.push(
+                tab_evs
+                    .iter()
+                    .find_map(|e| match e {
+                        Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                        _ => None,
+                    })
+                    .unwrap(),
+            );
+        }
+        (state, ws_id, tab_ids[0].clone(), tab_ids[1].clone())
+    }
+
+    #[tokio::test]
+    async fn happy_path_removes_tab_from_reducer_and_sqlite() {
+        let (state, ws_id, tab_a, tab_b) = seed_workspace_with_two_tabs().await;
+
+        // Sanity: both tabs present pre-delete.
+        {
+            let s = state.srv_state.lock().await;
+            assert_eq!(s.workspaces[&ws_id].tab_ids, vec![tab_a.clone(), tab_b.clone()]);
+            assert!(s.tabs.contains_key(&tab_a));
+        }
+        assert!(state.wstore.get::<Tab>(&tab_a).unwrap().is_some());
+
+        let result = run(&state, ws_id.clone(), tab_a.clone()).await.unwrap();
+        assert_eq!(result["tab_id"], tab_a);
+        assert_eq!(result["workspace_id"], ws_id);
+
+        // Reducer: tab_a gone; workspace.tab_ids has only tab_b.
+        let s = state.srv_state.lock().await;
+        assert!(!s.tabs.contains_key(&tab_a));
+        assert_eq!(s.workspaces[&ws_id].tab_ids, vec![tab_b.clone()]);
+        drop(s);
+
+        // SQLite: tab gone; workspace.tabids reflects.
+        assert!(state.wstore.get::<Tab>(&tab_a).unwrap().is_none());
+        let ws_persist = state.wstore.get::<Workspace>(&ws_id).unwrap().unwrap();
+        assert_eq!(ws_persist.tabids, vec![tab_b]);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_workspace_not_found() {
+        let state = test_state();
+        let err = run(&state, "ghost-ws".into(), "ghost-tab".into())
+            .await
+            .unwrap_err();
+        assert!(err.contains("workspace not found"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn rejects_when_tab_not_in_workspace() {
+        let (state, ws_id, _tab_a, _tab_b) = seed_workspace_with_two_tabs().await;
+        let err = run(&state, ws_id, "ghost-tab".into()).await.unwrap_err();
+        assert!(err.contains("not in workspace"), "got: {}", err);
+    }
+
+    #[tokio::test]
+    async fn rejects_last_tab() {
+        let state = test_state();
+        let ws_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateWorkspace { name: "w".into() },
+        )
+        .await;
+        let ws_id = ws_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::WorkspaceCreated { workspace_id, .. } => Some(workspace_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let tab_evs = dispatch_apply(
+            &state,
+            agentmux_common::ipc::Command::CreateTab {
+                workspace_id: ws_id.clone(),
+                name: "only".into(),
+            },
+        )
+        .await;
+        let only_tab = tab_evs
+            .iter()
+            .find_map(|e| match e {
+                Event::TabCreated { tab_id, .. } => Some(tab_id.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let err = run(&state, ws_id, only_tab).await.unwrap_err();
+        assert!(err.contains("last tab"), "got: {}", err);
+    }
+}

--- a/agentmux-srv/src/sagas/delete_tab.rs
+++ b/agentmux-srv/src/sagas/delete_tab.rs
@@ -66,16 +66,20 @@ pub async fn run(
     workspace_id: String,
     tab_id: String,
 ) -> Result<Value, String> {
-    // Pre-conditions: tab exists in workspace.
+    // Pre-conditions: tab exists in workspace; not the last tab.
     //
-    // (reagent P1 PR #633.) The last-tab guard is now ENFORCED IN
-    // THE REDUCER (`reducer::handle_delete_tab`) so check + delete
-    // is atomic with the state lock. The earlier pre-check version
-    // had a TOCTOU window: read state under lock, drop lock,
-    // dispatch re-acquires — two concurrent CloseTab RPCs in a
-    // 2-tab workspace could both pass and both succeed. The reducer
-    // now rejects with `Event::Error` if `tab_ids.len() <= 1`, and
-    // `SagaCtx::dispatch` surfaces that as the saga's Err return.
+    // **Last-tab pre-check is best-effort.** A reducer-level guard
+    // would be atomic but it broke legitimate CreateTab compensation
+    // (codex P1 round 2 #633) and frontend keyboard flow (codex P1
+    // round 1 #633). Round 3 walked back the reducer guard. The
+    // saga keeps a soft pre-check here as a UX guard; the TOCTOU
+    // window (two concurrent CloseTabs on different tabs in a 2-tab
+    // workspace) is reachable in theory but the user-facing call
+    // sites (tabbar close button at `tabbar.tsx:63`, keyboard handler
+    // at `keymodel.ts::simpleCloseStaticTab`) gate with
+    // `if (allTabs.length <= 1) return`, so user-driven concurrent
+    // CloseTabs can't reach this saga. Automated test harnesses
+    // could still race; document the limitation, accept it.
     {
         let s = state.srv_state.lock().await;
         let Some(workspace) = s.workspaces.get(&workspace_id) else {
@@ -88,6 +92,12 @@ pub async fn run(
             return Err(format!(
                 "DeleteTab: tab {} is not in workspace {}",
                 tab_id, workspace_id
+            ));
+        }
+        if workspace.tab_ids.len() <= 1 {
+            return Err(format!(
+                "DeleteTab: cannot delete last tab in workspace {}",
+                workspace_id
             ));
         }
         if !s.tabs.contains_key(&tab_id) {

--- a/agentmux-srv/src/sagas/delete_tab.rs
+++ b/agentmux-srv/src/sagas/delete_tab.rs
@@ -108,6 +108,18 @@ pub async fn run(
         }
     }
 
+    // Capture the tab's block_ids before dispatch — we'll use these
+    // to clean up PTY controllers if the saga partially succeeds
+    // (reducer dispatched, SQLite apply failed). (codex P2 PR #633
+    // round 3.)
+    let block_ids_to_cleanup: Vec<String> = {
+        let s = state.srv_state.lock().await;
+        s.tabs
+            .get(&tab_id)
+            .map(|t| t.block_ids.clone())
+            .unwrap_or_default()
+    };
+
     let saga_id = alloc_saga_id(state);
     if let Err(e) = emit_saga_started(
         state,
@@ -123,7 +135,20 @@ pub async fn run(
         return Err(e);
     }
     let ctx = SagaCtx::new(state, saga_id);
-    let result = run_saga("delete_tab", run_inner(ctx, workspace_id, tab_id)).await;
+    let result = run_saga("delete_tab", run_inner(ctx, workspace_id, tab_id.clone())).await;
+    // If the tab is gone from reducer state, the reducer dispatched
+    // (whether or not SQLite apply succeeded). Kill controllers for
+    // every block that was in the tab. Idempotent on missing
+    // controllers. Same pattern as `delete_block::run` (codex P2
+    // round 2 + 3).
+    {
+        let tab_still_in_reducer = state.srv_state.lock().await.tabs.contains_key(&tab_id);
+        if !tab_still_in_reducer {
+            for block_id in &block_ids_to_cleanup {
+                crate::backend::blockcontroller::delete_controller(block_id);
+            }
+        }
+    }
     emit_terminal(state, saga_id, classify_run_saga_result(&result)).await;
     result
 }

--- a/agentmux-srv/src/sagas/delete_tab.rs
+++ b/agentmux-srv/src/sagas/delete_tab.rs
@@ -166,6 +166,9 @@ async fn run_inner(
         .dispatch(Command::DeleteTab {
             workspace_id: workspace_id.clone(),
             tab_id: tab_id.clone(),
+            // User-facing flow — reducer enforces last-tab guard
+            // atomically (codex P2 round 4 PR #633).
+            force: false,
         })
         .await
     {

--- a/agentmux-srv/src/sagas/mod.rs
+++ b/agentmux-srv/src/sagas/mod.rs
@@ -41,6 +41,8 @@
 //   (gap; Phase F).
 // * Saga state across srv restart (gap; Phase F+).
 
+pub mod delete_block;
+pub mod delete_tab;
 pub mod log;
 pub mod promote_block_to_tab;
 pub mod restore_torn_off_tab;

--- a/agentmux-srv/src/sagas/promote_block_to_tab.rs
+++ b/agentmux-srv/src/sagas/promote_block_to_tab.rs
@@ -128,9 +128,13 @@ async fn run_inner(
         .await
     {
         // Compensate: delete the empty new tab.
+        // force=true so the last-tab guard doesn't reject when the
+        // workspace ends up with this single just-created tab
+        // (codex P1 round 2 PR #633).
         ctx.compensate(Command::DeleteTab {
             workspace_id: workspace_id.clone(),
             tab_id: new_tab_id.clone(),
+            force: true,
         })
         .await;
         return Err(format!("PromoteBlockToTab step 2 (MoveBlock): {}", reason));

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -1038,6 +1038,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                         agentmux_common::ipc::Command::DeleteTab {
                             workspace_id: ws_id.clone(),
                             tab_id: tid.clone(),
+                            // Compensation must bypass the last-tab
+                            // guard to roll back a just-created sole
+                            // tab when its persist failed (codex P1
+                            // round 2 + P2 round 4 PR #633).
+                            force: true,
                         },
                         store,
                     )
@@ -1433,6 +1438,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                             agentmux_common::ipc::Command::DeleteTab {
                                 workspace_id: ws_id.clone(),
                                 tab_id: source_tab_id.clone(),
+                                // Auto-close already gated on
+                                // `total_tabs > 1` above; reducer's
+                                // last-tab guard is defense-in-depth
+                                // for the race window.
+                                force: false,
                             },
                         )
                         .await;
@@ -1548,6 +1558,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                             agentmux_common::ipc::Command::DeleteTab {
                                 workspace_id: ws_id.clone(),
                                 tab_id: source_tab_id.clone(),
+                                // Auto-close already gated on
+                                // `total_tabs > 1` above; reducer's
+                                // last-tab guard is defense-in-depth
+                                // for the race window.
+                                force: false,
                             },
                         )
                         .await;
@@ -1911,6 +1926,9 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                             agentmux_common::ipc::Command::DeleteTab {
                                 workspace_id: source_ws_id.clone(),
                                 tab_id: source_tab_id.clone(),
+                                // Auto-close already gated on
+                                // total_tabs > 1.
+                                force: false,
                             },
                         )
                         .await;

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -192,9 +192,12 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 ),
             }
         }
-        // Phase E.2c.4 — DeleteBlock SQLite-first via wcore (cascades
-        // for PTY/controller already handled before the wcore call),
-        // then dispatch reducer's DeleteBlock to keep state in sync.
+        // Phase E.5.7 (Step 5 PR 1) — DeleteBlock saga. The legacy
+        // SQLite-first pattern (wcore::delete_block + reducer-sync
+        // dispatch) is replaced by `sagas::delete_block::run`, which
+        // routes through the reducer + persist subscriber. The saga
+        // also handles the controller-kill cascade (matches the old
+        // ordering: controller down → reducer dispatch → SQLite).
         ("object", "DeleteBlock") => {
             let tab_id = match call
                 .uicontext
@@ -208,24 +211,9 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            // Stop and remove the block controller before removing from DB so the PTY
-            // and child process are torn down and the registry entry is cleared
-            // regardless of DB outcome.
-            blockcontroller::delete_controller(&block_id);
-            if let Err(e) = wcore::delete_block(store, &tab_id, &block_id) {
-                return WebReturnType::error(e.to_string());
+            if let Err(reason) = crate::sagas::delete_block::run(state, tab_id, block_id).await {
+                return WebReturnType::error(reason);
             }
-            // Reducer dispatch is silent on missing — safe to call
-            // unconditionally now that SQLite is consistent.
-            let events = dispatch_to_reducer(
-                state,
-                agentmux_common::ipc::Command::DeleteBlock {
-                    tab_id: tab_id.clone(),
-                    block_id: block_id.clone(),
-                },
-            )
-            .await;
-            publish_events(state, &events);
             WebReturnType::success_empty()
         }
         ("object", "UpdateObject") => {
@@ -1225,12 +1213,15 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 WebReturnType::success_empty()
             }
         }
-        // Phase E.2c.3b — CloseTab applies SQLite first via wcore
-        // (cascades to blocks + layouts), then dispatches the
-        // reducer's DeleteTab to keep state in sync. Same SQLite-
-        // first pattern as DeleteWorkspace — Delete cascades touch
-        // many records and rolling back the reducer on a partial
-        // wcore failure is impractical.
+        // Phase E.5.7 (Step 5 PR 1) — CloseTab via DeleteTab saga.
+        // Replaces the legacy SQLite-first pattern (wcore::delete_tab
+        // followed by reducer-sync dispatch) with a saga-driven
+        // reducer + persist-subscriber flow. The saga also enforces
+        // the not-the-last-tab pre-condition mirrored from
+        // TearOffTab; user-facing CloseTab now refuses to drain a
+        // workspace to zero tabs (callers wanting full teardown
+        // should issue DeleteWorkspace instead — that path migrates
+        // in Step 5 PR 2).
         ("workspace", "CloseTab") => {
             let ws_id: String = match service::get_arg(args, 0) {
                 Ok(v) => v,
@@ -1240,20 +1231,11 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                 Ok(v) => v,
                 Err(e) => return WebReturnType::error(e),
             };
-            if let Err(e) = wcore::delete_tab(store, &ws_id, &tab_id) {
-                return WebReturnType::error(e.to_string());
+            if let Err(reason) =
+                crate::sagas::delete_tab::run(state, ws_id.clone(), tab_id.clone()).await
+            {
+                return WebReturnType::error(reason);
             }
-            // Reducer dispatch is silent on missing — safe to call
-            // unconditionally now that SQLite is consistent.
-            let events = dispatch_to_reducer(
-                state,
-                agentmux_common::ipc::Command::DeleteTab {
-                    workspace_id: ws_id.clone(),
-                    tab_id: tab_id.clone(),
-                },
-            )
-            .await;
-            publish_events(state, &events);
             let rtn = CloseTabRtnType {
                 closewindow: false,
                 newactivetabid: String::new(),

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -155,6 +155,15 @@ function simpleCloseStaticTab() {
     debugLog("simpleCloseStaticTab called");
     const ws = atoms.workspace();
     const tabId = atoms.activeTabId();
+    // Guard: don't close the only tab. Mirrors the same check in the
+    // tabbar close button (`tabbar.tsx:63`). Without this gate, the
+    // backend rejects the CloseTab as "last tab" but
+    // `deleteLayoutModelForTab` still runs unconditionally, leaving
+    // client/server diverged. (reagent P1 round 2 PR #633.)
+    const allTabs = (ws.tabids ?? []).concat(ws.pinnedtabids ?? []);
+    if (allTabs.length <= 1) {
+        return;
+    }
     WorkspaceService.CloseTab(ws.oid, tabId).catch((e) => {
         console.error("[closeTab] failed:", e);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.543",
+  "version": "0.33.544",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.543",
+      "version": "0.33.544",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.545",
+  "version": "0.33.546",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.545",
+      "version": "0.33.546",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.544",
+  "version": "0.33.545",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.544",
+      "version": "0.33.545",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.547",
+  "version": "0.33.548",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.547",
+      "version": "0.33.548",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.546",
+  "version": "0.33.547",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.546",
+      "version": "0.33.547",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.543",
+  "version": "0.33.544",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.546",
+  "version": "0.33.547",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.544",
+  "version": "0.33.545",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.547",
+  "version": "0.33.548",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.545",
+  "version": "0.33.546",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Step 5 (PR 1 of 2) of the architecture-completeness plan. Converts the
SQLite-first DeleteBlock + DeleteTab paths into proper sagas through
the reducer + persist subscriber. DeleteWorkspace ships in PR 2 of
this step (cascade-heavy, deserves its own review focus).

Closes (partial): [reducer-architecture-gaps §4 SQLite-first deletes](../blob/main/docs/retro/reducer-architecture-gaps-2026-05-01.md).

Plan: \`docs/retro/next-steps-architecture-completeness-2026-05-01.md\` step 5.

## What changed

- New: \`agentmux-srv/src/sagas/delete_block.rs\` (~140 LOC + tests)
- New: \`agentmux-srv/src/sagas/delete_tab.rs\` (~150 LOC + tests)
- Modified: \`service.rs\` — \`("object", "DeleteBlock")\` and \`("workspace", "CloseTab")\` RPCs route through new sagas. Other in-tree call-sites of \`Command::DeleteTab\` (auto-close in MoveBlockToTab / PromoteBlockToTab cleanup paths, etc.) are out of scope per the brief.
- Modified: \`sagas/mod.rs\` — register new modules.

## Saga shape

Both sagas use the existing \`SagaCtx::dispatch\` (which now writes to the durable saga log under the hood, transparent — landed via PR #631). Steps:

- **DeleteBlock** — pre-check (block exists, in expected tab) → drop block controller (PTY/process subtree, idempotent on missing) → \`SagaCtx::dispatch(DeleteBlock)\`. Persist subscriber's \`apply_block_deleted\` runs \`wcore::delete_block\` (SQLite + layout prune).
- **DeleteTab** — pre-check (tab exists in workspace, **not the last tab**) → \`SagaCtx::dispatch(DeleteTab)\`. Persist subscriber's \`apply_tab_deleted\` runs \`wcore::delete_tab\` which cascades to blocks + layout + per-block PTY controllers.

## Last-tab guard (DeleteTab)

The legacy \`("workspace", "CloseTab")\` handler did not enforce a last-tab guard; the saga adds one, mirroring \`TearOffTab\`. Rationale: leaving a workspace with zero tabs is awkward UI state, and callers who want full teardown should issue \`DeleteWorkspace\` (Step 5 PR 2). Auto-close paths inside MoveBlockToTab / PromoteBlockToTab already gate on \`total_tabs > 1\` and stay on direct \`Command::DeleteTab\` dispatch (out of scope per brief), so no internal regression.

## Compensation

Delete sagas are awkward to compensate (un-delete is rarely clean). Approach:
- DeleteBlock: log warning on failure, no automatic re-create.
- DeleteTab: same.
- DeleteWorkspace (PR 2 follow-up): cascade is the hard part, compensation strategy gets dedicated review there.

## Test plan

- [x] \`cargo check -p agentmux-srv\` clean
- [x] \`cargo test -p agentmux-srv --bin agentmux-srv sagas::\` — 28/28 passing (existing 21 + 7 new: 3 \`delete_block\` + 4 \`delete_tab\`)
- [ ] Smoke: delete a block in UI, verify cascade events emit + SQLite state correct
- [ ] Smoke: delete a tab, verify same

🤖 Generated with [Claude Code](https://claude.com/claude-code)