### PR TITLE
feat(cpd-1): saga_id schema for host-bound Commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.562"
+version = "0.33.563"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.562"
+version = "0.33.563"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.562"
+version = "0.33.563"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.562"
+version = "0.33.563"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.562"
+version = "0.33.563"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -420,7 +420,11 @@ pub fn report_pool_window_added(label: String) {
     let Some(tx) = COMMAND_TX.get() else {
         return;
     };
-    let cmd = Command::ReportPoolWindowAdded { label };
+    // CPD-1 (schema-only): host's existing `report_pool_window_added`
+    // call sites are organic refills (not yet saga-driven); pass
+    // `saga_id: None` per spec §3.3. CPD-3 wires the saga-driven
+    // path that will pass `Some(N)` through here.
+    let cmd = Command::ReportPoolWindowAdded { label, saga_id: None };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!("[launcher-ipc] report_pool_window_added: channel closed ({})", e);
     }
@@ -481,7 +485,9 @@ pub fn report_panes_reaped(label: String) {
     let Some(tx) = COMMAND_TX.get() else {
         return;
     };
-    let cmd = Command::ReportPanesReaped { label };
+    // CPD-1 (schema-only): existing call sites are organic; CPD-3
+    // adds the saga-driven path that fills `saga_id`.
+    let cmd = Command::ReportPanesReaped { label, saga_id: None };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!("[launcher-ipc] report_panes_reaped: channel closed ({})", e);
     }
@@ -505,7 +511,13 @@ pub fn report_pool_drain_decision(label: String, was_last: bool) {
     let Some(tx) = COMMAND_TX.get() else {
         return;
     };
-    let cmd = Command::ReportPoolDrainDecision { label, was_last };
+    // CPD-1 (schema-only): existing call sites are organic; CPD-3
+    // adds the saga-driven path that fills `saga_id`.
+    let cmd = Command::ReportPoolDrainDecision {
+        label,
+        was_last,
+        saga_id: None,
+    };
     if let Err(e) = tx.send(cmd) {
         tracing::warn!(
             "[launcher-ipc] report_pool_drain_decision: channel closed ({})",

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.562"
+version = "0.33.563"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -93,6 +93,21 @@ pub enum Command {
     /// `ReportPoolWindowRemoved` on pre-promote destroy.
     ReportPoolWindowAdded {
         label: String,
+        /// Phase CPD-1 (cross-process dispatch) — saga correlation
+        /// echo. `Some(N)` when the host is replying to a saga-issued
+        /// `Command::SpawnPoolWindow { saga_id: N }`; `None` for
+        /// organic refills (e.g. host's implicit `spawn_pool_window`
+        /// inside `promote_pool_window`). The launcher reducer
+        /// passes the value through to `Event::PoolWindowAdded` so
+        /// per-saga correlation (CPD-4) can match the response to
+        /// the originating saga.
+        ///
+        /// `#[serde(default)]` for forward-compat with hosts running
+        /// pre-CPD-1 builds — they emit no `saga_id` field, which
+        /// deserializes as `None` (organic). Removed once CPD-1+CPD-3
+        /// have soaked one release cycle.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase B.4 follow-up — host reports a pool window leaving the
     /// pool (promote, destroy, or app exit).
@@ -510,7 +525,19 @@ pub enum Command {
     /// produce the `Event::PoolWindowAdded` it waits for. F.6 (or
     /// the cross-process command dispatch follow-up) replaces the
     /// log with a real wire-level send.
-    SpawnPoolWindow,
+    ///
+    /// Phase CPD-1 (cross-process dispatch) — `saga_id` is mandatory
+    /// on the wire (every host-bound command carries the originating
+    /// saga's id so the host can echo it on the corresponding
+    /// `Report*` reply). Defaults to `0` via `#[serde(default)]` for
+    /// forward-compat with launchers running pre-CPD-1 builds; the
+    /// soak default is removed in a later PR (CPD-3) once the wire
+    /// has shipped a release cycle. `0` is reserved as "no saga"
+    /// and is treated by the host as a non-saga-driven dispatch.
+    SpawnPoolWindow {
+        #[serde(default)]
+        saga_id: u64,
+    },
     /// Phase F.6 — host reports that all browser-pane HWNDs belonging
     /// to a closing top-level window have been reaped. Emitted from
     /// `client.rs::on_before_close` after the subwindow cascade and
@@ -528,6 +555,16 @@ pub enum Command {
     /// Host-only — same gate as `ReportWindowClosed`.
     ReportPanesReaped {
         label: String,
+        /// Phase CPD-1 — saga correlation echo. `Some(N)` when the
+        /// host is replying to a saga-issued
+        /// `Command::ReapPanes { saga_id: N }`; `None` for organic
+        /// reports (e.g. host's existing implicit pane drain inside
+        /// `on_before_close` that wasn't saga-driven).
+        ///
+        /// `#[serde(default)]` for forward-compat with pre-CPD-1
+        /// hosts.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase F.6 — host reports the result of the post-close
     /// drain-pool-if-last decision. `was_last == true` when the
@@ -544,6 +581,15 @@ pub enum Command {
     ReportPoolDrainDecision {
         label: String,
         was_last: bool,
+        /// Phase CPD-1 — saga correlation echo. `Some(N)` when the
+        /// host is replying to a saga-issued
+        /// `Command::DrainPoolIfLast { saga_id: N }`; `None` for
+        /// organic reports.
+        ///
+        /// `#[serde(default)]` for forward-compat with pre-CPD-1
+        /// hosts.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase F.6 — launcher-side saga coordinator asks the host to
     /// reap all browser-pane HWNDs for a window that just closed.
@@ -556,8 +602,14 @@ pub enum Command {
     /// pane drain inside `on_before_close` produces the
     /// `Event::PanesReaped` the saga waits for. F.7 / cross-process
     /// dispatch follow-up replaces the log with a real wire send.
+    ///
+    /// Phase CPD-1 — `saga_id` is mandatory on the wire (host echoes
+    /// back on `ReportPanesReaped`). `#[serde(default)]` returning `0`
+    /// for forward-compat soak; removed in CPD-3.
     ReapPanes {
         label: String,
+        #[serde(default)]
+        saga_id: u64,
     },
     /// Phase F.6 — launcher-side saga coordinator asks the host to
     /// drain the warm pool if the just-closed window was the last
@@ -569,8 +621,29 @@ pub enum Command {
     /// inline check; the saga relies on the resulting
     /// `Event::PoolDrained` / `Event::PoolNotLast` to close its
     /// bracket.
+    ///
+    /// Phase CPD-1 — `saga_id` is mandatory on the wire.
+    /// `#[serde(default)]` for forward-compat soak; removed in CPD-3.
     DrainPoolIfLast {
         label: String,
+        #[serde(default)]
+        saga_id: u64,
+    },
+    /// Phase CPD-1 — host-emitted report that a saga-issued action
+    /// failed (e.g. window not found, IPC error). Carries the
+    /// originating `saga_id` and a human-readable `reason`. The
+    /// launcher reducer translates this into `Event::SagaActionFailed`
+    /// so the saga coordinator can terminate the matching saga as
+    /// `SagaFailed`.
+    ///
+    /// Schema-only in CPD-1: hosts don't yet read commands from the
+    /// pipe (CPD-2 wires that), so no producer for this command
+    /// exists yet. The shape is added now so launcher reducer arms
+    /// + saga coordinator wiring can soak before CPD-3 makes the
+    /// dispatch live.
+    ReportSagaActionFailed {
+        saga_id: u64,
+        reason: String,
     },
 }
 
@@ -696,6 +769,17 @@ pub enum Event {
     PoolWindowAdded {
         label: String,
         version: u64,
+        /// Phase CPD-1 — saga correlation. Mirrors the `saga_id` that
+        /// arrived on the originating
+        /// `Command::ReportPoolWindowAdded { saga_id }`. `None` for
+        /// organic refills (no saga in flight). Subscribers (CPD-4
+        /// per-saga correlation) match on this to scope events to the
+        /// originating saga.
+        ///
+        /// `#[serde(default)]` for forward-compat with old
+        /// `launcher-events.log` entries that pre-date CPD-1.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     PoolWindowRemoved {
         label: String,
@@ -724,6 +808,14 @@ pub enum Event {
     PanesReaped {
         label: String,
         version: u64,
+        /// Phase CPD-1 — saga correlation. Mirrors `saga_id` from the
+        /// originating `ReportPanesReaped`. `None` for organic
+        /// reports (non-saga-driven pane drains).
+        ///
+        /// `#[serde(default)]` for forward-compat with pre-CPD-1
+        /// log entries.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase F.6 — emitted by the launcher when the host reports it
     /// kicked off Stage 1 of the close-cascade pool drain (i.e. the
@@ -740,6 +832,11 @@ pub enum Event {
     PoolDrained {
         label: String,
         version: u64,
+        /// Phase CPD-1 — saga correlation. Mirrors `saga_id` from the
+        /// originating `ReportPoolDrainDecision`. `None` for organic
+        /// reports.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase F.6 — emitted by the launcher when the host reports a
     /// close that did NOT trigger a pool drain (other user-visible
@@ -749,6 +846,11 @@ pub enum Event {
     PoolNotLast {
         label: String,
         version: u64,
+        /// Phase CPD-1 — saga correlation. Mirrors `saga_id` from the
+        /// originating `ReportPoolDrainDecision`. `None` for organic
+        /// reports.
+        #[serde(default)]
+        saga_id: Option<u64>,
     },
     /// Phase B.5 (window_id_map step a) — launcher recorded the
     /// label → backend window ID mapping. Subscribers (host's
@@ -1159,6 +1261,49 @@ pub enum Event {
         node_id: String,
         version: u64,
     },
+    /// Phase CPD-1 (cross-process dispatch) — emitted by the launcher
+    /// when the host reports that a saga-issued action failed
+    /// (`Command::ReportSagaActionFailed { saga_id, reason }`). The
+    /// saga coordinator's bus loop will (in CPD-3) treat this as a
+    /// terminal signal for the matching saga, emitting
+    /// `Event::SagaFailed` and removing it from the in-flight
+    /// registry. CPD-1 ships the wire shape only; no producer
+    /// (host) and no consumer (saga coordinator) are wired yet.
+    SagaActionFailed {
+        saga_id: u64,
+        reason: String,
+        version: u64,
+    },
+}
+
+/// Phase CPD-1 (cross-process dispatch) — envelope enum for frames
+/// sent over the launcher → host pipe direction. Today the host's
+/// read loop only expects `Event` JSON; CPD-2 extends the read loop
+/// to recognize this tagged union and dispatch by `kind`:
+///
+/// * `event` → existing event-handling code (state sync from
+///   launcher reducer broadcasts).
+/// * `command` → new command-handling code (saga-issued actions).
+///
+/// Newline-delimited JSON, one frame per line. `#[serde(tag = "kind",
+/// rename_all = "snake_case")]` so the wire shape is e.g.
+/// `{"kind":"event","event":"pool_window_added",...}` or
+/// `{"kind":"command","cmd":"spawn_pool_window","saga_id":42}`.
+///
+/// Schema-only in CPD-1: introduced now so the launcher's host-pipe
+/// writer (CPD-2) and the host's read loop (CPD-2/CPD-3) can be
+/// built against a stable wire envelope without further schema
+/// churn.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum HostFrame {
+    /// Wraps a launcher-emitted Event being pushed down to the host
+    /// (existing fanout path; CPD-2 refactors the writer to go
+    /// through this envelope).
+    Event(Event),
+    /// Wraps a saga-issued Command being dispatched from the launcher
+    /// to the host. Carries `saga_id` inside the Command payload.
+    Command(Command),
 }
 
 /// Phase D.1 — serializable view of one window in the launcher
@@ -1319,6 +1464,344 @@ mod tests {
     fn unknown_cmd_fails_to_deserialize() {
         let json = r#"{"cmd":"banana"}"#;
         let r: Result<Command, _> = serde_json::from_str(json);
+        assert!(r.is_err());
+    }
+
+    // ---------- Phase CPD-1 — saga_id schema additions ----------
+
+    #[test]
+    fn cpd1_spawn_pool_window_round_trip_with_saga_id() {
+        let c = Command::SpawnPoolWindow { saga_id: 42 };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"cmd\":\"spawn_pool_window\""));
+        assert!(json.contains("\"saga_id\":42"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::SpawnPoolWindow { saga_id } => assert_eq!(saga_id, 42),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_spawn_pool_window_forward_compat_default_zero() {
+        // Pre-CPD-1 hosts emit the bare command with no `saga_id`
+        // field; serde_default fills in 0.
+        let json = r#"{"cmd":"spawn_pool_window"}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::SpawnPoolWindow { saga_id } => assert_eq!(saga_id, 0),
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_reap_panes_round_trip_with_saga_id() {
+        let c = Command::ReapPanes {
+            label: "main".into(),
+            saga_id: 7,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"cmd\":\"reap_panes\""));
+        assert!(json.contains("\"saga_id\":7"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::ReapPanes { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, 7);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_reap_panes_forward_compat_default_zero() {
+        let json = r#"{"cmd":"reap_panes","label":"main"}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::ReapPanes { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, 0);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_drain_pool_if_last_round_trip_with_saga_id() {
+        let c = Command::DrainPoolIfLast {
+            label: "main".into(),
+            saga_id: 13,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"cmd\":\"drain_pool_if_last\""));
+        assert!(json.contains("\"saga_id\":13"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::DrainPoolIfLast { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, 13);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_drain_pool_if_last_forward_compat_default_zero() {
+        let json = r#"{"cmd":"drain_pool_if_last","label":"main"}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::DrainPoolIfLast { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, 0);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_window_added_round_trip_with_some() {
+        let c = Command::ReportPoolWindowAdded {
+            label: "pool-xyz".into(),
+            saga_id: Some(99),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"saga_id\":99"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::ReportPoolWindowAdded { label, saga_id } => {
+                assert_eq!(label, "pool-xyz");
+                assert_eq!(saga_id, Some(99));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_window_added_forward_compat_default_none() {
+        // Pre-CPD-1 hosts omit `saga_id` entirely; deserializes to
+        // `None`. JSON with explicit null is also valid.
+        let json = r#"{"cmd":"report_pool_window_added","label":"pool-xyz"}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::ReportPoolWindowAdded { label, saga_id } => {
+                assert_eq!(label, "pool-xyz");
+                assert_eq!(saga_id, None);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_panes_reaped_round_trip_with_some() {
+        let c = Command::ReportPanesReaped {
+            label: "main".into(),
+            saga_id: Some(11),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::ReportPanesReaped { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, Some(11));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_panes_reaped_forward_compat_default_none() {
+        let json = r#"{"cmd":"report_panes_reaped","label":"main"}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::ReportPanesReaped { label, saga_id } => {
+                assert_eq!(label, "main");
+                assert_eq!(saga_id, None);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_drain_decision_round_trip_with_some() {
+        let c = Command::ReportPoolDrainDecision {
+            label: "main".into(),
+            was_last: true,
+            saga_id: Some(101),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::ReportPoolDrainDecision {
+                label,
+                was_last,
+                saga_id,
+            } => {
+                assert_eq!(label, "main");
+                assert!(was_last);
+                assert_eq!(saga_id, Some(101));
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_drain_decision_forward_compat_default_none() {
+        let json = r#"{"cmd":"report_pool_drain_decision","label":"main","was_last":false}"#;
+        let back: Command = serde_json::from_str(json).unwrap();
+        match back {
+            Command::ReportPoolDrainDecision {
+                label,
+                was_last,
+                saga_id,
+            } => {
+                assert_eq!(label, "main");
+                assert!(!was_last);
+                assert_eq!(saga_id, None);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_saga_action_failed_round_trip() {
+        let c = Command::ReportSagaActionFailed {
+            saga_id: 55,
+            reason: "window not found".into(),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"cmd\":\"report_saga_action_failed\""));
+        assert!(json.contains("\"saga_id\":55"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        match back {
+            Command::ReportSagaActionFailed { saga_id, reason } => {
+                assert_eq!(saga_id, 55);
+                assert_eq!(reason, "window not found");
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_event_pool_window_added_round_trip_with_saga_id() {
+        let e = Event::PoolWindowAdded {
+            label: "pool-xyz".into(),
+            version: 7,
+            saga_id: Some(42),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"saga_id\":42"));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn cpd1_event_panes_reaped_forward_compat_default_none() {
+        // Pre-CPD-1 launcher-events.log entries lack `saga_id`.
+        let json = r#"{"event":"panes_reaped","label":"main","version":1}"#;
+        let back: Event = serde_json::from_str(json).unwrap();
+        match back {
+            Event::PanesReaped {
+                label,
+                version,
+                saga_id,
+            } => {
+                assert_eq!(label, "main");
+                assert_eq!(version, 1);
+                assert_eq!(saga_id, None);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_event_pool_drained_round_trip_with_saga_id() {
+        let e = Event::PoolDrained {
+            label: "main".into(),
+            version: 9,
+            saga_id: Some(3),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn cpd1_event_pool_not_last_forward_compat_default_none() {
+        let json = r#"{"event":"pool_not_last","label":"main","version":3}"#;
+        let back: Event = serde_json::from_str(json).unwrap();
+        match back {
+            Event::PoolNotLast {
+                label,
+                version,
+                saga_id,
+            } => {
+                assert_eq!(label, "main");
+                assert_eq!(version, 3);
+                assert_eq!(saga_id, None);
+            }
+            other => panic!("wrong variant: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_event_saga_action_failed_round_trip() {
+        let e = Event::SagaActionFailed {
+            saga_id: 12,
+            reason: "host pipe broken".into(),
+            version: 100,
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains("\"event\":\"saga_action_failed\""));
+        assert!(json.contains("\"saga_id\":12"));
+        let back: Event = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, e);
+    }
+
+    #[test]
+    fn cpd1_host_frame_event_round_trip() {
+        let frame = HostFrame::Event(Event::PoolWindowAdded {
+            label: "pool-xyz".into(),
+            version: 5,
+            saga_id: Some(7),
+        });
+        let json = serde_json::to_string(&frame).unwrap();
+        assert!(json.contains("\"kind\":\"event\""));
+        assert!(json.contains("\"event\":\"pool_window_added\""));
+        let back: HostFrame = serde_json::from_str(&json).unwrap();
+        match back {
+            HostFrame::Event(Event::PoolWindowAdded {
+                label,
+                version,
+                saga_id,
+            }) => {
+                assert_eq!(label, "pool-xyz");
+                assert_eq!(version, 5);
+                assert_eq!(saga_id, Some(7));
+            }
+            other => panic!("wrong frame: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_host_frame_command_round_trip() {
+        let frame = HostFrame::Command(Command::SpawnPoolWindow { saga_id: 31 });
+        let json = serde_json::to_string(&frame).unwrap();
+        assert!(json.contains("\"kind\":\"command\""));
+        assert!(json.contains("\"cmd\":\"spawn_pool_window\""));
+        assert!(json.contains("\"saga_id\":31"));
+        let back: HostFrame = serde_json::from_str(&json).unwrap();
+        match back {
+            HostFrame::Command(Command::SpawnPoolWindow { saga_id }) => {
+                assert_eq!(saga_id, 31);
+            }
+            other => panic!("wrong frame: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_host_frame_unknown_kind_fails() {
+        let json = r#"{"kind":"banana"}"#;
+        let r: Result<HostFrame, _> = serde_json::from_str(json);
         assert!(r.is_err());
     }
 }

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.562"
+version = "0.33.563"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -291,6 +291,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::BlockDeleted { version, .. }
         | Event::FocusedNodeChanged { version, .. }
         | Event::MagnifiedNodeChanged { version, .. }
+        | Event::SagaActionFailed { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -594,7 +594,7 @@ async fn enforce_register_first(
         // command. Sent to the launcher pipe before Register: same
         // soft-error treatment as the srv-pipe misroutes (the client
         // can recover by registering or routing correctly).
-        Command::SpawnPoolWindow => {
+        Command::SpawnPoolWindow { .. } => {
             ("SpawnPoolWindow is a launcher→host command; sent to launcher pipe by mistake".to_string(), false)
         }
         // Phase F.6 — host-only reports; same fatal-before-Register
@@ -612,6 +612,12 @@ async fn enforce_register_first(
         }
         Command::DrainPoolIfLast { .. } => {
             ("DrainPoolIfLast is a launcher→host command; sent to launcher pipe by mistake".to_string(), false)
+        }
+        // Phase CPD-1 — host-only saga-action-failed report. Same
+        // fatal-before-Register treatment as the other Report*
+        // commands above.
+        Command::ReportSagaActionFailed { .. } => {
+            ("ReportSagaActionFailed before Register".to_string(), true)
         }
         Command::ReportHostCounts { .. } => {
             ("ReportHostCounts before Register".to_string(), true)

--- a/agentmux-launcher/src/reducer.rs
+++ b/agentmux-launcher/src/reducer.rs
@@ -105,11 +105,11 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }
             handle_report_window_closed(state, label)
         }
-        Command::ReportPoolWindowAdded { label } => {
+        Command::ReportPoolWindowAdded { label, saga_id } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
                 return vec![err];
             }
-            handle_report_pool_window_added(state, label)
+            handle_report_pool_window_added(state, label, saga_id)
         }
         Command::ReportPoolWindowRemoved { label } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowRemoved") {
@@ -135,7 +135,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         // error so the client knows the dispatch was wrong (vs silently
         // appearing successful with no reply). Same misrouted-error
         // pattern as the srv-pipe commands below.
-        Command::SpawnPoolWindow => {
+        Command::SpawnPoolWindow { .. } => {
             let v = state.bump_version();
             vec![Event::Error {
                 code: agentmux_common::ipc::ErrorCode::InvalidCommand,
@@ -153,22 +153,26 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         // structures (lifecycle entries, pane HWND map), not the
         // launcher's mirror; the launcher just narrates the
         // transition for subscribers.
-        Command::ReportPanesReaped { label } => {
+        Command::ReportPanesReaped { label, saga_id } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPanesReaped") {
                 return vec![err];
             }
-            handle_report_panes_reaped(state, label)
+            handle_report_panes_reaped(state, label, saga_id)
         }
         // Phase F.6 — host reports the result of the post-close
         // drain-pool-if-last decision. `was_last == true` →
         // `Event::PoolDrained`; `was_last == false` →
         // `Event::PoolNotLast`. Both are terminal alternatives for
         // the window-cleanup-cascade saga's Step 2.
-        Command::ReportPoolDrainDecision { label, was_last } => {
+        Command::ReportPoolDrainDecision {
+            label,
+            was_last,
+            saga_id,
+        } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolDrainDecision") {
                 return vec![err];
             }
-            handle_report_pool_drain_decision(state, label, was_last)
+            handle_report_pool_drain_decision(state, label, was_last, saga_id)
         }
         // Phase F.6 — `ReapPanes` and `DrainPoolIfLast` are
         // launcher→host direction commands, NOT host→launcher
@@ -191,6 +195,18 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 fatal: false,
                 version: v,
             }]
+        }
+        // Phase CPD-1 — host-emitted report that a saga-issued action
+        // failed. Pure pass-through arm: translates the wire command
+        // into `Event::SagaActionFailed`. The saga coordinator's bus
+        // loop (CPD-3) will treat this as a terminal signal for the
+        // matching `saga_id` and emit `Event::SagaFailed`. Host-only
+        // gate same as other Report* arms.
+        Command::ReportSagaActionFailed { saga_id, reason } => {
+            if let Some(err) = enforce_host_only(state, ctx, "ReportSagaActionFailed") {
+                return vec![err];
+            }
+            handle_report_saga_action_failed(state, saga_id, reason)
         }
         Command::ReportHostCounts { windows, pool } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportHostCounts") {
@@ -589,10 +605,18 @@ fn handle_report_host_counts(state: &mut State, host_windows: u32, host_pool: u3
 /// Phase B.4 follow-up — record pool inventory growth. Idempotent
 /// on duplicate labels (HashSet semantics) but the event still fires
 /// so subscribers can track add-attempts even if redundant.
-fn handle_report_pool_window_added(state: &mut State, label: String) -> Vec<Event> {
+fn handle_report_pool_window_added(
+    state: &mut State,
+    label: String,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
     state.pool.insert(label.clone());
     let v = state.bump_version();
-    vec![Event::PoolWindowAdded { label, version: v }]
+    vec![Event::PoolWindowAdded {
+        label,
+        version: v,
+        saga_id,
+    }]
 }
 
 /// Phase B.4 follow-up — record pool inventory shrink (promote or
@@ -639,7 +663,11 @@ fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<E
 /// Idempotent / context-free: the saga matches the `label` against
 /// its own `closed_label`, so a stray report for a label that no
 /// in-flight saga is tracking is a harmless broadcast.
-fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
+fn handle_report_panes_reaped(
+    state: &mut State,
+    label: String,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
     // No state.windows gate — round 4's gate had an ordering bug:
     // host sends ReportWindowClosed BEFORE ReportPanesReaped on the
     // same channel, so by the time the reducer processes this, the
@@ -650,8 +678,15 @@ fn handle_report_panes_reaped(state: &mut State, label: String) -> Vec<Event> {
     // unpromoted-pool drains where no saga is in flight, the event
     // appears stray on the bus but is harmless (no subscriber acts
     // on it). Cosmetic only; correct saga lifecycle restored.
+    //
+    // CPD-1: `saga_id` flows through unchanged (None for organic
+    // reports, Some(N) once CPD-3 hosts echo back the saga's id).
     let v = state.bump_version();
-    vec![Event::PanesReaped { label, version: v }]
+    vec![Event::PanesReaped {
+        label,
+        version: v,
+        saga_id,
+    }]
 }
 
 /// Phase F.6 — host-emitted signal carrying the result of the
@@ -668,15 +703,44 @@ fn handle_report_pool_drain_decision(
     state: &mut State,
     label: String,
     was_last: bool,
+    saga_id: Option<u64>,
 ) -> Vec<Event> {
     // Same rationale as handle_report_panes_reaped: round 4's gate
     // had an ordering bug; round 5 reverts to emit-unconditionally.
+    //
+    // CPD-1: `saga_id` flows through unchanged.
     let v = state.bump_version();
     if was_last {
-        vec![Event::PoolDrained { label, version: v }]
+        vec![Event::PoolDrained {
+            label,
+            version: v,
+            saga_id,
+        }]
     } else {
-        vec![Event::PoolNotLast { label, version: v }]
+        vec![Event::PoolNotLast {
+            label,
+            version: v,
+            saga_id,
+        }]
     }
+}
+
+/// Phase CPD-1 — host reported a saga-issued action failed. Pure
+/// pass-through translation into `Event::SagaActionFailed`. The
+/// saga coordinator's bus loop will (CPD-3) treat the event as a
+/// terminal signal for the matching `saga_id` and emit
+/// `Event::SagaFailed`, dropping the saga from in-flight.
+fn handle_report_saga_action_failed(
+    state: &mut State,
+    saga_id: u64,
+    reason: String,
+) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::SagaActionFailed {
+        saga_id,
+        reason,
+        version: v,
+    }]
 }
 
 /// Phase B.4 — gate window-mirror reports to Host clients only. The
@@ -1231,6 +1295,7 @@ mod tests {
             | Event::BlockDeleted { version, .. }
             | Event::FocusedNodeChanged { version, .. }
             | Event::MagnifiedNodeChanged { version, .. }
+            | Event::SagaActionFailed { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }
@@ -1503,6 +1568,7 @@ mod tests {
             &mut state,
             Command::ReportPoolWindowAdded {
                 label: "window-pool-abc".into(),
+                saga_id: None,
             },
             &host_ctx,
         );
@@ -1526,6 +1592,143 @@ mod tests {
             Event::PoolWindowRemoved { label, .. } if label == "window-pool-abc"
         ));
         assert!(!state.pool.contains("window-pool-abc"));
+    }
+
+    /// Phase CPD-1 — saga_id from the Report* commands is plumbed
+    /// unchanged into the resulting Events. Pass-through invariant for
+    /// the reducer arms; per-saga correlation in CPD-4 relies on this.
+    #[test]
+    fn cpd1_report_panes_reaped_passes_saga_id_through() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let evs = update(
+            &mut state,
+            Command::ReportPanesReaped {
+                label: "main".into(),
+                saga_id: Some(42),
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::PanesReaped {
+                label,
+                saga_id,
+                ..
+            } => {
+                assert_eq!(label, "main");
+                assert_eq!(*saga_id, Some(42));
+            }
+            other => panic!("expected Event::PanesReaped, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_panes_reaped_with_none_saga_id_passes_through() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let evs = update(
+            &mut state,
+            Command::ReportPanesReaped {
+                label: "main".into(),
+                saga_id: None,
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::PanesReaped { saga_id, .. } => {
+                assert_eq!(*saga_id, None);
+            }
+            other => panic!("expected Event::PanesReaped, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_drain_decision_passes_saga_id_through() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let evs = update(
+            &mut state,
+            Command::ReportPoolDrainDecision {
+                label: "main".into(),
+                was_last: true,
+                saga_id: Some(7),
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::PoolDrained { label, saga_id, .. } => {
+                assert_eq!(label, "main");
+                assert_eq!(*saga_id, Some(7));
+            }
+            other => panic!("expected Event::PoolDrained, got {:?}", other),
+        }
+
+        let evs = update(
+            &mut state,
+            Command::ReportPoolDrainDecision {
+                label: "secondary".into(),
+                was_last: false,
+                saga_id: Some(8),
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::PoolNotLast { label, saga_id, .. } => {
+                assert_eq!(label, "secondary");
+                assert_eq!(*saga_id, Some(8));
+            }
+            other => panic!("expected Event::PoolNotLast, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_pool_window_added_passes_saga_id_through() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let evs = update(
+            &mut state,
+            Command::ReportPoolWindowAdded {
+                label: "pool-1".into(),
+                saga_id: Some(99),
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::PoolWindowAdded { label, saga_id, .. } => {
+                assert_eq!(label, "pool-1");
+                assert_eq!(*saga_id, Some(99));
+            }
+            other => panic!("expected Event::PoolWindowAdded, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cpd1_report_saga_action_failed_emits_saga_action_failed_event() {
+        let mut state = State::default();
+        let host_ctx = register_host_and_get_ctx(&mut state, 1234);
+        let evs = update(
+            &mut state,
+            Command::ReportSagaActionFailed {
+                saga_id: 21,
+                reason: "host pipe closed".into(),
+            },
+            &host_ctx,
+        );
+        assert_eq!(evs.len(), 1);
+        match &evs[0] {
+            Event::SagaActionFailed {
+                saga_id, reason, ..
+            } => {
+                assert_eq!(*saga_id, 21);
+                assert_eq!(reason, "host pipe closed");
+            }
+            other => panic!("expected Event::SagaActionFailed, got {:?}", other),
+        }
     }
 
     #[test]
@@ -1620,6 +1823,7 @@ mod tests {
             &mut state,
             Command::ReportPoolWindowAdded {
                 label: "window-pool-xyz".into(),
+                saga_id: None,
             },
             &host_ctx,
         );
@@ -1718,6 +1922,7 @@ mod tests {
             &mut state,
             Command::ReportPoolWindowAdded {
                 label: "window-pool-a".into(),
+                saga_id: None,
             },
             &host_ctx,
         );
@@ -1750,6 +1955,7 @@ mod tests {
             &mut state,
             Command::ReportPoolWindowAdded {
                 label: "window-pool-x".into(),
+                saga_id: None,
             },
             &host_ctx,
         );
@@ -1848,6 +2054,7 @@ mod tests {
             &mut state,
             Command::ReportPoolWindowAdded {
                 label: "spoof-pool".into(),
+                saga_id: None,
             },
             &ctx_with_pid(1, 9999),
         );
@@ -2767,7 +2974,7 @@ mod tests {
                     Command::ReportWindowOpened { label, kind, parent_label }
                 }),
             3 => "[a-c]{1,3}".prop_map(|label| Command::ReportWindowClosed { label }),
-            2 => "pool-[a-c]{1,2}".prop_map(|label| Command::ReportPoolWindowAdded { label }),
+            2 => "pool-[a-c]{1,2}".prop_map(|label| Command::ReportPoolWindowAdded { label, saga_id: None }),
             2 => "pool-[a-c]{1,2}".prop_map(|label| Command::ReportPoolWindowRemoved { label }),
             2 => ("[a-c]{1,3}", "[0-9a-f]{4}").prop_map(|(label, window_id)| {
                 Command::ReportBackendWindowIdRegistered { label, window_id }
@@ -2926,6 +3133,7 @@ mod tests {
         for label in &["pool-1", "pool-2", "pool-3"] {
             let _ = update(&mut state, Command::ReportPoolWindowAdded {
                 label: (*label).into(),
+                saga_id: None,
             }, &host_ctx);
         }
 
@@ -2999,6 +3207,7 @@ mod tests {
         }, &host_ctx);
         let _ = update(&mut state, Command::ReportPoolWindowAdded {
             label: "pool-x".into(),
+            saga_id: None,
         }, &host_ctx);
         let _ = update(&mut state, Command::ReportBackendWindowIdRegistered {
             label: "main".into(),
@@ -3168,7 +3377,7 @@ mod tests {
             }
             F7HostOp::PoolAdd => update(
                 state,
-                Command::ReportPoolWindowAdded { label },
+                Command::ReportPoolWindowAdded { label, saga_id: None },
                 host_ctx,
             ),
             F7HostOp::PoolRemove => update(
@@ -3182,11 +3391,11 @@ mod tests {
                 host_ctx,
             ),
             F7HostOp::PanesReaped => {
-                update(state, Command::ReportPanesReaped { label }, host_ctx)
+                update(state, Command::ReportPanesReaped { label, saga_id: None }, host_ctx)
             }
             F7HostOp::PoolDrainDecision { was_last } => update(
                 state,
-                Command::ReportPoolDrainDecision { label, was_last },
+                Command::ReportPoolDrainDecision { label, was_last, saga_id: None },
                 host_ctx,
             ),
         }
@@ -3316,7 +3525,7 @@ mod tests {
             // PanesReaped: must emit exactly one Event::PanesReaped.
             let evs = update(
                 &mut state,
-                Command::ReportPanesReaped { label: label.clone() },
+                Command::ReportPanesReaped { label: label.clone(), saga_id: None },
                 &host_ctx,
             );
             prop_assert_eq!(evs.len(), 1);
@@ -3332,7 +3541,7 @@ mod tests {
             // PoolDrainDecision: maps cleanly to one terminal event.
             let evs = update(
                 &mut state,
-                Command::ReportPoolDrainDecision { label, was_last },
+                Command::ReportPoolDrainDecision { label, was_last, saga_id: None },
                 &host_ctx,
             );
             prop_assert_eq!(evs.len(), 1);

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -586,6 +586,7 @@ mod tests {
             Event::PoolWindowAdded {
                 label: "window-pool-abc".into(),
                 version: 1,
+                saga_id: None,
             },
             Event::PoolWindowRemoved {
                 label: "window-pool-abc".into(),
@@ -608,14 +609,17 @@ mod tests {
             Event::PanesReaped {
                 label: "main".into(),
                 version: 1,
+                saga_id: None,
             },
             Event::PoolDrained {
                 label: "main".into(),
                 version: 1,
+                saga_id: None,
             },
             Event::PoolNotLast {
                 label: "main".into(),
                 version: 1,
+                saga_id: None,
             },
         ];
         for event in cases {
@@ -907,10 +911,12 @@ mod tests {
         let _ = events_tx.send(Event::PanesReaped {
             label: "main".into(),
             version: 2,
+            saga_id: None,
         });
         let _ = events_tx.send(Event::PoolDrained {
             label: "main".into(),
             version: 3,
+            saga_id: None,
         });
         // And ONE pool-respawn saga to completion.
         let _ = events_tx.send(Event::PoolWindowPromoted {
@@ -920,6 +926,7 @@ mod tests {
         let _ = events_tx.send(Event::PoolWindowAdded {
             label: "pool-2".into(),
             version: 5,
+            saga_id: None,
         });
 
         // Drain the bus with a deadline. Count one terminal event

--- a/agentmux-launcher/src/saga/pool_respawn.rs
+++ b/agentmux-launcher/src/saga/pool_respawn.rs
@@ -174,9 +174,14 @@ impl Saga for PoolRespawn {
         // such pipe exists yet — see module docstring).
         debug_assert_eq!(self.phase, Phase::Initial);
         self.phase = Phase::WaitingForRefill;
+        // CPD-1 schema-only: the wire shape now carries saga_id, but
+        // the saga's `apply_action` for `IssueCmd::Host` is still
+        // log-only (CPD-3 wires real dispatch). We pass `0` here as
+        // a placeholder; CPD-3's `inject_saga_id()` helper rewrites
+        // it to the live saga's id at dispatch time.
         SagaAction::IssueCmd {
             target: PipeTarget::Host,
-            cmd: Command::SpawnPoolWindow,
+            cmd: Command::SpawnPoolWindow { saga_id: 0 },
         }
     }
 
@@ -219,7 +224,7 @@ mod tests {
         match action {
             SagaAction::IssueCmd { target, cmd } => {
                 assert_eq!(target, PipeTarget::Host);
-                assert!(matches!(cmd, Command::SpawnPoolWindow));
+                assert!(matches!(cmd, Command::SpawnPoolWindow { .. }));
             }
             other => panic!(
                 "expected IssueCmd(SpawnPoolWindow) on start, got {:?}",
@@ -236,6 +241,7 @@ mod tests {
             &Event::PoolWindowAdded {
                 label: "window-pool-xyz".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -293,6 +299,7 @@ mod tests {
             &Event::PoolWindowAdded {
                 label: "window-pool-first".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -337,6 +344,7 @@ mod tests {
         let _ = events_tx.send(Event::PoolWindowAdded {
             label: "window-pool-xyz".into(),
             version: 2,
+            saga_id: None,
         });
 
         // Drain witness with a brief budget; we expect at minimum:

--- a/agentmux-launcher/src/saga/window_cleanup.rs
+++ b/agentmux-launcher/src/saga/window_cleanup.rs
@@ -210,10 +210,14 @@ impl Saga for WindowCleanupCascade {
         // such pipe exists yet — see module docstring).
         debug_assert_eq!(self.phase, Phase::Initial);
         self.phase = Phase::ReapingPanes;
+        // CPD-1 schema-only: saga_id placeholder (0) — coordinator's
+        // `apply_action` for `IssueCmd::Host` remains log-only;
+        // CPD-3 will inject the live saga's id at dispatch time.
         SagaAction::IssueCmd {
             target: PipeTarget::Host,
             cmd: Command::ReapPanes {
                 label: self.closed_label.clone(),
+                saga_id: 0,
             },
         }
     }
@@ -229,10 +233,13 @@ impl Saga for WindowCleanupCascade {
                 if label == &self.closed_label =>
             {
                 self.phase = Phase::DrainingPool;
+                // CPD-1 schema-only: saga_id placeholder (0); CPD-3
+                // injects the live saga's id at dispatch time.
                 SagaAction::IssueCmd {
                     target: PipeTarget::Host,
                     cmd: Command::DrainPoolIfLast {
                         label: self.closed_label.clone(),
+                        saga_id: 0,
                     },
                 }
             }
@@ -278,7 +285,7 @@ mod tests {
             SagaAction::IssueCmd { target, cmd } => {
                 assert_eq!(target, PipeTarget::Host);
                 match cmd {
-                    Command::ReapPanes { label } => assert_eq!(label, "main"),
+                    Command::ReapPanes { label, .. } => assert_eq!(label, "main"),
                     other => panic!("expected ReapPanes, got {:?}", other),
                 }
             }
@@ -298,6 +305,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -305,7 +313,7 @@ mod tests {
             SagaAction::IssueCmd { target, cmd } => {
                 assert_eq!(target, PipeTarget::Host);
                 match cmd {
-                    Command::DrainPoolIfLast { label } => assert_eq!(label, "main"),
+                    Command::DrainPoolIfLast { label, .. } => assert_eq!(label, "main"),
                     other => panic!("expected DrainPoolIfLast, got {:?}", other),
                 }
             }
@@ -326,6 +334,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -333,6 +342,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "main".into(),
                 version: 101,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -348,6 +358,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "secondary".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -355,6 +366,7 @@ mod tests {
             &Event::PoolNotLast {
                 label: "secondary".into(),
                 version: 101,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -383,6 +395,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "different-window".into(),
                 version: 51,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -394,6 +407,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "main".into(),
                 version: 52,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -422,6 +436,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -431,6 +446,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "other".into(),
                 version: 101,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -439,6 +455,7 @@ mod tests {
             &Event::PoolNotLast {
                 label: "other".into(),
                 version: 102,
+                saga_id: None,
             },
             &ctx(7),
         );
@@ -477,11 +494,13 @@ mod tests {
         let _ = events_tx.send(Event::PanesReaped {
             label: "main".into(),
             version: 2,
+            saga_id: None,
         });
         // Step 2 terminal — pick the "drained" branch.
         let _ = events_tx.send(Event::PoolDrained {
             label: "main".into(),
             version: 3,
+            saga_id: None,
         });
 
         let mut saw_started = false;
@@ -559,10 +578,12 @@ mod tests {
         let _ = events_tx.send(Event::PanesReaped {
             label: "secondary".into(),
             version: 3,
+            saga_id: None,
         });
         let _ = events_tx.send(Event::PoolNotLast {
             label: "secondary".into(),
             version: 4,
+            saga_id: None,
         });
 
         let mut started_count = 0u32;

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.562"
+version = "0.33.563"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -291,6 +291,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::BlockDeleted { version, .. }
         | Event::FocusedNodeChanged { version, .. }
         | Event::MagnifiedNodeChanged { version, .. }
+        | Event::SagaActionFailed { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -1254,6 +1254,7 @@ mod tests {
             | Event::BlockMoved { version, .. }
             | Event::FocusedNodeChanged { version, .. }
             | Event::MagnifiedNodeChanged { version, .. }
+            | Event::SagaActionFailed { version, .. }
             | Event::Error { version, .. } => *version,
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.562",
+  "version": "0.33.563",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.562",
+      "version": "0.33.563",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.562",
+  "version": "0.33.563",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR 1 of 5 in the **Cross-Process Dispatch** thread (CPD). Schema-only additions to the `Command` / `Event` enums in `agentmux-common::ipc` plus reducer plumbing in `agentmux-launcher::reducer`. **No behavior change** — saga coordinator's `apply_action` for `IssueCmd::Host` remains log-only; hosts still don't read commands from the pipe (CPD-2 wires that).

Reference: [`docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md`](docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md) §3.2 (Command payloads), §3.3 (Report* echo of saga_id), §4 PR1 (~150 LOC scope, schema soak).

## What changed

### Host-bound Commands (mandatory `saga_id: u64`)

Each carries the originating saga's id; host echoes it on the corresponding `Report*` reply for per-saga correlation (CPD-4).

- `Command::SpawnPoolWindow { saga_id }`
- `Command::ReapPanes { label, saga_id }`
- `Command::DrainPoolIfLast { label, saga_id }`

### Report* Commands (host → launcher) — `saga_id: Option<u64>`

`Some(N)` when responding to a saga-issued command; `None` for organic reports.

- `Command::ReportPoolWindowAdded { label, saga_id }`
- `Command::ReportPanesReaped { label, saga_id }`
- `Command::ReportPoolDrainDecision { label, was_last, saga_id }`

### New Command + Event for saga-action failures

- `Command::ReportSagaActionFailed { saga_id, reason }`
- `Event::SagaActionFailed { saga_id, reason, version }`

### Events that mirror Report* — `saga_id: Option<u64>`

Reducer plumbs `saga_id` from incoming Report* command into emitted Event unchanged.

- `Event::PoolWindowAdded { label, version, saga_id }`
- `Event::PanesReaped { label, version, saga_id }`
- `Event::PoolDrained { label, version, saga_id }`
- `Event::PoolNotLast { label, version, saga_id }`

### `HostFrame` envelope

```rust
#[derive(Serialize, Deserialize)]
#[serde(tag = "kind", rename_all = "snake_case")]
pub enum HostFrame {
    Event(Event),
    Command(Command),
}
```

For the launcher → host pipe (used in CPD-2 to dispatch tagged frames). Schema only here; no producer/consumer wired.

### `#[serde(default)]` rationale (forward-compat soak)

Every new field has `#[serde(default)]` so:

- A new launcher reading a frame from a **pre-CPD-1 host** (no `saga_id` field in the JSON) gets the safe default (`None` for `Option<u64>`, `0` for `u64`).
- A new host reading a frame from a **pre-CPD-1 launcher** (none in production yet) likewise defaults.

The mandatory `u64` defaults to `0` — reserved as "no saga" sentinel; CPD-3's `inject_saga_id()` rewrites it to the live id at dispatch time, and the soak default is removed once both sides have shipped one release cycle.

### Reducer arms

`agentmux-launcher/src/reducer.rs`:

- `Command::ReportPoolWindowAdded { label, saga_id }` → `Event::PoolWindowAdded { label, version, saga_id }`
- `Command::ReportPanesReaped { label, saga_id }` → `Event::PanesReaped { label, version, saga_id }`
- `Command::ReportPoolDrainDecision { label, was_last, saga_id }` → `Event::PoolDrained { label, version, saga_id }` or `Event::PoolNotLast { label, version, saga_id }`
- `Command::ReportSagaActionFailed { saga_id, reason }` → `Event::SagaActionFailed { saga_id, reason, version }` (new arm)
- Existing `SpawnPoolWindow { .. }` / `ReapPanes { .. }` / `DrainPoolIfLast { .. }` misroute-error arms updated to ignore the new field.

### Scope guard

Only narrow mechanical updates outside `agentmux-common` + `agentmux-launcher`:

- `agentmux-cef/src/launcher_ipc.rs`: existing organic call sites pass `saga_id: None` (compile-required). CPD-3 adds the saga-driven path.
- `agentmux-launcher/src/saga/{mod,pool_respawn,window_cleanup}.rs`: test fixtures + saga step constructors updated. Saga-issued IssueCmd commands carry placeholder `saga_id: 0`; CPD-3 injects the live id at dispatch.
- `agentmux-launcher/src/{event_log,ipc/server}.rs` + `agentmux-srv/src/{event_log,reducer}.rs`: `Event::SagaActionFailed` added to `extract_version` arms; pre-Register guard added for `Command::ReportSagaActionFailed`.

`apply_action` in `saga/mod.rs` is **not** modified (CPD-3's scope).

## Tests

- **18 new round-trip + forward-compat tests** in `agentmux-common/src/ipc.rs` covering each new variant, both with `Some(N)` / `Some(value)` and the missing-field path that exercises `#[serde(default)]`.
- **4 new reducer tests** in `agentmux-launcher/src/reducer.rs`:
  - `cpd1_report_panes_reaped_passes_saga_id_through`
  - `cpd1_report_pool_drain_decision_passes_saga_id_through` (covers both `PoolDrained` and `PoolNotLast` arms)
  - `cpd1_report_pool_window_added_passes_saga_id_through`
  - `cpd1_report_saga_action_failed_emits_saga_action_failed_event`

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p agentmux-common` — 24 passed (including 18 new CPD-1 tests)
- [x] `cargo test -p agentmux-launcher` — 102 passed, 0 failed
- [x] `cargo test -p agentmux-cef` — 41 passed, 0 failed
- [x] `cargo test -p agentmux-srv` — 780 passed, 4 failed (preserves pre-existing baseline failures: `provider_list_has_six_entries`, `test_handler_inject_success`, `test_sweep_archives_inactive_session`, `test_ensure_initial_data_first_launch`; plus the integration_test.rs `reqwest::blocking` baseline compile failure)

Diff: 10 files, +777/-28 (mostly tests in `agentmux-common`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)