### PR TITLE
fix(cef): kill sidecar before CEF early-exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.580"
+version = "0.33.581"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.580"
+version = "0.33.581"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -441,6 +441,15 @@ fn main() {
     );
     if init_result != 1 {
         let exit_code = get_exit_code();
+        // Sidecar was spawned before cef_initialize(); std::process::exit()
+        // bypasses the normal shutdown block, so kill it here first.
+        {
+            let mut sidecar = app_state.sidecar_child.lock();
+            if let Some(ref mut child) = *sidecar {
+                tracing::info!("CEF early exit: killing backend sidecar before exit");
+                let _ = child.kill();
+            }
+        }
         match exit_code {
             0 | 24 | 36 | 38 => {
                 tracing::info!(

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.580"
+version = "0.33.581"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.580"
+version = "0.33.581"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.580"
+version = "0.33.581"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.580",
+  "version": "0.33.581",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #652. Addresses the two P1s raised by Codex and ReAgent in that review:

- **[P1] Orphaned sidecar on CEF early-exit** — the backend sidecar is spawned before `cef_initialize()`. The early-exit path (codes 0/24/36/38 — process singleton, AUTO_DE_ELEVATED, etc.) called `std::process::exit()` directly, bypassing the normal shutdown block. This left a stale `agentmux-srv` process holding port/auth state, causing conflicts on the next `task dev` run. Fix: kill `app_state.sidecar_child` before each early-exit call.
- **[P1] Version duplicate** — 0.33.580 was used in parallel by the `agentc/tab-modal-layer` branch. Bumped to 0.33.581.

## Test plan

- [ ] `task dev` while another instance is running — second instance exits cleanly, no orphaned `agentmux-srv` visible in task list afterward
- [ ] `task dev` unelevated — still works (window opens, sidecar starts normally)
- [ ] Elevated shell — exit_code=38 logged, clean exit, no orphaned sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)