### PR TITLE
feat(cef): pane + browser parallel writes — PR #2 of host reducer Phase H buildout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.580"
+version = "0.33.581"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -188,6 +188,16 @@ impl BrowserPaneManager {
                 ))
             }
             RegisterResult::Fresh(label) => {
+                // Phase H.1.a — parallel write: mirror the new pane entry
+                // into the host reducer's `panes` map. PaneStateMachine
+                // remains authoritative until step e (PR #2 final commit)
+                // deletes it.
+                state.host_dispatch(
+                    crate::reducer::HostCommand::EnqueuePaneCreate {
+                        block_id: block_id.to_string(),
+                        label: label.clone(),
+                    },
+                );
                 let mut task = CreatePaneTask::new(
                     state.clone(),
                     block_id.to_string(),
@@ -266,8 +276,22 @@ impl BrowserPaneManager {
     /// user expects to persist across close). If beforeunload becomes
     /// important, revisit.
     pub fn close(&self, block_id: &str, state: &Arc<AppState>) {
+        // Phase H.1.a — parallel write: mirror the close request into the
+        // host reducer's `panes` map. EnqueuePaneClose flips entry to
+        // Closing; CompletePaneClose (after `close_with` returns) removes
+        // it. PaneStateMachine remains authoritative until step e.
+        state.host_dispatch(
+            crate::reducer::HostCommand::EnqueuePaneClose {
+                block_id: block_id.to_string(),
+            },
+        );
         let ops = AppStateCloseOps(state);
         self.close_with(block_id, &ops);
+        state.host_dispatch(
+            crate::reducer::HostCommand::CompletePaneClose {
+                block_id: block_id.to_string(),
+            },
+        );
     }
 
     /// The testable body of `close()`. See `PaneCloseOps` for the seam.
@@ -295,9 +319,15 @@ impl BrowserPaneManager {
     /// so this is a no-op in that case — but `on_before_close` may still
     /// fire async as Chromium's refcount hits zero, and `drain_by_label`
     /// is idempotent so the callback is safe.
-    pub fn drain_closed_label(&self, label: &str) {
-        if self.lifecycle.drain_by_label(label) {
-            tracing::info!(label, "browser pane drained from lifecycle map");
+    pub fn drain_closed_label(&self, state: &Arc<AppState>, label: &str) {
+        if let Some(block_id) = self.lifecycle.drain_by_label(label) {
+            tracing::info!(label, block_id = %block_id, "browser pane drained from lifecycle map");
+            // Phase H.1.a — parallel write: ensure the host reducer's
+            // `panes` map is also cleaned up. Idempotent on the reducer
+            // side (CompletePaneClose returns no-op if entry already gone).
+            state.host_dispatch(
+                crate::reducer::HostCommand::CompletePaneClose { block_id },
+            );
         }
     }
 

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -52,6 +52,15 @@ impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
     fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
         let browser = self.0.browsers.lock().remove(label)?;
 
+        // Phase H.2.a — parallel write: mirror the unregister into the
+        // host reducer. Done after the legacy remove so the reducer
+        // side sees the same state transition.
+        self.0.host_dispatch(
+            crate::reducer::HostCommand::UnregisterBrowser {
+                label: label.to_string(),
+            },
+        );
+
         #[cfg(target_os = "windows")]
         let hwnd = browser.host().and_then(|h| {
             let wh = h.window_handle();

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -207,6 +207,37 @@ impl AgentMuxHandler {
 
         let is_top_level_window = !label.starts_with("browser-pane-");
 
+        // Phase H.2.a — parallel write: mirror the new browser into the
+        // host reducer's `browsers` map. Determine BrowserKind from:
+        //   - is_pane (the AgentMuxClient field): pane child window
+        //   - label prefix `window-pool-` + membership in
+        //     `unpromoted_pool_labels`: pool window (TopLevel { is_pool: true })
+        //   - everything else: TopLevel { is_pool: false }
+        // AppState.browsers remains authoritative until step e.
+        let kind = if self.is_pane {
+            // Pane label format: `browser-pane-<block_id>-<seq>` per
+            // pane/lifecycle.rs::next_label. Strip prefix + trailing `-<seq>`
+            // to recover block_id.
+            let block_id = label
+                .strip_prefix("browser-pane-")
+                .and_then(|rest| rest.rfind('-').map(|i| rest[..i].to_string()))
+                .unwrap_or_default();
+            crate::state::BrowserKind::Pane { block_id }
+        } else if label.starts_with("window-pool-")
+            && self.state.unpromoted_pool_labels.lock().contains(&label)
+        {
+            crate::state::BrowserKind::TopLevel { is_pool: true }
+        } else {
+            crate::state::BrowserKind::TopLevel { is_pool: false }
+        };
+        self.state.host_dispatch(
+            crate::reducer::HostCommand::RegisterBrowser {
+                label: label.clone(),
+                browser: browser.clone(),
+                kind,
+            },
+        );
+
         // Phase B.5 (window_meta step d, refined) — write host's
         // local `window_meta` ONCE here, synchronously from the
         // popped pending entry. This is no longer the authoritative
@@ -461,6 +492,14 @@ impl AgentMuxHandler {
             }
             label
         };
+
+        // Phase H.2.a — parallel write: mirror the unregister into the host
+        // reducer. Idempotent on the reducer side (no-op if absent).
+        if let Some(ref lbl) = label {
+            self.state.host_dispatch(
+                crate::reducer::HostCommand::UnregisterBrowser { label: lbl.clone() },
+            );
+        }
 
         // Pane-specific on_before_close work (drain lifecycle entry) lives
         // in `crate::pane::callbacks` after Phase 4.

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -648,6 +648,13 @@ fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
     // Browser or host already gone — do `on_before_close`'s job
     // inline since CEF won't fire it for this label.
     state.browsers.lock().remove(label);
+    // Phase H.2.a — parallel write: mirror the unregister into the host
+    // reducer. Idempotent on the reducer side.
+    state.host_dispatch(
+        crate::reducer::HostCommand::UnregisterBrowser {
+            label: label.to_string(),
+        },
+    );
     state.window_meta.lock().remove(label);
     crate::launcher_ipc::report_window_closed(label.to_string());
     // Refill (graceful path gets this via on_pool_window_destroyed).

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -82,7 +82,7 @@ pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
 /// with the same block_id gets a fresh Live state. Idempotent — if the
 /// explicit `close()` path already drained it, this is a no-op.
 pub fn on_before_close_pane(state: &Arc<AppState>, label: &str) {
-    state.browser_panes.drain_closed_label(label);
+    state.browser_panes.drain_closed_label(state, label);
 
     // Labels are `browser-pane-<uuid>-<seq>`; strip prefix + trailing `-<seq>`
     // to recover the block_id, then wipe any HWND context entries the

--- a/agentmux-cef/src/pane/lifecycle.rs
+++ b/agentmux-cef/src/pane/lifecycle.rs
@@ -108,9 +108,13 @@ impl PaneStateMachine {
 
     /// Remove an entry by label. Called from CEF's `on_before_close` if
     /// it fires. Idempotent — if the entry was already removed by the
-    /// explicit close path, this is a no-op. Returns true iff an entry
-    /// was actually removed.
-    pub fn drain_by_label(&self, label: &str) -> bool {
+    /// explicit close path, this is a no-op. Returns the drained
+    /// `block_id` iff an entry was actually removed; `None` otherwise.
+    ///
+    /// (Phase H.1.a — was `bool`; now returns `Option<String>` so the
+    /// caller has the block_id needed to dispatch `CompletePaneClose` to
+    /// the host reducer in parallel writes.)
+    pub fn drain_by_label(&self, label: &str) -> Option<String> {
         let mut panes = self.panes.lock();
         let victim = panes
             .iter()
@@ -118,9 +122,9 @@ impl PaneStateMachine {
             .map(|(k, _)| k.clone());
         if let Some(block_id) = victim {
             panes.remove(&block_id);
-            true
+            Some(block_id)
         } else {
-            false
+            None
         }
     }
 
@@ -274,15 +278,15 @@ mod tests {
     fn drain_by_label_removes_matching_entry() {
         let m = PaneStateMachine::new();
         m.test_insert_live("b1", "browser-pane-b1-1");
-        assert!(m.drain_by_label("browser-pane-b1-1"));
+        assert_eq!(m.drain_by_label("browser-pane-b1-1"), Some("b1".to_string()));
         assert!(!m.test_has_entry("b1"));
     }
 
     #[test]
-    fn drain_by_label_returns_false_on_miss() {
+    fn drain_by_label_returns_none_on_miss() {
         let m = PaneStateMachine::new();
         m.test_insert_live("b1", "browser-pane-b1-1");
-        assert!(!m.drain_by_label("browser-pane-other-99"));
+        assert_eq!(m.drain_by_label("browser-pane-other-99"), None);
         assert!(m.test_has_entry("b1"));
     }
 
@@ -290,8 +294,8 @@ mod tests {
     fn drain_by_label_idempotent() {
         let m = PaneStateMachine::new();
         m.test_insert_live("b1", "browser-pane-b1-1");
-        assert!(m.drain_by_label("browser-pane-b1-1"));
-        assert!(!m.drain_by_label("browser-pane-b1-1"));
+        assert_eq!(m.drain_by_label("browser-pane-b1-1"), Some("b1".to_string()));
+        assert_eq!(m.drain_by_label("browser-pane-b1-1"), None);
     }
 
     #[test]
@@ -299,7 +303,7 @@ mod tests {
         let m = PaneStateMachine::new();
         m.test_insert_live("b1", "browser-pane-b1-1");
         m.test_mark_closing("b1");
-        assert!(m.drain_by_label("browser-pane-b1-1"));
+        assert_eq!(m.drain_by_label("browser-pane-b1-1"), Some("b1".to_string()));
         assert!(!m.test_has_entry("b1"));
     }
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.580"
+version = "0.33.581"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.580"
+version = "0.33.581"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.580"
+version = "0.33.581"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.580",
+  "version": "0.33.581",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.580",
+      "version": "0.33.581",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.580",
+  "version": "0.33.581",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #2 of the host-reducer Phase H buildout. **Scope narrowed from the original 5-PR plan:** this PR ships only the parallel-writes foundation (H.1.a + H.2.a). The remaining steps (reads-with-fallback, flip-reads, drop-legacy-writes, delete-legacy-fields) split into PR #3 because they touch 38+ call sites across 12 files and benefit from getting bot validation on the parallel-writes design first.

**Net effect:** zero behavior change. Existing PaneStateMachine and \`AppState.browsers\` remain authoritative. The host reducer's \`panes\` and \`browsers\` maps now mirror them on every mutation, ready to be the source of truth in PR #3.

## Two parallel-write migrations

### H.1.a — pane lifecycle parallel writes

\`BrowserPaneManager\` now dispatches to the host reducer alongside its existing \`PaneStateMachine\` mutations:

| Site | Existing call | Added dispatch |
|---|---|---|
| \`create() RegisterResult::Fresh\` | \`lifecycle.try_register_live(block_id)\` | \`EnqueuePaneCreate { block_id, label }\` |
| \`close()\` | \`lifecycle.try_mark_closing(block_id)\` → \`take_browser_hwnd\` → \`lifecycle.remove\` | \`EnqueuePaneClose\` before, \`CompletePaneClose\` after |
| \`drain_closed_label()\` | \`lifecycle.drain_by_label(label)\` | \`CompletePaneClose { block_id }\` if drain returned Some |

**Signature changes (small):**
- \`PaneStateMachine::drain_by_label\` now returns \`Option<String>\` (the drained block_id) instead of \`bool\`. Production caller in \`pane/callbacks.rs\` updated. 4 unit tests adapted.
- \`BrowserPaneManager::drain_closed_label\` takes \`&Arc<AppState>\` to dispatch the reducer command. Single caller updated.

### H.2.a — browser handle parallel writes

Four lifecycle sites mirror \`state.browsers\` mutations into the reducer:

| Site | Existing call | Added dispatch |
|---|---|---|
| \`client.rs::on_after_created\` | \`browsers.insert(label, browser)\` | \`RegisterBrowser { label, browser, kind }\` |
| \`client.rs::on_before_close\` | \`browsers.remove(lbl)\` | \`UnregisterBrowser { label }\` |
| \`browser_panes.rs::take_browser_hwnd\` | \`browsers.lock().remove(label)\` | \`UnregisterBrowser { label }\` |
| \`commands/window_pool.rs::cleanup_failed_promote_orphan\` | \`browsers.lock().remove(label)\` | \`UnregisterBrowser { label }\` |

**\`BrowserKind\` determination in \`on_after_created\`:**
- \`self.is_pane\` flag → \`BrowserKind::Pane { block_id }\` where block_id is parsed from label format \`browser-pane-<block_id>-<seq>\` via \`rfind('-')\`.
- Label \`window-pool-*\` + membership in \`unpromoted_pool_labels\` → \`BrowserKind::TopLevel { is_pool: true }\`.
- Else → \`BrowserKind::TopLevel { is_pool: false }\`.

## Tests

**57 tests passing** (30 reducer + 27 pane/browser_panes/lifecycle):
- All 30 reducer tests from PR #1 still green.
- 4 \`drain_by_label\` lifecycle tests adapted to \`Option<String>\` return type.
- All existing \`BrowserPaneManager\` close-path tests (using mocked \`PaneCloseOps\`) still pass — parallel writes don't disrupt the test seam.

## What's NOT in this PR (deferred to PR #3)

- **H.1.b + H.2.b — reads with fallback:** convert read sites to use reducer first, fall back to legacy, log drift.
- **H.1.c + H.2.c — flip reads:** drop fallback, reducer-only.
- **H.1.d + H.2.d — drop legacy writes:** \`PaneStateMachine\` and \`AppState.browsers\` become read-only/skeletal.
- **H.1.e + H.2.e — delete legacy fields:** delete \`PaneStateMachine\` struct + \`AppState.browsers\` field.

PR #3 (\`agenta/h3-panes-browsers-reads-flip-delete\`) tackles all four steps in one go. Estimated 38+ read site conversions across 12 files.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean (only pre-existing warnings)
- [x] \`cargo test pane:: browser_panes:: reducer::\` → 57/57 passing
- [x] No behavior change verified (parallel writes only; legacy paths unchanged)
- [ ] Bot review (reagentx-workflow + codex)

## Bump

Patch: \`0.33.580 → 0.33.581\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)