### PR TITLE
feat(cef): host reducer Phase H foundations — state, commands, events (PR #1 of 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.579"
+version = "0.33.580"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.579"
+version = "0.33.580"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -882,9 +882,18 @@ fn handle_pool_ready(state: &mut HostState, label: String) -> DispatchOutput {
 }
 
 fn handle_pool_destroyed_before_promote(state: &mut HostState, label: String) -> DispatchOutput {
+    // Pool windows can be destroyed in two states (codex P1 PR #654 round 2):
+    //   1. Still in `unpromoted` — never reached renderer-ready.
+    //   2. Already in `queue` — passed renderer-ready, awaiting promotion,
+    //      then closed externally before promote.
+    // Both must be cleaned up; otherwise the queue retains a dead label
+    // and a later `PromotePoolWindow` operates on stale inventory.
     let was_unpromoted = state.pool.unpromoted.remove(&label);
+    let queue_len_before = state.pool.queue.len();
+    state.pool.queue.retain(|l| l != &label);
+    let was_in_queue = state.pool.queue.len() < queue_len_before;
     state.pool.respawn_in_flight = false;
-    if !was_unpromoted {
+    if !was_unpromoted && !was_in_queue {
         return DispatchOutput::default();
     }
     let v = state.bump_version();
@@ -1671,6 +1680,47 @@ mod tests {
         let out = update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
         assert!(out.events.is_empty()); // suppressed
         assert!(state.pool.unpromoted.is_empty());
+    }
+
+    /// Regression test for codex P1 on PR #654 round 2.
+    ///
+    /// `PoolWindowReady` moves a label from `unpromoted` to `queue`.
+    /// If the window is then destroyed externally before promotion,
+    /// the destroy handler must scrub the label from BOTH sets — not
+    /// just `unpromoted`. Otherwise dead inventory remains in `queue`
+    /// and a later `PromotePoolWindow` operates on a stale label.
+    #[test]
+    fn pool_destroy_after_ready_clears_queue() {
+        let mut state = HostState::default();
+        // Step 1: spawn + ready → label lands in queue.
+        update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
+        update(&mut state, HostCommand::PoolWindowReady { label: "p1".into() });
+        assert_eq!(state.pool.queue.len(), 1);
+        assert!(!state.pool.unpromoted.contains("p1"));
+        // Step 2: external destroy after ready, before promote.
+        let out = update(
+            &mut state,
+            HostCommand::PoolWindowDestroyedBeforePromote { label: "p1".into() },
+        );
+        // CRITICAL: queue must be drained.
+        assert!(state.pool.queue.is_empty(), "queue must not retain destroyed label");
+        assert!(state.pool.unpromoted.is_empty());
+        // Event must fire (we did real cleanup).
+        assert!(
+            out.events.iter().any(|e| matches!(e, HostEvent::PoolWindowLeft { reason: PoolLeaveReason::DestroyedBeforePromote, .. })),
+            "PoolWindowLeft event must fire for queue-state destroy"
+        );
+    }
+
+    /// Sister test: destroy with the label in NEITHER set is still a no-op.
+    #[test]
+    fn pool_destroy_with_unknown_label_is_noop() {
+        let mut state = HostState::default();
+        let out = update(
+            &mut state,
+            HostCommand::PoolWindowDestroyedBeforePromote { label: "ghost".into() },
+        );
+        assert!(out.events.is_empty());
     }
 
     /// Regression test for codex P1 on PR #654 round 1.

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -1008,8 +1008,18 @@ fn handle_enqueue_top_level_window(
 /// Internal helper: if in_flight is None and queue has work, pop the front
 /// and start it. Emits `TopLevelCreationRequested`, `TopLevelCreationStarted`,
 /// `Effect::PostCreateWindow`, and updated queue length.
+///
+/// **Quit gating** (codex P1 PR #654 round 1): if `quit_state != Running`,
+/// don't start anything — queued background requests stay queued but will
+/// never fire (host is exiting; in-memory queue dies with the process).
+/// Without this guard, an in-flight completion during `Draining` would pop
+/// a queued background pool refill and emit `Effect::PostCreateWindow`,
+/// creating a new window mid-shutdown and preventing drain completion.
 fn start_next_top_level_if_idle(state: &mut HostState) -> DispatchOutput {
     if state.top_level_creation.in_flight.is_some() {
+        return DispatchOutput::default();
+    }
+    if state.quit_state != QuitState::Running {
         return DispatchOutput::default();
     }
     let request = match state.top_level_creation.queue.pop_front() {
@@ -1661,5 +1671,59 @@ mod tests {
         let out = update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
         assert!(out.events.is_empty()); // suppressed
         assert!(state.pool.unpromoted.is_empty());
+    }
+
+    /// Regression test for codex P1 on PR #654 round 1.
+    ///
+    /// Setup: in-flight User creation, Background queued behind it. Begin
+    /// drain. Complete the in-flight. The queued Background request must
+    /// NOT be started — even though it was enqueued before drain, starting
+    /// it would create a new window mid-shutdown and prevent drain completion.
+    #[test]
+    fn queued_background_does_not_start_after_drain_begins() {
+        let mut state = HostState::default();
+        // Step 1: User-initiated creation goes in-flight.
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("user-window", TopLevelSource::User),
+            },
+        );
+        assert!(state.top_level_creation.in_flight.is_some());
+        // Step 2: Background pool refill queues behind it.
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("pool-refill", TopLevelSource::Background),
+            },
+        );
+        assert_eq!(state.top_level_creation.queue.len(), 1);
+        // Step 3: User triggers shutdown (last window closed). Drain begins.
+        update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
+        assert!(matches!(state.quit_state, QuitState::Draining { .. }));
+        // Step 4: The in-flight user-window's CEF callback fires. Normally
+        // this would pop the queued Background request and start it. With
+        // the quit gate it must NOT.
+        let out = update(
+            &mut state,
+            HostCommand::TopLevelCallbackFired { label: "user-window".into() },
+        );
+        assert!(state.top_level_creation.in_flight.is_none(), "in-flight cleared after callback");
+        assert_eq!(state.top_level_creation.queue.len(), 1, "queued background still queued");
+        // CRITICAL: no PostCreateWindow effect emitted.
+        let post_create_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(
+                e,
+                HostEvent::Effect { effect: EffectKind::PostCreateWindow { .. }, .. }
+            ))
+            .count();
+        assert_eq!(post_create_count, 0, "no PostCreateWindow effect during drain");
+        // The completion event for the user-window should still fire.
+        assert!(
+            out.events.iter().any(|e| matches!(e, HostEvent::TopLevelCreationCompleted { .. })),
+            "user-window completion still emitted"
+        );
     }
 }

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -909,11 +909,19 @@ fn handle_pool_destroyed_before_promote(state: &mut HostState, label: String) ->
 }
 
 fn handle_promote_pool_window(state: &mut HostState, label: String) -> DispatchOutput {
-    let in_queue = state.pool.queue.iter().position(|l| l == &label).is_some();
-    if in_queue {
-        state.pool.queue.retain(|l| l != &label);
+    // Idempotent no-op for truly unknown labels (reagent P2 PR #654 round 3).
+    // Symmetric with `handle_pool_destroyed_before_promote`'s pattern: only
+    // emit `PoolWindowLeft` if we actually removed the label from one of
+    // the pool sets. Without this, a stale promote command (e.g., from a
+    // race between PromotePoolWindow and PoolWindowDestroyedBeforePromote)
+    // would emit a phantom `PoolWindowLeft` event that observers might act on.
+    let queue_len_before = state.pool.queue.len();
+    state.pool.queue.retain(|l| l != &label);
+    let was_in_queue = state.pool.queue.len() < queue_len_before;
+    let was_in_unpromoted = state.pool.unpromoted.remove(&label);
+    if !was_in_queue && !was_in_unpromoted {
+        return DispatchOutput::default();
     }
-    state.pool.unpromoted.remove(&label);
     // Mark the corresponding browser handle as no-longer-pool.
     if let Some(handle) = state.browsers.get_mut(&label) {
         if let BrowserKind::TopLevel { is_pool } = &mut handle.kind {
@@ -1710,6 +1718,35 @@ mod tests {
             out.events.iter().any(|e| matches!(e, HostEvent::PoolWindowLeft { reason: PoolLeaveReason::DestroyedBeforePromote, .. })),
             "PoolWindowLeft event must fire for queue-state destroy"
         );
+    }
+
+    /// Regression test for reagent P2 on PR #654 round 3.
+    ///
+    /// `handle_promote_pool_window` should be idempotent for truly unknown
+    /// labels (matching `handle_pool_destroyed_before_promote`'s pattern).
+    /// A stale promote command — e.g., racing with destroy — must not emit
+    /// a phantom `PoolWindowLeft` event that observers might act on.
+    #[test]
+    fn pool_promote_with_unknown_label_is_noop() {
+        let mut state = HostState::default();
+        let out = update(&mut state, HostCommand::PromotePoolWindow { label: "ghost".into() });
+        assert!(out.events.is_empty(), "promote of unknown label must be no-op");
+        assert!(state.pool.queue.is_empty());
+        assert!(state.pool.unpromoted.is_empty());
+    }
+
+    /// Confirms promote DOES emit when the label was in queue (the normal flow).
+    #[test]
+    fn pool_promote_with_known_label_emits_event() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
+        update(&mut state, HostCommand::PoolWindowReady { label: "p1".into() });
+        let out = update(&mut state, HostCommand::PromotePoolWindow { label: "p1".into() });
+        assert!(state.pool.queue.is_empty());
+        assert!(out.events.iter().any(|e| matches!(
+            e,
+            HostEvent::PoolWindowLeft { reason: PoolLeaveReason::Promoted, .. }
+        )));
     }
 
     /// Sister test: destroy with the label in NEITHER set is still a no-op.

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -27,9 +27,22 @@
 // F.1 in-process avoids serializing `PendingWindowCreation` over a
 // pipe just to satisfy a pattern that has no current consumer.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
 
-use crate::state::PendingWindowCreation;
+use cef::Browser;
+
+use crate::state::{
+    BrowserHandle, BrowserKind, CompletedCreation, CreationPhase, DragSession, EffectKind,
+    InFlightCreation, PaneEntry, PaneLifecycle, PendingWindowCreation, PoolState, QuitReason,
+    QuitState, TopLevelCreationOutcome, TopLevelCreationRequest, TopLevelCreationState,
+    TopLevelSource,
+};
+
+/// Capacity of `TopLevelCreationState.history` ring buffer. Configurable
+/// via `~/.agentmux/config.toml [host.reducer]` once H.5 (config) lands;
+/// hard-coded for PR #1.
+pub const TOP_LEVEL_CREATION_HISTORY_CAP: usize = 50;
 
 /// Lifecycle phase of the host reducer. Mirrors the launcher and srv
 /// reducers' phase enum.
@@ -65,6 +78,40 @@ pub struct HostState {
     ///   never has a corresponding entry here.
     pub pending_window_creations: VecDeque<PendingWindowCreation>,
 
+    // ── Phase H — added in PR #1 (h1-foundations); populated by reducer
+    // arms below; no production callers yet. PRs #2-#5 wire each through
+    // the a→e migration ratchet. See SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md.
+
+    /// H.1 — pane lifecycle map. Replaces `BrowserPaneManager::PaneStateMachine`
+    /// (pane/lifecycle.rs:60). Keyed by `block_id`.
+    #[allow(dead_code)]
+    pub panes: HashMap<String, PaneEntry>,
+
+    /// H.2 — browser handle registry. Replaces `AppState.browsers:
+    /// Mutex<HashMap<String, Browser>>` (state.rs:210). Keyed by label
+    /// (e.g., `window-...`, `browser-pane-...`, `window-pool-...`).
+    #[allow(dead_code)]
+    pub browsers: HashMap<String, BrowserHandle>,
+
+    /// H.3 — active drag session (singleton). Replaces `AppState.active_drag:
+    /// Mutex<Option<DragSession>>`.
+    #[allow(dead_code)]
+    pub active_drag: Option<DragSession>,
+
+    /// H.4 — pool state (queue + unpromoted + in-flight semaphore).
+    /// Replaces three separate fields on AppState.
+    #[allow(dead_code)]
+    pub pool: PoolState,
+
+    /// H.5 — quit lifecycle. Replaces `AppState.is_quitting: AtomicBool`.
+    #[allow(dead_code)]
+    pub quit_state: QuitState,
+
+    /// H.6 — top-level window creation runner state (queue, in-flight,
+    /// history). Event-driven; no watchdog.
+    #[allow(dead_code)]
+    pub top_level_creation: TopLevelCreationState,
+
     /// Lifecycle phase. `Running` is the operating state; the others
     /// gate command acceptance.
     pub lifecycle: HostLifecyclePhase,
@@ -78,6 +125,14 @@ impl Default for HostState {
     fn default() -> Self {
         Self {
             pending_window_creations: VecDeque::new(),
+            // Phase H foundations (PR #1) — empty defaults; populated as
+            // PRs #2-#5 wire callers through the reducer.
+            panes: HashMap::new(),
+            browsers: HashMap::new(),
+            active_drag: None,
+            pool: PoolState::default(),
+            quit_state: QuitState::default(),
+            top_level_creation: TopLevelCreationState::default(),
             // Boot directly into Running — nothing in F.1 needs the
             // pre-init guard yet. Future PRs (drag, tear-off hooks)
             // will move boot through Bootstrapping → Running.
@@ -97,7 +152,10 @@ impl HostState {
 }
 
 /// Commands handled by the host reducer.
-#[derive(Debug, Clone)]
+///
+/// Manual `Debug` impl below because `RegisterBrowser` carries a
+/// `cef::Browser` which doesn't impl Debug.
+#[derive(Clone)]
 pub enum HostCommand {
     /// Append a pending-window-creation handoff. Producer side of the
     /// `pending_window_creations` queue (replaces the four direct
@@ -110,6 +168,225 @@ pub enum HostCommand {
     /// Consumer side of the queue (replaces
     /// `client.rs::on_after_created`'s direct `pop_front`).
     DequeuePendingWindowCreation,
+
+    // ── H.1 — pane lifecycle ────────────────────────────────────────────
+
+    /// Caller (pane create code) requests a new pane lifecycle entry.
+    /// Reducer inserts with `Live`. Reject if `block_id` already present.
+    EnqueuePaneCreate { block_id: String, label: String },
+
+    /// CEF on_after_created fired for a pane browser; confirm it's Live.
+    /// No-op if already Live or absent (idempotent against late callbacks).
+    CompletePaneCreate { block_id: String },
+
+    /// Caller requests pane close. Reducer flips entry to `Closing`.
+    EnqueuePaneClose { block_id: String },
+
+    /// CEF on_before_close fired for a pane; remove entry from map.
+    CompletePaneClose { block_id: String },
+
+    /// Pane creation failed before reaching Live (e.g., CEF callback
+    /// never fired, browser host returned 0). Reducer removes entry.
+    AbortPaneCreate { block_id: String, reason: String },
+
+    // ── H.2 — browser handle registry ───────────────────────────────────
+
+    /// Insert browser into `browsers` map. Caller is on the CEF UI thread
+    /// (e.g., client.rs::on_after_created). Reject (with Error) if label
+    /// already present (collision indicates a bug).
+    RegisterBrowser {
+        label: String,
+        browser: Browser,
+        kind: BrowserKind,
+    },
+
+    /// Remove browser from `browsers` map. Idempotent; no-op if absent.
+    UnregisterBrowser { label: String },
+
+    // ── H.3 — drag state ────────────────────────────────────────────────
+
+    /// Begin a cross-window drag session. Reject if one is already
+    /// active (singleton invariant).
+    StartDrag { session: DragSession },
+
+    /// End the active drag. `drag_id` must match the current session.
+    EndDrag { drag_id: String, outcome: DragOutcome },
+
+    // ── H.4 — pool state ────────────────────────────────────────────────
+
+    /// Pool window spawn started. Adds label to `unpromoted` set; sets
+    /// `respawn_in_flight = true` if not already.
+    PoolWindowSpawnStart { label: String },
+
+    /// Frontend signaled the pool window's renderer is fully initialized.
+    /// Move from `unpromoted` to `queue`; clear `respawn_in_flight`.
+    PoolWindowReady { label: String },
+
+    /// Pool window was destroyed before renderer-ready (e.g., user
+    /// closed it externally during pre-warm). Remove from `unpromoted`,
+    /// clear `respawn_in_flight`. Reducer may emit a refill effect.
+    PoolWindowDestroyedBeforePromote { label: String },
+
+    /// Promote a pool window into a user-visible top-level. Removes from
+    /// `queue` and `unpromoted`, marks the corresponding `BrowserHandle`
+    /// as `is_pool: false`.
+    PromotePoolWindow { label: String },
+
+    /// Drain all pool windows on shutdown. Idempotent.
+    PoolDrainAll,
+
+    // ── H.5 — quit lifecycle ────────────────────────────────────────────
+
+    /// Transition Running → Draining. Suppresses pool refills, awaits
+    /// drain completion.
+    BeginDrain { reason: QuitReason },
+
+    /// All drainable resources are gone (pool empty, browsers empty).
+    /// Transition Draining → Quit.
+    ConfirmDrained,
+
+    // ── H.6 — top-level window creation runner ──────────────────────────
+
+    /// Caller requests a top-level window. Reducer either:
+    /// - rejects (User-initiated + busy) with Error; caller propagates
+    ///   visible error to frontend.
+    /// - queues (Background) for later auto-advance.
+    /// - starts immediately (idle slot) and emits `Effect::PostCreateWindow`.
+    EnqueueTopLevelWindow { request: TopLevelCreationRequest },
+
+    /// CEF on_after_created fired for `label`. If matches in-flight,
+    /// mark Completed and advance queue. If doesn't match (orphan from
+    /// stale state), emit `Effect::CloseOrphanBrowser`.
+    TopLevelCallbackFired { label: String },
+
+    /// CEF on_render_process_terminated fired for the renderer process
+    /// associated with `label`. If matches in-flight, mark Failed and
+    /// advance queue.
+    TopLevelRendererTerminated { label: String, status: String },
+
+    /// CEF on_before_close fired for `label` while still in-flight.
+    /// User or external code closed the window mid-creation. Mark Failed.
+    TopLevelExternallyClosed { label: String },
+}
+
+impl std::fmt::Debug for HostCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HostCommand::EnqueuePendingWindowCreation { entry } => f
+                .debug_struct("EnqueuePendingWindowCreation")
+                .field("entry", entry)
+                .finish(),
+            HostCommand::DequeuePendingWindowCreation => {
+                f.write_str("DequeuePendingWindowCreation")
+            }
+            HostCommand::EnqueuePaneCreate { block_id, label } => f
+                .debug_struct("EnqueuePaneCreate")
+                .field("block_id", block_id)
+                .field("label", label)
+                .finish(),
+            HostCommand::CompletePaneCreate { block_id } => f
+                .debug_struct("CompletePaneCreate")
+                .field("block_id", block_id)
+                .finish(),
+            HostCommand::EnqueuePaneClose { block_id } => f
+                .debug_struct("EnqueuePaneClose")
+                .field("block_id", block_id)
+                .finish(),
+            HostCommand::CompletePaneClose { block_id } => f
+                .debug_struct("CompletePaneClose")
+                .field("block_id", block_id)
+                .finish(),
+            HostCommand::AbortPaneCreate { block_id, reason } => f
+                .debug_struct("AbortPaneCreate")
+                .field("block_id", block_id)
+                .field("reason", reason)
+                .finish(),
+            HostCommand::RegisterBrowser { label, kind, .. } => f
+                .debug_struct("RegisterBrowser")
+                .field("label", label)
+                .field("kind", kind)
+                .field("browser", &"<cef::Browser>")
+                .finish(),
+            HostCommand::UnregisterBrowser { label } => f
+                .debug_struct("UnregisterBrowser")
+                .field("label", label)
+                .finish(),
+            HostCommand::StartDrag { session } => f
+                .debug_struct("StartDrag")
+                .field("drag_id", &session.drag_id)
+                .field("source_window", &session.source_window)
+                .finish(),
+            HostCommand::EndDrag { drag_id, outcome } => f
+                .debug_struct("EndDrag")
+                .field("drag_id", drag_id)
+                .field("outcome", outcome)
+                .finish(),
+            HostCommand::PoolWindowSpawnStart { label } => f
+                .debug_struct("PoolWindowSpawnStart")
+                .field("label", label)
+                .finish(),
+            HostCommand::PoolWindowReady { label } => f
+                .debug_struct("PoolWindowReady")
+                .field("label", label)
+                .finish(),
+            HostCommand::PoolWindowDestroyedBeforePromote { label } => f
+                .debug_struct("PoolWindowDestroyedBeforePromote")
+                .field("label", label)
+                .finish(),
+            HostCommand::PromotePoolWindow { label } => f
+                .debug_struct("PromotePoolWindow")
+                .field("label", label)
+                .finish(),
+            HostCommand::PoolDrainAll => f.write_str("PoolDrainAll"),
+            HostCommand::BeginDrain { reason } => f
+                .debug_struct("BeginDrain")
+                .field("reason", reason)
+                .finish(),
+            HostCommand::ConfirmDrained => f.write_str("ConfirmDrained"),
+            HostCommand::EnqueueTopLevelWindow { request } => f
+                .debug_struct("EnqueueTopLevelWindow")
+                .field("label", &request.label)
+                .field("source", &request.source)
+                .finish(),
+            HostCommand::TopLevelCallbackFired { label } => f
+                .debug_struct("TopLevelCallbackFired")
+                .field("label", label)
+                .finish(),
+            HostCommand::TopLevelRendererTerminated { label, status } => f
+                .debug_struct("TopLevelRendererTerminated")
+                .field("label", label)
+                .field("status", status)
+                .finish(),
+            HostCommand::TopLevelExternallyClosed { label } => f
+                .debug_struct("TopLevelExternallyClosed")
+                .field("label", label)
+                .finish(),
+        }
+    }
+}
+
+/// Outcome of an ended drag session.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum DragOutcome {
+    /// Drop completed successfully (block moved to target).
+    Dropped { target_label: String },
+    /// Drag cancelled by user (e.g., escape key, drop outside any target).
+    Cancelled,
+    /// Tear-off into a new window completed.
+    TornOff { new_label: String },
+}
+
+/// Reason a pool window left the pool.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum PoolLeaveReason {
+    /// Promoted into a user-visible top-level (tear-off, etc.).
+    Promoted,
+    /// Destroyed before promote (e.g., user closed externally).
+    DestroyedBeforePromote,
+    /// Drained on shutdown.
+    DrainedOnShutdown,
 }
 
 /// Events emitted by the host reducer.
@@ -143,6 +420,120 @@ pub enum HostEvent {
     /// synthesize a UUID-labelled FullInstance entry).
     PendingWindowQueueEmpty { version: u64 },
 
+    // ── H.1 — pane lifecycle events ─────────────────────────────────────
+
+    PaneCreateRequested {
+        block_id: String,
+        label: String,
+        version: u64,
+    },
+    PaneLive {
+        block_id: String,
+        label: String,
+        version: u64,
+    },
+    PaneClosing {
+        block_id: String,
+        version: u64,
+    },
+    PaneClosed {
+        block_id: String,
+        version: u64,
+    },
+    PaneCreationFailed {
+        block_id: String,
+        reason: String,
+        version: u64,
+    },
+
+    // ── H.2 — browser registry events ───────────────────────────────────
+
+    BrowserRegistered {
+        label: String,
+        kind: BrowserKind,
+        version: u64,
+    },
+    BrowserUnregistered {
+        label: String,
+        version: u64,
+    },
+
+    // ── H.3 — drag events ───────────────────────────────────────────────
+
+    DragStarted {
+        drag_id: String,
+        source_window: String,
+        version: u64,
+    },
+    DragEnded {
+        drag_id: String,
+        outcome: DragOutcome,
+        version: u64,
+    },
+
+    // ── H.4 — pool events ───────────────────────────────────────────────
+
+    PoolWindowEntered {
+        label: String,
+        queue_len_after: usize,
+        version: u64,
+    },
+    PoolWindowLeft {
+        label: String,
+        queue_len_after: usize,
+        reason: PoolLeaveReason,
+        version: u64,
+    },
+    PoolEmpty { version: u64 },
+
+    // ── H.5 — quit events ───────────────────────────────────────────────
+
+    QuitDraining {
+        reason: QuitReason,
+        version: u64,
+    },
+    QuitReady { version: u64 },
+
+    // ── H.6 — top-level creation events ─────────────────────────────────
+
+    TopLevelCreationRequested {
+        creation_id: u64,
+        source: TopLevelSource,
+        label: String,
+        version: u64,
+    },
+    TopLevelCreationStarted {
+        creation_id: u64,
+        label: String,
+        version: u64,
+    },
+    TopLevelCreationCompleted {
+        creation_id: u64,
+        label: String,
+        latency_ms: u64,
+        version: u64,
+    },
+    TopLevelCreationFailed {
+        creation_id: u64,
+        label: String,
+        outcome: TopLevelCreationOutcome,
+        version: u64,
+    },
+    TopLevelQueueLengthChanged {
+        len: usize,
+        version: u64,
+    },
+
+    // ── Effect carrier ──────────────────────────────────────────────────
+
+    /// Side-effect descriptor. The reducer emits these but never executes
+    /// them; `AppState::host_dispatch_with_effects` is responsible for
+    /// running each kind. See `EffectKind` for variants.
+    Effect {
+        effect: EffectKind,
+        version: u64,
+    },
+
     /// A command was rejected. Mirrors `Event::Error` in srv/launcher
     /// reducers — kept generic for future arms.
     Error { message: String, version: u64 },
@@ -174,6 +565,56 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
         }
         HostCommand::DequeuePendingWindowCreation => {
             handle_dequeue_pending_window_creation(state)
+        }
+        // H.1 panes
+        HostCommand::EnqueuePaneCreate { block_id, label } => {
+            handle_enqueue_pane_create(state, block_id, label)
+        }
+        HostCommand::CompletePaneCreate { block_id } => {
+            handle_complete_pane_create(state, block_id)
+        }
+        HostCommand::EnqueuePaneClose { block_id } => {
+            handle_enqueue_pane_close(state, block_id)
+        }
+        HostCommand::CompletePaneClose { block_id } => {
+            handle_complete_pane_close(state, block_id)
+        }
+        HostCommand::AbortPaneCreate { block_id, reason } => {
+            handle_abort_pane_create(state, block_id, reason)
+        }
+        // H.2 browsers
+        HostCommand::RegisterBrowser { label, browser, kind } => {
+            handle_register_browser(state, label, browser, kind)
+        }
+        HostCommand::UnregisterBrowser { label } => {
+            handle_unregister_browser(state, label)
+        }
+        // H.3 drag
+        HostCommand::StartDrag { session } => handle_start_drag(state, session),
+        HostCommand::EndDrag { drag_id, outcome } => handle_end_drag(state, drag_id, outcome),
+        // H.4 pool
+        HostCommand::PoolWindowSpawnStart { label } => handle_pool_spawn_start(state, label),
+        HostCommand::PoolWindowReady { label } => handle_pool_ready(state, label),
+        HostCommand::PoolWindowDestroyedBeforePromote { label } => {
+            handle_pool_destroyed_before_promote(state, label)
+        }
+        HostCommand::PromotePoolWindow { label } => handle_promote_pool_window(state, label),
+        HostCommand::PoolDrainAll => handle_pool_drain_all(state),
+        // H.5 quit
+        HostCommand::BeginDrain { reason } => handle_begin_drain(state, reason),
+        HostCommand::ConfirmDrained => handle_confirm_drained(state),
+        // H.6 top-level runner
+        HostCommand::EnqueueTopLevelWindow { request } => {
+            handle_enqueue_top_level_window(state, request)
+        }
+        HostCommand::TopLevelCallbackFired { label } => {
+            handle_top_level_callback_fired(state, label)
+        }
+        HostCommand::TopLevelRendererTerminated { label, status } => {
+            handle_top_level_renderer_terminated(state, label, status)
+        }
+        HostCommand::TopLevelExternallyClosed { label } => {
+            handle_top_level_externally_closed(state, label)
         }
     }
 }
@@ -231,6 +672,531 @@ fn handle_dequeue_pending_window_creation(state: &mut HostState) -> DispatchOutp
             }
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Phase H reducer arms — added in PR #1 (h1-foundations)
+//
+// All arms are pure: `&mut HostState` in, `DispatchOutput` (events) out.
+// No I/O, no async, no logging (logging happens in `state::log_host_event`
+// after dispatch returns). Reducer arms emit Effect events; the effect
+// handler in `AppState::host_dispatch_with_effects` (added in PR #4)
+// dispatches each Effect to its imperative handler.
+// ─────────────────────────────────────────────────────────────────────────
+
+fn emit_error(state: &mut HostState, message: String) -> DispatchOutput {
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::Error { message, version: v }],
+        dequeued: None,
+    }
+}
+
+// ── H.1 — pane lifecycle ─────────────────────────────────────────────────
+
+fn handle_enqueue_pane_create(
+    state: &mut HostState,
+    block_id: String,
+    label: String,
+) -> DispatchOutput {
+    if state.lifecycle == HostLifecyclePhase::ShuttingDown {
+        return emit_error(state, format!("enqueue_pane_create: shutting down (block_id={})", block_id));
+    }
+    if state.panes.contains_key(&block_id) {
+        return emit_error(state, format!("enqueue_pane_create: block_id {} already has a pane", block_id));
+    }
+    state.panes.insert(
+        block_id.clone(),
+        PaneEntry {
+            block_id: block_id.clone(),
+            label: label.clone(),
+            lifecycle: PaneLifecycle::Live,
+        },
+    );
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneCreateRequested { block_id, label, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_complete_pane_create(state: &mut HostState, block_id: String) -> DispatchOutput {
+    let entry = match state.panes.get(&block_id) {
+        Some(e) => e.clone(),
+        None => return DispatchOutput::default(), // late callback for already-removed pane; idempotent no-op
+    };
+    // Already Live by EnqueuePaneCreate's invariant; this is a no-op
+    // confirmation event for observers.
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneLive { block_id, label: entry.label, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_enqueue_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
+    let entry = match state.panes.get_mut(&block_id) {
+        Some(e) => e,
+        None => return DispatchOutput::default(), // close request for already-gone pane; idempotent
+    };
+    if matches!(entry.lifecycle, PaneLifecycle::Closing { .. }) {
+        return DispatchOutput::default(); // already Closing; idempotent
+    }
+    entry.lifecycle = PaneLifecycle::Closing { since: Instant::now() };
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneClosing { block_id, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_complete_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
+    if state.panes.remove(&block_id).is_none() {
+        return DispatchOutput::default(); // idempotent
+    }
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneClosed { block_id, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_abort_pane_create(
+    state: &mut HostState,
+    block_id: String,
+    reason: String,
+) -> DispatchOutput {
+    state.panes.remove(&block_id);
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PaneCreationFailed { block_id, reason, version: v }],
+        dequeued: None,
+    }
+}
+
+// ── H.2 — browser handle registry ────────────────────────────────────────
+
+fn handle_register_browser(
+    state: &mut HostState,
+    label: String,
+    browser: Browser,
+    kind: BrowserKind,
+) -> DispatchOutput {
+    if state.lifecycle == HostLifecyclePhase::ShuttingDown {
+        return emit_error(state, format!("register_browser: shutting down (label={})", label));
+    }
+    if state.browsers.contains_key(&label) {
+        return emit_error(state, format!("register_browser: label {} already registered", label));
+    }
+    state.browsers.insert(
+        label.clone(),
+        BrowserHandle {
+            label: label.clone(),
+            browser,
+            kind: kind.clone(),
+            registered_at: Instant::now(),
+        },
+    );
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::BrowserRegistered { label, kind, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_unregister_browser(state: &mut HostState, label: String) -> DispatchOutput {
+    if state.browsers.remove(&label).is_none() {
+        return DispatchOutput::default(); // idempotent
+    }
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::BrowserUnregistered { label, version: v }],
+        dequeued: None,
+    }
+}
+
+// ── H.3 — drag state ─────────────────────────────────────────────────────
+
+fn handle_start_drag(state: &mut HostState, session: DragSession) -> DispatchOutput {
+    if state.active_drag.is_some() {
+        return emit_error(state, "start_drag: drag session already active".to_string());
+    }
+    let drag_id = session.drag_id.clone();
+    let source_window = session.source_window.clone();
+    state.active_drag = Some(session);
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::DragStarted { drag_id, source_window, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_end_drag(
+    state: &mut HostState,
+    drag_id: String,
+    outcome: DragOutcome,
+) -> DispatchOutput {
+    let active_id = state.active_drag.as_ref().map(|s| s.drag_id.clone());
+    match active_id {
+        Some(id) if id == drag_id => {
+            state.active_drag = None;
+            let v = state.bump_version();
+            DispatchOutput {
+                events: vec![HostEvent::DragEnded { drag_id, outcome, version: v }],
+                dequeued: None,
+            }
+        }
+        _ => DispatchOutput::default(), // mismatched or no drag; idempotent no-op
+    }
+}
+
+// ── H.4 — pool state ─────────────────────────────────────────────────────
+
+fn handle_pool_spawn_start(state: &mut HostState, label: String) -> DispatchOutput {
+    if state.quit_state != QuitState::Running {
+        return DispatchOutput::default(); // pool refills suppressed during drain
+    }
+    state.pool.unpromoted.insert(label);
+    state.pool.respawn_in_flight = true;
+    DispatchOutput::default()
+}
+
+fn handle_pool_ready(state: &mut HostState, label: String) -> DispatchOutput {
+    if !state.pool.unpromoted.remove(&label) {
+        // Not in unpromoted (race or duplicate signal); idempotent.
+        return DispatchOutput::default();
+    }
+    if !state.pool.queue.iter().any(|l| l == &label) {
+        state.pool.queue.push_back(label.clone());
+    }
+    state.pool.respawn_in_flight = false;
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PoolWindowEntered {
+            label,
+            queue_len_after: state.pool.queue.len(),
+            version: v,
+        }],
+        dequeued: None,
+    }
+}
+
+fn handle_pool_destroyed_before_promote(state: &mut HostState, label: String) -> DispatchOutput {
+    let was_unpromoted = state.pool.unpromoted.remove(&label);
+    state.pool.respawn_in_flight = false;
+    if !was_unpromoted {
+        return DispatchOutput::default();
+    }
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PoolWindowLeft {
+            label,
+            queue_len_after: state.pool.queue.len(),
+            reason: PoolLeaveReason::DestroyedBeforePromote,
+            version: v,
+        }],
+        dequeued: None,
+    }
+}
+
+fn handle_promote_pool_window(state: &mut HostState, label: String) -> DispatchOutput {
+    let in_queue = state.pool.queue.iter().position(|l| l == &label).is_some();
+    if in_queue {
+        state.pool.queue.retain(|l| l != &label);
+    }
+    state.pool.unpromoted.remove(&label);
+    // Mark the corresponding browser handle as no-longer-pool.
+    if let Some(handle) = state.browsers.get_mut(&label) {
+        if let BrowserKind::TopLevel { is_pool } = &mut handle.kind {
+            *is_pool = false;
+        }
+    }
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::PoolWindowLeft {
+            label,
+            queue_len_after: state.pool.queue.len(),
+            reason: PoolLeaveReason::Promoted,
+            version: v,
+        }],
+        dequeued: None,
+    }
+}
+
+fn handle_pool_drain_all(state: &mut HostState) -> DispatchOutput {
+    let drained: Vec<String> = state
+        .pool
+        .queue
+        .drain(..)
+        .chain(state.pool.unpromoted.drain())
+        .collect();
+    state.pool.respawn_in_flight = false;
+    let mut events = Vec::new();
+    for label in drained {
+        let v = state.bump_version();
+        events.push(HostEvent::PoolWindowLeft {
+            label,
+            queue_len_after: 0,
+            reason: PoolLeaveReason::DrainedOnShutdown,
+            version: v,
+        });
+    }
+    let v = state.bump_version();
+    events.push(HostEvent::PoolEmpty { version: v });
+    DispatchOutput { events, dequeued: None }
+}
+
+// ── H.5 — quit lifecycle ─────────────────────────────────────────────────
+
+fn handle_begin_drain(state: &mut HostState, reason: QuitReason) -> DispatchOutput {
+    if state.quit_state != QuitState::Running {
+        return DispatchOutput::default(); // already draining or quit; idempotent
+    }
+    state.quit_state = QuitState::Draining { reason: reason.clone() };
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::QuitDraining { reason, version: v }],
+        dequeued: None,
+    }
+}
+
+fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
+    if !matches!(state.quit_state, QuitState::Draining { .. }) {
+        return DispatchOutput::default(); // not draining; idempotent
+    }
+    state.quit_state = QuitState::Quit;
+    let v = state.bump_version();
+    DispatchOutput {
+        events: vec![HostEvent::QuitReady { version: v }],
+        dequeued: None,
+    }
+}
+
+// ── H.6 — top-level window creation runner ───────────────────────────────
+
+fn handle_enqueue_top_level_window(
+    state: &mut HostState,
+    request: TopLevelCreationRequest,
+) -> DispatchOutput {
+    if state.quit_state != QuitState::Running {
+        return emit_error(state, format!("enqueue_top_level_window: not Running (label={})", request.label));
+    }
+
+    // Fail-fast for User-initiated requests when in-flight is occupied.
+    // Background (pool refill) requests queue silently.
+    if state.top_level_creation.in_flight.is_some()
+        && request.source == TopLevelSource::User
+    {
+        return emit_error(state, format!("enqueue_top_level_window: busy in-flight (label={})", request.label));
+    }
+
+    state.top_level_creation.queue.push_back(request);
+    let queue_len = state.top_level_creation.queue.len();
+    let v = state.bump_version();
+    let mut out = DispatchOutput {
+        events: vec![HostEvent::TopLevelQueueLengthChanged { len: queue_len, version: v }],
+        dequeued: None,
+    };
+    // If idle, start immediately; chain the start arm's events.
+    if state.top_level_creation.in_flight.is_none() {
+        let started = start_next_top_level_if_idle(state);
+        out.events.extend(started.events);
+    }
+    out
+}
+
+/// Internal helper: if in_flight is None and queue has work, pop the front
+/// and start it. Emits `TopLevelCreationRequested`, `TopLevelCreationStarted`,
+/// `Effect::PostCreateWindow`, and updated queue length.
+fn start_next_top_level_if_idle(state: &mut HostState) -> DispatchOutput {
+    if state.top_level_creation.in_flight.is_some() {
+        return DispatchOutput::default();
+    }
+    let request = match state.top_level_creation.queue.pop_front() {
+        Some(r) => r,
+        None => return DispatchOutput::default(),
+    };
+    state.top_level_creation.next_creation_id =
+        state.top_level_creation.next_creation_id.wrapping_add(1);
+    let creation_id = state.top_level_creation.next_creation_id;
+    let now = Instant::now();
+    state.top_level_creation.in_flight = Some(InFlightCreation {
+        creation_id,
+        label: request.label.clone(),
+        started_at: now,
+        phase: CreationPhase::Started,
+    });
+    let label = request.label.clone();
+    let source = request.source.clone();
+    let queue_len = state.top_level_creation.queue.len();
+    let v_req = state.bump_version();
+    let v_started = state.bump_version();
+    let v_eff = state.bump_version();
+    let v_qlen = state.bump_version();
+    DispatchOutput {
+        events: vec![
+            HostEvent::TopLevelCreationRequested {
+                creation_id,
+                source,
+                label: label.clone(),
+                version: v_req,
+            },
+            HostEvent::TopLevelCreationStarted {
+                creation_id,
+                label: label.clone(),
+                version: v_started,
+            },
+            HostEvent::Effect {
+                effect: EffectKind::PostCreateWindow { request, creation_id },
+                version: v_eff,
+            },
+            HostEvent::TopLevelQueueLengthChanged { len: queue_len, version: v_qlen },
+        ],
+        dequeued: None,
+    }
+}
+
+fn handle_top_level_callback_fired(state: &mut HostState, label: String) -> DispatchOutput {
+    let matches_in_flight = state
+        .top_level_creation
+        .in_flight
+        .as_ref()
+        .map(|c| c.label == label)
+        .unwrap_or(false);
+    if !matches_in_flight {
+        // Orphan callback: a CEF browser fired on_after_created with a
+        // label we don't have in flight. Could be from a previously-evicted
+        // creation (won't happen in PR #1 since we don't evict) or a stale
+        // label. Emit an effect to close the orphan, preventing collision.
+        let orphan_browser = state.browsers.get(&label).map(|h| h.browser.clone());
+        if let Some(browser) = orphan_browser {
+            let v = state.bump_version();
+            return DispatchOutput {
+                events: vec![HostEvent::Effect {
+                    effect: EffectKind::CloseOrphanBrowser { browser },
+                    version: v,
+                }],
+                dequeued: None,
+            };
+        }
+        return DispatchOutput::default();
+    }
+    let inflight = state.top_level_creation.in_flight.take().unwrap();
+    let now = Instant::now();
+    let latency_ms = now.duration_since(inflight.started_at).as_millis() as u64;
+    push_top_level_history(
+        state,
+        CompletedCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label.clone(),
+            outcome: TopLevelCreationOutcome::Completed,
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase: CreationPhase::BrowserCallbackFired,
+        },
+    );
+    let v_done = state.bump_version();
+    let mut out = DispatchOutput {
+        events: vec![HostEvent::TopLevelCreationCompleted {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            latency_ms,
+            version: v_done,
+        }],
+        dequeued: None,
+    };
+    let next = start_next_top_level_if_idle(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn handle_top_level_renderer_terminated(
+    state: &mut HostState,
+    label: String,
+    status: String,
+) -> DispatchOutput {
+    let matches = state
+        .top_level_creation
+        .in_flight
+        .as_ref()
+        .map(|c| c.label == label)
+        .unwrap_or(false);
+    if !matches {
+        return DispatchOutput::default();
+    }
+    let inflight = state.top_level_creation.in_flight.take().unwrap();
+    let now = Instant::now();
+    let outcome = TopLevelCreationOutcome::RendererTerminated { status };
+    push_top_level_history(
+        state,
+        CompletedCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label.clone(),
+            outcome: outcome.clone(),
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase: inflight.phase,
+        },
+    );
+    let v = state.bump_version();
+    let mut out = DispatchOutput {
+        events: vec![HostEvent::TopLevelCreationFailed {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            outcome,
+            version: v,
+        }],
+        dequeued: None,
+    };
+    let next = start_next_top_level_if_idle(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn handle_top_level_externally_closed(state: &mut HostState, label: String) -> DispatchOutput {
+    let matches = state
+        .top_level_creation
+        .in_flight
+        .as_ref()
+        .map(|c| c.label == label)
+        .unwrap_or(false);
+    if !matches {
+        return DispatchOutput::default();
+    }
+    let inflight = state.top_level_creation.in_flight.take().unwrap();
+    let now = Instant::now();
+    let outcome = TopLevelCreationOutcome::ExternallyClosed;
+    push_top_level_history(
+        state,
+        CompletedCreation {
+            creation_id: inflight.creation_id,
+            label: inflight.label.clone(),
+            outcome: outcome.clone(),
+            started_at: inflight.started_at,
+            finished_at: now,
+            last_phase: inflight.phase,
+        },
+    );
+    let v = state.bump_version();
+    let mut out = DispatchOutput {
+        events: vec![HostEvent::TopLevelCreationFailed {
+            creation_id: inflight.creation_id,
+            label: inflight.label,
+            outcome,
+            version: v,
+        }],
+        dequeued: None,
+    };
+    let next = start_next_top_level_if_idle(state);
+    out.events.extend(next.events);
+    out
+}
+
+fn push_top_level_history(state: &mut HostState, entry: CompletedCreation) {
+    if state.top_level_creation.history.len() >= TOP_LEVEL_CREATION_HISTORY_CAP {
+        state.top_level_creation.history.pop_front();
+    }
+    state.top_level_creation.history.push_back(entry);
 }
 
 #[cfg(test)]
@@ -318,10 +1284,33 @@ mod tests {
         let out2 = update(&mut state, HostCommand::DequeuePendingWindowCreation);
         let out3 = update(&mut state, HostCommand::DequeuePendingWindowCreation);
 
+        // Helper that pulls the `version` field out of any HostEvent.
+        // Kept exhaustive so adding a new event variant forces an
+        // explicit decision here (vs. silently defaulting to 0).
         let extract_version = |events: &[HostEvent]| match &events[0] {
             HostEvent::PendingWindowEnqueued { version, .. } => *version,
             HostEvent::PendingWindowDequeued { version, .. } => *version,
             HostEvent::PendingWindowQueueEmpty { version } => *version,
+            HostEvent::PaneCreateRequested { version, .. } => *version,
+            HostEvent::PaneLive { version, .. } => *version,
+            HostEvent::PaneClosing { version, .. } => *version,
+            HostEvent::PaneClosed { version, .. } => *version,
+            HostEvent::PaneCreationFailed { version, .. } => *version,
+            HostEvent::BrowserRegistered { version, .. } => *version,
+            HostEvent::BrowserUnregistered { version, .. } => *version,
+            HostEvent::DragStarted { version, .. } => *version,
+            HostEvent::DragEnded { version, .. } => *version,
+            HostEvent::PoolWindowEntered { version, .. } => *version,
+            HostEvent::PoolWindowLeft { version, .. } => *version,
+            HostEvent::PoolEmpty { version } => *version,
+            HostEvent::QuitDraining { version, .. } => *version,
+            HostEvent::QuitReady { version } => *version,
+            HostEvent::TopLevelCreationRequested { version, .. } => *version,
+            HostEvent::TopLevelCreationStarted { version, .. } => *version,
+            HostEvent::TopLevelCreationCompleted { version, .. } => *version,
+            HostEvent::TopLevelCreationFailed { version, .. } => *version,
+            HostEvent::TopLevelQueueLengthChanged { version, .. } => *version,
+            HostEvent::Effect { version, .. } => *version,
             HostEvent::Error { version, .. } => *version,
         };
         let v1 = extract_version(&out1.events);
@@ -329,5 +1318,348 @@ mod tests {
         let v3 = extract_version(&out3.events);
         assert!(v1 < v2);
         assert!(v2 < v3);
+    }
+
+    // ── Phase H foundations tests ───────────────────────────────────────
+
+    fn pane_request(block_id: &str, label: &str) -> HostCommand {
+        HostCommand::EnqueuePaneCreate {
+            block_id: block_id.to_string(),
+            label: label.to_string(),
+        }
+    }
+
+    fn top_level_request(label: &str, source: TopLevelSource) -> TopLevelCreationRequest {
+        TopLevelCreationRequest {
+            label: label.to_string(),
+            kind: WindowKind::FullInstance,
+            parent_instance_id: None,
+            url: format!("https://example.test/{}", label),
+            pos: (0, 0),
+            size: (800, 600),
+            frameless: true,
+            source,
+        }
+    }
+
+    // ── H.1 panes ────────────────────────────────────────────────────────
+
+    #[test]
+    fn enqueue_pane_create_inserts_live() {
+        let mut state = HostState::default();
+        let out = update(&mut state, pane_request("b1", "browser-pane-b1-1"));
+        assert!(state.panes.contains_key("b1"));
+        assert!(matches!(state.panes["b1"].lifecycle, PaneLifecycle::Live));
+        assert!(matches!(out.events[0], HostEvent::PaneCreateRequested { .. }));
+    }
+
+    #[test]
+    fn enqueue_pane_create_duplicate_rejected() {
+        let mut state = HostState::default();
+        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
+        let out = update(&mut state, pane_request("b1", "browser-pane-b1-2"));
+        assert!(matches!(out.events[0], HostEvent::Error { .. }));
+        assert_eq!(state.panes.len(), 1);
+    }
+
+    #[test]
+    fn pane_close_lifecycle() {
+        let mut state = HostState::default();
+        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
+        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
+        assert!(matches!(
+            state.panes["b1"].lifecycle,
+            PaneLifecycle::Closing { .. }
+        ));
+        update(&mut state, HostCommand::CompletePaneClose { block_id: "b1".into() });
+        assert!(!state.panes.contains_key("b1"));
+    }
+
+    #[test]
+    fn pane_abort_removes_entry() {
+        let mut state = HostState::default();
+        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
+        let out = update(
+            &mut state,
+            HostCommand::AbortPaneCreate {
+                block_id: "b1".into(),
+                reason: "test".into(),
+            },
+        );
+        assert!(!state.panes.contains_key("b1"));
+        assert!(matches!(out.events[0], HostEvent::PaneCreationFailed { .. }));
+    }
+
+    #[test]
+    fn pane_close_idempotent_for_missing() {
+        let mut state = HostState::default();
+        let out = update(&mut state, HostCommand::EnqueuePaneClose { block_id: "missing".into() });
+        assert!(out.events.is_empty()); // idempotent no-op
+    }
+
+    // ── H.3 drag (singleton invariant) ───────────────────────────────────
+
+    fn drag_session(id: &str) -> DragSession {
+        DragSession {
+            drag_id: id.to_string(),
+            drag_type: crate::state::DragType::Tab,
+            source_window: "main".to_string(),
+            source_workspace_id: "ws1".to_string(),
+            source_tab_id: "tab1".to_string(),
+            payload: crate::state::DragPayload {
+                block_id: None,
+                tab_id: Some("tab1".to_string()),
+            },
+            started_at: 0,
+        }
+    }
+
+    #[test]
+    fn drag_singleton_invariant() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::StartDrag { session: drag_session("d1") });
+        assert!(state.active_drag.is_some());
+        let out = update(&mut state, HostCommand::StartDrag { session: drag_session("d2") });
+        assert!(matches!(out.events[0], HostEvent::Error { .. }));
+        assert_eq!(state.active_drag.as_ref().unwrap().drag_id, "d1");
+    }
+
+    #[test]
+    fn drag_end_clears_session() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::StartDrag { session: drag_session("d1") });
+        update(
+            &mut state,
+            HostCommand::EndDrag {
+                drag_id: "d1".into(),
+                outcome: DragOutcome::Cancelled,
+            },
+        );
+        assert!(state.active_drag.is_none());
+    }
+
+    #[test]
+    fn drag_end_with_wrong_id_is_noop() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::StartDrag { session: drag_session("d1") });
+        let out = update(
+            &mut state,
+            HostCommand::EndDrag {
+                drag_id: "wrong".into(),
+                outcome: DragOutcome::Cancelled,
+            },
+        );
+        assert!(out.events.is_empty());
+        assert!(state.active_drag.is_some());
+    }
+
+    // ── H.5 quit (monotonic transitions) ─────────────────────────────────
+
+    #[test]
+    fn quit_state_monotonic() {
+        let mut state = HostState::default();
+        assert_eq!(state.quit_state, QuitState::Running);
+        update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
+        assert!(matches!(state.quit_state, QuitState::Draining { .. }));
+        update(&mut state, HostCommand::ConfirmDrained);
+        assert_eq!(state.quit_state, QuitState::Quit);
+        // Subsequent BeginDrain is a no-op (monotonic).
+        let out = update(&mut state, HostCommand::BeginDrain { reason: QuitReason::External });
+        assert!(out.events.is_empty());
+        assert_eq!(state.quit_state, QuitState::Quit);
+    }
+
+    // ── H.6 top-level runner (singleton + fail-fast) ─────────────────────
+
+    #[test]
+    fn enqueue_top_level_when_idle_starts_immediately() {
+        let mut state = HostState::default();
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        assert!(state.top_level_creation.in_flight.is_some());
+        assert_eq!(state.top_level_creation.in_flight.as_ref().unwrap().label, "a");
+        let begin_count = out
+            .events
+            .iter()
+            .filter(|e| matches!(
+                e,
+                HostEvent::Effect { effect: EffectKind::PostCreateWindow { .. }, .. }
+            ))
+            .count();
+        assert_eq!(begin_count, 1);
+    }
+
+    #[test]
+    fn user_initiated_when_busy_fails_fast() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        // Second user-initiated request: in-flight is occupied → error.
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b", TopLevelSource::User),
+            },
+        );
+        assert!(matches!(out.events[0], HostEvent::Error { .. }));
+        assert_eq!(state.top_level_creation.queue.len(), 0); // not queued
+    }
+
+    #[test]
+    fn background_when_busy_queues_silently() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        // Background request queues even though in-flight occupied.
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b", TopLevelSource::Background),
+            },
+        );
+        assert_eq!(state.top_level_creation.queue.len(), 1);
+        assert_eq!(state.top_level_creation.in_flight.as_ref().unwrap().label, "a");
+    }
+
+    #[test]
+    fn callback_fired_advances_queue() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("b", TopLevelSource::Background),
+            },
+        );
+        let out = update(
+            &mut state,
+            HostCommand::TopLevelCallbackFired { label: "a".into() },
+        );
+        // a archived to history; b now in-flight.
+        assert_eq!(state.top_level_creation.history.len(), 1);
+        assert_eq!(state.top_level_creation.in_flight.as_ref().unwrap().label, "b");
+        assert!(out.events.iter().any(|e| matches!(e, HostEvent::TopLevelCreationCompleted { .. })));
+    }
+
+    #[test]
+    fn renderer_terminated_fails_in_flight() {
+        let mut state = HostState::default();
+        update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        update(
+            &mut state,
+            HostCommand::TopLevelRendererTerminated {
+                label: "a".into(),
+                status: "killed".into(),
+            },
+        );
+        assert!(state.top_level_creation.in_flight.is_none());
+        assert_eq!(state.top_level_creation.history.len(), 1);
+        assert!(matches!(
+            state.top_level_creation.history.back().unwrap().outcome,
+            TopLevelCreationOutcome::RendererTerminated { .. }
+        ));
+    }
+
+    #[test]
+    fn callback_fired_with_unknown_label_is_noop_or_orphan_close() {
+        let mut state = HostState::default();
+        // No in-flight, no browser registered for this label.
+        let out = update(
+            &mut state,
+            HostCommand::TopLevelCallbackFired { label: "ghost".into() },
+        );
+        assert!(out.events.is_empty()); // pure no-op when no orphan to close
+    }
+
+    #[test]
+    fn enqueue_top_level_during_quit_rejected() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
+        let out = update(
+            &mut state,
+            HostCommand::EnqueueTopLevelWindow {
+                request: top_level_request("a", TopLevelSource::User),
+            },
+        );
+        assert!(matches!(out.events[0], HostEvent::Error { .. }));
+        assert!(state.top_level_creation.in_flight.is_none());
+    }
+
+    #[test]
+    fn history_caps_at_50() {
+        let mut state = HostState::default();
+        for i in 0..60 {
+            let label = format!("w{}", i);
+            update(
+                &mut state,
+                HostCommand::EnqueueTopLevelWindow {
+                    request: top_level_request(&label, TopLevelSource::Background),
+                },
+            );
+            update(
+                &mut state,
+                HostCommand::TopLevelCallbackFired { label },
+            );
+        }
+        assert_eq!(state.top_level_creation.history.len(), TOP_LEVEL_CREATION_HISTORY_CAP);
+        assert_eq!(state.top_level_creation.history.front().unwrap().label, "w10");
+        assert_eq!(state.top_level_creation.history.back().unwrap().label, "w59");
+    }
+
+    // ── H.4 pool ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn pool_spawn_then_ready_enters_queue() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
+        assert!(state.pool.unpromoted.contains("p1"));
+        assert!(state.pool.respawn_in_flight);
+        update(&mut state, HostCommand::PoolWindowReady { label: "p1".into() });
+        assert!(!state.pool.unpromoted.contains("p1"));
+        assert_eq!(state.pool.queue.len(), 1);
+        assert!(!state.pool.respawn_in_flight);
+    }
+
+    #[test]
+    fn pool_drain_clears_all() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
+        update(&mut state, HostCommand::PoolWindowReady { label: "p1".into() });
+        update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p2".into() });
+        let out = update(&mut state, HostCommand::PoolDrainAll);
+        assert!(state.pool.queue.is_empty());
+        assert!(state.pool.unpromoted.is_empty());
+        assert!(out.events.iter().any(|e| matches!(e, HostEvent::PoolEmpty { .. })));
+    }
+
+    #[test]
+    fn pool_spawn_during_quit_suppressed() {
+        let mut state = HostState::default();
+        update(&mut state, HostCommand::BeginDrain { reason: QuitReason::LastWindowClosed });
+        let out = update(&mut state, HostCommand::PoolWindowSpawnStart { label: "p1".into() });
+        assert!(out.events.is_empty()); // suppressed
+        assert!(state.pool.unpromoted.is_empty());
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -107,6 +107,290 @@ pub struct PendingWindowCreation {
     pub parent_instance_id: Option<String>,
 }
 
+// ── Phase H — host reducer buildout ──────────────────────────────────────
+//
+// All types below are reducer-only state. PR #1 (h1-foundations) declares
+// them; subsequent PRs (#2-#5) wire callers through the reducer per the
+// a→b→c→d→e migration ratchet. See:
+//   docs/specs/SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md
+//   docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md
+//
+// These types intentionally have `#[allow(dead_code)]` because PR #1 ships
+// the scaffolding without callers — fields are populated by reducer arms but
+// no production code reads them yet. Subsequent PRs lift the allow as they
+// wire each migration.
+
+// ── Pane lifecycle (H.1) ─────────────────────────────────────────────────
+
+/// Lifecycle state of a browser pane (the `defwidget@browser` widget). Held
+/// inside `HostState.panes` keyed by `block_id`. Mirrors the existing
+/// `PaneStateMachine::PaneLifecycle` (pane/lifecycle.rs:28); the existing
+/// type stays during PR #2's a→e migration. PR #2 step e deletes the
+/// pane/lifecycle.rs version and migrates all readers to this one.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum PaneLifecycle {
+    /// Pane is alive and accepting operations (focus, resize, navigate).
+    Live,
+    /// Close requested; awaiting CEF on_before_close to fully tear down.
+    /// `since` carries the request timestamp for diagnostic purposes only;
+    /// nothing in the reducer is timer-driven.
+    Closing { since: std::time::Instant },
+}
+
+/// Per-pane reducer-managed entry. Replaces `pane::lifecycle::PaneEntry`
+/// (lifecycle.rs:42) at PR #2 step e.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct PaneEntry {
+    pub block_id: String,
+    pub label: String,
+    pub lifecycle: PaneLifecycle,
+}
+
+// ── Browser handle registry (H.2) ────────────────────────────────────────
+
+/// Wrapped CEF Browser handle stored in `HostState.browsers`. Replaces the
+/// raw `Mutex<HashMap<String, Browser>>` at `state.rs::AppState.browsers`
+/// at PR #2 step e.
+///
+/// `cef::Browser` is `Clone` (refcounted FFI handle) and safe to store
+/// inside the reducer's mutex-guarded state. Doesn't impl Debug, hence
+/// the manual `impl Debug` below for `BrowserHandle`.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct BrowserHandle {
+    pub label: String,
+    pub browser: Browser,
+    pub kind: BrowserKind,
+    pub registered_at: std::time::Instant,
+}
+
+impl std::fmt::Debug for BrowserHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BrowserHandle")
+            .field("label", &self.label)
+            .field("kind", &self.kind)
+            .field("registered_at", &self.registered_at)
+            .field("browser", &"<cef::Browser>")
+            .finish()
+    }
+}
+
+/// Distinguishes top-level CEF Browsers (full-instance windows + pool
+/// windows) from pane CEF Browsers (children of a top-level). Determines
+/// taskbar treatment, lifecycle ownership, etc.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum BrowserKind {
+    /// Top-level window. `is_pool=true` while the window is in the warm
+    /// pool; cleared on promote.
+    TopLevel { is_pool: bool },
+    /// Browser pane child window. `block_id` correlates with the
+    /// `HostState.panes` entry.
+    Pane { block_id: String },
+}
+
+// ── Pool state (H.4) ─────────────────────────────────────────────────────
+
+/// Pre-warmed window pool state. Replaces three separate fields on
+/// `AppState`: `window_pool: Mutex<VecDeque<String>>`,
+/// `unpromoted_pool_labels: Mutex<HashSet<String>>`, and
+/// `window_pool_respawn_in_flight: AtomicBool`. PR #3 migrates each
+/// caller through the a→e ratchet.
+#[derive(Default, Clone, Debug)]
+#[allow(dead_code)]
+pub struct PoolState {
+    /// Labels of pool windows whose renderer signaled ready (eligible
+    /// for promotion).
+    pub queue: std::collections::VecDeque<String>,
+    /// Labels spawned but not yet renderer-ready (and therefore not yet
+    /// in `queue`). Used for taskbar/exclusion filters during the spawn
+    /// → ready window.
+    pub unpromoted: std::collections::HashSet<String>,
+    /// Single-flight semaphore: true while a respawn task is in flight,
+    /// preventing stacked refills.
+    pub respawn_in_flight: bool,
+}
+
+// ── Quit state (H.5) ─────────────────────────────────────────────────────
+
+/// Host process quit lifecycle. Replaces `is_quitting: AtomicBool` at
+/// `state.rs::AppState`. Three states; transitions are monotonic
+/// (Running → Draining → Quit, no regression).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum QuitState {
+    /// Normal operation. All commands accepted (subject to per-arm rules).
+    Running,
+    /// `BeginDrain` dispatched. Pool refills suppressed; awaiting pool +
+    /// browsers to drain.
+    Draining { reason: QuitReason },
+    /// `ConfirmDrained` dispatched. Host quitting; no further commands.
+    Quit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum QuitReason {
+    /// User closed the last user-visible top-level window. Standard exit.
+    LastWindowClosed,
+    /// Launcher signaled HostShouldQuit (cross-process shutdown).
+    LauncherRequested,
+    /// External force-quit (Win32 WM_QUIT, signal, etc.).
+    External,
+}
+
+impl Default for QuitState {
+    fn default() -> Self { QuitState::Running }
+}
+
+// ── Top-level window creation runner (H.6) ───────────────────────────────
+
+/// A request to create a top-level window. Pushed to
+/// `HostState.top_level_creation.queue` via `EnqueueTopLevelWindow`.
+/// Carries the full spec the effect handler needs to call
+/// `ui_tasks::post_create_window`.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct TopLevelCreationRequest {
+    pub label: String,
+    pub kind: WindowKind,
+    pub parent_instance_id: Option<String>,
+    pub url: String,
+    pub pos: (i32, i32),
+    pub size: (i32, i32),
+    pub frameless: bool,
+    /// `User`-initiated (fail-fast on contention) vs `Background` (pool
+    /// refill — may queue silently).
+    pub source: TopLevelSource,
+}
+
+/// Distinguishes user-facing creation requests (which fail-fast on
+/// contention) from background ones (pool refill — may queue indefinitely).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum TopLevelSource {
+    /// Triggered by a user action (click "open new window", tear off a
+    /// tab, etc.). Reducer rejects with error if in-flight slot is
+    /// occupied — caller propagates a visible error to the frontend.
+    User,
+    /// Triggered by the runner itself (pool refill, recovery). Queues
+    /// behind in-flight; no caller waiting on completion.
+    Background,
+}
+
+/// The single in-flight top-level creation. Singleton invariant enforced
+/// by the reducer (at most one Some across all action sequences).
+///
+/// **No `deadline` field. No watchdog.** The reducer reacts only to
+/// observable CEF callbacks: `on_after_created` (success),
+/// `on_render_process_terminated` (renderer crash), `on_before_close`
+/// (cancel mid-create). If none fire, the slot stays occupied
+/// permanently — user-initiated creates fail-fast with visible error
+/// per the no-timer directive.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct InFlightCreation {
+    pub creation_id: u64,
+    pub label: String,
+    pub started_at: std::time::Instant,
+    pub phase: CreationPhase,
+}
+
+/// Phase progression of an in-flight top-level creation. Monotonic;
+/// `AdvanceCreationPhase` (if added later) refuses regression.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+#[allow(dead_code)]
+pub enum CreationPhase {
+    /// Effect handler has dispatched `post_create_window`; CEF has not
+    /// yet fired any callback.
+    Started = 0,
+    /// CEF `on_after_created` fired — Browser exists, renderer alive.
+    BrowserCallbackFired = 1,
+}
+
+/// Archived completion record for the runner's history ring buffer.
+/// Bounded at `TOP_LEVEL_CREATION_HISTORY_CAP` (50); oldest evicted FIFO.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub struct CompletedCreation {
+    pub creation_id: u64,
+    pub label: String,
+    pub outcome: TopLevelCreationOutcome,
+    pub started_at: std::time::Instant,
+    pub finished_at: std::time::Instant,
+    pub last_phase: CreationPhase,
+}
+
+/// Why a top-level creation completed. `Completed` is happy-path; the
+/// other variants are observable failure modes.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub enum TopLevelCreationOutcome {
+    /// CEF `on_after_created` fired; browser registered. Normal completion.
+    Completed,
+    /// CEF `on_render_process_terminated` fired during creation. Renderer
+    /// process died (crash, OOM, killed).
+    RendererTerminated { status: String },
+    /// CEF `on_before_close` fired during creation. Browser closed
+    /// externally (user action, parent close, etc.).
+    ExternallyClosed,
+}
+
+/// Reducer-managed runner state. Owns the queue, in-flight slot, history,
+/// and id allocator.
+#[derive(Default, Clone, Debug)]
+#[allow(dead_code)]
+pub struct TopLevelCreationState {
+    pub queue: std::collections::VecDeque<TopLevelCreationRequest>,
+    pub in_flight: Option<InFlightCreation>,
+    pub history: std::collections::VecDeque<CompletedCreation>,
+    pub next_creation_id: u64,
+}
+
+// ── Effects (carrier for side-effect-bearing events) ─────────────────────
+
+/// Side-effect descriptor emitted by reducer arms. Carried inside
+/// `HostEvent::Effect(EffectKind)`. The effects executor in
+/// `AppState::host_dispatch_with_effects` dispatches each kind to the
+/// appropriate imperative handler (e.g., posting a CEF UI task).
+///
+/// Reducer arms emit effects but never execute them; this preserves the
+/// pure-functional discipline of `update()`. Manual Debug impl below
+/// because `cef::Browser` doesn't impl Debug.
+#[derive(Clone)]
+#[allow(dead_code)]
+pub enum EffectKind {
+    /// Begin top-level window creation by posting `ui_tasks::post_create_window`.
+    /// Carried by `HostEvent::TopLevelCreationStarted`'s effect path.
+    PostCreateWindow { request: TopLevelCreationRequest, creation_id: u64 },
+    /// Spawn a pool window (PR #3 wires this when pool drops below TARGET_SIZE).
+    SpawnPoolWindow,
+    /// Close an orphan CEF browser whose label doesn't match any in-flight
+    /// or registered entry. Used by H.6's mismatched-callback handler to
+    /// prevent label collision.
+    CloseOrphanBrowser { browser: Browser },
+}
+
+impl std::fmt::Debug for EffectKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EffectKind::PostCreateWindow { request, creation_id } => f
+                .debug_struct("PostCreateWindow")
+                .field("creation_id", creation_id)
+                .field("label", &request.label)
+                .finish(),
+            EffectKind::SpawnPoolWindow => f.write_str("SpawnPoolWindow"),
+            EffectKind::CloseOrphanBrowser { .. } => f
+                .debug_struct("CloseOrphanBrowser")
+                .field("browser", &"<cef::Browser>")
+                .finish(),
+        }
+    }
+}
+
 /// Shared application state for the CEF host.
 ///
 /// Unlike the Tauri version, this uses `Arc<AppState>` directly instead of
@@ -521,6 +805,121 @@ fn log_host_event(ev: &crate::reducer::HostEvent) {
             event = "PendingWindowQueueEmpty",
             version,
             "[host-reducer] dequeue on empty queue — caller will fall back",
+        ),
+        // ── H.1 panes ────────────────────────────────────────────────────
+        HostEvent::PaneCreateRequested { block_id, label, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PaneCreateRequested",
+            block_id = %block_id, label = %label, version,
+        ),
+        HostEvent::PaneLive { block_id, label, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PaneLive",
+            block_id = %block_id, label = %label, version,
+        ),
+        HostEvent::PaneClosing { block_id, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PaneClosing",
+            block_id = %block_id, version,
+        ),
+        HostEvent::PaneClosed { block_id, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PaneClosed",
+            block_id = %block_id, version,
+        ),
+        HostEvent::PaneCreationFailed { block_id, reason, version } => tracing::warn!(
+            target: "host-reducer",
+            event = "PaneCreationFailed",
+            block_id = %block_id, reason = %reason, version,
+        ),
+        // ── H.2 browsers ─────────────────────────────────────────────────
+        HostEvent::BrowserRegistered { label, kind, version } => tracing::info!(
+            target: "host-reducer",
+            event = "BrowserRegistered",
+            label = %label, kind = ?kind, version,
+        ),
+        HostEvent::BrowserUnregistered { label, version } => tracing::info!(
+            target: "host-reducer",
+            event = "BrowserUnregistered",
+            label = %label, version,
+        ),
+        // ── H.3 drag ─────────────────────────────────────────────────────
+        HostEvent::DragStarted { drag_id, source_window, version } => tracing::info!(
+            target: "host-reducer",
+            event = "DragStarted",
+            drag_id = %drag_id, source_window = %source_window, version,
+        ),
+        HostEvent::DragEnded { drag_id, outcome, version } => tracing::info!(
+            target: "host-reducer",
+            event = "DragEnded",
+            drag_id = %drag_id, outcome = ?outcome, version,
+        ),
+        // ── H.4 pool ─────────────────────────────────────────────────────
+        HostEvent::PoolWindowEntered { label, queue_len_after, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PoolWindowEntered",
+            label = %label, queue_len_after, version,
+        ),
+        HostEvent::PoolWindowLeft { label, queue_len_after, reason, version } => tracing::info!(
+            target: "host-reducer",
+            event = "PoolWindowLeft",
+            label = %label, queue_len_after, reason = ?reason, version,
+        ),
+        HostEvent::PoolEmpty { version } => tracing::info!(
+            target: "host-reducer",
+            event = "PoolEmpty",
+            version,
+        ),
+        // ── H.5 quit ─────────────────────────────────────────────────────
+        HostEvent::QuitDraining { reason, version } => tracing::warn!(
+            target: "host-reducer",
+            event = "QuitDraining",
+            reason = ?reason, version,
+            "[host-reducer] entering drain mode",
+        ),
+        HostEvent::QuitReady { version } => tracing::warn!(
+            target: "host-reducer",
+            event = "QuitReady",
+            version,
+            "[host-reducer] drain complete; host quitting",
+        ),
+        // ── H.6 top-level runner ─────────────────────────────────────────
+        HostEvent::TopLevelCreationRequested {
+            creation_id, source, label, version,
+        } => tracing::info!(
+            target: "host-reducer",
+            event = "TopLevelCreationRequested",
+            creation_id, source = ?source, label = %label, version,
+        ),
+        HostEvent::TopLevelCreationStarted { creation_id, label, version } => tracing::info!(
+            target: "host-reducer",
+            event = "TopLevelCreationStarted",
+            creation_id, label = %label, version,
+        ),
+        HostEvent::TopLevelCreationCompleted {
+            creation_id, label, latency_ms, version,
+        } => tracing::info!(
+            target: "host-reducer",
+            event = "TopLevelCreationCompleted",
+            creation_id, label = %label, latency_ms, version,
+        ),
+        HostEvent::TopLevelCreationFailed {
+            creation_id, label, outcome, version,
+        } => tracing::error!(
+            target: "host-reducer",
+            event = "TopLevelCreationFailed",
+            creation_id, label = %label, outcome = ?outcome, version,
+        ),
+        HostEvent::TopLevelQueueLengthChanged { len, version } => tracing::debug!(
+            target: "host-reducer",
+            event = "TopLevelQueueLengthChanged",
+            len, version,
+        ),
+        // ── Effect carrier ───────────────────────────────────────────────
+        HostEvent::Effect { effect, version } => tracing::debug!(
+            target: "host-reducer",
+            event = "Effect",
+            effect = ?effect, version,
         ),
         HostEvent::Error { message, version } => tracing::warn!(
             target: "host-reducer",

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.579"
+version = "0.33.580"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.579"
+version = "0.33.580"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.579"
+version = "0.33.580"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/reducer-architecture-current-state-2026-05-02.md
+++ b/docs/retro/reducer-architecture-current-state-2026-05-02.md
@@ -1,0 +1,373 @@
+# Reducer Architecture — Current State Report
+
+**Date:** 2026-05-02
+**Branch reflected:** `main` HEAD `48ad4e58` (post-PR #650 merge)
+**Author:** AgentA
+**Scope:** factual catalog of current reducer + saga architecture and state that lives outside it. No speculation; every claim cites file:line in source.
+
+**In-flight not reflected in this report:**
+- PR #651 (`feat(cef): host reducer-driven top-level window creation runner — Phase 2`) — open, not merged. Adds `top_level_creation_queue`, `in_flight_top_level_creation`, watchdog. Not on main.
+
+---
+
+## Three reducers — one per process
+
+AgentMux has three reducers, one per process, modeled after the same pattern: pure-functional `update(&mut State, Cmd) -> events`, snapshot-and-drop mutex discipline, monotonic `event_version`, lifecycle-phase gating.
+
+| Process | Reducer state | Reducer fn | Mounted on |
+|---|---|---|---|
+| Launcher | `agentmux-launcher/src/state.rs:130` (`State`) | `agentmux-launcher/src/reducer.rs:79` (`update`) | `Arc<Mutex<State>>` |
+| Srv | `agentmux-srv/src/state.rs:119` (`State`) | `agentmux-srv/src/reducer.rs:41` (`update`) | `Arc<Mutex<State>>` |
+| Host (CEF) | `agentmux-cef/src/reducer.rs:52` (`HostState`) | `agentmux-cef/src/reducer.rs:170` (`update`) | `AppState.host_state: parking_lot::Mutex<HostState>` (state.rs:234) |
+
+---
+
+## Launcher reducer
+
+### State (`State` struct, `agentmux-launcher/src/state.rs:130-200`)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `lifecycle` | `LifecyclePhase` | Bootstrap → Running → Quitting → Dead |
+| `processes` | `HashMap<u32, ProcessRecord>` | PID → process metadata |
+| `windows` | `HashMap<String, WindowMirror>` | Phase B.4 — label → top-level window mirror (kind, parent_label) |
+| `pool` | `HashSet<String>` | pool window labels |
+| `instance_registry` | `HashMap<String, u32>` | Phase B.5 — label → instance number |
+| `next_instance_num` | `u32` | starts at 2; "main" pre-seeded as 1 |
+| `backend_window_ids` | `HashMap<String, String>` | Phase B.5 step a — label → backend window id |
+| `event_version` | `u64` | monotonic event counter |
+| `next_client_id` | `u64` | client id allocator |
+| `monitors` | `Vec<Rect>` | Phase B.9.1 WRR — monitor topology |
+| `pending_hwnds` | `HashMap<u64, PendingHwnd>` | Phase B.9.1 WRR — HWND → pending metadata |
+
+### Commands (subset of `agentmux-common::ipc::Command` handled by launcher)
+
+All wire-serializable (cross-process IPC). Cited at `reducer.rs`:
+
+`Register`, `Goodbye`, `Ping` (lifecycle); `ReportWindowOpened`, `ReportWindowClosed`, `ReportPoolWindowAdded`, `ReportPoolWindowRemoved`, `ReportPoolWindowPromoted` (host→launcher mirror updates); `ReportHwndOpened`, `ReportHwndPositionChanged`, `ReportHwndForegroundChanged`, `ReportHwndVisibilityChanged`, `ReportHwndIconicChanged`, `ReportHwndDestroyed`, `ReportMonitorTopologyChanged`, `ReportWindowHwndsReleased` (Phase B.9.1 WRR mirror); plus saga-bound reports (`ReportPanesReaped`, `ReportPoolDrainDecision`, `ReportSagaActionFailed`).
+
+### Events (subset of `agentmux-common::ipc::Event` emitted by launcher)
+
+All wire-serializable. Broadcast to subscribers via tokio broadcast channel.
+
+`ProcessSpawned`, `LifecyclePhaseChanged`, `Registered`, `Pong`, `ProcessExited` (lifecycle); `WindowOpened`, `WindowClosed` (B.4); `PoolWindowAdded`, `PoolWindowRemoved`, `PoolWindowPromoted` (B.5); `WindowInstanceAssigned`, `WindowInstanceReleased` (B.5e); `BackendWindowIdRegistered`, `BackendWindowIdUnregistered` (B.5 step a); `HwndDriftClassified` (B.9.1 WRR); plus saga lifecycle events (`SagaStarted`, `SagaCompleted`, `SagaFailed`).
+
+### Lifecycle gating
+
+`Bootstrap → Running` on first Register (`reducer.rs:178-189`). Quitting placeholder per B.9.3.
+
+### Durability
+
+- **No SQLite for reducer state.** Window mirror, instance registry, etc. are session-only — bootstrapped empty on launcher start, fed by host reports.
+- **Saga durability is separate** — see saga section below.
+
+---
+
+## Srv reducer
+
+### State (`State` struct, `agentmux-srv/src/state.rs:119-149`)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `lifecycle` | `LifecyclePhase` | Same shape as launcher |
+| `processes` | `HashMap<u32, ProcessRecord>` | client process metadata |
+| `event_version` | `u64` | monotonic event counter |
+| `next_client_id` | `u64` | client id allocator |
+| `workspaces` | `HashMap<String, WorkspaceRecord>` | E.2 — workspace_id → workspace |
+| `tabs` | `HashMap<String, TabRecord>` | E.2b — tab_id → tab (with `block_ids: Vec<String>` ordered, `focused_node_id`, `magnified_node_id`) |
+| `blocks` | `HashMap<String, BlockRecord>` | E.3 — block_id → block |
+| `windows` | `HashMap<String, WindowRecord>` | E.5 — window_id ↔ workspace mapping |
+
+### Commands
+
+Wire-serializable. From `reducer.rs:43-83`:
+
+Lifecycle: `Register`, `Goodbye`, `Ping`, `GetSrvSnapshot`.
+
+Workspace/tab/block: `CreateWorkspace`, `DeleteWorkspace`, `CreateTab`, `DeleteTab`, `SetActiveTab`, `ReorderTab`, `CreateBlock`, `DeleteBlock`, `SetFocusedNode` (E.4), `SetMagnifiedNode` (E.4), `RenameWorkspace`, `RenameTab`, `UpdateWorkspaceMeta`, `UpdateTabMeta`, `UpdateBlockMeta`, `MoveTab`, `MoveBlock`, `ReorderTabsBulk`.
+
+Window-binding: `CreateWindow` (E.5), `CloseWindowInternal` (E.5), `SwitchWorkspace` (E.5).
+
+### Events
+
+Wire-serializable. From `reducer.rs`:
+
+`WorkspaceCreated/Deleted`, `TabCreated/Deleted/ActiveChanged/Reordered`, `BlockCreated/Deleted`, `FocusedNodeChanged`, `MagnifiedNodeChanged`, `WindowCreated/Closed/WorkspaceSwitched`, plus generic `ProcessSpawned`/`Registered`/`Pong`/`ProcessExited`/`LifecyclePhaseChanged`.
+
+### Durability
+
+- **Reducer state is session-only.** Workspace/tab/block durability is in `WaveStore` (objects.db SQLite, see `reference_persistence_files.md` memory) — that's a *separate* persistence layer, not the reducer.
+- **Saga log SQLite at `~/.agentmux/sagas.db`** (`agentmux-srv/src/sagas/log.rs:11`) — see saga section.
+
+---
+
+## Host reducer (CEF process)
+
+### State (`HostState`, `agentmux-cef/src/reducer.rs:52-76`)
+
+| Field | Type | Purpose |
+|---|---|---|
+| `pending_window_creations` | `VecDeque<PendingWindowCreation>` | F.1 — FIFO pre-create handoff: caller pushes label/kind/parent_instance_id; `client::on_after_created` pops |
+| `lifecycle` | `HostLifecyclePhase` | Bootstrapping → Running → ShuttingDown |
+| `event_version` | `u64` | monotonic event counter |
+
+That is **the entire host reducer state today on main.** All other host-side state (CEF browser handles, pane lifecycle, drag state, pool windows, focus state, etc.) lives outside the reducer — see "State NOT in any reducer" below.
+
+### Commands (`HostCommand`, `reducer.rs:101-113`)
+
+**Host-internal only — not wire-serializable.** F.1 comment (`reducer.rs:22-28`) explicitly states host commands do not cross IPC.
+
+- `EnqueuePendingWindowCreation { entry }`
+- `DequeuePendingWindowCreation`
+
+### Events (`HostEvent`, `reducer.rs:123-149`)
+
+**Host-internal only — not wire-serializable.**
+
+- `PendingWindowEnqueued { label, queue_len_after, version }`
+- `PendingWindowDequeued { label, queue_len_after, version }`
+- `PendingWindowQueueEmpty { version }`
+- `Error { message, version }`
+
+### Durability
+
+**None.** Session-only in-memory state.
+
+---
+
+## Saga coordinator (launcher only)
+
+Lives in `agentmux-launcher/src/saga/mod.rs`. Subscribes to launcher event broadcast, runs in-flight sagas, dispatches saga actions.
+
+### Saga trait (`saga/mod.rs:180-197`)
+
+```rust
+pub trait Saga: Send {
+    fn start(&mut self, ctx: &SagaCtx) -> SagaAction;
+    fn on_event(&mut self, event: &Event, ctx: &SagaCtx) -> SagaAction;
+    fn name(&self) -> &'static str;
+    fn input_snapshot(&self) -> serde_json::Value { Value::Null }
+    fn timeout(&self) -> Duration { Duration::from_secs(5) }
+}
+```
+
+### `SagaAction` (`saga/mod.rs:130-149`)
+
+```rust
+enum SagaAction {
+    IssueCmd { target: PipeTarget, cmd: Command },  // dispatch and stay in-flight
+    Done,                                            // saga succeeded
+    Failed { reason: String },                       // saga failed (CPD-3 host-send-error)
+    Wait,                                            // wait for next event
+}
+```
+
+`PipeTarget` (`saga/mod.rs:112-116`): `LauncherSelf`, `Host`, `Srv`. F.5+ dispatches to `Host` are LIVE via `HostPipe::send_command()`.
+
+### Active sagas — verified at `agentmux-launcher/src/saga/mod.rs:835-852`
+
+```rust
+fn match_trigger(event: &Event) -> Option<Box<dyn Saga>> {
+    match event {
+        Event::PoolWindowPromoted { label, .. } =>
+            Some(Box::new(pool_respawn::PoolRespawn::new(label.clone()))),
+        Event::WindowClosed { label, crash_detected: false, .. } =>
+            Some(Box::new(window_cleanup::WindowCleanupCascade::new(label.clone()))),
+        _ => None,
+    }
+}
+```
+
+**Two and only two sagas exist:**
+
+1. **`pool_respawn::PoolRespawn`** (`saga/pool_respawn.rs`)
+   - Trigger: `Event::PoolWindowPromoted`
+   - Actions: `IssueCmd { target: Host, cmd: Command::SpawnPoolWindow }`
+   - Termination: `Event::PoolWindowAdded` → `Done`
+   - Compensation: none
+
+2. **`window_cleanup::WindowCleanupCascade`** (`saga/window_cleanup.rs`)
+   - Trigger: `Event::WindowClosed { crash_detected: false }` (clean closes only — crash-detected closes skip the cascade per codex P1 PR #637)
+   - Actions: `IssueCmd { target: Host, cmd: Command::ReapPanes }`, then `IssueCmd { target: Host, cmd: Command::DrainPoolIfLast }`
+   - Termination: after both reports received → `Done`
+   - Compensation: none (cleanup is idempotent)
+
+### Cross-process dispatch (CPD-1 to CPD-5, all LIVE)
+
+| Item | Where | Status |
+|---|---|---|
+| Launcher saga sends `Command` to host | `HostPipe::send_command()` in `agentmux-launcher/src/host_pipe/mod.rs` | LIVE |
+| `HostFrame::{Event, Command}` envelope | wire format | LIVE |
+| Host receives command, dispatches via `LiveActionRunner` | `agentmux-cef/src/saga_dispatch.rs:331-352` | LIVE |
+| Per-saga `claim_terminal` atomic guard | `saga/mod.rs` | LIVE |
+| `HostPipe::cancel_saga(saga_id)` purges pending buffer on terminal | `host_pipe/mod.rs` | LIVE |
+| `host_session_id` generation prevents stale fanout | `host_pipe/mod.rs` | LIVE |
+| Host-side idempotency LRU (256 entries) | `agentmux-cef/src/saga_dispatch.rs::SagaIdempotencyLru` | LIVE |
+| Per-saga event correlation via `saga_id` | event payloads carry `saga_id` (CPD-4) | LIVE |
+| `Saga::timeout()` — default 5s, F.6 overrides 30s | `saga/mod.rs:200-202` | LIVE |
+
+### Saga durability (LSD-1 to LSD-4, all LIVE)
+
+**`LauncherSagaLog`** at `~/.agentmux/launcher-sagas.db` (`agentmux-launcher/src/saga/log/mod.rs:8-9`):
+
+| Capability | File:line | Status |
+|---|---|---|
+| Schema: `launcher_saga` (saga_id, name, state, started_at, ended_at, failure_reason, input_json) + `launcher_saga_step` | `saga/log/schema.rs` | LIVE |
+| WAL mode + 5s busy timeout + foreign_keys=ON | `saga/log/mod.rs` | LIVE |
+| `start_saga` / `terminate_saga` / `start_step` / `finish_step` / `fail_step` | `saga/log/mod.rs:214-350` | LIVE |
+| `next_saga_id` seeded from `max_saga_id() + 1` on startup | `saga/log/mod.rs` | LIVE (LSD-1) |
+| Recovery walker — marks unresolved sagas `failed_compensation` on restart, preserves original `failure_reason` | `agentmux-launcher/src/saga/recovery.rs` | LIVE (LSD-3, PR #647) |
+| Startup retention vacuum (default 7 days, configurable) | `saga/log/mod.rs` | LIVE (LSD-4, PR #646) |
+| `--diag sagas` operator command (read-only via `LauncherSagaLog::open_read_only`) | `agentmux-launcher/src/diag.rs` | LIVE (LSD-3) |
+| `--diag sagas` runs BEFORE CEF runtime check | `agentmux-launcher/src/main.rs` | LIVE |
+
+**`SagaLog`** at `~/.agentmux/sagas.db` (`agentmux-srv/src/sagas/log.rs:11`):
+
+Per-srv saga log. Same schema shape as launcher's. Used by srv-internal sagas (none active today; reserved for E-class).
+
+---
+
+## State NOT in any reducer
+
+**This is the operational gap.** Every entry below is a piece of mutable state currently protected by a raw `Mutex` / `RwLock` / `AtomicBool` / `OnceLock<Mutex<...>>`, mutated outside the reducer's `update()` function, with no event log, no replay, no `--diag` visibility, no cross-state invariant enforcement.
+
+Order: most freeze-relevant first.
+
+### Host (CEF) — pane and browser state (the freeze surface)
+
+| State | File:line | Type | Why it's not in reducer | Mutated at |
+|---|---|---|---|---|
+| `state.browsers` | `agentmux-cef/src/state.rs:210` | `Mutex<HashMap<String, Browser>>` | FFI handle to Chromium browser; can't serialize over IPC. Locked directly across the codebase (40+ call sites — see grep `state\.browsers\.lock`). | `client.rs::on_after_created` (insert), `pane/callbacks.rs` (remove), `commands/drag.rs`, `commands/window.rs`, `commands/window_pool.rs` |
+| `BrowserPaneManager::PaneStateMachine` | `agentmux-cef/src/pane/lifecycle.rs:60-62` | own internal `Mutex<HashMap<String, PaneEntry>>` | Independent state machine with `PaneLifecycle::{Live, Closing}`; never integrated into host reducer | `try_register_live` / `try_mark_closing` / `remove` / `drain_by_label` |
+| `ALLOW_PANE_FOCUS_ONCE` | `agentmux-cef/src/pane/hwnd.rs:71-72` | global `AtomicBool` | Win32 WM_SETFOCUS subclass flag; mutated from CEF callbacks + pane WndProc hook | `commands/window.rs::focus_pane` (set), pane WndProc (load/swap) |
+| `PANE_WNDPROCS` | `agentmux-cef/src/pane/hwnd.rs:24-26` | global `Mutex<HashMap<usize, isize>>` | HWND → original WndProc, for subclass delegation | `install_pane_focus_redirect` (insert), pane WndProc cleanup |
+| `PANE_HWND_CONTEXT` | `agentmux-cef/src/pane/hwnd.rs:39-41` | global `Mutex<HashMap<usize, PaneContext>>` | Pane HWND → context (state Arc + block_id). Lookup target for the WndProc hook. | `install_pane_focus_redirect`, `remove_contexts_for_block` |
+| `PANE_REDIRECT_LAST_AT` | `agentmux-cef/src/pane/hwnd.rs:81-83` | global `Mutex<HashMap<usize, Instant>>` | Per-root rate-limit map for focus redirects (PR #650 freeze fix) | `should_redirect_pane_focus_to_root` |
+| `active_drag` | `agentmux-cef/src/state.rs:302` | `Mutex<Option<DragSession>>` | Cross-window drag session (singleton). Spec §3.3 says Phase F.3 will retire. | `commands/drag.rs` start/end |
+| `window_pool` | `agentmux-cef/src/state.rs:252` | `Mutex<VecDeque<String>>` | Pre-warmed hidden window queue. Spec §3.2 says NOT migrating — needs synchronous host-local checks. | `commands/window_pool.rs::spawn_pool_window` (push), `promote_pool_window` (pop) |
+| `unpromoted_pool_labels` | `agentmux-cef/src/state.rs:266` | `Mutex<HashSet<String>>` | Labels of pool windows spawned but not yet promoted. | `spawn_pool_window` (insert), `promote_pool_window` (remove), destroy-before-promote |
+| `window_pool_respawn_in_flight` | `agentmux-cef/src/state.rs:272` | `AtomicBool` | Single-flight semaphore for pool refill. | `spawn_pool_window` swap |
+| `is_quitting` | `agentmux-cef/src/state.rs:281` | `AtomicBool` | "Last user-visible window is closing" flag. Cross-window read site. | `on_before_close` (set), `spawn_pool_window` (read guard) |
+
+### Host (CEF) — Win32 / WRR scaffolding
+
+| State | File:line | Type | Notes |
+|---|---|---|---|
+| `HOOK_HANDLES` | `agentmux-cef/src/wrr/win_event.rs` | `OnceLock<Mutex<Vec<HookHandle>>>` | Win32 SetWinEventHook handles |
+| `POSITION_DEBOUNCE_MAP` | `agentmux-cef/src/wrr/position_debounce.rs` | `OnceLock<Mutex<HashMap<u64, Instant>>>` | Per-HWND debounce timestamps for ReportHwndPositionChanged |
+
+### Host (CEF) — shadow projections of launcher state
+
+These are read-only projections fed by launcher `Event` subscriptions (`launcher_ipc::apply_event_to_shadow`). Host code never mutates these directly; they're not in the host reducer because the launcher reducer is authoritative.
+
+| State | File:line | Source event |
+|---|---|---|
+| `shadow_instance_registry` | `state.rs:161` | `WindowInstanceAssigned` / `WindowInstanceReleased` |
+| `shadow_backend_window_ids` | `state.rs:171` | `BackendWindowIdRegistered` / `BackendWindowIdUnregistered` |
+| `shadow_window_meta` | `state.rs:183` | `WindowOpened` / `WindowClosed` |
+
+### Host (CEF) — config and IPC caches
+
+These are setup-time values, not really "reducible" — included for completeness.
+
+| State | File:line | Notes |
+|---|---|---|
+| `auth_key`, `backend_endpoints`, `sidecar_child`, `backend_pid`, `backend_started_at`, `zoom_factor`, `client_id`, `window_id`, `active_tab_id`, `window_init_status`, `version_data_dir`, `version_config_dir`, `user_home_dir`, `debug_port` | `state.rs:122-316` | All `Mutex<...>` in AppState — set once at startup or rarely. Low value to migrate. |
+| `browser_api: BrowserApiState` | `state.rs:309` | CDP target cache + connection pool internals |
+
+### Launcher — none
+
+All launcher state is in the reducer's `State` struct. The only persistence outside is the saga log SQLite — which is the saga coordinator's concern, not "state not in reducer."
+
+### Srv — none functional
+
+All workspace/tab/block/window state is in the reducer's `State` struct. The objects.db (`WaveStore`) persistence is *separate* — it's the durable storage layer that the reducer's session state is rehydrated from on boot, but that's a different concern from "is this in the reducer."
+
+---
+
+## Wire serialization summary
+
+- **All launcher reducer events** are in `agentmux-common::ipc::Event` → wire-serializable, broadcast to subscribers.
+- **All srv reducer events** are in `agentmux-common::ipc::Event` → wire-serializable.
+- **All host reducer events** (`HostEvent` in `agentmux-cef/src/reducer.rs:123`) are **NOT** in `agentmux-common::ipc` → host-internal only by design (F.1 comment, `reducer.rs:22-28`).
+- **Cross-process saga commands** (`SpawnPoolWindow`, `ReapPanes`, `DrainPoolIfLast`) ARE in `agentmux-common::ipc::Command` → wire-serializable. CPD-3 dispatches them launcher→host via `HostPipe::send_command`.
+
+---
+
+## Phase migration roadmap as of 2026-05-02 main
+
+Drawn from the spec headers, plus the actual state of `match_trigger` and reducer struct contents:
+
+| Phase | Item | Status |
+|---|---|---|
+| B.4 | Launcher window mirror | LIVE |
+| B.5 (a→b→c→d→e) | Window meta migration to launcher | LIVE |
+| B.5e | Sequential instance numbers in launcher | LIVE |
+| B.7 | Client launcher event bridge | LIVE |
+| B.9.1 | WRR (Window Reality Reconciliation) — launcher mirror of OS HWND topology | LIVE |
+| B.9.3 | WRR drain mode → quit propagation | LIVE |
+| E (whole) | Srv reducer (workspaces, tabs, blocks, windows) | LIVE |
+| E.2c | Saga durability for srv (`sagas.db`) | LIVE |
+| F.1 | Host reducer (`pending_window_creations` only) | LIVE |
+| F.3 | Drag arms in host reducer | DEFERRED |
+| F.4 | Tear-off hook arms in host reducer | DEFERRED |
+| F.5 | Launcher saga coordinator + cross-process saga dispatch | LIVE (PRs #629-#640) |
+| F.6 | `WindowCleanupCascade` saga | LIVE (PR #635) |
+| F.7 | Host reducer proptests | LIVE (PR #640) |
+| LSD-1 | Launcher saga log foundation | LIVE (PR #641) |
+| LSD-2 | Coordinator wiring to LauncherSagaLog | LIVE (PR #645) |
+| LSD-3 | Recovery walker + `--diag sagas` | LIVE (PR #647) |
+| LSD-4 | Retention vacuum | LIVE (PR #646) |
+| CPD-1 | Saga_id schema for host commands | LIVE (PR #643) |
+| CPD-2 | HostPipe wrapper with reconnect + buffer | LIVE (PR #642) |
+| CPD-3 | Wire saga dispatch — F.5 stops being narrator | LIVE (PR #644) |
+| CPD-4 | Per-saga event correlation | LIVE (PR #648) |
+| CPD-5 | Host-side saga_id LRU + HostFrame parser | LIVE (PR #649) |
+| Phase 2 (ad-hoc, this session) | Host reducer-driven top-level window-create runner | **OPEN PR #651, NOT MERGED** |
+
+---
+
+## Implications for the 2026-05-02 freeze investigation
+
+The freeze reproduces deterministically when:
+- A browser pane (a `defwidget@browser` block) exists in any window
+- The user opens a new top-level window (TearOff or "open new window")
+
+User-confirmed: **without browser panes, the app is stable**. The wedge fingerprint is two AboveNormal CEF threads in `EventPairLow` + `Unknown` lock-wait, after CEF's `on_after_created` log line.
+
+**What the reducer architecture does NOT cover today (relevant to this bug):**
+
+1. **Browser pane lifecycle** is in `PaneStateMachine` (own state, own mutex) — invisible to the host reducer. The reducer cannot enforce "no pane operations during top-level creation" because pane state isn't reducer-mediated.
+
+2. **`state.browsers`** is a raw `Mutex<HashMap>` containing both top-level browsers AND pane browsers. The lock is taken at 40+ call sites including some that hold across CEF FFI calls. This is the lock the wedged UI thread is waiting on at `client.rs:149` per the Phase 1 trace data.
+
+3. **No central event log** combining pane lifecycle + top-level lifecycle + drag state + pool state. When the freeze happens, there's no replayable record of "what state was the host in 200ms before the wedge."
+
+4. **No saga supervising compound pane operations.** Pane create + load + focus runs as imperative CEF calls. A saga with timeout + compensation could detect and recover from a partial-state pane.
+
+5. **Cross-state invariants are not declarable.** Today's reducer arms are independent. There's no place to express "the host reducer rejects a top-level creation request while a pane is in `PaneLifecycle::Live` with non-zero in-flight focus operations."
+
+**What integrating panes into the host reducer would buy:**
+
+- Single ordered event log: `PaneCreated`, `PaneFocused`, `PaneClosed`, `TopLevelEnqueued`, `TopLevelStarted`, `TopLevelCallback`, etc., interleaved with monotonic `event_version`. Replayable via `--diag windows` + a durable log analogous to LSD-1.
+- Reducer rule: refuse `EnqueueTopLevelWindow` while any pane is mid-transition (or, more nuanced, signal to the runner to wait until panes are quiesced).
+- Saga model for pane operations: `PaneCreateSaga`, with timeout and compensation. The same pattern PRs #641-#649 shipped for cross-process work.
+- Operator visibility: `--diag panes` reads the same SQLite the reducer writes to, even when the host is wedged or has crashed.
+
+**Cost estimate:** comparable in scope to E-class (srv reducer migration) — Phase F.6 in the existing host reducer spec was the placeholder for pane state but was deferred indefinitely. To do it well: ~2-3 weeks of phased work mirroring B.5's a→b→c→d→e ratchet (parallel writes → flip reads → drop writes → delete legacy field).
+
+---
+
+## What's missing from this report
+
+This is a structural catalog, not a behavioral one. It does not document:
+
+- Operational behavior of in-flight sagas (how often they fire, latency distributions)
+- The actual correctness invariants each reducer enforces (only their type-system invariants — what `apply()` actually returns)
+- Drift between intent (specs) and implementation (this is hinted at in some spec references but not exhaustively audited)
+
+For those, the relevant docs are `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`, `docs/retro/saga-architecture-migration-complete-2026-05-02.md`, and individual saga PR descriptions.
+
+---
+
+End of report.

--- a/docs/specs/SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md
+++ b/docs/specs/SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md
@@ -1,0 +1,749 @@
+# SPEC: Host Reducer Buildout — 5-PR Plan
+
+**Date:** 2026-05-02
+**Status:** Draft — operational plan
+**Author:** AgentA
+**Branch base:** `main` HEAD `48ad4e58`
+
+**Companion docs:**
+- `docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md` — granular Phase H spec; this doc is its 5-PR compression. Reference the granular spec for full type definitions, reducer semantics, and decision log.
+- `docs/retro/reducer-architecture-current-state-2026-05-02.md` — verified factual catalog of what's in / out of reducers today.
+- `docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md` — 2026-05-02 freeze investigation (dump analysis, root cause).
+
+---
+
+## Overview
+
+Migrate all host-side mutable state (panes, CEF browser handles, drag, pool, quit, top-level creation) into the host reducer. **Five PRs**, each one representing a logical phase. The granular a→b→c→d→e migration ratchet from B.5 still applies — it's now compressed into per-PR commit sequences instead of separate PRs.
+
+**Architectural directives (unchanged from Phase H spec):**
+1. NO timers, NO watchdogs in any reducer arm. Event-driven only.
+2. Fail-fast for user-initiated operations under contention.
+3. Single source of truth — every state field owned by exactly one reducer arm.
+4. Cross-state invariants are first-class.
+
+**Total effort:** 2-3 weeks wall-clock + bot review iteration. Same ballpark as the saga reducer migration (PRs #641-#649).
+
+---
+
+## PR sequence at a glance
+
+| # | Branch | Title | Depends on | Effort | Risk |
+|---|---|---|---|---|---|
+| 1 | `agenta/h1-foundations` | feat(cef): host reducer foundations — state, commands, events, no behavior change | main | 1 day | Low |
+| 2 | `agenta/h2-panes-and-browsers` | feat(cef): migrate pane lifecycle + state.browsers map into host reducer | PR #1 | 4-5 days | High |
+| 3 | `agenta/h3-drag-pool-quit` | feat(cef): migrate drag, pool, quit state into host reducer | PR #1 (parallel to #2) | 3-4 days | Medium |
+| 4 | `agenta/h4-top-level-runner-and-sagas` | feat(cef): event-driven top-level window creation runner + cross-state sagas | PR #1, #2, #3 | 3-4 days | High |
+| 5 | `agenta/h5-durability-diag-wire-promote` | feat(cef): host reducer durable log + --diag windows + wire-promoted events | PR #1-#4 | 2-3 days | Low |
+
+PR #2 and PR #3 can run in parallel after PR #1 lands. PR #4 needs both. PR #5 is gravy at the end.
+
+---
+
+## PR #1 — Foundations
+
+**Branch:** `agenta/h1-foundations`
+**Title:** `feat(cef): host reducer foundations — state, commands, events, no behavior change`
+**Effort:** ~1 day
+**Risk:** Low (no behavior change)
+
+### Goal
+
+Add ALL the new `HostState` fields, `HostCommand` variants, `HostEvent` variants, and reducer arms required by PRs #2-#5 — but DON'T wire any callers yet. Existing state continues to be authoritative; new reducer fields are present but dormant. This avoids reducer-scaffolding churn in every subsequent PR.
+
+### Files touched
+
+- `agentmux-cef/src/state.rs` — add new types: `PaneEntry`, `PaneLifecycle`, `BrowserHandle`, `BrowserKind`, `DragSession` (already exists), `PoolState`, `TopLevelCreationRequest`, `InFlightCreation`, `CreationPhase`, `CompletedCreation`, `QuitState`, `QuitReason`.
+- `agentmux-cef/src/reducer.rs` — extend `HostState` with new fields (default-initialized empty/None); add `HostCommand` variants; add `HostEvent` variants; add reducer arms.
+- `agentmux-cef/src/state.rs::log_host_event` — extend match to log new events.
+
+### State added to `HostState`
+
+```rust
+pub struct HostState {
+    // F.1 (existing):
+    pub pending_window_creations: VecDeque<PendingWindowCreation>,
+    pub lifecycle: HostLifecyclePhase,
+    pub event_version: u64,
+    
+    // H.1:
+    pub panes: HashMap<String /* block_id */, PaneEntry>,
+    
+    // H.2:
+    pub browsers: HashMap<String /* label */, BrowserHandle>,
+    
+    // H.3:
+    pub active_drag: Option<DragSession>,
+    
+    // H.4:
+    pub pool: PoolState,
+    
+    // H.5:
+    pub quit_state: QuitState,
+    
+    // H.6:
+    pub top_level_creation: TopLevelCreationState,
+}
+```
+
+Type definitions per granular Phase H spec §"Phase H.0".
+
+### Commands added
+
+```rust
+HostCommand::EnqueuePaneCreate { block_id, label }
+HostCommand::CompletePaneCreate { block_id }
+HostCommand::EnqueuePaneClose { block_id }
+HostCommand::CompletePaneClose { block_id }
+HostCommand::AbortPaneCreate { block_id, reason }
+
+HostCommand::RegisterBrowser { label, browser, kind }
+HostCommand::UnregisterBrowser { label }
+
+HostCommand::StartDrag { drag_id, drag_type, source_window, source_workspace_id, source_tab_id, payload }
+HostCommand::EndDrag { drag_id, outcome }
+
+HostCommand::PoolWindowSpawnStart { label }
+HostCommand::PoolWindowReady { label }
+HostCommand::PoolWindowDestroyedBeforePromote { label }
+HostCommand::PromotePoolWindow { label, /* ... */ }
+HostCommand::PoolDrainAll
+
+HostCommand::BeginDrain { reason }
+HostCommand::ConfirmDrained
+
+HostCommand::EnqueueTopLevelWindow { request, source: TopLevelSource }
+HostCommand::TopLevelCallbackFired { label }
+HostCommand::TopLevelRendererTerminated { label, status }
+HostCommand::TopLevelExternallyClosed { label }
+```
+
+`TopLevelSource::{User, Background}` — distinguishes fail-fast (user) from queue-able (background pool refill).
+
+### Events added
+
+```rust
+HostEvent::PaneCreateRequested { block_id, label, version }
+HostEvent::PaneLive { block_id, label, version }
+HostEvent::PaneClosing { block_id, version }
+HostEvent::PaneClosed { block_id, version }
+HostEvent::PaneCreationFailed { block_id, reason, version }
+
+HostEvent::BrowserRegistered { label, kind, version }
+HostEvent::BrowserUnregistered { label, version }
+
+HostEvent::DragStarted { drag_id, drag_type, source_window, version }
+HostEvent::DragEnded { drag_id, outcome, version }
+
+HostEvent::PoolWindowEntered { label, queue_len_after, version }
+HostEvent::PoolWindowLeft { label, queue_len_after, reason, version }
+HostEvent::PoolEmpty { version }
+
+HostEvent::QuitDraining { reason, version }
+HostEvent::QuitReady { version }
+
+HostEvent::TopLevelCreationRequested { creation_id, request, source, version }
+HostEvent::TopLevelCreationStarted { creation_id, label, version }
+HostEvent::TopLevelCreationCompleted { creation_id, label, latency_ms, version }
+HostEvent::TopLevelCreationFailed { creation_id, label, reason, version }
+HostEvent::TopLevelQueueLengthChanged { len, version }
+```
+
+Plus an `HostEvent::Effect(EffectKind)` carrier for side-effect-bearing events (used by PR #4's effect handler).
+
+### Reducer arms
+
+All arms implemented per the granular spec's reducer rules (§"Phase H.1" through "Phase H.6"). Arms are pure functions, no I/O.
+
+### Tests
+
+- Unit test per command (input → state change + emitted events).
+- Proptests for invariants:
+  - `panes` map: every `EnqueuePaneCreate` followed by either `CompletePaneCreate` (Live) or `AbortPaneCreate` (removed) — no orphans.
+  - `top_level_creation.in_flight`: at most one Some across any action sequence.
+  - `pool.respawn_in_flight`: never two concurrent spawn-starts.
+  - `quit_state`: monotonic — Running → Draining → Quit, no regression.
+- Existing F.1 tests remain green (untouched).
+
+### Acceptance criteria
+
+- All new types compile.
+- All new commands route through `update()`.
+- All new events log via `log_host_event`.
+- New reducer fields have no callers yet (dead-code warnings expected; `#[allow(dead_code)]` on the new fields with TODO comments referencing PR #2-#5).
+- `cargo test reducer::tests` → 100% pass, including new tests.
+- No existing behavior changes — PaneStateMachine, state.browsers HashMap, active_drag, etc. all still work as before.
+
+### Bump
+
+Patch version (e.g., 0.33.580). Internal-only changes.
+
+---
+
+## PR #2 — Panes + Browsers
+
+**Branch:** `agenta/h2-panes-and-browsers`
+**Title:** `feat(cef): migrate pane lifecycle + state.browsers map into host reducer`
+**Effort:** ~4-5 days
+**Risk:** High (touches 40+ lock sites for `state.browsers`; pane lifecycle is core operational logic)
+
+### Goal
+
+Migrate two tightly-coupled pieces in one PR:
+1. **`PaneStateMachine` → `HostState.panes`** (replaces `BrowserPaneManager::PaneStateMachine`).
+2. **`AppState.browsers: Mutex<HashMap>` → `HostState.browsers`** (replaces direct mutex; consolidates 40+ lock sites through reducer queries).
+
+These migrate together because the `state.browsers` map contains both top-level browsers AND pane browsers, and pane lifecycle transitions trigger browser-handle insertions/removals. Migrating them separately would require carefully coordinated parallel writes — easier to do them together.
+
+### Internal commit sequence (the a→e ratchet, compressed)
+
+PR #2 will have ~10-15 commits internally, structured for stepwise review:
+
+```
+commit 1 (H.1.a): pane parallel writes — PaneStateMachine.try_register_live ALSO dispatches EnqueuePaneCreate
+commit 2 (H.2.a): browser parallel writes — state.browsers.insert ALSO dispatches RegisterBrowser
+commit 3 (H.1.b): pane reads with fallback — list_live_panes prefers reducer, falls back to PaneStateMachine
+commit 4 (H.2.b): browser reads with fallback — get_browser/list_browsers prefer reducer, fall back to AppState.browsers
+commit 5 (H.1.c+H.2.c): flip reads — no fallback, pure reducer reads
+commit 6 (H.1.d+H.2.d): drop legacy writes — PaneStateMachine and AppState.browsers become read-only/skeletal
+commit 7 (H.1.e+H.2.e): delete legacy fields — PaneStateMachine struct gone; AppState.browsers field gone
+commit 8: integration tests + smoke verification
+```
+
+This lets reviewers walk the PR commit-by-commit while shipping atomically.
+
+### Files touched
+
+- `agentmux-cef/src/pane/lifecycle.rs` — `PaneStateMachine` first becomes a thin shim, then deleted.
+- `agentmux-cef/src/browser_panes.rs` — `BrowserPaneManager` reads via reducer queries; close/focus/resize call sites update.
+- `agentmux-cef/src/pane/callbacks.rs` — `on_after_created_pane` dispatches `CompletePaneCreate`; `on_before_close` dispatches `EnqueuePaneClose` + `CompletePaneClose`.
+- `agentmux-cef/src/pane/creation.rs` — pane creation dispatches `EnqueuePaneCreate` + `RegisterBrowser`.
+- `agentmux-cef/src/client.rs` — `on_after_created` dispatches `RegisterBrowser` for top-level (existing `state.browsers.insert` call site, line ~205).
+- `agentmux-cef/src/state.rs` — read helpers (`get_browser`, `list_browsers`, `list_live_panes`, etc.) added to `AppState`. Eventually `pub browsers` field deleted.
+- All ~40 `state.browsers.lock()` call sites — converted to reducer query helpers.
+
+### Migration of `state.browsers` lock sites
+
+Categorize the 40+ sites by usage pattern:
+
+| Pattern | Conversion |
+|---|---|
+| `browsers.lock().get(&label).cloned()` | `state.get_browser(label)` |
+| `browsers.lock().contains_key(&label)` | `state.has_browser(label)` |
+| `browsers.lock().keys().collect()` | `state.list_browser_labels()` |
+| `browsers.lock().iter().filter(...)` | `state.list_browsers().iter().filter(...)` (clones, but FFI handles are refcounted so cheap) |
+| `browsers.lock().insert(label, browser)` | `state.host_dispatch(RegisterBrowser{label, browser, kind})` |
+| `browsers.lock().remove(&label)` | `state.host_dispatch(UnregisterBrowser{label})` |
+
+The reducer effect for `RegisterBrowser` performs the actual map insert into `HostState.browsers`. For `UnregisterBrowser`, removes from map and emits `BrowserUnregistered`.
+
+**Snapshot-and-drop preserved:** read helpers acquire the host_state lock, clone the value, drop the lock — same discipline as `host_dispatch`.
+
+### Tests
+
+- Pane lifecycle: create → live → close → closed (via reducer).
+- Browser registration: register top-level, register pane (matched to live pane entry), unregister.
+- Read helpers: `get_browser` returns clone of registered browser; `list_live_panes` returns all panes in `Live` state.
+- Drift detection (commits 3-4): assert reducer state and PaneStateMachine state are consistent across a workload.
+- Existing tests for `BrowserPaneManager` adapted to use reducer-backed `AppState`.
+
+### Smoke verification (manual, before merge)
+
+- Open AgentMux. Create a tab with multiple browser blocks. Close the tab. All browsers cleanly unregistered.
+- Drag-and-drop a tab between windows. Browser handles correctly tracked.
+- Open multiple top-level windows. Each registered. Close each. Each unregistered.
+- **Freeze probe:** open a top-level window with a browser pane present. (Without PR #4's runner, this may still freeze — that's expected. PR #2 doesn't claim to fix the freeze, only to make pane state observable in the reducer.)
+
+### Acceptance criteria
+
+- `cargo test` 100% pass.
+- 0 remaining `state.browsers.lock()` call sites in `agentmux-cef/src/` (grep verifies).
+- 0 remaining references to `PaneStateMachine` (grep verifies).
+- Smoke checklist above passes.
+- `BrowserPaneManager` is now a stateless utility wrapper around reducer queries.
+
+### Bump
+
+Minor version bump (e.g., 0.34.0). Architectural change, even though externally-visible behavior is unchanged.
+
+### Risk mitigation
+
+- **Smoke test before merge.** This PR touches the highest-traffic mutex in the host. Land only after a thorough manual exercise.
+- **Internal commit boundaries.** Each commit is reviewable independently; if step c surfaces drift, hold the PR until investigated rather than merging the whole thing.
+- **Drift detection in commits 3-4** runs in production-like conditions (smoke test) before commit 5 flips reads to reducer-only.
+
+---
+
+## PR #3 — Drag + Pool + Quit
+
+**Branch:** `agenta/h3-drag-pool-quit`
+**Title:** `feat(cef): migrate drag, pool, quit state into host reducer`
+**Effort:** ~3-4 days
+**Risk:** Medium (multiple state pieces, but each is small and self-contained)
+
+### Goal
+
+Migrate three smaller, independent state pieces into the reducer:
+- `active_drag: Mutex<Option<DragSession>>` → `HostState.active_drag`
+- `window_pool` + `unpromoted_pool_labels` + `window_pool_respawn_in_flight` atomic → `HostState.pool: PoolState`
+- `is_quitting: AtomicBool` → `HostState.quit_state: QuitState`
+
+Can run in parallel with PR #2 since these state pieces don't overlap with panes/browsers.
+
+### Internal commit sequence
+
+```
+commit 1 (H.3.a→e): drag migration (active_drag → HostState.active_drag, full a→e in one batch since few call sites)
+commit 2 (H.4.a→b): pool parallel writes + reads with fallback
+commit 3 (H.4.c→e): pool flip reads, drop writes, delete legacy fields
+commit 4 (H.5.a→e): quit state migration (small, single batch)
+commit 5: integration tests + smoke
+```
+
+### Files touched
+
+- `agentmux-cef/src/state.rs` — read helpers; eventually delete `active_drag`, `window_pool`, `unpromoted_pool_labels`, `window_pool_respawn_in_flight`, `is_quitting` fields.
+- `agentmux-cef/src/commands/drag.rs` — drag start/end via reducer.
+- `agentmux-cef/src/commands/window_pool.rs` — `spawn_pool_window` dispatches `PoolWindowSpawnStart`; `mark_pool_window_renderer_ready` dispatches `PoolWindowReady`; `promote_pool_window` dispatches `PromotePoolWindow`.
+- `agentmux-cef/src/wrr/mod.rs` (or wherever `is_quitting` is read) — read via reducer.
+- `agentmux-cef/src/client.rs::on_before_close` — dispatch `BeginDrain` when last user-visible window closes.
+
+### Pool refill effect
+
+When the reducer's `PoolWindowLeft` arm runs and `pool.queue.len() < POOL_TARGET_SIZE`:
+
+```rust
+if !state.pool.respawn_in_flight 
+   && state.pool.queue.len() < POOL_TARGET_SIZE 
+   && state.quit_state == QuitState::Running {
+    state.pool.respawn_in_flight = true;
+    out.events.push(HostEvent::Effect(EffectKind::SpawnPoolWindow));
+}
+```
+
+The effect handler (in PR #1's `host_dispatch_with_effects`) executes the imperative CEF call. On `PoolWindowReady`, reducer clears `respawn_in_flight`.
+
+### Tests
+
+- Drag start/end: invariant — at most one `Some` active at a time.
+- Pool: spawn → ready → enter queue → promote → leave queue → refill effect emitted (mocked CEF call counts).
+- Quit: Running → Draining → Quit transitions; subsequent commands rejected per state.
+
+### Smoke verification
+
+- Drag a tab between two windows. Drag state cleanly registered and cleared.
+- Tear off a tab to create a new window. Pool window correctly promoted; refill triggered.
+- Close the last window. Drain mode kicks in; no further pool refills.
+
+### Acceptance criteria
+
+- `cargo test` 100% pass.
+- 0 remaining `active_drag.lock()` / `window_pool.lock()` / `is_quitting.load()` call sites outside the reducer.
+- All existing tear-off + drag tests still pass (smoke-tested manually).
+
+### Bump
+
+Patch version.
+
+### Risk mitigation
+
+- Drag and pool are well-tested code paths today (`tear_off_hook.rs`, `window_pool.rs` have substantial coverage). Migration shouldn't change their semantics.
+- Quit state is small (~3 transitions). Easy to exhaustively test.
+
+---
+
+## PR #4 — Top-level Runner + Cross-state Sagas
+
+**Branch:** `agenta/h4-top-level-runner-and-sagas`
+**Title:** `feat(cef): event-driven top-level window creation runner + cross-state sagas`
+**Effort:** ~3-4 days
+**Risk:** High (the actual freeze fix; new CEF callback wiring; cross-state invariants are new territory)
+
+**Depends on:** PR #1 (foundations), PR #2 (panes + browsers in reducer), PR #3 (pool + quit in reducer).
+
+### Goal
+
+The freeze fix. Build the top-level window creation runner using ONLY observable CEF callbacks (no timers, no watchdogs). Add cross-state invariants that the reducer can now enforce (e.g., refuse top-level creation while panes are mid-transition).
+
+### Internal commit sequence
+
+```
+commit 1 (H.6.a): wire CEF callbacks — on_after_created, on_render_process_terminated, on_before_close — to dispatch reducer commands
+commit 2 (H.6.b): reroute commands/window.rs::open_window_with_kind through reducer (user-initiated; fail-fast)
+commit 3 (H.6.c): reroute commands/window_pool.rs::spawn_pool_window through reducer (background; queues)
+commit 4 (H.6.d): make post_create_window private; only effect handler calls it
+commit 5 (H.6.e): delete legacy direct queueing code paths
+commit 6 (H.7): cross-state invariant — reducer rejects EnqueueTopLevelWindow if any pane is in PaneLifecycle::Closing
+commit 7 (H.7): NewWindowSaga + PaneCreateSaga (launcher-side sagas observing host events; depends on H.5's wire-promote — note this may need to defer to PR #5 or land minimally)
+commit 8: integration tests + smoke
+```
+
+### Files touched
+
+- `agentmux-cef/src/client.rs` — add `on_render_process_terminated` callback. Existing `on_after_created` and `on_before_close` updated to dispatch top-level lifecycle commands.
+- `agentmux-cef/src/commands/window.rs::open_window_with_kind` — dispatch `EnqueueTopLevelWindow { source: User }`. Return error if reducer rejects (busy in-flight or pane in transition).
+- `agentmux-cef/src/commands/window_pool.rs::spawn_pool_window` — dispatch `EnqueueTopLevelWindow { source: Background }`. Reducer queues if busy.
+- `agentmux-cef/src/ui_tasks.rs::post_create_window` — visibility narrowed; only `host_dispatch_with_effects` calls it.
+- `agentmux-launcher/src/saga/new_window_saga.rs` — new saga (if H.7 fully lands here; otherwise deferred).
+- `agentmux-launcher/src/saga/pane_create_saga.rs` — new saga.
+
+### Reducer rules (per granular spec §"Phase H.6")
+
+#### `EnqueueTopLevelWindow { request, source }`:
+
+- If `quit_state != Running` → reject with Error.
+- If `source == User` AND `top_level_creation.in_flight.is_some()` → return error `BusyInFlight`. Caller propagates to frontend.
+- If `source == User` AND any pane has `lifecycle: Closing` → return error `PaneInTransition`. (Probe; verify it helps in production. May need to be a configurable feature flag.)
+- If `source == Background` → enqueue to back. Auto-advance if idle.
+- If idle → start immediately. Emit `BeginCreationEffect`.
+
+#### `TopLevelCallbackFired { label }`:
+
+- If matches in-flight → mark `Completed`, push to history, advance queue.
+- If doesn't match → close orphan browser via reducer effect (prevent label collision).
+
+#### `TopLevelRendererTerminated { label, status }`:
+
+- If matches in-flight → mark `Failed { reason: RendererTerminated { status } }`, advance queue.
+
+#### `TopLevelExternallyClosed { label }`:
+
+- If matches in-flight → mark `Failed { reason: ExternallyClosed }`, advance queue.
+
+#### **No timer-driven transitions.** No `TopLevelTimeoutTick`. No watchdog.
+
+### Cross-state invariant — H.7 probe
+
+Per the granular Phase H spec §"Phase H.7":
+
+```rust
+HostCommand::EnqueueTopLevelWindow { request, source: TopLevelSource::User } => {
+    let any_pane_closing = state.panes.values()
+        .any(|p| matches!(p.lifecycle, PaneLifecycle::Closing { .. }));
+    if any_pane_closing {
+        return reject_error("pane mid-transition; retry shortly");
+    }
+    // ... proceed
+}
+```
+
+This is the **freeze probe**. The 2026-05-02 freeze investigation identified that opening a top-level window while a browser pane exists triggers a CEF deadlock. This invariant blocks the trigger condition. Verifiable in production immediately after this PR ships.
+
+If the invariant doesn't help (the deadlock is wider than "Closing" panes), relax to "any pane existing in any state" or remove. If it helps, keep.
+
+### Sagas (H.7)
+
+Two sagas added in launcher, observing host events broadcast across IPC. **This requires H.5 (wire-promote) to be partially complete** — specifically, `HostEvent::TopLevelCreationStarted/Completed/Failed` and `HostEvent::PaneLive/Closed/CreationFailed` need to cross IPC. PR #4 may need to include a minimal wire-promote of just these events (the rest waits for PR #5).
+
+```rust
+// agentmux-launcher/src/saga/new_window_saga.rs
+pub struct NewWindowSaga { creation_id: u64 }
+impl Saga for NewWindowSaga {
+    fn start(&mut self, _ctx: &SagaCtx) -> SagaAction { SagaAction::Wait }
+    fn on_event(&mut self, event: &Event, _ctx: &SagaCtx) -> SagaAction {
+        match event {
+            Event::HostTopLevelCreationCompleted { creation_id, .. } if *creation_id == self.creation_id => SagaAction::Done,
+            Event::HostTopLevelCreationFailed { creation_id, reason, .. } if *creation_id == self.creation_id => SagaAction::Failed { reason: reason.clone() },
+            _ => SagaAction::Wait,
+        }
+    }
+    fn name(&self) -> &'static str { "new_window" }
+    // No timeout — relies on observable CEF events.
+}
+```
+
+`PaneCreateSaga` analogous.
+
+### Tests
+
+- Reducer arms for top-level lifecycle: every state transition.
+- User-initiated rejection scenarios: busy in-flight, pane in transition, quit draining.
+- Background queueing: pool refill chains correctly.
+- Orphan-browser handling: `TopLevelCallbackFired` for unknown label closes the orphan.
+- Saga completion: `TopLevelCreationCompleted` event terminates `NewWindowSaga::Done`.
+- Saga failure: `TopLevelCreationFailed` terminates as `Failed`.
+
+### Smoke verification (CRITICAL — this is the freeze test)
+
+- **Repro the freeze scenario:** Open AgentMux. Add a browser pane block. Open a new top-level window via "open new window". Verify:
+  - Either succeeds normally (no deadlock — invariant kicked in or CEF coopered), OR
+  - User-initiated request fails fast with visible error (reducer rejected because pane transition).
+  - **The host UI thread does NOT freeze.**
+- Open multiple windows back-to-back. Each completes or fails-fast in turn.
+- Trigger CEF renderer crash mid-creation (kill a child process). Reducer evicts in-flight as `Failed`, queue advances.
+- Pool refill: tear off a tab. New pool window created. Pool refill triggered correctly.
+
+### Acceptance criteria
+
+- `cargo test` 100% pass including new saga tests.
+- **Freeze repro from 2026-05-02 either does not occur OR fails fast with visible error (no UI hang).**
+- Operator can `--diag windows` to see in-flight state (foundation for PR #5).
+- 0 remaining direct calls to `post_create_window` outside the reducer effect handler.
+
+### Bump
+
+Minor version bump (e.g., 0.35.0). Major behavior change.
+
+### Risk mitigation
+
+- **This is the freeze fix.** Do extensive manual smoke testing before merging. The bot reviewers will not catch a deadlock — only a human exercise can.
+- The H.7 invariant is a probe — log when it fires so we can measure if it's actually blocking the trigger condition.
+- If smoke testing reveals the cross-state invariant doesn't fix the freeze, **don't merge with the invariant declared as the fix**. Revisit the diagnosis (probably need a debugger walk of the wedged threads).
+
+### Open question for this PR
+
+Does CEF reliably fire `on_render_process_terminated` for the wedged-renderer case? Per the 2026-05-02 dump, render workers stayed `Responding=True` during the wedge — they weren't dead. If CEF doesn't fire the callback, the in-flight slot stays occupied permanently when wedged. User-initiated creates fail-fast with visible error; pool refill blocks until restart. **Acceptable per the no-timer directive, but worth verifying.**
+
+---
+
+## PR #5 — Durability + Diag + Wire-promote
+
+**Branch:** `agenta/h5-durability-diag-wire-promote`
+**Title:** `feat(cef): host reducer durable log + --diag windows + wire-promoted events`
+**Effort:** ~2-3 days
+**Risk:** Low (additive observability, no semantic change)
+
+**Depends on:** PR #1-#4.
+
+### Goal
+
+Make the host reducer's state inspectable via SQLite log + operator command, and promote selected events to the IPC wire so launcher sagas can subscribe natively.
+
+### Internal commit sequence
+
+```
+commit 1 (H.8): HostReducerLog SQLite at <data-dir>/host-reducer.db, schema, append per reducer arm
+commit 2 (H.8): recovery walker — mark orphan rows from prior host_pid as failed_recovery
+commit 3 (H.8): agentmux --diag windows operator command
+commit 4 (H.9): wire-promote remaining HostEvent variants to agentmux-common::ipc::Event
+commit 5: integration tests + acceptance smoke
+```
+
+### Files added
+
+- `agentmux-cef/src/host_reducer_log.rs` — SQLite wrapper analogous to `agentmux-launcher/src/saga/log/mod.rs`.
+- `agentmux-cef/src/host_reducer_recovery.rs` — recovery walker.
+- `agentmux-launcher/src/diag.rs` — extend with `--diag windows`.
+
+### Schema (`<data-dir>/host-reducer.db`)
+
+```sql
+CREATE TABLE pane_creation (
+    seq INTEGER PRIMARY KEY,
+    block_id TEXT NOT NULL,
+    label TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    closed_at INTEGER,
+    final_state TEXT NOT NULL  -- 'live' | 'closed' | 'failed_recovery'
+);
+
+CREATE TABLE top_level_creation (
+    creation_id INTEGER PRIMARY KEY,
+    label TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    finished_at INTEGER,
+    outcome TEXT NOT NULL,  -- 'completed' | 'renderer_terminated' | 'externally_closed' | 'failed_recovery'
+    failure_reason TEXT,
+    host_pid INTEGER NOT NULL,
+    host_version TEXT NOT NULL
+);
+
+CREATE INDEX idx_pane_started ON pane_creation(created_at);
+CREATE INDEX idx_top_level_started ON top_level_creation(started_at);
+```
+
+### Recovery walker
+
+```rust
+// agentmux-cef/src/host_reducer_recovery.rs
+pub fn recover_orphans(log: &HostReducerLog, current_pid: u32) {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    log.mark_orphan_panes(now_ms, "failed_recovery");
+    log.mark_orphan_top_level(now_ms, "failed_recovery", current_pid);
+}
+```
+
+Called from `agentmux-cef/src/main.rs` BEFORE the first reducer dispatch.
+
+### `--diag windows`
+
+```
+$ agentmux --diag windows
+
+== HOST REDUCER STATE (live) ==
+Top-level in-flight: creation_id=42, label=window-abc, started 8s ago, phase=Started
+Top-level queued: 2 (next: window-xyz, source=Background)
+Pool: 2 ready, 1 unpromoted, refill-in-flight=false
+Panes live: 3 (b1, b2, b7)
+Panes closing: 0
+Quit state: Running
+
+== RECENT TOP-LEVEL CREATIONS (last 20) ==
+   ID  | Label                    | Started        | Outcome              | Latency
+   ----|--------------------------|----------------|----------------------|--------
+   42  | window-abc...            | 12:34:56       | (in-flight)          | ----
+   41  | window-pool-...          | 12:34:55       | completed            | 142ms
+   40  | window-...               | 12:34:51       | renderer_terminated  | 8902ms
+   ...
+
+== RECENT PANE LIFECYCLE (last 20) ==
+   Block ID  | Label             | Created    | Closed     | State
+   ----------|-------------------|------------|------------|-------
+   b7        | browser-pane-b7-3 | 12:34:42   | (live)     | live
+   b2        | browser-pane-b2-2 | 12:34:30   | 12:34:48   | closed
+   ...
+```
+
+Reads from SQLite (works even if host is wedged or has crashed) plus optionally queries the running host's reducer state via a debug IPC.
+
+### Wire-promote (H.9)
+
+Promote these `HostEvent` variants to `agentmux-common::ipc::Event` so they cross IPC:
+
+```rust
+Event::HostPaneCreated { block_id, label }
+Event::HostPaneClosed { block_id }
+Event::HostTopLevelCreationStarted { creation_id, label }
+Event::HostTopLevelCreationCompleted { creation_id, label, latency_ms }
+Event::HostTopLevelCreationFailed { creation_id, label, reason }
+Event::HostQuitDraining
+Event::HostQuitReady
+```
+
+(Some may already be promoted in PR #4 if needed for sagas; PR #5 ensures the full set.)
+
+### Tests
+
+- Log writes: every reducer arm produces the corresponding SQLite row.
+- Recovery walker: simulated crash → restart → orphan rows marked `failed_recovery`.
+- `--diag windows`: reads from SQLite + (optionally) live state; renders correctly.
+
+### Smoke verification
+
+- Run app, open + close windows + panes. `--diag windows` shows correct history.
+- Force-kill host mid-creation. Restart. `--diag windows` shows the orphan as `failed_recovery`.
+- Verify wire-promoted events show up in launcher's broadcast (e.g., a saga subscribed to `HostTopLevelCreationCompleted` fires).
+
+### Acceptance criteria
+
+- `host-reducer.db` exists after first host run.
+- Schema correct.
+- `--diag windows` works whether host is running or not.
+- Wire-promoted events visible in launcher event log.
+
+### Bump
+
+Patch version.
+
+### Risk
+
+Low. Pure observability + wire-promote of already-existing events. No state semantic changes.
+
+---
+
+## Cross-PR concerns
+
+### Backward compatibility
+
+- PRs #1, #3, #5 are internal-only; no wire format changes.
+- PR #2 changes the SHAPE of host-internal types (PaneStateMachine deleted) — no wire impact.
+- PR #4 adds new wire `Event` variants (for sagas) — older launchers without these recognized just log+skip per existing pattern (`launcher_ipc.rs:269-275`).
+
+### Testing during the multi-PR migration
+
+Between each PR:
+- Build a portable. Smoke-test the full app.
+- Repro the freeze scenario (open browser pane, open top-level window). Document outcome.
+- Tail `~/.agentmux/logs/agentmux-host-v<version>.log.*` for any `[host-reducer]` warnings or errors.
+
+After PR #4 specifically:
+- The freeze should either NOT occur or fail-fast with a visible error. If neither, the H.7 invariant probe is wrong and we revisit.
+
+### Decision points during the migration
+
+| After | Decision |
+|---|---|
+| PR #2 | Confirm 0 `state.browsers.lock()` call sites. If any sneaked in, halt and clean up before PR #3. |
+| PR #3 | Confirm tear-off and pool refill still work end-to-end. |
+| PR #4 | **Confirm freeze is gone or fails-fast.** If the bug persists despite the cross-state invariant, revisit diagnosis (probably need debugger trace of the wedged threads). |
+| PR #5 | Confirm `--diag windows` provides actionable info during a real freeze repro. |
+
+### Rollback per PR
+
+Each PR is independently revertable. Critical: if PR #4 lands and the freeze bug worsens (unlikely, but possible), revert PR #4 alone — PRs #1-#3 stay merged, the runner architecture still exists, just nobody routes through it.
+
+### Configuration knobs (introduced incrementally)
+
+```toml
+[host.reducer]
+# H.4 (introduced PR #3)
+pool_target_size = 2  # default; configurable
+
+# H.6 (introduced PR #4)
+top_level_creation_user_fail_fast = true  # default; can be set false to revert to legacy queueing for debugging
+
+# H.7 (introduced PR #4)
+refuse_top_level_during_pane_close = true  # the freeze probe; false to disable
+
+# H.8 (introduced PR #5)
+host_reducer_log_retention_days = 7
+```
+
+---
+
+## Time estimate (per-PR, including bot review)
+
+| PR | Implementation | Tests + smoke | Bot review | Total |
+|---|---|---|---|---|
+| #1 | 1 day | 1 day | 1-2 rounds | 2-3 days |
+| #2 | 3 days | 1 day | 3-5 rounds | 5-7 days |
+| #3 | 2 days | 1 day | 2-3 rounds | 3-5 days |
+| #4 | 2 days | 1 day (smoke-heavy) | 3-5 rounds | 5-7 days |
+| #5 | 2 days | 0.5 day | 2-3 rounds | 3-4 days |
+
+**Total wall-clock: 2.5-3.5 weeks** with bot oscillation. **Active work: ~10 days.**
+
+PR #2 + PR #3 in parallel saves ~3-5 days off the critical path. PRs #4 and #5 are sequential.
+
+---
+
+## What this 5-PR plan does NOT change from the granular Phase H spec
+
+- All architectural directives unchanged (no timers, fail-fast, single source of truth, cross-state invariants).
+- All state migrations end at the same destination (full host reducer ownership).
+- All sagas defined per the granular spec.
+- Durability schema same.
+- Failure modes same.
+
+The compression is purely operational — fewer, larger PRs instead of 15-20 small ones. Same end state.
+
+---
+
+## Open questions
+
+1. **Should H.7's pane-closing invariant be configurable?** Spec says yes (config knob). Default-on but operators can disable for debugging.
+
+2. **Does `on_render_process_terminated` actually fire when CEF wedges?** Need to verify in PR #4. If not, accept that wedges leave permanent in-flight state.
+
+3. **Does PR #2's `state.browsers` migration require BOTH read helpers AND saga-style snapshot mutex management?** Probably. The 40+ call sites have varied patterns; some need the reducer state directly (for invariant checks), others just need the browser handle. Read helpers handle the latter; commands handle the former.
+
+4. **Is the 5-PR sequencing optimal vs alternatives?** Considered:
+   - **Foundation + freeze fix in PR 1** (combine #1 + #4 minimal) — no, foundation needs to land cleanly first to avoid scaffolding churn.
+   - **Smaller PRs, more of them** — this is what the granular spec does (15-20 PRs). User asked for 5.
+   - **Skip PR 5** — durability/diag is gravy. Could defer indefinitely. Spec ships it because operator visibility makes future debugging tractable.
+
+5. **What happens to existing PR #650 (already merged)?** Stays. The Phase 1 tracing it added is still useful and lives compatibly with the reducer migration.
+
+---
+
+## Cross-references
+
+- Granular Phase H spec: `docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md`
+- Current state catalog: `docs/retro/reducer-architecture-current-state-2026-05-02.md`
+- Freeze investigation: `docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md`
+- Original Phase F spec: `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`
+- Saga reducer migration retro: `docs/retro/saga-architecture-migration-complete-2026-05-02.md`
+
+---
+
+End of 5-PR plan.

--- a/docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md
+++ b/docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md
@@ -1,0 +1,676 @@
+# SPEC: Host Reducer Buildout — Phase H
+
+**Date:** 2026-05-02
+**Status:** Draft — implementation plan, replaces PR #651
+**Author:** AgentA
+**Branch base:** `main` HEAD `48ad4e58`
+
+**Companion docs:**
+- `docs/retro/reducer-architecture-current-state-2026-05-02.md` — verified current-state catalog (what IS in reducers, what isn't)
+- `docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md` — 2026-05-02 freeze investigation, dump analysis, why per-window-isolated RequestContext + browser panes triggers it
+- `docs/specs/SPEC_HOST_WINDOW_CREATION_RUNNER_2026-05-02.md` — superseded by this spec; PR #651 to be closed
+- `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md` — original F.1 spec; this is its successor
+- `docs/retro/migration-pattern.md` — the a→b→c→d→e ratchet used in B.5 and reused here
+
+---
+
+## TL;DR
+
+Build out the host reducer to own all host-side state currently held in raw `Mutex` / `RwLock` / `AtomicBool` / global statics: pane lifecycle, the `state.browsers` CEF handle map, drag state, tear-off hook state, pool windows, top-level window creation. Use the same a→b→c→d→e migration ratchet that retired the host-side `WindowInstanceRegistry` in Phase B.5.
+
+**Architectural directives from the 2026-05-02 freeze investigation:**
+
+1. **NO TIMERS. NO WATCHDOGS.** Reducer state transitions react only to observable signals (CEF callbacks, OS events, user actions). If a signal never fires, the reducer state holds permanently — failure becomes visible (operator can `--diag windows` and see a stuck state) rather than silently absorbed by a deadline.
+2. **Fail-fast for user-initiated operations.** When an operation cannot proceed because reducer state forbids it (e.g., busy in-flight creation), return an error to the caller instead of queueing silently. Background operations (pool refill) may queue; user-facing ones return errors.
+3. **Single source of truth.** Every host-side state field is owned by exactly one reducer arm. No parallel mirrors except the read-only `shadow_*` projections of launcher state that already exist.
+4. **Cross-state invariants are first-class.** The reducer is the place to declare "operation X is forbidden while state Y is in flux." Today such invariants are invisible — buried in lock orderings and ad-hoc checks.
+
+This is a multi-phase, multi-week effort comparable in scope to the saga reducer migration shipped in PRs #641-#649. **PR #651 is closed in favor of this plan.**
+
+---
+
+## Why this supersedes PR #651
+
+PR #651 added a top-level window creation runner with a 30-second watchdog. It addressed a real symptom (the host UI thread freezing under concurrent CEF browser creation) by serializing creation with a deadline-based eviction.
+
+**Three problems with that approach, surfaced by 2026-05-02 testing:**
+
+1. **The watchdog is brittle.** Verified user critique: timers are stand-ins for "I don't know if this will resolve." When the deadline fires, the runner evicts the in-flight slot but the wedged CEF browser keeps existing — its `on_after_created` callback can fire later and collide with a different creation, producing the "closed wrong window" symptom.
+2. **The runner doesn't address the root trigger.** User-confirmed: the freeze does NOT reproduce when no browser pane exists. With a pane present, opening a top-level window deadlocks two CEF threads in `EventPairLow` + `Unknown` lock-wait. The runner serializes top-level creation but doesn't coordinate with pane state, so the trigger condition still arises.
+3. **The runner is a one-off architectural addition.** It introduces in-flight slot semantics specific to one operation. Other operations (drag, tear-off, pool refill, pane lifecycle) remain in raw mutexes. No consistency, no replay, no `--diag` visibility for the rest.
+
+The right fix is **the full host reducer.** PR #651's runner code becomes one phase of this larger plan, simplified to remove the watchdog and rely on observable CEF signals instead.
+
+---
+
+## Scope summary
+
+**In scope (covered by phases below):**
+- Pane lifecycle (replaces `BrowserPaneManager::PaneStateMachine`)
+- `state.browsers` CEF handle registry
+- `active_drag` state
+- `window_pool`, `unpromoted_pool_labels`, `window_pool_respawn_in_flight`
+- `is_quitting`
+- Top-level window creation runner (event-driven, no watchdog)
+- Cross-state invariants (refuse operations during incompatible in-flight states)
+- Cross-state sagas (`NewWindowSaga`, `PaneCreateSaga`)
+- Durability (`HostReducerLog` SQLite + recovery walker + `--diag windows`)
+- Wire-promote of selected events for launcher saga subscribers
+
+**Out of scope:**
+- Win32 subclass scaffolding (`PANE_WNDPROCS`, `PANE_HWND_CONTEXT`, `ALLOW_PANE_FOCUS_ONCE`, `PANE_REDIRECT_LAST_AT`) — these are CEF-callback-internal mechanics, not application state. Stay in their current global statics.
+- WRR position-debounce + Win32 hook handles — same reasoning.
+- Shadow projections (`shadow_instance_registry`, `shadow_backend_window_ids`, `shadow_window_meta`) — already correctly NOT in host reducer; launcher is authoritative.
+- IPC config / sidecar handles / auth key / zoom factor — set-once values, no reducer benefit.
+
+**Estimated scope:** 15-20 PRs over 2-3 weeks of wall-clock with bot review oscillation. Comparable to PRs #641-#649 (saga reducer migration: 9 PRs, ~5 hours wall-clock + days of bot iteration).
+
+---
+
+## Migration ratchet — recap of B.5
+
+Each piece of state migrates through five steps. This is the proven pattern from B.5 (which retired host-side `WindowInstanceRegistry` in favor of launcher's `instance_registry`).
+
+| Step | Behavior | Read source | Write source |
+|---|---|---|---|
+| **a** — parallel writes | Both old field and new reducer state mutated on every change. Reads still hit old field. | Old | Both |
+| **b** — flip reads (with fallback) | Reads prefer reducer; fall back to old field if reducer is empty. Drift logged. | Reducer (with fallback) | Both |
+| **c** — flip reads (no fallback) | Reads only consult reducer. Old field still mutated for safety net. | Reducer | Both |
+| **d** — drop old writes | Old field becomes vestigial. Only reducer is mutated. | Reducer | Reducer only |
+| **e** — delete old field | Old field removed from `AppState`. PR is largely deletions. | Reducer | Reducer |
+
+**Each step is a separate PR.** Bots review each independently. If step c reveals drift, step d doesn't ship until drift is zero.
+
+---
+
+## Phase H.0 — Foundations
+
+**Goal:** Add reducer scaffolding for ALL the new state at once, even though the migrations land sequentially. This avoids per-phase reducer-skeleton churn.
+
+**State additions to `HostState`:**
+
+```rust
+pub struct HostState {
+    // F.1 (existing):
+    pub pending_window_creations: VecDeque<PendingWindowCreation>,
+    pub lifecycle: HostLifecyclePhase,
+    pub event_version: u64,
+    
+    // H — pane lifecycle (replaces PaneStateMachine):
+    pub panes: HashMap<String /* block_id */, PaneEntry>,
+    
+    // H — CEF browser handle registry (replaces state.browsers):
+    pub browsers: HashMap<String /* label */, BrowserHandle>,
+    
+    // H — drag state (replaces active_drag):
+    pub active_drag: Option<DragSession>,
+    
+    // H — pool state (replaces window_pool + unpromoted_pool_labels + atomic):
+    pub pool: PoolState,
+    
+    // H — top-level creation runner (PR #651 idea, sans watchdog):
+    pub top_level_creation: TopLevelCreationState,
+    
+    // H — quit state (replaces is_quitting AtomicBool):
+    pub quit_state: QuitState,
+}
+
+pub enum PaneLifecycle {
+    Live,                              // pane alive, accepting operations
+    Closing { since: Instant },        // close requested, awaiting CEF teardown
+    // No `Closed` variant — entry is removed from map on close-completion event
+}
+
+pub struct PaneEntry {
+    pub block_id: String,
+    pub label: String,
+    pub lifecycle: PaneLifecycle,
+}
+
+pub struct BrowserHandle {
+    pub label: String,
+    pub browser: cef::Browser,         // the FFI handle (Clone, refcounted)
+    pub kind: BrowserKind,             // TopLevel | Pane
+    pub registered_at: Instant,
+}
+
+pub enum BrowserKind {
+    TopLevel { is_pool: bool },
+    Pane { block_id: String },
+}
+
+pub struct PoolState {
+    pub queue: VecDeque<String>,        // labels of fully-ready pool windows
+    pub unpromoted: HashSet<String>,    // labels spawned but not yet promoted
+    pub respawn_in_flight: bool,        // single-flight semaphore for refill
+}
+
+pub struct TopLevelCreationState {
+    pub queue: VecDeque<TopLevelCreationRequest>,
+    pub in_flight: Option<InFlightCreation>,
+    pub history: VecDeque<CompletedCreation>,
+    pub next_creation_id: u64,
+}
+
+pub struct InFlightCreation {
+    pub creation_id: u64,
+    pub label: String,
+    pub started_at: Instant,
+    pub phase: CreationPhase,
+    // NO `deadline` field. NO watchdog.
+}
+
+pub enum CreationPhase {
+    Started,                  // BeginCreationEffect emitted
+    BrowserCallbackFired,     // CEF on_after_created fired
+    RendererProcessTerminated,// CEF on_render_process_terminated fired (failure path)
+}
+
+pub enum QuitState {
+    Running,
+    Draining { reason: QuitReason },
+    Quit,
+}
+```
+
+**Action additions to `HostCommand`:** see per-phase sections.
+
+**Event additions to `HostEvent`:** see per-phase sections. Some events promoted to `agentmux-common::ipc::Event` for cross-process subscribers (Phase H.9).
+
+**Test additions:** unit tests for each new arm. Proptests for invariants (singleton in-flight, FIFO ordering, no orphan transitions).
+
+**Effort:** ~1 day. One PR, low risk (no behavior change — fields exist but no callers yet).
+
+**Acceptance:** all type definitions compile. Reducer dispatch covers all new commands. No existing behavior changes.
+
+---
+
+## Phase H.1 — Pane lifecycle into reducer
+
+The `BrowserPaneManager::PaneStateMachine` is the smallest cohesive piece to migrate first. Doing this first also unblocks the "no top-level creation while pane in transition" invariant that (per the freeze diagnosis) might prevent the deadlock entirely.
+
+### Commands
+
+```rust
+HostCommand::EnqueuePaneCreate { block_id: String, label: String }
+HostCommand::CompletePaneCreate { block_id: String }     // after CEF on_after_created for pane
+HostCommand::EnqueuePaneClose { block_id: String }
+HostCommand::CompletePaneClose { block_id: String }      // after CEF on_before_close for pane
+HostCommand::AbortPaneCreate { block_id: String, reason: String }  // CEF callback never fired
+```
+
+### Events
+
+```rust
+HostEvent::PaneCreateRequested { block_id, label, version }
+HostEvent::PaneLive { block_id, label, version }
+HostEvent::PaneClosing { block_id, version }
+HostEvent::PaneClosed { block_id, version }
+HostEvent::PaneCreationFailed { block_id, reason, version }
+```
+
+### Reducer rules
+
+- `EnqueuePaneCreate` → if block_id already in map, reject with Error event. Else insert with `Live` (or new `Pending` if we want to track create-in-flight). Emit `PaneCreateRequested`.
+- `CompletePaneCreate` → confirm transition to `Live` (no-op if already `Live`).
+- `EnqueuePaneClose` → flip to `Closing { since: now }`. Emit `PaneClosing`.
+- `CompletePaneClose` → remove from map. Emit `PaneClosed`.
+- `AbortPaneCreate` → remove from map (no entry to clean up if create never completed).
+
+### Migration steps (a→e)
+
+| Step | Description |
+|---|---|
+| H.1.a | Wire `PaneStateMachine::try_register_live` etc. to ALSO dispatch `EnqueuePaneCreate` to the reducer. Existing PaneStateMachine continues to be authoritative; reducer state mirrors. |
+| H.1.b | `BrowserPaneManager` reads (e.g., `defocus_all` iterating live panes) prefer reducer; fall back to PaneStateMachine. Log drift target=`pane-reducer:drift`. |
+| H.1.c | Reads switch to reducer-only. PaneStateMachine still writes. |
+| H.1.d | Drop PaneStateMachine writes. `try_register_live` etc. become thin shims around reducer dispatch. |
+| H.1.e | Delete `PaneStateMachine` struct, `PaneEntry`, etc. `BrowserPaneManager` becomes a stateless utility around reducer queries + CEF FFI. |
+
+**Per-step PRs:** 5. Each is small (~50-200 lines). Each ships independently.
+
+---
+
+## Phase H.2 — `state.browsers` into reducer
+
+This is the highest-traffic mutex in the host (40+ lock sites). Migrating it consolidates all CEF handle access through the reducer.
+
+The CEF `Browser` handle is `Clone` (refcounted) and `Send`-via-Mutex. Storing it in `HostState` (which lives in `parking_lot::Mutex<HostState>`) is safe.
+
+### Commands
+
+```rust
+HostCommand::RegisterBrowser { label: String, browser: cef::Browser, kind: BrowserKind }
+HostCommand::UnregisterBrowser { label: String }
+```
+
+### Events
+
+```rust
+HostEvent::BrowserRegistered { label, kind, version }
+HostEvent::BrowserUnregistered { label, version }
+```
+
+### Reducer queries (read-only, snapshot-and-drop)
+
+```rust
+// On AppState — bypass `host_dispatch` for reads (no event emission needed).
+impl AppState {
+    pub fn get_browser(&self, label: &str) -> Option<cef::Browser> {
+        self.host_state.lock().browsers.get(label).map(|b| b.browser.clone())
+    }
+    pub fn list_browsers(&self) -> Vec<(String, BrowserKind)> {
+        self.host_state.lock().browsers.iter()
+            .map(|(k, v)| (k.clone(), v.kind.clone())).collect()
+    }
+    pub fn browser_kind(&self, label: &str) -> Option<BrowserKind> {
+        self.host_state.lock().browsers.get(label).map(|b| b.kind.clone())
+    }
+}
+```
+
+### Migration steps (a→e)
+
+The 40+ existing `state.browsers.lock()` call sites split into two patterns:
+1. **Read-only** (~30 sites): `browsers.lock().get(&label).cloned()` → use `state.get_browser(label)` or `state.list_browsers()`.
+2. **Mutating** (~10 sites): `browsers.lock().insert(...)` / `.remove(...)` → use `host_dispatch(RegisterBrowser/UnregisterBrowser)`.
+
+| Step | Description |
+|---|---|
+| H.2.a | Add reducer arms; mirror writes (when `state.browsers.insert` happens, also dispatch `RegisterBrowser`). |
+| H.2.b | Add read helpers on `AppState`. Convert read sites to use them, falling back to `state.browsers.lock()` if reducer is empty. Log drift. |
+| H.2.c | Convert read sites to reducer-only (no fallback). |
+| H.2.d | Convert write sites: `state.browsers.lock().insert(...)` → `host_dispatch(RegisterBrowser)`. Reducer effect performs the insert into `state.browsers` for now (still mirrored). |
+| H.2.e | Make `state.browsers` either go away or become an internal field of `HostState.browsers` (it already is — phase out the standalone field). |
+
+**Per-step PRs:** 5. Some larger (the H.2.b read-conversion touches many files).
+
+**Risk:** medium — large surface area. Mitigation: do read sites first (H.2.b/c), defer write sites until reads are stable.
+
+---
+
+## Phase H.3 — Drag state
+
+`active_drag: Mutex<Option<DragSession>>` (state.rs:302) becomes a reducer field. Drag is naturally a state machine — start, in-flight, end/cancel.
+
+### Commands
+
+```rust
+HostCommand::StartDrag { drag_id, drag_type, source_window, source_workspace_id, source_tab_id, payload }
+HostCommand::EndDrag { drag_id, outcome: DragOutcome }
+```
+
+### Reducer rules
+
+- `StartDrag` while `active_drag.is_some()` → reject (only one drag at a time).
+- `EndDrag` matching active drag's `drag_id` → clear, emit `DragEnded`.
+
+### Migration steps
+
+Standard a→e. ~3-4 PRs (drag is touched in fewer places than `state.browsers`).
+
+---
+
+## Phase H.4 — Pool state
+
+`window_pool`, `unpromoted_pool_labels`, `window_pool_respawn_in_flight` collapse into `HostState.pool: PoolState`.
+
+This phase is **important for the freeze investigation** because pool refill is one of the operations whose ordering relative to top-level creation matters. With pool in the reducer, "no pool refill while top-level creation in flight" becomes a declarable invariant.
+
+### Commands
+
+```rust
+HostCommand::PoolWindowSpawnStart { label }
+HostCommand::PoolWindowReady { label }              // renderer-ready signal
+HostCommand::PoolWindowDestroyedBeforePromote { label }
+HostCommand::PromotePoolWindow { /* fields per existing promote */ }
+HostCommand::PoolDrainAll                           // shutdown
+```
+
+### Events
+
+```rust
+HostEvent::PoolWindowEntered { label, queue_len_after }
+HostEvent::PoolWindowLeft { label, queue_len_after, reason: PoolLeaveReason }
+HostEvent::PoolEmpty                                // for sagas to react
+```
+
+### Reducer effect: pool refill
+
+When a pool window leaves (promote / destroy-before-promote / shutdown drain), the reducer checks: should we refill?
+
+```rust
+// In reducer's PoolWindowLeft handler:
+if !state.pool.respawn_in_flight 
+   && state.pool.queue.len() < POOL_TARGET_SIZE 
+   && state.quit_state == QuitState::Running {
+    state.pool.respawn_in_flight = true;
+    out.events.push(HostEvent::Effect(EffectKind::SpawnPoolWindow));
+}
+```
+
+Effect handler runs `commands::window_pool::spawn_pool_window_now` (the imperative CEF call). On `PoolWindowReady`, reducer clears `respawn_in_flight`.
+
+### Migration steps
+
+a→e for each of the three fields. ~5-6 PRs.
+
+---
+
+## Phase H.5 — Quit state
+
+`is_quitting: AtomicBool` becomes `HostState.quit_state: QuitState`. Three states: Running → Draining → Quit.
+
+### Commands
+
+```rust
+HostCommand::BeginDrain { reason: QuitReason }
+HostCommand::ConfirmDrained                          // pool empty + browsers empty
+```
+
+### Reducer rules
+
+- `BeginDrain` from `Running` → transition to `Draining`, emit pool-drain effects.
+- `ConfirmDrained` from `Draining` → transition to `Quit`, emit `HostQuitReady`.
+- All operations that today read `is_quitting` (e.g., `spawn_pool_window`, top-level creation) gate on `quit_state != Running`.
+
+**~2 PRs.** Small and contained.
+
+---
+
+## Phase H.6 — Top-level window creation runner (event-driven, no watchdog)
+
+This is PR #651's idea, redesigned per the no-timer directive.
+
+### State (already declared in H.0)
+
+`HostState.top_level_creation` with queue, in-flight slot, history.
+
+### Commands
+
+```rust
+HostCommand::EnqueueTopLevelWindow { request: TopLevelCreationRequest }
+HostCommand::TopLevelCallbackFired { label }         // from CEF on_after_created
+HostCommand::TopLevelRendererTerminated { label, status }   // from CEF on_render_process_terminated
+HostCommand::TopLevelExternallyClosed { label }      // from CEF on_before_close (cancel mid-create)
+```
+
+### Events
+
+```rust
+HostEvent::TopLevelCreationRequested { creation_id, request, version }
+HostEvent::TopLevelCreationStarted { creation_id, label, version }
+HostEvent::TopLevelCreationCompleted { creation_id, label, latency_ms, version }
+HostEvent::TopLevelCreationFailed { creation_id, label, reason, version }
+HostEvent::TopLevelQueueLengthChanged { len, version }
+```
+
+### Reducer rules
+
+- `EnqueueTopLevelWindow`:
+  - If `quit_state != Running` → reject with Error.
+  - If `top_level_creation.in_flight.is_some()` and request is **user-initiated** → return error (fail-fast). Caller (e.g., `commands/window.rs::open_window_with_kind`) propagates error to frontend.
+  - If `in_flight.is_some()` and request is **background** (pool refill) → enqueue to back of queue.
+  - If `in_flight.is_none()` → start immediately. Emit `BeginCreationEffect`.
+
+- `TopLevelCallbackFired`:
+  - If matches in-flight label → advance phase to `BrowserCallbackFired`. **This is the SUCCESS signal.** No deadline involved. Mark completed, push to history, advance queue.
+  - If doesn't match in-flight (e.g., a pool window registering, or an orphan from a prior failed attempt) → close the orphan browser via reducer effect to prevent label collision.
+
+- `TopLevelRendererTerminated`:
+  - If matches in-flight label → fail in-flight with `Reason::RendererTerminated { status }`. Push to history. Advance queue.
+  - If doesn't match → log diagnostic. Browser is gone; nothing to do.
+
+- `TopLevelExternallyClosed`:
+  - If matches in-flight label → fail in-flight with `Reason::ExternallyClosed`. Advance queue.
+
+**No timer-driven transitions.** If neither `TopLevelCallbackFired`, `TopLevelRendererTerminated`, nor `TopLevelExternallyClosed` fires for an in-flight request, the slot stays occupied. New user-initiated creates fail-fast with a visible error. Pool refill blocks (acceptable — user can still operate the existing window).
+
+### Effect handler
+
+`BeginCreationEffect` → calls `ui_tasks::post_create_window` (existing). The reducer's effect dispatch is the ONLY place that calls `post_create_window` after this phase lands.
+
+### Failure modes
+
+| Scenario | What happens |
+|---|---|
+| CEF `on_after_created` fires within ms | Normal — completed, queue advances |
+| CEF renderer crashes during init | `on_render_process_terminated` fires → failed, queue advances |
+| User closes the still-loading window | `on_before_close` fires → failed, queue advances |
+| CEF wedges with no callback ever firing | In-flight slot stays occupied permanently. User-initiated creates fail-fast with error. `agentmux --diag windows` shows the stuck creation, operator can decide to restart |
+| User opens 5 windows rapidly | First starts immediately. Subsequent 4 fail-fast with "AgentMux is busy creating a window — try again in a moment." |
+| Pool refill triggered while user create in-flight | Pool request queues (background). Runs after user create completes |
+
+### CEF callback wiring
+
+These hooks must exist or be added in `agentmux-cef/src/client.rs`:
+- `on_after_created` (already exists — line 130) → dispatch `TopLevelCallbackFired { label }` if label is top-level (not pane).
+- `on_render_process_terminated` → dispatch `TopLevelRendererTerminated { label, status }`. **NEW HOOK** — needs to be implemented if not present.
+- `on_before_close` (already exists) → if label has an in-flight creation, dispatch `TopLevelExternallyClosed { label }`.
+
+### Migration steps
+
+| Step | Description |
+|---|---|
+| H.6.a | Add reducer arms + effect handler. Add CEF callback wiring. Existing `post_create_window` call sites unchanged — they still call directly. |
+| H.6.b | Convert `commands/window.rs::open_window_with_kind` to dispatch `EnqueueTopLevelWindow`. Pool refill and tear-off paths still call `post_create_window` directly. Drift logged. |
+| H.6.c | Convert `commands/window_pool.rs::spawn_pool_window` to dispatch `EnqueueTopLevelWindow` (background flag). |
+| H.6.d | Make `post_create_window` private; only the reducer effect handler calls it. |
+| H.6.e | Delete legacy queueing code paths. |
+
+**~5 PRs.**
+
+---
+
+## Phase H.7 — Cross-state sagas
+
+Now that pane state, browser state, and top-level creation are all in the reducer, we can express invariants spanning them.
+
+### `NewWindowSaga`
+
+Triggered by: `HostEvent::TopLevelCreationRequested`.
+
+Runs in the launcher (where the saga coordinator lives — see Phase H.9 for wire-promote of relevant events).
+
+```
+trigger: TopLevelCreationRequested { creation_id, request }
+state: AwaitingCallback
+on_event: 
+  TopLevelCreationCompleted { creation_id } → Done
+  TopLevelCreationFailed { creation_id, reason } → Failed
+compensation: none (reducer already cleaned up via TopLevelCreationFailed)
+```
+
+### `PaneCreateSaga`
+
+Triggered by: `HostEvent::PaneCreateRequested`.
+
+```
+trigger: PaneCreateRequested { block_id, label }
+state: AwaitingPaneLive
+on_event:
+  PaneLive { block_id } → Done
+  PaneCreationFailed { block_id, reason } → Failed
+```
+
+### Cross-state invariant: refuse new top-level creation while a pane is in `Closing`
+
+Hypothesis to test (per freeze diagnosis): the deadlock is triggered when a top-level window is being created while a pane is in CEF's renderer-init / browser-init lifecycle. Adding a reducer rule:
+
+```rust
+HostCommand::EnqueueTopLevelWindow { request } if user_initiated => {
+    let any_pane_in_transition = state.panes.values()
+        .any(|p| matches!(p.lifecycle, PaneLifecycle::Closing { .. }));
+    if any_pane_in_transition {
+        return reject_error("pane mid-transition; retry shortly");
+    }
+    // ... proceed
+}
+```
+
+This is a **probe** — not a guaranteed fix. The actual deadlock surface needs verification via the trace data we get from H.6 in production. If the rule doesn't help, we relax it. If it does, it stays.
+
+### Migration steps
+
+H.7 requires H.1, H.2, H.6 to be complete. Lands as 1-2 PRs once those are stable.
+
+---
+
+## Phase H.8 — Durability + `--diag windows`
+
+Mirror the LSD-1/LSD-3 pattern from PRs #641-#647.
+
+### `HostReducerLog` SQLite
+
+`<data-dir>/host-reducer.db`. Schema captures the lifecycle of each reducer-managed entity:
+
+```sql
+CREATE TABLE pane_creation (
+    seq INTEGER PRIMARY KEY,
+    block_id TEXT NOT NULL,
+    label TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    closed_at INTEGER,
+    final_state TEXT NOT NULL  -- 'live' | 'closed' | 'failed_recovery'
+);
+
+CREATE TABLE top_level_creation (
+    creation_id INTEGER PRIMARY KEY,
+    label TEXT NOT NULL,
+    started_at INTEGER NOT NULL,
+    finished_at INTEGER,
+    outcome TEXT NOT NULL,  -- 'completed' | 'renderer_terminated' | 'externally_closed' | 'failed_recovery'
+    failure_reason TEXT,
+    host_pid INTEGER NOT NULL,
+    host_version TEXT NOT NULL
+);
+```
+
+### Recovery walker
+
+On host startup, mark any `outcome IS NULL` rows from a previous host_pid as `failed_recovery`. Mirrors LSD-3 from PR #647.
+
+### `agentmux --diag windows`
+
+Read-only access to the host-reducer log + live state if host is running. Shows:
+- Recent pane creations (last 50, with state)
+- Recent top-level creations (last 50, with phase and latency)
+- Current in-flight top-level (if any) with how long it's been stuck
+- Pool state (queue length, unpromoted count, respawn-in-flight)
+
+**~3 PRs.** Adds value once H.6 is shipped (no point earlier).
+
+---
+
+## Phase H.9 — Wire-promote selected events
+
+Some host reducer events should cross IPC for launcher saga subscribers. Today host events are intentionally host-internal (F.1 design). Phase H.9 promotes a curated subset.
+
+### Events to promote (host → launcher broadcast)
+
+```rust
+// Promote into agentmux-common::ipc::Event::
+HostPaneCreated { block_id, label }
+HostPaneClosed { block_id }
+HostTopLevelCreationStarted { creation_id, label }
+HostTopLevelCreationCompleted { creation_id, label, latency_ms }
+HostTopLevelCreationFailed { creation_id, label, reason }
+HostQuitDraining
+HostQuitReady
+```
+
+These let launcher sagas (existing or new) subscribe to host lifecycle without polling.
+
+### Effect on existing host-internal events
+
+Most host events stay host-internal (they're noise outside the host process). Only the ones above get promoted.
+
+**~2 PRs.** Coordinated with launcher saga work that wants to consume them.
+
+---
+
+## Saga tests
+
+Each new saga gets:
+- Unit tests of the saga state machine (pure)
+- Integration tests against the host reducer (no CEF in the loop)
+- Proptests where applicable
+
+Same testing discipline as PRs #641-#649.
+
+---
+
+## Rollout sequencing
+
+```
+H.0 (foundations)
+ ├─ H.1 (panes)        ──┐
+ ├─ H.2 (browsers map) ──┤
+ ├─ H.3 (drag)         ──┼── independent, can land in any order
+ ├─ H.4 (pool)         ──┤
+ └─ H.5 (quit)         ──┘
+       └─→ H.6 (top-level runner — depends on H.4 quit + H.0 state)
+            └─→ H.7 (cross-state sagas — depends on H.1, H.6)
+                 └─→ H.8 (durability + --diag windows)
+                      └─→ H.9 (wire-promote events)
+```
+
+H.0 first (one PR, ~1 day). Then H.1-H.5 in parallel (each is independent of the others — different mutex). H.6 after H.4 + H.5 (needs quit state + pool state). H.7 needs H.1 and H.6 stable. H.8 and H.9 are gravy at the end.
+
+Total: **15-20 PRs over 2-3 weeks**, mirroring the saga reducer migration shipped in PRs #641-#649.
+
+---
+
+## Observability throughout the migration
+
+Each phase adds events to `HostEvent`. Each event is logged via `state.rs::log_host_event` (the existing observability hook). This means:
+
+- Even before H.8 ships, every reducer-mediated state change is in the host log
+- Operators can correlate freeze symptoms with reducer state (which pane is `Closing`? which top-level creation is in-flight?)
+- The freeze investigation that drove this whole spec gets a reproducible answer rather than a dump-walking exercise
+
+---
+
+## What this does NOT solve
+
+Honest list of things this spec doesn't fix:
+
+1. **The CEF v146 underlying wedge.** If CEF's `window_create_top_level` deadlocks because of a renderer-process LPC race (the hypothesis from the 2026-05-02 trace), the reducer makes the failure observable and recoverable but doesn't make CEF un-deadlock. We rely on observable signals (renderer terminated, etc.) to escape. If CEF gives no signal, in-flight stays stuck — we trade silence for visible failure, not failure for success.
+
+2. **Existing Win32 subclass scaffolding.** `PANE_WNDPROCS`, `PANE_HWND_CONTEXT`, `ALLOW_PANE_FOCUS_ONCE`, `PANE_REDIRECT_LAST_AT` stay as global statics. They're CEF-callback mechanics, not application state.
+
+3. **Backend persistence.** `WaveStore` (objects.db) remains separate. The host reducer is session state; persistent workspace data is in srv.
+
+4. **Frontend state.** Solid stores in the renderer process are unaffected. They're a different layer.
+
+5. **Cross-process atomicity.** The host reducer is in-process. Cross-process operations (e.g., "is the launcher still alive when I dispatch this command?") still rely on the launcher↔host pipe semantics.
+
+---
+
+## Open questions
+
+1. **Does the H.7 invariant ("refuse top-level create while pane closing") actually fix the freeze?** Won't know until H.6 ships and we observe. Worst case: invariant doesn't help, we relax it. Best case: deadlock disappears.
+
+2. **Does CEF reliably fire `on_render_process_terminated` for a wedged renderer?** Per the 2026-05-02 dump, render workers stayed `Responding=True` during the wedge — they weren't dead. So `on_render_process_terminated` may not fire. If true, the only escape from a wedge is operator-initiated restart. Acceptable per the no-timer directive.
+
+3. **Should `state.browsers` migration be H.2 or H.6?** Doing it earlier consolidates more code through reducer mediation. Doing it later defers the highest-risk migration. Spec proposes earlier (H.2) — revisit if H.1 surfaces unexpected complexity.
+
+4. **Does the wire-promote in H.9 introduce launcher dependencies on host reducer events?** If yes, those become tightly coupled. Proposed: launcher sagas subscribe to specific events but don't require them (saga's `on_event` is a passive observer; missing events stall the saga without crash). This is the same shape as existing PoolRespawn / WindowCleanupCascade.
+
+5. **What happens to PR #651's smoke-test data and 16 unit tests?** Tests are reusable for H.6 (the reducer logic is similar; the watchdog code becomes deletion). Smoke data (the trace from 0.33.582 testing, dump from 0.33.580) is preserved in `docs/specs/SPEC_WINDOW_FLEET_REDUCER_2026-05-02.md` for reference.
+
+---
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-05-02 | NO timers, NO watchdogs in any reducer arm. | User directive: brittleness of arbitrary deadlines + orphan-browser symptom from PR #651 watchdog. |
+| 2026-05-02 | Fail-fast for user-initiated operations under contention. | Visible error > silent queueing. Pool refill (background) may queue. |
+| 2026-05-02 | Migrate state via the proven a→b→c→d→e ratchet from B.5. | Same shape that successfully retired host-side `WindowInstanceRegistry`. Each step is a separate PR. |
+| 2026-05-02 | Close PR #651 in favor of this plan. | The runner is one piece of a larger consistent reducer; shipping it standalone with watchdog creates orphans. |
+| 2026-05-02 | Host reducer events stay host-internal except a curated subset (H.9). | Most host state is irrelevant outside the host process. Curated wire-promote keeps the IPC surface small. |
+
+---
+
+End of spec.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.579",
+  "version": "0.33.580",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.579",
+      "version": "0.33.580",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.579",
+  "version": "0.33.580",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #1 of 5 in the host-reducer Phase H buildout. Adds reducer scaffolding for the full migration: new `HostState` fields, new `HostCommand` variants, new `HostEvent` variants, reducer arms with full pure-functional semantics, exhaustive event logging. **No production callers wire to these yet** — subsequent PRs (#2-#5) migrate each piece through the a→b→c→d→e ratchet.

## Specs (included in this PR)

- \`docs/retro/reducer-architecture-current-state-2026-05-02.md\` — verified factual catalog (file:line cited) of what's in vs out of reducers today. The gap analysis that motivated Phase H.
- \`docs/specs/SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md\` — granular Phase H spec.
- \`docs/specs/SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md\` — operational 5-PR plan; this is PR #1.

## Architectural directives (from 2026-05-02 freeze investigation)

1. **NO timers, NO watchdogs in any reducer arm.** Event-driven only. Reducer transitions react to observable signals (CEF callbacks, OS events, user actions). If a signal never fires, state holds permanently — visible failure via \`--diag windows\` (PR #5) rather than silently absorbed.
2. **Fail-fast for user-initiated operations under contention.** Background operations (pool refill) may queue silently.
3. **Single source of truth.** Every state field owned by one reducer arm.
4. **Cross-state invariants are first-class** — declarable in the reducer.

## State added to \`HostState\`

| Field | Type | Replaces (in PR #2-#5) |
|---|---|---|
| \`panes\` | \`HashMap<block_id, PaneEntry>\` | \`BrowserPaneManager::PaneStateMachine\` |
| \`browsers\` | \`HashMap<label, BrowserHandle>\` | \`AppState.browsers: Mutex<HashMap>\` |
| \`active_drag\` | \`Option<DragSession>\` | \`AppState.active_drag\` |
| \`pool\` | \`PoolState\` | \`window_pool\` + \`unpromoted_pool_labels\` + \`window_pool_respawn_in_flight\` |
| \`quit_state\` | \`QuitState\` | \`AppState.is_quitting\` |
| \`top_level_creation\` | \`TopLevelCreationState\` | (new — runner) |

All fields default-initialized empty + \`#[allow(dead_code)]\`. PR #2-#5 lift the allow as they wire callers.

## Commands added to \`HostCommand\`

- **H.1 panes:** \`EnqueuePaneCreate\`, \`CompletePaneCreate\`, \`EnqueuePaneClose\`, \`CompletePaneClose\`, \`AbortPaneCreate\`
- **H.2 browsers:** \`RegisterBrowser\`, \`UnregisterBrowser\`
- **H.3 drag:** \`StartDrag\`, \`EndDrag\`
- **H.4 pool:** \`PoolWindowSpawnStart\`, \`PoolWindowReady\`, \`PoolWindowDestroyedBeforePromote\`, \`PromotePoolWindow\`, \`PoolDrainAll\`
- **H.5 quit:** \`BeginDrain\`, \`ConfirmDrained\`
- **H.6 top-level runner:** \`EnqueueTopLevelWindow\`, \`TopLevelCallbackFired\`, \`TopLevelRendererTerminated\`, \`TopLevelExternallyClosed\`

## Events added to \`HostEvent\`

H.1-H.6 lifecycle events per command + \`HostEvent::Effect { effect, version }\` carrier for side-effect-bearing events. \`EffectKind\` variants: \`PostCreateWindow\`, \`SpawnPoolWindow\`, \`CloseOrphanBrowser\`.

Effect emission preserves snapshot-and-drop discipline: reducer arms emit effects but never execute them. \`AppState::host_dispatch_with_effects\` (added in PR #4) dispatches effects to imperative handlers.

## Top-level runner specifics (the freeze fix surface)

- **No \`deadline\` field** on \`InFlightCreation\`. **No watchdog.**
- Reducer reacts only to: \`on_after_created\` (success), \`on_render_process_terminated\` (renderer crash), \`on_before_close\` (cancel mid-create).
- \`User\`-initiated \`EnqueueTopLevelWindow\` with \`in_flight\` occupied → returns Error event. Caller (in PR #4) propagates visible error to frontend.
- \`Background\` (pool refill) \`EnqueueTopLevelWindow\` queues silently behind in-flight.
- Orphan-callback path: \`TopLevelCallbackFired\` with unknown label emits \`CloseOrphanBrowser\` effect to prevent label collision (the bug that caused "closed wrong window" in PR #651's watchdog-eviction path).

## Tests

**25 reducer tests passing** (5 pre-existing F.1 + 20 new H):

- **H.1 panes:** create inserts Live, duplicate rejected, close lifecycle, abort removes entry, close idempotent for missing
- **H.3 drag:** singleton invariant, end clears, mismatched id no-op
- **H.5 quit:** monotonic Running → Draining → Quit; subsequent BeginDrain no-op
- **H.6 top-level runner:** idle-start, busy-fail-fast for User, busy-queue for Background, callback advances queue, renderer-terminated fails, orphan callback no-op, history caps at 50, enqueue during quit rejected
- **H.4 pool:** spawn → ready → enter queue, drain clears all, suppression during quit

## Code-quality notes

Manual \`Debug\` impls for \`HostCommand\`, \`BrowserHandle\`, and \`EffectKind\` because \`cef::Browser\` doesn't impl Debug. Browser fields render as \`<cef::Browser>\` placeholder; everything else displays normally.

Existing F.1 tests adapted to handle the new \`HostEvent\` variants in the exhaustive \`extract_version\` match.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean (warnings only, all pre-existing)
- [x] \`cargo test -p agentmux-cef --bin agentmux-cef reducer::\` → 25/25 passing
- [x] No behavior change verified: existing PaneStateMachine, state.browsers, etc. all still work as before. New reducer fields are dormant.
- [ ] Bot review (reagentx-workflow + codex)

## Subsequent PRs

| PR | Branch | Goal |
|---|---|---|
| #2 | \`agenta/h2-panes-and-browsers\` | Wire callers through reducer for H.1 + H.2 (the heavyweight migration) |
| #3 | \`agenta/h3-drag-pool-quit\` | Wire callers for H.3, H.4, H.5 |
| #4 | \`agenta/h4-top-level-runner-and-sagas\` | Wire H.6 + cross-state invariants (the actual freeze fix attempt) |
| #5 | \`agenta/h5-durability-diag-wire-promote\` | SQLite log + \`--diag windows\` + wire-promote events for sagas |

Each subsequent PR is independently mergeable; #2 and #3 can run in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)