### PR TITLE
feat(cpd-4): per-saga event correlation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.575"
+version = "0.33.576"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.575"
+version = "0.33.576"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.575"
+version = "0.33.576"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.575"
+version = "0.33.576"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.575"
+version = "0.33.576"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.575"
+version = "0.33.576"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.575"
+version = "0.33.576"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -631,20 +631,20 @@ impl SagaCoordinator {
         // (codex P2 PR #644 round 2.)
         let action = {
             let mut registry = self.in_flight.lock().await;
-            // (codex P1 PR #634) Observability for the known
-            // concurrent-correlation limitation. With more than one
-            // saga of the same kind in flight, broadcast event
-            // routing mis-correlates: the first matching event
-            // completes ALL of them. Logged here so operators can
-            // spot the pattern in `--diag wrr` output. Closed when
-            // CPD-4 adds saga-id event correlation.
+            // CPD-4 — concurrent same-kind sagas now correlate by
+            // saga_id (`Saga::on_event` filters on
+            // `ctx.saga_id == event.saga_id`). The pre-CPD-4
+            // observability warning (PR #634 codex P1) is retained
+            // at info level for operators tracking concurrency
+            // density via `--diag wrr`, but the underlying
+            // correctness issue is closed.
             let same_kind_count = registry
                 .values()
                 .filter(|s| s.saga.name() == name)
                 .count();
             if same_kind_count >= 1 {
                 crate::log(&format!(
-                    "[saga] WARN: starting {} saga_id={} while {} other(s) of same kind in flight; concurrent-correlation limitation may produce premature SagaCompleted events (PR #634 / codex P1 known issue)",
+                    "[saga] starting {} saga_id={} while {} other(s) of same kind in flight (CPD-4 per-saga correlation — sagas coexist cleanly)",
                     name, saga_id, same_kind_count,
                 ));
             }
@@ -820,10 +820,11 @@ fn inject_saga_id(cmd: Command, saga_id: u64) -> Command {
 ///
 /// Future sagas extend this match.
 ///
-/// Note: this returns a *candidate* saga. The coordinator may still
-/// evict a same-kind in-flight saga via the evict-and-replace
-/// serialization gate before `spawn_saga` (codex P1 PR #634 round 3
-/// — see `run_coordinator`).
+/// CPD-4 — the coordinator no longer evicts same-kind in-flight
+/// sagas before `spawn_saga`; per-saga event correlation
+/// (`Saga::on_event` filters by `ctx.saga_id`) lets concurrent
+/// same-kind sagas coexist cleanly. The pre-CPD-4 evict-and-replace
+/// gate (PR #634 round 3) is removed in `run_coordinator`.
 fn match_trigger(event: &Event) -> Option<Box<dyn Saga>> {
     match event {
         Event::PoolWindowPromoted { label, .. } => {
@@ -919,69 +920,30 @@ pub async fn run_coordinator(
                 }
 
                 // Step 1 — start any new sagas this event triggers.
-                // (codex P1 PR #634 round 3.) Evict-and-replace: if a
-                // saga of the same kind is already in flight, EVICT
-                // it (mark Failed + remove from registry) and start
-                // the new one. Round 2's silent-drop fix had a
-                // permanent-deadlock failure mode: a stalled saga
-                // (refill never arrived) would block all future
-                // promote sagas for the rest of the process.
                 //
-                // Trade-offs of evict-and-replace:
-                // - Pros: no permanent block; each new promote gets
-                //   a fresh bracket; reducer + SQLite stay correct.
-                // - Cons: when both promotes are healthy in quick
-                //   succession, the first promote's bracket is cut
-                //   short with SagaFailed (the late refill event for
-                //   that promote completes the new saga instead).
-                //   Renderer-visible: one premature SagaFailed +
-                //   one correct SagaCompleted.
-                // Proper FIFO routing / per-event saga_id correlation
-                // ships in F.6/F.7 alongside cross-process dispatch.
+                // **CPD-4 — evict-and-replace retired.** Pre-CPD-4
+                // (codex P1 PR #634 round 3) the coordinator forced
+                // at-most-one same-kind saga in flight by emitting
+                // `SagaFailed { reason: "evicted" }` on the prior
+                // saga whenever a fresh trigger landed. That was a
+                // workaround for the broadcast-routing limitation:
+                // every `PoolWindowAdded` / `PanesReaped` /
+                // `PoolDrained` / `PoolNotLast` advanced *every*
+                // matching in-flight saga, so two concurrent sagas
+                // would cross-talk and complete each other's bracket.
+                //
+                // CPD-4 closes that limitation. Saga `on_event` now
+                // filters by `event.saga_id == ctx.saga_id`
+                // (`pool_respawn::on_event`,
+                // `window_cleanup::on_event`). Concurrent same-kind
+                // sagas coexist; each consumes only events tagged
+                // with its own coordinator-allocated id. Eviction is
+                // no longer needed — and would actively harm
+                // correctness (a healthy saga gets `SagaFailed`d the
+                // moment a sibling fires).
+                //
+                // Per spec §3.7 + execution-plan §2 batch 3.
                 if let Some(saga) = match_trigger(&event) {
-                    let new_kind = saga.name();
-                    let evict_ids: Vec<u64> = {
-                        let registry = coord.in_flight.lock().await;
-                        registry
-                            .iter()
-                            .filter(|(_, s)| s.saga.name() == new_kind)
-                            .map(|(id, _)| *id)
-                            .collect()
-                    };
-                    for evict_id in evict_ids {
-                        // claim_terminal removes from in_flight AND
-                        // ensures the timeout task / SagaActionFailed
-                        // listener can't double-emit a terminal event
-                        // for this saga_id. (reagent P1 PR #644
-                        // round 1.)
-                        if !coord.claim_terminal(evict_id).await {
-                            // Lost the race — another path (timeout,
-                            // SagaActionFailed) already terminated.
-                            continue;
-                        }
-                        crate::log(&format!(
-                            "[saga] evicting prior {} saga_id={} to make room for new trigger (codex P1 #634 round 3 evict-and-replace)",
-                            new_kind, evict_id,
-                        ));
-                        let evict_reason =
-                            "evicted: same-kind saga restarted (codex P1 #634 round 3)";
-                        // LSD-2 — record the eviction in the durable
-                        // saga row so `--diag sagas` shows it.
-                        if let Some(log) = coord.log.as_ref() {
-                            if let Err(e) = log.terminate_saga(
-                                evict_id,
-                                SagaOutcome::Failed {
-                                    reason: evict_reason.to_string(),
-                                },
-                            ) {
-                                crate::log(&format!(
-                                    "[saga] saga_id={} evict terminate_saga(Failed) log write failed: {}",
-                                    evict_id, e
-                                ));
-                            }
-                        }
-                        coord.emit_failed(evict_id, evict_reason.to_string()).await;
-                    }
                     coord.spawn_saga(saga).await;
                 }
 
@@ -1403,21 +1365,22 @@ mod tests {
         }
     }
 
-    /// Coordinator-level invariant: under random sequences of
-    /// trigger events, no two same-kind sagas are ever active
-    /// simultaneously — the evict-and-replace policy guarantees at
-    /// most one in-flight saga per kind. Drives the coordinator with
-    /// synthetic events and asserts the `in_flight` registry has at
-    /// most one entry per name (≤2 total: pool_respawn +
-    /// window_cleanup).
+    /// **CPD-4 — concurrent same-kind sagas coexist without
+    /// cross-talk.** Random sequences of trigger events drive the
+    /// coordinator; the registry is allowed to hold multiple sagas of
+    /// the same kind simultaneously (the pre-CPD-4 evict-and-replace
+    /// gate is retired). Invariant under test: NO `SagaFailed` event
+    /// fires with reason `"evicted"` — sagas only terminate via
+    /// `Done` (their tagged echo lands) or via the saga timeout
+    /// (~5-30s, far longer than this test's 50ms settling window).
     ///
-    /// Run as a single tokio test (proptest can't drive an async
-    /// closure directly). Iterates several seeded sequences inline —
-    /// enough surface area to catch concurrent-overlap regressions
-    /// without ballooning test time. Uses a hand-rolled LCG so we
-    /// don't pull in `rand` as a dev-dependency for one test.
+    /// Replaces `f7_evict_and_replace_keeps_one_saga_per_kind`. The
+    /// behavioral inversion is the core of CPD-4: pre-CPD-4 we
+    /// asserted ≤1 in-flight per kind (and accepted premature
+    /// `SagaFailed { reason: "evicted" }`); CPD-4 asserts no
+    /// premature evictions.
     #[tokio::test]
-    async fn f7_evict_and_replace_keeps_one_saga_per_kind() {
+    async fn cpd4_concurrent_sagas_no_eviction() {
         // Tiny LCG for deterministic per-seed sequences. Glibc's
         // constants — quality irrelevant; we just need reproducible
         // bit patterns across CI runs.
@@ -1433,6 +1396,7 @@ mod tests {
             let (events_tx, _) = tokio::sync::broadcast::channel::<Event>(256);
             let state = Arc::new(tokio::sync::Mutex::new(crate::state::State::default()));
             let coord = Arc::new(SagaCoordinator::new(events_tx.clone(), Arc::clone(&state)));
+            let mut witness = events_tx.subscribe();
             let coord_rx = events_tx.subscribe();
             let _handle = tokio::spawn(run_coordinator(Arc::clone(&coord), coord_rx));
             tokio::task::yield_now().await;
@@ -1463,27 +1427,30 @@ mod tests {
             // the last few events + emit terminal lifecycles.
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-            // Invariant: at most one saga per name in flight.
-            let registry = coord.in_flight.lock().await;
-            let mut counts = std::collections::HashMap::<&str, u32>::new();
-            for s in registry.values() {
-                *counts.entry(s.saga.name()).or_insert(0) += 1;
+            // Invariant: NO SagaFailed with "evicted" reason.
+            // We don't assert the registry size — concurrent sagas
+            // are allowed to pile up under per-saga correlation
+            // because we never feed them their tagged terminal
+            // events in this test. They'll reach their timeout
+            // eventually, but not within 50ms.
+            let mut evictions = 0u32;
+            while let Ok(Ok(ev)) = tokio::time::timeout(
+                std::time::Duration::from_millis(5),
+                witness.recv(),
+            )
+            .await
+            {
+                if let Event::SagaFailed { reason, .. } = ev {
+                    if reason.contains("evicted") {
+                        evictions += 1;
+                    }
+                }
             }
-            for (name, count) in &counts {
-                assert!(
-                    *count <= 1,
-                    "seed {} — saga kind {:?} has {} concurrent in-flight; evict-and-replace policy violated",
-                    seed,
-                    name,
-                    count,
-                );
-            }
-            // And the 2-kind ceiling (we only register two saga kinds).
-            assert!(
-                registry.len() <= 2,
-                "seed {} — registry has {} sagas, expected ≤2 (one per kind)",
-                seed,
-                registry.len(),
+            assert_eq!(
+                evictions, 0,
+                "seed {} — CPD-4 invariant violated: observed {} SagaFailed events with reason='evicted'; \
+                 evict-and-replace should be retired so concurrent same-kind sagas coexist",
+                seed, evictions,
             );
         }
     }
@@ -1505,43 +1472,61 @@ mod tests {
         let _handle = tokio::spawn(run_coordinator(Arc::clone(&coord), coord_rx));
         tokio::task::yield_now().await;
 
-        // Drive ONE clean cleanup-cascade saga to completion.
+        // Drive ONE clean cleanup-cascade saga + ONE pool-respawn
+        // saga to completion. CPD-4: route terminals by saga_id, so
+        // we trigger each saga, capture its allocated id from
+        // SagaStarted, then send the matching tagged terminal events.
         let _ = events_tx.send(Event::WindowClosed {
             label: "main".into(),
             version: 1,
             crash_detected: false,
         });
-        let _ = events_tx.send(Event::PanesReaped {
-            label: "main".into(),
-            version: 2,
-            saga_id: None,
-        });
-        let _ = events_tx.send(Event::PoolDrained {
-            label: "main".into(),
-            version: 3,
-            saga_id: None,
-        });
-        // And ONE pool-respawn saga to completion.
         let _ = events_tx.send(Event::PoolWindowPromoted {
             label: "pool-1".into(),
-            version: 4,
-        });
-        let _ = events_tx.send(Event::PoolWindowAdded {
-            label: "pool-2".into(),
-            version: 5,
-            saga_id: None,
+            version: 2,
         });
 
         // Drain the bus with a deadline. Count one terminal event
-        // (SagaCompleted xor SagaFailed) per saga_id.
+        // (SagaCompleted xor SagaFailed) per saga_id. As each
+        // SagaStarted lands, dispatch the matching tagged terminals.
         let mut started_ids = std::collections::HashSet::<u64>::new();
+        let mut cleanup_saga_id: Option<u64> = None;
+        let mut respawn_saga_id: Option<u64> = None;
+        let mut version: u64 = 100;
         let mut terminal_for_id = std::collections::HashMap::<u64, &'static str>::new();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
         while std::time::Instant::now() < deadline {
             match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
             {
-                Ok(Ok(Event::SagaStarted { saga_id, .. })) => {
+                Ok(Ok(Event::SagaStarted { saga_id, name, .. })) => {
                     started_ids.insert(saga_id);
+                    if name == "window_cleanup_cascade" && cleanup_saga_id.is_none() {
+                        cleanup_saga_id = Some(saga_id);
+                        version += 1;
+                        let _ = events_tx.send(Event::PanesReaped {
+                            label: "main".into(),
+                            version,
+                            saga_id: Some(saga_id),
+                        });
+                    } else if name == "pool_respawn_on_promote" && respawn_saga_id.is_none() {
+                        respawn_saga_id = Some(saga_id);
+                        version += 1;
+                        let _ = events_tx.send(Event::PoolWindowAdded {
+                            label: "pool-2".into(),
+                            version,
+                            saga_id: Some(saga_id),
+                        });
+                    }
+                }
+                Ok(Ok(Event::PanesReaped { saga_id: Some(sid), .. })) => {
+                    if Some(sid) == cleanup_saga_id {
+                        version += 1;
+                        let _ = events_tx.send(Event::PoolDrained {
+                            label: "main".into(),
+                            version,
+                            saga_id: Some(sid),
+                        });
+                    }
                 }
                 Ok(Ok(Event::SagaCompleted { saga_id, .. })) => {
                     let prev = terminal_for_id.insert(saga_id, "completed");
@@ -1641,20 +1626,33 @@ mod tests {
     #[tokio::test]
     async fn saga_completes_writes_lifecycle_to_log() {
         let (coord, log, events_tx) = spawn_coord_with_log();
+        let mut witness = events_tx.subscribe();
         let coord_rx = events_tx.subscribe();
         let _handle = tokio::spawn(run_coordinator(StdArc::clone(&coord), coord_rx));
         tokio::task::yield_now().await;
 
-        // Trigger the saga + give it the awaited terminal event.
+        // Trigger the saga.
         let _ = events_tx.send(Event::PoolWindowPromoted {
             label: "window-pool-abc".into(),
             version: 1,
         });
-        let _ = events_tx.send(Event::PoolWindowAdded {
-            label: "window-pool-xyz".into(),
-            version: 2,
-            saga_id: None,
-        });
+        // CPD-4: wait for SagaStarted to learn the saga_id, then send
+        // the awaited terminal tagged with that id. Pre-CPD-4 we
+        // could send `saga_id: None`; under per-saga correlation
+        // the saga only consumes its own echo.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if let Ok(Ok(Event::SagaStarted { saga_id, .. })) =
+                tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
+            {
+                let _ = events_tx.send(Event::PoolWindowAdded {
+                    label: "window-pool-xyz".into(),
+                    version: 2,
+                    saga_id: Some(saga_id),
+                });
+                break;
+            }
+        }
 
         // Settle: coordinator runs apply_action which awaits state
         // mutex + bus send. 200ms is generous for the in-process loop.
@@ -1673,13 +1671,17 @@ mod tests {
         assert_eq!(parsed["promoted_label"], "window-pool-abc");
     }
 
-    /// LSD-2 — when a saga is evicted by the same-kind concurrent
-    /// gate (codex P1 PR #634), the durable log records its terminal
-    /// state as 'failed' with a failure_reason. The replacement saga
-    /// gets its own row.
+    /// **CPD-4 — two concurrent same-kind sagas BOTH complete
+    /// cleanly.** Repurposed from `saga_fails_writes_failed_state`
+    /// (which previously verified the evict-and-replace path).
+    /// Per-saga event correlation lets two `pool_respawn_on_promote`
+    /// sagas coexist; each consumes its own saga_id-tagged refill
+    /// echo, so the durable log records two `completed` rows — no
+    /// `failed` rows from the retired eviction policy.
     #[tokio::test]
-    async fn saga_fails_writes_failed_state() {
+    async fn saga_concurrent_same_kind_both_complete() {
         let (coord, log, events_tx) = spawn_coord_with_log();
+        let mut witness = events_tx.subscribe();
         let coord_rx = events_tx.subscribe();
         let _handle = tokio::spawn(run_coordinator(StdArc::clone(&coord), coord_rx));
         tokio::task::yield_now().await;
@@ -1689,39 +1691,59 @@ mod tests {
             label: "window-pool-a".into(),
             version: 1,
         });
-        // Second promote BEFORE A's terminal arrives — evicts A,
-        // starts saga B. Saga A's durable row must transition to
-        // 'failed' with the eviction reason.
+        // Second promote BEFORE A's terminal arrives — under CPD-4
+        // saga B coexists with A (no eviction).
         let _ = events_tx.send(Event::PoolWindowPromoted {
             label: "window-pool-b".into(),
             version: 2,
         });
-        // Saga B's terminal so it completes (don't leave it dangling
-        // — guards against the test's cleanup masking a real bug).
-        let _ = events_tx.send(Event::PoolWindowAdded {
-            label: "window-pool-c".into(),
-            version: 3,
-            saga_id: None,
-        });
+
+        // Capture both saga_ids from their `SagaStarted` brackets,
+        // then fire each saga's tagged refill so both terminate
+        // Completed. The order doesn't matter because per-saga
+        // correlation routes events by id, not by FIFO.
+        let mut ids = Vec::<u64>::new();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        let mut version: u64 = 100;
+        while std::time::Instant::now() < deadline {
+            if let Ok(Ok(ev)) =
+                tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
+            {
+                if let Event::SagaStarted { saga_id, name, .. } = ev {
+                    if name == "pool_respawn_on_promote" {
+                        ids.push(saga_id);
+                        version += 1;
+                        let _ = events_tx.send(Event::PoolWindowAdded {
+                            label: format!("refill-for-{}", saga_id),
+                            version,
+                            saga_id: Some(saga_id),
+                        });
+                    }
+                }
+                if ids.len() == 2 {
+                    break;
+                }
+            }
+        }
+        assert_eq!(ids.len(), 2, "expected 2 SagaStarted events");
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let snapshots = log.snapshot_recent(10).expect("snapshot_recent");
-        assert_eq!(snapshots.len(), 2, "expected two saga rows (evicted + replacement)");
-        // One must be 'failed' (evicted), the other 'completed' (B).
-        let states: Vec<_> = snapshots.iter().map(|s| s.state.as_str()).collect();
-        assert!(states.contains(&"failed"), "missing 'failed' row: {:?}", states);
-        assert!(states.contains(&"completed"), "missing 'completed' row: {:?}", states);
-        let failed_row = snapshots.iter().find(|s| s.state == "failed").unwrap();
-        assert!(
-            failed_row
-                .failure_reason
-                .as_deref()
-                .map(|r| r.contains("evicted"))
-                .unwrap_or(false),
-            "evicted saga's failure_reason should mention 'evicted', got {:?}",
-            failed_row.failure_reason,
+        assert_eq!(
+            snapshots.len(),
+            2,
+            "expected two saga rows (concurrent, no eviction)"
         );
+        // BOTH must be 'completed' — eviction is retired.
+        for s in &snapshots {
+            assert_eq!(
+                s.state, "completed",
+                "CPD-4: both concurrent sagas must complete cleanly, got state={:?} reason={:?}",
+                s.state, s.failure_reason,
+            );
+            assert!(s.failure_reason.is_none());
+        }
     }
 
     /// LSD-2 — when a saga's `on_event` consumes its awaited bus
@@ -1735,6 +1757,7 @@ mod tests {
     #[tokio::test]
     async fn saga_step_finish_records_event_payload() {
         let (coord, log, events_tx) = spawn_coord_with_log();
+        let mut witness = events_tx.subscribe();
         let coord_rx = events_tx.subscribe();
         let _handle = tokio::spawn(run_coordinator(StdArc::clone(&coord), coord_rx));
         tokio::task::yield_now().await;
@@ -1744,16 +1767,27 @@ mod tests {
         // pending→succeeded but Step 1 (`DrainPoolIfLast`) stays
         // pending — the saga remains in_flight + queryable as
         // unresolved.
+        //
+        // CPD-4: tag PanesReaped with the saga's id so the saga
+        // actually advances (per-saga correlation).
         let _ = events_tx.send(Event::WindowClosed {
             label: "main".into(),
             version: 1,
             crash_detected: false,
         });
-        let _ = events_tx.send(Event::PanesReaped {
-            label: "main".into(),
-            version: 2,
-            saga_id: None,
-        });
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while std::time::Instant::now() < deadline {
+            if let Ok(Ok(Event::SagaStarted { saga_id, .. })) =
+                tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
+            {
+                let _ = events_tx.send(Event::PanesReaped {
+                    label: "main".into(),
+                    version: 2,
+                    saga_id: Some(saga_id),
+                });
+                break;
+            }
+        }
         // INTENTIONALLY no `PoolDrained` / `PoolNotLast`.
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;

--- a/agentmux-launcher/src/saga/pool_respawn.rs
+++ b/agentmux-launcher/src/saga/pool_respawn.rs
@@ -188,15 +188,25 @@ impl Saga for PoolRespawn {
         }
     }
 
-    fn on_event(&mut self, event: &Event, _ctx: &SagaCtx) -> SagaAction {
+    fn on_event(&mut self, event: &Event, ctx: &SagaCtx) -> SagaAction {
         // Only pivot on `PoolWindowAdded`. Every other event the bus
         // carries is unrelated to this saga's terminal condition.
         // A coordinator that drove this saga to Done because of an
         // unrelated event would fire the `SagaCompleted` bracket
         // before refill actually finished — the renderer's buffered
         // state would flush prematurely.
+        //
+        // **CPD-4 — per-saga event correlation.** Filter
+        // `PoolWindowAdded` by `saga_id`: only the event tagged with
+        // *this* saga's id advances us. Untagged events (organic pool
+        // refills) and events from sibling concurrent sagas are
+        // ignored. Retires the evict-and-replace workaround from
+        // PR #634 — concurrent same-kind sagas now coexist without
+        // false-positive `SagaCompleted` cross-talk.
         match (&self.phase, event) {
-            (Phase::WaitingForRefill, Event::PoolWindowAdded { label, .. }) => {
+            (Phase::WaitingForRefill, Event::PoolWindowAdded { label, saga_id, .. })
+                if *saga_id == Some(ctx.saga_id) =>
+            {
                 // The refill produced a new label. Record + complete.
                 // (Spec § 7.1: Step 3 is just `Done`; no further
                 // dispatch.)
@@ -204,8 +214,9 @@ impl Saga for PoolRespawn {
                 SagaAction::Done
             }
             // Still waiting; or — for `Initial` — coordinator
-            // hasn't called `start` yet, in which case we're not
-            // supposed to be receiving events. Either way: no-op.
+            // hasn't called `start` yet; or the event's saga_id
+            // doesn't match (concurrent saga or organic refill).
+            // Either way: no-op.
             _ => SagaAction::Wait,
         }
     }
@@ -238,18 +249,61 @@ mod tests {
 
     #[test]
     fn pool_window_added_completes_the_saga() {
+        // CPD-4 — saga_id-tagged event for *this* saga advances it.
         let mut saga = PoolRespawn::new("window-pool-abc".into());
         let _ = saga.start(&ctx(7));
         let action = saga.on_event(
             &Event::PoolWindowAdded {
                 label: "window-pool-xyz".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
         assert!(matches!(action, SagaAction::Done));
         assert_eq!(saga.refilled_label(), Some("window-pool-xyz"));
+    }
+
+    /// CPD-4 — `PoolWindowAdded` with `saga_id: None` (organic refill,
+    /// no saga in flight on the host side) does NOT terminate the
+    /// saga. Pre-CPD-4, ANY `PoolWindowAdded` would complete the saga;
+    /// per-saga correlation now scopes terminal events to the
+    /// originating saga only.
+    #[test]
+    fn organic_pool_window_added_does_not_complete_saga() {
+        let mut saga = PoolRespawn::new("window-pool-abc".into());
+        let _ = saga.start(&ctx(7));
+        let action = saga.on_event(
+            &Event::PoolWindowAdded {
+                label: "window-pool-organic".into(),
+                version: 100,
+                saga_id: None,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+        assert!(saga.refilled_label().is_none());
+    }
+
+    /// CPD-4 — `PoolWindowAdded` tagged with a *different* saga_id
+    /// (sibling concurrent saga's echo) is ignored. This is the
+    /// invariant that retires evict-and-replace: two concurrent
+    /// PoolRespawn sagas can coexist, each consuming only its own
+    /// echo.
+    #[test]
+    fn pool_window_added_with_foreign_saga_id_is_ignored() {
+        let mut saga = PoolRespawn::new("window-pool-abc".into());
+        let _ = saga.start(&ctx(7));
+        let action = saga.on_event(
+            &Event::PoolWindowAdded {
+                label: "window-pool-sibling".into(),
+                version: 100,
+                saga_id: Some(8),
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+        assert!(saga.refilled_label().is_none());
     }
 
     #[test]
@@ -289,20 +343,19 @@ mod tests {
 
     #[test]
     fn first_pool_window_added_after_start_wins() {
-        // The saga records the FIRST PoolWindowAdded after start as
-        // the refill — even if a later one would be a closer match.
-        // The coordinator's job is to scope events to this saga; the
-        // saga itself does not disambiguate against concurrent
-        // promotes (concurrent promotes spawn distinct sagas with
-        // distinct saga_ids; coordinator routes events appropriately
-        // — see super::run_coordinator for the routing logic).
+        // The saga records the FIRST PoolWindowAdded *for its own
+        // saga_id* after start as the refill. CPD-4 — the coordinator
+        // dispatches the saga's IssueCmd with `saga_id` injected, so
+        // the host's matching report carries `saga_id: Some(N)`. The
+        // saga itself filters by `ctx.saga_id`; events with foreign
+        // ids (sibling concurrent sagas) are ignored.
         let mut saga = PoolRespawn::new("window-pool-abc".into());
         let _ = saga.start(&ctx(7));
         let _ = saga.on_event(
             &Event::PoolWindowAdded {
                 label: "window-pool-first".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -342,23 +395,15 @@ mod tests {
             version: 1,
         });
 
-        // Step 2 — the saga waits for refill. Push a synthetic
-        // PoolWindowAdded representing the host's implicit refill.
-        let _ = events_tx.send(Event::PoolWindowAdded {
-            label: "window-pool-xyz".into(),
-            version: 2,
-            saga_id: None,
-        });
-
-        // Drain witness with a brief budget; we expect at minimum:
-        //   PoolWindowPromoted (input) → SagaStarted → PoolWindowAdded
-        //   (input) → SagaCompleted.
-        // The order between the input events and the coordinator's
-        // emissions can interleave (coordinator runs concurrently),
-        // but causally SagaCompleted MUST follow SagaStarted.
+        // CPD-4: wait for SagaStarted to learn the coordinator-
+        // allocated saga_id before publishing the matching
+        // PoolWindowAdded. Pre-CPD-4 we could send `saga_id: None`
+        // because every PoolWindowAdded advanced every in-flight
+        // saga; under per-saga correlation the saga only consumes
+        // its own echo.
+        let mut saga_id_started: Option<u64> = None;
         let mut saw_started = false;
         let mut saw_completed_after_started = false;
-        let mut saga_id_started: Option<u64> = None;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while std::time::Instant::now() < deadline {
             match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
@@ -367,6 +412,14 @@ mod tests {
                     assert_eq!(name, "pool_respawn_on_promote");
                     saw_started = true;
                     saga_id_started = Some(saga_id);
+                    // Step 2 — the saga waits for refill. Push a
+                    // synthetic PoolWindowAdded tagged with the saga's
+                    // allocated id (CPD-4 per-saga correlation).
+                    let _ = events_tx.send(Event::PoolWindowAdded {
+                        label: "window-pool-xyz".into(),
+                        version: 2,
+                        saga_id: Some(saga_id),
+                    });
                 }
                 Ok(Ok(Event::SagaCompleted { saga_id, .. })) => {
                     if saw_started {

--- a/agentmux-launcher/src/saga/window_cleanup.rs
+++ b/agentmux-launcher/src/saga/window_cleanup.rs
@@ -232,15 +232,25 @@ impl Saga for WindowCleanupCascade {
         }
     }
 
-    fn on_event(&mut self, event: &Event, _ctx: &SagaCtx) -> SagaAction {
+    fn on_event(&mut self, event: &Event, ctx: &SagaCtx) -> SagaAction {
+        // **CPD-4 — per-saga event correlation.** Filter
+        // `PanesReaped` / `PoolDrained` / `PoolNotLast` by `saga_id`:
+        // only events tagged with *this* saga's id advance us. The
+        // label match remains as defense-in-depth (events for the
+        // wrong window cannot end up with this saga's id, but the
+        // double-check costs nothing). Untagged events (organic host
+        // reports) and events from sibling concurrent sagas are
+        // ignored — retires the evict-and-replace workaround from
+        // PR #634 so two simultaneous `WindowClosed`s now produce
+        // two clean `SagaCompleted` brackets instead of one
+        // premature `SagaFailed { reason: "evicted" }` + one
+        // `SagaCompleted`.
         match (&self.phase, event) {
             // Step 1 → Step 2 transition. `PanesReaped` arrives from
             // the host (`report_panes_reaped` inside
-            // `on_before_close`). Match on the label so a stray
-            // event from another window's close doesn't advance us
-            // (defense-in-depth — see `closed_label` field doc).
-            (Phase::ReapingPanes, Event::PanesReaped { label, .. })
-                if label == &self.closed_label =>
+            // `on_before_close`).
+            (Phase::ReapingPanes, Event::PanesReaped { label, saga_id, .. })
+                if *saga_id == Some(ctx.saga_id) && label == &self.closed_label =>
             {
                 self.phase = Phase::DrainingPool;
                 // CPD-1 schema-only: saga_id placeholder (0); CPD-3
@@ -254,8 +264,8 @@ impl Saga for WindowCleanupCascade {
                 }
             }
             // Step 2 terminal — drain happened (last window closed).
-            (Phase::DrainingPool, Event::PoolDrained { label, .. })
-                if label == &self.closed_label =>
+            (Phase::DrainingPool, Event::PoolDrained { label, saga_id, .. })
+                if *saga_id == Some(ctx.saga_id) && label == &self.closed_label =>
             {
                 self.drained_pool = Some(true);
                 SagaAction::Done
@@ -263,16 +273,16 @@ impl Saga for WindowCleanupCascade {
             // Step 2 terminal — drain skipped (other windows remain).
             // Equally a success: the saga's job is to bracket the
             // drain *decision*, not enforce a particular outcome.
-            (Phase::DrainingPool, Event::PoolNotLast { label, .. })
-                if label == &self.closed_label =>
+            (Phase::DrainingPool, Event::PoolNotLast { label, saga_id, .. })
+                if *saga_id == Some(ctx.saga_id) && label == &self.closed_label =>
             {
                 self.drained_pool = Some(false);
                 SagaAction::Done
             }
             // Anything else: still waiting; or — for `Initial` —
-            // coordinator hasn't called `start` yet, in which case
-            // we're not supposed to be receiving events. Either way:
-            // no-op.
+            // coordinator hasn't called `start` yet; or the event's
+            // saga_id doesn't match (concurrent saga or organic
+            // report). Either way: no-op.
             _ => SagaAction::Wait,
         }
     }
@@ -309,13 +319,14 @@ mod tests {
 
     #[test]
     fn panes_reaped_advances_to_drain_pool_step() {
+        // CPD-4 — saga_id-tagged terminal event for *this* saga.
         let mut saga = WindowCleanupCascade::new("main".into());
         let _ = saga.start(&ctx(7));
         let action = saga.on_event(
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -344,7 +355,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -352,7 +363,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "main".into(),
                 version: 101,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -368,7 +379,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "secondary".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -376,12 +387,50 @@ mod tests {
             &Event::PoolNotLast {
                 label: "secondary".into(),
                 version: 101,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
         assert!(matches!(action, SagaAction::Done));
         assert_eq!(saga.drained_pool(), Some(false));
+    }
+
+    /// CPD-4 — terminal events with `saga_id: None` (organic host
+    /// reports) must NOT advance the saga. Pre-CPD-4 ANY label-
+    /// matching `PanesReaped` would advance Step 1; per-saga
+    /// correlation now scopes terminal events to their originating
+    /// saga.
+    #[test]
+    fn organic_panes_reaped_does_not_advance_saga() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+        let action = saga.on_event(
+            &Event::PanesReaped {
+                label: "main".into(),
+                version: 100,
+                saga_id: None,
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
+    }
+
+    /// CPD-4 — a terminal event tagged with a *foreign* saga_id
+    /// (sibling concurrent cleanup-cascade saga) is ignored. This is
+    /// the invariant that retires evict-and-replace.
+    #[test]
+    fn foreign_saga_id_panes_reaped_does_not_advance_saga() {
+        let mut saga = WindowCleanupCascade::new("main".into());
+        let _ = saga.start(&ctx(7));
+        let action = saga.on_event(
+            &Event::PanesReaped {
+                label: "main".into(),
+                version: 100,
+                saga_id: Some(99),
+            },
+            &ctx(7),
+        );
+        assert!(matches!(action, SagaAction::Wait));
     }
 
     #[test]
@@ -405,7 +454,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "different-window".into(),
                 version: 51,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -417,7 +466,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "main".into(),
                 version: 52,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -446,7 +495,7 @@ mod tests {
             &Event::PanesReaped {
                 label: "main".into(),
                 version: 100,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -456,7 +505,7 @@ mod tests {
             &Event::PoolDrained {
                 label: "other".into(),
                 version: 101,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -465,7 +514,7 @@ mod tests {
             &Event::PoolNotLast {
                 label: "other".into(),
                 version: 102,
-                saga_id: None,
+                saga_id: Some(7),
             },
             &ctx(7),
         );
@@ -500,22 +549,14 @@ mod tests {
             version: 1,
             crash_detected: false,
         });
-        // Step 1 terminal.
-        let _ = events_tx.send(Event::PanesReaped {
-            label: "main".into(),
-            version: 2,
-            saga_id: None,
-        });
-        // Step 2 terminal — pick the "drained" branch.
-        let _ = events_tx.send(Event::PoolDrained {
-            label: "main".into(),
-            version: 3,
-            saga_id: None,
-        });
 
+        // CPD-4: wait for SagaStarted to learn the coordinator-
+        // allocated saga_id, then publish step-1 + step-2 terminals
+        // tagged with that id.
+        let mut saga_id_started: Option<u64> = None;
         let mut saw_started = false;
         let mut saw_completed_after_started = false;
-        let mut saga_id_started: Option<u64> = None;
+        let mut sent_terminals = false;
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
         while std::time::Instant::now() < deadline {
             match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
@@ -524,6 +565,22 @@ mod tests {
                     if name == "window_cleanup_cascade" {
                         saw_started = true;
                         saga_id_started = Some(saga_id);
+                        if !sent_terminals {
+                            // Step 1 terminal.
+                            let _ = events_tx.send(Event::PanesReaped {
+                                label: "main".into(),
+                                version: 2,
+                                saga_id: Some(saga_id),
+                            });
+                            // Step 2 terminal — pick the "drained"
+                            // branch.
+                            let _ = events_tx.send(Event::PoolDrained {
+                                label: "main".into(),
+                                version: 3,
+                                saga_id: Some(saga_id),
+                            });
+                            sent_terminals = true;
+                        }
                     }
                 }
                 Ok(Ok(Event::SagaCompleted { saga_id, .. })) => {
@@ -547,18 +604,20 @@ mod tests {
         );
     }
 
-    /// Concurrent-window-close scenario: two `WindowClosed` events
-    /// arrive in close succession. Per the F.5 evict-and-replace
-    /// policy in `saga::mod.rs::run_coordinator`, the second close
-    /// evicts the first saga (emitting `SagaFailed` with "evicted"
-    /// reason) and starts a fresh one. Both close events still end
-    /// with terminal lifecycle activity:
-    ///   - first close → `SagaFailed` (evicted)
-    ///   - second close → `SagaStarted` + `SagaCompleted`
-    /// We assert that we observe at least one of each lifecycle
-    /// type on the bus.
+    /// **CPD-4 — concurrent same-kind sagas correlate cleanly.**
+    /// Two `WindowClosed` events arrive in close succession; both
+    /// sagas coexist in the registry. Each consumes only its own
+    /// saga_id-tagged terminal events. Both produce a clean
+    /// `SagaStarted` + `SagaCompleted` bracket — no premature
+    /// `SagaFailed { reason: "evicted" }` from the retired
+    /// evict-and-replace policy (PR #634).
+    ///
+    /// Pre-CPD-4 this test (formerly
+    /// `coordinator_evicts_on_concurrent_window_close`) asserted the
+    /// inverse: one premature `SagaFailed` + one `SagaCompleted`. The
+    /// behavioral inversion is the core of CPD-4.
     #[tokio::test]
-    async fn coordinator_evicts_on_concurrent_window_close() {
+    async fn coordinator_concurrent_window_close_runs_two_sagas_to_completion() {
         use crate::saga::{run_coordinator, SagaCoordinator};
 
         let (events_tx, _) = tokio::sync::broadcast::channel::<Event>(64);
@@ -577,70 +636,113 @@ mod tests {
             version: 1,
             crash_detected: false,
         });
-        // Second close BEFORE saga A's terminals arrive → evicts A,
-        // starts saga B.
+        // Second close BEFORE saga A's terminals arrive → with
+        // evict-and-replace removed, saga B coexists with saga A.
         let _ = events_tx.send(Event::WindowClosed {
             label: "secondary".into(),
             version: 2,
             crash_detected: false,
         });
-        // Saga B's terminals.
-        let _ = events_tx.send(Event::PanesReaped {
-            label: "secondary".into(),
-            version: 3,
-            saga_id: None,
-        });
-        let _ = events_tx.send(Event::PoolNotLast {
-            label: "secondary".into(),
-            version: 4,
-            saga_id: None,
-        });
 
-        let mut started_count = 0u32;
-        let mut completed_count = 0u32;
-        let mut failed_evict_count = 0u32;
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        // Drain the bus: capture both saga_ids from SagaStarted, then
+        // send each saga's terminal events tagged with its own id.
+        // Track a per-saga state machine: we send PanesReaped only
+        // after the saga's start is observed, then PoolDrained/
+        // PoolNotLast.
+        let mut saga_a_id: Option<u64> = None;
+        let mut saga_b_id: Option<u64> = None;
+        let mut saga_a_complete = false;
+        let mut saga_b_complete = false;
+        let mut saga_a_panes_sent = false;
+        let mut saga_b_panes_sent = false;
+        let mut version: u64 = 100;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
         while std::time::Instant::now() < deadline {
             match tokio::time::timeout(std::time::Duration::from_millis(50), witness.recv()).await
             {
-                Ok(Ok(Event::SagaStarted { name, .. })) => {
+                Ok(Ok(Event::SagaStarted { saga_id, name, .. })) => {
                     if name == "window_cleanup_cascade" {
-                        started_count += 1;
+                        if saga_a_id.is_none() {
+                            saga_a_id = Some(saga_id);
+                            // Saga A's PanesReaped (Step 1 terminal).
+                            version += 1;
+                            let _ = events_tx.send(Event::PanesReaped {
+                                label: "main".into(),
+                                version,
+                                saga_id: Some(saga_id),
+                            });
+                            saga_a_panes_sent = true;
+                        } else if saga_b_id.is_none() {
+                            saga_b_id = Some(saga_id);
+                            version += 1;
+                            let _ = events_tx.send(Event::PanesReaped {
+                                label: "secondary".into(),
+                                version,
+                                saga_id: Some(saga_id),
+                            });
+                            saga_b_panes_sent = true;
+                        }
                     }
                 }
-                Ok(Ok(Event::SagaCompleted { .. })) => {
-                    completed_count += 1;
-                }
-                Ok(Ok(Event::SagaFailed { reason, .. })) => {
-                    if reason.contains("evicted") {
-                        failed_evict_count += 1;
+                Ok(Ok(Event::PanesReaped { saga_id: Some(sid), .. })) => {
+                    // After Step 1 echo lands, send Step 2 terminal
+                    // tagged with the same saga id.
+                    if Some(sid) == saga_a_id && saga_a_panes_sent {
+                        version += 1;
+                        let _ = events_tx.send(Event::PoolDrained {
+                            label: "main".into(),
+                            version,
+                            saga_id: Some(sid),
+                        });
+                    } else if Some(sid) == saga_b_id && saga_b_panes_sent {
+                        version += 1;
+                        let _ = events_tx.send(Event::PoolNotLast {
+                            label: "secondary".into(),
+                            version,
+                            saga_id: Some(sid),
+                        });
                     }
                 }
-                Ok(Ok(_)) => {}
-                Ok(Err(_)) => break,
-                Err(_) => {
-                    // No new events for 50ms — break early once we've
-                    // seen the expected pattern.
-                    if started_count >= 2 && completed_count >= 1 && failed_evict_count >= 1 {
+                Ok(Ok(Event::SagaCompleted { saga_id, .. })) => {
+                    if Some(saga_id) == saga_a_id {
+                        saga_a_complete = true;
+                    } else if Some(saga_id) == saga_b_id {
+                        saga_b_complete = true;
+                    }
+                    if saga_a_complete && saga_b_complete {
                         break;
                     }
                 }
+                Ok(Ok(Event::SagaFailed { reason, saga_id, .. })) => {
+                    panic!(
+                        "CPD-4 invariant violated: saga_id={} got SagaFailed reason={} — \
+                         evict-and-replace should be retired so concurrent sagas no \
+                         longer cross-talk",
+                        saga_id, reason,
+                    );
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(_)) => break,
+                Err(_) => continue,
             }
         }
+
         assert!(
-            started_count >= 2,
-            "expected ≥2 SagaStarted (one per close), got {}",
-            started_count
+            saga_a_id.is_some(),
+            "expected saga A's SagaStarted from first WindowClosed"
         );
         assert!(
-            failed_evict_count >= 1,
-            "expected ≥1 SagaFailed with 'evicted' reason from evict-and-replace policy, got {}",
-            failed_evict_count
+            saga_b_id.is_some(),
+            "expected saga B's SagaStarted from second WindowClosed (no eviction)"
+        );
+        assert_ne!(saga_a_id, saga_b_id, "concurrent sagas must have distinct ids");
+        assert!(
+            saga_a_complete,
+            "saga A (label=main) should complete cleanly with its own saga_id-tagged terminals"
         );
         assert!(
-            completed_count >= 1,
-            "expected ≥1 SagaCompleted (the surviving saga), got {}",
-            completed_count
+            saga_b_complete,
+            "saga B (label=secondary) should complete cleanly with its own saga_id-tagged terminals"
         );
     }
 }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.575"
+version = "0.33.576"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.575",
+  "version": "0.33.576",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.575",
+      "version": "0.33.576",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.575",
+  "version": "0.33.576",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Wires per-saga event correlation for `PoolRespawn` (F.5) and `WindowCleanupCascade` (F.6) sagas, retiring the evict-and-replace workaround introduced in PR #634. Concurrent same-kind sagas now coexist cleanly — each consumes only events tagged with its own coordinator-allocated `saga_id`.

Specs:
- `docs/specs/SPEC_SAGA_ARCHITECTURE_TARGET_2026-05-01.md` §3.7 (per-saga event correlation)
- `docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md` §3.7 + §4 PR4
- `docs/specs/SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md` §2 batch 3

## Changes

- `Saga::on_event` (both F.5 and F.6) now filters terminal events by `event.saga_id == ctx.saga_id`. Untagged events (`saga_id: None`, organic host reports) and events from sibling concurrent sagas are ignored — return `SagaAction::Wait`.
- Saga-side `Phase::WaitingForRefill` / `Phase::ReapingPanes` / `Phase::DrainingPool` patterns now match `saga_id`. Defense-in-depth label match retained for `WindowCleanupCascade`.
- Removed the evict-and-replace gate from `run_coordinator` (`agentmux-launcher/src/saga/mod.rs`). The pre-CPD-4 forced at-most-one-per-kind serialization is no longer needed. Updated `match_trigger` doc + the `same_kind_count` log line accordingly.
- `expected_saga_id` lives on `SagaCtx` already (no new field needed). The coordinator passes it via the existing `SagaCtx { saga_id }` to `on_event`.

## Tests

- **Repurposed `f7_evict_and_replace_keeps_one_saga_per_kind` → `cpd4_concurrent_sagas_no_eviction`** — random sequences must produce ZERO `SagaFailed { reason: "evicted" }`.
- **Repurposed `coordinator_evicts_on_concurrent_window_close` → `coordinator_concurrent_window_close_runs_two_sagas_to_completion`** — two concurrent `WindowCleanupCascade` sagas both Complete cleanly with their own tagged terminals.
- **Repurposed `saga_fails_writes_failed_state` → `saga_concurrent_same_kind_both_complete`** — durable log records two `completed` rows (no `failed` from eviction).
- **Added 4 unit tests:** `organic_pool_window_added_does_not_complete_saga`, `pool_window_added_with_foreign_saga_id_is_ignored`, `organic_panes_reaped_does_not_advance_saga`, `foreign_saga_id_panes_reaped_does_not_advance_saga`.
- **Updated 8 existing tests** to publish `saga_id`-tagged terminal events (most learn the saga_id by listening for `SagaStarted` first).

`cargo test -p agentmux-launcher` — 144 passed, 0 failed.

## Test plan

- [x] `cargo check -p agentmux-launcher` — clean
- [x] `cargo test -p agentmux-launcher` — 144/144 pass
- [x] Workspace cargo check — clean (warnings only)
- [ ] Smoke test: open AgentMux, open + close 3 windows rapidly, observe single `SagaCompleted` per window in `~/.agentmux/log/launcher.log` (no `SagaFailed { reason: "evicted" }`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)