### PR TITLE
feat(F.6): window-cleanup cascade saga

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.551"
+version = "0.33.552"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.551"
+version = "0.33.552"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.551"
+version = "0.33.552"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.551"
+version = "0.33.552"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.552"
+version = "0.33.553"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.552"
+version = "0.33.553"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.552"
+version = "0.33.553"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.552"
+version = "0.33.553"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.550"
+version = "0.33.551"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.550"
+version = "0.33.551"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.550"
+version = "0.33.551"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.550"
+version = "0.33.551"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.555"
+version = "0.33.556"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.555"
+version = "0.33.556"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.555"
+version = "0.33.556"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.555"
+version = "0.33.556"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.556"
+version = "0.33.557"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.556"
+version = "0.33.557"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.556"
+version = "0.33.557"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.556"
+version = "0.33.557"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.553"
+version = "0.33.554"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.553"
+version = "0.33.554"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.553"
+version = "0.33.554"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.553"
+version = "0.33.554"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.554"
+version = "0.33.555"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.554"
+version = "0.33.555"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.554"
+version = "0.33.555"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.554"
+version = "0.33.555"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.553"
+version = "0.33.554"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.555"
+version = "0.33.556"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.551"
+version = "0.33.552"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.552"
+version = "0.33.553"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.556"
+version = "0.33.557"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.554"
+version = "0.33.555"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.550"
+version = "0.33.551"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -523,8 +523,17 @@ impl AgentMuxHandler {
         // top-level windows; emitting `PanesReaped` for pane labels
         // would be a stray report (no in-flight saga to consume it).
         // Same gate as `report_window_closed` above.
+        // (codex P2 PR #637 round 3.) Also exclude `window-pool-*` —
+        // unpromoted pool windows are not mirrored as windows
+        // (`report_window_opened` skips them at client.rs:276) and
+        // `ReportWindowClosed` for unknown labels is intentionally
+        // dropped by the launcher reducer. Without this gate, F.6
+        // would broadcast `PanesReaped` (and `PoolDrained|PoolNotLast`
+        // below) for pool drain with no matching `WindowClosed`
+        // trigger, producing stray cleanup-terminal events outside
+        // any saga bracket.
         if let Some(ref lbl) = label {
-            if !lbl.starts_with("browser-pane-") {
+            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
                 crate::launcher_ipc::report_panes_reaped(lbl.clone());
             }
         }
@@ -603,7 +612,9 @@ impl AgentMuxHandler {
         // not have started yet by the time the report is sent, but
         // the decision itself is final.
         if let Some(ref lbl) = label {
-            if !lbl.starts_with("browser-pane-") {
+            // Also exclude `window-pool-*` per codex P2 PR #637 round 3
+            // — same rationale as report_panes_reaped above.
+            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
                 let was_last = user_browser_count == 0 && !self.is_pane;
                 crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);
             }

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -522,18 +522,17 @@ impl AgentMuxHandler {
         // `Event::WindowClosed`, which only fires for non-pane
         // top-level windows; emitting `PanesReaped` for pane labels
         // would be a stray report (no in-flight saga to consume it).
-        // Same gate as `report_window_closed` above.
-        // (codex P2 PR #637 round 3.) Also exclude `window-pool-*` —
-        // unpromoted pool windows are not mirrored as windows
-        // (`report_window_opened` skips them at client.rs:276) and
-        // `ReportWindowClosed` for unknown labels is intentionally
-        // dropped by the launcher reducer. Without this gate, F.6
-        // would broadcast `PanesReaped` (and `PoolDrained|PoolNotLast`
-        // below) for pool drain with no matching `WindowClosed`
-        // trigger, producing stray cleanup-terminal events outside
-        // any saga bracket.
+        // Same gate as `report_window_closed` above. Pool-window
+        // discrimination (unpromoted pool drain vs promoted tear-off
+        // close) is done LAUNCHER-side — see
+        // `handle_report_panes_reaped` in `agentmux-launcher/src/reducer.rs`,
+        // which gates the typed event emission on whether the label
+        // is in `state.windows`. Filtering here on prefix would
+        // wrongly suppress promoted pool windows (which keep the
+        // `window-pool-*` prefix but ARE tracked windows; codex P1
+        // PR #637 round 3).
         if let Some(ref lbl) = label {
-            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
+            if !lbl.starts_with("browser-pane-") {
                 crate::launcher_ipc::report_panes_reaped(lbl.clone());
             }
         }
@@ -612,9 +611,10 @@ impl AgentMuxHandler {
         // not have started yet by the time the report is sent, but
         // the decision itself is final.
         if let Some(ref lbl) = label {
-            // Also exclude `window-pool-*` per codex P2 PR #637 round 3
-            // — same rationale as report_panes_reaped above.
-            if !lbl.starts_with("browser-pane-") && !lbl.starts_with("window-pool-") {
+            // Pool-window discrimination is launcher-side (see
+            // report_panes_reaped above); filtering on prefix here
+            // would suppress promoted pool windows.
+            if !lbl.starts_with("browser-pane-") {
                 let was_last = user_browser_count == 0 && !self.is_pane;
                 crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);
             }

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -522,15 +522,13 @@ impl AgentMuxHandler {
         // `Event::WindowClosed`, which only fires for non-pane
         // top-level windows; emitting `PanesReaped` for pane labels
         // would be a stray report (no in-flight saga to consume it).
-        // Same gate as `report_window_closed` above. Pool-window
-        // discrimination (unpromoted pool drain vs promoted tear-off
-        // close) is done LAUNCHER-side — see
-        // `handle_report_panes_reaped` in `agentmux-launcher/src/reducer.rs`,
-        // which gates the typed event emission on whether the label
-        // is in `state.windows`. Filtering here on prefix would
+        // Same gate as `report_window_closed` above — skip
+        // browser-pane-* labels (sub-views, not top-level windows).
+        // Don't filter window-pool-* here: filtering on prefix would
         // wrongly suppress promoted pool windows (which keep the
-        // `window-pool-*` prefix but ARE tracked windows; codex P1
-        // PR #637 round 3).
+        // `window-pool-*` prefix but ARE tracked windows). Stray
+        // events for unpromoted-pool drains are emitted but harmless
+        // — no F.6 saga is in flight to consume them.
         if let Some(ref lbl) = label {
             if !lbl.starts_with("browser-pane-") {
                 crate::launcher_ipc::report_panes_reaped(lbl.clone());
@@ -611,9 +609,9 @@ impl AgentMuxHandler {
         // not have started yet by the time the report is sent, but
         // the decision itself is final.
         if let Some(ref lbl) = label {
-            // Pool-window discrimination is launcher-side (see
-            // report_panes_reaped above); filtering on prefix here
-            // would suppress promoted pool windows.
+            // Same gate as report_panes_reaped above: skip
+            // browser-pane-* only. window-pool-* labels (promoted)
+            // are tracked windows and need their cleanup events.
             if !lbl.starts_with("browser-pane-") {
                 let was_last = user_browser_count == 0 && !self.is_pane;
                 crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -511,6 +511,24 @@ impl AgentMuxHandler {
             }
         }
 
+        // Phase F.6 — narrate the pane-reap step for the launcher's
+        // window-cleanup-cascade saga. By the time we reach here, the
+        // pane lifecycle drain (`on_before_close_pane` for browser-
+        // pane labels) and the subwindow cascade above have run for
+        // this label. The saga uses this signal as the Step 1
+        // terminal so it can advance to Step 2 (drain-pool decision).
+        //
+        // Skip for browser-pane labels: the saga is triggered by
+        // `Event::WindowClosed`, which only fires for non-pane
+        // top-level windows; emitting `PanesReaped` for pane labels
+        // would be a stray report (no in-flight saga to consume it).
+        // Same gate as `report_window_closed` above.
+        if let Some(ref lbl) = label {
+            if !lbl.starts_with("browser-pane-") {
+                crate::launcher_ipc::report_panes_reaped(lbl.clone());
+            }
+        }
+
         dlog(&format!("backend_window_id: {:?}", backend_window_id));
 
         if let Some(index) = self
@@ -562,6 +580,34 @@ impl AgentMuxHandler {
             "[trace] app-exit gate: closing_label={:?} user_count={} is_pane={} browsers={:?} unpromoted_pool={:?}",
             label, user_browser_count, self.is_pane, browsers_keys, pool_keys
         );
+
+        // Phase F.6 — narrate the post-close pool-drain decision for
+        // the launcher's window-cleanup-cascade saga. The saga's
+        // Step 2 terminal: `was_last == true` → `Event::PoolDrained`
+        // (the wrr two-stage cascade below kicked off Stage 1's
+        // pool drain); `was_last == false` → `Event::PoolNotLast`
+        // (other windows remain; pool stays warm). Both close the
+        // saga's `SagaStarted` bracket successfully — the saga's job
+        // is to narrate the decision, not enforce a particular
+        // outcome.
+        //
+        // Same skip-pane gate as `report_panes_reaped` above: the
+        // saga is triggered by `Event::WindowClosed`, which only
+        // fires for non-pane top-level windows. Pane closes don't
+        // start a saga, so the report would be a no-op stray on the
+        // bus.
+        //
+        // Computed here (BEFORE the wrr two-stage cascade below) so
+        // the same condition the cascade gates on is what gets
+        // reported. The boolean flag captures intent — Stage 1 may
+        // not have started yet by the time the report is sent, but
+        // the decision itself is final.
+        if let Some(ref lbl) = label {
+            if !lbl.starts_with("browser-pane-") {
+                let was_last = user_browser_count == 0 && !self.is_pane;
+                crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);
+            }
+        }
 
         // ── Phase B.9.3 — two-stage close cascade ─────────────────
         //

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -462,6 +462,58 @@ pub fn report_pool_window_promoted(label: String) {
     }
 }
 
+/// Phase F.6 — sync API: tell the launcher that all browser-pane
+/// HWNDs belonging to a closing top-level window have been reaped
+/// (lifecycle entries drained, pane HWND map cleared, subwindow
+/// cascade closes initiated). Sent from `client.rs::on_before_close`
+/// AFTER the pane drain step, BEFORE the post-close pool-drain
+/// decision is reported.
+///
+/// The launcher's window-cleanup-cascade saga uses this as the
+/// Step 1 → Step 2 transition signal: it marks the implicit pane
+/// reap as observed and lets the saga issue its `DrainPoolIfLast`
+/// IssueCmd (currently log-only — see `saga/window_cleanup.rs`
+/// module docstring for the saga-as-narrator scope decision).
+///
+/// Same no-op-if-disconnected semantics as the other `report_*`
+/// helpers; `task dev` mode silently drops.
+pub fn report_panes_reaped(label: String) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportPanesReaped { label };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!("[launcher-ipc] report_panes_reaped: channel closed ({})", e);
+    }
+}
+
+/// Phase F.6 — sync API: tell the launcher the result of the
+/// post-close drain-pool-if-last decision. `was_last == true` when
+/// the closing window was the last user-visible window (Stage 1 of
+/// the wrr two-stage close cascade just kicked off in
+/// `client.rs::on_before_close`); `false` when other windows
+/// remain and the warm pool stays warm.
+///
+/// Step 2 terminal signal for the launcher's
+/// window-cleanup-cascade saga. Both branches close the
+/// `SagaStarted` bracket successfully — the saga's job is to
+/// narrate the decision, not enforce a particular outcome.
+///
+/// Same no-op-if-disconnected semantics as the other `report_*`
+/// helpers.
+pub fn report_pool_drain_decision(label: String, was_last: bool) {
+    let Some(tx) = COMMAND_TX.get() else {
+        return;
+    };
+    let cmd = Command::ReportPoolDrainDecision { label, was_last };
+    if let Err(e) = tx.send(cmd) {
+        tracing::warn!(
+            "[launcher-ipc] report_pool_drain_decision: channel closed ({})",
+            e
+        );
+    }
+}
+
 /// Phase B.4 follow-up — sync API: report the host's current
 /// authoritative counts so the launcher reducer can compare against
 /// its mirror and emit `Event::DriftDetected` on mismatch. Callers

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.553"
+version = "0.33.554"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.556"
+version = "0.33.557"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.555"
+version = "0.33.556"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.551"
+version = "0.33.552"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.554"
+version = "0.33.555"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.552"
+version = "0.33.553"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.550"
+version = "0.33.551"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -656,6 +656,19 @@ pub enum Event {
     WindowClosed {
         label: String,
         version: u64,
+        /// (codex P1 PR #637.) `true` when the close was detected by
+        /// `wrr::apply_hwnd_destroyed` after a host/renderer crash —
+        /// no clean `on_before_close` ran, so the host did NOT send
+        /// the `ReportPanesReaped` / `ReportPoolDrainDecision` reports
+        /// the F.6 saga waits for. Subscribers that drive
+        /// cleanup-cascade sagas must filter on `!crash_detected` to
+        /// avoid spawning an in-flight saga that can never reach a
+        /// terminal state.
+        ///
+        /// `#[serde(default)]` so pre-existing producers default to
+        /// `false` (clean close).
+        #[serde(default)]
+        crash_detected: bool,
     },
     /// Phase B.4 follow-up — pool inventory transitioned. Emitted in
     /// response to `ReportPoolWindow{Added,Removed}`. Subscribers

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -491,6 +491,67 @@ pub enum Command {
     /// the cross-process command dispatch follow-up) replaces the
     /// log with a real wire-level send.
     SpawnPoolWindow,
+    /// Phase F.6 — host reports that all browser-pane HWNDs belonging
+    /// to a closing top-level window have been reaped. Emitted from
+    /// `client.rs::on_before_close` after the subwindow cascade and
+    /// pane lifecycle drain finish for the closing window.
+    ///
+    /// Distinct from `ReportWindowClosed` — that event marks the
+    /// CEF browser leaving the host's `browsers` map; this one marks
+    /// the host's pane bookkeeping (lifecycle entries, pane HWND map)
+    /// for that label being fully drained. Today both happen in the
+    /// same `on_before_close` body so the events arrive back-to-back,
+    /// but the saga distinguishes them so future fine-grained
+    /// reapers (e.g. async pane teardown for embedded browsers) can
+    /// land without rewriting the saga.
+    ///
+    /// Host-only — same gate as `ReportWindowClosed`.
+    ReportPanesReaped {
+        label: String,
+    },
+    /// Phase F.6 — host reports the result of the post-close
+    /// drain-pool-if-last decision. `was_last == true` when the
+    /// closing window was the last user-visible window and the host
+    /// just kicked off the warm-pool drain (Stage 1 of the two-stage
+    /// close cascade in `client.rs::on_before_close`); `false` when
+    /// other user-visible windows remain and the pool stays warm.
+    ///
+    /// The launcher's window-cleanup-cascade saga uses this to close
+    /// out its bracket regardless of which branch fires (both are
+    /// terminal for the saga).
+    ///
+    /// Host-only.
+    ReportPoolDrainDecision {
+        label: String,
+        was_last: bool,
+    },
+    /// Phase F.6 — launcher-side saga coordinator asks the host to
+    /// reap all browser-pane HWNDs for a window that just closed.
+    ///
+    /// **F.6 status: framework-only.** Same as `SpawnPoolWindow` in
+    /// F.5: no launcher→host command pipe exists yet. The saga
+    /// issues this with `target = PipeTarget::Host` for forward
+    /// compatibility; the coordinator's IssueCmd handler logs the
+    /// dispatch without transmitting. The host's existing implicit
+    /// pane drain inside `on_before_close` produces the
+    /// `Event::PanesReaped` the saga waits for. F.7 / cross-process
+    /// dispatch follow-up replaces the log with a real wire send.
+    ReapPanes {
+        label: String,
+    },
+    /// Phase F.6 — launcher-side saga coordinator asks the host to
+    /// drain the warm pool if the just-closed window was the last
+    /// user-visible window (i.e. trigger Stage 1 of the close
+    /// cascade).
+    ///
+    /// **F.6 status: framework-only** (same caveat as `ReapPanes`).
+    /// Today the host's `on_before_close` already runs the equivalent
+    /// inline check; the saga relies on the resulting
+    /// `Event::PoolDrained` / `Event::PoolNotLast` to close its
+    /// bracket.
+    DrainPoolIfLast {
+        label: String,
+    },
 }
 
 /// Phase B.9.1 — rectangle in Win32 screen coordinates (pixels).
@@ -620,6 +681,39 @@ pub enum Event {
     /// fires on pre-promote destroy (closing without promoting), where
     /// no refill saga should run.
     PoolWindowPromoted {
+        label: String,
+        version: u64,
+    },
+    /// Phase F.6 — emitted by the launcher when the host reports that
+    /// all browser-pane HWNDs belonging to a closing top-level window
+    /// have been reaped (`Command::ReportPanesReaped`). Step-1
+    /// terminal signal for the window-cleanup-cascade saga.
+    PanesReaped {
+        label: String,
+        version: u64,
+    },
+    /// Phase F.6 — emitted by the launcher when the host reports it
+    /// kicked off Stage 1 of the close-cascade pool drain (i.e. the
+    /// just-closed window was the last user-visible window).
+    /// Step-2 terminal signal (success branch) for the
+    /// window-cleanup-cascade saga.
+    ///
+    /// "Drained" here means "drain initiated"; the actual pool
+    /// teardown is async and surfaces as a series of
+    /// `PoolWindowRemoved` events as each pool browser's
+    /// `on_before_close` fires. The saga doesn't wait for those —
+    /// the bracket closes when drain is *decided*, not when it
+    /// completes.
+    PoolDrained {
+        label: String,
+        version: u64,
+    },
+    /// Phase F.6 — emitted by the launcher when the host reports a
+    /// close that did NOT trigger a pool drain (other user-visible
+    /// windows remain). Step-2 terminal signal (no-op branch) for
+    /// the window-cleanup-cascade saga; the bracket closes
+    /// successfully because nothing further is needed.
+    PoolNotLast {
         label: String,
         version: u64,
     },

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.551"
+version = "0.33.552"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.552"
+version = "0.33.553"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.556"
+version = "0.33.557"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.553"
+version = "0.33.554"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.554"
+version = "0.33.555"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.555"
+version = "0.33.556"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.550"
+version = "0.33.551"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -671,8 +671,8 @@ fn format_event(e: &Event) -> String {
             "v={:>3} WindowOpened       label={} kind={:?} parent={:?}",
             version, label, kind, parent_label
         ),
-        Event::WindowClosed { label, version } => format!(
-            "v={:>3} WindowClosed       label={}", version, label
+        Event::WindowClosed { label, version, crash_detected } => format!(
+            "v={:>3} WindowClosed       label={} crash_detected={}", version, label, crash_detected
         ),
         Event::WindowInstanceAssigned { label, num, version } => format!(
             "v={:>3} InstanceAssigned   label={} num={}", version, label, num

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -253,6 +253,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::PoolWindowAdded { version, .. }
         | Event::PoolWindowRemoved { version, .. }
         | Event::PoolWindowPromoted { version, .. }
+        | Event::PanesReaped { version, .. }
+        | Event::PoolDrained { version, .. }
+        | Event::PoolNotLast { version, .. }
         | Event::WindowInstanceAssigned { version, .. }
         | Event::WindowInstanceReleased { version, .. }
         | Event::BackendWindowIdRegistered { version, .. }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -595,6 +595,22 @@ async fn enforce_register_first(
         Command::SpawnPoolWindow => {
             ("SpawnPoolWindow is a launcher→host command; sent to launcher pipe by mistake".to_string(), false)
         }
+        // Phase F.6 — host-only reports; same fatal-before-Register
+        // treatment as the other window-mirror reports above.
+        Command::ReportPanesReaped { .. } => {
+            ("ReportPanesReaped before Register".to_string(), true)
+        }
+        Command::ReportPoolDrainDecision { .. } => {
+            ("ReportPoolDrainDecision before Register".to_string(), true)
+        }
+        // Phase F.6 — launcher→host direction commands. Same
+        // soft-error treatment as `SpawnPoolWindow` above.
+        Command::ReapPanes { .. } => {
+            ("ReapPanes is a launcher→host command; sent to launcher pipe by mistake".to_string(), false)
+        }
+        Command::DrainPoolIfLast { .. } => {
+            ("DrainPoolIfLast is a launcher→host command; sent to launcher pipe by mistake".to_string(), false)
+        }
         Command::ReportHostCounts { .. } => {
             ("ReportHostCounts before Register".to_string(), true)
         }

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -648,11 +648,10 @@ fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
     // confuse subscribers. Mirrors the silent-drop pattern in
     // `handle_report_window_closed` for unknown labels.
     if !state.windows.contains_key(&label) {
-        tracing::debug!(
-            target: "saga.f6",
-            label = %label,
-            "[saga] panes_reaped: dropping report for untracked label (unpromoted pool)"
-        );
+        crate::log(&format!(
+            "[saga] panes_reaped: dropping report for untracked label '{}' (unpromoted pool)",
+            label
+        ));
         return Vec::new();
     }
     let v = state.bump_version();
@@ -677,11 +676,10 @@ fn handle_report_pool_drain_decision(
     // Same gating as `handle_report_panes_reaped` — drop reports for
     // untracked labels (unpromoted pool drains).
     if !state.windows.contains_key(&label) {
-        tracing::debug!(
-            target: "saga.f6",
-            label = %label,
-            "[saga] pool_drain_decision: dropping report for untracked label (unpromoted pool)"
-        );
+        crate::log(&format!(
+            "[saga] pool_drain_decision: dropping report for untracked label '{}' (unpromoted pool)",
+            label
+        ));
         return Vec::new();
     }
     let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -640,20 +640,16 @@ fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<E
 /// its own `closed_label`, so a stray report for a label that no
 /// in-flight saga is tracking is a harmless broadcast.
 fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
-    // (codex P1 PR #637 round 3.) Discriminate promoted pool windows
-    // (tracked in `state.windows`, F.6 saga ran on their WindowClosed)
-    // from unpromoted pool drains (NOT in `state.windows`, no saga
-    // started). For untracked labels, emit nothing — the typed event
-    // would otherwise appear outside any SagaStarted bracket and
-    // confuse subscribers. Mirrors the silent-drop pattern in
-    // `handle_report_window_closed` for unknown labels.
-    if !state.windows.contains_key(&label) {
-        crate::log(&format!(
-            "[saga] panes_reaped: dropping report for untracked label '{}' (unpromoted pool)",
-            label
-        ));
-        return Vec::new();
-    }
+    // No state.windows gate — round 4's gate had an ordering bug:
+    // host sends ReportWindowClosed BEFORE ReportPanesReaped on the
+    // same channel, so by the time the reducer processes this, the
+    // label is already gone from state.windows (closed by the prior
+    // command's reducer arm). The gate then dropped EVERY
+    // PanesReaped, leaving the F.6 saga stuck in WaitingForPanesReaped
+    // indefinitely. Round 5 reversal: emit unconditionally; for
+    // unpromoted-pool drains where no saga is in flight, the event
+    // appears stray on the bus but is harmless (no subscriber acts
+    // on it). Cosmetic only; correct saga lifecycle restored.
     let v = state.bump_version();
     vec![Event::PanesReaped { label, version: v }]
 }
@@ -673,15 +669,8 @@ fn handle_report_pool_drain_decision(
     label: String,
     was_last: bool,
 ) -> Vec<Event> {
-    // Same gating as `handle_report_panes_reaped` — drop reports for
-    // untracked labels (unpromoted pool drains).
-    if !state.windows.contains_key(&label) {
-        crate::log(&format!(
-            "[saga] pool_drain_decision: dropping report for untracked label '{}' (unpromoted pool)",
-            label
-        ));
-        return Vec::new();
-    }
+    // Same rationale as handle_report_panes_reaped: round 4's gate
+    // had an ordering bug; round 5 reverts to emit-unconditionally.
     let v = state.bump_version();
     if was_last {
         vec![Event::PoolDrained { label, version: v }]

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -144,6 +144,54 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
+        // Phase F.6 — host-only signal that all browser-pane HWNDs
+        // belonging to a closing top-level window have been reaped.
+        // Pure-reducer arm: emits the typed event so the
+        // window-cleanup-cascade saga can advance from Step 1
+        // (ReapingPanes) to Step 2 (DrainingPool). State is
+        // unchanged — pane bookkeeping lives in the host's session
+        // structures (lifecycle entries, pane HWND map), not the
+        // launcher's mirror; the launcher just narrates the
+        // transition for subscribers.
+        Command::ReportPanesReaped { label } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportPanesReaped") {
+                return vec![err];
+            }
+            handle_report_panes_reaped(state, label)
+        }
+        // Phase F.6 — host reports the result of the post-close
+        // drain-pool-if-last decision. `was_last == true` →
+        // `Event::PoolDrained`; `was_last == false` →
+        // `Event::PoolNotLast`. Both are terminal alternatives for
+        // the window-cleanup-cascade saga's Step 2.
+        Command::ReportPoolDrainDecision { label, was_last } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportPoolDrainDecision") {
+                return vec![err];
+            }
+            handle_report_pool_drain_decision(state, label, was_last)
+        }
+        // Phase F.6 — `ReapPanes` and `DrainPoolIfLast` are
+        // launcher→host direction commands, NOT host→launcher
+        // reports. Same misrouted-error pattern as `SpawnPoolWindow`
+        // above.
+        Command::ReapPanes { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "ReapPanes is a launcher→host command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
+        Command::DrainPoolIfLast { .. } => {
+            let v = state.bump_version();
+            vec![Event::Error {
+                code: agentmux_common::ipc::ErrorCode::InvalidCommand,
+                message: "DrainPoolIfLast is a launcher→host command; sent to launcher pipe by mistake".into(),
+                fatal: false,
+                version: v,
+            }]
+        }
         Command::ReportHostCounts { windows, pool } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportHostCounts") {
                 return vec![err];
@@ -580,6 +628,43 @@ fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Ev
 fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
     let v = state.bump_version();
     vec![Event::PoolWindowPromoted { label, version: v }]
+}
+
+/// Phase F.6 — host-emitted signal that browser-pane HWNDs for a
+/// closing top-level window have been reaped. Pure pass-through:
+/// state stays untouched (the host owns pane bookkeeping); the
+/// reducer just translates the wire command into the typed event so
+/// the window-cleanup-cascade saga can advance.
+///
+/// Idempotent / context-free: the saga matches the `label` against
+/// its own `closed_label`, so a stray report for a label that no
+/// in-flight saga is tracking is a harmless broadcast.
+fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::PanesReaped { label, version: v }]
+}
+
+/// Phase F.6 — host-emitted signal carrying the result of the
+/// post-close drain-pool-if-last decision. Maps `was_last` directly
+/// to the corresponding terminal event for Step 2 of the
+/// window-cleanup-cascade saga:
+/// * `true` → `Event::PoolDrained` (last user-visible window
+///   closed; warm-pool drain initiated)
+/// * `false` → `Event::PoolNotLast` (other windows remain; pool
+///   stays warm)
+///
+/// Pure pass-through (same reasoning as `handle_report_panes_reaped`).
+fn handle_report_pool_drain_decision(
+    state: &mut State,
+    label: String,
+    was_last: bool,
+) -> Vec<Event> {
+    let v = state.bump_version();
+    if was_last {
+        vec![Event::PoolDrained { label, version: v }]
+    } else {
+        vec![Event::PoolNotLast { label, version: v }]
+    }
 }
 
 /// Phase B.4 — gate window-mirror reports to Host clients only. The
@@ -1093,6 +1178,9 @@ mod tests {
             | Event::PoolWindowAdded { version, .. }
             | Event::PoolWindowRemoved { version, .. }
             | Event::PoolWindowPromoted { version, .. }
+            | Event::PanesReaped { version, .. }
+            | Event::PoolDrained { version, .. }
+            | Event::PoolNotLast { version, .. }
             | Event::WindowInstanceAssigned { version, .. }
             | Event::WindowInstanceReleased { version, .. }
             | Event::BackendWindowIdRegistered { version, .. }

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -813,6 +813,9 @@ fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
     out.push(Event::WindowClosed {
         label: label.clone(),
         version: v,
+        // Clean close — host ran on_before_close before sending
+        // ReportWindowClosed. F.6 saga is safe to trigger.
+        crash_detected: false,
     });
     if let Some(num) = state.instance_registry.remove(&label) {
         let v = state.bump_version();

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -640,6 +640,21 @@ fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<E
 /// its own `closed_label`, so a stray report for a label that no
 /// in-flight saga is tracking is a harmless broadcast.
 fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
+    // (codex P1 PR #637 round 3.) Discriminate promoted pool windows
+    // (tracked in `state.windows`, F.6 saga ran on their WindowClosed)
+    // from unpromoted pool drains (NOT in `state.windows`, no saga
+    // started). For untracked labels, emit nothing — the typed event
+    // would otherwise appear outside any SagaStarted bracket and
+    // confuse subscribers. Mirrors the silent-drop pattern in
+    // `handle_report_window_closed` for unknown labels.
+    if !state.windows.contains_key(&label) {
+        tracing::debug!(
+            target: "saga.f6",
+            label = %label,
+            "[saga] panes_reaped: dropping report for untracked label (unpromoted pool)"
+        );
+        return Vec::new();
+    }
     let v = state.bump_version();
     vec![Event::PanesReaped { label, version: v }]
 }
@@ -659,6 +674,16 @@ fn handle_report_pool_drain_decision(
     label: String,
     was_last: bool,
 ) -> Vec<Event> {
+    // Same gating as `handle_report_panes_reaped` — drop reports for
+    // untracked labels (unpromoted pool drains).
+    if !state.windows.contains_key(&label) {
+        tracing::debug!(
+            target: "saga.f6",
+            label = %label,
+            "[saga] pool_drain_decision: dropping report for untracked label (unpromoted pool)"
+        );
+        return Vec::new();
+    }
     let v = state.bump_version();
     if was_last {
         vec![Event::PoolDrained { label, version: v }]

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -323,7 +323,15 @@ fn match_trigger(event: &Event) -> Option<Box<dyn Saga>> {
         Event::PoolWindowPromoted { label, .. } => {
             Some(Box::new(pool_respawn::PoolRespawn::new(label.clone())))
         }
-        Event::WindowClosed { label, .. } => Some(Box::new(
+        // (codex P1 PR #637.) Only fire the cleanup cascade on
+        // CLEAN closes. `Event::WindowClosed { crash_detected: true }`
+        // comes from `wrr::apply_hwnd_destroyed` after a host/renderer
+        // crash; the host never sent `ReportPanesReaped` /
+        // `ReportPoolDrainDecision`, so the saga would stay
+        // in-flight indefinitely (only cleared by a later same-kind
+        // eviction or launcher restart) leaving a SagaStarted
+        // bracket dangling for subscribers that buffer on lifecycle.
+        Event::WindowClosed { label, crash_detected: false, .. } => Some(Box::new(
             window_cleanup::WindowCleanupCascade::new(label.clone()),
         )),
         _ => None,
@@ -516,9 +524,27 @@ mod tests {
         let event = Event::WindowClosed {
             label: "main".into(),
             version: 1,
+            crash_detected: false,
         };
         let saga = match_trigger(&event).expect("WindowClosed should trigger a saga");
         assert_eq!(saga.name(), "window_cleanup_cascade");
+    }
+
+    /// (codex P1 PR #637 round 2.) Crash-detected closes (originating
+    /// from `wrr::apply_hwnd_destroyed`) must NOT trigger the saga —
+    /// the host never sent the cleanup reports, so the saga would
+    /// stay in-flight forever.
+    #[test]
+    fn match_trigger_skips_crash_detected_window_closed() {
+        let event = Event::WindowClosed {
+            label: "crashed-window".into(),
+            version: 1,
+            crash_detected: true,
+        };
+        assert!(
+            match_trigger(&event).is_none(),
+            "crash-detected close should NOT spawn a saga",
+        );
     }
 
     #[test]

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -69,6 +69,7 @@ use std::sync::Arc;
 use agentmux_common::ipc::{Command, Event};
 
 pub mod pool_respawn;
+pub mod window_cleanup;
 
 /// Where a `SagaAction::IssueCmd` should be dispatched.
 ///
@@ -306,17 +307,25 @@ impl SagaCoordinator {
 /// Inspect a bus event for "should this start a fresh saga?" Returns
 /// the constructed saga (boxed) on a hit; `None` otherwise.
 ///
-/// F.5 wires one trigger: `Event::PoolWindowPromoted` →
-/// `pool_respawn::PoolRespawn`. Future sagas extend this match.
+/// Triggers wired to date:
+/// * F.5: `Event::PoolWindowPromoted` → `pool_respawn::PoolRespawn`
+/// * F.6: `Event::WindowClosed` →
+///   `window_cleanup::WindowCleanupCascade`
+///
+/// Future sagas extend this match.
 ///
 /// Note: this returns a *candidate* saga. The coordinator may still
-/// reject it via the same-kind-in-flight serialization gate before
-/// `spawn_saga` (codex P1 PR #634 round 2 — see `run_coordinator`).
+/// evict a same-kind in-flight saga via the evict-and-replace
+/// serialization gate before `spawn_saga` (codex P1 PR #634 round 3
+/// — see `run_coordinator`).
 fn match_trigger(event: &Event) -> Option<Box<dyn Saga>> {
     match event {
         Event::PoolWindowPromoted { label, .. } => {
             Some(Box::new(pool_respawn::PoolRespawn::new(label.clone())))
         }
+        Event::WindowClosed { label, .. } => Some(Box::new(
+            window_cleanup::WindowCleanupCascade::new(label.clone()),
+        )),
         _ => None,
     }
 }
@@ -499,6 +508,19 @@ mod tests {
         assert_eq!(saga.name(), "pool_respawn_on_promote");
     }
 
+    /// F.6 — verify the trigger table picks up `WindowClosed`. The
+    /// end-to-end coordinator test lives in
+    /// `window_cleanup::tests::coordinator_brackets_close_with_saga_lifecycle_events`.
+    #[test]
+    fn match_trigger_window_closed_starts_window_cleanup_cascade() {
+        let event = Event::WindowClosed {
+            label: "main".into(),
+            version: 1,
+        };
+        let saga = match_trigger(&event).expect("WindowClosed should trigger a saga");
+        assert_eq!(saga.name(), "window_cleanup_cascade");
+    }
+
     #[test]
     fn match_trigger_returns_none_for_non_trigger_events() {
         let cases = vec![
@@ -519,6 +541,21 @@ mod tests {
             Event::LifecyclePhaseChanged {
                 from: LifecyclePhase::Starting,
                 to: LifecyclePhase::Running,
+                version: 1,
+            },
+            // F.6 step-1/step-2 terminal events are NOT triggers
+            // themselves — the saga consumes them, but receiving one
+            // when no saga is in flight should be a no-op.
+            Event::PanesReaped {
+                label: "main".into(),
+                version: 1,
+            },
+            Event::PoolDrained {
+                label: "main".into(),
+                version: 1,
+            },
+            Event::PoolNotLast {
+                label: "main".into(),
                 version: 1,
             },
         ];

--- a/agentmux-launcher/src/saga/window_cleanup.rs
+++ b/agentmux-launcher/src/saga/window_cleanup.rs
@@ -1,0 +1,611 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase F.6 — window-cleanup cascade saga.
+//
+// **What this saga does**
+//
+// When a user-visible top-level window closes, two cleanup steps
+// happen implicitly in the host today:
+//
+//   1. Browser-pane HWNDs that belong to the closing window get
+//      reaped (lifecycle entries drained, pane HWND map cleared,
+//      subwindow cascade closes children).
+//   2. If that window was the LAST user-visible window, Stage 1 of
+//      the wrr two-stage close cascade in
+//      `agentmux-cef::client::on_before_close` posts WM_CLOSE to
+//      every warm-pool browser so the app can drain to zero.
+//      Otherwise the pool stays warm.
+//
+// Both steps fire inside the same `on_before_close` body. Renderers
+// that want to buffer "this window is closing AND its post-close
+// cleanup is settling" atomically have nothing to pivot on today —
+// the launcher's `Event::WindowClosed` is the only signal, and it
+// fires BEFORE the cleanup steps complete.
+//
+// This saga formalizes the implicit cleanup as an explicit state
+// machine so the renderer sees a `SagaStarted` / `SagaCompleted`
+// bracket. Implementing the spec sketch from
+// `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` §7.2:
+//
+//   saga WindowCleanupCascade(closed_label):
+//       Step 1 — on Event::WindowClosed { label }:
+//                 issue Command::ReapPanes { label } → host
+//                 wait for: Event::PanesReaped { label }
+//       Step 2 — issue Command::DrainPoolIfLast { label } → host
+//                 wait for: Event::PoolDrained or Event::PoolNotLast
+//       Step 3 — Done
+//
+//       Compensation: none (cleanup failure is logged; next close
+//                     retries).
+//
+// **Scope of F.6 (this PR)**
+//
+// F.6 ships:
+//   - the saga state machine itself (this file),
+//   - the wire types (`Command::ReapPanes`,
+//     `Command::DrainPoolIfLast`, `Command::ReportPanesReaped`,
+//     `Command::ReportPoolDrainDecision`, `Event::PanesReaped`,
+//     `Event::PoolDrained`, `Event::PoolNotLast`),
+//   - host-side `report_panes_reaped` + `report_pool_drain_decision`
+//     calls inside `on_before_close`,
+//   - launcher reducer arms translating the reports into the typed
+//     events,
+//   - coordinator wiring that registers the saga as a consumer of
+//     `Event::WindowClosed`.
+//
+// F.6 does NOT ship:
+//   - The actual cross-process dispatch of `Command::ReapPanes` /
+//     `Command::DrainPoolIfLast` to the host. Today the launcher's
+//     named-pipe IPC is host→launcher only (host sends Commands up;
+//     launcher broadcasts Events back). A launcher→host command
+//     pipe doesn't exist yet. Both `IssueCmd::Host` actions are
+//     logged-only; the saga relies on the host's existing implicit
+//     cleanup flow inside `on_before_close` to produce the
+//     `Event::PanesReaped` + `Event::PoolDrained`/`PoolNotLast` it
+//     waits for. **This is acceptable scope per the F-spec § 7
+//     ("If the cross-process plumbing is too heavy a lift for one
+//     PR, scope down: implement the saga shape + the launcher-side
+//     coordinator entry, even if the actual cross-process dispatch
+//     is initially in-process").** The follow-up PR replaces the
+//     log with a real wire-level send — same trajectory as F.5's
+//     `SpawnPoolWindow`.
+//   - F.7 (cleanup audit + property tests).
+//   - Launcher-side saga durability — separate concern.
+//
+// **Why a saga at all if the IssueCmds are currently passive?**
+//
+// Same reasoning as F.5: the renderer-visible value is the
+// `SagaStarted` / `SagaCompleted` bracket. Subscribers see "saga
+// foo running" and can buffer related events for that saga_id
+// until the bracket closes. That works the same way whether the
+// launcher actively dispatches the cleanup or merely observes the
+// host doing it. When the cross-process pipe lands, only the
+// saga's `IssueCmd` handling needs to change — the renderer-facing
+// semantics are stable.
+//
+// **What if a terminal event never arrives?**
+//
+// Same behavior as F.5: the saga waits forever until the bus
+// closes (saga abandoned on launcher restart) or — once
+// per-saga timeouts land — a deadline force-fails it. F.6 keeps
+// behavior deliberately simple: if cleanup genuinely fails, the
+// next window close starts a fresh saga; the prior failed saga
+// stays in `in_flight` until the launcher exits or it gets
+// evicted by a same-kind successor (see `saga::mod.rs`'s
+// evict-and-replace policy from F.5 round 4).
+//
+// **Known limitation: concurrent-correlation** (inherited from
+// F.5). If two windows close simultaneously, the coordinator
+// broadcasts every event to every in-flight saga. The first
+// `PanesReaped` (or `PoolDrained`/`PoolNotLast`) advances ALL
+// matching sagas regardless of which window's close they belong
+// to — early `SagaCompleted` for one window's bracket, the other
+// window's terminal event left unbracketed.
+//
+// In practice this requires the user to close two windows in
+// rapid succession (under the host's `on_before_close` execution
+// latency, ~few ms). The user-visible consequence is a brief
+// renderer-side bracketing inconsistency; reducer + SQLite state
+// remain correct.
+//
+// Mitigation today: `saga::mod.rs::run_coordinator`'s
+// evict-and-replace policy (F.5 round 4) ensures only ONE
+// window-cleanup-cascade saga is in flight at a time. The second
+// `WindowClosed` evicts the first saga (emitting `SagaFailed`
+// with "evicted" reason), then starts a fresh one. Renderer-
+// visible: one premature `SagaFailed` + one correct
+// `SagaCompleted`. Same trade-off as F.5 documented for
+// concurrent promotes.
+//
+// Proper fix requires coordinator-level FIFO routing or per-saga
+// sequence-number correlation. Both depend on the cross-process
+// dispatch landing first (so the saga's `IssueCmd` is actually
+// causal). Closed alongside the launcher→host command pipe in a
+// future phase.
+
+use agentmux_common::ipc::{Command, Event};
+
+use super::{PipeTarget, Saga, SagaAction, SagaCtx};
+
+/// State of one in-flight window-cleanup-cascade saga.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Phase {
+    /// Saga just constructed — waiting for the coordinator to call
+    /// `start`. The first `start` call transitions to `ReapingPanes`
+    /// and emits the `IssueCmd` for `ReapPanes`.
+    Initial,
+    /// `ReapPanes` has been issued; waiting for any
+    /// `Event::PanesReaped` that matches our window label.
+    ReapingPanes,
+    /// `DrainPoolIfLast` has been issued; waiting for either
+    /// `Event::PoolDrained` or `Event::PoolNotLast`. Both are
+    /// terminal — the saga doesn't care WHICH branch fires, only
+    /// that ONE of them does.
+    DrainingPool,
+}
+
+/// Window-cleanup-cascade saga: fires once per window close, drives
+/// the implicit pane-reap + pool-drain-decision flow into an
+/// explicit two-step state machine, then completes.
+pub struct WindowCleanupCascade {
+    /// Label of the window that closed (the trigger event's payload).
+    /// The saga uses this for label-matching on terminal events:
+    /// `PanesReaped { label }` only advances Step 1 when `label`
+    /// matches; same for `PoolDrained`/`PoolNotLast` in Step 2.
+    ///
+    /// Note: under the coordinator's evict-and-replace policy, only
+    /// one window-cleanup-cascade saga is ever in flight at a time,
+    /// so label-matching is technically redundant for correctness.
+    /// Keep it anyway as cheap defense-in-depth + a clear
+    /// invariant-statement: "this saga belongs to *this* window's
+    /// cleanup, not whoever's terminal event happens to land first."
+    closed_label: String,
+    /// Whether the host's drain decision said "yes, that was the
+    /// last window" (`PoolDrained` arm) or "no, more windows
+    /// remain" (`PoolNotLast` arm). `None` until Step 2 resolves.
+    /// Exported for tests.
+    drained_pool: Option<bool>,
+    phase: Phase,
+}
+
+impl WindowCleanupCascade {
+    /// Construct a fresh saga for a close of `closed_label`.
+    /// Coordinator allocates the saga_id and calls `start` once.
+    pub fn new(closed_label: String) -> Self {
+        Self {
+            closed_label,
+            drained_pool: None,
+            phase: Phase::Initial,
+        }
+    }
+
+    /// Whether the host's drain decision flagged this close as
+    /// "last user-visible window" (`true` → `PoolDrained` branch
+    /// fired) or not (`false` → `PoolNotLast` branch fired). `None`
+    /// before Step 2 resolves. Exported for tests.
+    #[cfg(test)]
+    pub fn drained_pool(&self) -> Option<bool> {
+        self.drained_pool
+    }
+
+    /// Label this saga is tracking. Exported for tests.
+    #[cfg(test)]
+    pub fn closed_label(&self) -> &str {
+        &self.closed_label
+    }
+}
+
+impl Saga for WindowCleanupCascade {
+    fn name(&self) -> &'static str {
+        "window_cleanup_cascade"
+    }
+
+    fn start(&mut self, _ctx: &SagaCtx) -> SagaAction {
+        // Step 1 — issue the ReapPanes command, transition into the
+        // wait state. F.6 routes the action to `PipeTarget::Host`
+        // for forward compatibility with the cross-process dispatch
+        // follow-up; today the coordinator logs the IssueCmd and
+        // doesn't actually transmit it on a launcher→host pipe (no
+        // such pipe exists yet — see module docstring).
+        debug_assert_eq!(self.phase, Phase::Initial);
+        self.phase = Phase::ReapingPanes;
+        SagaAction::IssueCmd {
+            target: PipeTarget::Host,
+            cmd: Command::ReapPanes {
+                label: self.closed_label.clone(),
+            },
+        }
+    }
+
+    fn on_event(&mut self, event: &Event, _ctx: &SagaCtx) -> SagaAction {
+        match (&self.phase, event) {
+            // Step 1 → Step 2 transition. `PanesReaped` arrives from
+            // the host (`report_panes_reaped` inside
+            // `on_before_close`). Match on the label so a stray
+            // event from another window's close doesn't advance us
+            // (defense-in-depth — see `closed_label` field doc).
+            (Phase::ReapingPanes, Event::PanesReaped { label, .. })
+                if label == &self.closed_label =>
+            {
+                self.phase = Phase::DrainingPool;
+                SagaAction::IssueCmd {
+                    target: PipeTarget::Host,
+                    cmd: Command::DrainPoolIfLast {
+                        label: self.closed_label.clone(),
+                    },
+                }
+            }
+            // Step 2 terminal — drain happened (last window closed).
+            (Phase::DrainingPool, Event::PoolDrained { label, .. })
+                if label == &self.closed_label =>
+            {
+                self.drained_pool = Some(true);
+                SagaAction::Done
+            }
+            // Step 2 terminal — drain skipped (other windows remain).
+            // Equally a success: the saga's job is to bracket the
+            // drain *decision*, not enforce a particular outcome.
+            (Phase::DrainingPool, Event::PoolNotLast { label, .. })
+                if label == &self.closed_label =>
+            {
+                self.drained_pool = Some(false);
+                SagaAction::Done
+            }
+            // Anything else: still waiting; or — for `Initial` —
+            // coordinator hasn't called `start` yet, in which case
+            // we're not supposed to be receiving events. Either way:
+            // no-op.
+            _ => SagaAction::Wait,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    fn ctx(saga_id: u64) -> SagaCtx {
+        SagaCtx { saga_id }
+    }
+
+    #[test]
+    fn start_issues_reap_panes_to_host() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let action = saga.start(&ctx(7));
+        match action {
+            SagaAction::IssueCmd { target, cmd } => {
+                assert_eq!(target, PipeTarget::Host);
+                match cmd {
+                    Command::ReapPanes { label } => assert_eq!(label, "main"),
+                    other => panic!("expected ReapPanes, got {:?}", other),
+                }
+            }
+            other => panic!(
+                "expected IssueCmd(ReapPanes) on start, got {:?}",
+                other
+            ),
+        }
+        assert_eq!(saga.closed_label(), "main");
+    }
+
+    #[test]
+    fn panes_reaped_advances_to_drain_pool_step() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+        let action = saga.on_event(
+            &Event::PanesReaped {
+                label: "main".into(),
+                version: 100,
+            },
+            &ctx(7),
+        );
+        match action {
+            SagaAction::IssueCmd { target, cmd } => {
+                assert_eq!(target, PipeTarget::Host);
+                match cmd {
+                    Command::DrainPoolIfLast { label } => assert_eq!(label, "main"),
+                    other => panic!("expected DrainPoolIfLast, got {:?}", other),
+                }
+            }
+            other => panic!(
+                "expected IssueCmd(DrainPoolIfLast) on PanesReaped, got {:?}",
+                other
+            ),
+        }
+        // Drain decision not yet known.
+        assert_eq!(saga.drained_pool(), None);
+    }
+
+    #[test]
+    fn pool_drained_completes_the_saga_with_drain_flag_true() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+        let _ = saga.on_event(
+            &Event::PanesReaped {
+                label: "main".into(),
+                version: 100,
+            },
+            &ctx(7),
+        );
+        let action = saga.on_event(
+            &Event::PoolDrained {
+                label: "main".into(),
+                version: 101,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Done));
+        assert_eq!(saga.drained_pool(), Some(true));
+    }
+
+    #[test]
+    fn pool_not_last_completes_the_saga_with_drain_flag_false() {
+        let mut saga = WindowCleanupCascade::new("secondary".into());
+        let _ = saga.start(&ctx(7));
+        let _ = saga.on_event(
+            &Event::PanesReaped {
+                label: "secondary".into(),
+                version: 100,
+            },
+            &ctx(7),
+        );
+        let action = saga.on_event(
+            &Event::PoolNotLast {
+                label: "secondary".into(),
+                version: 101,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Done));
+        assert_eq!(saga.drained_pool(), Some(false));
+    }
+
+    #[test]
+    fn unrelated_events_keep_saga_waiting() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+
+        // WindowOpened — wholly unrelated.
+        let unrelated = Event::WindowOpened {
+            label: "other".into(),
+            kind: agentmux_common::ipc::WindowKind::FullInstance,
+            parent_label: None,
+            version: 50,
+        };
+        let action = saga.on_event(&unrelated, &ctx(7));
+        assert!(matches!(action, SagaAction::Wait));
+
+        // PanesReaped for a DIFFERENT label — must not advance us
+        // (defense-in-depth label match).
+        let action = saga.on_event(
+            &Event::PanesReaped {
+                label: "different-window".into(),
+                version: 51,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+
+        // PoolDrained while we're still in Step 1 — must not advance
+        // us (wrong phase).
+        let action = saga.on_event(
+            &Event::PoolDrained {
+                label: "main".into(),
+                version: 52,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+
+        // The trigger itself (WindowClosed) is what the coordinator
+        // uses to START the saga; the saga MUST NOT mistake a stray
+        // WindowClosed (e.g. from another close) for a step
+        // advancement.
+        let action = saga.on_event(
+            &Event::WindowClosed {
+                label: "main".into(),
+                version: 53,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+    }
+
+    #[test]
+    fn label_mismatch_in_drain_phase_keeps_saga_waiting() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+        let _ = saga.on_event(
+            &Event::PanesReaped {
+                label: "main".into(),
+                version: 100,
+            },
+            &ctx(7),
+        );
+        // Now in DrainingPool. A drain event for a different label
+        // must NOT terminate this saga.
+        let action = saga.on_event(
+            &Event::PoolDrained {
+                label: "other".into(),
+                version: 101,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+        let action = saga.on_event(
+            &Event::PoolNotLast {
+                label: "other".into(),
+                version: 102,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+        // Drain decision still unresolved.
+        assert_eq!(saga.drained_pool(), None);
+    }
+
+    /// End-to-end coordinator integration: emit `WindowClosed`,
+    /// watch the coordinator start the saga, observe the IssueCmds
+    /// via log, emit synthetic `PanesReaped` then
+    /// `PoolDrained`/`PoolNotLast`, watch the coordinator emit
+    /// `SagaStarted` then `SagaCompleted` bracket events on the bus.
+    #[tokio::test]
+    async fn coordinator_brackets_close_with_saga_lifecycle_events() {
+        use crate::saga::{run_coordinator, SagaCoordinator};
+
+        let (events_tx, _) = tokio::sync::broadcast::channel::<Event>(64);
+        let state = Arc::new(tokio::sync::Mutex::new(crate::state::State::default()));
+        let coord = Arc::new(SagaCoordinator::new(events_tx.clone(), Arc::clone(&state)));
+
+        let mut witness = events_tx.subscribe();
+        let coord_rx = events_tx.subscribe();
+        let _handle = tokio::spawn(run_coordinator(Arc::clone(&coord), coord_rx));
+
+        // Yield so coordinator's recv loop is parked before publish.
+        tokio::task::yield_now().await;
+
+        // Trigger.
+        let _ = events_tx.send(Event::WindowClosed {
+            label: "main".into(),
+            version: 1,
+        });
+        // Step 1 terminal.
+        let _ = events_tx.send(Event::PanesReaped {
+            label: "main".into(),
+            version: 2,
+        });
+        // Step 2 terminal — pick the "drained" branch.
+        let _ = events_tx.send(Event::PoolDrained {
+            label: "main".into(),
+            version: 3,
+        });
+
+        let mut saw_started = false;
+        let mut saw_completed_after_started = false;
+        let mut saga_id_started: Option<u64> = None;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
+            {
+                Ok(Ok(Event::SagaStarted { saga_id, name, .. })) => {
+                    if name == "window_cleanup_cascade" {
+                        saw_started = true;
+                        saga_id_started = Some(saga_id);
+                    }
+                }
+                Ok(Ok(Event::SagaCompleted { saga_id, .. })) => {
+                    if saw_started && Some(saga_id) == saga_id_started {
+                        saw_completed_after_started = true;
+                        break;
+                    }
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => continue,
+            }
+        }
+        assert!(
+            saw_started,
+            "expected coordinator to emit Event::SagaStarted for window_cleanup_cascade"
+        );
+        assert!(
+            saw_completed_after_started,
+            "expected coordinator to emit Event::SagaCompleted after SagaStarted"
+        );
+    }
+
+    /// Concurrent-window-close scenario: two `WindowClosed` events
+    /// arrive in close succession. Per the F.5 evict-and-replace
+    /// policy in `saga::mod.rs::run_coordinator`, the second close
+    /// evicts the first saga (emitting `SagaFailed` with "evicted"
+    /// reason) and starts a fresh one. Both close events still end
+    /// with terminal lifecycle activity:
+    ///   - first close → `SagaFailed` (evicted)
+    ///   - second close → `SagaStarted` + `SagaCompleted`
+    /// We assert that we observe at least one of each lifecycle
+    /// type on the bus.
+    #[tokio::test]
+    async fn coordinator_evicts_on_concurrent_window_close() {
+        use crate::saga::{run_coordinator, SagaCoordinator};
+
+        let (events_tx, _) = tokio::sync::broadcast::channel::<Event>(64);
+        let state = Arc::new(tokio::sync::Mutex::new(crate::state::State::default()));
+        let coord = Arc::new(SagaCoordinator::new(events_tx.clone(), Arc::clone(&state)));
+
+        let mut witness = events_tx.subscribe();
+        let coord_rx = events_tx.subscribe();
+        let _handle = tokio::spawn(run_coordinator(Arc::clone(&coord), coord_rx));
+
+        tokio::task::yield_now().await;
+
+        // First close → starts saga A.
+        let _ = events_tx.send(Event::WindowClosed {
+            label: "main".into(),
+            version: 1,
+        });
+        // Second close BEFORE saga A's terminals arrive → evicts A,
+        // starts saga B.
+        let _ = events_tx.send(Event::WindowClosed {
+            label: "secondary".into(),
+            version: 2,
+        });
+        // Saga B's terminals.
+        let _ = events_tx.send(Event::PanesReaped {
+            label: "secondary".into(),
+            version: 3,
+        });
+        let _ = events_tx.send(Event::PoolNotLast {
+            label: "secondary".into(),
+            version: 4,
+        });
+
+        let mut started_count = 0u32;
+        let mut completed_count = 0u32;
+        let mut failed_evict_count = 0u32;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
+            {
+                Ok(Ok(Event::SagaStarted { name, .. })) => {
+                    if name == "window_cleanup_cascade" {
+                        started_count += 1;
+                    }
+                }
+                Ok(Ok(Event::SagaCompleted { .. })) => {
+                    completed_count += 1;
+                }
+                Ok(Ok(Event::SagaFailed { reason, .. })) => {
+                    if reason.contains("evicted") {
+                        failed_evict_count += 1;
+                    }
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => {
+                    // No new events for 50ms — break early once we've
+                    // seen the expected pattern.
+                    if started_count >= 2 && completed_count >= 1 && failed_evict_count >= 1 {
+                        break;
+                    }
+                }
+            }
+        }
+        assert!(
+            started_count >= 2,
+            "expected ≥2 SagaStarted (one per close), got {}",
+            started_count
+        );
+        assert!(
+            failed_evict_count >= 1,
+            "expected ≥1 SagaFailed with 'evicted' reason from evict-and-replace policy, got {}",
+            failed_evict_count
+        );
+        assert!(
+            completed_count >= 1,
+            "expected ≥1 SagaCompleted (the surviving saga), got {}",
+            completed_count
+        );
+    }
+}

--- a/agentmux-launcher/src/saga/window_cleanup.rs
+++ b/agentmux-launcher/src/saga/window_cleanup.rs
@@ -407,6 +407,7 @@ mod tests {
             &Event::WindowClosed {
                 label: "main".into(),
                 version: 53,
+                crash_detected: false,
             },
             &ctx(7),
         );
@@ -470,6 +471,7 @@ mod tests {
         let _ = events_tx.send(Event::WindowClosed {
             label: "main".into(),
             version: 1,
+            crash_detected: false,
         });
         // Step 1 terminal.
         let _ = events_tx.send(Event::PanesReaped {
@@ -544,12 +546,14 @@ mod tests {
         let _ = events_tx.send(Event::WindowClosed {
             label: "main".into(),
             version: 1,
+            crash_detected: false,
         });
         // Second close BEFORE saga A's terminals arrive → evicts A,
         // starts saga B.
         let _ = events_tx.send(Event::WindowClosed {
             label: "secondary".into(),
             version: 2,
+            crash_detected: false,
         });
         // Saga B's terminals.
         let _ = events_tx.send(Event::PanesReaped {

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -205,6 +205,11 @@ pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64) -> Vec<Event> {
         let closed = Event::WindowClosed {
             label: label.clone(),
             version: v_closed,
+            // crash-detected close: host's on_before_close didn't
+            // run, so the F.6 cleanup saga must skip this trigger
+            // (it would never receive the panes-reaped / pool-drain
+            // terminal reports).
+            crash_detected: true,
         };
         let mut out = vec![drift, closed];
         if let Some(num) = released_num {

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.551"
+version = "0.33.552"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.553"
+version = "0.33.554"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.552"
+version = "0.33.553"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.556"
+version = "0.33.557"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.550"
+version = "0.33.551"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.554"
+version = "0.33.555"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.555"
+version = "0.33.556"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -253,6 +253,9 @@ fn event_version(e: &Event) -> u64 {
         | Event::PoolWindowAdded { version, .. }
         | Event::PoolWindowRemoved { version, .. }
         | Event::PoolWindowPromoted { version, .. }
+        | Event::PanesReaped { version, .. }
+        | Event::PoolDrained { version, .. }
+        | Event::PoolNotLast { version, .. }
         | Event::WindowInstanceAssigned { version, .. }
         | Event::WindowInstanceReleased { version, .. }
         | Event::BackendWindowIdRegistered { version, .. }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -1205,6 +1205,9 @@ mod tests {
             | Event::PoolWindowAdded { version, .. }
             | Event::PoolWindowRemoved { version, .. }
             | Event::PoolWindowPromoted { version, .. }
+            | Event::PanesReaped { version, .. }
+            | Event::PoolDrained { version, .. }
+            | Event::PoolNotLast { version, .. }
             | Event::WindowInstanceAssigned { version, .. }
             | Event::WindowInstanceReleased { version, .. }
             | Event::BackendWindowIdRegistered { version, .. }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.551",
+  "version": "0.33.552",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.551",
+      "version": "0.33.552",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.556",
+  "version": "0.33.557",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.556",
+      "version": "0.33.557",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.552",
+  "version": "0.33.553",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.552",
+      "version": "0.33.553",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.554",
+  "version": "0.33.555",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.554",
+      "version": "0.33.555",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.550",
+  "version": "0.33.551",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.550",
+      "version": "0.33.551",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.555",
+  "version": "0.33.556",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.555",
+      "version": "0.33.556",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.553",
+  "version": "0.33.554",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.553",
+      "version": "0.33.554",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.552",
+  "version": "0.33.553",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.555",
+  "version": "0.33.556",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.551",
+  "version": "0.33.552",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.553",
+  "version": "0.33.554",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.556",
+  "version": "0.33.557",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.554",
+  "version": "0.33.555",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.550",
+  "version": "0.33.551",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements the second cross-process saga from
[`docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` §7.2](../blob/main/docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md#72-second-window-cleanup-cascade):

```
saga WindowCleanupCascade(closed_label):
    Step 1 — on Event::WindowClosed { label }:
              issue Command::ReapPanes { label } → host
              wait for: Event::PanesReaped { label }
    Step 2 — issue Command::DrainPoolIfLast { label } → host
              wait for: Event::PoolDrained or Event::PoolNotLast
    Step 3 — Done

    Compensation: none (cleanup failure is logged; next close retries).
```

Today this cleanup is implicit in `agentmux-cef::client::on_before_close` (pane drain + subwindow cascade + wrr two-stage close cascade). The saga formalizes it as an explicit two-step state machine so renderers see a `SagaStarted`/`SagaCompleted` bracket around the post-close cleanup settle.

This is **Thread 1 step 1** of the Phase F-G forward plan in [`docs/retro/phase-fg-roadmap-2026-05-01.md` §3](../blob/main/docs/retro/phase-fg-roadmap-2026-05-01.md), the next-to-last piece of Phase F core after F.5 (PR #634).

## Pattern reuse from F.5

Mirrors F.5's `pool_respawn` saga (PR #634) almost line-for-line:

- **Saga-as-narrator scope.** `IssueCmd::Host` for `ReapPanes` + `DrainPoolIfLast` is logged-only today — no launcher→host command pipe exists yet. The saga relies on host's existing implicit cleanup flow inside `on_before_close` to produce the `Event::PanesReaped` + `Event::PoolDrained`/`PoolNotLast` it waits for. The renderer-visible value is the bracket itself; cross-process dispatch lands in a future PR (Thread 3 of the F-G roadmap).
- **Concurrent-saga policy: evict-and-replace.** Inherited from F.5 round 4 (PR #634). When two windows close in rapid succession, the second `WindowClosed` evicts the first saga (emitting `SagaFailed` with "evicted" reason) and starts a fresh one. Documented limitation: brief renderer-visible bracketing inconsistency (one premature `SagaFailed` + one correct `SagaCompleted`); reducer state stays correct. Same trade-off F.5 has for concurrent promotes — proper FIFO/saga-id correlation depends on cross-process dispatch landing first.

Module docstring in `agentmux-launcher/src/saga/window_cleanup.rs` enumerates both, mirroring the structure of `pool_respawn.rs`.

## Wire types added (`agentmux-common/src/ipc.rs`)

Host → launcher reports:
- `Command::ReportPanesReaped { label }`
- `Command::ReportPoolDrainDecision { label, was_last }` (boolean carries which Step-2 branch fires)

Launcher → host commands (framework-only — currently logged):
- `Command::ReapPanes { label }`
- `Command::DrainPoolIfLast { label }`

Launcher-broadcast events:
- `Event::PanesReaped { label, version }` — Step 1 terminal
- `Event::PoolDrained { label, version }` — Step 2 terminal (last-window branch)
- `Event::PoolNotLast { label, version }` — Step 2 terminal (other-windows-remain branch)

## Host hooks

`agentmux-cef/src/client.rs::on_before_close`:
- `report_panes_reaped` after the subwindow cascade kicks off
- `report_pool_drain_decision` after the `user_browser_count` gate (boolean = `user_browser_count == 0 && !self.is_pane`)

Both gated on `!lbl.starts_with("browser-pane-")` — saga only triggers on top-level `WindowClosed`, not pane closes.

## Test plan

- [x] `cargo check --workspace` — clean.
- [x] `cargo test -p agentmux-launcher saga::` — 19 tests pass (was 10, +9 new).
- [x] `cargo test -p agentmux-launcher` — 88 tests pass (was 79, +9 new).
- [x] `cargo test -p agentmux-cef` — 41 tests pass (no regressions).
- [x] Pre-existing failing tests in `agentmux-srv` (5) and `reqwest::blocking` integration test resolution failure verified to also fail on `main` — not introduced by F.6.

New tests in `saga/window_cleanup.rs`:
- 5 unit tests: `start_issues_reap_panes_to_host`, `panes_reaped_advances_to_drain_pool_step`, `pool_drained_completes_the_saga_with_drain_flag_true`, `pool_not_last_completes_the_saga_with_drain_flag_false`, `unrelated_events_keep_saga_waiting`, `label_mismatch_in_drain_phase_keeps_saga_waiting`
- 2 end-to-end coordinator tests: `coordinator_brackets_close_with_saga_lifecycle_events` (single close → SagaStarted + SagaCompleted), `coordinator_evicts_on_concurrent_window_close` (two closes → first evicted, second completes)

New tests in `saga/mod.rs`:
- `match_trigger_window_closed_starts_window_cleanup_cascade` — trigger table coverage
- `match_trigger_returns_none_for_non_trigger_events` extended with `PanesReaped` / `PoolDrained` / `PoolNotLast` (terminal events should not themselves trigger sagas)

## Out of scope (per F-G roadmap)

- Real launcher→host command pipe (Thread 3 — next work after F.6).
- Refactoring the existing close paths in `on_before_close` — only added the report calls.
- Migrating browsers/pool maps into the host reducer (out per F-spec §3.2).
- Saga durability for the launcher (future PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)