### PR TITLE
feat(ui): per-tab launch modal rearchitecture (TabModalLayer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.582"
+version = "0.33.583"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.582"
+version = "0.33.583"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.582"
+version = "0.33.583"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.582"
+version = "0.33.583"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.581"
+version = "0.33.582"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.581"
+version = "0.33.582"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.581"
+version = "0.33.582"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.581"
+version = "0.33.582"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.581"
+version = "0.33.582"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.582"
+version = "0.33.583"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.581"
+version = "0.33.582"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.582"
+version = "0.33.583"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.582"
+version = "0.33.583"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.581"
+version = "0.33.582"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.582"
+version = "0.33.583"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.581"
+version = "0.33.582"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/launch-modal-rearchitecture-2026-05-01.md
+++ b/docs/specs/launch-modal-rearchitecture-2026-05-01.md
@@ -1,0 +1,419 @@
+# Launch Agent Modal — Performance & Per-Tab Scoping
+
+**Date:** 2026-05-01
+**Status:** Spec / Proposal
+**Repo state:** main @ `257bf0ff`, AgentMux v0.33.549
+**Author:** AgentC
+
+---
+
+## Problem
+
+Two separate but related defects in the agent launch modal (`AgentLaunchModal`):
+
+**P1 — Severe input lag.** Selecting a radio option, toggling advanced, and especially typing in the instance-name field have visibly large latency. The interaction does not feel like a SolidJS app should — strongly suggests reactive cascades through unmemoized parents and Portal-anchored heavy children.
+
+**P2 — Wrong scope.** The modal is global (Portal-mounted to `document.body`) and visually covers the entire window including the top tab bar. It should be **per-tab**:
+
+- The top tab bar must remain interactive — the user can switch tabs while the modal is open.
+- Within the originating tab, widgets are blurred/disabled by the modal.
+- Switching to a different tab shows that tab normally; the modal does not appear there.
+- The modal is bound to the tab where the launch was initiated.
+
+---
+
+## TL;DR
+
+- Current modal is mounted via Solid `<Portal mount={document.body}>` in `modal-v2.tsx:329`. State lives at the wrong level (`AgentPicker.tsx:70`). The modal renders as a sibling of an expensive list (`AgentCard` + Popover + memos), so every keystroke schedules work through the picker's reactive scope and the Popover children.
+- The codebase already has a working **per-pane absolute overlay** pattern: `AgentFocusedPanel` (`agent-view.tsx:554-562`, `_focused-overlay.scss:8-18`). We should mirror it.
+- Fix: replace the Portal-mounted modal with a **tab-scoped overlay** that mounts inside the tab content area but **outside the widget grid**, dimming/disabling the widgets only. Move modal state to a tab-scoped container, isolate the form's signals so input changes never cross the modal boundary.
+- Estimated change: 4–5 files, ~150 LOC. No DB or RPC changes.
+
+---
+
+## Current Architecture
+
+### DOM / component tree (today)
+
+```
+App (app.tsx:38)
+└─ Workspace (workspace.tsx:54)
+   ├─ TabBar (tabbar.tsx:41)                    ← interactive
+   └─ TabContent  ← rendered for every tab; inactive hidden via display:none (tabcontent.tsx:37)
+      └─ TileLayout
+         └─ Block (per pane)
+            └─ AgentViewWrapper (agent-view.tsx)
+               ├─ AgentPicker (when no agent bound)
+               │  ├─ <For> over AgentCard (each with Popover)
+               │  └─ <Show when={launchModalAgent()}>
+               │     └─ AgentLaunchModal              ← (1) state lives here
+               │        └─ Modal (modal-v2.tsx)
+               │           └─ <Portal mount={document.body}>   ← (2) escapes the tab
+               │              └─ .modal-root (position:fixed; inset:0)
+               │                 ├─ .modal-backdrop  ← covers the whole window
+               │                 └─ .modal-panel
+               └─ AgentPresentationView (when agent bound)
+```
+
+### Modal open/close state location
+
+- **State signal:** `AgentPicker.tsx:70` — `const [launchModalAgent, setLaunchModalAgent] = createSignal<ForgeAgent|null>(null)`.
+- **Open:** `AgentPicker.tsx:81-83` — `handleSelect(agent)` sets the signal; called from `AgentCard`'s `onLaunch`.
+- **Close:** `AgentPicker.tsx:102` and the modal's own `onCancel`.
+- **Render:** `AgentPicker.tsx:205-212` — `<Show when={launchModalAgent()}>` inside the picker's JSX.
+
+This couples modal lifetime to the picker's reactive scope.
+
+### Portal escape
+
+- `modal-v2.tsx:327-379` — `<Portal mount={resolveMountDocument().body}>` puts the modal root in `document.body`.
+- `modal-v2.scss:9-31` — `.modal-root { position:fixed; inset:0; z-index:var(--z-modal); }` with `.modal-backdrop { backdrop-filter: blur(8px); }`.
+- `modal-v2.tsx:163-166` — `resolveMountDocument()` is window-aware (good for multi-window), but **not tab-aware**.
+
+Result: when the user switches tabs, the originating tab's `TabContent` gets `display:none` (`tabcontent.tsx:37`), but the Portal node lives in `document.body` and stays visible. The modal "leaks" across tabs.
+
+### Tab system
+
+- `tabbar.tsx:41-568` — top tab bar. Already its own component, already always interactive.
+- `workspace.tsx:33-44` — every tab's `TabContent` is mounted; inactive ones use `display:none` (`tabcontent.tsx:37`). Comment at `tabcontent.tsx:18-20` is explicit: "Keep every tab mounted so terminals preserve their xterm.js instance and scrollback across tab switches."
+- This is good for us: an overlay rendered **inside** TabContent will hide automatically with the tab.
+
+### Existing per-pane overlay precedent
+
+`AgentFocusedPanel` is the pattern to copy:
+
+- `agent-view.tsx:554-562` — rendered inside `AgentPresentationView`; not portaled.
+- `_focused-overlay.scss:8-18`:
+  ```scss
+  .agent-focused-overlay {
+      position: absolute;
+      top: 0; left: 0; right: 0;
+      height: 50%;
+      z-index: 20;
+  }
+  ```
+- Tab switch hides the panel automatically because its DOM ancestor is hidden.
+
+---
+
+## Performance Root Cause (P1)
+
+Hypothesis with file:line evidence.
+
+### A — Local form signals read directly in JSX
+
+`AgentLaunchModal.tsx:42-47`:
+
+```tsx
+const [name, setName] = createSignal("");
+const [runtime, setRuntime] = createSignal<"host" | "container">("host");
+const [image, setImage] = createSignal<string>("");
+const [submitting, setSubmitting] = createSignal(false);
+const [error, setError] = createSignal<string | null>(null);
+const [showAdvanced, setShowAdvanced] = createSignal(false);
+```
+
+`AgentLaunchModal.tsx:53-55` derived helpers used in render:
+
+```tsx
+const hasName = () => name().trim().length > 0;
+const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
+```
+
+`AgentLaunchModal.tsx:118` keystrokes:
+
+```tsx
+<input onInput={(e) => setName(e.currentTarget.value)} ... />
+```
+
+`AgentLaunchModal.tsx:200-205` renders `slugifyInstanceName(name().trim())` on every keystroke.
+
+These are not the bottleneck on their own — Solid's fine-grained reactivity should keep this cheap. The bottleneck is what's **above** the modal.
+
+### B — The modal is a child of an expensive parent
+
+`AgentPicker.tsx:160-212` renders, in order:
+
+1. `<For each={agents()}>` over forge agents (each card hosts a Popover).
+2. A `<Show when={nodejsError()}>` notice.
+3. `AgentActionBar`.
+4. `<Show when={launchModalAgent()}>` → modal.
+
+`AgentCard.tsx:65-80` per card:
+
+```tsx
+const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
+const icon = () => props.agent.icon || catalog()?.icon || "•";
+// ...
+<Popover placement="right-start" offset={8}>
+    <InfoPopoverTrigger ... />
+    <PopoverContent className="agent-card-info-popover">
+        ...
+    </PopoverContent>
+</Popover>
+```
+
+Popover is a heavy primitive (floating-ui placement, autoUpdate, focus trap). Every card mounts one.
+
+### C — Portal-mounted backdrop with `backdrop-filter: blur(8px)`
+
+`modal-v2.scss:9-31`:
+
+```scss
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(8px);
+}
+```
+
+`backdrop-filter: blur(8px)` over a full-window viewport with the agent picker (with N Popovers) and any active panes behind is **the most expensive single line of CSS in this view**. Each input keystroke causes the panel above to re-layout fractionally; with the blur layer in place, the compositor re-rasterizes the blurred region. On a high-DPI display with many widgets, this alone is a strong candidate for the visible lag.
+
+### D — Live event subscriptions in the picker
+
+`AgentPicker.tsx:30-59` (`useForgeAgents`):
+
+```tsx
+const unsub = waveEventSubscribe({
+    eventType: "forgeagents:changed",
+    handler: () => load(),
+});
+```
+
+If any modal action emits an event interpreted as `forgeagents:changed`, the agent list refetches and re-renders the cards mid-typing.
+
+### Net read
+
+The lag is the sum of:
+
+1. **Backdrop blur** rasterizing the full window, including the picker grid and any heavy panes behind it. Largest single contributor.
+2. **Picker scope** — modal is a child of the picker, so any framework-level boundary work involves the card list.
+3. **Popover-per-card** — N heavy children rendered behind the blur.
+4. **Possible refetch loops** if `forgeagents:changed` fires during launch.
+
+Fix the scoping (P2) and most of these go away naturally because the blur and overlay only cover the widget area inside one tab, not the whole picker grid + tab bar + status bar.
+
+---
+
+## Target Architecture
+
+### Goals
+
+1. Top tab bar always interactive.
+2. Modal lives **per tab**, scoped to the tab's content area (not viewport).
+3. Modal blurs/dims widgets within the originating tab only.
+4. No Portal escape — modal lives inside `TabContent`, hidden automatically with `display:none`.
+5. Modal form state isolated; input changes don't reach the picker grid.
+
+### Component tree (proposed)
+
+```
+TabBar                                ← unchanged, always interactive
+TabContent  (display:none when inactive)
+└─ TabModalLayer  (NEW) — tab-scoped per-tab overlay host
+   ├─ TileLayout                       ← widgets, dimmed/disabled when modal open
+   │  └─ Block × N
+   │     └─ AgentViewWrapper / etc.    ← AgentPicker NO LONGER renders the modal
+   │
+   └─ <Show when={openModal()}>
+      └─ TabModalOverlay
+         ├─ .tab-modal-backdrop  (position:absolute; inset:0; backdrop-filter)
+         └─ .tab-modal-panel     (centered)
+            └─ AgentLaunchModal   ← form-only; no Portal, no <Modal> wrapper
+```
+
+### State
+
+A per-tab signal `openModal: Signal<TabModalRequest | null>` lives on `TabModalLayer`. A small context (`TabModalContext`) exposes:
+
+```ts
+interface TabModalApi {
+  open(req: TabModalRequest): void;
+  close(): void;
+  current: Accessor<TabModalRequest | null>;
+}
+```
+
+`TabModalRequest` is a discriminated union; for now `{ kind: "launch-agent"; agent: ForgeAgent; originBlockId: string }`. `TabModalLayer` provides this context to its descendants. `AgentPicker` consumes it via `useTabModal()` and calls `open({ kind: "launch-agent", agent, originBlockId: model.blockId })`.
+
+This makes the modal **tab-scoped** by construction: each tab has its own `TabModalLayer`, each layer has its own context, each context has its own signal. No global state.
+
+### Pointer/focus behavior — widgets dimmed, tabs interactive
+
+Two layers:
+
+- The widget area (the `TileLayout`) gets `inert` (or `pointer-events: none` plus `aria-hidden="true"`) and a class that triggers blur/dim styling whenever `openModal()` is non-null.
+- The tab bar lives **outside** `TabContent`, so it's not under the overlay. No special handling needed.
+
+CSS:
+
+```scss
+.tab-content[data-modal-open="true"] {
+    .tile-layout {
+        filter: blur(2px) saturate(0.7);
+        pointer-events: none;
+        user-select: none;
+    }
+}
+
+.tab-modal-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: var(--z-tab-modal);
+    display: grid;
+    place-items: center;
+}
+
+.tab-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(6px);
+}
+```
+
+The blur is now scoped to the tab content area. If the tab content is small (e.g. half a screen), the GPU work is proportionally smaller.
+
+### Form state isolation
+
+Move the form's local signals into a new `<LaunchAgentForm>` component nested *inside* the modal panel. Parent (`TabModalLayer`) only holds `TabModalRequest`; the form's `name`, `runtime`, `image`, `showAdvanced` signals live entirely inside `LaunchAgentForm` and never escape it. `LaunchAgentForm` returns final values via a single `onSubmit(payload)`.
+
+This guarantees a Solid keystroke on `name` cannot trigger any reactivity outside the form.
+
+### Backdrop blur — keep it cheap
+
+Reduce the blur radius from 8px to 6px (already proposed above), and consider skipping `backdrop-filter` entirely on lower-end machines via `@media (prefers-reduced-transparency)` or a setting. Alternative: replace `backdrop-filter` with a `background: rgba(0,0,0,0.65)` solid scrim — visually similar, near-zero GPU cost. Recommend solid scrim as default; optional blur as a setting.
+
+### Tab switch behavior
+
+Open question: what happens to the modal when the user switches tabs and back?
+
+Two options:
+
+- **A — preserve form state.** The modal's form is a child of the still-mounted `TabContent` (just hidden). The signals retain their values. When the user returns, the modal is still open with the same partial input. Recommended default — matches the spirit of "the modal is bound to the tab".
+- **B — close on tab switch.** Subscribe to `atoms.activeTabId` in `TabModalLayer`; when it changes away from this tab, call `close()`.
+
+Pick A. It's the natural behavior of `display:none`, requires no extra code, and matches the user's stated mental model ("modal is per-tab").
+
+---
+
+## Implementation Plan
+
+Ordered, with file:line targets.
+
+### 1 — Create `TabModalLayer` and context
+
+- New file `frontend/app/view/tabcontent/TabModalLayer.tsx` (host + context provider + render slot).
+- New file `frontend/app/view/tabcontent/tab-modal.ts` (context + types + `useTabModal` hook).
+- Wrap `TileLayout` inside `TabContent` (`tabcontent.tsx:114`) with `<TabModalLayer>...</TabModalLayer>`. Layer renders its children plus an overlay slot.
+
+### 2 — Add CSS
+
+- New file `frontend/app/view/tabcontent/_tab-modal.scss`. Defines `.tab-content[data-modal-open]`, `.tab-modal-overlay`, `.tab-modal-backdrop`, `.tab-modal-panel`.
+- Import into `tabcontent.scss` (or the workspace stylesheet that owns tab content styles).
+- Add a `--z-tab-modal` token below `--z-modal` in `theme.scss`. Tab modal stacks below global modals so a future global confirm dialog still works.
+
+### 3 — Refactor `AgentLaunchModal` — remove Modal/Portal
+
+- `AgentLaunchModal.tsx:93-219` — remove the `<Modal open={true} ...>` wrapper. The component becomes a plain panel that the layer renders inside its panel slot.
+- Extract the form into a child `<LaunchAgentForm>` so its local signals (`name`, `runtime`, `image`, `showAdvanced`) cannot affect anything outside.
+- Replace `usePaneOverlay` plumbing (`modal-v2.tsx:64-67`) with the tab modal layer's CEF-pane clip — see step 7.
+
+### 4 — Move modal state out of `AgentPicker`
+
+- `AgentPicker.tsx:70` — delete `[launchModalAgent, setLaunchModalAgent]`.
+- `AgentPicker.tsx:81-84` — `handleSelect` becomes a one-liner: `useTabModal().open({ kind: "launch-agent", agent, originBlockId: model.blockId })`.
+- `AgentPicker.tsx:86-106` — `handleLaunchSubmit` no longer closes a local signal; it calls the context's `close()` on success.
+- `AgentPicker.tsx:205-212` — delete the `<Show>` block that renders `AgentLaunchModal`. The picker no longer mounts the modal.
+
+### 5 — Render the modal in `TabModalLayer`
+
+- `TabModalLayer` owns the `<Show when={current()}>` and dispatches by `kind`. For `"launch-agent"`, it renders `<AgentLaunchModal agent={req.agent} onCancel={close} onSubmit={...}/>` inside `.tab-modal-panel`.
+- Hooking `onSubmit`: keep the current behavior (call `model.launchForgeAgent`) but lift that call into `TabModalLayer` so the picker stays presentational. The `originBlockId` in the request lets the layer locate the right model if needed.
+
+### 6 — Apply dim/inert to widgets
+
+- `TabModalLayer` toggles `data-modal-open="true"` on the closest `.tab-content` element when `current() != null`.
+- The CSS rule in step 2 blurs `.tile-layout` and removes pointer events. Keyboard focus-trap stays inside the modal panel.
+- Use `inert` attribute (broadly supported in Chromium / CEF) on the `.tile-layout` wrapper for correctness.
+
+### 7 — CEF pane overlay clip
+
+- Existing `usePaneOverlay()` in `modal-v2.tsx:64-67` registers the modal rect with the host so native CEF panes don't paint over it. Reuse the same hook from `TabModalLayer` against its overlay element. Without this, sidecar panes will continue to paint over the modal.
+
+### 8 — Optional: solid scrim instead of blur
+
+- Default `.tab-modal-backdrop` to `background: rgba(0,0,0,0.65); backdrop-filter: none;`.
+- Gate the blur on a setting (`ui.modalBlurEnabled`, default false). Largest single perf win.
+
+### 9 — Cleanup
+
+- Delete or minimize the legacy `Modal` (modal-v2.tsx) usage from launch flow only; leave it in place for any other modals that still rely on global Portal scoping until they migrate. Do not rip out modal-v2 wholesale — out of scope.
+- Update `_focused-overlay.scss` z-index if it conflicts with `--z-tab-modal` (verify visually).
+
+---
+
+## Affected Files
+
+| # | File | Change |
+|---|---|---|
+| 1 | `frontend/app/view/tabcontent/TabModalLayer.tsx` | **new** — context provider + overlay host |
+| 2 | `frontend/app/view/tabcontent/tab-modal.ts` | **new** — context, hook, types |
+| 3 | `frontend/app/view/tabcontent/_tab-modal.scss` | **new** — overlay + dim/blur styles |
+| 4 | `frontend/app/view/tabcontent/tabcontent.tsx` | wrap TileLayout in `<TabModalLayer>` (~L114) |
+| 5 | `frontend/app/view/agent/components/AgentPicker.tsx` | remove modal state + render (L70, L81-84, L102, L205-212); use `useTabModal()` |
+| 6 | `frontend/app/view/agent/components/AgentLaunchModal.tsx` | remove `<Modal>` wrapper (L93-219); extract `<LaunchAgentForm>` |
+| 7 | `frontend/app/view/theme/theme.scss` | add `--z-tab-modal` token |
+| 8 | (no DB / no RPC changes) | — |
+
+Total: 3 new files + 4 edits. ~150 LOC.
+
+---
+
+## Performance Expectations (post-change)
+
+- **Backdrop blur cost:** down ~70–90% (scrim default; tab-area scoped if blur enabled).
+- **Reactive cascade:** form signals isolated inside `<LaunchAgentForm>` — no propagation to picker or cards.
+- **Popover render path:** unchanged at idle, but no longer visible behind the modal during input (the dim/inert layer composites them once).
+- **Tab switch:** instant — modal hides via existing `display:none` on the inactive `TabContent`; preserved via the same mechanism on return.
+
+A simple sanity benchmark: open the modal, open Chrome DevTools Performance, type "the quick brown fox jumps over the lazy dog" in the name field. Expect:
+
+- **Before:** input event handlers >16ms each, frequent compositor invalidations of the full window, occasional dropped frames.
+- **After:** input handlers <2ms, compositor invalidations limited to the form preview row, no dropped frames.
+
+---
+
+## Risks and Open Questions
+
+**R1 — `inert` support.** CEF tracks Chromium; modern CEF versions support `inert` natively. Verify in dev. Fallback: `pointer-events: none` + `aria-hidden="true"` + a focus-trap on the modal panel.
+
+**R2 — Z-index ordering vs. `AgentFocusedPanel`.** `_focused-overlay.scss:8-18` uses `z-index: 20`. Tab modal needs to stack above that. Define `--z-tab-modal: 100` (or higher) and document the scale.
+
+**R3 — Form state on tab switch.** Recommended: preserve (default behavior of `display:none`). If product wants close-on-switch, add a one-line subscription. Pick a default and lock it.
+
+**R4 — Multiple panes in one tab.** Each pane has its own picker. The tab has one `TabModalLayer`, so only one launch modal can be open per tab at a time. This is desirable. The `originBlockId` on the request keeps which pane initiated unambiguous.
+
+**R5 — Multi-window.** Each window has its own workspace and its own tab tree, so per-tab scoping is automatically per-window. No cross-window leakage. `usePaneOverlay()`'s window-aware mount logic (`modal-v2.tsx:163-166`) is no longer needed.
+
+**R6 — Unrelated modals.** This refactor only touches `AgentLaunchModal`. The rest of the app's modals still use `Modal v2` and Portal-to-body. They keep their existing semantics until separately migrated. We are not consolidating modal infrastructure in this change.
+
+**R7 — `forgeagents:changed` event during launch.** If any RPC during launch emits this event, the picker's list re-fetches. Out of scope for this spec, but worth confirming during testing — should not be visible because the picker is dimmed/inert during the modal.
+
+---
+
+## Out of Scope
+
+- Identity binding inside the modal (covered by `identity-system-research-2026-05-01.md`).
+- Migrating other modals off `Modal v2` / Portal.
+- Tab-bar / tab-mounting refactor.
+- Performance work in `AgentCard` Popover or `useForgeAgents` polling.
+
+These are independent and can land before, after, or alongside this change.
+
+---
+
+## Bottom Line
+
+Two surface-level bugs share one root cause: the modal escapes its tab via Portal-to-body, which forces it to be globally scoped, makes the backdrop blur span the full window, and ties its lifecycle to the picker's reactive scope. A small `TabModalLayer` wrapping the tile layout — with a context, an overlay slot, and a tab-scoped CSS layer — fixes both issues, recovers the perf budget, and gives us a clean place to host any future tab-scoped overlays.

--- a/docs/specs/modal-cleanup-migration-2026-05-01.md
+++ b/docs/specs/modal-cleanup-migration-2026-05-01.md
@@ -1,0 +1,191 @@
+# Modal Cleanup — Migration Audit & Plan
+
+**Date:** 2026-05-01
+**Status:** Audit / Plan
+**Repo state:** main @ `257bf0ff`, AgentMux v0.33.549
+**Author:** AgentC
+**Companion to:** `launch-modal-rearchitecture-2026-05-01.md`
+
+---
+
+## Goal
+
+After landing `TabModalLayer` for the launch modal, walk every dialog/overlay in the app and decide whether it stays global, migrates to tab-scope, or stays as a pane-inline panel. This is the audit needed before deciding what else (if anything) gets migrated.
+
+---
+
+## Method
+
+- Grepped all consumers of `Modal` from `@/element/modal-v2`.
+- Grepped `Portal` from `solid-js/web` for ad-hoc overlays.
+- Walked the legacy `ModalsRenderer` registry (`workspace.tsx:46`, `modals/modalregistry.tsx`).
+- Searched filenames: `*-modal*`, `*-dialog*`, `*-overlay*`, `*-panel*`, `*-popover*`.
+- Cross-checked every result against the four classifications.
+
+---
+
+## Classifications
+
+- **(A)** Migrate to `TabModalLayer` — conceptually tab/pane-scoped; should follow the active tab; should not block the tab bar.
+- **(B)** Stay global Portal — window-level (command palette, about, backend-driven prompts).
+- **(C)** Already pane-scoped, leave alone — inline overlays inside their owning pane (e.g., `AgentFocusedPanel`).
+- **(D)** Re-classify — currently mis-scoped; needs deliberate rework.
+- **Out of scope** — popovers, tooltips, context menus, toasts, drag overlays.
+
+---
+
+## (A) Migrate to TabModalLayer
+
+| Modal | File | Trigger | Current scoping | State location | Complexity |
+|---|---|---|---|---|---|
+| **AgentLaunchModal** | `frontend/app/view/agent/components/AgentLaunchModal.tsx:38` | Click agent card in picker | Portal-to-body via Modal v2 | `launchModalAgent` signal in `AgentPicker.tsx:70` | Small |
+| **ImportPreviewModal** | `frontend/app/view/agent/components/ImportPreviewModal.tsx:15` | Drag/paste forge agents into pane | Portal-to-body via Modal v2 | Local signals in `AgentActionBar` | Small |
+| **AgentPicker delete confirm** | `frontend/app/view/agent/components/AgentPicker.tsx:214-235` | Delete forge agent definition | Portal-to-body via Modal v2 | `deleteCandidate`, `deleteError` in `AgentPicker` | Small |
+| **AgentView close confirm** | `frontend/app/view/agent/agent-view.tsx:~360` | Close pane with running processes | Portal-to-body via Modal v2 | `closeConfirm` signal in `AgentPresentationView` | Small–Medium |
+
+**Why these.** Each is initiated by an action inside one pane and is only relevant to that pane. Today they cover the whole window via Portal-to-body, which means they incorrectly block the tab bar and follow the user across tabs. After migration, each renders inside its tab's `TabModalLayer` and disappears with the tab.
+
+**Total estimated work:** ~1 engineer-day, after `TabModalLayer` infrastructure is in place.
+
+---
+
+## (B) Stay Global Portal
+
+| Modal | File | Why global |
+|---|---|---|
+| **CommandPaletteModal** | `frontend/app/modals/command-palette.tsx:28` | App-wide hotkey; must overlay everything. |
+| **AboutModal** | `frontend/app/modals/about.tsx:13` | App-level metadata; not tab-scoped. |
+| **UserInputModal** | `frontend/app/modals/userinputmodal.tsx:14` | Backend RPC initiates; can pertain to any tab; safer to be window-level. |
+| **MessageModal** | `frontend/app/modals/messagemodal.tsx:10` | Generic backend message; window-level scope is correct. |
+| **TokenBreakdownPopover (+ nested reset confirm)** | `frontend/app/statusbar/TokenBreakdownPopover.tsx:51,165` | Anchored to the status bar (window chrome); the nested confirm has window-wide consequence. |
+
+**Action:** No change. These continue to use `Modal v2` + Portal-to-body and the legacy `ModalsRenderer` registry as they do today.
+
+---
+
+## (C) Already Pane-Scoped — Leave Alone
+
+These are inline overlays already mounted inside their pane's component tree. Not modals in the strict sense; they don't Portal anywhere.
+
+| Component | File | Notes |
+|---|---|---|
+| **AgentFocusedPanel** | `frontend/app/view/agent/components/AgentFocusedPanel.tsx:26` | Half-pane settings overlay; precedent for the per-pane absolute pattern. `_focused-overlay.scss:8-18` shows the CSS approach we're echoing in `TabModalLayer`. |
+| **AgentCardSettingsPanel** | `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx:40` | Inline expansion under an agent card; not a modal. |
+| **SlashHelpPanel** | `frontend/app/view/agent/components/SlashHelpPanel.tsx:57` | Inline `/help` panel inside agent pane. |
+| **ActivityLogPanel** | `frontend/app/view/agent/components/ActivityLogPanel.tsx` | Collapsible section above composer. |
+| **SlashCommandPicker** | `frontend/app/view/agent/components/SlashCommandPicker.tsx` | Floating-UI picker tied to slash command flow. |
+| **AgentIdentityPanel** | `frontend/app/view/agent/components/AgentIdentityPanel.tsx:45` | Inline identity tab inside `AgentCardSettingsPanel`. |
+| **DragOverlay** | `frontend/app/drag/DragOverlay.tsx:43` | Cross-window drop indicator; visual feedback only. |
+
+**Action:** No change. Document these as the "inline overlay" tier.
+
+---
+
+## (D) Re-classify
+
+None found. The four (A) candidates were initially considered for (D) reclassification (mis-scoped today), but they are coherently scoped if you redefine the modal layer — which is exactly what `TabModalLayer` does. So they go in (A).
+
+---
+
+## Out of Scope (Non-Modal Surfaces)
+
+Listed for completeness. None of these need migration; none belong in `TabModalLayer`.
+
+- **Popovers** — `element/popover.tsx`, `statusbar/HostPopover.tsx`, `notification/notificationpopover.tsx`. Floating-UI anchored, not modal.
+- **Tooltips** — `element/tooltip.tsx`.
+- **Context menus** — dispatched via `ContextMenuModel.showContextMenu()`.
+- **TypeAheadModal (connection picker)** — `modals/typeaheadmodal.tsx:87`. Despite the name, this Portal-mounts to `props.blockRef.current` (block-scoped), not body. It's a searchable dropdown, not a modal dialog.
+- **ChangeConnectionBlockModal** — `modals/conntypeahead.tsx:303`. Uses TypeAheadModal under the hood; same story.
+- **Notifications & notification center** — `notification/notificationpopover.tsx`, `notification/notificationbubbles.tsx`.
+- **Emoji palette** — `element/emojipalette.tsx`.
+- **FlyoutMenu** — `element/flyoutmenu.tsx`. Portal-rendered dropdown menu.
+
+---
+
+## Open Questions Resolved During Audit
+
+- **Identity dialog?** None as a standalone modal. `AgentIdentityPanel` is inline (C), `AccountForm` is inline. Nothing to migrate.
+- **App-level Settings/Preferences?** None as a modal — settings open as a widget pane. Out of scope.
+- **First-run / onboarding?** Removed (per `modals/modalregistry.tsx:10` comment).
+- **Update available?** Goes through the notification system, not a modal.
+- **Quit confirm?** Not in frontend; handled at the host/OS layer.
+- **File pickers?** Backend/OS, not frontend.
+- **DevTools/inspector?** CEF, not frontend.
+
+---
+
+## Shared Infrastructure Surfacing From the Audit
+
+These should be designed once during Phase 1 and reused by every (A) migration.
+
+1. **Z-index scale.** Add `--z-tab-modal` between pane content and `--z-modal` (the global Modal v2 token, used in `modal-v2.tsx:25`). Document the order: pane content → focused-overlay → tab-modal → global modal → context menu/tooltip.
+2. **CEF pane airspace clipping.** Today `Modal v2` calls `usePaneOverlay()` (`modal-v2.tsx:42`) so native CEF panes don't paint over the modal. `TabModalLayer` overlays must do the same against the *tab-scoped* overlay rect, not the viewport. Reusable hook.
+3. **Focus trap.** Modal v2 implements its own (`modal-v2.tsx:139-314`). Two options:
+   - **Compose:** keep `<Modal>` *inside* `TabModalLayer`'s panel slot, but mount it through the layer rather than through Portal-to-body. This reuses the focus-trap logic for free.
+   - **Extract:** pull focus-trap into a `useFocusTrap(ref)` hook and call from both layers.
+   Recommended: **compose for v1, extract later if a third user appears.**
+4. **Backdrop + ESC behavior.** Same composition argument — let Modal v2 handle backdrop click and ESC, but render the resulting Portal-less node into the tab layer.
+5. **State store.** Today the legacy `ModalsModel` (`modalmodel.ts:8`) registers global modals. For (A) modals, state lives on a per-tab `TabModalLayer` context (one per `TabContent`). Distinct stores; do not merge. Each tab's layer is independent and self-cleaning.
+
+---
+
+## Migration Order
+
+### Phase 0 — Land the launch modal first
+
+Ship `launch-modal-rearchitecture-2026-05-01.md` end-to-end. It is the proof. Don't touch any other modal until it's working and shipped.
+
+### Phase 1 — Infrastructure cleanup (after Phase 0)
+
+Once `TabModalLayer` exists, generalize:
+
+1. Move the launch-specific request shape into a discriminated union: `TabModalRequest = { kind: "launch-agent"; ... } | { kind: "confirm"; ... } | { kind: "import-preview"; ... }`.
+2. Provide a generic `<TabConfirm>` component (title, body, cancel, confirm) so each (A) migration is a one-line `open({ kind: "confirm", ... })` call.
+3. Add the `--z-tab-modal` token + the shared backdrop component.
+
+No user-visible changes in this phase.
+
+### Phase 2 — Mechanical migrations (low-risk)
+
+In this order, smallest blast radius first:
+
+1. **AgentPicker delete confirm** — smallest, isolated to picker. Good first migration to validate `<TabConfirm>`.
+2. **ImportPreviewModal** — small, isolated to import flow.
+3. **AgentLaunchModal already migrated in Phase 0.**
+
+### Phase 3 — Higher coupling (Medium risk)
+
+1. **AgentView close confirm** — touches pane lifecycle. Verify the close-confirm modal disappears cleanly when its tab is closed externally (e.g., parent tab kill) so the user can't see a stranded modal. Should fall out of `display:none` semantics, but worth a manual test.
+
+### Phase 4 — Hold
+
+Everything in (B) and (C) stays where it is. Do not migrate.
+
+**Total estimated effort:** ~1 engineer-day for Phase 1 + 2 + 3 combined, on top of the launch-modal landing.
+
+---
+
+## Risks
+
+- **R1 — Focus-trap composition.** If we keep `<Modal>` inside `TabModalLayer` for focus-trap, we must ensure the inner Modal does not Portal. Either pass a `disablePortal` flag (cleanest) or inline the rendering primitive. Decide before Phase 1.
+- **R2 — Z-index regressions.** Adding `--z-tab-modal` must not interfere with `_focused-overlay.scss:8-18` (`z-index: 20`). Audit all `z-index` literals in the frontend during Phase 1 and consolidate into the token scale.
+- **R3 — Per-tab state leak.** Each `TabModalLayer` instance must clean up its signal on tab close. Tabs are mounted-but-hidden today (`tabcontent.tsx:18-20`), so cleanup actually happens on workspace tear-down, not tab close. Acceptable, but document.
+- **R4 — Backend-driven pane modals.** If a backend RPC ever wants to surface a confirm/input modal "in the active tab", we need a router that looks up the active tab's layer context. Out of scope for now — current backend RPCs target the global registry.
+
+---
+
+## Migration Complexity Summary
+
+| Category | Count | Effort |
+|---|---|---|
+| (A) Migrate | 4 | ~1 engineer-day after infra |
+| (B) Stay global | 5 | 0 |
+| (C) Inline | 7 | 0 |
+| (D) Reclassify | 0 | 0 |
+| Out of scope | 8+ | 0 |
+
+---
+
+## Bottom Line
+
+The cleanup is **bounded and small**. Four modals migrate, five stay global, seven stay inline. After `TabModalLayer` lands, the rest is mechanical: a generic `<TabConfirm>`, a discriminated request union, and three short PRs. No DB, RPC, or backend changes anywhere in the audit. The infrastructure work is the meaningful design effort; the per-modal migrations are find-and-replace once the API is right.

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -20,7 +20,7 @@
  * See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
-import { createSignal, Show, type Accessor, type Component, type JSX } from "solid-js";
+import { createSignal, onCleanup, onMount, Show, type Accessor, type Component, type JSX } from "solid-js";
 
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
@@ -37,8 +37,21 @@ interface TabModalLayerProps {
 // rect. Without this, hardware-windowed panes composite above HTML
 // regardless of CSS z-index and render on top of the modal.
 // Mirrors the ModalPaneOverlayClip pattern in modal-v2.tsx.
+//
+// ResizeObserver supplement: inactive tabs go display:none on their
+// container, which makes the overlay's bounding rect collapse to zero.
+// usePaneOverlay only refreshes on window.resize, so we observe the
+// element for size changes and dispatch a synthetic resize to flush the
+// now-zero rect to the backend, clearing the stale clip.
 const PaneOverlayClip: Component<{ getEl: Accessor<HTMLElement | null | undefined> }> = (p) => {
     usePaneOverlay(p.getEl);
+    onMount(() => {
+        const el = p.getEl();
+        if (!el) return;
+        const ro = new ResizeObserver(() => window.dispatchEvent(new Event("resize")));
+        ro.observe(el);
+        onCleanup(() => ro.disconnect());
+    });
     return null;
 };
 
@@ -91,14 +104,20 @@ export const TabModalLayer: Component<TabModalLayerProps> = (props) => {
                                 overlay area, so e.target === e.currentTarget on the
                                 overlay would never fire. */}
                             <div class="tab-modal-backdrop" onClick={safeClose} />
-                            <div
-                                class="tab-modal-panel"
-                                role="dialog"
-                                aria-modal="true"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                {renderRequest(req(), api, setSubmitting)}
-                            </div>
+                            {(() => {
+                                const { label, panel } = renderRequest(req(), api, setSubmitting);
+                                return (
+                                    <div
+                                        class="tab-modal-panel"
+                                        role="dialog"
+                                        aria-modal="true"
+                                        aria-label={label}
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        {panel}
+                                    </div>
+                                );
+                            })()}
                         </div>
                     );
                 }}
@@ -113,25 +132,28 @@ function renderRequest(
     req: TabModalRequest,
     api: TabModalApi,
     setSubmitting: (v: boolean) => void,
-): JSX.Element {
+): { label: string; panel: JSX.Element } {
     switch (req.kind) {
         case "launch-agent":
-            return (
-                <AgentLaunchModalPanel
-                    agent={req.agent}
-                    onCancel={api.close}
-                    onSubmit={async (overrides) => {
-                        setSubmitting(true);
-                        try {
-                            await req.onSubmit(overrides);
-                            setSubmitting(false);
-                            api.close();
-                        } catch (e) {
-                            setSubmitting(false);
-                            throw e;
-                        }
-                    }}
-                />
-            );
+            return {
+                label: `Launch ${req.agent.name}`,
+                panel: (
+                    <AgentLaunchModalPanel
+                        agent={req.agent}
+                        onCancel={api.close}
+                        onSubmit={async (overrides) => {
+                            setSubmitting(true);
+                            try {
+                                await req.onSubmit(overrides);
+                                setSubmitting(false);
+                                api.close();
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
+                        }}
+                    />
+                ),
+            };
     }
 }

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -4,23 +4,18 @@
 /**
  * TabModalLayer — per-tab modal host.
  *
- * Wraps a tab's tile layout, provides a context for opening tab-scoped
- * modals, and renders the overlay + panel inline (no Portal). Because
- * it lives inside `<TabContent>`, switching tabs hides the modal via
- * the existing `display:none` on inactive tab content. The top tab bar
- * is outside this layer and stays interactive.
+ * Provides a context for opening tab-scoped modals and renders the
+ * overlay as a sibling of `<TileLayout>` inside `<TabContent>`. No
+ * extra DOM wrappers are added around the tile layout — `<Context.Provider>`
+ * emits no DOM node, so the existing flex layout in TabContent is
+ * completely undisturbed. The overlay uses `position:absolute; inset:0`
+ * against TabContent's `position:relative` root div.
  *
- * Rationale:
- *   - Form input lag in the original launch modal came largely from a
- *     Portal-mounted full-window backdrop blur and from the modal
- *     sharing a reactive scope with the agent picker. Both are gone:
- *     the backdrop is scoped to the tab area, and the modal renders in
- *     a sibling slot of the tile layout, isolated from the picker tree.
- *   - The user's mental model is "the modal is bound to the tab I
- *     opened it from"; rendering inside `<TabContent>` matches that.
- *   - The legacy global `Modal` (modal-v2) stays for window-level
- *     dialogs (command palette, about, backend prompts). This layer is
- *     additive, not a replacement.
+ * Switching tabs hides the modal via the existing `display:none` on
+ * inactive tab content. The top tab bar stays interactive.
+ *
+ * The legacy global `Modal` (modal-v2) stays for window-level dialogs
+ * (command palette, about, backend prompts). This layer is additive.
  *
  * See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
@@ -46,52 +41,51 @@ export const TabModalLayer: Component<TabModalLayerProps> = (props) => {
     };
 
     // Backdrop click closes. Panel click is stopped from bubbling so a
-    // click inside the form doesn't reach the backdrop. ESC closes via
-    // the layer's keyDown handler — caught here so unrelated ESC users
-    // in the tile layout aren't pre-empted by a global listener.
+    // click inside the form doesn't reach the backdrop. ESC is handled
+    // on the overlay itself so we don't need a wrapper div around
+    // TileLayout (which would break its flex layout).
     const handleBackdropClick = (e: MouseEvent) => {
         if (e.target === e.currentTarget) {
             api.close();
         }
     };
 
-    const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === "Escape" && current() != null) {
+    const handleOverlayKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape") {
             e.stopPropagation();
             api.close();
         }
     };
 
+    // Context.Provider emits no DOM node, so TileLayout (props.children)
+    // remains a direct child of TabContent's flex container. The overlay
+    // is a sibling rendered after it; `position:absolute; inset:0` on
+    // .tab-modal-overlay pins it to TabContent's `position:relative` root.
     return (
         <TabModalContext.Provider value={api}>
-            <div
-                class="tab-modal-layer"
-                data-modal-open={current() != null ? "true" : undefined}
-                onKeyDown={handleKeyDown}
-            >
-                <div
-                    class="tab-modal-content"
-                    inert={current() != null || undefined}
-                    aria-hidden={current() != null ? "true" : undefined}
-                >
-                    {props.children}
-                </div>
-                <Show when={current()}>
-                    {(req) => (
-                        <div class="tab-modal-overlay" role="presentation" onClick={handleBackdropClick}>
-                            <div class="tab-modal-backdrop" />
-                            <div
-                                class="tab-modal-panel"
-                                role="dialog"
-                                aria-modal="true"
-                                onClick={(e) => e.stopPropagation()}
-                            >
-                                {renderRequest(req(), api)}
-                            </div>
+            {props.children}
+            <Show when={current()}>
+                {(req) => (
+                    <div
+                        class="tab-modal-overlay"
+                        role="presentation"
+                        // eslint-disable-next-line jsx-a11y/no-autofocus
+                        tabIndex={-1}
+                        onClick={handleBackdropClick}
+                        onKeyDown={handleOverlayKeyDown}
+                    >
+                        <div class="tab-modal-backdrop" />
+                        <div
+                            class="tab-modal-panel"
+                            role="dialog"
+                            aria-modal="true"
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {renderRequest(req(), api)}
                         </div>
-                    )}
-                </Show>
-            </div>
+                    </div>
+                )}
+            </Show>
         </TabModalContext.Provider>
     );
 };

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -1,0 +1,119 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TabModalLayer — per-tab modal host.
+ *
+ * Wraps a tab's tile layout, provides a context for opening tab-scoped
+ * modals, and renders the overlay + panel inline (no Portal). Because
+ * it lives inside `<TabContent>`, switching tabs hides the modal via
+ * the existing `display:none` on inactive tab content. The top tab bar
+ * is outside this layer and stays interactive.
+ *
+ * Rationale:
+ *   - Form input lag in the original launch modal came largely from a
+ *     Portal-mounted full-window backdrop blur and from the modal
+ *     sharing a reactive scope with the agent picker. Both are gone:
+ *     the backdrop is scoped to the tab area, and the modal renders in
+ *     a sibling slot of the tile layout, isolated from the picker tree.
+ *   - The user's mental model is "the modal is bound to the tab I
+ *     opened it from"; rendering inside `<TabContent>` matches that.
+ *   - The legacy global `Modal` (modal-v2) stays for window-level
+ *     dialogs (command palette, about, backend prompts). This layer is
+ *     additive, not a replacement.
+ *
+ * See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
+ */
+
+import { createSignal, Show, type Component, type JSX } from "solid-js";
+
+import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
+
+import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
+import "./tab-modal.scss";
+
+interface TabModalLayerProps {
+    children: JSX.Element;
+}
+
+export const TabModalLayer: Component<TabModalLayerProps> = (props) => {
+    const [current, setCurrent] = createSignal<TabModalRequest | null>(null);
+
+    const api: TabModalApi = {
+        open: (req) => setCurrent(req),
+        close: () => setCurrent(null),
+        current,
+    };
+
+    // Backdrop click closes. Panel click is stopped from bubbling so a
+    // click inside the form doesn't reach the backdrop. ESC closes via
+    // the layer's keyDown handler — caught here so unrelated ESC users
+    // in the tile layout aren't pre-empted by a global listener.
+    const handleBackdropClick = (e: MouseEvent) => {
+        if (e.target === e.currentTarget) {
+            api.close();
+        }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Escape" && current() != null) {
+            e.stopPropagation();
+            api.close();
+        }
+    };
+
+    return (
+        <TabModalContext.Provider value={api}>
+            <div
+                class="tab-modal-layer"
+                data-modal-open={current() != null ? "true" : undefined}
+                onKeyDown={handleKeyDown}
+            >
+                <div
+                    class="tab-modal-content"
+                    inert={current() != null || undefined}
+                    aria-hidden={current() != null ? "true" : undefined}
+                >
+                    {props.children}
+                </div>
+                <Show when={current()}>
+                    {(req) => (
+                        <div class="tab-modal-overlay" role="presentation" onClick={handleBackdropClick}>
+                            <div class="tab-modal-backdrop" />
+                            <div
+                                class="tab-modal-panel"
+                                role="dialog"
+                                aria-modal="true"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                {renderRequest(req(), api)}
+                            </div>
+                        </div>
+                    )}
+                </Show>
+            </div>
+        </TabModalContext.Provider>
+    );
+};
+
+// ── Render dispatch ──────────────────────────────────────────────────────────
+//
+// One branch per request `kind`. The panel's `onSubmit` re-throws on
+// failure so the panel can surface the error in its own UI; on success
+// the layer closes itself.
+
+function renderRequest(req: TabModalRequest, api: TabModalApi): JSX.Element {
+    switch (req.kind) {
+        case "launch-agent":
+            return (
+                <AgentLaunchModalPanel
+                    agent={req.agent}
+                    onCancel={api.close}
+                    onSubmit={async (overrides) => {
+                        await req.onSubmit(overrides);
+                        api.close();
+                    }}
+                />
+            );
+    }
+}

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -20,8 +20,9 @@
  * See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
-import { createSignal, Show, type Component, type JSX } from "solid-js";
+import { createSignal, Show, type Accessor, type Component, type JSX } from "solid-js";
 
+import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
@@ -31,72 +32,88 @@ interface TabModalLayerProps {
     children: JSX.Element;
 }
 
+// Registers the overlay element with the backend pane-clip system so
+// native browser-pane HWNDs cut a transparent hole matching the overlay
+// rect. Without this, hardware-windowed panes composite above HTML
+// regardless of CSS z-index and render on top of the modal.
+// Mirrors the ModalPaneOverlayClip pattern in modal-v2.tsx.
+const PaneOverlayClip: Component<{ getEl: Accessor<HTMLElement | null | undefined> }> = (p) => {
+    usePaneOverlay(p.getEl);
+    return null;
+};
+
 export const TabModalLayer: Component<TabModalLayerProps> = (props) => {
     const [current, setCurrent] = createSignal<TabModalRequest | null>(null);
+    const [submitting, setSubmitting] = createSignal(false);
 
-    const api: TabModalApi = {
-        open: (req) => setCurrent(req),
-        close: () => setCurrent(null),
-        current,
+    // Guard close: ESC and backdrop click are blocked while a submit RPC is
+    // in-flight so the user can't lose error feedback or trigger a duplicate launch.
+    const safeClose = () => {
+        if (!submitting()) setCurrent(null);
     };
 
-    // Backdrop click closes. Panel click is stopped from bubbling so a
-    // click inside the form doesn't reach the backdrop. ESC is handled
-    // on the overlay itself so we don't need a wrapper div around
-    // TileLayout (which would break its flex layout).
-    const handleBackdropClick = (e: MouseEvent) => {
-        if (e.target === e.currentTarget) {
-            api.close();
-        }
+    const api: TabModalApi = {
+        open: (req) => { setSubmitting(false); setCurrent(req); },
+        close: safeClose,
+        current,
     };
 
     const handleOverlayKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
             e.stopPropagation();
-            api.close();
+            safeClose();
         }
     };
 
-    // Context.Provider emits no DOM node, so TileLayout (props.children)
-    // remains a direct child of TabContent's flex container. The overlay
-    // is a sibling rendered after it; `position:absolute; inset:0` on
-    // .tab-modal-overlay pins it to TabContent's `position:relative` root.
+    // `display:contents` is layout-transparent — TileLayout still sees
+    // TabContent's flex-row container as its parent. `inert` makes the
+    // subtree non-interactive when a modal is open, trapping focus inside
+    // the overlay panel without the layout disruption a normal div would cause.
     return (
         <TabModalContext.Provider value={api}>
-            {props.children}
+            <div style="display:contents" inert={current() != null || undefined}>
+                {props.children}
+            </div>
             <Show when={current()}>
-                {(req) => (
-                    <div
-                        class="tab-modal-overlay"
-                        role="presentation"
-                        // eslint-disable-next-line jsx-a11y/no-autofocus
-                        tabIndex={-1}
-                        onClick={handleBackdropClick}
-                        onKeyDown={handleOverlayKeyDown}
-                    >
-                        <div class="tab-modal-backdrop" />
+                {(req) => {
+                    let overlayRef: HTMLDivElement | undefined;
+                    return (
                         <div
-                            class="tab-modal-panel"
-                            role="dialog"
-                            aria-modal="true"
-                            onClick={(e) => e.stopPropagation()}
+                            class="tab-modal-overlay"
+                            ref={(el) => { overlayRef = el; }}
+                            role="presentation"
+                            tabIndex={-1}
+                            onKeyDown={handleOverlayKeyDown}
                         >
-                            {renderRequest(req(), api)}
+                            <PaneOverlayClip getEl={() => overlayRef} />
+                            {/* Click on backdrop (not panel) closes. Handler is on the
+                                backdrop element itself — the backdrop covers the full
+                                overlay area, so e.target === e.currentTarget on the
+                                overlay would never fire. */}
+                            <div class="tab-modal-backdrop" onClick={safeClose} />
+                            <div
+                                class="tab-modal-panel"
+                                role="dialog"
+                                aria-modal="true"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                {renderRequest(req(), api, setSubmitting)}
+                            </div>
                         </div>
-                    </div>
-                )}
+                    );
+                }}
             </Show>
         </TabModalContext.Provider>
     );
 };
 
 // ── Render dispatch ──────────────────────────────────────────────────────────
-//
-// One branch per request `kind`. The panel's `onSubmit` re-throws on
-// failure so the panel can surface the error in its own UI; on success
-// the layer closes itself.
 
-function renderRequest(req: TabModalRequest, api: TabModalApi): JSX.Element {
+function renderRequest(
+    req: TabModalRequest,
+    api: TabModalApi,
+    setSubmitting: (v: boolean) => void,
+): JSX.Element {
     switch (req.kind) {
         case "launch-agent":
             return (
@@ -104,8 +121,15 @@ function renderRequest(req: TabModalRequest, api: TabModalApi): JSX.Element {
                     agent={req.agent}
                     onCancel={api.close}
                     onSubmit={async (overrides) => {
-                        await req.onSubmit(overrides);
-                        api.close();
+                        setSubmitting(true);
+                        try {
+                            await req.onSubmit(overrides);
+                            setSubmitting(false);
+                            api.close();
+                        } catch (e) {
+                            setSubmitting(false);
+                            throw e;
+                        }
                     }}
                 />
             );

--- a/frontend/app/tab/tab-modal.scss
+++ b/frontend/app/tab/tab-modal.scss
@@ -61,7 +61,4 @@
     .tab-modal-panel {
         animation: none;
     }
-    .tab-modal-content {
-        transition: none;
-    }
 }

--- a/frontend/app/tab/tab-modal.scss
+++ b/frontend/app/tab/tab-modal.scss
@@ -3,40 +3,11 @@
 
 // TabModalLayer — per-tab modal scaffolding.
 //
-// The layer is a positioned ancestor of both the tab's tile content and
-// the modal overlay. The overlay uses `position: absolute; inset: 0;`
-// to fill the tab area only — never the tab bar above or anything
-// outside `<TabContent>`. Backdrop is a solid scrim (no `backdrop-filter`)
-// to keep input handling cheap; full-window blur was a major contributor
-// to the original lag.
-
-.tab-modal-layer {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    min-height: 0;
-    width: 100%;
-}
-
-.tab-modal-content {
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
-    min-height: 0;
-    width: 100%;
-
-    // When a modal is open, dim the tile layout and disable pointer
-    // events so the user can't interact with widgets behind the panel.
-    // `inert` would be ideal but its CSS support is uneven; we use
-    // pointer-events + aria-hidden via the parent's data attribute.
-    .tab-modal-layer[data-modal-open="true"] & {
-        pointer-events: none;
-        user-select: none;
-        filter: saturate(0.7) brightness(0.85);
-        transition: filter 120ms ease-out;
-    }
-}
+// No wrapper div is added around TileLayout. The overlay is a sibling
+// of TileLayout inside TabContent's `position:relative` root div.
+// `position: absolute; inset: 0` on .tab-modal-overlay pins it to that
+// ancestor, covering only the tab area (not the tab bar above).
+// Backdrop is a solid scrim — no backdrop-filter — to keep rendering cheap.
 
 .tab-modal-overlay {
     position: absolute;

--- a/frontend/app/tab/tab-modal.scss
+++ b/frontend/app/tab/tab-modal.scss
@@ -1,0 +1,96 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// TabModalLayer — per-tab modal scaffolding.
+//
+// The layer is a positioned ancestor of both the tab's tile content and
+// the modal overlay. The overlay uses `position: absolute; inset: 0;`
+// to fill the tab area only — never the tab bar above or anything
+// outside `<TabContent>`. Backdrop is a solid scrim (no `backdrop-filter`)
+// to keep input handling cheap; full-window blur was a major contributor
+// to the original lag.
+
+.tab-modal-layer {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    min-height: 0;
+    width: 100%;
+}
+
+.tab-modal-content {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+    min-height: 0;
+    width: 100%;
+
+    // When a modal is open, dim the tile layout and disable pointer
+    // events so the user can't interact with widgets behind the panel.
+    // `inert` would be ideal but its CSS support is uneven; we use
+    // pointer-events + aria-hidden via the parent's data attribute.
+    .tab-modal-layer[data-modal-open="true"] & {
+        pointer-events: none;
+        user-select: none;
+        filter: saturate(0.7) brightness(0.85);
+        transition: filter 120ms ease-out;
+    }
+}
+
+.tab-modal-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: var(--z-tab-modal);
+    display: grid;
+    place-items: center;
+    padding: var(--space-6);
+    // Re-enable pointer events on the overlay itself — the dim layer
+    // above kills them on the content beneath.
+    pointer-events: auto;
+}
+
+.tab-modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    animation: tab-modal-fade-in 120ms ease-out;
+}
+
+.tab-modal-panel {
+    position: relative;
+    max-width: 100%;
+    max-height: calc(100% - #{2 * 24px});
+    overflow: auto;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-modal);
+    animation: tab-modal-pop-in 140ms cubic-bezier(0.2, 1, 0.3, 1);
+
+    &:focus-visible {
+        box-shadow: var(--shadow-modal), var(--shadow-focus-ring);
+        outline: none;
+    }
+}
+
+@keyframes tab-modal-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes tab-modal-pop-in {
+    from { opacity: 0; transform: scale(0.96) translateY(4px); }
+    to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tab-modal-backdrop,
+    .tab-modal-panel {
+        animation: none;
+    }
+    .tab-modal-content {
+        transition: none;
+    }
+}

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -1,0 +1,70 @@
+// Copyright 2024-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TabModalLayer types + context — per-tab modal scoping.
+ *
+ * Each `<TabContent>` wraps its tile layout in a `<TabModalLayer>` which
+ * provides this context. Components inside a tab call `useTabModal()` to
+ * open and close tab-scoped modals (e.g., AgentLaunchModal). The layer
+ * handles rendering the overlay; consumers only declare the request.
+ *
+ * See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
+ */
+
+import { createContext, useContext, type Accessor } from "solid-js";
+
+// ── Request shape ────────────────────────────────────────────────────────────
+//
+// Discriminated union so the layer can dispatch on `kind`. New tab-modal
+// surfaces add a variant here and a render branch in TabModalLayer.
+
+export type TabModalRequest = LaunchAgentRequest;
+
+export interface LaunchAgentRequest {
+    kind: "launch-agent";
+    /** Forge definition the user clicked. */
+    agent: ForgeAgent;
+    /** Block id of the pane that opened the modal. */
+    originBlockId: string;
+    /**
+     * Called by the layer when the user submits valid form data. Returns
+     * a promise so the modal can show "Launching…" until it resolves; on
+     * resolve, the layer closes the modal automatically. If the promise
+     * rejects, the modal stays open and surfaces the error.
+     */
+    onSubmit: (overrides: LaunchAgentSubmit) => Promise<void> | void;
+}
+
+export interface LaunchAgentSubmit {
+    instanceName: string;
+    agentType: "host" | "container";
+    environment: "local" | "docker";
+    containerImage?: string;
+}
+
+// ── Context API ──────────────────────────────────────────────────────────────
+
+export interface TabModalApi {
+    /** Open or replace the current tab modal request. */
+    open: (req: TabModalRequest) => void;
+    /** Close the current modal, if any. No-op when nothing is open. */
+    close: () => void;
+    /** The currently open request, or null. */
+    current: Accessor<TabModalRequest | null>;
+}
+
+export const TabModalContext = createContext<TabModalApi | null>(null);
+
+/**
+ * Access the tab-scoped modal API. Throws when called outside a
+ * `<TabModalLayer>` so misuses surface immediately rather than silently
+ * no-op'ing.
+ */
+export function useTabModal(): TabModalApi {
+    const ctx = useContext(TabModalContext);
+    if (!ctx) {
+        throw new Error("useTabModal called outside <TabModalLayer>");
+    }
+    return ctx;
+}

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -3,6 +3,7 @@
 
 import { Block } from "@/app/block/block";
 import { ContextMenuModel } from "@/app/store/contextmenu";
+import { TabModalLayer } from "@/app/tab/TabModalLayer";
 import { CenteredDiv } from "@/element/quickelems";
 import { ContentRenderer, NodeModel, PreviewRenderer, TileLayout } from "@/layout/index";
 import { TileLayoutContents } from "@/layout/lib/types";
@@ -111,11 +112,13 @@ function TabContent(props: { tabId: string }): JSX.Element {
                 when={tabData() != null}
                 fallback={<CenteredDiv>Tab Not Found</CenteredDiv>}
             >
-                <TileLayout
-                    contents={tileLayoutContents()}
-                    tabAtom={tabAtom()}
-                    getCursorPoint={getApi().getCursorPoint}
-                />
+                <TabModalLayer>
+                    <TileLayout
+                        contents={tileLayoutContents()}
+                        tabAtom={tabAtom()}
+                        getCursorPoint={getApi().getCursorPoint}
+                    />
+                </TabModalLayer>
             </Show>
         </div>
     );

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -274,6 +274,7 @@
     --z-flash-error:   7000;
     --z-typeahead:     8000;
     --z-popover:       8500;
+    --z-tab-modal:     8800;
     --z-modal:         9000;
     --z-flyout-menu:   9500;
     --z-context-menu:  10000;

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -2,17 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentLaunchModal — shown when the user clicks a definition card in
- * the agent picker. Collects the instance name + runtime (host vs
- * container) and submits them to the caller, which is responsible
- * for calling launchForgeAgent with the overrides.
+ * AgentLaunchModalPanel — the form rendered inside `<TabModalLayer>`
+ * when the user clicks a definition card in the agent picker. Collects
+ * the instance name + runtime (host vs container) and submits them to
+ * the caller, which is responsible for calling launchForgeAgent with
+ * the overrides.
  *
- * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md §6.
+ * No Portal, no Modal v2 wrapper — the layer owns positioning, backdrop,
+ * ESC, and backdrop-click semantics. This file contributes the form
+ * panel only. See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
 import { createMemo, createSignal, Show, type JSX } from "solid-js";
+
 import { Button } from "@/element/button";
-import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
+
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slug";
 
@@ -29,13 +33,13 @@ export interface LaunchOverrides {
     containerImage?: string;
 }
 
-interface AgentLaunchModalProps {
+interface AgentLaunchModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
     onSubmit: (overrides: LaunchOverrides) => Promise<void> | void;
 }
 
-export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
+export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
     const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
     const displayName = () => catalog()?.displayName ?? props.agent.name;
 
@@ -46,14 +50,8 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
     const [error, setError] = createSignal<string | null>(null);
     const [showAdvanced, setShowAdvanced] = createSignal(false);
 
-    // Live preview of the instance slug — shown inside Advanced as
-    // "Its files will live in <slug>" so power users can see what
-    // their name will become. The backend stamps the real slug on
-    // submit, but this is close enough for the user to recognise it.
     const hasName = () => name().trim().length > 0;
-
     const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
-
     const containerSupported = () => catalog()?.containerSupported ?? true;
 
     const resolvedImage = () => {
@@ -73,16 +71,16 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                 environment: runtime() === "container" ? "docker" : "local",
                 containerImage: runtime() === "container" ? resolvedImage() : undefined,
             });
+            // Success: layer closes the panel; we leave `submitting`
+            // true so the button keeps its "Launching…" label until
+            // unmount.
         } catch (e: any) {
             setError(String(e?.message ?? e));
             setSubmitting(false);
         }
-        // Success: parent closes the modal so we leave submitting true.
     };
 
-    // Modal v2 handles ESC (topmost-aware), backdrop click, focus
-    // trap, focus restoration, and scroll lock. We only need to add
-    // Enter-to-submit since the modal doesn't prescribe form semantics.
+    // Enter submits; ESC and backdrop click are handled by the layer.
     const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Enter" && canSubmit()) {
             e.preventDefault();
@@ -91,15 +89,11 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
     };
 
     return (
-        <Modal
-            open={true}
-            onClose={() => { if (!submitting()) props.onCancel(); }}
-            closeOnBackdropClick={!submitting()}
-            closeOnEscape={!submitting()}
-            size="md"
-        >
-            <ModalHeader title={`Launch ${displayName()}`} />
-            <ModalBody>
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">Launch {displayName()}</h2>
+            </header>
+            <div class="modal-panel-body">
                 <div class="agent-launch-modal-body" onKeyDown={handleKeyDown}>
                     <Show when={catalog()}>
                         <p class="agent-launch-modal-blurb">
@@ -118,6 +112,12 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                             onInput={(e) => setName(e.currentTarget.value)}
                             disabled={submitting()}
                             aria-label="Agent name"
+                            // Autofocus so the user can start typing immediately.
+                            // Layer renders us inside its panel; the focus is
+                            // contained because the dimmed content beneath is
+                            // marked `inert`.
+                            // eslint-disable-next-line jsx-a11y/no-autofocus
+                            autofocus
                         />
                         <span class="agent-launch-modal-hint">
                             So you can tell it apart from other agents. 1–64 characters.
@@ -206,17 +206,17 @@ export const AgentLaunchModal = (props: AgentLaunchModalProps): JSX.Element => {
                         </div>
                     </details>
                 </div>
-            </ModalBody>
-            <ModalFooter>
+            </div>
+            <footer class="modal-panel-footer">
                 <Button onClick={props.onCancel} disabled={submitting()}>
                     Cancel
                 </Button>
                 <Button onClick={() => void handleSubmit()} disabled={!canSubmit()}>
                     {submitting() ? "Launching…" : "Launch"}
                 </Button>
-            </ModalFooter>
-        </Modal>
+            </footer>
+        </>
     );
 };
 
-AgentLaunchModal.displayName = "AgentLaunchModal";
+AgentLaunchModalPanel.displayName = "AgentLaunchModalPanel";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -14,11 +14,12 @@ import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js"
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
+import { useTabModal } from "@/app/tab/tab-modal";
 import type { AgentViewModel } from "../agent-model";
 import { AgentCard } from "./AgentCard";
 import { AgentCardSettingsPanel } from "./AgentCardSettingsPanel";
 import { AgentActionBar } from "./AgentActionBar";
-import { AgentLaunchModal, type LaunchOverrides } from "./AgentLaunchModal";
+import type { LaunchOverrides } from "./AgentLaunchModal";
 import { ConfirmModal } from "@/element/modal-v2";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
@@ -67,42 +68,41 @@ interface AgentPickerProps {
 export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const [launching, setLaunching] = createSignal<string | null>(null);
     const [nodejsError, setNodejsError] = createSignal<string | null>(null);
-    const [launchModalAgent, setLaunchModalAgent] = createSignal<ForgeAgent | null>(null);
     const [deleteCandidate, setDeleteCandidate] = createSignal<ForgeAgent | null>(null);
     const [deleteError, setDeleteError] = createSignal<string | null>(null);
     const agents = useForgeAgents();
+    const tabModal = useTabModal();
 
     // Inline Forge-settings panel: which definition is expanded.
     // Session-local only — not persisted to block meta.
     const [expandedId, setExpandedId] = createSignal<string | null>(null);
 
-    // Clicking the card opens the Launch modal. The actual launch
-    // happens on modal submit.
+    // Clicking the card opens the launch modal in the tab-scoped layer.
+    // The picker no longer owns the modal's open/closed signal — that
+    // lives on TabModalLayer. We pass an `onSubmit` callback in the
+    // request; the layer closes the modal when it resolves.
     const handleSelect = (agent: ForgeAgent) => {
         setNodejsError(null);
-        setLaunchModalAgent(agent);
-    };
-
-    const handleLaunchSubmit = async (overrides: LaunchOverrides) => {
-        const agent = launchModalAgent();
-        if (!agent) return;
-        setLaunching(agent.id);
-        try {
-            await props.model.launchForgeAgent(agent, overrides);
-            if (props.model.nodejsError) {
-                setNodejsError(props.model.nodejsError);
-                props.model.nodejsError = null;
-            }
-            // Close the modal only on the happy path. If
-            // `launchForgeAgent` ever throws (it currently logs-and-
-            // swallows, but that can change), letting the error
-            // propagate lets the modal's own try/catch surface the
-            // message to the user instead of the modal silently
-            // disappearing under a `finally` close.
-            setLaunchModalAgent(null);
-        } finally {
-            setLaunching(null);
-        }
+        tabModal.open({
+            kind: "launch-agent",
+            agent,
+            originBlockId: props.model.blockId,
+            onSubmit: async (overrides: LaunchOverrides) => {
+                setLaunching(agent.id);
+                try {
+                    await props.model.launchForgeAgent(agent, overrides);
+                    if (props.model.nodejsError) {
+                        // Surface the missing-Node banner inside the
+                        // picker after the layer closes the modal —
+                        // matches the pre-refactor behaviour.
+                        setNodejsError(props.model.nodejsError);
+                        props.model.nodejsError = null;
+                    }
+                } finally {
+                    setLaunching(null);
+                }
+            },
+        });
     };
 
     const openForgeFor = (agent: ForgeAgent) => {
@@ -201,15 +201,6 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     </div>
                     <AgentActionBar />
                 </div>
-            </Show>
-            <Show when={launchModalAgent()}>
-                {(agent) => (
-                    <AgentLaunchModal
-                        agent={agent()}
-                        onCancel={() => setLaunchModalAgent(null)}
-                        onSubmit={handleLaunchSubmit}
-                    />
-                )}
             </Show>
             <Show when={deleteCandidate()}>
                 {(agent) => (

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.581",
+  "version": "0.33.582",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.582",
+  "version": "0.33.583",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Fixes form input lag** in the agent launch modal: root cause was the modal sharing SolidJS reactive scope with the `<For>` card list + Popovers in `AgentPicker`, plus a full-window `backdrop-filter: blur(8px)` re-running on every keystroke.
- **Fixes overlay scope**: the old modal used `<Modal v2>` → `<Portal mount={document.body}>` with `position: fixed`, covering the entire window including the tab bar. Now the overlay is scoped to the active tab only.
- **Tab bar stays interactive**: switching tabs while the modal is open works correctly. The modal hides automatically via the existing `display:none` on inactive tab content.

## New architecture

```
TabContent
└── TabModalLayer          ← new, wraps TileLayout
    ├── div.tab-modal-content  [inert when modal open]
    │   └── TileLayout
    └── Show when={current()}
        └── div.tab-modal-overlay  (position: absolute, tab-scoped)
            ├── div.tab-modal-backdrop  (solid scrim, no blur)
            └── div.tab-modal-panel [role=dialog]
                └── AgentLaunchModalPanel  ← stripped to pure form
```

**Key points:**
- No Portal. Modal renders inline, inside `<TabContent>`.
- `TabModalContext` / `useTabModal()` hook — extensible for future request kinds.
- `AgentLaunchModalPanel` is now a pure form component (no Modal v2 wrapper). All positioning/overlay/ESC/backdrop-click is owned by the layer.
- `AgentPicker` no longer holds any modal open/close signal — it just calls `tabModal.open({ kind: "launch-agent", ... })`.
- `--z-tab-modal: 8800` token added to `theme.scss` (between `--z-popover: 8500` and `--z-modal: 9000`).

## Files

| File | Change |
|------|--------|
| `frontend/app/tab/tab-modal.ts` | New — context types, `TabModalRequest` union, `useTabModal()` |
| `frontend/app/tab/TabModalLayer.tsx` | New — provider + overlay host |
| `frontend/app/tab/tab-modal.scss` | New — overlay styles |
| `frontend/app/tab/tabcontent.tsx` | Wraps `<TileLayout>` in `<TabModalLayer>` |
| `frontend/app/theme.scss` | Adds `--z-tab-modal` token |
| `frontend/app/view/agent/components/AgentLaunchModal.tsx` | Stripped to pure form panel |
| `frontend/app/view/agent/components/AgentPicker.tsx` | Uses `useTabModal()`, removes old modal signal |
| `docs/specs/launch-modal-rearchitecture-2026-05-01.md` | Full rearchitecture spec |
| `docs/specs/modal-cleanup-migration-2026-05-01.md` | Modal audit + phase 2 migration plan |

## Test plan

- [ ] Click an agent card → launch modal opens, tab bar stays interactive
- [ ] Type in the name field → no lag, instant response
- [ ] Switch to another tab while modal open → modal disappears with the tab
- [ ] Return to original tab → modal is still open where you left it
- [ ] ESC closes the modal
- [ ] Backdrop click closes the modal
- [ ] Click inside the form panel → does not close the modal
- [ ] Cancel button closes
- [ ] Launch button submits (happy path: agent launches, modal closes)
- [ ] Launch error → error banner shown inside panel, modal stays open
- [ ] Delete confirm modal (`ConfirmModal` via modal-v2) still works
- [ ] Command palette (global modal) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)