### PR TITLE
feat(lsd-3): recovery walker + --diag sagas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.577"
+version = "0.33.578"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.577"
+version = "0.33.578"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.577"
+version = "0.33.578"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.577"
+version = "0.33.578"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.576"
+version = "0.33.577"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.576"
+version = "0.33.577"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.576"
+version = "0.33.577"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.576"
+version = "0.33.577"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.577"
+version = "0.33.578"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.576"
+version = "0.33.577"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.577"
+version = "0.33.578"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.576"
+version = "0.33.577"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.576"
+version = "0.33.577"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.577"
+version = "0.33.578"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -781,41 +781,47 @@ async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), S
             println!("    input: {}", s.input_json);
         }
 
-        // Step rows. unresolved_sagas carries the full step list; for
-        // terminal sagas we don't have steps in the snapshot view
-        // (snapshot_recent doesn't return step rows — by design, to
-        // keep summary output bounded). We surface step detail only
-        // for unresolved sagas, which is where it matters most:
-        // operator review of `failed_compensation` sagas to see what
-        // was attempted before the crash.
-        if let Some(u) = unresolved.iter().find(|u| u.saga_id == s.saga_id) {
-            if !u.steps.is_empty() {
-                println!("    steps:");
-                for step in &u.steps {
-                    let target = step.target.as_deref().unwrap_or("—");
-                    let cmd_snippet = step
-                        .cmd_json
-                        .as_deref()
-                        .map(|c| truncate_for_display(c, 120))
-                        .unwrap_or_else(|| "—".into());
-                    println!(
-                        "      {:>3}  {:30} target={:<14} state={:<10} cmd={}",
-                        step.step_index, step.name, target, step.state, cmd_snippet
-                    );
-                    if let Some(reason) = &step.failure_reason {
-                        println!("           failure: {}", reason);
-                    }
+        // Step rows. Surface step detail for both `unresolved` sagas
+        // AND `failed_compensation` sagas (recovered crashes) — the
+        // latter is the operator triage flow per LSD spec §3.5.
+        // (codex P1 PR #647 round 1: unresolved_sagas() filters
+        // out failed_compensation, so we fall back to a direct
+        // get_saga_steps query for those.)
+        let steps: Vec<crate::saga::log::UnresolvedLauncherStep> = if let Some(u) =
+            unresolved.iter().find(|u| u.saga_id == s.saga_id)
+        {
+            u.steps.clone()
+        } else if s.state == "failed_compensation" {
+            log.get_saga_steps(s.saga_id).unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        if !steps.is_empty() {
+            println!("    steps:");
+            for step in &steps {
+                let target = step.target.as_deref().unwrap_or("—");
+                let cmd_snippet = step
+                    .cmd_json
+                    .as_deref()
+                    .map(|c| truncate_for_display(c, 120))
+                    .unwrap_or_else(|| "—".into());
+                println!(
+                    "      {:>3}  {:30} target={:<14} state={:<10} cmd={}",
+                    step.step_index, step.name, target, step.state, cmd_snippet
+                );
+                if let Some(reason) = &step.failure_reason {
+                    println!("           failure: {}", reason);
                 }
-                // Pinpoint the in-flight step at crash time, mirroring
-                // the example in spec §3.5: "[step 2 was in-flight when
-                // launcher exited]". The step in `pending` state at the
-                // highest index is the one the saga was waiting on.
-                if let Some(in_flight) = u.steps.iter().rev().find(|st| st.state == "pending") {
-                    println!(
-                        "      [step {} was in-flight when launcher exited]",
-                        in_flight.step_index
-                    );
-                }
+            }
+            // Pinpoint the in-flight step at crash time, mirroring
+            // the example in spec §3.5: "[step 2 was in-flight when
+            // launcher exited]". The step in `pending` state at the
+            // highest index is the one the saga was waiting on.
+            if let Some(in_flight) = steps.iter().rev().find(|st| st.state == "pending") {
+                println!(
+                    "      [step {} was in-flight when launcher exited]",
+                    in_flight.step_index
+                );
             }
         }
         println!();

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -743,8 +743,10 @@ async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), S
         return Ok(());
     }
 
-    let log = crate::saga::LauncherSagaLog::open(&saga_log_path)
-        .map_err(|e| format!("open saga log {:?}: {}", saga_log_path, e))?;
+    // Read-only open: an operator's diagnostic invocation must not
+    // mutate the log a running launcher owns. (codex P2 PR #647 round 3.)
+    let log = crate::saga::LauncherSagaLog::open_read_only(&saga_log_path)
+        .map_err(|e| format!("open saga log {:?} (read-only): {}", saga_log_path, e))?;
 
     let snapshot = log
         .snapshot_recent(50)
@@ -792,7 +794,17 @@ async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), S
         {
             u.steps.clone()
         } else if s.state == "failed_compensation" {
-            log.get_saga_steps(s.saga_id).unwrap_or_default()
+            // Surface step-query failures rather than silently
+            // returning empty — operators need visibility into "why
+            // are step rows missing for this recovered saga".
+            // (codex P2 PR #647 round 3.)
+            match log.get_saga_steps(s.saga_id) {
+                Ok(steps) => steps,
+                Err(e) => {
+                    println!("    [step query failed: {} — saga rows may exist but cannot be read]", e);
+                    Vec::new()
+                }
+            }
         } else {
             Vec::new()
         };

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -687,3 +687,274 @@ fn format_event(e: &Event) -> String {
         other => serde_json::to_string(other).unwrap_or_else(|_| format!("{:?}", other)),
     }
 }
+
+// ---------------------------------------------------------------------------
+// LSD-3 — `agentmux.exe --diag sagas`
+//
+// Operator visibility into the launcher saga log
+// (`<data-dir>/launcher-sagas.db`). Unlike `--diag wrr` and
+// `--diag srv`, this command does NOT need a running launcher: the
+// SQLite log is a passive on-disk artefact. We open it read-only via
+// `LauncherSagaLog::open` and call `snapshot_recent(50)`. Useful when
+// the launcher won't start (operator wants to see what sagas were
+// in flight at the last crash) or post-mortem on a portable instance.
+//
+// Output mirrors the example in LSD spec §3.5 — saga header line per
+// saga, followed by step rows showing target + state + cmd snippet.
+// Sagas marked `failed_compensation` by the startup recovery walker
+// are flagged "(recovered on restart)" in the header so operators
+// can spot them at a glance.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+pub async fn run_sagas_diag(launcher_exe_dir: &std::path::Path) -> Result<(), String> {
+    run_sagas_diag_impl(launcher_exe_dir).await
+}
+
+#[cfg(not(target_os = "windows"))]
+pub async fn run_sagas_diag(launcher_exe_dir: &std::path::Path) -> Result<(), String> {
+    // The saga log is a SQLite file with no platform-specific bits;
+    // the cross-platform parity goal for `--diag sagas` is "works
+    // wherever the launcher writes the log." Phase 7 will wire the
+    // POSIX data_dir resolution, but the rest of the formatter is
+    // already platform-agnostic, so we reuse the impl on every
+    // target.
+    run_sagas_diag_impl(launcher_exe_dir).await
+}
+
+async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), String> {
+    let version = env!("CARGO_PKG_VERSION");
+    let is_dev = cfg!(debug_assertions);
+
+    let paths = crate::data_dir::resolve_paths(launcher_exe_dir, version, is_dev)
+        .map_err(|e| format!("path resolution failed: {}", e))?;
+    let saga_log_path = paths.data_dir.join("launcher-sagas.db");
+
+    println!("AgentMux launcher saga diagnostic");
+    println!("Data dir: {}", paths.data_dir.display());
+    println!("Saga log: {}", saga_log_path.display());
+    println!();
+
+    if !saga_log_path.exists() {
+        println!(
+            "(no saga log at {} — launcher hasn't written one yet, or this isn't an AgentMux data dir)",
+            saga_log_path.display()
+        );
+        return Ok(());
+    }
+
+    let log = crate::saga::LauncherSagaLog::open(&saga_log_path)
+        .map_err(|e| format!("open saga log {:?}: {}", saga_log_path, e))?;
+
+    let snapshot = log
+        .snapshot_recent(50)
+        .map_err(|e| format!("snapshot_recent: {}", e))?;
+    let unresolved = log
+        .unresolved_sagas()
+        .map_err(|e| format!("unresolved_sagas: {}", e))?;
+
+    if snapshot.is_empty() {
+        println!("(saga log is empty)");
+        return Ok(());
+    }
+
+    println!("Recent launcher sagas (last {}):", snapshot.len());
+    for s in &snapshot {
+        let recovered_marker = if s.state == "failed_compensation" {
+            " (recovered on restart)"
+        } else {
+            ""
+        };
+        let ended = s.ended_at.as_deref().unwrap_or("—");
+        println!(
+            "  saga_id={} name={} state={}{}",
+            s.saga_id, s.name, s.state, recovered_marker
+        );
+        println!(
+            "    started={} ended={} steps_progressed={}",
+            s.started_at, ended, s.step_count
+        );
+        if let Some(reason) = &s.failure_reason {
+            println!("    failure: {}", reason);
+        }
+        if !s.input_json.is_empty() && s.input_json != "null" {
+            println!("    input: {}", s.input_json);
+        }
+
+        // Step rows. unresolved_sagas carries the full step list; for
+        // terminal sagas we don't have steps in the snapshot view
+        // (snapshot_recent doesn't return step rows — by design, to
+        // keep summary output bounded). We surface step detail only
+        // for unresolved sagas, which is where it matters most:
+        // operator review of `failed_compensation` sagas to see what
+        // was attempted before the crash.
+        if let Some(u) = unresolved.iter().find(|u| u.saga_id == s.saga_id) {
+            if !u.steps.is_empty() {
+                println!("    steps:");
+                for step in &u.steps {
+                    let target = step.target.as_deref().unwrap_or("—");
+                    let cmd_snippet = step
+                        .cmd_json
+                        .as_deref()
+                        .map(|c| truncate_for_display(c, 120))
+                        .unwrap_or_else(|| "—".into());
+                    println!(
+                        "      {:>3}  {:30} target={:<14} state={:<10} cmd={}",
+                        step.step_index, step.name, target, step.state, cmd_snippet
+                    );
+                    if let Some(reason) = &step.failure_reason {
+                        println!("           failure: {}", reason);
+                    }
+                }
+                // Pinpoint the in-flight step at crash time, mirroring
+                // the example in spec §3.5: "[step 2 was in-flight when
+                // launcher exited]". The step in `pending` state at the
+                // highest index is the one the saga was waiting on.
+                if let Some(in_flight) = u.steps.iter().rev().find(|st| st.state == "pending") {
+                    println!(
+                        "      [step {} was in-flight when launcher exited]",
+                        in_flight.step_index
+                    );
+                }
+            }
+        }
+        println!();
+    }
+
+    let recovered_count = snapshot
+        .iter()
+        .filter(|s| s.state == "failed_compensation")
+        .count();
+    if recovered_count > 0 {
+        println!(
+            "Note: {} saga(s) marked `failed_compensation` by the startup recovery walker.",
+            recovered_count
+        );
+        println!("These were unresolved when the launcher last exited; their effects on host state");
+        println!("may be partially applied. Inspect step rows above to see what was attempted.");
+    }
+
+    Ok(())
+}
+
+/// Trim a JSON snippet to `max_chars` for one-line display, appending
+/// `…` if it was truncated. Used to keep `--diag sagas` cmd columns
+/// readable when commands carry large payloads (e.g. block meta).
+fn truncate_for_display(s: &str, max_chars: usize) -> String {
+    if s.chars().count() <= max_chars {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max_chars).collect();
+        format!("{}…", truncated)
+    }
+}
+
+#[cfg(test)]
+mod sagas_diag_tests {
+    use super::*;
+    use crate::saga::{LauncherSagaLog, PipeTarget};
+    use agentmux_common::ipc::{Command, Event};
+
+    #[test]
+    fn truncate_for_display_shortens_long_strings_and_keeps_short_ones() {
+        assert_eq!(truncate_for_display("hi", 10), "hi");
+        let long = "a".repeat(200);
+        let truncated = truncate_for_display(&long, 50);
+        // 50 a's + ellipsis.
+        assert_eq!(truncated.chars().count(), 51);
+        assert!(truncated.ends_with('…'));
+    }
+
+    /// Smoke test: build a fixture saga log, run `snapshot_recent`
+    /// and `unresolved_sagas`, and verify the formatter assembles the
+    /// expected fields without panicking. We don't snapshot stdout
+    /// (printing is fine; what matters is the data we'd print is
+    /// what the spec describes).
+    #[test]
+    fn sagas_diag_fixture_log_has_expected_summary_fields() {
+        let log = LauncherSagaLog::open_in_memory().unwrap();
+
+        // Saga 1 — completed cleanly.
+        log.start_saga(
+            1,
+            "window_cleanup_cascade",
+            &serde_json::json!({"label": "win-1"}),
+        )
+        .unwrap();
+        log.start_step(
+            1,
+            0,
+            "issue_cmd_host_reap_panes",
+            PipeTarget::Host,
+            &Command::Ping { nonce: 1 },
+        )
+        .unwrap();
+        log.finish_step(1, 0, &Event::Pong { nonce: 1, version: 1 })
+            .unwrap();
+        log.terminate_saga(1, crate::saga::log::SagaOutcome::Completed)
+            .unwrap();
+
+        // Saga 2 — recovered (failed_compensation), with a pending
+        // step row to demonstrate the "[step N was in-flight ..]" line.
+        log.start_saga(
+            2,
+            "window_cleanup_cascade",
+            &serde_json::json!({"label": "win-3"}),
+        )
+        .unwrap();
+        log.start_step(
+            2,
+            0,
+            "issue_cmd_host_reap_panes",
+            PipeTarget::Host,
+            &Command::Ping { nonce: 2 },
+        )
+        .unwrap();
+        log.finish_step(2, 0, &Event::Pong { nonce: 2, version: 1 })
+            .unwrap();
+        log.start_step(
+            2,
+            1,
+            "issue_cmd_host_drain_pool",
+            PipeTarget::Host,
+            &Command::Ping { nonce: 3 },
+        )
+        .unwrap();
+        // Step 1 stays pending — saga 2 was in-flight at "crash" time.
+        // Then run the recovery walker manually.
+        log.mark_failed_compensation(2, "launcher restarted while saga in state 'running'")
+            .unwrap();
+
+        let snapshot = log.snapshot_recent(50).unwrap();
+        assert_eq!(snapshot.len(), 2);
+
+        // snapshot_recent returns most-recent-first.
+        let s2 = &snapshot[0];
+        let s1 = &snapshot[1];
+        assert_eq!(s1.saga_id, 1);
+        assert_eq!(s1.state, "completed");
+        assert_eq!(s1.step_count, 1);
+
+        assert_eq!(s2.saga_id, 2);
+        assert_eq!(s2.state, "failed_compensation");
+        // step_count counts succeeded+compensated, so 1 succeeded
+        // (the reap-panes step). The pending drain-pool step is NOT
+        // counted as progress.
+        assert_eq!(s2.step_count, 1);
+        assert!(s2
+            .failure_reason
+            .as_deref()
+            .unwrap_or("")
+            .contains("launcher restarted"));
+
+        // Step rows for saga 2 still surface via unresolved_sagas? No —
+        // saga 2 is in failed_compensation, which is terminal, so
+        // unresolved_sagas EXCLUDES it. The formatter handles this by
+        // simply skipping the step list for terminal-recovered sagas.
+        // That's fine: operators looking for in-flight detail get it
+        // for sagas STILL unresolved; for already-recovered ones, the
+        // failure_reason header already names the prior state.
+        let unresolved = log.unresolved_sagas().unwrap();
+        assert!(unresolved.iter().all(|u| u.saga_id != 2));
+    }
+}

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -695,7 +695,7 @@ fn format_event(e: &Event) -> String {
 // (`<data-dir>/launcher-sagas.db`). Unlike `--diag wrr` and
 // `--diag srv`, this command does NOT need a running launcher: the
 // SQLite log is a passive on-disk artefact. We open it read-only via
-// `LauncherSagaLog::open` and call `snapshot_recent(50)`. Useful when
+// `LauncherSagaLog::open_read_only` and call `snapshot_recent(50)`. Useful when
 // the launcher won't start (operator wants to see what sagas were
 // in flight at the last crash) or post-mortem on a portable instance.
 //

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -106,12 +106,25 @@ async fn main() {
                     std::process::exit(1);
                 }
             },
+            // LSD-3 — operator visibility into the launcher saga log.
+            // Reads `<data-dir>/launcher-sagas.db` directly (no IPC,
+            // no running launcher required). Surfaces sagas marked
+            // `failed_compensation` by the startup recovery walker
+            // alongside the most recent 50 sagas of any state. Spec
+            // `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.5.
+            "sagas" => match diag::run_sagas_diag(exe_dir).await {
+                Ok(()) => std::process::exit(0),
+                Err(msg) => {
+                    eprintln!("--diag sagas failed: {}", msg);
+                    std::process::exit(1);
+                }
+            },
             "" => {
-                eprintln!("usage: agentmux.exe --diag <topic>\nknown topics: wrr, srv");
+                eprintln!("usage: agentmux.exe --diag <topic>\nknown topics: wrr, srv, sagas");
                 std::process::exit(2);
             }
             other => {
-                eprintln!("unknown --diag topic: {} (known: wrr, srv)", other);
+                eprintln!("unknown --diag topic: {} (known: wrr, srv, sagas)", other);
                 std::process::exit(2);
             }
         }
@@ -327,15 +340,31 @@ async fn run_windows(
         }
     };
 
+    // LSD-3 — startup recovery walker. Walks the durable saga log,
+    // marks any saga still in `running` / `compensating` / `failed`
+    // (left over from a crashed prior run) as `failed_compensation`
+    // so operators see them in `--diag sagas` and the next coordinator
+    // run can't accidentally double-act on partially-applied effects.
+    // MUST run BEFORE `tokio::spawn(saga::run_coordinator(..))` below
+    // (LSD spec §5 risk #5: don't spawn while recovery is in progress).
+    // Runs BEFORE LSD-4 vacuum so just-recovered sagas land in their
+    // failed_compensation state for the operator to see — vacuum
+    // honors the 7-day retention window and won't immediately purge.
+    // Spec `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.5.
+    if let Err(e) = saga::compensate_unresolved_launcher_sagas(&saga_log).await {
+        log(&format!(
+            "[saga-recovery] WARN: walker failed: {} — coordinator will still spawn; prior crashed sagas remain unresolved until next restart",
+            e
+        ));
+    }
+
     // LSD-4 — startup retention vacuum. Runs once per launcher boot,
     // before the coordinator subscribes, so any rows it deletes are
     // already terminal and can't possibly belong to an in-flight saga
     // the coordinator is about to drive (see `vacuum_older_than` SQL —
     // `running` and `compensating` rows are unreachable by the DELETE
-    // regardless of timing). Failure is non-fatal: a corrupted /
-    // unwritable saga log row is a diagnostic concern, not a launcher-
-    // startup blocker. Spec
-    // `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.6.
+    // regardless of timing). Failure is non-fatal.
+    // Spec §3.6.
     let retention_days =
         config::load_saga_retention_days(&paths.user_home_dir, |w| log(w));
     let cutoff = chrono::Utc::now() - chrono::Duration::days(retention_days);

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -63,6 +63,27 @@ async fn main() {
     }
     log("SetDllDirectoryW done");
 
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    // LSD-3 — `agentmux.exe --diag sagas` is OFFLINE: it reads the
+    // launcher saga SQLite log directly, with no IPC and no running
+    // launcher. So it MUST run BEFORE the CEF runtime existence
+    // check below — the offline-diagnostic value is most needed
+    // exactly when the launcher won't start (e.g. corrupt runtime
+    // folder). (codex P1 + reagent P1 PR #647 round 3.)
+    if matches!(
+        (args.first().map(String::as_str), args.get(1).map(String::as_str)),
+        (Some("--diag"), Some("sagas"))
+    ) {
+        match diag::run_sagas_diag(exe_dir).await {
+            Ok(()) => std::process::exit(0),
+            Err(msg) => {
+                eprintln!("--diag sagas failed: {}", msg);
+                std::process::exit(1);
+            }
+        }
+    }
+
     let real_exe = find_cef_binary(&runtime_dir);
     log(&format!("resolved CEF binary: {}", real_exe.display()));
     if !real_exe.exists() {
@@ -77,14 +98,13 @@ async fn main() {
         std::process::exit(1);
     }
 
-    let args: Vec<String> = std::env::args().skip(1).collect();
     log(&format!("forwarding {} CLI args to host", args.len()));
 
-    // Phase B.8 — `agentmux.exe --diag wrr` Tool client. Connects
-    // to the running launcher, captures events for a short window,
-    // prints a summary, exits. Doesn't spawn srv/host; doesn't
-    // bind the pipe; doesn't drive the reducer's lifecycle. Skip
-    // straight to the Tool flow before any privileged setup.
+    // Phase B.8 — `agentmux.exe --diag wrr` and `--diag srv` Tool
+    // clients. Connect to the running launcher (or srv) over IPC,
+    // capture events for a short window, print summary, exit.
+    // (Note: --diag sagas is handled above, before the CEF runtime
+    // check, since it doesn't need IPC.)
     if matches!(args.first().map(String::as_str), Some("--diag")) {
         let topic = args.get(1).map(String::as_str).unwrap_or("");
         match topic {
@@ -106,19 +126,12 @@ async fn main() {
                     std::process::exit(1);
                 }
             },
-            // LSD-3 — operator visibility into the launcher saga log.
-            // Reads `<data-dir>/launcher-sagas.db` directly (no IPC,
-            // no running launcher required). Surfaces sagas marked
-            // `failed_compensation` by the startup recovery walker
-            // alongside the most recent 50 sagas of any state. Spec
-            // `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.5.
-            "sagas" => match diag::run_sagas_diag(exe_dir).await {
-                Ok(()) => std::process::exit(0),
-                Err(msg) => {
-                    eprintln!("--diag sagas failed: {}", msg);
-                    std::process::exit(1);
-                }
-            },
+            // sagas is handled above, before the runtime check.
+            "sagas" => {
+                // Should never reach here — `sagas` is matched + handled
+                // above the CEF runtime check. Kept for completeness.
+                unreachable!("--diag sagas is handled before runtime check");
+            }
             "" => {
                 eprintln!("usage: agentmux.exe --diag <topic>\nknown topics: wrr, srv, sagas");
                 std::process::exit(2);

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -216,6 +216,26 @@ impl LauncherSagaLog {
         Self::configure_and_migrate(conn)
     }
 
+    /// Open the saga log in read-only mode. Used by `--diag sagas`
+    /// so an operator's diagnostic invocation can't accidentally
+    /// schema-migrate or modify a log that a running launcher owns.
+    /// Skips `configure_and_migrate` (read-only opens shouldn't run
+    /// migrations) and skips the `foreign_keys=ON` pragma since we
+    /// don't write. (codex P2 PR #647 round 3.)
+    pub fn open_read_only(path: &Path) -> Result<Self, LogError> {
+        let conn = Connection::open_with_flags(
+            path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        // Read-only PRAGMAs only: busy_timeout for WAL coexistence with
+        // a running launcher, no journal_mode change, no migrations.
+        conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
     /// Open an in-memory saga log for testing. Used by `tests.rs`
     /// and by future PR LSD-2 coordinator integration tests.
     #[allow(dead_code)] // exercised under #[cfg(test)] only; see saga/log/tests.rs
@@ -483,9 +503,13 @@ impl LauncherSagaLog {
 
     /// Mark a saga as `failed_compensation` — the recovery walker's
     /// terminal write. Idempotent across repeated calls (the saga
-    /// stays in `failed_compensation`; only `ended_at` and
-    /// `failure_reason` get overwritten with the latest values).
-    /// LSD spec §3.5 — operator-review terminal state.
+    /// stays in `failed_compensation`; `ended_at` is rewritten to
+    /// the latest call's timestamp; `failure_reason` is preserved
+    /// when already populated and the new reason is APPENDED rather
+    /// than overwritten — see SQL CASE WHEN below). This preserves
+    /// the original failure cause (e.g. timeout) while adding the
+    /// recovery context. (codex P2 PR #647 round 1: post-mortem
+    /// preservation.) LSD spec §3.5 — operator-review terminal state.
     #[allow(dead_code)] // wired in PR LSD-3 (recovery walker)
     pub fn mark_failed_compensation(
         &self,

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -494,9 +494,23 @@ impl LauncherSagaLog {
     ) -> Result<(), LogError> {
         let now = now_rfc3339();
         let conn = self.conn.lock().unwrap();
+        // Preserve original failure_reason when already populated.
+        // A saga in `failed` state pre-crash carries the precise
+        // original cause (timeout, dispatch error, etc.) that
+        // operators need for post-mortem. Recovery transitions
+        // state to `failed_compensation` but augments rather than
+        // replaces failure_reason — appends the restart context
+        // so both signals are visible in `--diag sagas`.
+        // (codex P2 PR #647 round 1.)
         conn.execute(
             "UPDATE launcher_saga
-             SET state = 'failed_compensation', ended_at = ?1, failure_reason = ?2
+             SET state = 'failed_compensation',
+                 ended_at = ?1,
+                 failure_reason = CASE
+                     WHEN failure_reason IS NULL OR failure_reason = ''
+                       THEN ?2
+                     ELSE failure_reason || ' | recovered: ' || ?2
+                 END
              WHERE saga_id = ?3",
             params![now, reason, saga_id as i64],
         )?;

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -448,6 +448,39 @@ impl LauncherSagaLog {
         Ok(out)
     }
 
+    /// Fetch the step rows for a single saga regardless of saga state.
+    /// `unresolved_sagas` filters out `failed_compensation` (and other
+    /// terminal states), but `--diag sagas` needs to surface step rows
+    /// for sagas the recovery walker just marked `failed_compensation`
+    /// — operators triaging a recovered crash need to see what was
+    /// pending when the launcher exited. (codex P1 PR #647 round 1.)
+    pub fn get_saga_steps(&self, saga_id: u64) -> Result<Vec<UnresolvedLauncherStep>, LogError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT step_index, name, state, target, cmd_json,
+                    output_json, started_at, ended_at, failure_reason
+             FROM launcher_saga_step
+             WHERE saga_id = ?1
+             ORDER BY step_index ASC",
+        )?;
+        let steps: Vec<UnresolvedLauncherStep> = stmt
+            .query_map(params![saga_id as i64], |row| {
+                Ok(UnresolvedLauncherStep {
+                    step_index: row.get::<_, i64>(0)? as u32,
+                    name: row.get::<_, String>(1)?,
+                    state: row.get::<_, String>(2)?,
+                    target: row.get::<_, Option<String>>(3)?,
+                    cmd_json: row.get::<_, Option<String>>(4)?,
+                    output_json: row.get::<_, Option<String>>(5)?,
+                    started_at: row.get::<_, String>(6)?,
+                    ended_at: row.get::<_, Option<String>>(7)?,
+                    failure_reason: row.get::<_, Option<String>>(8)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(steps)
+    }
+
     /// Mark a saga as `failed_compensation` — the recovery walker's
     /// terminal write. Idempotent across repeated calls (the saga
     /// stays in `failed_compensation`; only `ended_at` and

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -408,7 +408,6 @@ impl LauncherSagaLog {
     /// without restart-time recovery would still benefit from the
     /// `failed_compensation` upgrade so `--diag sagas` consistently
     /// surfaces it as "needs operator attention."
-    #[allow(dead_code)] // wired in PR LSD-3 (recovery walker)
     pub fn unresolved_sagas(&self) -> Result<Vec<UnresolvedLauncherSaga>, LogError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
@@ -510,7 +509,6 @@ impl LauncherSagaLog {
     /// the original failure cause (e.g. timeout) while adding the
     /// recovery context. (codex P2 PR #647 round 1: post-mortem
     /// preservation.) LSD spec §3.5 — operator-review terminal state.
-    #[allow(dead_code)] // wired in PR LSD-3 (recovery walker)
     pub fn mark_failed_compensation(
         &self,
         saga_id: u64,
@@ -544,7 +542,6 @@ impl LauncherSagaLog {
     /// Return up to `limit` recent sagas for `--diag sagas`. Sorted
     /// most-recent-first by `COALESCE(ended_at, started_at)`. Mirrors
     /// srv's `snapshot_recent` shape.
-    #[allow(dead_code)] // wired in PR LSD-3 (`--diag sagas` printer)
     pub fn snapshot_recent(&self, limit: usize) -> Result<Vec<SagaSummary>, LogError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(

--- a/agentmux-launcher/src/saga/log/tests.rs
+++ b/agentmux-launcher/src/saga/log/tests.rs
@@ -196,20 +196,32 @@ fn unresolved_sagas_returns_only_in_flight_or_failed() {
 }
 
 #[test]
-fn mark_failed_compensation_is_idempotent() {
-    // PR LSD-3's recovery walker may run repeatedly across crash-
-    // restart cycles; calling mark_failed_compensation twice on the
-    // same saga must not error or duplicate any rows. The state
-    // stays in failed_compensation; only ended_at and failure_reason
-    // get rewritten with the latest call's values.
+fn mark_failed_compensation_preserves_original_failure_reason() {
+    // PR LSD-3 round 3 (codex P2): when a saga is already in `failed`
+    // state at restart with a populated failure_reason (e.g. from
+    // terminate_saga(SagaOutcome::Failed{reason})), recovery marking
+    // must PRESERVE the original reason and APPEND the restart
+    // context — overwriting would discard the precise pre-crash
+    // cause that operators need for post-mortem.
+    //
+    // Idempotence is also exercised: calling mark twice doesn't
+    // duplicate rows.
     let log = LauncherSagaLog::open_in_memory().unwrap();
     log.start_saga(7, "saga_recov", &serde_json::json!({})).unwrap();
+    // First call: failure_reason starts NULL, gets the new reason.
     log.mark_failed_compensation(7, "first attempt").unwrap();
+    let snap1 = log.snapshot_recent(10).unwrap();
+    assert_eq!(snap1[0].failure_reason.as_deref(), Some("first attempt"));
+    // Second call: failure_reason is populated; new reason gets
+    // APPENDED (not overwritten).
     log.mark_failed_compensation(7, "second attempt").unwrap();
-    let snap = log.snapshot_recent(10).unwrap();
-    assert_eq!(snap.len(), 1, "no duplicate rows after repeated marks");
-    assert_eq!(snap[0].state, "failed_compensation");
-    assert_eq!(snap[0].failure_reason.as_deref(), Some("second attempt"));
+    let snap2 = log.snapshot_recent(10).unwrap();
+    assert_eq!(snap2.len(), 1, "no duplicate rows after repeated marks");
+    assert_eq!(snap2[0].state, "failed_compensation");
+    assert_eq!(
+        snap2[0].failure_reason.as_deref(),
+        Some("first attempt | recovered: second attempt")
+    );
     // And the saga is no longer "unresolved" once marked.
     let unresolved = log.unresolved_sagas().unwrap();
     assert!(unresolved.iter().all(|s| s.saga_id != 7));

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -81,9 +81,16 @@ mod integration_tests;
 // the coordinator to write through `LauncherSagaLog` on every state
 // transition. See `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`
 // §4 PR1 for the staged-rollout rationale.
-mod log;
+pub(crate) mod log;
 pub use log::LauncherSagaLog;
 use log::SagaOutcome;
+
+// LSD-3 — startup recovery walker for unresolved launcher sagas.
+// `main.rs::run_windows` calls `compensate_unresolved_launcher_sagas`
+// after opening the durable saga log and BEFORE spawning the saga
+// coordinator. See `saga/recovery.rs` for design notes.
+mod recovery;
+pub use recovery::compensate_unresolved_launcher_sagas;
 
 /// Where a `SagaAction::IssueCmd` should be dispatched.
 ///

--- a/agentmux-launcher/src/saga/recovery.rs
+++ b/agentmux-launcher/src/saga/recovery.rs
@@ -1,0 +1,204 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// LSD-3 — startup recovery walker for unresolved launcher sagas.
+//
+// Spec: `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.5.
+// Companion plan: `docs/specs/SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md` §2 batch 3.
+//
+// Called from `main.rs::run_windows` AFTER opening `LauncherSagaLog`
+// and BEFORE spawning the saga coordinator. The walker:
+//   1. Reads `saga_log.unresolved_sagas()` (sagas in `running` /
+//      `compensating` / `failed` state — see LSD spec §3.3).
+//   2. For each unresolved saga, calls
+//      `saga_log.mark_failed_compensation(saga_id, ..reason..)` with
+//      a human-readable reason that names the prior state.
+//   3. Logs a `[saga-recovery]` warning per saga (id + name + state)
+//      and an info line with the total count.
+//
+// **Critical: we DO NOT auto-replay or auto-compensate launcher sagas.**
+// LSD spec §3.5 — launcher sagas drive host-side effects on live OS
+// state (pane reaps, pool drains) that may already be partially
+// applied. Re-issuing the forward command might double-act; deriving
+// an inverse without pre-state is unsound. The right escape hatch is
+// operator review via `--diag sagas`. The recovery walker's job is to
+// move the row from "in-flight at restart" to a clearly-marked
+// terminal state so the operator can see it and decide.
+//
+// Compare with srv's recovery (`agentmux-srv/src/sagas/recovery.rs`):
+// srv DOES drive inverse-command compensation through the reducer,
+// because srv saga effects are reducer-level state mutations the
+// reducer can undo. Launcher sagas don't have that property — they
+// dispatch real-world host commands. Hence the asymmetry.
+//
+// The walker is idempotent: `mark_failed_compensation` is itself
+// idempotent (LSD-1 PR), and `unresolved_sagas` only returns rows
+// not already in `failed_compensation`. A second crash mid-recovery
+// just re-touches the same rows on the next restart with the same
+// reason string.
+
+use std::sync::Arc;
+
+use super::LauncherSagaLog;
+
+/// Walk all unresolved sagas in the durable log and mark each as
+/// `failed_compensation`. Returns the count of sagas touched.
+///
+/// Errors propagate from `LauncherSagaLog::unresolved_sagas` (read
+/// failure: corrupt SQLite, schema mismatch). A failure here should
+/// be fatal at the caller — without recovery, sagas left over from a
+/// prior crash stay in `running` state forever and the next restart
+/// would do the same dance.
+///
+/// Per-saga `mark_failed_compensation` failures are logged but NOT
+/// fatal — the walker continues to subsequent sagas. Stopping on one
+/// row's write failure would leave later unresolved sagas in `running`
+/// when we could have cleaned them. Operators see the per-saga error
+/// in the launcher log.
+pub async fn compensate_unresolved_launcher_sagas(
+    saga_log: &Arc<LauncherSagaLog>,
+) -> Result<usize, String> {
+    let unresolved = saga_log
+        .unresolved_sagas()
+        .map_err(|e| format!("read unresolved sagas: {}", e))?;
+
+    if unresolved.is_empty() {
+        crate::log("[saga-recovery] no unresolved sagas at startup");
+        return Ok(0);
+    }
+
+    let total = unresolved.len();
+    crate::log(&format!(
+        "[saga-recovery] found {} unresolved saga(s) at startup — marking failed_compensation",
+        total
+    ));
+
+    let mut touched = 0usize;
+    for saga in &unresolved {
+        let reason = format!(
+            "launcher restarted while saga in state '{}'",
+            saga.state
+        );
+        crate::log(&format!(
+            "[saga-recovery] WARN saga {} ({}) was '{}' when launcher last exited; marking failed_compensation",
+            saga.saga_id, saga.name, saga.state
+        ));
+        match saga_log.mark_failed_compensation(saga.saga_id, &reason) {
+            Ok(()) => {
+                touched += 1;
+            }
+            Err(e) => {
+                // Best-effort: log + keep walking. A single SQLite
+                // write hiccup shouldn't block the rest of the cleanup.
+                crate::log(&format!(
+                    "[saga-recovery] WARN saga {} mark_failed_compensation failed: {} — leaving in '{}'",
+                    saga.saga_id, e, saga.state
+                ));
+            }
+        }
+    }
+
+    crate::log(&format!(
+        "[saga-recovery] processed {}/{} unresolved sagas",
+        touched, total
+    ));
+    Ok(touched)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::saga::PipeTarget;
+    use agentmux_common::ipc::Command;
+
+    /// Integration: simulate a "crashed" saga by writing a `running`
+    /// row directly via `LauncherSagaLog`. Run the recovery walker.
+    /// Assert the saga is now `failed_compensation`.
+    #[tokio::test]
+    async fn recovery_walker_marks_running_saga_failed_compensation() {
+        let log = Arc::new(LauncherSagaLog::open_in_memory().unwrap());
+        // Crashed saga: started + one step dispatched, never terminated.
+        log.start_saga(11, "window_cleanup_cascade", &serde_json::json!({"label": "win-3"}))
+            .unwrap();
+        log.start_step(
+            11,
+            0,
+            "issue_cmd_host_reap_panes",
+            PipeTarget::Host,
+            &Command::Ping { nonce: 0 },
+        )
+        .unwrap();
+
+        let touched = compensate_unresolved_launcher_sagas(&log).await.unwrap();
+        assert_eq!(touched, 1);
+
+        // Saga has moved to failed_compensation; no longer unresolved.
+        let unresolved = log.unresolved_sagas().unwrap();
+        assert!(
+            unresolved.is_empty(),
+            "saga 11 should no longer be unresolved, got: {:?}",
+            unresolved
+        );
+        let snap = log.snapshot_recent(10).unwrap();
+        let saga = snap.iter().find(|s| s.saga_id == 11).unwrap();
+        assert_eq!(saga.state, "failed_compensation");
+        assert!(
+            saga.failure_reason
+                .as_deref()
+                .unwrap_or("")
+                .contains("launcher restarted while saga in state 'running'"),
+            "expected failure_reason to name the prior state, got: {:?}",
+            saga.failure_reason
+        );
+    }
+
+    /// Recovery on an empty log is a no-op + returns 0.
+    #[tokio::test]
+    async fn recovery_walker_empty_log_returns_zero() {
+        let log = Arc::new(LauncherSagaLog::open_in_memory().unwrap());
+        let touched = compensate_unresolved_launcher_sagas(&log).await.unwrap();
+        assert_eq!(touched, 0);
+    }
+
+    /// Recovery walker is idempotent: calling it twice doesn't error
+    /// and doesn't re-touch sagas already in `failed_compensation`.
+    /// Mirrors srv's recovery idempotence guarantee.
+    #[tokio::test]
+    async fn recovery_walker_is_idempotent_across_repeated_calls() {
+        let log = Arc::new(LauncherSagaLog::open_in_memory().unwrap());
+        log.start_saga(7, "saga_a", &serde_json::json!({})).unwrap();
+
+        let first = compensate_unresolved_launcher_sagas(&log).await.unwrap();
+        assert_eq!(first, 1);
+
+        // Second call — saga 7 is now failed_compensation, NOT
+        // unresolved, so the walker touches 0.
+        let second = compensate_unresolved_launcher_sagas(&log).await.unwrap();
+        assert_eq!(second, 0);
+    }
+
+    /// Multiple unresolved sagas → all get marked, return value is the
+    /// total touched count.
+    #[tokio::test]
+    async fn recovery_walker_handles_multiple_unresolved_sagas() {
+        let log = Arc::new(LauncherSagaLog::open_in_memory().unwrap());
+        log.start_saga(1, "saga_a", &serde_json::json!({})).unwrap();
+        log.start_saga(2, "saga_b", &serde_json::json!({"x": 2})).unwrap();
+        log.start_saga(3, "saga_c", &serde_json::json!({})).unwrap();
+        // Saga 3 is also failed (still surfaces via unresolved_sagas
+        // per LSD-1 + spec §3.5 — recovery upgrades it too).
+        log.terminate_saga(
+            3,
+            super::super::log::SagaOutcome::Failed {
+                reason: "evicted".into(),
+            },
+        )
+        .unwrap();
+
+        let touched = compensate_unresolved_launcher_sagas(&log).await.unwrap();
+        assert_eq!(touched, 3);
+
+        let unresolved = log.unresolved_sagas().unwrap();
+        assert!(unresolved.is_empty(), "all sagas resolved post-walk");
+    }
+}

--- a/agentmux-launcher/src/saga/recovery.rs
+++ b/agentmux-launcher/src/saga/recovery.rs
@@ -45,10 +45,14 @@ use super::LauncherSagaLog;
 /// `failed_compensation`. Returns the count of sagas touched.
 ///
 /// Errors propagate from `LauncherSagaLog::unresolved_sagas` (read
-/// failure: corrupt SQLite, schema mismatch). A failure here should
-/// be fatal at the caller — without recovery, sagas left over from a
-/// prior crash stay in `running` state forever and the next restart
-/// would do the same dance.
+/// failure: corrupt SQLite, schema mismatch). The caller (`main.rs`)
+/// treats a walker failure as **non-fatal** — the launcher logs a
+/// WARN and continues. Rationale: the saga log is open (open()
+/// succeeded), so the schema is intact; a transient SELECT failure
+/// is best-surfaced as a launcher-log warning so the saga
+/// coordinator still spawns. Prior crashed sagas stay in `running`
+/// for one more restart cycle in that case (and get cleaned up
+/// next time). (reagent P2 PR #647 round 1: doc/contract sync.)
 ///
 /// Per-saga `mark_failed_compensation` failures are logged but NOT
 /// fatal — the walker continues to subsequent sagas. Stopping on one

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.577"
+version = "0.33.578"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.576"
+version = "0.33.577"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.576",
+  "version": "0.33.577",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.576",
+      "version": "0.33.577",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.577",
+  "version": "0.33.578",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.577",
+      "version": "0.33.578",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.576",
+  "version": "0.33.577",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.577",
+  "version": "0.33.578",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Implements PR LSD-3 from `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.5 (recovery on startup) and `docs/specs/SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md` §2 batch 3.

- **Startup recovery walker.** In `main.rs::run_windows`, after the durable saga log opens and BEFORE `tokio::spawn(saga::run_coordinator(...))`, walk all unresolved sagas (states `running` / `compensating` / `failed`) and mark each `failed_compensation` with a reason naming the prior state. We deliberately do NOT auto-replay or auto-compensate (LSD spec §3.5): launcher sagas drive host-side effects on live OS state (pane reaps, pool drains) that may already be partially applied — re-issuing forwards could double-act, and deriving inverses without pre-state is unsound. Operator review via `--diag sagas` is the right escape hatch. This contrasts with srv's recovery, which DOES drive inverse compensation through the reducer because srv saga effects are reducer-level state mutations.
- **`--diag sagas` command.** Reads `<data-dir>/launcher-sagas.db` directly (no IPC, no running launcher required), calls `snapshot_recent(50)`, and pretty-prints saga summaries with full step rows for any still-unresolved entries (matching the example format from spec §3.5: header line + step rows with target/state/cmd, plus a `[step N was in-flight when launcher exited]` pinpoint for the pending step at the highest index). Sagas in `failed_compensation` are flagged `(recovered on restart)` in the header.
- **Tests.** New `saga::recovery::tests` (4 tests covering: marks running saga as failed_compensation; idempotent across repeated walks; handles multiple unresolved sagas; no-op on empty log). New `diag::sagas_diag_tests` (2 tests covering: fixture log produces expected summary fields; `truncate_for_display` boundary behaviour). All 141 launcher tests pass.

## Files

- `agentmux-launcher/src/saga/recovery.rs` (new): walker + 4 tokio tests.
- `agentmux-launcher/src/saga/mod.rs`: declare `mod recovery`, re-export `compensate_unresolved_launcher_sagas`, relax `mod log;` → `pub(crate) mod log;` so the diag test module can see `SagaOutcome` for fixture setup.
- `agentmux-launcher/src/main.rs`: add `"sagas" =>` arm to the `--diag` matcher; call `saga::compensate_unresolved_launcher_sagas(&saga_log).await` between log open and coordinator spawn.
- `agentmux-launcher/src/diag.rs`: add `pub async fn run_sagas_diag(...)`, `truncate_for_display`, and `sagas_diag_tests` module.

## Critical rules respected

- agentmux-launcher uses `crate::log()` macro, not `tracing` — recovery walker logs via `crate::log(...)`.
- Recovery runs BEFORE coordinator spawn: the call sits between `LauncherSagaLog::open` and the `tokio::spawn(saga::run_coordinator(...))` block.
- Used `bump patch --commit` after staging code changes (workflow note: bump only commits version files).

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p agentmux-launcher` — 141 passed, 0 failed
- [x] New saga::recovery tests pass (4)
- [x] New diag::sagas_diag tests pass (2)
- [ ] Manual: kill -9 launcher mid-saga, restart, verify `agentmux --diag sagas` shows `failed_compensation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)