### PR TITLE
feat(cpd-5): host-side saga_id LRU + HostFrame parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.574"
+version = "0.33.575"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.574"
+version = "0.33.575"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.574"
+version = "0.33.575"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.574"
+version = "0.33.575"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.574"
+version = "0.33.575"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 use std::sync::OnceLock;
 
-use agentmux_common::ipc::{ClientKind, Command, Event};
+use agentmux_common::ipc::{ClientKind, Command, Event, HostFrame};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{mpsc, Mutex};
 
@@ -192,26 +192,91 @@ pub async fn connect_to_launcher(
     // from the launcher's authoritative event stream. Host has no
     // local `WindowInstanceRegistry` post-B.5e — the shadow IS the
     // read path.
+    //
+    // Phase CPD-5 — the reader now accepts `HostFrame` envelopes
+    // (CPD-1) so the launcher can push saga-issued `Command`s down
+    // alongside `Event`s. Each line is parsed as `HostFrame` first;
+    // on parse failure we fall back to raw `Event` JSON for
+    // backward-compatibility with launchers that haven't yet
+    // adopted the envelope shape (the legacy fanout path emits
+    // bare `Event` JSON; CPD-2's `HostPipe::send_event` wraps in
+    // `HostFrame::Event`).
+    //
+    // Saga-issued `Command`s are dispatched via the host-side
+    // idempotency LRU (`saga_dispatch::dispatch_host_command`):
+    // duplicate `(saga_id, kind)` pairs re-emit the same Report
+    // without re-running the action. The reply Commands are pushed
+    // through the existing `COMMAND_TX` channel, which the drain
+    // task spawned above already serializes to the writer.
     let state_for_reader = std::sync::Arc::clone(&state);
+    let saga_lru = std::sync::Arc::new(parking_lot::Mutex::new(
+        crate::saga_dispatch::SagaIdempotencyLru::with_default_cap(),
+    ));
+    // The reply path uses the same `COMMAND_TX` published above.
+    // Snapshot a sender clone NOW so the reader doesn't have to
+    // probe the OnceLock on every command (which would also race
+    // with the unset-OnceLock window during the brief gap between
+    // Register flush and `COMMAND_TX.set`).
+    let reply_tx = COMMAND_TX
+        .get()
+        .expect("COMMAND_TX set before reader task spawn")
+        .clone();
+    let saga_runner = std::sync::Arc::new(crate::saga_dispatch::LiveActionRunner {
+        state: std::sync::Arc::clone(&state),
+    });
     let reader_task = tokio::spawn(async move {
         let reader = BufReader::new(read_half);
         let mut lines = reader.lines();
         loop {
             match lines.next_line().await {
                 Ok(Some(line)) if line.trim().is_empty() => continue,
-                Ok(Some(line)) => match serde_json::from_str::<Event>(&line) {
-                    Ok(event) => {
-                        tracing::info!("[launcher-ipc] received event: {:?}", event);
-                        apply_event_to_shadow(&state_for_reader, &event);
+                Ok(Some(line)) => {
+                    // Try the envelope first.
+                    match serde_json::from_str::<HostFrame>(&line) {
+                        Ok(HostFrame::Event(event)) => {
+                            tracing::info!("[launcher-ipc] received event: {:?}", event);
+                            apply_event_to_shadow(&state_for_reader, &event);
+                        }
+                        Ok(HostFrame::Command(cmd)) => {
+                            tracing::info!(
+                                "[launcher-ipc] received saga command: {:?}",
+                                cmd
+                            );
+                            let outcome = crate::saga_dispatch::dispatch_host_command(
+                                &cmd,
+                                saga_runner.as_ref(),
+                                &saga_lru,
+                                &reply_tx,
+                            );
+                            tracing::debug!(
+                                "[launcher-ipc] saga command outcome: {:?}",
+                                outcome
+                            );
+                        }
+                        Err(_envelope_err) => {
+                            // Backward-compat fallback: pre-CPD-2 launchers
+                            // emit bare `Event` JSON without the `HostFrame`
+                            // wrapper. Parse as raw `Event`; on failure
+                            // log and skip.
+                            match serde_json::from_str::<Event>(&line) {
+                                Ok(event) => {
+                                    tracing::info!(
+                                        "[launcher-ipc] received event (legacy bare-Event): {:?}",
+                                        event
+                                    );
+                                    apply_event_to_shadow(&state_for_reader, &event);
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "[launcher-ipc] could not parse line as HostFrame or Event ({}): {}",
+                                        e,
+                                        line
+                                    );
+                                }
+                            }
+                        }
                     }
-                    Err(e) => {
-                        tracing::warn!(
-                            "[launcher-ipc] could not parse event line ({}): {}",
-                            e,
-                            line
-                        );
-                    }
-                },
+                }
                 Ok(None) => {
                     tracing::info!("[launcher-ipc] launcher pipe EOF — connection closed");
                     return;

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -36,6 +36,7 @@ mod srv_ipc;
 mod memory_heartbeat;
 mod pane;
 mod reducer;
+mod saga_dispatch;
 mod sidecar;
 mod state;
 mod ui_tasks;

--- a/agentmux-cef/src/saga_dispatch.rs
+++ b/agentmux-cef/src/saga_dispatch.rs
@@ -1,0 +1,729 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase CPD-5 — host-side saga command dispatch + idempotency LRU.
+//
+// After CPD-1+2+3 merged, the launcher dispatches `IssueCmd::Host`
+// saga commands carrying `saga_id` over the launcher → host pipe.
+// CPD-3 made the wire live; this module makes host processing
+// idempotent so a launcher retry (e.g. after host pipe reconnect
+// drains the launcher's `pending_buffer`) does NOT re-execute the
+// same command — instead the host re-emits the same `Report*` reply
+// it produced the first time.
+//
+// **Why not just dedupe at the launcher?** The launcher already does
+// best-effort dedupe via single-flight per saga, but the buffer →
+// reconnect → drain path can legitimately re-deliver a command if
+// the host crashed mid-processing (the launcher has no way to know
+// whether the host saw the original send). Defense-in-depth: launcher
+// avoids resends when it can; host absorbs the rest with this LRU.
+//
+// **Key:** `(saga_id, CommandKind)`. `saga_id` alone is not enough —
+// a future feature could legitimately issue multiple distinct host
+// commands inside one saga (e.g. a saga that both reaps panes AND
+// drains the pool, each with a different `Command` variant). Keying
+// on `(saga_id, kind)` lets the LRU hold one entry per (saga, action
+// type) pair without collisions.
+//
+// **Bound:** 256 entries. Saga rate is human-driven (window opens /
+// closes); 256 covers far more than any realistic concurrent-saga
+// burst. Drop-oldest on overflow.
+//
+// **Test coverage:** see `#[cfg(test)] mod tests` at the bottom —
+// covers (a) duplicate command re-emits same Report without re-action,
+// (b) LRU eviction at the 257th distinct entry preserves recency
+// ordering.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use agentmux_common::ipc::Command;
+use parking_lot::Mutex;
+use tokio::sync::mpsc::UnboundedSender;
+
+/// Discriminator for the host-bound saga command variants. Tracks
+/// the three commands the host actually consumes today
+/// (`SpawnPoolWindow`, `ReapPanes`, `DrainPoolIfLast`); future host-
+/// bound commands add a variant here.
+///
+/// Used as half of the LRU key `(saga_id, CommandKind)` so the same
+/// `saga_id` can carry multiple distinct host actions (a saga that
+/// reaps panes AND drains pool, each with a different Command kind)
+/// without collision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CommandKind {
+    SpawnPoolWindow,
+    ReapPanes,
+    DrainPoolIfLast,
+}
+
+impl CommandKind {
+    /// Extract the discriminator from a host-bound saga `Command`.
+    /// Returns `None` for commands that aren't host-bound saga
+    /// payloads (e.g. `Report*` Commands flowing in the OTHER
+    /// direction, or `Register` / `Ping`).
+    pub fn from_command(cmd: &Command) -> Option<Self> {
+        match cmd {
+            Command::SpawnPoolWindow { .. } => Some(Self::SpawnPoolWindow),
+            Command::ReapPanes { .. } => Some(Self::ReapPanes),
+            Command::DrainPoolIfLast { .. } => Some(Self::DrainPoolIfLast),
+            _ => None,
+        }
+    }
+}
+
+/// Maximum number of `(saga_id, kind)` entries held in the LRU.
+/// Spec §3.7: bound 256 — far above any realistic concurrent saga
+/// count.
+pub const SAGA_LRU_CAP: usize = 256;
+
+/// Idempotency LRU keyed by `(saga_id, CommandKind)`. Stores the
+/// resulting `Report*` Command so a duplicate dispatch re-emits the
+/// same reply payload without re-running the action.
+///
+/// Implementation: simple `VecDeque` of `(key, report)` pairs. Front
+/// is oldest, back is most-recent. Linear scan on lookup is fine at
+/// `cap=256`: the entire scan is a few microseconds and only happens
+/// once per saga command (a human-rate event).
+pub struct SagaIdempotencyLru {
+    entries: VecDeque<((u64, CommandKind), Command)>,
+    cap: usize,
+}
+
+impl SagaIdempotencyLru {
+    pub fn new(cap: usize) -> Self {
+        Self {
+            entries: VecDeque::with_capacity(cap),
+            cap,
+        }
+    }
+
+    pub fn with_default_cap() -> Self {
+        Self::new(SAGA_LRU_CAP)
+    }
+
+    /// Look up the cached Report for `(saga_id, kind)`. On hit,
+    /// promotes the entry to most-recent (back of the deque) and
+    /// returns a clone of the cached Report. On miss, returns None.
+    pub fn get(&mut self, saga_id: u64, kind: CommandKind) -> Option<Command> {
+        let key = (saga_id, kind);
+        let pos = self.entries.iter().position(|(k, _)| *k == key)?;
+        // Promote to most-recent: remove + push to back.
+        let (k, v) = self.entries.remove(pos)?;
+        let cloned = v.clone();
+        self.entries.push_back((k, v));
+        Some(cloned)
+    }
+
+    /// Cache the Report for `(saga_id, kind)`. If at capacity, drops
+    /// the oldest entry (front). If a duplicate key exists, updates
+    /// in place + promotes (defensive — caller usually hits via
+    /// `get` first; this branch covers a race where two duplicate
+    /// commands raced through `get` with both seeing miss).
+    pub fn insert(&mut self, saga_id: u64, kind: CommandKind, report: Command) {
+        let key = (saga_id, kind);
+        if let Some(pos) = self.entries.iter().position(|(k, _)| *k == key) {
+            // Defensive duplicate — replace + promote.
+            self.entries.remove(pos);
+        } else if self.entries.len() >= self.cap {
+            // Drop-oldest on overflow.
+            self.entries.pop_front();
+        }
+        self.entries.push_back((key, report));
+    }
+
+    /// Current number of entries (for tests + diagnostics).
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Return the saga_id of the oldest entry, or None if empty.
+    /// Used in tests to verify drop-oldest semantics.
+    #[cfg(test)]
+    pub fn oldest_saga_id(&self) -> Option<u64> {
+        self.entries.front().map(|(k, _)| k.0)
+    }
+}
+
+impl Default for SagaIdempotencyLru {
+    fn default() -> Self {
+        Self::with_default_cap()
+    }
+}
+
+/// Outcome of `dispatch_host_command`: tells the caller whether the
+/// dispatch was a fresh execution (action ran, Report was inserted
+/// + sent) or a duplicate (Report was re-sent from cache, action
+/// did NOT re-run).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchOutcome {
+    /// First-time dispatch: action executed, cached Report sent.
+    Fresh,
+    /// Duplicate dispatch: cached Report re-emitted, no action.
+    Duplicate,
+    /// Command had no `saga_id` (or `saga_id == 0`, the
+    /// "no-saga" sentinel) — the LRU is bypassed and the action
+    /// runs unconditionally. This branch is mostly defensive: the
+    /// launcher's CPD-3 wiring always issues with a real saga_id,
+    /// but a stray legacy / forward-compat dispatch could hit this.
+    NoSagaBypass,
+    /// Command kind isn't a known host-bound saga payload (e.g.
+    /// the reader received a `Report*` echo that should never have
+    /// been sent down to the host). Logged at warn; no action, no
+    /// reply.
+    Unrecognized,
+}
+
+/// Dispatcher trait — abstracted so tests can inject a fake action
+/// runner without spawning real CEF windows. Production code uses
+/// `LiveActionRunner` which calls into `commands::window_pool` /
+/// host close-path code.
+pub trait SagaActionRunner: Send + Sync {
+    /// Run the `SpawnPoolWindow` action. Returns the resulting
+    /// pool window label (the host normally synthesizes a
+    /// `window-pool-<uuid>` label; for the saga reply we report
+    /// "pending" so the launcher reducer can correlate the
+    /// follow-up `ReportPoolWindowAdded` organic event by saga_id).
+    /// In production the spawn is fire-and-forget on the UI thread
+    /// — the actual label is reported via the existing organic
+    /// `report_pool_window_added` path. The saga's `Report` here
+    /// carries an empty/sentinel label indicating "spawn requested,
+    /// pool will fill asynchronously."
+    fn spawn_pool_window(&self) -> String;
+
+    /// Run the `ReapPanes` action for the named window. In current
+    /// architecture the host's `on_before_close` already drains
+    /// panes synchronously when a window closes, so this is a
+    /// best-effort acknowledge — the saga relies on the organic
+    /// `Event::PanesReaped` (via `report_panes_reaped` in
+    /// `client.rs`) for the real signal. The Report this returns
+    /// is a saga-correlated echo so the saga's `expected_saga_id`
+    /// filter matches.
+    fn reap_panes(&self, label: &str);
+
+    /// Run the `DrainPoolIfLast` action for the named window.
+    /// Returns true if the host considers `label` to have been the
+    /// last user-visible window (i.e. a drain WOULD be triggered).
+    /// Like `reap_panes`, the host's existing `on_before_close`
+    /// already does this decision inline; the saga's command path
+    /// is a re-issue / confirmation channel.
+    fn drain_pool_if_last(&self, label: &str) -> bool;
+}
+
+/// Dispatch a host-bound saga `Command`: check the LRU, run the
+/// action if not cached, build the corresponding `Report*`,
+/// cache it, and send via `reply_tx`. Returns the outcome so callers
+/// can log / count fresh vs. duplicate dispatch.
+///
+/// `lru` is a shared `Arc<Mutex<...>>` so the read-loop task and
+/// any future direct-dispatch path share a single cache.
+pub fn dispatch_host_command<R: SagaActionRunner>(
+    cmd: &Command,
+    runner: &R,
+    lru: &Arc<Mutex<SagaIdempotencyLru>>,
+    reply_tx: &UnboundedSender<Command>,
+) -> DispatchOutcome {
+    let kind = match CommandKind::from_command(cmd) {
+        Some(k) => k,
+        None => {
+            tracing::warn!(
+                "[saga-dispatch] received non-host-bound command on host pipe: {:?}",
+                cmd
+            );
+            return DispatchOutcome::Unrecognized;
+        }
+    };
+
+    // Extract saga_id from the command. For each variant the field
+    // name is `saga_id: u64`. `0` is the "no saga" sentinel per
+    // CPD-1 spec — bypass the LRU in that case (the action just
+    // runs without dedupe; useful for legacy / forward-compat
+    // launchers that stamp `0`).
+    let saga_id = match cmd {
+        Command::SpawnPoolWindow { saga_id } => *saga_id,
+        Command::ReapPanes { saga_id, .. } => *saga_id,
+        Command::DrainPoolIfLast { saga_id, .. } => *saga_id,
+        _ => unreachable!("kind matched but variant didn't — schema drift"),
+    };
+
+    if saga_id == 0 {
+        // Legacy / no-saga path: run action, build Report with
+        // saga_id = None (organic), send. No LRU touch.
+        let report = build_and_run_report(cmd, kind, runner, None);
+        let _ = reply_tx.send(report);
+        return DispatchOutcome::NoSagaBypass;
+    }
+
+    // Hot path — saga_id present. Check LRU.
+    {
+        let mut guard = lru.lock();
+        if let Some(cached_report) = guard.get(saga_id, kind) {
+            tracing::info!(
+                "[saga-dispatch] duplicate saga command (saga_id={}, kind={:?}) — re-emitting cached report",
+                saga_id, kind
+            );
+            // Send the cached report; do NOT re-run the action.
+            let _ = reply_tx.send(cached_report);
+            return DispatchOutcome::Duplicate;
+        }
+    }
+
+    // Miss — run action, build Report, cache, send. We hold no
+    // lock across the action call (action may post UI tasks /
+    // touch CEF state).
+    let report = build_and_run_report(cmd, kind, runner, Some(saga_id));
+    {
+        let mut guard = lru.lock();
+        guard.insert(saga_id, kind, report.clone());
+    }
+    let _ = reply_tx.send(report);
+    DispatchOutcome::Fresh
+}
+
+/// Run the action for `cmd` and synthesize the corresponding
+/// `Report*` Command. `saga_id_for_report` is what the Report's
+/// echo field carries — `Some(N)` when the dispatch was saga-driven,
+/// `None` for the no-saga bypass path.
+fn build_and_run_report<R: SagaActionRunner>(
+    cmd: &Command,
+    kind: CommandKind,
+    runner: &R,
+    saga_id_for_report: Option<u64>,
+) -> Command {
+    match (cmd, kind) {
+        (Command::SpawnPoolWindow { .. }, CommandKind::SpawnPoolWindow) => {
+            let label = runner.spawn_pool_window();
+            Command::ReportPoolWindowAdded {
+                label,
+                saga_id: saga_id_for_report,
+            }
+        }
+        (Command::ReapPanes { label, .. }, CommandKind::ReapPanes) => {
+            runner.reap_panes(label);
+            Command::ReportPanesReaped {
+                label: label.clone(),
+                saga_id: saga_id_for_report,
+            }
+        }
+        (Command::DrainPoolIfLast { label, .. }, CommandKind::DrainPoolIfLast) => {
+            let was_last = runner.drain_pool_if_last(label);
+            Command::ReportPoolDrainDecision {
+                label: label.clone(),
+                was_last,
+                saga_id: saga_id_for_report,
+            }
+        }
+        _ => unreachable!("kind/cmd mismatch — guarded by from_command()"),
+    }
+}
+
+// ── Production action runner ──────────────────────────────────────
+//
+// Wraps real host code paths. Kept thin so the test runner can
+// substitute deterministic stubs without pulling in CEF.
+
+#[cfg(target_os = "windows")]
+pub struct LiveActionRunner {
+    pub state: Arc<crate::state::AppState>,
+}
+
+#[cfg(target_os = "windows")]
+impl SagaActionRunner for LiveActionRunner {
+    fn spawn_pool_window(&self) -> String {
+        // Fire the real spawn. The host's existing
+        // `report_pool_window_added` organic path will report the
+        // freshly minted label; the saga-correlated reply this
+        // dispatcher emits carries an empty label as a sentinel —
+        // the launcher reducer matches by saga_id, not label.
+        crate::commands::window_pool::spawn_pool_window(&self.state);
+        String::new()
+    }
+
+    fn reap_panes(&self, label: &str) {
+        // Host's `on_before_close` is the canonical pane-reaper.
+        // A saga-issued `ReapPanes` for a window whose close is
+        // already in flight is a redundant nudge — log and rely
+        // on the organic `report_panes_reaped` for the real signal.
+        // Future expansion (forced-close-from-saga) can hook here.
+        tracing::info!(
+            "[saga-dispatch] ReapPanes saga command for label={} — acknowledged (host close-path is canonical reaper)",
+            label
+        );
+    }
+
+    fn drain_pool_if_last(&self, label: &str) -> bool {
+        // Compute the same condition `on_before_close` uses to
+        // decide drain. Read-only snapshot of host state.
+        let unpromoted = self.state.unpromoted_pool_labels.lock();
+        let browsers = self.state.browsers.lock();
+        let user_count = browsers
+            .iter()
+            .filter(|(k, _)| !unpromoted.contains(*k) && !k.starts_with("browser-pane-"))
+            .count();
+        // `was_last` semantics: closing window is the last user-
+        // visible window. Caller's `label` should be subtracted —
+        // but at saga-dispatch time the close hasn't happened yet
+        // (or has just happened); count of 0 OR count of 1 with
+        // the closing window in the set both indicate "last."
+        let label_present = browsers.contains_key(label);
+        drop(browsers);
+        drop(unpromoted);
+        user_count == 0 || (user_count == 1 && label_present)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::mpsc;
+
+    /// Test runner: counts how many times each action runs so
+    /// duplicate-dispatch tests can verify idempotency.
+    struct CountingRunner {
+        spawn_calls: AtomicUsize,
+        reap_calls: AtomicUsize,
+        drain_calls: AtomicUsize,
+        drain_returns_was_last: bool,
+    }
+
+    impl CountingRunner {
+        fn new() -> Self {
+            Self {
+                spawn_calls: AtomicUsize::new(0),
+                reap_calls: AtomicUsize::new(0),
+                drain_calls: AtomicUsize::new(0),
+                drain_returns_was_last: false,
+            }
+        }
+    }
+
+    impl SagaActionRunner for CountingRunner {
+        fn spawn_pool_window(&self) -> String {
+            let n = self.spawn_calls.fetch_add(1, Ordering::SeqCst);
+            format!("window-pool-test-{}", n)
+        }
+
+        fn reap_panes(&self, _label: &str) {
+            self.reap_calls.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn drain_pool_if_last(&self, _label: &str) -> bool {
+            self.drain_calls.fetch_add(1, Ordering::SeqCst);
+            self.drain_returns_was_last
+        }
+    }
+
+    fn drain_replies(rx: &mut mpsc::UnboundedReceiver<Command>) -> Vec<Command> {
+        let mut out = Vec::new();
+        while let Ok(cmd) = rx.try_recv() {
+            out.push(cmd);
+        }
+        out
+    }
+
+    #[test]
+    fn duplicate_spawn_pool_window_does_not_respawn_but_reemits_report() {
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let cmd = Command::SpawnPoolWindow { saga_id: 42 };
+
+        // First dispatch — fresh.
+        let outcome1 = dispatch_host_command(&cmd, &runner, &lru, &tx);
+        assert_eq!(outcome1, DispatchOutcome::Fresh);
+        assert_eq!(runner.spawn_calls.load(Ordering::SeqCst), 1);
+
+        // Second dispatch with same saga_id — duplicate; should
+        // NOT re-spawn, but SHOULD re-emit the same Report.
+        let outcome2 = dispatch_host_command(&cmd, &runner, &lru, &tx);
+        assert_eq!(outcome2, DispatchOutcome::Duplicate);
+        assert_eq!(
+            runner.spawn_calls.load(Ordering::SeqCst),
+            1,
+            "spawn must not re-execute on duplicate"
+        );
+
+        let replies = drain_replies(&mut rx);
+        assert_eq!(replies.len(), 2, "expected one reply per dispatch");
+        // Both replies must serialize to byte-identical JSON
+        // (Command itself isn't PartialEq because it carries
+        // some non-comparable nested types).
+        let j0 = serde_json::to_string(&replies[0]).unwrap();
+        let j1 = serde_json::to_string(&replies[1]).unwrap();
+        assert_eq!(j0, j1, "duplicate dispatch must re-emit identical Report");
+        match &replies[0] {
+            Command::ReportPoolWindowAdded { label, saga_id } => {
+                assert_eq!(label, "window-pool-test-0");
+                assert_eq!(*saga_id, Some(42));
+            }
+            other => panic!("unexpected reply: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn duplicate_reap_panes_does_not_rerun_but_reemits_report() {
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let cmd = Command::ReapPanes {
+            label: "win-1".to_string(),
+            saga_id: 7,
+        };
+
+        assert_eq!(
+            dispatch_host_command(&cmd, &runner, &lru, &tx),
+            DispatchOutcome::Fresh
+        );
+        assert_eq!(
+            dispatch_host_command(&cmd, &runner, &lru, &tx),
+            DispatchOutcome::Duplicate
+        );
+        assert_eq!(runner.reap_calls.load(Ordering::SeqCst), 1);
+
+        let replies = drain_replies(&mut rx);
+        assert_eq!(replies.len(), 2);
+        let j0 = serde_json::to_string(&replies[0]).unwrap();
+        let j1 = serde_json::to_string(&replies[1]).unwrap();
+        assert_eq!(j0, j1);
+    }
+
+    #[test]
+    fn duplicate_drain_pool_if_last_reuses_was_last_decision() {
+        let mut runner = CountingRunner::new();
+        runner.drain_returns_was_last = true;
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let cmd = Command::DrainPoolIfLast {
+            label: "win-1".to_string(),
+            saga_id: 99,
+        };
+
+        assert_eq!(
+            dispatch_host_command(&cmd, &runner, &lru, &tx),
+            DispatchOutcome::Fresh
+        );
+        assert_eq!(
+            dispatch_host_command(&cmd, &runner, &lru, &tx),
+            DispatchOutcome::Duplicate
+        );
+        assert_eq!(runner.drain_calls.load(Ordering::SeqCst), 1);
+
+        let replies = drain_replies(&mut rx);
+        assert_eq!(replies.len(), 2);
+        // Even though the runner's `drain_returns_was_last` was
+        // captured at first call, the second reply must echo the
+        // same `was_last` (defense against runner state changing
+        // mid-flight — the LRU MUST hold the original decision).
+        match (&replies[0], &replies[1]) {
+            (
+                Command::ReportPoolDrainDecision {
+                    was_last: a,
+                    saga_id: id_a,
+                    ..
+                },
+                Command::ReportPoolDrainDecision {
+                    was_last: b,
+                    saga_id: id_b,
+                    ..
+                },
+            ) => {
+                assert_eq!(a, b);
+                assert_eq!(*a, true);
+                assert_eq!(id_a, id_b);
+                assert_eq!(*id_a, Some(99));
+            }
+            other => panic!("unexpected reply pair: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn lru_evicts_oldest_at_capacity() {
+        // Use a small cap to keep test runtime cheap.
+        let cap = 4;
+        let mut lru = SagaIdempotencyLru::new(cap);
+        for i in 0..cap as u64 {
+            lru.insert(
+                i,
+                CommandKind::SpawnPoolWindow,
+                Command::ReportPoolWindowAdded {
+                    label: format!("w{}", i),
+                    saga_id: Some(i),
+                },
+            );
+        }
+        assert_eq!(lru.len(), cap);
+        assert_eq!(lru.oldest_saga_id(), Some(0));
+
+        // Insert one more — saga_id=0 should be evicted (oldest).
+        lru.insert(
+            cap as u64,
+            CommandKind::SpawnPoolWindow,
+            Command::ReportPoolWindowAdded {
+                label: format!("w{}", cap),
+                saga_id: Some(cap as u64),
+            },
+        );
+        assert_eq!(lru.len(), cap);
+        assert_eq!(lru.oldest_saga_id(), Some(1));
+        assert!(lru.get(0, CommandKind::SpawnPoolWindow).is_none());
+        assert!(lru.get(cap as u64, CommandKind::SpawnPoolWindow).is_some());
+    }
+
+    #[test]
+    fn lru_eviction_at_257th_distinct_command() {
+        // Per spec §3.7: bound 256.
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Fill to capacity (256 distinct saga_ids).
+        for i in 1..=SAGA_LRU_CAP as u64 {
+            let cmd = Command::SpawnPoolWindow { saga_id: i };
+            let outcome = dispatch_host_command(&cmd, &runner, &lru, &tx);
+            assert_eq!(outcome, DispatchOutcome::Fresh);
+        }
+        assert_eq!(lru.lock().len(), SAGA_LRU_CAP);
+
+        // 257th distinct command — accepted; oldest (saga_id=1) evicted.
+        let cmd = Command::SpawnPoolWindow {
+            saga_id: SAGA_LRU_CAP as u64 + 1,
+        };
+        let outcome = dispatch_host_command(&cmd, &runner, &lru, &tx);
+        assert_eq!(outcome, DispatchOutcome::Fresh);
+        assert_eq!(lru.lock().len(), SAGA_LRU_CAP);
+
+        // Verify saga_id=1 is gone (replaying it now would be a
+        // fresh call, not a duplicate).
+        let replay = Command::SpawnPoolWindow { saga_id: 1 };
+        let outcome = dispatch_host_command(&replay, &runner, &lru, &tx);
+        assert_eq!(
+            outcome,
+            DispatchOutcome::Fresh,
+            "evicted entry must NOT be served from cache"
+        );
+
+        // Verify saga_id=257 is still cached (recent).
+        let replay = Command::SpawnPoolWindow {
+            saga_id: SAGA_LRU_CAP as u64 + 1,
+        };
+        let outcome = dispatch_host_command(&replay, &runner, &lru, &tx);
+        assert_eq!(outcome, DispatchOutcome::Duplicate);
+    }
+
+    #[test]
+    fn distinct_kinds_with_same_saga_id_dont_collide() {
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Same saga_id, different kinds — both should be Fresh.
+        let spawn = Command::SpawnPoolWindow { saga_id: 5 };
+        let reap = Command::ReapPanes {
+            label: "x".to_string(),
+            saga_id: 5,
+        };
+        assert_eq!(
+            dispatch_host_command(&spawn, &runner, &lru, &tx),
+            DispatchOutcome::Fresh
+        );
+        assert_eq!(
+            dispatch_host_command(&reap, &runner, &lru, &tx),
+            DispatchOutcome::Fresh
+        );
+
+        // Re-issue both — both Duplicate.
+        assert_eq!(
+            dispatch_host_command(&spawn, &runner, &lru, &tx),
+            DispatchOutcome::Duplicate
+        );
+        assert_eq!(
+            dispatch_host_command(&reap, &runner, &lru, &tx),
+            DispatchOutcome::Duplicate
+        );
+    }
+
+    #[test]
+    fn saga_id_zero_bypasses_lru() {
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // saga_id=0 is the "no saga" sentinel; LRU must not track.
+        let cmd = Command::SpawnPoolWindow { saga_id: 0 };
+        for _ in 0..3 {
+            let outcome = dispatch_host_command(&cmd, &runner, &lru, &tx);
+            assert_eq!(outcome, DispatchOutcome::NoSagaBypass);
+        }
+        assert_eq!(runner.spawn_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(lru.lock().len(), 0);
+
+        let replies = drain_replies(&mut rx);
+        assert_eq!(replies.len(), 3);
+        for r in &replies {
+            match r {
+                Command::ReportPoolWindowAdded { saga_id, .. } => {
+                    assert_eq!(*saga_id, None, "no-saga bypass must report None");
+                }
+                _ => panic!("unexpected reply"),
+            }
+        }
+    }
+
+    #[test]
+    fn unrecognized_command_is_logged_and_dropped() {
+        let runner = CountingRunner::new();
+        let lru = Arc::new(Mutex::new(SagaIdempotencyLru::with_default_cap()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        // A `Report*` Command flowing the wrong way (host → host
+        // is nonsense; the launcher sends Reports? — no, Reports
+        // are host → launcher only) — verify we don't try to act
+        // on it.
+        let bogus = Command::ReportPanesReaped {
+            label: "x".to_string(),
+            saga_id: Some(1),
+        };
+        let outcome = dispatch_host_command(&bogus, &runner, &lru, &tx);
+        assert_eq!(outcome, DispatchOutcome::Unrecognized);
+        assert_eq!(runner.reap_calls.load(Ordering::SeqCst), 0);
+        assert!(drain_replies(&mut rx).is_empty());
+    }
+
+    #[test]
+    fn lru_get_promotes_to_most_recent() {
+        let mut lru = SagaIdempotencyLru::new(3);
+        for i in 1..=3u64 {
+            lru.insert(
+                i,
+                CommandKind::SpawnPoolWindow,
+                Command::ReportPoolWindowAdded {
+                    label: format!("w{}", i),
+                    saga_id: Some(i),
+                },
+            );
+        }
+        assert_eq!(lru.oldest_saga_id(), Some(1));
+        // Touch saga_id=1 — it should move to most-recent.
+        let _ = lru.get(1, CommandKind::SpawnPoolWindow);
+        assert_eq!(lru.oldest_saga_id(), Some(2));
+        // Insert a new entry; saga_id=2 (now oldest) gets evicted,
+        // not saga_id=1 (which we just touched).
+        lru.insert(
+            4,
+            CommandKind::SpawnPoolWindow,
+            Command::ReportPoolWindowAdded {
+                label: "w4".to_string(),
+                saga_id: Some(4),
+            },
+        );
+        assert_eq!(lru.oldest_saga_id(), Some(3));
+        assert!(lru.get(2, CommandKind::SpawnPoolWindow).is_none());
+        assert!(lru.get(1, CommandKind::SpawnPoolWindow).is_some());
+    }
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.574"
+version = "0.33.575"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.574"
+version = "0.33.575"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.574"
+version = "0.33.575"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.574",
+  "version": "0.33.575",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.574",
+      "version": "0.33.575",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.574",
+  "version": "0.33.575",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

CPD-5 — host-side saga command idempotency. After CPD-3 wired saga
dispatch from launcher to host, host processing was non-idempotent:
a launcher retry (after host pipe reconnect drains pending_buffer,
or host crash mid-process) would re-execute the same command. This
PR adds defense-in-depth on the host so duplicate `(saga_id,
CommandKind)` dispatches re-emit the cached `Report*` payload
without re-running the action.

**Spec:** `docs/specs/SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md` §3.7 + §4 PR5
**Plan:** `docs/specs/SAGA_ARCHITECTURE_EXECUTION_PLAN_2026-05-01.md` §2 batch 3 (Agent 7)

## Changes

- **New module** `agentmux-cef/src/saga_dispatch.rs` (~280 LOC of
  code + ~440 of tests/comments):
  - `SagaIdempotencyLru` — `VecDeque<((saga_id, CommandKind), Command)>`
    with bound 256, drop-oldest on overflow, promote-on-get LRU semantics
  - `SagaActionRunner` trait — abstracted so unit tests inject
    deterministic stubs without spawning real CEF windows
  - `LiveActionRunner` (Windows-only) wraps existing host code paths
  - `dispatch_host_command()` — cache check, action run on miss,
    Report cached + sent. Returns `DispatchOutcome::{Fresh, Duplicate,
    NoSagaBypass, Unrecognized}`
- **`launcher_ipc.rs`** — reader loop now parses `HostFrame` envelope
  first; falls back to bare `Event` JSON for backward compat with
  pre-CPD-2 launchers. `HostFrame::Command` dispatches through the
  new LRU; replies flow back through the existing `COMMAND_TX`
  channel that CPD-3+ already uses.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `cargo test -p agentmux-cef saga_dispatch` — 9 tests pass:
  - `duplicate_spawn_pool_window_does_not_respawn_but_reemits_report`
  - `duplicate_reap_panes_does_not_rerun_but_reemits_report`
  - `duplicate_drain_pool_if_last_reuses_was_last_decision`
  - `lru_evicts_oldest_at_capacity` (cap=4 micro)
  - `lru_eviction_at_257th_distinct_command` (full cap=256 — spec
    acceptance test for this PR)
  - `distinct_kinds_with_same_saga_id_dont_collide`
  - `saga_id_zero_bypasses_lru`
  - `unrecognized_command_is_logged_and_dropped`
  - `lru_get_promotes_to_most_recent`
- [x] `cargo test -p agentmux-cef` — 50 passed, 0 failed (no regression)
- [x] `cargo test --workspace --lib --bins` — pre-existing 6 failures
  in agentmux-srv preserved (all unrelated: providers/reactive/
  filestore/session_archive/wcore — none touch saga or IPC)
- [x] `bump verify` — version 0.33.575 consistent across all manifests

## Acceptance criteria (spec §6)

Per execution plan §6:
> CPD-5: `test_duplicate_saga_command_idempotent` (host LRU) passes

This PR's `duplicate_spawn_pool_window_does_not_respawn_but_reemits_report`,
`duplicate_reap_panes_*`, `duplicate_drain_pool_if_last_*` tests
collectively cover that gate (spawn was the highest-impact action;
the other two are acknowledge-only because host's `on_before_close`
is the canonical reaper/drainer per CPD-1 commentary).