### PR TITLE
feat(cef): host reducer-driven top-level window creation runner (Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.579"
+version = "0.33.580"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -207,6 +207,35 @@ impl AgentMuxHandler {
 
         let is_top_level_window = !label.starts_with("browser-pane-");
 
+        // Phase 2 — release the runner's in-flight slot so the next queued
+        // top-level can start. We use on_after_created as the renderer-ready
+        // signal because the CEF Chrome profile-init competition (the actual
+        // cause of the freeze) is past this point — the renderer process is
+        // alive and registered. The frontend may still be loading its JS
+        // bundle, but that doesn't compete for the resource we're guarding.
+        //
+        // Pool / pane / synthesized fallback labels: skip — only the
+        // runner-managed `window-*` labels (top-level FullInstance/Subwindow)
+        // were enqueued via EnqueueTopLevelWindow. The label-mismatch path
+        // in MarkTopLevelRendererReady would no-op anyway, but skipping
+        // here avoids the dispatch noise.
+        if is_top_level_window && !label.starts_with("window-pool-") {
+            self.state.host_dispatch(
+                crate::reducer::HostCommand::MarkTopLevelRendererReady {
+                    label: label.clone(),
+                },
+            );
+        } else if label.starts_with("window-pool-") {
+            // Pool windows ARE managed by the runner now (we route them
+            // through EnqueueTopLevelWindow in spawn_pool_window). Same
+            // signal applies.
+            self.state.host_dispatch(
+                crate::reducer::HostCommand::MarkTopLevelRendererReady {
+                    label: label.clone(),
+                },
+            );
+        }
+
         // Phase B.5 (window_meta step d, refined) — write host's
         // local `window_meta` ONCE here, synchronously from the
         // popped pending entry. This is no longer the authoritative

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -618,22 +618,39 @@ fn open_window_with_kind(
     let (pos_x, pos_y) = get_offset_position();
     let (win_w, win_h) = get_secondary_window_size(pos_x, pos_y);
 
-    // Phase F.1 — routed through the host reducer.
+    // Phase F.1 — pre-create handoff (kind/parent metadata) for
+    // on_after_created. This queue is consumed by client::on_after_created
+    // when CEF reports the new browser; the reducer pops the matching
+    // entry to populate window_meta + emit ReportWindowOpened.
     state.host_dispatch(
         crate::reducer::HostCommand::EnqueuePendingWindowCreation {
             entry: crate::state::PendingWindowCreation {
                 label: label.clone(),
                 kind,
-                parent_instance_id,
+                parent_instance_id: parent_instance_id.clone(),
             },
         },
     );
 
-    // Post to CEF UI thread — window_create_top_level must run there.
-    // true = frameless: secondary app windows use the same custom title bar as main.
-    crate::ui_tasks::post_create_window(
-        state, &url, &label, pos_x, pos_y, win_w, win_h,
-        true,
+    // Phase 2 — request top-level creation through the runner. The reducer
+    // serializes (one in-flight at a time) so we don't trigger the CEF v146
+    // Chrome profile-init deadlock under concurrent load. Effects executor
+    // calls `post_create_window` when the in-flight slot is free; the
+    // 30s watchdog evicts wedged inits so the queue advances.
+    state.host_dispatch_with_effects(
+        crate::reducer::HostCommand::EnqueueTopLevelWindow {
+            request: crate::state::TopLevelCreationRequest {
+                label: label.clone(),
+                kind,
+                parent_instance_id,
+                url,
+                pos: (pos_x, pos_y),
+                size: (win_w, win_h),
+                // true = frameless: secondary app windows use the same
+                // custom title bar as main.
+                frameless: true,
+            },
+        },
     );
 
     // Phase B.7.3.3 — typed launcher events drive InstancePanel

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -133,11 +133,10 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
         base_url, separator, ipc_port, ipc_token, label
     );
 
-    // Phase B.5 (window_meta step d) — combined pre-create handoff.
-    // Pool windows graduate to tear-off destinations, which are
-    // FullInstance from the user's perspective.
-    //
-    // Phase F.1 — routed through the host reducer.
+    // Phase B.5 (window_meta step d) — combined pre-create handoff
+    // (kind + parent metadata for on_after_created). Pool windows
+    // graduate to tear-off destinations, which are FullInstance from
+    // the user's perspective.
     state.host_dispatch(
         crate::reducer::HostCommand::EnqueuePendingWindowCreation {
             entry: crate::state::PendingWindowCreation {
@@ -154,19 +153,26 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
         "[pool] spawning pool window"
     );
 
-    // Spawn at off-screen coords. The window is technically
-    // visible (frameless) but well outside any monitor bounds, so
-    // the user never sees it; CEF still paints it because Windows
-    // considers it a normal HWND.
-    crate::ui_tasks::post_create_window(
-        state,
-        &url,
-        &label,
-        POOL_OFFSCREEN_X,
-        POOL_OFFSCREEN_Y,
-        POOL_WIDTH,
-        POOL_HEIGHT,
-        true,
+    // Phase 2 — request top-level creation through the runner. Pool
+    // windows are created at off-screen coords (frameless, technically
+    // visible but well outside any monitor bounds, so the user never
+    // sees them; CEF still paints because Windows treats them as
+    // normal HWNDs). Going through the runner means pool spawns are
+    // serialized too — important because pool refill triggers right
+    // after promotion, which is exactly the concurrent-creation
+    // scenario that triggered the freeze.
+    state.host_dispatch_with_effects(
+        crate::reducer::HostCommand::EnqueueTopLevelWindow {
+            request: crate::state::TopLevelCreationRequest {
+                label: label.clone(),
+                kind: WindowKind::FullInstance,
+                parent_instance_id: None,
+                url,
+                pos: (POOL_OFFSCREEN_X, POOL_OFFSCREEN_Y),
+                size: (POOL_WIDTH, POOL_HEIGHT),
+                frameless: true,
+            },
+        },
     );
 
     // The window registers in `state.browsers` via on_after_created

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -40,6 +40,7 @@ mod saga_dispatch;
 mod sidecar;
 mod state;
 mod ui_tasks;
+mod window_creation_watchdog;
 mod wrr;
 
 use std::sync::Arc;
@@ -245,6 +246,14 @@ fn main() {
     // doesn't set `AGENTMUX_SRV_PIPE_PATH` — host runs without the
     // bridge, frontend uses the legacy waveobj:update path.
     let _srv_ipc = runtime.block_on(srv_ipc::connect_to_srv(app_state.clone()));
+
+    // Phase 2 — top-level window creation watchdog. Wakes at the in-flight
+    // creation's deadline (or every 5s when idle), evicts stalled creations
+    // so the runner queue advances. See
+    // `docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md`.
+    runtime.block_on(async {
+        window_creation_watchdog::spawn_watchdog(app_state.clone());
+    });
 
     // Phase B.1: if launcher already spawned srv (the normal portable
     // / installed path post-PR-#570 + B.1), populate state from the

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -28,8 +28,27 @@
 // pipe just to satisfy a pattern that has no current consumer.
 
 use std::collections::VecDeque;
+use std::time::{Duration, Instant};
 
-use crate::state::PendingWindowCreation;
+use crate::state::{
+    CompletedTopLevelCreation, InFlightTopLevelCreation, PendingWindowCreation,
+    TopLevelCreationOutcome, TopLevelCreationPhase, TopLevelCreationRequest,
+};
+
+/// Per-creation deadline. A wedged CEF profile init or a hung renderer is
+/// evicted after this many seconds and the queue advances. 30s is generous
+/// enough to absorb realistic profile-init latency under load while still
+/// bounding the worst case where today the freeze is unbounded.
+///
+/// Future: make configurable via `~/.agentmux/config.toml` — see
+/// `docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md` §"Configurable
+/// knobs". For now, hard-coded.
+pub const TOP_LEVEL_CREATION_DEADLINE: Duration = Duration::from_secs(30);
+
+/// History ring buffer cap. Old entries evicted FIFO when this is reached.
+/// Sized so `--diag windows` shows enough recent activity to be useful
+/// without growing `HostState` unboundedly.
+pub const TOP_LEVEL_CREATION_HISTORY_CAP: usize = 50;
 
 /// Lifecycle phase of the host reducer. Mirrors the launcher and srv
 /// reducers' phase enum.
@@ -65,6 +84,34 @@ pub struct HostState {
     ///   never has a corresponding entry here.
     pub pending_window_creations: VecDeque<PendingWindowCreation>,
 
+    // ── Phase 2 (window-creation runner) ─────────────────────────────────
+    // Serializes top-level window creation through a single in-flight slot
+    // with a watchdog deadline. Routes around the CEF v146 Chrome profile-
+    // init deadlock under concurrent load (see freeze investigation
+    // 2026-05-02).
+    //
+    // Pane creation does NOT use these fields — pane code paths still
+    // enqueue/dequeue through `pending_window_creations` only.
+
+    /// Queue of top-level window creation requests waiting to start.
+    /// Producer: `EnqueueTopLevelWindow`. Consumer: `StartNextTopLevelIfIdle`
+    /// (auto-emitted by Enqueue when the in-flight slot is empty, and by
+    /// `MarkTopLevelRendererReady` / `TopLevelTimeoutTick` /
+    /// `AbortInFlightTopLevel` when an in-flight completes).
+    pub top_level_creation_queue: VecDeque<TopLevelCreationRequest>,
+
+    /// The creation currently being processed by CEF, or `None` if idle.
+    /// Singleton invariant — the reducer enforces at most one across all
+    /// arms.
+    pub in_flight_top_level_creation: Option<InFlightTopLevelCreation>,
+
+    /// Ring buffer of completed top-level creations (any outcome). Capped
+    /// at `TOP_LEVEL_CREATION_HISTORY_CAP`; oldest evicted FIFO.
+    pub top_level_creation_history: VecDeque<CompletedTopLevelCreation>,
+
+    /// Monotonic id allocator for `creation_id` in `InFlightTopLevelCreation`.
+    pub next_top_level_creation_id: u64,
+
     /// Lifecycle phase. `Running` is the operating state; the others
     /// gate command acceptance.
     pub lifecycle: HostLifecyclePhase,
@@ -78,6 +125,10 @@ impl Default for HostState {
     fn default() -> Self {
         Self {
             pending_window_creations: VecDeque::new(),
+            top_level_creation_queue: VecDeque::new(),
+            in_flight_top_level_creation: None,
+            top_level_creation_history: VecDeque::new(),
+            next_top_level_creation_id: 0,
             // Boot directly into Running — nothing in F.1 needs the
             // pre-init guard yet. Future PRs (drag, tear-off hooks)
             // will move boot through Bootstrapping → Running.
@@ -110,6 +161,46 @@ pub enum HostCommand {
     /// Consumer side of the queue (replaces
     /// `client.rs::on_after_created`'s direct `pop_front`).
     DequeuePendingWindowCreation,
+
+    // ── Phase 2 (window-creation runner) ─────────────────────────────────
+
+    /// Append a top-level window creation request to the runner queue. If
+    /// the in-flight slot is empty, the reducer auto-emits
+    /// `BeginTopLevelCreationEffect` for this request (and pops it from
+    /// the queue into the in-flight slot). If busy, it just queues.
+    EnqueueTopLevelWindow { request: TopLevelCreationRequest },
+
+    /// Try to start the next queued request. No-op if the in-flight slot
+    /// is occupied or the queue is empty. Auto-dispatched internally by
+    /// the reducer after Enqueue / RendererReady / TimeoutTick / Abort —
+    /// callers don't normally dispatch this directly.
+    StartNextTopLevelIfIdle,
+
+    /// Move the in-flight phase forward (Started → BrowserCallbackFired →
+    /// RendererReady). Refuses regression. Dispatched by lifecycle
+    /// observers (e.g., `client::on_after_created` advances to
+    /// BrowserCallbackFired).
+    AdvanceTopLevelPhase {
+        label: String,
+        phase: TopLevelCreationPhase,
+    },
+
+    /// Mark the in-flight top-level creation as completed and advance the
+    /// queue. Dispatched by `client::on_after_created` after
+    /// `Registered browser` (post-renderer-init for our purposes — the
+    /// CEF profile-init competition is past at that point).
+    MarkTopLevelRendererReady { label: String },
+
+    /// Watchdog tick — checks whether the in-flight creation has exceeded
+    /// its deadline. If yes, evicts the in-flight slot, archives it as
+    /// `TimedOut`, and auto-advances the queue. If no in-flight or not
+    /// past deadline, no-op.
+    TopLevelTimeoutTick { now: Instant },
+
+    /// Explicit abort of the in-flight creation. Used by saga compensation
+    /// paths (Phase 3). Archives the in-flight slot as `Aborted` and
+    /// auto-advances the queue.
+    AbortInFlightTopLevel { reason: String },
 }
 
 /// Events emitted by the host reducer.
@@ -143,6 +234,50 @@ pub enum HostEvent {
     /// synthesize a UUID-labelled FullInstance entry).
     PendingWindowQueueEmpty { version: u64 },
 
+    // ── Phase 2 (window-creation runner) ─────────────────────────────────
+
+    /// Side-effect bearer: the effect handler should call
+    /// `ui_tasks::post_create_window` for this request. Emitted by the
+    /// reducer when an `EnqueueTopLevelWindow` finds the in-flight slot
+    /// empty, or when an in-flight terminal advances the queue.
+    BeginTopLevelCreationEffect {
+        creation_id: u64,
+        request: TopLevelCreationRequest,
+        version: u64,
+    },
+
+    /// In-flight creation reached `RendererReady` and was archived.
+    TopLevelCreationCompleted {
+        creation_id: u64,
+        label: String,
+        latency_ms: u64,
+        version: u64,
+    },
+
+    /// In-flight creation exceeded its deadline; archived as TimedOut.
+    /// The wedged renderer/browser is leaked from our perspective —
+    /// recoverable across restarts. Operator-visible via `--diag windows`
+    /// (Phase 3).
+    TopLevelCreationTimedOut {
+        creation_id: u64,
+        label: String,
+        last_phase: TopLevelCreationPhase,
+        elapsed_ms: u64,
+        version: u64,
+    },
+
+    /// In-flight creation was explicitly aborted (saga compensation path).
+    TopLevelCreationAborted {
+        creation_id: u64,
+        label: String,
+        reason: String,
+        version: u64,
+    },
+
+    /// Top-level creation queue length changed. Diagnostic — for spotting
+    /// pile-ups under load.
+    TopLevelQueueLengthChanged { len: usize, version: u64 },
+
     /// A command was rejected. Mirrors `Event::Error` in srv/launcher
     /// reducers — kept generic for future arms.
     Error { message: String, version: u64 },
@@ -174,6 +309,20 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         }
         HostCommand::DequeuePendingWindowCreation => {
             handle_dequeue_pending_window_creation(state)
+        }
+        HostCommand::EnqueueTopLevelWindow { request } => {
+            handle_enqueue_top_level(state, request)
+        }
+        HostCommand::StartNextTopLevelIfIdle => handle_start_next_top_level(state),
+        HostCommand::AdvanceTopLevelPhase { label, phase } => {
+            handle_advance_top_level_phase(state, label, phase)
+        }
+        HostCommand::MarkTopLevelRendererReady { label } => {
+            handle_mark_top_level_renderer_ready(state, label)
+        }
+        HostCommand::TopLevelTimeoutTick { now } => handle_top_level_timeout_tick(state, now),
+        HostCommand::AbortInFlightTopLevel { reason } => {
+            handle_abort_in_flight_top_level(state, reason)
         }
     }
 }
@@ -231,6 +380,214 @@ fn handle_dequeue_pending_window_creation(state: &mut HostState) -> DispatchOutp
             }
         }
     }
+}
+
+// ── Phase 2 (window-creation runner) reducer arms ────────────────────────
+
+fn handle_enqueue_top_level(
+    state: &mut HostState,
+    request: TopLevelCreationRequest,
+) -> DispatchOutput {
+    if state.lifecycle == HostLifecyclePhase::ShuttingDown {
+        let v = state.bump_version();
+        return DispatchOutput {
+            events: vec![HostEvent::Error {
+                message: "enqueue_top_level_window: host is shutting down".to_string(),
+                version: v,
+            }],
+            dequeued: None,
+        };
+    }
+    state.top_level_creation_queue.push_back(request);
+    let len = state.top_level_creation_queue.len();
+    let v = state.bump_version();
+    let mut out = DispatchOutput {
+        events: vec![HostEvent::TopLevelQueueLengthChanged { len, version: v }],
+        dequeued: None,
+    };
+    // Auto-advance: if we're idle, fire the start now. Inline so callers
+    // see all emitted events (BeginTopLevelCreationEffect) on the same
+    // dispatch return.
+    if state.in_flight_top_level_creation.is_none() {
+        let next = handle_start_next_top_level(state);
+        out.events.extend(next.events);
+    }
+    out
+}
+
+fn handle_start_next_top_level(state: &mut HostState) -> DispatchOutput {
+    if state.in_flight_top_level_creation.is_some() {
+        // Already busy. No-op.
+        return DispatchOutput::default();
+    }
+    let request = match state.top_level_creation_queue.pop_front() {
+        Some(r) => r,
+        None => return DispatchOutput::default(),
+    };
+    state.next_top_level_creation_id = state.next_top_level_creation_id.wrapping_add(1);
+    let creation_id = state.next_top_level_creation_id;
+    let now = Instant::now();
+    state.in_flight_top_level_creation = Some(InFlightTopLevelCreation {
+        creation_id,
+        label: request.label.clone(),
+        started_at: now,
+        phase: TopLevelCreationPhase::Started,
+        deadline: now + TOP_LEVEL_CREATION_DEADLINE,
+    });
+    let v = state.bump_version();
+    let queue_len = state.top_level_creation_queue.len();
+    DispatchOutput {
+        events: vec![
+            HostEvent::BeginTopLevelCreationEffect {
+                creation_id,
+                request,
+                version: v,
+            },
+            HostEvent::TopLevelQueueLengthChanged {
+                len: queue_len,
+                version: state.bump_version(),
+            },
+        ],
+        dequeued: None,
+    }
+}
+
+fn handle_advance_top_level_phase(
+    state: &mut HostState,
+    label: String,
+    phase: TopLevelCreationPhase,
+) -> DispatchOutput {
+    if let Some(ref mut inflight) = state.in_flight_top_level_creation {
+        if inflight.label == label && phase > inflight.phase {
+            inflight.phase = phase;
+        }
+    }
+    // No event emission — pure state mutation for diag visibility. (Phase
+    // 3 may add an event for saga subscribers.)
+    DispatchOutput::default()
+}
+
+fn handle_mark_top_level_renderer_ready(state: &mut HostState, label: String) -> DispatchOutput {
+    let inflight = match state.in_flight_top_level_creation.as_ref() {
+        Some(c) if c.label == label => state.in_flight_top_level_creation.take().unwrap(),
+        _ => {
+            // Mismatched label or no in-flight. Ignore — could be a stale
+            // signal from a previously-evicted (timed-out) creation.
+            return DispatchOutput::default();
+        }
+    };
+    let now = Instant::now();
+    let latency_ms = now.duration_since(inflight.started_at).as_millis() as u64;
+    let v_completed = state.bump_version();
+    let completed_event = HostEvent::TopLevelCreationCompleted {
+        creation_id: inflight.creation_id,
+        label: inflight.label.clone(),
+        latency_ms,
+        version: v_completed,
+    };
+    push_top_level_history(
+        state,
+        CompletedTopLevelCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            outcome: TopLevelCreationOutcome::Completed,
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase: TopLevelCreationPhase::RendererReady,
+        },
+    );
+    let mut out = DispatchOutput {
+        events: vec![completed_event],
+        dequeued: None,
+    };
+    // Auto-advance: try to start the next queued request.
+    let next = handle_start_next_top_level(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn handle_top_level_timeout_tick(state: &mut HostState, now: Instant) -> DispatchOutput {
+    let should_evict = matches!(
+        state.in_flight_top_level_creation.as_ref(),
+        Some(c) if now >= c.deadline
+    );
+    if !should_evict {
+        return DispatchOutput::default();
+    }
+    let inflight = state.in_flight_top_level_creation.take().unwrap();
+    let elapsed_ms = now.duration_since(inflight.started_at).as_millis() as u64;
+    let last_phase = inflight.phase;
+    let v = state.bump_version();
+    let timed_out_event = HostEvent::TopLevelCreationTimedOut {
+        creation_id: inflight.creation_id,
+        label: inflight.label.clone(),
+        last_phase,
+        elapsed_ms,
+        version: v,
+    };
+    push_top_level_history(
+        state,
+        CompletedTopLevelCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            outcome: TopLevelCreationOutcome::TimedOut {
+                reason: format!("exceeded {}s deadline at phase {:?}", TOP_LEVEL_CREATION_DEADLINE.as_secs(), last_phase),
+            },
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase,
+        },
+    );
+    let mut out = DispatchOutput {
+        events: vec![timed_out_event],
+        dequeued: None,
+    };
+    // Critical: advance queue even on timeout. A wedged CEF init must not
+    // permanently block the queue.
+    let next = handle_start_next_top_level(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn handle_abort_in_flight_top_level(state: &mut HostState, reason: String) -> DispatchOutput {
+    let inflight = match state.in_flight_top_level_creation.take() {
+        Some(c) => c,
+        None => return DispatchOutput::default(),
+    };
+    let now = Instant::now();
+    let last_phase = inflight.phase;
+    let v = state.bump_version();
+    let aborted_event = HostEvent::TopLevelCreationAborted {
+        creation_id: inflight.creation_id,
+        label: inflight.label.clone(),
+        reason: reason.clone(),
+        version: v,
+    };
+    push_top_level_history(
+        state,
+        CompletedTopLevelCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            outcome: TopLevelCreationOutcome::Aborted { reason },
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase,
+        },
+    );
+    let mut out = DispatchOutput {
+        events: vec![aborted_event],
+        dequeued: None,
+    };
+    let next = handle_start_next_top_level(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn push_top_level_history(state: &mut HostState, entry: CompletedTopLevelCreation) {
+    if state.top_level_creation_history.len() >= TOP_LEVEL_CREATION_HISTORY_CAP {
+        state.top_level_creation_history.pop_front();
+    }
+    state.top_level_creation_history.push_back(entry);
 }
 
 #[cfg(test)]
@@ -322,6 +679,11 @@ mod tests {
             HostEvent::PendingWindowEnqueued { version, .. } => *version,
             HostEvent::PendingWindowDequeued { version, .. } => *version,
             HostEvent::PendingWindowQueueEmpty { version } => *version,
+            HostEvent::BeginTopLevelCreationEffect { version, .. } => *version,
+            HostEvent::TopLevelCreationCompleted { version, .. } => *version,
+            HostEvent::TopLevelCreationTimedOut { version, .. } => *version,
+            HostEvent::TopLevelCreationAborted { version, .. } => *version,
+            HostEvent::TopLevelQueueLengthChanged { version, .. } => *version,
             HostEvent::Error { version, .. } => *version,
         };
         let v1 = extract_version(&out1.events);
@@ -329,5 +691,360 @@ mod tests {
         let v3 = extract_version(&out3.events);
         assert!(v1 < v2);
         assert!(v2 < v3);
+    }
+
+    // ── Phase 2 (window-creation runner) tests ───────────────────────────
+
+    fn top_level_request(label: &str) -> TopLevelCreationRequest {
+        TopLevelCreationRequest {
+            label: label.to_string(),
+            kind: WindowKind::FullInstance,
+            parent_instance_id: None,
+            url: format!("https://example.test/{}", label),
+            pos: (0, 0),
+            size: (800, 600),
+            frameless: true,
+        }
+    }
+
+    #[test]
+    fn enqueue_when_idle_starts_creation_immediately() {
+        let mut state = HostState::default();
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        assert!(state.in_flight_top_level_creation.is_some());
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "a"
+        );
+        let begin_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::BeginTopLevelCreationEffect { .. }))
+            .count();
+        assert_eq!(begin_count, 1, "should emit exactly one BeginTopLevelCreationEffect");
+    }
+
+    #[test]
+    fn enqueue_when_busy_only_queues() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        assert!(state.in_flight_top_level_creation.is_some());
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b"),
+            },
+        );
+        assert_eq!(state.top_level_creation_queue.len(), 1, "b still queued");
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "a",
+            "a still in-flight"
+        );
+        let begin_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::BeginTopLevelCreationEffect { .. }))
+            .count();
+        assert_eq!(begin_count, 0, "no second start while busy");
+    }
+
+    #[test]
+    fn renderer_ready_advances_queue() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b"),
+            },
+        );
+        let out = update(
+            &mut state,
+            HostCommand::MarkTopLevelRendererReady {
+                label: "a".into(),
+            },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "b",
+            "b now in-flight"
+        );
+        assert_eq!(
+            state.top_level_creation_history.back().unwrap().label,
+            "a",
+            "a archived to history"
+        );
+        let completed_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::TopLevelCreationCompleted { .. }))
+            .count();
+        assert_eq!(completed_count, 1);
+        let begin_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::BeginTopLevelCreationEffect { .. }))
+            .count();
+        assert_eq!(begin_count, 1, "next request auto-started");
+    }
+
+    #[test]
+    fn timeout_tick_evicts_and_advances_queue() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b"),
+            },
+        );
+        let deadline = state
+            .in_flight_top_level_creation
+            .as_ref()
+            .unwrap()
+            .deadline;
+        let past_deadline = deadline + Duration::from_millis(1);
+        let out = update(
+            &mut state,
+            HostCommand::TopLevelTimeoutTick { now: past_deadline },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "b",
+            "queue advanced after timeout"
+        );
+        assert!(matches!(
+            state.top_level_creation_history.back().unwrap().outcome,
+            TopLevelCreationOutcome::TimedOut { .. }
+        ));
+        let timed_out_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::TopLevelCreationTimedOut { .. }))
+            .count();
+        assert_eq!(timed_out_count, 1);
+    }
+
+    #[test]
+    fn timeout_tick_before_deadline_is_noop() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        let well_before = state
+            .in_flight_top_level_creation
+            .as_ref()
+            .unwrap()
+            .started_at;
+        let out = update(
+            &mut state,
+            HostCommand::TopLevelTimeoutTick { now: well_before },
+        );
+        assert!(state.in_flight_top_level_creation.is_some(), "still in-flight");
+        assert!(state.top_level_creation_history.is_empty());
+        assert!(
+            out.events.is_empty(),
+            "no events from before-deadline tick"
+        );
+    }
+
+    #[test]
+    fn renderer_ready_with_wrong_label_is_noop() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        let out = update(
+            &mut state,
+            HostCommand::MarkTopLevelRendererReady {
+                label: "wrong".into(),
+            },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "a"
+        );
+        assert!(out.events.is_empty());
+    }
+
+    #[test]
+    fn abort_evicts_and_advances() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b"),
+            },
+        );
+        let out = update(
+            &mut state,
+            HostCommand::AbortInFlightTopLevel {
+                reason: "test reason".into(),
+            },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().label,
+            "b"
+        );
+        assert!(matches!(
+            state.top_level_creation_history.back().unwrap().outcome,
+            TopLevelCreationOutcome::Aborted { .. }
+        ));
+        let aborted_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(e, HostEvent::TopLevelCreationAborted { .. }))
+            .count();
+        assert_eq!(aborted_count, 1);
+    }
+
+    #[test]
+    fn history_caps_at_50() {
+        let mut state = HostState::default();
+        for i in 0..60 {
+            let label = format!("w{}", i);
+            update(
+                &mut state,
+                HostCommand::EnqueueTopLevelWindow {
+                    request: top_level_request(&label),
+                },
+            );
+            update(
+                &mut state,
+                HostCommand::MarkTopLevelRendererReady { label },
+            );
+        }
+        assert_eq!(
+            state.top_level_creation_history.len(),
+            TOP_LEVEL_CREATION_HISTORY_CAP
+        );
+        assert_eq!(
+            state.top_level_creation_history.front().unwrap().label,
+            "w10",
+            "oldest 10 evicted (60 created, cap 50)"
+        );
+        assert_eq!(
+            state.top_level_creation_history.back().unwrap().label,
+            "w59"
+        );
+    }
+
+    #[test]
+    fn advance_phase_refuses_regression() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        // Started → BrowserCallbackFired
+        update(
+            &mut state,
+            HostCommand::AdvanceTopLevelPhase {
+                label: "a".into(),
+                phase: TopLevelCreationPhase::BrowserCallbackFired,
+            },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().phase,
+            TopLevelCreationPhase::BrowserCallbackFired
+        );
+        // Try to regress to Started — should be ignored.
+        update(
+            &mut state,
+            HostCommand::AdvanceTopLevelPhase {
+                label: "a".into(),
+                phase: TopLevelCreationPhase::Started,
+            },
+        );
+        assert_eq!(
+            state.in_flight_top_level_creation.as_ref().unwrap().phase,
+            TopLevelCreationPhase::BrowserCallbackFired,
+            "phase did not regress"
+        );
+    }
+
+    #[test]
+    fn enqueue_top_level_during_shutdown_is_rejected() {
+        let mut state = HostState::default();
+        state.lifecycle = HostLifecyclePhase::ShuttingDown;
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a"),
+            },
+        );
+        assert!(matches!(out.events.as_slice(), [HostEvent::Error { .. }]));
+        assert!(state.in_flight_top_level_creation.is_none());
+        assert!(state.top_level_creation_queue.is_empty());
+    }
+
+    #[test]
+    fn singleton_invariant_under_random_actions() {
+        // Mini fuzz: hammer the reducer with a fixed-but-mixed sequence
+        // and assert the in-flight singleton invariant + queue advancement
+        // are both preserved.
+        let mut state = HostState::default();
+        let labels = ["a", "b", "c", "d", "e"];
+        for label in labels {
+            update(
+                &mut state,
+                HostCommand::EnqueueTopLevelWindow {
+                    request: top_level_request(label),
+                },
+            );
+            // After every enqueue, exactly one in-flight if queue+inflight
+            // > 0.
+            let total = state.top_level_creation_queue.len()
+                + state.in_flight_top_level_creation.iter().count();
+            assert!(total > 0);
+            assert!(state.in_flight_top_level_creation.is_some());
+        }
+        // Drain by alternating ready + timeout.
+        while state.in_flight_top_level_creation.is_some() {
+            let label = state
+                .in_flight_top_level_creation
+                .as_ref()
+                .unwrap()
+                .label
+                .clone();
+            update(&mut state, HostCommand::MarkTopLevelRendererReady { label });
+        }
+        assert!(state.top_level_creation_queue.is_empty());
+        assert_eq!(state.top_level_creation_history.len(), 5);
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -107,6 +107,87 @@ pub struct PendingWindowCreation {
     pub parent_instance_id: Option<String>,
 }
 
+// ── Phase 2 (window-creation runner) ─────────────────────────────────────
+// Types parallel to `PendingWindowCreation` but specific to TOP-LEVEL window
+// creation, which goes through the runner (serialized one-at-a-time with a
+// watchdog deadline). Browser PANES do NOT use these — pane creation is fast
+// and safe (shared parent context, no profile init) and stays on the existing
+// `pending_window_creations` queue path.
+//
+// See `docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md` for the full
+// design + rationale (the freeze investigation 2026-05-02 traced the deadlock
+// to concurrent CEF Chrome profile-init under load; this serialization routes
+// around it without dropping per-window renderer isolation).
+
+/// A top-level window creation request, queued by `EnqueueTopLevelWindow`
+/// and processed one-at-a-time by the host reducer's runner. Carries the
+/// FULL spec needed for `post_create_window` so the reducer's effect
+/// handler can issue the CEF UI task without a separate lookup.
+#[derive(Clone, Debug)]
+pub struct TopLevelCreationRequest {
+    pub label: String,
+    pub kind: WindowKind,
+    pub parent_instance_id: Option<String>,
+    pub url: String,
+    pub pos: (i32, i32),
+    pub size: (i32, i32),
+    pub frameless: bool,
+}
+
+/// A top-level window creation that is currently being processed by CEF.
+/// Singleton invariant: the host reducer ensures at most one is in-flight
+/// at any time (the whole point of the runner).
+#[derive(Clone, Debug)]
+pub struct InFlightTopLevelCreation {
+    pub creation_id: u64,
+    pub label: String,
+    pub started_at: std::time::Instant,
+    pub phase: TopLevelCreationPhase,
+    pub deadline: std::time::Instant,
+}
+
+/// Phase progression of an in-flight top-level creation. Monotonic — phases
+/// are assigned numeric values so `AdvanceTopLevelPhase` can refuse to
+/// regress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum TopLevelCreationPhase {
+    /// `BeginTopLevelCreationEffect` emitted; effect handler has not yet
+    /// posted the CEF UI task. (Transient — usually <1ms.)
+    Started = 0,
+    /// CEF `on_after_created` callback fired — Browser exists, browsers
+    /// map registered the new entry. The renderer-process IPC chatter
+    /// from profile init is past this point.
+    BrowserCallbackFired = 1,
+    /// Frontend / on_after_created signaled the renderer is sufficiently
+    /// initialized to release the in-flight slot. Equivalent to
+    /// `MarkTopLevelRendererReady` in the reducer.
+    RendererReady = 2,
+}
+
+/// History entry for a completed top-level creation. Pushed to the
+/// reducer's ring buffer (cap 50) so `--diag windows` can show recent
+/// activity.
+#[derive(Clone, Debug)]
+pub struct CompletedTopLevelCreation {
+    pub creation_id: u64,
+    pub label: String,
+    pub outcome: TopLevelCreationOutcome,
+    pub started_at: std::time::Instant,
+    pub finished_at: std::time::Instant,
+    pub last_phase: TopLevelCreationPhase,
+}
+
+/// Outcome of a completed top-level creation. `TimedOut` is the watchdog
+/// path; `Aborted` is explicit abort (e.g., from a saga compensation
+/// path); `Completed` is the normal-flow happy path.
+#[derive(Clone, Debug)]
+pub enum TopLevelCreationOutcome {
+    Completed,
+    TimedOut { reason: String },
+    Aborted { reason: String },
+}
+
 /// Shared application state for the CEF host.
 ///
 /// Unlike the Tauri version, this uses `Arc<AppState>` directly instead of
@@ -389,6 +470,57 @@ impl AppState {
         out
     }
 
+    /// Phase 2 — dispatch a command and run the side-effects emitted by
+    /// the reducer.
+    ///
+    /// `host_dispatch` returns events but doesn't act on them (snapshot-
+    /// and-drop discipline keeps the reducer pure). For commands like
+    /// `EnqueueTopLevelWindow` whose emitted events include a
+    /// `BeginTopLevelCreationEffect` that requires posting a CEF UI task,
+    /// callers use this wrapper instead. The wrapper:
+    ///
+    /// 1. Calls `host_dispatch` (locks reducer mutex briefly, mutates
+    ///    state, returns events).
+    /// 2. Iterates events looking for effect-bearing variants and runs
+    ///    their side-effects with the reducer mutex DROPPED — so the
+    ///    side-effect (which may post a CEF task that eventually calls
+    ///    back into the reducer) cannot deadlock.
+    ///
+    /// Use `host_dispatch` for read-style commands and pure mutations;
+    /// use this for commands that emit `BeginTopLevelCreationEffect`.
+    pub fn host_dispatch_with_effects(
+        self: &std::sync::Arc<Self>,
+        cmd: crate::reducer::HostCommand,
+    ) -> crate::reducer::DispatchOutput {
+        let out = self.host_dispatch(cmd);
+        for ev in &out.events {
+            if let crate::reducer::HostEvent::BeginTopLevelCreationEffect {
+                creation_id,
+                request,
+                ..
+            } = ev
+            {
+                tracing::info!(
+                    creation_id = %creation_id,
+                    label = %request.label,
+                    kind = ?request.kind,
+                    "[runner] dispatching CEF create-window task"
+                );
+                crate::ui_tasks::post_create_window(
+                    self,
+                    &request.url,
+                    &request.label,
+                    request.pos.0,
+                    request.pos.1,
+                    request.size.0,
+                    request.size.1,
+                    request.frameless,
+                );
+            }
+        }
+        out
+    }
+
     /// Phase F.1 — non-mutating peek at the back of the
     /// `pending_window_creations` queue.
     ///
@@ -521,6 +653,68 @@ fn log_host_event(ev: &crate::reducer::HostEvent) {
             event = "PendingWindowQueueEmpty",
             version,
             "[host-reducer] dequeue on empty queue — caller will fall back",
+        ),
+        HostEvent::BeginTopLevelCreationEffect {
+            creation_id,
+            request,
+            version,
+        } => tracing::info!(
+            target: "host-reducer",
+            event = "BeginTopLevelCreationEffect",
+            creation_id,
+            label = %request.label,
+            version,
+            "[host-reducer] begin top-level creation",
+        ),
+        HostEvent::TopLevelCreationCompleted {
+            creation_id,
+            label,
+            latency_ms,
+            version,
+        } => tracing::info!(
+            target: "host-reducer",
+            event = "TopLevelCreationCompleted",
+            creation_id,
+            label = %label,
+            latency_ms,
+            version,
+            "[host-reducer] top-level creation completed",
+        ),
+        HostEvent::TopLevelCreationTimedOut {
+            creation_id,
+            label,
+            last_phase,
+            elapsed_ms,
+            version,
+        } => tracing::error!(
+            target: "host-reducer",
+            event = "TopLevelCreationTimedOut",
+            creation_id,
+            label = %label,
+            last_phase = ?last_phase,
+            elapsed_ms,
+            version,
+            "[host-reducer] top-level creation timed out — wedged init evicted, queue advanced",
+        ),
+        HostEvent::TopLevelCreationAborted {
+            creation_id,
+            label,
+            reason,
+            version,
+        } => tracing::warn!(
+            target: "host-reducer",
+            event = "TopLevelCreationAborted",
+            creation_id,
+            label = %label,
+            reason = %reason,
+            version,
+            "[host-reducer] top-level creation aborted",
+        ),
+        HostEvent::TopLevelQueueLengthChanged { len, version } => tracing::debug!(
+            target: "host-reducer",
+            event = "TopLevelQueueLengthChanged",
+            len,
+            version,
         ),
         HostEvent::Error { message, version } => tracing::warn!(
             target: "host-reducer",

--- a/agentmux-cef/src/window_creation_watchdog.rs
+++ b/agentmux-cef/src/window_creation_watchdog.rs
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase 2 — top-level window creation watchdog.
+//
+// Wakes at the in-flight creation's deadline (or every 5s when idle) and
+// dispatches `TopLevelTimeoutTick` to the host reducer. The reducer either:
+//   - Finds the in-flight slot empty or under-deadline → no-op; or
+//   - Finds it past-deadline → evicts as `TimedOut`, archives to history,
+//     auto-emits `StartNextTopLevelIfIdle` to advance the queue.
+//
+// The wedged renderer/browser is leaked (we can't safely tear it down — it's
+// stuck inside CEF). Recoverable across restarts. Operator-visible via
+// `--diag windows` (Phase 3).
+//
+// See `docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md` §"Watchdog".
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const IDLE_POLL: Duration = Duration::from_secs(5);
+const SLOP: Duration = Duration::from_millis(100);
+
+/// Spawn the watchdog tokio task. Lives for the lifetime of the host
+/// process; tokio runtime shutdown cancels it.
+pub fn spawn_watchdog(state: Arc<crate::state::AppState>) {
+    tokio::spawn(async move {
+        tracing::info!("[window-create-watchdog] started");
+        loop {
+            // Read the deadline of any current in-flight request, holding
+            // the reducer mutex only briefly. Snapshot-and-drop.
+            let next_wake_at = {
+                let host = state.host_state.lock();
+                host.in_flight_top_level_creation
+                    .as_ref()
+                    .map(|c| c.deadline)
+            };
+
+            match next_wake_at {
+                Some(deadline) => {
+                    let now = Instant::now();
+                    let sleep_dur = deadline.saturating_duration_since(now) + SLOP;
+                    tokio::time::sleep(sleep_dur).await;
+                }
+                None => {
+                    // No in-flight request; poll periodically in case one
+                    // starts while we're sleeping. Cheap.
+                    tokio::time::sleep(IDLE_POLL).await;
+                }
+            }
+
+            // Tick the reducer. If there's no in-flight or it's not past
+            // deadline, this is a no-op. Otherwise the reducer evicts the
+            // slot and auto-advances.
+            let out = state.host_dispatch(crate::reducer::HostCommand::TopLevelTimeoutTick {
+                now: Instant::now(),
+            });
+
+            // Visible alert when we actually evicted something.
+            for ev in &out.events {
+                if let crate::reducer::HostEvent::TopLevelCreationTimedOut {
+                    creation_id,
+                    label,
+                    last_phase,
+                    elapsed_ms,
+                    ..
+                } = ev
+                {
+                    tracing::error!(
+                        creation_id = %creation_id,
+                        label = %label,
+                        last_phase = ?last_phase,
+                        elapsed_ms = %elapsed_ms,
+                        "[window-create-watchdog] creation timed out — wedged init evicted"
+                    );
+                }
+            }
+        }
+    });
+}

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.579"
+version = "0.33.580"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.579"
+version = "0.33.580"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.579"
+version = "0.33.580"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.579",
+  "version": "0.33.580",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.579",
+      "version": "0.33.580",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.579",
+  "version": "0.33.580",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Stacks on #650

This PR is based on \`agenta/wfr-pane-guard-and-tracing\` (PR #650). Merge #650 first, or change this PR's base to main after #650 lands.

## Summary

Serializes top-level window creation through a single in-flight slot in the host reducer. Routes around the CEF v146 Chrome async browser-creation wedge observed under concurrent load (one creation in ~6 wedged in 0.33.582 testing, last_phase=Started, never reached \`on_after_created\`). Pane creation paths are unchanged — panes share parent context and don't trigger the wedge.

Full investigation in \`docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md\` and \`docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md\`.

## Reducer extension

**New types in \`state.rs\`:**
- \`TopLevelCreationRequest\` — full creation spec (label, kind, parent_instance_id, url, pos, size, frameless)
- \`InFlightTopLevelCreation\` — singleton, monotonic phase tracking, deadline
- \`TopLevelCreationPhase\` — Started → BrowserCallbackFired → RendererReady (refuses regression)
- \`CompletedTopLevelCreation\` + \`TopLevelCreationOutcome\` — history archive types

**New \`HostState\` fields:**
- \`top_level_creation_queue: VecDeque<TopLevelCreationRequest>\` — runner queue
- \`in_flight_top_level_creation: Option<InFlightTopLevelCreation>\` — singleton invariant enforced by reducer
- \`top_level_creation_history: VecDeque<CompletedTopLevelCreation>\` — cap 50, FIFO ring buffer
- \`next_top_level_creation_id: u64\` — monotonic id allocator

**New \`HostCommand\` variants:** \`EnqueueTopLevelWindow\`, \`StartNextTopLevelIfIdle\`, \`AdvanceTopLevelPhase\`, \`MarkTopLevelRendererReady\`, \`TopLevelTimeoutTick\`, \`AbortInFlightTopLevel\`.

**New \`HostEvent\` variants:** \`BeginTopLevelCreationEffect\` (effect bearer), \`TopLevelCreationCompleted\`, \`TopLevelCreationTimedOut\`, \`TopLevelCreationAborted\`, \`TopLevelQueueLengthChanged\`.

**Auto-advance:** \`Enqueue\` + \`RendererReady\` + \`TimeoutTick\` + \`Abort\` all chain into \`StartNextTopLevelIfIdle\` so the queue can never permanently stall.

## Effect handler

\`AppState::host_dispatch_with_effects\` wraps \`host_dispatch\` and runs side-effects emitted by the reducer. For \`BeginTopLevelCreationEffect\`, calls \`ui_tasks::post_create_window\` with the creation spec. **Reducer mutex is dropped before the effect runs** — no deadlock risk if the effect (which posts a CEF UI task) eventually calls back into the reducer.

## Watchdog

New module \`agentmux-cef/src/window_creation_watchdog.rs\`. Tokio task wakes at the in-flight creation's deadline (or 5s when idle), ticks the reducer with \`TopLevelTimeoutTick\`, evicts stalled creations as \`TimedOut\` so the queue advances. 30s default deadline (\`TOP_LEVEL_CREATION_DEADLINE\`).

**Known limitation:** the watchdog evicts the runner's in-flight slot but doesn't kill the wedged CEF browser process. If \`on_after_created\` fires for the evicted label later, it can collide with a different creation. **The user reported a "closed wrong window" symptom in 0.33.582 testing that's likely caused by this orphan-mapping confusion.** A follow-up PR (Phase 2.5, no-watchdog event-driven design) is planned to remove the watchdog entirely and rely only on observable CEF callbacks (\`on_render_process_terminated\`, etc.) — see follow-up discussion.

## Migration

- \`commands/window.rs::open_window_with_kind\` — routes through \`host_dispatch_with_effects(EnqueueTopLevelWindow{...})\`. Legacy \`EnqueuePendingWindowCreation\` handoff still fires for the kind/parent metadata that \`on_after_created\` consumes.
- \`commands/window_pool.rs::spawn_pool_window\` — same migration. Pool windows go through the runner because pool refill chains right after promotion (the concurrent-creation pattern that triggered the freeze).
- \`client.rs::on_after_created\` — dispatches \`MarkTopLevelRendererReady\` after \`Registered browser\`, releasing the runner slot for the next queued creation.

## Tests

16 unit tests passing in \`reducer.rs::tests\`:
- enqueue-when-idle starts creation immediately
- enqueue-when-busy only queues
- renderer-ready advances queue
- timeout-tick evicts and advances queue
- timeout-tick before deadline is no-op
- renderer-ready with wrong label is no-op
- abort evicts and advances
- history caps at 50
- advance_phase refuses regression
- enqueue during shutdown is rejected
- singleton invariant under random actions
- (plus all 5 pre-existing F.1 tests)

## Test plan

- [x] cargo check -p agentmux-cef clean
- [x] cargo test reducer:: → 16/16 passing
- [x] Smoke test 0.33.582 portable: 7 windows created via runner, serialization invariant verified (every BeginTopLevelCreationEffect followed by matching outcome before next begin), watchdog correctly evicted creation_id=6 at 30.108s
- [x] No freeze observed during smoke (was previously deterministic)
- [ ] Address orphan-browser symptom in follow-up PR (no-watchdog design)
- [ ] Bot review (reagentx-workflow + codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)