### PR TITLE
feat(E.4): flip handle_move_tab to strict mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.557"
+version = "0.33.558"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.557"
+version = "0.33.558"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.557"
+version = "0.33.558"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -63,7 +63,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.557"
+version = "0.33.558"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.557"
+version = "0.33.558"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.557"
+version = "0.33.558"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.557"
+version = "0.33.558"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.557"
+version = "0.33.558"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -874,20 +874,13 @@ fn handle_move_tab(
             version: v,
         }];
     }
-    // **Migration-tolerant validation** (codex P1 round-2 #621):
-    // tab existence + workspace_id checks are dropped during the
-    // migration window. Some tab-creating/moving paths
-    // (`PromoteBlockToTab`, etc.) are still wcore-direct — their
-    // writes don't flow into reducer state, so `state.tabs` and
-    // `state.workspaces[*].tab_ids` can lag SQLite. The saga / RPC
-    // handler that called us has already validated against SQLite
-    // (the source of truth); here we only enforce that both
-    // workspaces exist in the reducer (so we can mutate them) and
-    // trust the caller for the tab. If the tab isn't in
-    // `state.tabs`, lazy-insert a synthetic record stamped with the
-    // dst workspace_id (name unset — refilled when later events
-    // touch the tab). PR 4 reinstates strict validation once the
-    // remaining wcore-direct paths migrate.
+    // Strict validation (Phase E.4 strict-mode flip): the
+    // migration-tolerant lazy-import fallback (codex P1 round-2
+    // #621) was removed once the soak window closed with no
+    // `lazy-import` warnings observed in production. All reducer-
+    // routed paths now keep `state.tabs` and
+    // `state.workspaces[*].tab_ids` consistent with SQLite, so we
+    // can reject unknown tabs and workspace_id mismatches outright.
     if !state.workspaces.contains_key(&src_workspace_id) {
         let v = state.bump_version();
         return vec![Event::Error {
@@ -906,11 +899,34 @@ fn handle_move_tab(
             version: v,
         }];
     }
+    let tab_workspace_id: Option<String> =
+        state.tabs.get(&tab_id).map(|t| t.workspace_id.clone());
+    match tab_workspace_id {
+        None => {
+            let v = state.bump_version();
+            return vec![Event::Error {
+                code: ErrorCode::InvalidCommand,
+                message: format!("MoveTab: tab not found in state: {}", tab_id),
+                fatal: false,
+                version: v,
+            }];
+        }
+        Some(actual_ws) if actual_ws != src_workspace_id => {
+            let v = state.bump_version();
+            return vec![Event::Error {
+                code: ErrorCode::InvalidCommand,
+                message: format!(
+                    "MoveTab: workspace_id mismatch — tab {} belongs to {}, not {}",
+                    tab_id, actual_ws, src_workspace_id
+                ),
+                fatal: false,
+                version: v,
+            }];
+        }
+        Some(_) => {}
+    }
 
-    // Remove from src. Even if the reducer's view shows the tab
-    // isn't in src.tab_ids (stale state), the persist subscriber's
-    // apply_tab_moved reads SQLite and removes from there, so the
-    // disk-side ordering ends up correct.
+    // Remove from src.
     let new_src_active_tab_id: Option<String> = {
         let src = state.workspaces.get_mut(&src_workspace_id).expect("checked");
         src.tab_ids.retain(|id| id != &tab_id);
@@ -933,30 +949,12 @@ fn handle_move_tab(
         clamped as u32
     };
 
-    // Update the tab's parent. If the reducer's view didn't have
-    // this tab (a wcore-direct creation/move slipped past), lazy-
-    // insert a TabRecord. Name is left empty — subsequent events
-    // (TabRenamed, etc.) will refill it. The launcher's snapshot
-    // view tolerates empty names (renderer reads names from SQLite
-    // -sourced events).
-    match state.tabs.get_mut(&tab_id) {
-        Some(tab) => {
-            tab.workspace_id = dst_workspace_id.clone();
-        }
-        None => {
-            state.tabs.insert(
-                tab_id.clone(),
-                crate::state::TabRecord {
-                    tab_id: tab_id.clone(),
-                    workspace_id: dst_workspace_id.clone(),
-                    name: String::new(),
-                    block_ids: Vec::new(),
-                    focused_node_id: String::new(),
-                    magnified_node_id: String::new(),
-                },
-            );
-        }
-    }
+    // Update the tab's parent.
+    state
+        .tabs
+        .get_mut(&tab_id)
+        .expect("checked")
+        .workspace_id = dst_workspace_id.clone();
 
     let v = state.bump_version();
     vec![Event::TabMoved {
@@ -2806,65 +2804,30 @@ mod tests {
         );
         assert!(matches!(&events[0], Event::Error { .. }));
 
-        // codex P1 round-2 #621: unknown tabs are now ACCEPTED
-        // (lazy-imported into state.tabs), since wcore-direct paths
-        // can create tabs the reducer hasn't seen. Pre-checks live
-        // in the saga / RPC layer (against SQLite). The reducer
-        // here only validates that both workspaces exist.
+        // Phase E.4 strict-mode flip: unknown tabs are now REJECTED.
+        // The migration-tolerant lazy-import fallback was removed once
+        // the soak window closed without `lazy-import` warnings being
+        // observed in production. See `move_tab_unknown_tab_rejects`
+        // for the dedicated test.
         let events = update(
             &mut state,
             Command::MoveTab {
                 tab_id: "ghost-tab".into(),
-                src_workspace_id: src.clone(),
+                src_workspace_id: src,
                 dst_workspace_id: dst,
                 dst_index: 0,
             },
             &ctx(4),
         );
-        assert!(
-            matches!(&events[0], Event::TabMoved { .. }),
-            "unknown tab should be lazy-imported, got {:?}",
-            events.first()
-        );
+        assert!(matches!(&events[0], Event::Error { .. }));
     }
 
-    /// codex P1 round-2 #621: handle_move_tab tolerates a tab whose
-    /// reducer-state workspace_id mismatches `src_workspace_id`. The
-    /// reducer's view can lag SQLite during the migration window
-    /// (wcore-direct paths create/move tabs without dispatching),
-    /// so a strict check would reject valid moves. The saga/RPC
-    /// reads SQLite (the source of truth) for the membership check;
-    /// the reducer here just performs the move.
+    /// Phase E.4 strict-mode flip: an unknown tab id (not present in
+    /// `state.tabs`) is rejected with a clear "tab not found" error
+    /// rather than being lazy-imported. Replaces the migration-window
+    /// `move_tab_lazy_imports_unknown_tab` test.
     #[test]
-    fn move_tab_tolerates_workspace_id_mismatch_during_migration() {
-        let mut state = State::default();
-        let real_src = create_workspace(&mut state, "src");
-        let dst = create_workspace(&mut state, "dst");
-        let t1 = create_tab(&mut state, &real_src, "t1");
-        let other = create_workspace(&mut state, "other");
-        let _ = create_tab(&mut state, &other, "filler");
-        // Move with src_workspace_id = "other" even though the tab
-        // technically belongs to real_src per reducer state.
-        let events = update(
-            &mut state,
-            Command::MoveTab {
-                tab_id: t1.clone(),
-                src_workspace_id: other,
-                dst_workspace_id: dst.clone(),
-                dst_index: 0,
-            },
-            &ctx(2),
-        );
-        assert!(matches!(&events[0], Event::TabMoved { .. }));
-        // Tab's workspace_id should now point at dst.
-        assert_eq!(state.tabs[&t1].workspace_id, dst);
-    }
-
-    /// codex P1 round-2 #621: lazy-import populates state.tabs for
-    /// a tab the reducer hadn't seen. After the move, state.tabs
-    /// has an entry with workspace_id = dst.
-    #[test]
-    fn move_tab_lazy_imports_unknown_tab() {
+    fn move_tab_unknown_tab_rejects() {
         let mut state = State::default();
         let src = create_workspace(&mut state, "src");
         let dst = create_workspace(&mut state, "dst");
@@ -2875,17 +2838,68 @@ mod tests {
             Command::MoveTab {
                 tab_id: unknown_id.clone(),
                 src_workspace_id: src,
+                dst_workspace_id: dst,
+                dst_index: 0,
+            },
+            &ctx(2),
+        );
+        match &events[0] {
+            Event::Error { code, message, .. } => {
+                assert_eq!(*code, ErrorCode::InvalidCommand);
+                assert!(
+                    message.contains("tab not found"),
+                    "error should mention `tab not found`, got: {}",
+                    message
+                );
+            }
+            other => panic!("expected Error event, got {:?}", other),
+        }
+        // No lazy import side-effect.
+        assert!(!state.tabs.contains_key(&unknown_id));
+    }
+
+    /// Phase E.4 strict-mode flip: a known tab whose reducer-state
+    /// `workspace_id` doesn't match `src_workspace_id` is rejected.
+    /// Replaces the migration-window
+    /// `move_tab_tolerates_workspace_id_mismatch_during_migration`
+    /// test.
+    #[test]
+    fn move_tab_wrong_workspace_rejects() {
+        let mut state = State::default();
+        let real_src = create_workspace(&mut state, "real_src");
+        let dst = create_workspace(&mut state, "dst");
+        let other = create_workspace(&mut state, "other");
+        let t1 = create_tab(&mut state, &real_src, "t1");
+        let filler = create_tab(&mut state, &other, "filler");
+        // Claim the tab lives in `other` even though it actually
+        // belongs to `real_src` per reducer state.
+        let events = update(
+            &mut state,
+            Command::MoveTab {
+                tab_id: t1.clone(),
+                src_workspace_id: other.clone(),
                 dst_workspace_id: dst.clone(),
                 dst_index: 0,
             },
             &ctx(2),
         );
-        assert!(matches!(&events[0], Event::TabMoved { .. }));
-        let tab = state
-            .tabs
-            .get(&unknown_id)
-            .expect("unknown tab should be lazy-imported");
-        assert_eq!(tab.workspace_id, dst);
+        match &events[0] {
+            Event::Error { code, message, .. } => {
+                assert_eq!(*code, ErrorCode::InvalidCommand);
+                assert!(
+                    message.contains("workspace_id mismatch"),
+                    "error should mention `workspace_id mismatch`, got: {}",
+                    message
+                );
+            }
+            other => panic!("expected Error event, got {:?}", other),
+        }
+        // Reducer state untouched: t1 still in real_src, filler still
+        // in other, dst empty.
+        assert_eq!(state.tabs[&t1].workspace_id, real_src);
+        assert_eq!(state.workspaces[&real_src].tab_ids, vec![t1]);
+        assert_eq!(state.workspaces[&other].tab_ids, vec![filler]);
+        assert!(state.workspaces[&dst].tab_ids.is_empty());
     }
 
     // ---- Phase E.5.5 — MoveBlock tests ----

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.557",
+  "version": "0.33.558",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

E.4 Option A has soaked since 2026-05-01 with no `lazy-import` warnings observed in production logs. This PR flips `handle_move_tab` from migration-tolerant to strict mode by removing the lazy-import fallback that was added in PR #621.

### Behavior change

`handle_move_tab` now rejects (`Event::Error` / `ErrorCode::InvalidCommand`):

- **Unknown tab id** -> `MoveTab: tab not found in state: <id>` (was: lazy-imported a synthetic `TabRecord`)
- **Mismatched workspace_id** -> `MoveTab: workspace_id mismatch -- tab <id> belongs to <actual>, not <claimed>` (was: silently re-parented)

The same-workspace, unknown-src-workspace, and unknown-dst-workspace rejections are unchanged.

### Tests

- **Added** `move_tab_unknown_tab_rejects` -- asserts `Event::Error` with `tab not found` message and that the unknown id is NOT lazy-inserted into `state.tabs`. Replaces `move_tab_lazy_imports_unknown_tab`.
- **Added** `move_tab_wrong_workspace_rejects` -- asserts `Event::Error` with `workspace_id mismatch` and that all three workspaces (real_src, other, dst) are untouched. Replaces `move_tab_tolerates_workspace_id_mismatch_during_migration`.
- Existing happy-path test (`move_tab_cross_workspace_updates_lists_and_parent`) and the unknown-src/dst rejection test (`move_tab_rejects_unknown_src_or_dst_or_tab`, with its ghost-tab arm flipped to expect `Error`) continue to pass.

### Dead code removed

- The migration-tolerant comment block (~14 lines) explaining lazy-insert semantics.
- The `match state.tabs.get_mut(&tab_id)` arms with the lazy `state.tabs.insert(...)` synthetic `TabRecord` path -- replaced with a single `expect("checked")` after the strict pre-check.
- Comment about stale-state tolerance on the `src.tab_ids.retain(...)` block.

Diff: +102 / -88 lines in `agentmux-srv/src/reducer.rs`.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p agentmux-srv --bin agentmux-srv reducer::` (68 tests pass)
- [x] `cargo test -p agentmux-srv --bin agentmux-srv sagas::` (55 tests pass, all tear-off / promote / restore sagas still green)
- [x] Two new strict-mode test cases assert error path + state-untouched invariants

## Notes

- No production-runtime feature flag is needed: the lazy-import path was reducer-internal; sagas/RPC handlers already pre-validate against SQLite (the source of truth) before calling `MoveTab`, so any caller that previously slipped past would also have failed the SQLite-layer check.
- 5 pre-existing test failures in `backend::*` (storage / providers / wcore) are unrelated to this change and reproduce on `origin/main` without these edits.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>