### PR TITLE
feat(lsd-4): startup retention vacuum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.573"
+version = "0.33.574"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.573"
+version = "0.33.574"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.573"
+version = "0.33.574"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.573"
+version = "0.33.574"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml",
  "uuid",
  "windows-sys 0.59.0",
  "winres",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.573"
+version = "0.33.574"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.573"
+version = "0.33.574"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -54,6 +54,11 @@ uuid = { version = "1", features = ["v4"] }
 agentmux-common = { path = "../agentmux-common" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# LSD-4: TOML parsing for `~/.agentmux/config.toml` so operators can
+# override saga-log retention via `[saga.launcher] retention_days = N`.
+# Pinned to 0.5 because that's what srv pulls in transitively (per
+# Cargo.lock); using the same version avoids a duplicate dep tree.
+toml = "0.5"
 # LSD-1: `#[derive(thiserror::Error)]` on the saga log's `LogError`
 # enum keeps the SQLite + serde_json + io error wrapping clean. Same
 # pin as srv so any cross-crate refactor stays trivial.

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.573"
+version = "0.33.574"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/config.rs
+++ b/agentmux-launcher/src/config.rs
@@ -1,0 +1,201 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// LSD-4 — operator-overridable launcher config loaded from
+// `<user_home_dir>/config.toml` (typically `~/.agentmux/config.toml`).
+//
+// Spec: `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`
+//   - §3.6 retention default 7 days, configurable via `[saga.launcher]`
+//   - §4 PR4 scope: read this file at startup, apply
+//     `vacuum_older_than(now - retention_days)` once before the
+//     coordinator starts.
+//
+// Design:
+//   - File is OPTIONAL. Missing file, unreadable file, or malformed
+//     TOML all fall back to the compiled-in defaults; we log a WARN
+//     line so operators see the misconfiguration but the launcher
+//     keeps starting. The saga log's behavior shouldn't be load-
+//     bearing on a config file the user may never have created.
+//   - Sections are namespaced under `[saga.launcher]` so future srv
+//     bits can land at `[saga.srv]` without colliding. Top-level
+//     `unknown_keys` are tolerated (serde default) so an older
+//     launcher reading a newer config doesn't crash.
+//
+// Example `~/.agentmux/config.toml`:
+//
+//     [saga.launcher]
+//     retention_days = 14
+//
+// Tests live below in `#[cfg(test)] mod tests` — exercise the parse
+// path on a `tempfile::NamedTempFile` containing valid + malformed
+// TOML.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+/// LSD spec §3.6 default — 7 days. Tunable via config file.
+pub const DEFAULT_SAGA_RETENTION_DAYS: i64 = 7;
+
+/// Top-level launcher config schema. Only the saga subtree is
+/// populated today; future PRs append siblings.
+#[derive(Debug, Default, Deserialize)]
+struct LauncherConfig {
+    #[serde(default)]
+    saga: SagaConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SagaConfig {
+    #[serde(default)]
+    launcher: SagaLauncherConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SagaLauncherConfig {
+    /// Days to retain terminal sagas (`completed` / `failed` /
+    /// `failed_compensation`) before the startup vacuum sweeps them.
+    /// In-flight sagas (`running` / `compensating`) are never vacuumed
+    /// regardless of age — see `vacuum_older_than` SQL filter.
+    retention_days: Option<i64>,
+}
+
+/// Read `<user_home_dir>/config.toml` if it exists and return the
+/// configured saga retention days, falling back to
+/// `DEFAULT_SAGA_RETENTION_DAYS` on any error. The optional `log_warn`
+/// closure receives a human-readable diagnostic line per failure path
+/// (file unreadable / malformed / negative value) so callers can
+/// route it through `crate::log()` without introducing a tracing dep.
+pub fn load_saga_retention_days(
+    user_home_dir: &Path,
+    mut log_warn: impl FnMut(&str),
+) -> i64 {
+    let path = user_home_dir.join("config.toml");
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Missing file is the expected case for fresh installs;
+            // no warning needed.
+            return DEFAULT_SAGA_RETENTION_DAYS;
+        }
+        Err(e) => {
+            log_warn(&format!(
+                "[config] failed to read {}: {} — using default retention {} days",
+                path.display(),
+                e,
+                DEFAULT_SAGA_RETENTION_DAYS
+            ));
+            return DEFAULT_SAGA_RETENTION_DAYS;
+        }
+    };
+    match toml::from_str::<LauncherConfig>(&raw) {
+        Ok(cfg) => match cfg.saga.launcher.retention_days {
+            Some(d) if d > 0 => d,
+            Some(d) => {
+                log_warn(&format!(
+                    "[config] [saga.launcher] retention_days = {} is non-positive; using default {} days",
+                    d, DEFAULT_SAGA_RETENTION_DAYS
+                ));
+                DEFAULT_SAGA_RETENTION_DAYS
+            }
+            None => DEFAULT_SAGA_RETENTION_DAYS,
+        },
+        Err(e) => {
+            log_warn(&format!(
+                "[config] failed to parse {}: {} — using default retention {} days",
+                path.display(),
+                e,
+                DEFAULT_SAGA_RETENTION_DAYS
+            ));
+            DEFAULT_SAGA_RETENTION_DAYS
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // Tests collect each warning passed through `log_warn` into a
+    // `RefCell<Vec<String>>` and assert on the resulting list. Keeps
+    // the closure trivial without requiring a generic `FnMut` factory.
+
+    fn run(home: &Path) -> (i64, Vec<String>) {
+        let warnings: RefCell<Vec<String>> = RefCell::new(Vec::new());
+        let days = load_saga_retention_days(home, |w| warnings.borrow_mut().push(w.to_string()));
+        (days, warnings.into_inner())
+    }
+
+    #[test]
+    fn missing_file_returns_default_no_warning() {
+        let dir = TempDir::new().unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, DEFAULT_SAGA_RETENTION_DAYS);
+        assert!(warns.is_empty(), "missing file is silent, got: {warns:?}");
+    }
+
+    #[test]
+    fn valid_config_returns_configured_value() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            "[saga.launcher]\nretention_days = 14\n",
+        )
+        .unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, 14);
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn malformed_toml_logs_warning_and_returns_default() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("config.toml"), "not = toml = bro\n").unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, DEFAULT_SAGA_RETENTION_DAYS);
+        assert_eq!(warns.len(), 1);
+        assert!(warns[0].contains("failed to parse"), "got: {}", warns[0]);
+    }
+
+    #[test]
+    fn missing_section_returns_default_no_warning() {
+        // Empty + irrelevant keys are tolerated.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            "[some_other_section]\nfoo = 1\n",
+        )
+        .unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, DEFAULT_SAGA_RETENTION_DAYS);
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn non_positive_retention_logs_warning_and_returns_default() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            "[saga.launcher]\nretention_days = 0\n",
+        )
+        .unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, DEFAULT_SAGA_RETENTION_DAYS);
+        assert_eq!(warns.len(), 1);
+        assert!(warns[0].contains("non-positive"));
+
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("config.toml"),
+            "[saga.launcher]\nretention_days = -3\n",
+        )
+        .unwrap();
+        let (days, warns) = run(dir.path());
+        assert_eq!(days, DEFAULT_SAGA_RETENTION_DAYS);
+        assert_eq!(warns.len(), 1);
+    }
+
+}

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -20,6 +20,7 @@
     windows_subsystem = "windows"
 )]
 
+mod config;
 mod data_dir;
 mod diag;
 mod event_log;
@@ -325,6 +326,26 @@ async fn run_windows(
             std::process::exit(2);
         }
     };
+
+    // LSD-4 — startup retention vacuum. Runs once per launcher boot,
+    // before the coordinator subscribes, so any rows it deletes are
+    // already terminal and can't possibly belong to an in-flight saga
+    // the coordinator is about to drive (see `vacuum_older_than` SQL —
+    // `running` and `compensating` rows are unreachable by the DELETE
+    // regardless of timing). Failure is non-fatal: a corrupted /
+    // unwritable saga log row is a diagnostic concern, not a launcher-
+    // startup blocker. Spec
+    // `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.6.
+    let retention_days =
+        config::load_saga_retention_days(&paths.user_home_dir, |w| log(w));
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days);
+    match saga_log.vacuum_older_than(cutoff) {
+        Ok(removed) => log(&format!(
+            "[saga-log] vacuumed {} sagas older than {} (retention {} days)",
+            removed, cutoff, retention_days
+        )),
+        Err(e) => log(&format!("[saga-log] WARN: vacuum failed: {}", e)),
+    }
 
     // CPD-2 — launcher → host pipe wrapper. Owns the writer half of
     // the host's IPC connection (installed by the per-connection

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -538,7 +538,7 @@ impl LauncherSagaLog {
     /// `ON DELETE CASCADE` on `launcher_saga_step.saga_id` ensures
     /// the corresponding step rows go with the saga in a single
     /// SQLite transaction — no manual cleanup needed.
-    #[allow(dead_code)] // wired in PR LSD-4 (startup retention task)
+    // LSD-4: wired by `main.rs::run_windows` startup retention task.
     pub fn vacuum_older_than(&self, cutoff: DateTime<Utc>) -> Result<usize, LogError> {
         let cutoff_str = cutoff.to_rfc3339();
         let conn = self.conn.lock().unwrap();

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.573"
+version = "0.33.574"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.573",
+  "version": "0.33.574",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.573",
+      "version": "0.33.574",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.573",
+  "version": "0.33.574",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Wires `LauncherSagaLog::vacuum_older_than(cutoff)` (added in LSD-1) as a once-per-startup task so the `launcher-sagas.db` doesn't grow unbounded. Spec: [`SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`](docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md) §3.6 retention + §4 PR4.

- New `agentmux-launcher/src/config.rs` reads `~/.agentmux/config.toml` for `[saga.launcher] retention_days = N` (default 7). Missing/malformed/non-positive falls back to 7 days with a logged WARN — config is opt-in, never load-bearing.
- `main.rs::run_windows` calls `saga_log.vacuum_older_than(now - retention_days)` immediately after `LauncherSagaLog::open` and before the saga coordinator subscribes; failure is non-fatal and logged via `crate::log()`.
- In-flight sagas (`running` / `compensating`) are never vacuumed — that filter is enforced in the existing `vacuum_older_than` SQL (LSD-1) and pinned by `vacuum_removes_only_terminal_rows_older_than_cutoff` test.

## Diff
| File | LOC |
|------|-----|
| `agentmux-launcher/Cargo.toml` | +5 (toml = "0.5") |
| `agentmux-launcher/src/main.rs` | +21 (mod decl + vacuum block) |
| `agentmux-launcher/src/config.rs` | +201 new (≈55 logic, rest tests + docs) |
| `agentmux-launcher/src/saga/log/mod.rs` | -1 `#[allow(dead_code)]` (vacuum is now wired) |

## Test plan

- [x] `cargo check -p agentmux-launcher` — clean (only pre-existing dead_code warns)
- [x] `cargo test -p agentmux-launcher` — 140/140 pass, including 5 new `config::tests::*` (missing file, valid, malformed, missing section, non-positive)
- [x] Existing `saga::log::tests::vacuum_removes_only_terminal_rows_older_than_cutoff` covers in-flight protection
- [ ] Manual: drop `[saga.launcher] retention_days = 1` in `~/.agentmux/config.toml`, restart launcher, verify `[saga-log] vacuumed N sagas older than ...` line in `agentmux-launcher.log`