### PR TITLE
feat(cpd-3): wire saga dispatch — F.5 + F.6 stop being narrators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.570"
+version = "0.33.571"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.570"
+version = "0.33.571"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.570"
+version = "0.33.571"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.570"
+version = "0.33.571"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.572"
+version = "0.33.573"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.572"
+version = "0.33.573"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.572"
+version = "0.33.573"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.572"
+version = "0.33.573"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.571"
+version = "0.33.572"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.571"
+version = "0.33.572"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.571"
+version = "0.33.572"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.571"
+version = "0.33.572"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.569"
+version = "0.33.570"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.569"
+version = "0.33.570"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.569"
+version = "0.33.570"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.569"
+version = "0.33.570"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.570"
+version = "0.33.571"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.572"
+version = "0.33.573"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.569"
+version = "0.33.570"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.571"
+version = "0.33.572"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.572"
+version = "0.33.573"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.570"
+version = "0.33.571"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.569"
+version = "0.33.570"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.571"
+version = "0.33.572"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.569"
+version = "0.33.570"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.571"
+version = "0.33.572"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.570"
+version = "0.33.571"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.572"
+version = "0.33.573"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -614,14 +614,13 @@ impl HostPipe {
 
 /// Pull the saga_id off a Command if its variant carries one.
 ///
-/// Today (pre-CPD-1) the host-bound Command variants don't have
-/// `saga_id` fields — that's the schema-addition work in CPD-1. So
-/// every variant returns `None`, which means CPD-2's drop semantics
-/// don't actually fail a saga yet. CPD-1 + CPD-3 together will start
-/// returning Some(id) for the relevant variants and the drop
-/// machinery becomes saga-correctness-relevant. Keeping the
-/// indirection here means CPD-3's diff against the saga coordinator
-/// stays narrow.
+/// Used by `send_frame`'s pending-buffer machinery: when a buffered
+/// command is dropped (overflow or 30s host-disconnect timeout),
+/// `emit_drop_failure` emits `Event::SagaFailed { saga_id }` so the
+/// saga's bracket closes cleanly instead of waiting forever.
+/// CPD-1 added `saga_id` fields on host-bound variants; CPD-3 made
+/// `send_command` live from the saga coordinator, so the drop
+/// machinery is now saga-correctness-relevant.
 fn saga_id_of(cmd: &Command) -> Option<u64> {
     // CPD-1 added saga_id fields to host-bound Commands; CPD-3 made
     // send_command live from the saga coordinator. Returning the real

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -331,9 +331,8 @@ impl HostPipe {
     /// `PENDING_BUFFER_CAP`; on overflow or 30s timeout, drops + emits
     /// `Event::SagaFailed` for the dropped Command's saga.
     ///
-    /// CPD-2 wires this method but does NOT call it from the saga
-    /// coordinator yet — that's CPD-3.
-    #[allow(dead_code)] // CPD-3 wires this into the saga coordinator
+    /// CPD-3 — called from the saga coordinator's `apply_action` when
+    /// dispatching `IssueCmd::Host` actions.
     pub async fn send_command(&self, cmd: &Command) -> Result<(), HostPipeError> {
         let saga_id = saga_id_of(cmd);
         let frame = HostFrame::Command(cmd.clone());
@@ -623,11 +622,18 @@ impl HostPipe {
 /// machinery becomes saga-correctness-relevant. Keeping the
 /// indirection here means CPD-3's diff against the saga coordinator
 /// stays narrow.
-fn saga_id_of(_cmd: &Command) -> Option<u64> {
-    // CPD-1 will replace the body of this match with per-variant
-    // returns of `Some(*saga_id)` for SpawnPoolWindow / ReapPanes /
-    // DrainPoolIfLast etc. once those variants gain the field.
-    None
+fn saga_id_of(cmd: &Command) -> Option<u64> {
+    // CPD-1 added saga_id fields to host-bound Commands; CPD-3 made
+    // send_command live from the saga coordinator. Returning the real
+    // id here means HostPipe's drop-on-overflow + 30s-timeout-flush
+    // paths can emit `Event::SagaFailed` for the right saga, instead
+    // of orphaning the buffered command. (reagent P1 PR #644 round 5.)
+    match cmd {
+        Command::SpawnPoolWindow { saga_id } => Some(*saga_id),
+        Command::ReapPanes { saga_id, .. } => Some(*saga_id),
+        Command::DrainPoolIfLast { saga_id, .. } => Some(*saga_id),
+        _ => None,
+    }
 }
 
 /// Serialize a `HostFrame` as newline-delimited JSON and write it

--- a/agentmux-launcher/src/host_pipe/mod.rs
+++ b/agentmux-launcher/src/host_pipe/mod.rs
@@ -291,6 +291,32 @@ impl HostPipe {
         }
     }
 
+    /// Remove every buffered frame whose `saga_id` matches `saga_id`.
+    /// Returns the count of removed frames.
+    ///
+    /// Called from `SagaCoordinator::claim_terminal` when a saga
+    /// terminates (Done / Failed / timeout / eviction / etc.) — the
+    /// terminal event closes the saga bracket, so any frames the
+    /// saga left in the pending buffer would, if drained on reconnect,
+    /// produce orphan side effects after the bracket is already
+    /// closed (and risk a second `SagaFailed` via the 30s expiry
+    /// path's `emit_drop_failure`). Purging here keeps the saga's
+    /// terminal slot atomic across both the bus and the wire.
+    /// (codex + reagent P1 PR #644 round 7.)
+    pub async fn cancel_saga(&self, saga_id: u64) -> usize {
+        let mut inner = self.inner.lock().await;
+        let before = inner.pending_buffer.len();
+        inner.pending_buffer.retain(|f| f.saga_id != Some(saga_id));
+        let removed = before - inner.pending_buffer.len();
+        if removed > 0 {
+            crate::log(&format!(
+                "[host_pipe] cancel_saga(saga_id={}) purged {} buffered frame(s)",
+                saga_id, removed
+            ));
+        }
+        removed
+    }
+
     /// Drain `pending_buffer` through the given writer in FIFO order.
     /// Used by `send_frame`'s ptr_eq-mismatch path to flush a frame
     /// that landed in the buffer after a writer-replacement race

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -326,11 +326,27 @@ async fn run_windows(
         }
     };
 
+    // CPD-2 — launcher → host pipe wrapper. Owns the writer half of
+    // the host's IPC connection (installed by the per-connection
+    // handler in `ipc::server` once the host registers) and exposes
+    // `send_command` / `send_event` to the rest of the launcher.
+    // CPD-2 wires the wrapper + refactors event fanout for the host
+    // connection to flow through here. CPD-3 wires this into the
+    // saga coordinator's `apply_action` so `IssueCmd::Host` actions
+    // dispatch live (no longer log-only).
+    let host_pipe = std::sync::Arc::new(host_pipe::HostPipe::new(
+        events_tx.clone(),
+        std::sync::Arc::clone(&state),
+    ));
+
     // Phase E.1a — saga coordinator task. Subscribes to the broadcast
     // bus, drives in-flight sagas. E.1a registry is empty — framework
     // only. E.5 adds the first concrete saga consumer (tear-off).
     // LSD-2 — durable saga log is now installed; every lifecycle
     // transition is persisted.
+    // CPD-3 — install `host_pipe` so saga `IssueCmd::Host` actions
+    // dispatch through the launcher → host wire instead of being
+    // log-only.
     //
     // Subscribe BEFORE spawning so the race window between construction
     // and first `recv()` doesn't drop early events. (reagent P2 PR #609.)
@@ -348,25 +364,13 @@ async fn run_windows(
                 e
             ));
             std::process::exit(1);
-        });
+        })
+        .with_host_pipe(std::sync::Arc::clone(&host_pipe));
     let saga_coord = std::sync::Arc::new(saga_coord_inner);
     let saga_rx = events_tx.subscribe();
     tokio::spawn(saga::run_coordinator(
         std::sync::Arc::clone(&saga_coord),
         saga_rx,
-    ));
-
-    // CPD-2 — launcher → host pipe wrapper. Owns the writer half of
-    // the host's IPC connection (installed by the per-connection
-    // handler in `ipc::server` once the host registers) and exposes
-    // `send_command` / `send_event` to the rest of the launcher.
-    // CPD-2 wires the wrapper + refactors event fanout for the host
-    // connection to flow through here. CPD-3 will swap saga
-    // coordinator's `IssueCmd::Host` log-only branch for a real
-    // `host_pipe.send_command()` call.
-    let host_pipe = std::sync::Arc::new(host_pipe::HostPipe::new(
-        events_tx.clone(),
-        std::sync::Arc::clone(&state),
     ));
 
     let _ipc_handle = ipc::run_ipc_server(

--- a/agentmux-launcher/src/saga/integration_tests.rs
+++ b/agentmux-launcher/src/saga/integration_tests.rs
@@ -119,15 +119,15 @@ async fn host_pipe_send_failure_terminates_saga() {
         version: 1,
     });
 
-    // Drain the bus until we see SagaFailed for this saga, or time
-    // out. Two acceptable failure surfaces:
-    //   1. `host pipe send failed: ...` (apply_action's Err arm)
-    //   2. `evicted: ...` (very unlikely here — only one saga)
-    // We assert on the saga_id, not the reason, so the test stays
-    // robust if the wording changes.
+    // Round 7: host-send-failure no longer terminates the saga
+    // immediately (round 4 design — the buffered retry path or the
+    // saga's own timeout handles definitive failure to avoid
+    // double-SagaFailed emission per reagent P1 round 6). PoolRespawn
+    // uses the default 5s saga timeout; wait past that for the
+    // deadline-task SagaFailed to fire.
     let mut saw_started: Option<u64> = None;
     let mut saw_failed_for: Option<u64> = None;
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(7);
     while std::time::Instant::now() < deadline {
         match tokio::time::timeout(std::time::Duration::from_millis(100), witness.recv()).await {
             Ok(Ok(Event::SagaStarted { saga_id, name, .. })) => {

--- a/agentmux-launcher/src/saga/integration_tests.rs
+++ b/agentmux-launcher/src/saga/integration_tests.rs
@@ -1,0 +1,234 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// CPD-3 — coordinator + host pipe integration tests.
+//
+// Verifies the CPD-3 wire-up end-to-end: a saga's `IssueCmd::Host`
+// dispatches through `HostPipe::send_command()` (the pre-CPD-3
+// log-only branch), and a host-pipe send failure (read-half closed,
+// simulating host crash) terminates the saga with `SagaFailed`
+// instead of leaving it stuck in_flight.
+//
+// See `docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md` §4 PR3
+// + §6 acceptance criteria.
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::{Command, Event, HostFrame};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::sync::{broadcast, Mutex};
+
+use super::{run_coordinator, SagaCoordinator};
+use crate::host_pipe::{make_shared_writer, BoxedWriter, HostPipe};
+use crate::state::State;
+
+fn make_state() -> Arc<Mutex<State>> {
+    Arc::new(Mutex::new(State::default()))
+}
+
+/// Spin up a coordinator wired to a HostPipe that holds a duplex
+/// stream's writer half. Returns the coordinator, the broadcast
+/// sender for synthetic events, the broadcast witness, and the
+/// duplex read half so callers can assert on dispatched frames or
+/// drop the read half to simulate a host crash.
+async fn make_coord_with_host_pipe() -> (
+    Arc<SagaCoordinator>,
+    broadcast::Sender<Event>,
+    broadcast::Receiver<Event>,
+    tokio::io::DuplexStream,
+) {
+    let (events_tx, _) = broadcast::channel::<Event>(64);
+    let state = make_state();
+    let host_pipe = Arc::new(HostPipe::new(events_tx.clone(), Arc::clone(&state)));
+
+    // Wire a duplex pair as the host's "write half"; the read half is
+    // returned so the test can either consume framed Commands or drop
+    // it to force the next write to fail.
+    let (a, b) = tokio::io::duplex(16 * 1024);
+    let boxed: BoxedWriter = Box::new(a);
+    let _session = host_pipe.set_writer(make_shared_writer(boxed)).await;
+
+    let coord = Arc::new(
+        SagaCoordinator::new(events_tx.clone(), state)
+            .with_host_pipe(Arc::clone(&host_pipe)),
+    );
+    let witness = events_tx.subscribe();
+    let coord_rx = events_tx.subscribe();
+    tokio::spawn(run_coordinator(Arc::clone(&coord), coord_rx));
+    tokio::task::yield_now().await;
+    (coord, events_tx, witness, b)
+}
+
+/// CPD-3 happy path: triggering F.5's pool-respawn saga issues a
+/// `Command::SpawnPoolWindow { saga_id }` over the host pipe with the
+/// real saga id injected. Verifies `apply_action` for `IssueCmd::Host`
+/// is no longer log-only.
+#[tokio::test]
+async fn pool_respawn_saga_dispatches_spawn_pool_window_to_host_pipe() {
+    let (_coord, events_tx, _witness, reader) = make_coord_with_host_pipe().await;
+
+    // Fire the trigger.
+    let _ = events_tx.send(Event::PoolWindowPromoted {
+        label: "window-pool-abc".into(),
+        version: 1,
+    });
+
+    // Read one HostFrame off the wire.
+    let mut bufr = BufReader::new(reader);
+    let mut line = String::new();
+    let read = tokio::time::timeout(std::time::Duration::from_secs(2), bufr.read_line(&mut line))
+        .await
+        .expect("HostPipe write should arrive within 2s")
+        .expect("read_line should succeed");
+    assert!(read > 0, "expected at least one HostFrame on the wire");
+    let frame: HostFrame =
+        serde_json::from_str(line.trim_end()).expect("frame parses as HostFrame");
+
+    match frame {
+        HostFrame::Command(Command::SpawnPoolWindow { saga_id }) => {
+            assert!(
+                saga_id > 0,
+                "coordinator should inject a real saga_id (>0), got {}",
+                saga_id
+            );
+        }
+        other => panic!("expected SpawnPoolWindow frame, got {:?}", other),
+    }
+}
+
+/// CPD-3 failure path: when the host pipe's write fails (read half
+/// closed — simulates host crash mid-saga), the saga terminates as
+/// `SagaFailed` and is removed from `in_flight`. Verifies the
+/// `Err(...)` arm in `apply_action`'s `host_pipe.send_command()`
+/// branch.
+#[tokio::test]
+async fn host_pipe_send_failure_terminates_saga() {
+    let (coord, events_tx, mut witness, reader) = make_coord_with_host_pipe().await;
+
+    // Drop the read half — subsequent writes will fail with
+    // BrokenPipe. The host-pipe wrapper translates this into
+    // `HostPipeError::WriteFailed`.
+    drop(reader);
+    // Give the OS a moment to actually tear down the duplex peer.
+    tokio::task::yield_now().await;
+
+    // Fire the trigger. The saga's start() emits IssueCmd::Host;
+    // apply_action calls host_pipe.send_command() which fails.
+    let _ = events_tx.send(Event::PoolWindowPromoted {
+        label: "window-pool-zzz".into(),
+        version: 1,
+    });
+
+    // Drain the bus until we see SagaFailed for this saga, or time
+    // out. Two acceptable failure surfaces:
+    //   1. `host pipe send failed: ...` (apply_action's Err arm)
+    //   2. `evicted: ...` (very unlikely here — only one saga)
+    // We assert on the saga_id, not the reason, so the test stays
+    // robust if the wording changes.
+    let mut saw_started: Option<u64> = None;
+    let mut saw_failed_for: Option<u64> = None;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(100), witness.recv()).await {
+            Ok(Ok(Event::SagaStarted { saga_id, name, .. })) => {
+                if name == "pool_respawn_on_promote" {
+                    saw_started = Some(saga_id);
+                }
+            }
+            Ok(Ok(Event::SagaFailed { saga_id, .. })) => {
+                if Some(saga_id) == saw_started {
+                    saw_failed_for = Some(saga_id);
+                    break;
+                }
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) => break,
+            Err(_) => continue,
+        }
+    }
+
+    let saga_id = saw_started.expect("expected SagaStarted for pool_respawn_on_promote");
+    assert_eq!(
+        saw_failed_for,
+        Some(saga_id),
+        "expected SagaFailed for the started saga (pipe error or timeout)"
+    );
+
+    // Saga is no longer in_flight.
+    let registry = coord.in_flight.lock().await;
+    assert!(
+        !registry.contains_key(&saga_id),
+        "saga_id={} should be removed from in_flight after SagaFailed",
+        saga_id
+    );
+}
+
+/// CPD-3 — `Event::SagaActionFailed` (host-emitted via
+/// `Command::ReportSagaActionFailed`) terminates the matching saga
+/// even if no Report* event arrives. Avoids hung sagas waiting
+/// forever on a Report* the host already gave up on.
+#[tokio::test]
+async fn saga_action_failed_event_terminates_matching_saga() {
+    let (coord, events_tx, mut witness, _reader) = make_coord_with_host_pipe().await;
+
+    // Start a saga.
+    let _ = events_tx.send(Event::PoolWindowPromoted {
+        label: "window-pool-q".into(),
+        version: 1,
+    });
+
+    // Capture saga_id from SagaStarted.
+    let saga_id = {
+        let mut id = None;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            match tokio::time::timeout(std::time::Duration::from_millis(100), witness.recv())
+                .await
+            {
+                Ok(Ok(Event::SagaStarted {
+                    saga_id,
+                    name,
+                    ..
+                })) if name == "pool_respawn_on_promote" => {
+                    id = Some(saga_id);
+                    break;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => continue,
+            }
+        }
+        id.expect("expected SagaStarted for pool_respawn_on_promote")
+    };
+
+    // Host reports the action failed.
+    let _ = events_tx.send(Event::SagaActionFailed {
+        saga_id,
+        reason: "spawn_pool_window: window not found".into(),
+        version: 99,
+    });
+
+    // Expect SagaFailed for this saga.
+    let mut saw_failed = false;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        match tokio::time::timeout(std::time::Duration::from_millis(100), witness.recv()).await {
+            Ok(Ok(Event::SagaFailed { saga_id: id, .. })) if id == saga_id => {
+                saw_failed = true;
+                break;
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) => break,
+            Err(_) => continue,
+        }
+    }
+    assert!(saw_failed, "expected SagaFailed for saga_id={}", saga_id);
+
+    // Saga removed from in_flight.
+    let registry = coord.in_flight.lock().await;
+    assert!(
+        !registry.contains_key(&saga_id),
+        "saga_id={} should be removed from in_flight after SagaActionFailed",
+        saga_id
+    );
+}

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -39,18 +39,16 @@
 // the appropriate pipe, and emits `SagaStarted` / `SagaCompleted`
 // / `SagaFailed` so subscribers (renderer) can buffer-until-complete.
 //
-// **Cross-process dispatch — F.5 caveat.** Today the launcher's
-// named-pipe IPC is host→launcher only (host sends Commands up;
-// launcher broadcasts Events back). A launcher→host command pipe
-// doesn't exist yet. F.5's `pool_respawn` saga issues
-// `Command::SpawnPoolWindow` with `target = PipeTarget::Host`, but
-// the coordinator's IssueCmd handler currently logs the dispatch
-// without transmitting it — the host's existing implicit
-// `spawn_pool_window` call inside `promote_pool_window` produces
-// the matching `Event::PoolWindowAdded` the saga waits for. F.6
-// (or the cross-process-dispatch follow-up) replaces the log with
-// a real wire-level send. See `pool_respawn.rs` module docstring
-// for the full rationale and scope decision.
+// **Cross-process dispatch — CPD-3 LIVE.** The launcher → host
+// command pipe is now wired via `HostPipe::send_command()` (CPD-2
+// + CPD-3). F.5's `pool_respawn` and F.6's `window_cleanup_cascade`
+// sagas issue `IssueCmd::Host` actions; the coordinator dispatches
+// them through the wire instead of merely logging. Per-saga
+// timeouts (`Saga::timeout()`, default 5s, F.6 overrides 30s)
+// + per-saga deadline tasks fire `SagaFailed` if a host action
+// stays unresolved past its budget. Host-emitted
+// `Command::ReportSagaActionFailed` translates into
+// `Event::SagaActionFailed` and terminates the matching saga.
 //
 // Per-variant `saga_id` tagging on existing Command/Event variants
 // is deferred; F.5's coordinator doesn't yet need it because:
@@ -453,35 +451,33 @@ impl SagaCoordinator {
                                 ApplyOutcome::in_flight_awaiting(step_index)
                             }
                             Err(e) => {
-                                // Same claim_terminal guard as the
-                                // Done/Failed paths — host-send-failure
-                                // is a terminal transition and must not
-                                // race against the timeout task or the
-                                // SagaActionFailed listener emitting
-                                // their own terminal events for the same
-                                // saga_id (codex P1 PR #644 round 2).
-                                if self.claim_terminal(saga_id).await {
-                                    crate::log(&format!(
-                                        "[saga] saga_id={} name={} host pipe send failed: {} — emitting SagaFailed",
-                                        saga_id, name, e
-                                    ));
-                                    let reason = format!("host pipe send failed: {}", e);
-                                    if let Some(log) = self.log.as_ref() {
-                                        if let Err(le) = log.terminate_saga(
-                                            saga_id,
-                                            SagaOutcome::Failed {
-                                                reason: reason.clone(),
-                                            },
-                                        ) {
-                                            crate::log(&format!(
-                                                "[saga] saga_id={} terminate_saga(Failed) log write failed: {}",
-                                                saga_id, le
-                                            ));
-                                        }
-                                    }
-                                    self.emit_failed(saga_id, reason).await;
-                                }
-                                ApplyOutcome::terminated()
+                                // CRITICAL: do NOT terminate the saga
+                                // here. send_command's send_frame already
+                                // re-buffered the failed frame for retry
+                                // on reconnect (with the real saga_id).
+                                // If we ALSO emit SagaFailed now:
+                                //   - 30s later expire_pending_if_timed_out
+                                //     drains the buffer + emit_drop_failure
+                                //     emits a SECOND SagaFailed for the
+                                //     same saga_id (double-emit), OR
+                                //   - host reconnects in <30s and the
+                                //     buffered command executes as an
+                                //     orphaned side effect after the saga
+                                //     bracket is already closed.
+                                // (reagent P1 PR #644 round 6.)
+                                //
+                                // Round 7 design: keep the saga in_flight.
+                                // The retry path resolves it (Report*
+                                // arrives → on_event drives forward) OR
+                                // the saga's own timeout (5s default,
+                                // 30s for F.6) fires + claim_terminal'd
+                                // SagaFailed. Either way, exactly one
+                                // terminal event is emitted.
+                                crate::log(&format!(
+                                    "[saga] saga_id={} name={} host pipe send transient err: {} — frame buffered for retry; saga stays in-flight (round 7 fix)",
+                                    saga_id, name, e
+                                ));
+                                ApplyOutcome::in_flight_awaiting(step_index)
                             }
                         }
                     }

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -559,8 +559,21 @@ impl SagaCoordinator {
     /// and by the eviction path in `run_coordinator`.
     /// (reagent P1 PR #644 round 1.)
     async fn claim_terminal(&self, saga_id: u64) -> bool {
-        let mut registry = self.in_flight.lock().await;
-        registry.remove(&saga_id).is_some()
+        let claimed = {
+            let mut registry = self.in_flight.lock().await;
+            registry.remove(&saga_id).is_some()
+        };
+        // Purge any host-pipe pending frames tagged with this saga_id
+        // so a host reconnect post-terminal doesn't drain them as
+        // orphan side effects, and the 30s expiry path doesn't emit
+        // a second SagaFailed for the same saga_id.
+        // (codex + reagent P1 PR #644 round 7.)
+        if claimed {
+            if let Some(pipe) = self.host_pipe.as_ref() {
+                pipe.cancel_saga(saga_id).await;
+            }
+        }
+        claimed
     }
 
     /// Register a fresh saga, calling `start` and applying its first

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -65,11 +65,17 @@
 // sagas; renderer-side timeouts cover the visible consequence.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use agentmux_common::ipc::{Command, Event};
 
+use crate::host_pipe::HostPipe;
+
 pub mod pool_respawn;
 pub mod window_cleanup;
+
+#[cfg(test)]
+mod integration_tests;
 
 // LSD-1 (PR LSD-1) — durable launcher saga log + API. Foundations
 // only: the coordinator does NOT call any of these methods yet.
@@ -183,6 +189,20 @@ pub trait Saga: Send {
     fn input_snapshot(&self) -> serde_json::Value {
         serde_json::Value::Null
     }
+
+    /// CPD-3 — per-saga deadline budget for completing all
+    /// `IssueCmd`+wait cycles. Coordinator arms a timer when the saga
+    /// registers; if the saga is still in_flight when `timeout()`
+    /// elapses, it is force-failed (`SagaFailed { reason: "saga
+    /// timeout" }`) and removed from the registry.
+    ///
+    /// Default 5s — fits class-C single-step host dispatch (e.g.
+    /// pool respawn). `WindowCleanupCascade` overrides to 30s
+    /// because pane drain on a workspace with many panes can
+    /// legitimately take that long. Per spec §3.10.
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(5)
+    }
 }
 
 /// Saga coordinator task.
@@ -238,6 +258,11 @@ pub struct SagaCoordinator {
     /// `Done` → `terminate_saga(Completed)`, `Failed` / evicted →
     /// `terminate_saga(Failed)`) writes to this log.
     log: Option<Arc<LauncherSagaLog>>,
+    /// CPD-3 — launcher → host pipe wrapper. `apply_action` for
+    /// `IssueCmd::Host` dispatches via `host_pipe.send_command()` when
+    /// installed. `None` in tests that don't exercise host dispatch
+    /// (those drive sagas via synthetic terminal events on the bus).
+    host_pipe: Option<Arc<HostPipe>>,
 }
 
 impl SagaCoordinator {
@@ -251,7 +276,18 @@ impl SagaCoordinator {
             events_tx,
             state,
             log: None,
+            host_pipe: None,
         }
+    }
+
+    /// CPD-3 — install the host pipe so `IssueCmd::Host` actions are
+    /// dispatched live (instead of log-only). Builder-style setter so
+    /// existing tests + the `next_id_is_monotonic` smoke don't have to
+    /// construct a HostPipe. Production wiring (`main.rs`) calls this
+    /// once before `run_coordinator` is spawned.
+    pub fn with_host_pipe(mut self, host_pipe: Arc<HostPipe>) -> Self {
+        self.host_pipe = Some(host_pipe);
+        self
     }
 
     /// LSD-2 — install the durable saga log so saga lifecycle
@@ -345,13 +381,12 @@ impl SagaCoordinator {
     ///     the InFlightSaga so the next non-`Wait` `on_event` return
     ///     can call `LauncherSagaLog::finish_step(saga_id, idx, ev)`.
     ///
-    /// **F.5 IssueCmd dispatch is logged-only for `Host` target.** No
-    /// launcher→host command pipe exists yet; the saga relies on the
-    /// host's existing implicit `spawn_pool_window` to produce the
-    /// terminal `PoolWindowAdded`. `LauncherSelf` and `Srv` targets
-    /// also fall back to log-only for now (no sagas use them yet —
-    /// future work). CPD-3 replaces the log with a real wire-level
-    /// send.
+    /// CPD-3 — `IssueCmd::Host` dispatches live through `HostPipe`
+    /// when one is installed. Tests without a host_pipe (the existing
+    /// F.5/F.6 unit + integration tests) fall back to log-only so
+    /// synthetic-terminal-event drivers continue to work.
+    /// `LauncherSelf` and `Srv` targets remain log-only — reserved
+    /// for class-D/E sagas, no consumer today.
     ///
     /// LSD-2 — every state transition writes to `LauncherSagaLog`
     /// when one is installed: `IssueCmd` → `start_step`, `Done` →
@@ -362,6 +397,12 @@ impl SagaCoordinator {
     /// On the first dispatch in `spawn_saga`, the caller passes 0;
     /// on subsequent dispatches from the event loop, the caller pulls
     /// + bumps the per-InFlightSaga counter.
+    ///
+    /// Terminal paths (`Done`, `Failed`, host-send-error) all go
+    /// through `claim_terminal` so only one of {normal Done/Failed,
+    /// timeout-task, SagaActionFailed listener, host-send-error}
+    /// can win the terminal-event race for a given saga_id.
+    /// (reagent P1 PR #644 round 1 + 2.)
     async fn apply_action(
         &self,
         saga_id: u64,
@@ -387,14 +428,87 @@ impl SagaCoordinator {
                     }
                 }
 
-                crate::log(&format!(
-                    "[saga] saga_id={} name={} IssueCmd target={:?} cmd={:?} (F.5: dispatch is log-only; awaiting cross-process pipe)",
-                    saga_id, name, target, cmd
-                ));
-                ApplyOutcome::in_flight_awaiting(step_index)
+                match target {
+                    PipeTarget::Host => {
+                        // CPD-3 — dispatch live through the host pipe
+                        // when installed. Tests without a host_pipe
+                        // (most existing F.5/F.6 unit + integration
+                        // tests) fall back to log-only so synthetic-
+                        // terminal-event drivers continue to work.
+                        let Some(host_pipe) = self.host_pipe.as_ref() else {
+                            crate::log(&format!(
+                                "[saga] saga_id={} name={} IssueCmd target=Host cmd={:?} (no host_pipe installed — log-only)",
+                                saga_id, name, cmd
+                            ));
+                            return ApplyOutcome::in_flight_awaiting(step_index);
+                        };
+                        let cmd_with_id = inject_saga_id(cmd, saga_id);
+                        match host_pipe.send_command(&cmd_with_id).await {
+                            Ok(()) => {
+                                crate::log(&format!(
+                                    "[saga] saga_id={} name={} IssueCmd::Host dispatched cmd={:?}",
+                                    saga_id, name, cmd_with_id
+                                ));
+                                ApplyOutcome::in_flight_awaiting(step_index)
+                            }
+                            Err(e) => {
+                                // Same claim_terminal guard as the
+                                // Done/Failed paths — host-send-failure
+                                // is a terminal transition and must not
+                                // race against the timeout task or the
+                                // SagaActionFailed listener emitting
+                                // their own terminal events for the same
+                                // saga_id (codex P1 PR #644 round 2).
+                                if self.claim_terminal(saga_id).await {
+                                    crate::log(&format!(
+                                        "[saga] saga_id={} name={} host pipe send failed: {} — emitting SagaFailed",
+                                        saga_id, name, e
+                                    ));
+                                    let reason = format!("host pipe send failed: {}", e);
+                                    if let Some(log) = self.log.as_ref() {
+                                        if let Err(le) = log.terminate_saga(
+                                            saga_id,
+                                            SagaOutcome::Failed {
+                                                reason: reason.clone(),
+                                            },
+                                        ) {
+                                            crate::log(&format!(
+                                                "[saga] saga_id={} terminate_saga(Failed) log write failed: {}",
+                                                saga_id, le
+                                            ));
+                                        }
+                                    }
+                                    self.emit_failed(saga_id, reason).await;
+                                }
+                                ApplyOutcome::terminated()
+                            }
+                        }
+                    }
+                    PipeTarget::LauncherSelf | PipeTarget::Srv => {
+                        // Reserved for class-D/E sagas; out of scope
+                        // per SPEC_CROSS_PROCESS_DISPATCH §3.6. Log-
+                        // only retains framework shape until a
+                        // consumer arrives.
+                        crate::log(&format!(
+                            "[saga] saga_id={} name={} IssueCmd target={:?} cmd={:?} (target not yet wired; log-only)",
+                            saga_id, name, target, cmd
+                        ));
+                        ApplyOutcome::in_flight_awaiting(step_index)
+                    }
+                }
             }
             SagaAction::Wait => ApplyOutcome::in_flight_no_change(),
             SagaAction::Done => {
+                // Atomic claim: only one of {normal Done, timeout-task,
+                // SagaActionFailed listener, host-send-error} can win
+                // the terminal-event race. Without this guard a Done
+                // could fire SagaCompleted while the timeout task
+                // simultaneously fires SagaFailed, producing duplicate
+                // terminal events for the same saga (reagent P1 PR
+                // #644 round 1).
+                if !self.claim_terminal(saga_id).await {
+                    return ApplyOutcome::terminated();
+                }
                 crate::log(&format!(
                     "[saga] saga_id={} name={} Done — emitting SagaCompleted",
                     saga_id, name
@@ -411,6 +525,9 @@ impl SagaCoordinator {
                 ApplyOutcome::terminated()
             }
             SagaAction::Failed { reason } => {
+                if !self.claim_terminal(saga_id).await {
+                    return ApplyOutcome::terminated();
+                }
                 crate::log(&format!(
                     "[saga] saga_id={} name={} Failed reason={} — emitting SagaFailed",
                     saga_id, name, reason
@@ -434,6 +551,21 @@ impl SagaCoordinator {
         }
     }
 
+    /// Atomically remove `saga_id` from `in_flight` and return whether
+    /// the caller was the one who removed it (i.e. has the right to
+    /// emit the terminal `SagaCompleted` / `SagaFailed`). Idempotent:
+    /// a second caller for the same saga_id sees `false`. Used by the
+    /// `SagaAction::Done` and `SagaAction::Failed` paths in
+    /// `apply_action`, by the per-saga timeout task in `spawn_saga`,
+    /// by the `Event::SagaActionFailed` listener in `run_coordinator`,
+    /// by the host-send-failure path in `apply_action::IssueCmd::Host`,
+    /// and by the eviction path in `run_coordinator`.
+    /// (reagent P1 PR #644 round 1.)
+    async fn claim_terminal(&self, saga_id: u64) -> bool {
+        let mut registry = self.in_flight.lock().await;
+        registry.remove(&saga_id).is_some()
+    }
+
     /// Register a fresh saga, calling `start` and applying its first
     /// action. The caller has already determined that the saga
     /// should fire (e.g. matched a trigger event). Returns the saga's
@@ -442,10 +574,19 @@ impl SagaCoordinator {
     /// LSD-2 — also writes a `running` row to the durable saga log
     /// before invoking `saga.start()`, and (via `apply_action`)
     /// records the saga's first dispatched step.
-    async fn spawn_saga(&self, mut saga: Box<dyn Saga>) -> u64 {
+    ///
+    /// CPD-3 — also arms a per-saga deadline timer. If the saga is
+    /// still in_flight when `saga.timeout()` elapses, a background
+    /// task force-fails it (`SagaFailed { reason: "saga timeout" }`)
+    /// and removes it from the registry. Per spec §3.10. Insert-then-
+    /// start ordering is required so `apply_action`'s `claim_terminal`
+    /// guard can succeed for immediate-completion sagas (codex P2 PR
+    /// #644 round 2).
+    async fn spawn_saga(self: &Arc<Self>, saga: Box<dyn Saga>) -> u64 {
         let saga_id = self.next_id();
         let name = saga.name();
         let input = saga.input_snapshot();
+        let saga_timeout = saga.timeout();
         crate::log(&format!(
             "[saga] starting saga_id={} name={}",
             saga_id, name
@@ -468,11 +609,17 @@ impl SagaCoordinator {
         // saga_id sees the bracket open before any per-step events.
         // Mirrors `agentmux-srv::sagas::emit_saga_started` ordering.
         self.emit_started(saga_id, name).await;
-        let ctx = SagaCtx { saga_id };
-        let action = saga.start(&ctx);
-        // First step on a fresh saga is index 0.
-        let outcome = self.apply_action(saga_id, name, action, 0).await;
-        if outcome.in_flight {
+
+        // CPD-3 — insert the saga into in_flight BEFORE calling
+        // start(), so that if start() returns SagaAction::Done or
+        // SagaAction::Failed immediately, apply_action's terminal
+        // paths can claim_terminal successfully and emit the matching
+        // SagaCompleted/SagaFailed bracket. Pre-round-3 we started
+        // saga.start() before insertion, which broke immediate-
+        // completion sagas (claim_terminal returned false → no
+        // terminal event → dangling SagaStarted bracket).
+        // (codex P2 PR #644 round 2.)
+        let action = {
             let mut registry = self.in_flight.lock().await;
             // (codex P1 PR #634) Observability for the known
             // concurrent-correlation limitation. With more than one
@@ -480,8 +627,7 @@ impl SagaCoordinator {
             // routing mis-correlates: the first matching event
             // completes ALL of them. Logged here so operators can
             // spot the pattern in `--diag wrr` output. Closed when
-            // F.6/F.7 adds proper FIFO routing or saga-id event
-            // correlation.
+            // CPD-4 adds saga-id event correlation.
             let same_kind_count = registry
                 .values()
                 .filter(|s| s.saga.name() == name)
@@ -492,20 +638,73 @@ impl SagaCoordinator {
                     name, saga_id, same_kind_count,
                 ));
             }
-            // If the first action allocated step 0, the saga is now
-            // parked awaiting that step's echo event; next allocation
-            // is index 1. Otherwise (Wait — saga has no first
-            // dispatch yet; nothing in F.5/F.6 sagas does this), keep
-            // the counter at 0.
-            let next_step_index = if outcome.awaiting_step.is_some() { 1 } else { 0 };
             registry.insert(
                 saga_id,
                 InFlightSaga {
                     saga,
-                    awaiting_step: outcome.awaiting_step,
-                    next_step_index,
+                    awaiting_step: None,
+                    next_step_index: 0,
                 },
             );
+            // Drive start() while still under the registry lock so
+            // we have a mutable reference to the just-inserted saga.
+            // start() is non-async and does no I/O — bounded hold time.
+            let in_flight_saga = registry.get_mut(&saga_id).expect("just inserted");
+            let ctx = SagaCtx { saga_id };
+            in_flight_saga.saga.start(&ctx)
+        };
+
+        // First step on a fresh saga is index 0. apply_action may
+        // remove the saga via claim_terminal (Done/Failed/host-send-
+        // error) without re-locking the registry from here.
+        let outcome = self.apply_action(saga_id, name, action, 0).await;
+        if outcome.in_flight {
+            // Update the bookkeeping for the freshly-issued step.
+            // If the first action allocated step 0, the saga is now
+            // parked awaiting that step's echo event; next allocation
+            // is index 1. Otherwise (Wait — saga has no first
+            // dispatch yet), keep the counter at 0.
+            let mut registry = self.in_flight.lock().await;
+            if let Some(in_flight_saga) = registry.get_mut(&saga_id) {
+                in_flight_saga.awaiting_step = outcome.awaiting_step;
+                in_flight_saga.next_step_index =
+                    if outcome.awaiting_step.is_some() { 1 } else { 0 };
+            }
+            drop(registry);
+
+            // CPD-3 — arm the per-saga deadline timer. If the saga
+            // is still in_flight when `saga_timeout` elapses, fail
+            // it out. Spawned task captures an Arc clone of the
+            // coordinator so it can outlive the saga's deadline.
+            // Uses `claim_terminal` so it doesn't race with the
+            // normal Done/Failed path. (reagent P1 PR #644 round 1.)
+            let coord_for_timeout = Arc::clone(self);
+            tokio::spawn(async move {
+                tokio::time::sleep(saga_timeout).await;
+                if coord_for_timeout.claim_terminal(saga_id).await {
+                    crate::log(&format!(
+                        "[saga] saga_id={} name={} timed out after {:?} — emitting SagaFailed",
+                        saga_id, name, saga_timeout
+                    ));
+                    let reason = "saga timeout".to_string();
+                    if let Some(log) = coord_for_timeout.log.as_ref() {
+                        if let Err(e) = log.terminate_saga(
+                            saga_id,
+                            SagaOutcome::Failed {
+                                reason: reason.clone(),
+                            },
+                        ) {
+                            crate::log(&format!(
+                                "[saga] saga_id={} timeout terminate_saga(Failed) log write failed: {}",
+                                saga_id, e
+                            ));
+                        }
+                    }
+                    coord_for_timeout
+                        .emit_failed(saga_id, reason)
+                        .await;
+                }
+            });
         }
         saga_id
     }
@@ -569,6 +768,36 @@ fn derive_step_name(cmd: &Command, target: PipeTarget) -> String {
         _ => "unknown".to_string(),
     };
     format!("issue_cmd_{}_{}", target_str, discriminant)
+}
+
+/// CPD-3 — fill in the `saga_id` field on a host-bound `Command`
+/// before dispatch. Sagas construct their `IssueCmd` actions with a
+/// placeholder `saga_id: 0` (they don't know their coordinator-
+/// allocated id at action-construction time); the coordinator
+/// rewrites the field at dispatch time so the host can echo it back
+/// on the matching `Report*`.
+///
+/// Exhaustive match: any host-bound Command variant added later that
+/// forgets to plumb `saga_id` will refuse to compile here. Non-host-
+/// bound variants (Report*, Identify, etc.) panic loudly because
+/// sagas only emit `IssueCmd::Host` for the three host-bound
+/// command kinds covered below.
+fn inject_saga_id(cmd: Command, saga_id: u64) -> Command {
+    match cmd {
+        Command::SpawnPoolWindow { .. } => Command::SpawnPoolWindow { saga_id },
+        Command::ReapPanes { label, .. } => Command::ReapPanes { label, saga_id },
+        Command::DrainPoolIfLast { label, .. } => {
+            Command::DrainPoolIfLast { label, saga_id }
+        }
+        // Defense-in-depth: every non-host-dispatched Command variant
+        // (Report*, Identify, etc.) is a coding bug if it reaches
+        // this point — the F.5/F.6 sagas only emit IssueCmd::Host
+        // for the three command kinds above.
+        other => panic!(
+            "inject_saga_id called on non-host-bound Command variant: {:?}",
+            other
+        ),
+    }
 }
 
 /// Inspect a bus event for "should this start a fresh saga?" Returns
@@ -642,6 +871,43 @@ pub async fn run_coordinator(
                     continue;
                 }
 
+                // CPD-3 — host reported via `Command::ReportSagaActionFailed`
+                // that a saga-issued action failed. Launcher reducer
+                // translates this into `Event::SagaActionFailed`
+                // (CPD-1 schema). Terminate the matching saga
+                // immediately rather than waiting for a Report* that
+                // won't come.
+                if let Event::SagaActionFailed { saga_id, reason, .. } = &event {
+                    let saga_id = *saga_id;
+                    let reason = reason.clone();
+                    // claim_terminal: atomic take-ownership of the
+                    // terminal-event slot, preventing duplicate-emission
+                    // races with the saga's own Done/Failed path or its
+                    // timeout task. (reagent P1 PR #644 round 1.)
+                    if coord.claim_terminal(saga_id).await {
+                        crate::log(&format!(
+                            "[saga] saga_id={} terminating from host SagaActionFailed reason={}",
+                            saga_id, reason
+                        ));
+                        let full_reason = format!("host action failed: {}", reason);
+                        if let Some(log) = coord.log.as_ref() {
+                            if let Err(e) = log.terminate_saga(
+                                saga_id,
+                                SagaOutcome::Failed {
+                                    reason: full_reason.clone(),
+                                },
+                            ) {
+                                crate::log(&format!(
+                                    "[saga] saga_id={} SagaActionFailed terminate_saga(Failed) log write failed: {}",
+                                    saga_id, e
+                                ));
+                            }
+                        }
+                        coord.emit_failed(saga_id, full_reason).await;
+                    }
+                    continue;
+                }
+
                 // Step 1 — start any new sagas this event triggers.
                 // (codex P1 PR #634 round 3.) Evict-and-replace: if a
                 // saga of the same kind is already in flight, EVICT
@@ -673,6 +939,16 @@ pub async fn run_coordinator(
                             .collect()
                     };
                     for evict_id in evict_ids {
+                        // claim_terminal removes from in_flight AND
+                        // ensures the timeout task / SagaActionFailed
+                        // listener can't double-emit a terminal event
+                        // for this saga_id. (reagent P1 PR #644
+                        // round 1.)
+                        if !coord.claim_terminal(evict_id).await {
+                            // Lost the race — another path (timeout,
+                            // SagaActionFailed) already terminated.
+                            continue;
+                        }
                         crate::log(&format!(
                             "[saga] evicting prior {} saga_id={} to make room for new trigger (codex P1 #634 round 3 evict-and-replace)",
                             new_kind, evict_id,
@@ -695,7 +971,6 @@ pub async fn run_coordinator(
                             }
                         }
                         coord.emit_failed(evict_id, evict_reason.to_string()).await;
-                        coord.in_flight.lock().await.remove(&evict_id);
                     }
                     coord.spawn_saga(saga).await;
                 }

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -93,9 +93,10 @@ use log::SagaOutcome;
 /// reducer" (in-process); `Host` and `Srv` mean "forward to the
 /// peer's pipe."
 ///
-/// **F.5 status:** `Host` is wired only as a log target — the
-/// launcher→host command pipe doesn't exist yet. Follow-up PRs
-/// replace the log with the actual transport.
+/// **CPD-3 status:** `Host` is now LIVE — the saga coordinator's
+/// `apply_action` dispatches `IssueCmd::Host` actions through
+/// `HostPipe::send_command()` over the launcher → host wire.
+/// `LauncherSelf` and `Srv` remain reserved for class-D/E sagas.
 ///
 /// F.7 cleanup audit: only `Host` is constructed today (F.5/F.6 saga
 /// IssueCmds). `LauncherSelf` and `Srv` are framework slots reserved

--- a/agentmux-launcher/src/saga/pool_respawn.rs
+++ b/agentmux-launcher/src/saga/pool_respawn.rs
@@ -45,23 +45,17 @@
 //     `Event::PoolWindowPromoted`.
 //
 // F.5 does NOT ship:
-//   - The actual cross-process dispatch of `Command::SpawnPoolWindow`
-//     to the host. Today the launcher's named-pipe IPC is host→
-//     launcher only (host sends Commands up; launcher broadcasts
-//     Events back). A launcher→host command pipe doesn't exist yet.
-//     Step 2's `SagaAction::IssueCmd` is logged-only; the saga
-//     relies on the host's existing implicit `spawn_pool_window`
-//     call inside `promote_pool_window` to produce the
-//     `Event::PoolWindowAdded` it waits for. **This is acceptable
-//     scope per the F-spec § 7.1 final paragraph** ("If the cross-
-//     process plumbing is too heavy a lift for one PR, scope down:
-//     implement the saga shape + the launcher-side coordinator
-//     entry, even if the actual cross-process dispatch is initially
-//     in-process"). The follow-up PR replaces the log with a real
-//     wire-level send.
 //   - F.6 window-cleanup cascade saga.
 //   - Launcher-side saga durability (separate concern; srv-side
 //     durability already shipped).
+//
+// **CPD-3 update.** Step 2's `SagaAction::IssueCmd` is now LIVE: the
+// coordinator dispatches `Command::SpawnPoolWindow { saga_id }`
+// through `HostPipe::send_command()` (see
+// `agentmux-launcher/src/saga/mod.rs::apply_action`). The saga is
+// structurally identical — what changed is the coordinator's
+// `IssueCmd::Host` arm. The saga is no longer a passive narrator of
+// the host's implicit refill: it now causally drives it.
 //
 // **Why a saga at all if Step 2 is currently passive?**
 //

--- a/agentmux-launcher/src/saga/window_cleanup.rs
+++ b/agentmux-launcher/src/saga/window_cleanup.rs
@@ -55,23 +55,16 @@
 //     `Event::WindowClosed`.
 //
 // F.6 does NOT ship:
-//   - The actual cross-process dispatch of `Command::ReapPanes` /
-//     `Command::DrainPoolIfLast` to the host. Today the launcher's
-//     named-pipe IPC is host→launcher only (host sends Commands up;
-//     launcher broadcasts Events back). A launcher→host command
-//     pipe doesn't exist yet. Both `IssueCmd::Host` actions are
-//     logged-only; the saga relies on the host's existing implicit
-//     cleanup flow inside `on_before_close` to produce the
-//     `Event::PanesReaped` + `Event::PoolDrained`/`PoolNotLast` it
-//     waits for. **This is acceptable scope per the F-spec § 7
-//     ("If the cross-process plumbing is too heavy a lift for one
-//     PR, scope down: implement the saga shape + the launcher-side
-//     coordinator entry, even if the actual cross-process dispatch
-//     is initially in-process").** The follow-up PR replaces the
-//     log with a real wire-level send — same trajectory as F.5's
-//     `SpawnPoolWindow`.
 //   - F.7 (cleanup audit + property tests).
 //   - Launcher-side saga durability — separate concern.
+//
+// **CPD-3 update.** Both `IssueCmd::Host` actions
+// (`Command::ReapPanes` and `Command::DrainPoolIfLast`) are now LIVE:
+// the coordinator dispatches them through `HostPipe::send_command()`
+// (see `agentmux-launcher/src/saga/mod.rs::apply_action`). This saga
+// also overrides `Saga::timeout()` to 30s (vs. 5s default) since
+// pane drain on a workspace with many panes can legitimately take
+// that long — see SPEC_CROSS_PROCESS_DISPATCH §3.10.
 //
 // **Why a saga at all if the IssueCmds are currently passive?**
 //
@@ -208,6 +201,14 @@ impl Saga for WindowCleanupCascade {
     /// lives in step rows.
     fn input_snapshot(&self) -> serde_json::Value {
         serde_json::json!({ "closed_label": self.closed_label })
+    }
+
+    /// CPD-3 — override the default 5s saga timeout. Pane drain
+    /// (Stage 1 of wrr's two-stage close cascade) on a workspace
+    /// with many panes can legitimately take longer than 5s. Per
+    /// SPEC_CROSS_PROCESS_DISPATCH §3.10.
+    fn timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(30)
     }
 
     fn start(&mut self, _ctx: &SagaCtx) -> SagaAction {

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.572"
+version = "0.33.573"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.571"
+version = "0.33.572"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.569"
+version = "0.33.570"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.570"
+version = "0.33.571"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.572",
+  "version": "0.33.573",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.572",
+      "version": "0.33.573",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.571",
+  "version": "0.33.572",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.571",
+      "version": "0.33.572",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.570",
+  "version": "0.33.571",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.570",
+      "version": "0.33.571",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.569",
+  "version": "0.33.570",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.569",
+      "version": "0.33.570",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.569",
+  "version": "0.33.570",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.571",
+  "version": "0.33.572",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.572",
+  "version": "0.33.573",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.570",
+  "version": "0.33.571",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third PR in the cross-process dispatch sequence (CPD-3). After CPD-1 (saga_id schema, #643) and CPD-2 (host pipe wrapper, #642), this PR is the operationally meaningful one: F.5 + F.6 sagas stop being narrators of the host's implicit flow and start *driving* host actions over the launcher → host wire via `HostPipe::send_command()`.

References:
- [`SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md`](docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md) §3.4 (SagaCoordinator dispatch), §3.10 (Saga timeouts), §4 PR3 (this PR's scope)
- [`SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md`](docs/specs/SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md) §2 batch 2

## What changed

- **`SagaCoordinator::apply_action`** for `IssueCmd::Host` calls `host_pipe.send_command(inject_saga_id(cmd, saga_id))`. On `Err` (e.g. host pipe down + buffer overflow): emit `SagaFailed` and remove from `in_flight`. On `Ok`: still in_flight (saga waits for echo via `on_event`).
- **`inject_saga_id()` helper**: rewrites the saga's placeholder `saga_id: 0` on host-bound Commands (`SpawnPoolWindow`, `ReapPanes`, `DrainPoolIfLast`) to the live coordinator-allocated id. Exhaustive match — non-host-bound variants panic.
- **`Saga::timeout()`** trait method (default 5s); `WindowCleanupCascade` overrides to 30s for pane-drain on large workspaces. Coordinator arms a per-saga deadline task in `spawn_saga` — sagas stuck past their budget fail-out as `SagaFailed { reason: "saga timeout" }`.
- **`run_coordinator()`** listens for `Event::SagaActionFailed` (CPD-1 schema, host-emitted via `Command::ReportSagaActionFailed`) and terminates the matching saga immediately.
- **`main.rs`**: HostPipe is now constructed BEFORE SagaCoordinator and threaded in via `with_host_pipe(...)`.
- **F.5 + F.6 module docstrings**: removed the "F.5/F.6 does NOT ship the actual cross-process dispatch" caveats; added the CPD-3 update note.

## Scope kept tight

Edits are localized to `apply_action` body, the constructor, the new `inject_saga_id` helper, and the new test file. The `SagaCoordinator` struct shape additions are minimal (`host_pipe: Option<Arc<HostPipe>>`) so the LSD-2 follow-up can add `LauncherSagaLog` integration without merge conflicts on those code paths.

## Tests

New `agentmux-launcher/src/saga/integration_tests.rs` (3 cases):

- `pool_respawn_saga_dispatches_spawn_pool_window_to_host_pipe` — fires `Event::PoolWindowPromoted`, asserts a `HostFrame::Command(SpawnPoolWindow { saga_id: N>0 })` lands on the wire.
- `host_pipe_send_failure_terminates_saga` — drops the duplex read half (simulates host crash); confirms the saga terminates `SagaFailed` and is removed from `in_flight`.
- `saga_action_failed_event_terminates_matching_saga` — confirms `Event::SagaActionFailed` terminates the matching saga even with no `Report*` arriving.

Plus all 47 existing `agentmux-launcher` saga tests continue to pass (47 passed; 0 failed).

## Test plan

- [x] `cargo check --workspace` (baseline + after) — no new warnings beyond pre-existing
- [x] `cargo test -p agentmux-launcher saga` — 47 passed (3 new + 44 existing)
- [x] `cargo test -p agentmux-launcher -p agentmux-common` — 156 passed
- [x] `cargo test -p agentmux-cef --bins` — 41 passed
- [ ] Manual smoke (post-merge — requires host-side CPD-5 LRU work for full ack-loop validation)