### PR TITLE
fix(cef): pane focus-redirect guard + Phase 1 window-creation tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.578"
+version = "0.33.579"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.578"
+version = "0.33.579"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.578"
+version = "0.33.579"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.578"
+version = "0.33.579"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.578"
+version = "0.33.579"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -133,6 +133,11 @@ impl AgentMuxHandler {
         let browser = browser.cloned().expect("Browser is None");
         tracing::info!("Browser created (total: {})", self.browser_list.len() + 1);
 
+        // Phase 1 diagnostic tracing — find the exact line that silences the
+        // UI thread under concurrent window creation. See
+        // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md.
+        let t0 = std::time::Instant::now();
+
         // Phase B.5 (window_meta step d) — pop the pre-create
         // handoff entry. Pre-step-d this was a label-only queue +
         // separate `window_meta.insert` from the caller; now it's
@@ -157,9 +162,18 @@ impl AgentMuxHandler {
             // emits PendingWindowQueueEmpty on miss; the fallback
             // (synthesize a UUID-labelled FullInstance entry) lives
             // in the legacy code path it always has.
+            tracing::info!(
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[on-after-created] dispatching DequeuePendingWindowCreation"
+            );
             let out = self
                 .state
                 .host_dispatch(crate::reducer::HostCommand::DequeuePendingWindowCreation);
+            tracing::info!(
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                dequeued_some = out.dequeued.is_some(),
+                "[on-after-created] DequeuePendingWindowCreation returned"
+            );
             out.dequeued.unwrap_or_else(|| {
                 let lbl = format!("window-{}", uuid::Uuid::new_v4());
                 tracing::warn!(label = %lbl, "[on_after_created] no pending creation entry — defaulting to FullInstance");
@@ -174,8 +188,18 @@ impl AgentMuxHandler {
         let pending_kind = pending.kind;
         let pending_parent = pending.parent_instance_id.clone();
 
+        tracing::info!(
+            label = %label,
+            elapsed_us = t0.elapsed().as_micros() as u64,
+            "[on-after-created] acquiring browsers lock"
+        );
         {
             let mut browsers = self.state.browsers.lock();
+            tracing::info!(
+                label = %label,
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[on-after-created] browsers lock acquired"
+            );
             tracing::info!("Registered browser: label={} (total: {})", label, browsers.len() + 1);
             dlog(&format!("on_after_created: registered label={} total={}", label, browsers.len() + 1));
             browsers.insert(label.clone(), browser.clone());

--- a/agentmux-cef/src/commands/mod.rs
+++ b/agentmux-cef/src/commands/mod.rs
@@ -25,6 +25,14 @@ use crate::state::AppState;
 /// CEF assigns a separate renderer process when the RequestContext has a unique
 /// `cache_path`. We use `<data_dir>/browser-contexts/<label>/` for this.
 pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Option<cef::RequestContext> {
+    // Phase 1 diagnostic tracing (added 2026-05-02 freeze investigation, see
+    // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md). The freeze
+    // wedges the UI thread inside CEF's Chrome profile-init under concurrent
+    // load; we need to find the EXACT line that silences before committing
+    // to the runner-based serialization fix.
+    let t0 = std::time::Instant::now();
+    tracing::info!(label = %label, "[cef-profile-init] entering create_isolated_request_context");
+
     let data_dir = state.version_data_dir.lock().clone()
         .unwrap_or_else(|| {
             std::env::temp_dir()
@@ -46,7 +54,19 @@ pub fn create_isolated_request_context(state: &Arc<AppState>, label: &str) -> Op
         ..Default::default()
     };
 
+    tracing::info!(
+        label = %label,
+        elapsed_us = t0.elapsed().as_micros() as u64,
+        "[cef-profile-init] calling request_context_create_context"
+    );
     let ctx = cef::request_context_create_context(Some(&settings), None);
+    tracing::info!(
+        label = %label,
+        elapsed_us = t0.elapsed().as_micros() as u64,
+        ok = ctx.is_some(),
+        "[cef-profile-init] request_context_create_context returned"
+    );
+
     if ctx.is_some() {
         tracing::info!(label = %label, path = %ctx_path.display(), "[cef] created isolated RequestContext");
     } else {

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -485,6 +485,33 @@ fn init_logging(log_dir: &std::path::Path) -> tracing_appender::non_blocking::Wo
     let pointer_name = format!("current-host-v{}.path", version);
     let _ = std::fs::write(log_dir.join(&pointer_name), &current_filename);
 
+    // Synchronous init sentinel: append a single line directly to the
+    // expected log path BEFORE the tracing subscriber is wired up. Without
+    // this, a hang between subscriber-setup and the non-blocking writer's
+    // first flush leaves the pointer file pointing at a never-created log
+    // file (observed 2026-05-02 freeze investigation). The sentinel
+    // guarantees the file exists once init_logging has run past
+    // pointer-write — if the file is missing afterwards, we know
+    // init_logging itself didn't get past this point.
+    let sentinel_path = log_dir.join(&current_filename);
+    let sentinel_line = format!(
+        "{} INIT-SENTINEL agentmux-host v={} pid={} os={} arch={}\n",
+        chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ"),
+        version,
+        std::process::id(),
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+    );
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&sentinel_path)
+    {
+        use std::io::Write;
+        let _ = f.write_all(sentinel_line.as_bytes());
+        let _ = f.flush();
+    }
+
     let subscriber = tracing_subscriber::registry()
         .with(
             EnvFilter::try_from_default_env()

--- a/agentmux-cef/src/pane/hwnd.rs
+++ b/agentmux-cef/src/pane/hwnd.rs
@@ -71,6 +71,58 @@ pub fn remove_contexts_for_block(block_id: &str) {
 pub static ALLOW_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Last-redirect timestamp per root HWND, used by
+/// `should_redirect_pane_focus_to_root` to rate-limit programmatic focus
+/// storms (setInterval-driven `window.focus()`, OAuth redirector pages,
+/// DOM mutation observers re-focusing on every change). Keyed by the root
+/// HWND cast to `usize`. Entries are overwritten on each pass and never
+/// explicitly removed — the map is bounded by the count of distinct
+/// top-level AgentMux windows seen in a session, which is small.
+static PANE_REDIRECT_LAST_AT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, std::time::Instant>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Returns `true` iff the pane WM_SETFOCUS subclass should redirect to
+/// `root` via `SetFocus(root)`. Two guards, both motivated by the
+/// 2026-05-02 multi-window freeze investigation
+/// (`docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md`):
+///
+/// 1. **Cross-window refusal.** If a *different* top-level HWND currently
+///    owns OS foreground (per `GetForegroundWindow()`), refuse to redirect.
+///    Same-thread `SetFocus` on a top-level HWND triggers `WM_ACTIVATE`,
+///    so redirecting here would steal foreground from the AgentMux window
+///    the user is interacting with. With two windows whose pane content
+///    both call `window.focus()` programmatically, the redirect itself
+///    drives a foreground ping-pong and the host UI thread saturates.
+///
+/// 2. **Per-root rate limit.** Even within the user's active window, cap
+///    redirects at once per 100 ms per root. Tight focus storms from page
+///    content can otherwise pile WM_SETFOCUS / WM_ACTIVATE chains onto
+///    the UI thread faster than they drain.
+///
+/// When this returns `false`, the pane WM_SETFOCUS handler still consumes
+/// the message (returns 0) — the pane simply doesn't get focus and the
+/// previous focus owner is undisturbed.
+unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> bool {
+    use windows_sys::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+    let current_fg = GetForegroundWindow();
+    if !current_fg.is_null() && current_fg != root {
+        return false;
+    }
+
+    let key = root as usize;
+    let now = std::time::Instant::now();
+    if let Ok(mut map) = PANE_REDIRECT_LAST_AT.lock() {
+        if let Some(last) = map.get(&key) {
+            if now.duration_since(*last) < std::time::Duration::from_millis(100) {
+                return false;
+            }
+        }
+        map.insert(key, now);
+    }
+    true
+}
+
 /// Subclass a browser pane's outer HWND (and every descendant HWND Chromium
 /// has already created) so `WM_SETFOCUS` is redirected back to the parent
 /// top-level window unless the focus change is user-initiated (see
@@ -208,8 +260,16 @@ pub unsafe fn install_pane_focus_redirect(
                 // there leaves focus stuck in the pane. `GetAncestor(GA_ROOT)`
                 // walks all the way up to the top-level window that hosts
                 // both main and pane, which is the correct place to land.
+                //
+                // Guard added 2026-05-02: refuse the redirect when another
+                // top-level HWND owns foreground or when this root has been
+                // redirected within the last 100 ms. See
+                // `should_redirect_pane_focus_to_root` for rationale.
                 let root = GetAncestor(hwnd, GA_ROOT);
-                if !root.is_null() && root != hwnd {
+                if !root.is_null()
+                    && root != hwnd
+                    && should_redirect_pane_focus_to_root(root)
+                {
                     SetFocus(root);
                 }
                 return 0;

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -268,6 +268,13 @@ wrap_task! {
         fn execute(&self) {
             use std::cell::RefCell;
 
+            // Phase 1 diagnostic tracing — see
+            // docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md.
+            // Identify which exact CEF call wedges the UI thread under
+            // concurrent window creation.
+            let t0 = std::time::Instant::now();
+            tracing::info!(label = %self.label, "[create-window] task entered UI thread");
+
             let settings = BrowserSettings {
                 background_color: 0xFF000000,
                 ..Default::default()
@@ -279,9 +286,19 @@ wrap_task! {
             let client = browsers.values().next()
                 .and_then(|b| b.host().map(|h| h.client()));
             drop(browsers);
+            tracing::info!(
+                label = %self.label,
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[create-window] got client"
+            );
 
             let mut request_context = crate::commands::create_isolated_request_context(
                 &self.state, &self.label,
+            );
+            tracing::info!(
+                label = %self.label,
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[create-window] request_context resolved"
             );
 
             let mut client_ref = client.flatten();
@@ -296,6 +313,12 @@ wrap_task! {
                 request_context.as_mut(),
                 Some(&mut bv_delegate),
             );
+            tracing::info!(
+                label = %self.label,
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[create-window] browser_view_create returned"
+            );
+
             let mut wd = crate::app::AgentMuxWindowDelegate::new(
                 RefCell::new(browser_view),
                 Some((self.x, self.y, self.w, self.h)),
@@ -303,6 +326,11 @@ wrap_task! {
                 RuntimeStyle::ALLOY,
             );
             window_create_top_level(Some(&mut wd));
+            tracing::info!(
+                label = %self.label,
+                elapsed_us = t0.elapsed().as_micros() as u64,
+                "[create-window] window_create_top_level returned"
+            );
         }
     }
 }

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.578"
+version = "0.33.579"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.578"
+version = "0.33.579"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.578"
+version = "0.33.579"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.578",
+  "version": "0.33.579",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.578",
+      "version": "0.33.579",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.578",
+  "version": "0.33.579",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two changes from the 2026-05-02 freeze investigation, neither alone fixes the freeze but both ship real value:

**A — Pane WM_SETFOCUS cross-window guard + per-root rate limit** (\`agentmux-cef/src/pane/hwnd.rs\`):
The pane focus-redirect (\`SetFocus(GA_ROOT)\` to defeat JS \`window.focus()\`) can itself drive a foreground ping-pong between two top-level windows when both have pane content that programmatically requests focus. Two guards added:
- Cross-window refusal: skip the redirect if a *different* top-level HWND owns OS foreground per \`GetForegroundWindow()\`. Programmatic focus from page content shouldn't fight the AgentMux window the user is interacting with.
- Per-root rate limit: cap redirects at 1 per 100ms per root HWND.

**A2 — Synchronous host log init sentinel** (\`agentmux-cef/src/main.rs\`):
The pointer file at \`<log_dir>/current-host-v<version>.path\` previously pointed at a tracing_appender::rolling::daily file that didn't materialize until the non-blocking writer's first flush. Crashes between subscriber-setup and first flush left the pointer pointing at a missing file (observed during 0.33.579 investigation). Sentinel guarantees the file exists once init_logging runs past pointer-write — if it's missing afterwards, we know init_logging didn't get past that point, which is itself diagnostic.

**B — Phase 1 diagnostic tracing for window creation** (\`agentmux-cef/src/{commands/mod.rs, ui_tasks.rs, client.rs}\`):
Adds focused tracing across the three stages of top-level window creation to identify the exact line that silences the UI thread under concurrent load. Three instrumentation points:

1. \`create_isolated_request_context\` — entry, pre-call, and post-return spans around \`request_context_create_context\`.
2. \`CreateWindowTask::execute\` — per-stage \`elapsed_us\` across get-client, request_context resolved, browser_view_create returned, window_create_top_level returned.
3. \`on_after_created\` — tracing inside the gap between "Browser created" and "Registered browser" (where the dump analysis showed the UI thread silenced 2026-05-02), specifically around \`DequeuePendingWindowCreation\` dispatch and \`browsers\` lock acquisition.

Pure-additive logging on already-instrumented paths — no behavior change.

## Investigation context

Full evidence trail in:
- \`docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md\` — diagnostic spec covering the freeze investigation, why per-window-isolated RequestContext triggers it, and why the focus-redirect guard alone doesn't fix it (pane WM_SETFOCUS path doesn't run before the freeze).
- \`docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md\` — implementation plan for Phases 1-4 (this PR is Phase 1; the runner is in a follow-up PR).

The Phase 1 tracing landed alongside successful completion data: window creation typically takes 25-100ms total with \`request_context_create_context\` returning in 2.7-5.8ms (median ~3.6ms). The wedge — when it occurs — is in CEF's async browser-creation pipeline AFTER \`window_create_top_level\` returns, between Views handing off to Chromium and \`on_after_created\` firing. That's libcef.dll's renderer-spawn / browser-init machinery, confirmed by trace data on creation_id=6 in 0.33.582 testing.

## Test plan

- [x] cargo check -p agentmux-cef clean (warnings only, all pre-existing)
- [x] All existing reducer tests still pass (5/5)
- [x] Manual smoke: 0.33.580 + 0.33.581 portables built and validated; user opened multiple windows, no freeze in 0.33.581 testing
- [ ] Bot review (reagentx-workflow + codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)