### PR TITLE
feat(cef): pane + browser reads-with-fallback + codex P2 fix — PR #3 of host reducer Phase H buildout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.583"
+version = "0.33.584"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.583"
+version = "0.33.584"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.583"
+version = "0.33.584"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.583"
+version = "0.33.584"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.583"
+version = "0.33.584"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -154,8 +154,10 @@ impl BrowserPaneManager {
     /// Look up the Browser iff the pane is Live. Returns None when closing
     /// so all ops short-circuit uniformly.
     fn live_browser(&self, state: &Arc<AppState>, block_id: &str) -> Option<Browser> {
-        let label = self.lifecycle.live_label_of(block_id)?;
-        state.browsers.lock().get(&label).cloned()
+        // Phase H.1.b + H.2.b — route reads through reducer-aware helpers
+        // with fallback + drift logging.
+        let label = state.live_pane_label(block_id)?;
+        state.get_browser(&label)
     }
 
     // ── Phase H.1.b — read passthroughs for AppState helpers ────────────
@@ -194,7 +196,8 @@ impl BrowserPaneManager {
         match self.lifecycle.try_register_live(block_id) {
             RegisterResult::AlreadyLive(label) => {
                 // Existing Live entry — re-navigate the existing browser.
-                if let Some(browser) = state.browsers.lock().get(&label).cloned() {
+                // Phase H.2.b — reducer-aware lookup with fallback.
+                if let Some(browser) = state.get_browser(&label) {
                     if let Some(frame) = browser.main_frame() {
                         frame.load_url(Some(&CefString::from(url)));
                     }
@@ -381,10 +384,12 @@ impl BrowserPaneManager {
     /// Panes in `Closing` are skipped — their HWND may be mid-destruction and
     /// `set_focus(0)` against it can hit an invalid render widget.
     pub fn defocus_all(&self, state: &Arc<AppState>) {
-        let labels = self.lifecycle.live_labels();
-        let browsers = state.browsers.lock();
+        // Phase H.1.b + H.2.b — read live labels via reducer-aware helper,
+        // then look up each browser via reducer-aware helper. Both with
+        // fallback + drift logging.
+        let labels = state.live_pane_labels();
         for label in &labels {
-            if let Some(browser) = browsers.get(label).cloned() {
+            if let Some(browser) = state.get_browser(label) {
                 if let Some(host) = browser.host() {
                     host.set_focus(0);
                 }
@@ -435,8 +440,8 @@ impl BrowserPaneManager {
         let requesting_top_level: *mut std::ffi::c_void = if window_label.is_empty() {
             std::ptr::null_mut()
         } else {
-            let browsers = state.browsers.lock();
-            match browsers.get(window_label).and_then(|b| b.host()) {
+            // Phase H.2.b — reducer-aware lookup with fallback.
+            match state.get_browser(window_label).and_then(|b| b.host()) {
                 Some(host) => {
                     let h = host.window_handle();
                     if h.0.is_null() {
@@ -449,10 +454,12 @@ impl BrowserPaneManager {
             }
         };
 
-        let labels = self.lifecycle.live_labels();
-        let browsers = state.browsers.lock();
+        // Phase H.1.b + H.2.b — labels via reducer-aware helper; per-label
+        // browser lookup via reducer-aware helper. Drops the held-across-loop
+        // legacy lock; each iteration now snapshots independently.
+        let labels = state.live_pane_labels();
         for label in &labels {
-            let browser = match browsers.get(label).cloned() {
+            let browser = match state.get_browser(label) {
                 Some(b) => b,
                 None => continue,
             };

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -287,27 +287,38 @@ impl BrowserPaneManager {
     pub fn close(&self, block_id: &str, state: &Arc<AppState>) {
         // Phase H.1.a — parallel write: mirror the close request into the
         // host reducer's `panes` map. EnqueuePaneClose flips entry to
-        // Closing; CompletePaneClose (after `close_with` returns) removes
-        // it. PaneStateMachine remains authoritative until step e.
+        // Closing. CompletePaneClose (which removes the entry) is dispatched
+        // ONLY when close_with actually performed the close transition —
+        // otherwise a duplicate close call would remove the reducer entry
+        // while the original call's teardown is still in progress, creating
+        // reducer/legacy drift (codex P2 PR #655).
         state.host_dispatch(
             crate::reducer::HostCommand::EnqueuePaneClose {
                 block_id: block_id.to_string(),
             },
         );
         let ops = AppStateCloseOps(state);
-        self.close_with(block_id, &ops);
-        state.host_dispatch(
-            crate::reducer::HostCommand::CompletePaneClose {
-                block_id: block_id.to_string(),
-            },
-        );
+        let did_close = self.close_with(block_id, &ops);
+        if did_close {
+            state.host_dispatch(
+                crate::reducer::HostCommand::CompletePaneClose {
+                    block_id: block_id.to_string(),
+                },
+            );
+        }
     }
 
     /// The testable body of `close()`. See `PaneCloseOps` for the seam.
-    fn close_with(&self, block_id: &str, ops: &dyn PaneCloseOps) {
+    ///
+    /// Returns `true` iff close_with actually performed the close transition
+    /// (`try_mark_closing` succeeded). Returns `false` for already-closing
+    /// or missing entries — duplicate / retry close calls. Caller uses the
+    /// return value to gate `CompletePaneClose` dispatch and avoid the
+    /// reducer-entry removal race documented above (codex P2 PR #655).
+    fn close_with(&self, block_id: &str, ops: &dyn PaneCloseOps) -> bool {
         let label = match self.lifecycle.try_mark_closing(block_id) {
             Some(l) => l,
-            None => return, // missing, or already closing — both no-op
+            None => return false, // missing, or already closing — both no-op
         };
 
         // take_browser_hwnd removes from state.browsers and drops the Browser
@@ -321,6 +332,7 @@ impl BrowserPaneManager {
         // Drop the lifecycle entry so the block_id can be reused.
         self.lifecycle.remove(block_id);
         tracing::info!(block_id, label, "browser pane lifecycle entry cleared");
+        true
     }
 
     /// Called from CEF's `on_before_close` if/when it fires for a pane
@@ -651,6 +663,42 @@ mod tests {
         assert!(ops.taken_labels().is_empty(),
             "take_browser_hwnd must not be called when entry is absent");
         assert!(ops.destroyed_hwnds().is_empty());
+    }
+
+    /// Regression test for codex P2 on PR #655.
+    ///
+    /// `close_with` returns `true` only when it actually performed the
+    /// close transition (`try_mark_closing` returned Some). Returns
+    /// `false` for missing entries and `false` for already-closing
+    /// entries — duplicate / retry close calls. The caller (`close()`)
+    /// uses this return value to gate `CompletePaneClose` dispatch and
+    /// avoid removing the reducer entry while the original close path
+    /// is still tearing down legacy state.
+    #[test]
+    fn close_with_returns_true_only_when_did_close() {
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        let ops = MockCloseOps::new();
+        ops.register("browser-pane-b1-1", 0xABCD);
+
+        // First call: actual transition. Returns true.
+        assert_eq!(m.close_with("b1", &ops), true);
+
+        // Second call (entry now removed): returns false.
+        assert_eq!(m.close_with("b1", &ops), false);
+
+        // Truly missing entry: returns false.
+        assert_eq!(m.close_with("never-existed", &ops), false);
+    }
+
+    #[test]
+    fn close_with_returns_false_for_already_closing_entry() {
+        let m = BrowserPaneManager::new();
+        m.test_insert_live("b1", "browser-pane-b1-1");
+        m.test_mark_closing("b1");
+        let ops = MockCloseOps::new();
+        // Entry exists but is already Closing — close_with no-ops, returns false.
+        assert_eq!(m.close_with("b1", &ops), false);
     }
 
     #[test]

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -158,6 +158,21 @@ impl BrowserPaneManager {
         state.browsers.lock().get(&label).cloned()
     }
 
+    // ── Phase H.1.b — read passthroughs for AppState helpers ────────────
+    //
+    // Exposes `PaneStateMachine` reads to `AppState::live_pane_label` /
+    // `live_pane_labels` so they can compare reducer vs legacy with drift
+    // logging. PR #4 (H.1.e) deletes `PaneStateMachine`; these passthroughs
+    // disappear at that point.
+
+    pub fn test_live_label_of(&self, block_id: &str) -> Option<String> {
+        self.lifecycle.live_label_of(block_id)
+    }
+
+    pub fn test_live_labels(&self) -> Vec<String> {
+        self.lifecycle.live_labels()
+    }
+
     /// Return the current URL of the pane's main frame, if the pane
     /// is Live. Used by the browser DOM API resolver
     /// (`crate::browser_api::resolver`) to match CEF `/json` targets

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -151,7 +151,8 @@ impl AgentMuxHandler {
         // their entry; if the queue is empty (legacy paths /
         // unexpected races) fall back to a generated UUID label
         // with FullInstance defaults.
-        let pending = if self.state.browsers.lock().is_empty() {
+        // Phase H.2.b — reducer-aware emptiness check with fallback.
+        let pending = if self.state.browsers_is_empty() {
             crate::state::PendingWindowCreation {
                 label: "main".to_string(),
                 kind: WindowKind::FullInstance,
@@ -564,7 +565,8 @@ impl AgentMuxHandler {
             if meta.kind == WindowKind::FullInstance {
                 let child_labels = self.state.subwindow_children_of(&meta.label);
                 for child_label in child_labels {
-                    if let Some(mut child) = self.state.browsers.lock().get(&child_label).cloned() {
+                    // Phase H.2.b — reducer-aware lookup with fallback.
+                    if let Some(mut child) = self.state.get_browser(&child_label) {
                         if let Some(host) = child.host() {
                             tracing::info!(parent = %meta.label, child = %child_label, "[subwindow-cascade] closing sub-window");
                             host.close_browser(1);
@@ -627,15 +629,16 @@ impl AgentMuxHandler {
         // Promoted pool windows ARE counted: they're removed from
         // `unpromoted_pool_labels` at promote time.
         let (user_browser_count, browsers_keys, pool_keys) = {
+            // Phase H.2.b — reducer-aware label snapshot. Single helper call
+            // replaces an interleaved pool_labels.lock + browsers.lock pair.
             let pool_labels = self.state.unpromoted_pool_labels.lock().clone();
-            let browsers = self.state.browsers.lock();
-            let count = browsers
+            let keys = self.state.list_browser_labels();
+            let count = keys
                 .iter()
-                .filter(|(label, _)| {
-                    !pool_labels.contains(*label) && !label.starts_with("browser-pane-")
+                .filter(|label| {
+                    !pool_labels.contains(label.as_str()) && !label.starts_with("browser-pane-")
                 })
                 .count();
-            let keys: Vec<String> = browsers.keys().cloned().collect();
             let pool: Vec<String> = pool_labels.iter().cloned().collect();
             (count, keys, pool)
         };
@@ -716,14 +719,14 @@ impl AgentMuxHandler {
                 .store(true, std::sync::atomic::Ordering::Release);
             tracing::warn!(target: "wrr", "[wrr] is_quitting=true (drain mode)");
 
-            let pool_browsers: Vec<cef::Browser> = {
-                let browsers = self.state.browsers.lock();
-                browsers
-                    .iter()
-                    .filter(|(label, _)| label.starts_with("window-pool-"))
-                    .map(|(_, b)| b.clone())
-                    .collect()
-            };
+            // Phase H.2.b — reducer-aware iteration with fallback + drift logging.
+            let pool_browsers: Vec<cef::Browser> = self
+                .state
+                .list_browsers()
+                .into_iter()
+                .filter(|(label, _)| label.starts_with("window-pool-"))
+                .map(|(_, b)| b)
+                .collect();
             tracing::warn!(
                 target: "wrr",
                 "[wrr] stage 1: user_count==0; closing {} pool browser(s)",

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -144,8 +144,8 @@ fn hit_test_windows(state: &Arc<AppState>, screen_x: f64, screen_y: f64) -> Opti
     use windows_sys::Win32::Foundation::RECT;
     use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect;
 
-    let browsers = state.browsers.lock();
-    for (label, browser) in browsers.iter() {
+    // Phase H.2.b — reducer-aware iteration with fallback.
+    for (label, browser) in state.list_browsers() {
         if let Some(host) = browser.host() {
             let hwnd = host.window_handle();
             if hwnd.0.is_null() { continue; }
@@ -240,14 +240,13 @@ pub fn release_drag_capture(state: &Arc<AppState>) -> Result<serde_json::Value, 
         };
         use windows_sys::Win32::Foundation::{BOOL, LPARAM};
 
-        // Use the main browser's HWND, or find_own_top_level_window as fallback
-        let hwnd = {
-            let browsers = state.browsers.lock();
-            browsers.get("main")
-                .and_then(|b| b.host())
-                .map(|h| h.window_handle().0 as *mut std::ffi::c_void)
-                .unwrap_or_else(|| unsafe { super::window::find_own_top_level_window() })
-        };
+        // Use the main browser's HWND, or find_own_top_level_window as fallback.
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        let hwnd = state
+            .get_browser("main")
+            .and_then(|b| b.host())
+            .map(|h| h.window_handle().0 as *mut std::ffi::c_void)
+            .unwrap_or_else(|| unsafe { super::window::find_own_top_level_window() });
 
         if !hwnd.is_null() {
             unsafe {
@@ -600,14 +599,12 @@ fn wait_for_browser_hwnd(
 ) -> Option<*mut std::ffi::c_void> {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
-        {
-            let browsers = state.browsers.lock();
-            if let Some(browser) = browsers.get(label) {
-                if let Some(host) = browser.host() {
-                    let h = host.window_handle();
-                    if !h.0.is_null() {
-                        return Some(h.0 as *mut std::ffi::c_void);
-                    }
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        if let Some(browser) = state.get_browser(label) {
+            if let Some(host) = browser.host() {
+                let h = host.window_handle();
+                if !h.0.is_null() {
+                    return Some(h.0 as *mut std::ffi::c_void);
                 }
             }
         }

--- a/agentmux-cef/src/commands/palette.rs
+++ b/agentmux-cef/src/commands/palette.rs
@@ -30,10 +30,10 @@ pub fn run_command(state: &Arc<AppState>, args: &serde_json::Value) -> Result<se
         id
     );
 
-    let browsers = state.browsers.lock();
-    let browser = browsers
-        .get(window_label)
-        .or_else(|| browsers.values().next());
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    let browser = state
+        .get_browser(window_label)
+        .or_else(|| state.first_browser().map(|(_, b)| b));
 
     if let Some(browser) = browser {
         if let Some(frame) = browser.main_frame() {
@@ -67,8 +67,8 @@ pub fn open_agent(state: &Arc<AppState>, args: &serde_json::Value) -> Result<ser
         agent_id
     );
 
-    let browsers = state.browsers.lock();
-    let browser = browsers.values().next();
+    // Phase H.2.b — reducer-aware "any browser" routing.
+    let browser = state.first_browser().map(|(_, b)| b);
 
     if let Some(browser) = browser {
         if let Some(frame) = browser.main_frame() {

--- a/agentmux-cef/src/commands/tear_off_hook.rs
+++ b/agentmux-cef/src/commands/tear_off_hook.rs
@@ -353,7 +353,15 @@ fn handle_mouse_move(cursor_x: i32, cursor_y: i32) {
         // emit_event calls below.
         let (candidate, prev_browser, next_browser, candidate_changed) = {
             use cef::Browser;
-            let browsers = ctx.state.browsers.lock();
+            // Phase H.2.b — reducer-aware browser snapshot. Materializes
+            // a HashMap so the existing candidate_label_under_cursor_locked
+            // helper signature stays stable. Collected once per hover tick
+            // (~16 ms cadence); allocation is negligible.
+            let browsers: std::collections::HashMap<String, Browser> = ctx
+                .state
+                .list_browsers()
+                .into_iter()
+                .collect();
             let candidate = candidate_label_under_cursor_locked(ctx, &browsers, cursor_x, cursor_y);
             let prev_label = ctx.current_target.borrow().clone();
             let candidate_changed = prev_label != candidate;
@@ -409,8 +417,16 @@ fn handle_button_up(cursor_x: i32, cursor_y: i32) {
         }
         *ctx.finalized.borrow_mut() = true;
 
+        // Phase H.2.b — reducer-aware browser snapshot for the finalize
+        // candidate lookup. Same materialize-into-HashMap pattern as
+        // on_mouse_move above.
         let candidate = {
-            let browsers = ctx.state.browsers.lock();
+            use cef::Browser;
+            let browsers: std::collections::HashMap<String, Browser> = ctx
+                .state
+                .list_browsers()
+                .into_iter()
+                .collect();
             candidate_label_under_cursor_locked(ctx, &browsers, cursor_x, cursor_y)
         };
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -81,8 +81,8 @@ pub fn close_window_by_label(
     unsafe {
         use cef::{ImplBrowser, ImplBrowserHost};
         use windows_sys::Win32::UI::WindowsAndMessaging::{PostMessageW, WM_CLOSE};
-        let browsers = state.browsers.lock();
-        if let Some(browser) = browsers.get(&label) {
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        if let Some(browser) = state.get_browser(&label) {
             if let Some(host) = browser.host() {
                 let hwnd = host.window_handle();
                 if !hwnd.0.is_null() {
@@ -387,13 +387,12 @@ pub fn get_double_click_time() -> serde_json::Value {
 /// fall back to label/index-based naming in that case.
 pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
     let pool_labels = state.unpromoted_pool_labels.lock().clone();
-    let browsers = state.browsers.lock();
-    let labels: Vec<String> = browsers
-        .keys()
-        .filter(|l| !pool_labels.contains(*l) && !l.starts_with("browser-pane-"))
-        .cloned()
+    // Phase H.2.b — reducer-aware label snapshot.
+    let labels: Vec<String> = state
+        .list_browser_labels()
+        .into_iter()
+        .filter(|l| !pool_labels.contains(l.as_str()) && !l.starts_with("browser-pane-"))
         .collect();
-    drop(browsers);
     // Read backend window IDs via `state.backend_window_id()`,
     // which queries the launcher-fed `shadow_backend_window_ids`
     // (sole source of truth post-B.5e). Resolve labels OUTSIDE
@@ -425,10 +424,11 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
 /// `on_pool_window_destroyed`.
 pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
     let pool_labels = state.unpromoted_pool_labels.lock().clone();
-    let browsers = state.browsers.lock();
-    let labels: Vec<&String> = browsers
-        .keys()
-        .filter(|l| !pool_labels.contains(*l))
+    // Phase H.2.b — reducer-aware label snapshot.
+    let labels: Vec<String> = state
+        .list_browser_labels()
+        .into_iter()
+        .filter(|l| !pool_labels.contains(l.as_str()))
         .collect();
     serde_json::json!(labels)
 }
@@ -439,8 +439,8 @@ pub fn focus_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<s
 
     #[cfg(target_os = "windows")]
     {
-        let browsers = state.browsers.lock();
-        if let Some(browser) = browsers.get(label) {
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        if let Some(browser) = state.get_browser(label) {
             if let Some(host) = browser.host() {
                 let hwnd = host.window_handle();
                 if !hwnd.0.is_null() {

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -197,9 +197,10 @@ pub fn register_pool_window(state: &Arc<AppState>, label: &str) {
         // on_after_created fires; if it doesn't, log and bail —
         // the pool entry is harmless until promote re-checks.
         use cef::{ImplBrowser, ImplBrowserHost};
-        let raw_hwnd: Option<*mut std::ffi::c_void> = {
-            let browsers = state.browsers.lock();
-            browsers.get(label).and_then(|browser| {
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        let raw_hwnd: Option<*mut std::ffi::c_void> = state
+            .get_browser(label)
+            .and_then(|browser| {
                 browser.host().and_then(|host| {
                     let h = host.window_handle();
                     if h.0.is_null() {
@@ -208,8 +209,7 @@ pub fn register_pool_window(state: &Arc<AppState>, label: &str) {
                         Some(h.0 as *mut std::ffi::c_void)
                     }
                 })
-            })
-        };
+            });
         if let Some(hwnd) = raw_hwnd {
             set_taskbar_hidden(hwnd, true);
         } else {
@@ -437,41 +437,39 @@ pub fn promote_pool_window(
     // expected failure — log per-step at ERROR so an operator can
     // tell which invariant broke.
     use cef::{ImplBrowser, ImplBrowserHost};
-    let raw_hwnd: Option<*mut std::ffi::c_void> = {
-        let browsers = state.browsers.lock();
-        match browsers.get(&label) {
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    let raw_hwnd: Option<*mut std::ffi::c_void> = match state.get_browser(&label) {
+        None => {
+            tracing::error!(
+                target: "dnd:tearoff:pool",
+                label = %label,
+                "[pool] promoted label not in browsers map (state inconsistency)"
+            );
+            None
+        }
+        Some(browser) => match browser.host() {
             None => {
                 tracing::error!(
                     target: "dnd:tearoff:pool",
                     label = %label,
-                    "[pool] promoted label not in browsers map (state inconsistency)"
+                    "[pool] browser has no host (state inconsistency)"
                 );
                 None
             }
-            Some(browser) => match browser.host() {
-                None => {
+            Some(host) => {
+                let h = host.window_handle();
+                if h.0.is_null() {
                     tracing::error!(
                         target: "dnd:tearoff:pool",
                         label = %label,
-                        "[pool] browser has no host (state inconsistency)"
+                        "[pool] host window handle is null (state inconsistency)"
                     );
                     None
+                } else {
+                    Some(h.0 as *mut std::ffi::c_void)
                 }
-                Some(host) => {
-                    let h = host.window_handle();
-                    if h.0.is_null() {
-                        tracing::error!(
-                            target: "dnd:tearoff:pool",
-                            label = %label,
-                            "[pool] host window handle is null (state inconsistency)"
-                        );
-                        None
-                    } else {
-                        Some(h.0 as *mut std::ffi::c_void)
-                    }
-                }
-            },
-        }
+            }
+        },
     };
 
     // Pool-slot leak guard: if HWND lookup fails after we've already
@@ -628,10 +626,8 @@ pub fn promote_pool_window(
 #[cfg(target_os = "windows")]
 fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
     use cef::{ImplBrowser, ImplBrowserHost};
-    let mut browser_clone = {
-        let browsers = state.browsers.lock();
-        browsers.get(label).cloned()
-    };
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    let mut browser_clone = state.get_browser(label);
     if let Some(ref mut browser) = browser_clone {
         if let Some(host) = browser.host() {
             // force_close = 1: don't run beforeunload, we know

--- a/agentmux-cef/src/events.rs
+++ b/agentmux-cef/src/events.rs
@@ -33,12 +33,12 @@ pub fn emit_event(browser: &Browser, event: &str, payload: &serde_json::Value) {
 /// Emit an event to the "main" browser stored in AppState.
 /// This is a convenience wrapper for use from command handlers and background tasks.
 pub fn emit_event_from_state(state: &crate::state::AppState, event: &str, payload: &serde_json::Value) {
-    let browsers = state.browsers.lock();
-    if let Some(browser) = browsers.get("main") {
-        emit_event(browser, event, payload);
-    } else if let Some((_label, browser)) = browsers.iter().next() {
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    if let Some(browser) = state.get_browser("main") {
+        emit_event(&browser, event, payload);
+    } else if let Some((_label, browser)) = state.first_browser() {
         // Fallback: emit to any available browser
-        emit_event(browser, event, payload);
+        emit_event(&browser, event, payload);
     } else {
         tracing::warn!("Cannot emit event '{}': no browser handle in state", event);
     }
@@ -46,13 +46,14 @@ pub fn emit_event_from_state(state: &crate::state::AppState, event: &str, payloa
 
 /// Emit an event to ALL browser windows (for cross-window drag broadcasts).
 pub fn emit_event_all_windows(state: &crate::state::AppState, event: &str, payload: &serde_json::Value) {
-    let browsers = state.browsers.lock();
-    if browsers.is_empty() {
+    // Phase H.2.b — reducer-aware iteration with fallback.
+    let all = state.list_browsers();
+    if all.is_empty() {
         tracing::warn!("Cannot broadcast event '{}': no browsers", event);
         return;
     }
-    for (_label, browser) in browsers.iter() {
-        emit_event(browser, event, payload);
+    for (_label, browser) in all {
+        emit_event(&browser, event, payload);
     }
 }
 
@@ -65,10 +66,10 @@ pub fn emit_event_to_window(
     event: &str,
     payload: &serde_json::Value,
 ) -> bool {
-    let browsers = state.browsers.lock();
-    match browsers.get(label) {
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    match state.get_browser(label) {
         Some(browser) => {
-            emit_event(browser, event, payload);
+            emit_event(&browser, event, payload);
             true
         }
         None => {

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -423,23 +423,20 @@ async fn route_command(
                 .to_string();
             tracing::info!("[ipc] main_window_focus window_label={}", window_label);
 
-            let target_browser = {
-                let browsers = state.browsers.lock();
-                browsers
-                    .get(&window_label)
-                    .cloned()
-                    .map(|b| (window_label.clone(), b))
-                    .or_else(|| {
-                        // Fallback: pick any non-pane browser. Covers the
-                        // corner case where the requested window label
-                        // isn't registered yet (race on first DOM focus
-                        // before registerBackendWindow lands).
-                        browsers
-                            .iter()
-                            .find(|(k, _)| !k.starts_with("browser-pane-"))
-                            .map(|(k, b)| (k.clone(), b.clone()))
-                    })
-            };
+            // Phase H.2.b — reducer-aware lookup with fallback. Try the
+            // requested label first; on miss, pick any non-pane browser
+            // (covers the corner case where the requested window label
+            // isn't registered yet — race on first DOM focus before
+            // registerBackendWindow lands).
+            let target_browser = state
+                .get_browser(&window_label)
+                .map(|b| (window_label.clone(), b))
+                .or_else(|| {
+                    state
+                        .list_browsers()
+                        .into_iter()
+                        .find(|(k, _)| !k.starts_with("browser-pane-"))
+                });
 
             if let Some((label, _browser)) = target_browser {
                 // Full focus reclaim has to run on the CEF UI thread:

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -52,8 +52,8 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
-    let browsers = state.browsers.lock();
-    for (label, browser) in browsers.iter() {
+    // Phase H.2.b — reducer-aware iteration with fallback.
+    for (label, browser) in state.list_browsers() {
         if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
             continue;
         }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -786,14 +786,13 @@ pub fn report_monitor_topology_changed(rects: Vec<agentmux_common::ipc::Rect>) {
 /// `docs/retro/multi-reducer-proposal-2026-04-28.md`), this becomes
 /// "report host's authoritative reducer-state to the launcher."
 pub fn compute_and_report_host_counts(state: &std::sync::Arc<crate::state::AppState>) {
-    let unpromoted = state.unpromoted_pool_labels.lock();
-    let browsers = state.browsers.lock();
+    // Phase H.2.b — reducer-aware label snapshot.
+    let unpromoted = state.unpromoted_pool_labels.lock().clone();
     let pool = unpromoted.len() as u32;
-    let windows = browsers
-        .keys()
-        .filter(|k| !k.starts_with("browser-pane-") && !unpromoted.contains(*k))
+    let windows = state
+        .list_browser_labels()
+        .into_iter()
+        .filter(|k| !k.starts_with("browser-pane-") && !unpromoted.contains(k.as_str()))
         .count() as u32;
-    drop(browsers);
-    drop(unpromoted);
     report_host_counts(windows, pool);
 }

--- a/agentmux-cef/src/pane/callbacks.rs
+++ b/agentmux-cef/src/pane/callbacks.rs
@@ -215,9 +215,10 @@ pub fn on_loading_state_change_pane(
 /// label whose browser handle matches the given one by `is_same`, then
 /// strip the prefix and the trailing `-<seq>` to recover the uuid.
 fn resolve_pane_block_id(state: &Arc<AppState>, browser: &Browser) -> Option<String> {
-    let browsers = state.browsers.lock();
-    browsers
-        .iter()
+    // Phase H.2.b — reducer-aware iteration with fallback.
+    state
+        .list_browsers()
+        .into_iter()
         .find(|(_k, b)| {
             let mut b_clone = b.clone();
             let mut browser_clone: cef::Browser = browser.clone();

--- a/agentmux-cef/src/saga_dispatch.rs
+++ b/agentmux-cef/src/saga_dispatch.rs
@@ -354,20 +354,19 @@ impl SagaActionRunner for LiveActionRunner {
     fn drain_pool_if_last(&self, label: &str) -> bool {
         // Compute the same condition `on_before_close` uses to
         // decide drain. Read-only snapshot of host state.
-        let unpromoted = self.state.unpromoted_pool_labels.lock();
-        let browsers = self.state.browsers.lock();
-        let user_count = browsers
+        // Phase H.2.b — reducer-aware label snapshot.
+        let unpromoted = self.state.unpromoted_pool_labels.lock().clone();
+        let labels = self.state.list_browser_labels();
+        let user_count = labels
             .iter()
-            .filter(|(k, _)| !unpromoted.contains(*k) && !k.starts_with("browser-pane-"))
+            .filter(|k| !unpromoted.contains(k.as_str()) && !k.starts_with("browser-pane-"))
             .count();
         // `was_last` semantics: closing window is the last user-
         // visible window. Caller's `label` should be subtracted —
         // but at saga-dispatch time the close hasn't happened yet
         // (or has just happened); count of 0 OR count of 1 with
         // the closing window in the set both indicate "last."
-        let label_present = browsers.contains_key(label);
-        drop(browsers);
-        drop(unpromoted);
+        let label_present = labels.iter().any(|k| k == label);
         user_count == 0 || (user_count == 1 && label_present)
     }
 }

--- a/agentmux-cef/src/srv_event_bridge.rs
+++ b/agentmux-cef/src/srv_event_bridge.rs
@@ -41,8 +41,8 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
-    let browsers = state.browsers.lock();
-    for (label, browser) in browsers.iter() {
+    // Phase H.2.b — reducer-aware iteration with fallback.
+    for (label, browser) in state.list_browsers() {
         if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
             continue;
         }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -701,7 +701,20 @@ impl AppState {
     // clones what's needed, drops the lock. Callers never hold either
     // lock across CEF FFI calls.
 
-    /// Get a browser handle by label. Reducer first; legacy fallback.
+    /// Get a browser handle by label. Legacy is authoritative; reducer
+    /// fallback (codex P1 + reagent P1 PR #659 round 2).
+    ///
+    /// **Why legacy first:** during the parallel-write phase the close
+    /// paths (`on_before_close`, pane close) remove from legacy FIRST and
+    /// dispatch `UnregisterBrowser` afterward. If we returned reducer-first,
+    /// concurrent readers in that drift window would observe `legacy=None`
+    /// but `reducer=Some` — handing back a Browser handle that legacy has
+    /// already retired (its HWND is mid-teardown). That regresses behavior
+    /// vs the original `state.browsers.lock().get(label).cloned()` which
+    /// returned `None` correctly during close.
+    ///
+    /// Drift logged in both directions for observability before PR #4 flips
+    /// to reducer-only.
     pub fn get_browser(&self, label: &str) -> Option<Browser> {
         let from_reducer = self
             .host_state
@@ -723,28 +736,39 @@ impl AppState {
             ),
             _ => {}
         }
-        // Prefer reducer; fall back to legacy. Both should agree post-H.2.a.
-        from_reducer.or(from_legacy)
+        // Legacy authoritative until PR #4 flips reads.
+        from_legacy.or(from_reducer)
     }
 
     /// Check whether a browser is registered under the given label.
+    ///
+    /// Same legacy-authoritative contract as `get_browser`. Logs drift in
+    /// BOTH directions for observability (was reagent P2 PR #659 round 1 —
+    /// previous version short-circuited on `in_reducer` with no legacy
+    /// check, missing reducer-has-but-legacy-doesn't drift).
     pub fn has_browser(&self, label: &str) -> bool {
         let in_reducer = self.host_state.lock().browsers.contains_key(label);
-        if in_reducer {
-            return true;
-        }
         let in_legacy = self.browsers.lock().contains_key(label);
-        if in_legacy {
-            tracing::warn!(
+        match (in_reducer, in_legacy) {
+            (true, false) => tracing::warn!(
                 target: "host-reducer:drift",
                 label = %label,
-                "browser in legacy but missing from reducer",
-            );
+                "has_browser: reducer has, legacy missing",
+            ),
+            (false, true) => tracing::warn!(
+                target: "host-reducer:drift",
+                label = %label,
+                "has_browser: legacy has, reducer missing",
+            ),
+            _ => {}
         }
         in_legacy
     }
 
     /// Are there any registered browsers?
+    ///
+    /// Legacy authoritative (matches caller intent: `on_after_created`'s
+    /// `is_empty()` check decides whether to take the "main" shortcut path).
     pub fn browsers_is_empty(&self) -> bool {
         let reducer_empty = self.host_state.lock().browsers.is_empty();
         let legacy_empty = self.browsers.lock().is_empty();
@@ -756,9 +780,7 @@ impl AppState {
                 "browsers is_empty drift",
             );
         }
-        // Conservatively report not-empty if either side has entries
-        // (preserves caller's "no windows exist yet" decisions).
-        reducer_empty && legacy_empty
+        legacy_empty
     }
 
     /// Snapshot of all registered browser labels (HashMap iteration order;

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -689,6 +689,203 @@ impl AppState {
         self.host_state.lock().pending_window_creations.back().cloned()
     }
 
+    // ── Phase H.2.b — browser read helpers (with fallback) ──────────────
+    //
+    // These wrap reads against `HostState.browsers` (the new reducer-managed
+    // map) with fallback to the legacy `AppState.browsers` mutex. Drift
+    // (entry in one but not the other) is logged via
+    // `target = "host-reducer:drift"` so production smoke can verify the
+    // parallel-write invariant before PR #4 flips reads to reducer-only.
+    //
+    // Snapshot-and-drop: each helper takes the relevant lock(s) briefly,
+    // clones what's needed, drops the lock. Callers never hold either
+    // lock across CEF FFI calls.
+
+    /// Get a browser handle by label. Reducer first; legacy fallback.
+    pub fn get_browser(&self, label: &str) -> Option<Browser> {
+        let from_reducer = self
+            .host_state
+            .lock()
+            .browsers
+            .get(label)
+            .map(|h| h.browser.clone());
+        let from_legacy = self.browsers.lock().get(label).cloned();
+        match (&from_reducer, &from_legacy) {
+            (Some(_), None) => tracing::warn!(
+                target: "host-reducer:drift",
+                label = %label,
+                "browser in reducer but missing from legacy",
+            ),
+            (None, Some(_)) => tracing::warn!(
+                target: "host-reducer:drift",
+                label = %label,
+                "browser in legacy but missing from reducer",
+            ),
+            _ => {}
+        }
+        // Prefer reducer; fall back to legacy. Both should agree post-H.2.a.
+        from_reducer.or(from_legacy)
+    }
+
+    /// Check whether a browser is registered under the given label.
+    pub fn has_browser(&self, label: &str) -> bool {
+        let in_reducer = self.host_state.lock().browsers.contains_key(label);
+        if in_reducer {
+            return true;
+        }
+        let in_legacy = self.browsers.lock().contains_key(label);
+        if in_legacy {
+            tracing::warn!(
+                target: "host-reducer:drift",
+                label = %label,
+                "browser in legacy but missing from reducer",
+            );
+        }
+        in_legacy
+    }
+
+    /// Are there any registered browsers?
+    pub fn browsers_is_empty(&self) -> bool {
+        let reducer_empty = self.host_state.lock().browsers.is_empty();
+        let legacy_empty = self.browsers.lock().is_empty();
+        if reducer_empty != legacy_empty {
+            tracing::warn!(
+                target: "host-reducer:drift",
+                reducer_empty,
+                legacy_empty,
+                "browsers is_empty drift",
+            );
+        }
+        // Conservatively report not-empty if either side has entries
+        // (preserves caller's "no windows exist yet" decisions).
+        reducer_empty && legacy_empty
+    }
+
+    /// Snapshot of all registered browser labels (HashMap iteration order;
+    /// callers must not assume ordering).
+    pub fn list_browser_labels(&self) -> Vec<String> {
+        use std::collections::HashSet;
+        let reducer_labels: HashSet<String> = self
+            .host_state
+            .lock()
+            .browsers
+            .keys()
+            .cloned()
+            .collect();
+        let legacy_labels: HashSet<String> = self.browsers.lock().keys().cloned().collect();
+        if reducer_labels != legacy_labels {
+            let only_reducer: Vec<&String> =
+                reducer_labels.difference(&legacy_labels).collect();
+            let only_legacy: Vec<&String> =
+                legacy_labels.difference(&reducer_labels).collect();
+            tracing::warn!(
+                target: "host-reducer:drift",
+                only_reducer = ?only_reducer,
+                only_legacy = ?only_legacy,
+                "browser label set drift",
+            );
+        }
+        // Use legacy as authoritative until H.2.c flips reads.
+        legacy_labels.into_iter().collect()
+    }
+
+    /// Snapshot of all registered browsers as (label, Browser) pairs.
+    /// Ordering is HashMap iteration order; callers must sort if order
+    /// matters.
+    pub fn list_browsers(&self) -> Vec<(String, Browser)> {
+        let from_reducer: Vec<(String, Browser)> = self
+            .host_state
+            .lock()
+            .browsers
+            .iter()
+            .map(|(k, h)| (k.clone(), h.browser.clone()))
+            .collect();
+        let from_legacy: Vec<(String, Browser)> = self
+            .browsers
+            .lock()
+            .iter()
+            .map(|(k, b)| (k.clone(), b.clone()))
+            .collect();
+        if from_reducer.len() != from_legacy.len() {
+            tracing::warn!(
+                target: "host-reducer:drift",
+                reducer_count = from_reducer.len(),
+                legacy_count = from_legacy.len(),
+                "browser count drift in list_browsers",
+            );
+        }
+        // Legacy is authoritative until flip.
+        from_legacy
+    }
+
+    /// First registered browser (for "any browser" callers like command
+    /// palette routing). Returns the label + Browser pair, or None if
+    /// the registry is empty.
+    pub fn first_browser(&self) -> Option<(String, Browser)> {
+        // Prefer the legacy iteration order (matches existing code's
+        // `.values().next()` semantics) until flip.
+        self.browsers
+            .lock()
+            .iter()
+            .next()
+            .map(|(k, b)| (k.clone(), b.clone()))
+    }
+
+    // ── Phase H.1.b — pane lifecycle read helpers (with fallback) ───────
+
+    /// Returns the pane's label iff entry is `Live`. Used by op gates
+    /// (focus/resize/navigate) — `None` indicates the pane is missing or
+    /// in `Closing`, in which case the caller must short-circuit rather
+    /// than touch the (possibly destroyed) HWND.
+    pub fn live_pane_label(&self, block_id: &str) -> Option<String> {
+        let from_reducer = self
+            .host_state
+            .lock()
+            .panes
+            .get(block_id)
+            .filter(|e| e.lifecycle == PaneLifecycle::Live)
+            .map(|e| e.label.clone());
+        let from_legacy = self.browser_panes.test_live_label_of(block_id);
+        if from_reducer != from_legacy {
+            tracing::warn!(
+                target: "host-reducer:drift",
+                block_id = %block_id,
+                reducer = ?from_reducer,
+                legacy = ?from_legacy,
+                "live_pane_label drift",
+            );
+        }
+        from_legacy.or(from_reducer)
+    }
+
+    /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.
+    pub fn live_pane_labels(&self) -> Vec<String> {
+        use std::collections::HashSet;
+        let reducer_labels: HashSet<String> = self
+            .host_state
+            .lock()
+            .panes
+            .values()
+            .filter(|e| e.lifecycle == PaneLifecycle::Live)
+            .map(|e| e.label.clone())
+            .collect();
+        let legacy_labels: HashSet<String> =
+            self.browser_panes.test_live_labels().into_iter().collect();
+        if reducer_labels != legacy_labels {
+            let only_reducer: Vec<&String> =
+                reducer_labels.difference(&legacy_labels).collect();
+            let only_legacy: Vec<&String> =
+                legacy_labels.difference(&reducer_labels).collect();
+            tracing::warn!(
+                target: "host-reducer:drift",
+                only_reducer = ?only_reducer,
+                only_legacy = ?only_legacy,
+                "live_pane_labels set drift",
+            );
+        }
+        legacy_labels.into_iter().collect()
+    }
+
     /// Phase B.5e — authoritative instance-number lookup. Reads
     /// the launcher-fed `shadow_instance_registry`, which is the
     /// sole source of truth post-B.5e (host's

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -783,23 +783,35 @@ impl AppState {
         legacy_empty
     }
 
-    /// Snapshot of all registered browser labels (HashMap iteration order;
-    /// callers must not assume ordering).
+    /// Snapshot of all registered browser labels (HashMap iteration order
+    /// preserved from the legacy map — stable per-HashMap-instance, same
+    /// characteristics as the original `state.browsers.lock().keys()`
+    /// pattern these helpers replaced).
+    ///
+    /// (codex P2 PR #659 round 3): previously routed through a fresh
+    /// `HashSet` per call, which has its own randomized hash seed →
+    /// non-deterministic order even when no windows changed. That caused
+    /// UI jitter in poll-driven views (`InstancePanel`'s window list).
+    /// Now Vec is built directly from legacy keys; HashSets are local to
+    /// the diff-detection logic.
     pub fn list_browser_labels(&self) -> Vec<String> {
         use std::collections::HashSet;
-        let reducer_labels: HashSet<String> = self
+        let reducer_labels: Vec<String> = self
             .host_state
             .lock()
             .browsers
             .keys()
             .cloned()
             .collect();
-        let legacy_labels: HashSet<String> = self.browsers.lock().keys().cloned().collect();
-        if reducer_labels != legacy_labels {
-            let only_reducer: Vec<&String> =
-                reducer_labels.difference(&legacy_labels).collect();
-            let only_legacy: Vec<&String> =
-                legacy_labels.difference(&reducer_labels).collect();
+        let legacy_labels: Vec<String> = self.browsers.lock().keys().cloned().collect();
+        // HashSets only for set-difference; legacy_labels Vec is what we return.
+        let reducer_set: HashSet<&String> = reducer_labels.iter().collect();
+        let legacy_set: HashSet<&String> = legacy_labels.iter().collect();
+        if reducer_set != legacy_set {
+            let only_reducer: Vec<&&String> =
+                reducer_set.difference(&legacy_set).collect();
+            let only_legacy: Vec<&&String> =
+                legacy_set.difference(&reducer_set).collect();
             tracing::warn!(
                 target: "host-reducer:drift",
                 only_reducer = ?only_reducer,
@@ -807,8 +819,9 @@ impl AppState {
                 "browser label set drift",
             );
         }
-        // Use legacy as authoritative until H.2.c flips reads.
-        legacy_labels.into_iter().collect()
+        // Legacy authoritative until PR #4 flips reads. Vec preserves
+        // HashMap iteration order (stable per instance).
+        legacy_labels
     }
 
     /// Snapshot of all registered browsers as (label, Browser) pairs.
@@ -881,9 +894,13 @@ impl AppState {
     }
 
     /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.
+    /// Order preserved from `PaneStateMachine.live_labels()` (legacy
+    /// HashMap iteration order — stable per instance, same as the
+    /// original code these helpers replaced). HashSets are local to
+    /// the drift-detection logic only.
     pub fn live_pane_labels(&self) -> Vec<String> {
         use std::collections::HashSet;
-        let reducer_labels: HashSet<String> = self
+        let reducer_labels: Vec<String> = self
             .host_state
             .lock()
             .panes
@@ -891,13 +908,14 @@ impl AppState {
             .filter(|e| e.lifecycle == PaneLifecycle::Live)
             .map(|e| e.label.clone())
             .collect();
-        let legacy_labels: HashSet<String> =
-            self.browser_panes.test_live_labels().into_iter().collect();
-        if reducer_labels != legacy_labels {
-            let only_reducer: Vec<&String> =
-                reducer_labels.difference(&legacy_labels).collect();
-            let only_legacy: Vec<&String> =
-                legacy_labels.difference(&reducer_labels).collect();
+        let legacy_labels: Vec<String> = self.browser_panes.test_live_labels();
+        let reducer_set: HashSet<&String> = reducer_labels.iter().collect();
+        let legacy_set: HashSet<&String> = legacy_labels.iter().collect();
+        if reducer_set != legacy_set {
+            let only_reducer: Vec<&&String> =
+                reducer_set.difference(&legacy_set).collect();
+            let only_legacy: Vec<&&String> =
+                legacy_set.difference(&reducer_set).collect();
             tracing::warn!(
                 target: "host-reducer:drift",
                 only_reducer = ?only_reducer,
@@ -905,7 +923,8 @@ impl AppState {
                 "live_pane_labels set drift",
             );
         }
-        legacy_labels.into_iter().collect()
+        // Legacy authoritative until PR #4 flips reads.
+        legacy_labels
     }
 
     /// Phase B.5e — authoritative instance-number lookup. Reads

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -19,9 +19,8 @@ use crate::state::AppState;
 
 /// Get the CEF Views Window for a browser label on the UI thread.
 fn get_window_on_ui(state: &Arc<AppState>, label: &str) -> Option<Window> {
-    let browsers = state.browsers.lock();
-    let mut browser = browsers.get(label)?.clone();
-    drop(browsers);
+    // Phase H.2.b — reducer-aware lookup with fallback.
+    let mut browser = state.get_browser(label)?;
     let browser_view = browser_view_get_for_browser(Some(&mut browser))?;
     browser_view.window()
 }
@@ -281,11 +280,12 @@ wrap_task! {
             };
             let cef_url = CefString::from(self.url.as_str());
 
-            // Get client from an existing browser
-            let browsers = self.state.browsers.lock();
-            let client = browsers.values().next()
-                .and_then(|b| b.host().map(|h| h.client()));
-            drop(browsers);
+            // Get client from an existing browser.
+            // Phase H.2.b — reducer-aware "any browser" via first_browser().
+            let client = self
+                .state
+                .first_browser()
+                .and_then(|(_, b)| b.host().map(|h| h.client()));
             tracing::info!(
                 label = %self.label,
                 elapsed_us = t0.elapsed().as_micros() as u64,
@@ -359,15 +359,14 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
-            let browsers = self.state.browsers.lock();
-            let browser = match browsers.get(&self.label) {
-                Some(b) => b.clone(),
+            // Phase H.2.b — reducer-aware lookup with fallback.
+            let browser = match self.state.get_browser(&self.label) {
+                Some(b) => b,
                 None => {
                     tracing::warn!("[devtools] browser '{}' not found", self.label);
                     return;
                 }
             };
-            drop(browsers);
 
             match browser.host() {
                 Some(host) => {
@@ -416,7 +415,8 @@ wrap_task! {
 
     impl Task {
         fn execute(&self) {
-            let mut browser = match self.state.browsers.lock().get(&self.label).cloned() {
+            // Phase H.2.b — reducer-aware lookup with fallback.
+            let mut browser = match self.state.get_browser(&self.label) {
                 Some(b) => b,
                 None => {
                     tracing::warn!("[main-focus-reclaim] no browser for label={}", self.label);
@@ -441,20 +441,19 @@ wrap_task! {
                 // Views top-level, so a naive EnumChildWindows would pick up
                 // their Chrome_RenderWidgetHostHWND and SetFocus on the wrong
                 // target.
-                let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = {
-                    let browsers = self.state.browsers.lock();
-                    browsers
-                        .iter()
-                        .filter(|(k, _)| k.starts_with("browser-pane-"))
-                        .filter_map(|(_, b)| {
-                            let mut b = b.clone();
-                            b.host().and_then(|h| {
-                                let wh = h.window_handle();
-                                if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
-                            })
+                // Phase H.2.b — reducer-aware iteration with fallback.
+                let pane_outer_hwnds: Vec<*mut std::ffi::c_void> = self
+                    .state
+                    .list_browsers()
+                    .into_iter()
+                    .filter(|(k, _)| k.starts_with("browser-pane-"))
+                    .filter_map(|(_, mut b)| {
+                        b.host().and_then(|h| {
+                            let wh = h.window_handle();
+                            if wh.0.is_null() { None } else { Some(wh.0 as *mut std::ffi::c_void) }
                         })
-                        .collect()
-                };
+                    })
+                    .collect();
 
                 match views_top_hwnd {
                     Some(top_hwnd) => unsafe {

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.583"
+version = "0.33.584"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.583"
+version = "0.33.584"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.583"
+version = "0.33.584"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.582",
+  "version": "0.33.583",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.582",
+      "version": "0.33.583",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.581",
+  "version": "0.33.582",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.581",
+      "version": "0.33.582",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.583",
+  "version": "0.33.584",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.583",
+      "version": "0.33.584",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.583",
+  "version": "0.33.584",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #3 of the host-reducer Phase H buildout. Folds in:
- **Codex P2 fix from PR #655:** \`close()\` only dispatches \`CompletePaneClose\` when \`close_with()\` actually performed the close transition. Avoids reducer-entry removal during duplicate / retry close calls.
- **H.1.b + H.2.b:** all browser + pane READ sites now route through reducer-aware helpers on \`AppState\` with fallback to legacy + drift logging.

Net effect: zero behavior change yet — all reads still return the legacy value. The drift-logging target \`host-reducer:drift\` lets production smoke verify the parallel-write invariant before PR #4 flips reads to reducer-only.

## Three commits

### Commit 1 — codex P2 fix (gate CompletePaneClose on close_with success)

\`close_with()\` returns \`bool\`: true iff \`try_mark_closing\` succeeded and the close transition was actually performed. \`close()\` only dispatches \`CompletePaneClose\` when \`close_with\` returned true. EnqueuePaneClose still dispatched unconditionally (idempotent on the reducer side).

Two regression tests:
- \`close_with_returns_true_only_when_did_close\` — first call true, second/missing false.
- \`close_with_returns_false_for_already_closing_entry\`.

### Commit 2 — read helpers on AppState (H.1.b + H.2.b foundation)

7 new helpers, each with reducer-first read + legacy fallback + drift logging:
- \`get_browser(label)\`
- \`has_browser(label)\`
- \`browsers_is_empty()\`
- \`list_browser_labels()\`
- \`list_browsers()\` → Vec<(String, Browser)>
- \`first_browser()\` → for "any browser" routing
- \`live_pane_label(block_id)\`
- \`live_pane_labels()\`

Drift via \`tracing::warn target="host-reducer:drift"\` whenever reducer and legacy disagree. PR #4 flips to reducer-only after smoke verifies zero drift.

Two passthroughs added on \`BrowserPaneManager\` (\`test_live_label_of\`, \`test_live_labels\`) so AppState helpers can compare reducer vs PaneStateMachine. Disappear in PR #4 step e when PaneStateMachine is deleted.

### Commit 3 — convert ~30 browser read sites + 2 pane read sites

15 files touched:

| File | Sites | Pattern |
|---|---|---|
| \`browser_panes.rs\` | 4 | \`live_browser\`, \`defocus_all\`, \`set_pane_overlay_clip\`, re-navigate-on-AlreadyLive |
| \`client.rs\` | 4 | \`is_empty\`, child cascade close, exit-gate filter, pool browsers iteration |
| \`ui_tasks.rs\` | 4 | \`get_window_on_ui\`, CreateWindowTask client lookup, ShowDevToolsTask, MainFocusReclaimTask + pane HWND collection |
| \`commands/window.rs\` | 4 | \`close_window_by_label\`, \`list_window_instances\`, \`list_windows\`, \`focus_window\` |
| \`commands/window_pool.rs\` | 3 | \`register_pool_window\`, \`promote_pool_window\`, \`cleanup_failed_promote_orphan\` |
| \`commands/drag.rs\` | 3 | \`enum_browser_rects\`, tear-off main HWND, \`wait_for_browser_ready_task\` |
| \`commands/palette.rs\` | 2 | \`run_command\`, \`open_agent\` |
| \`commands/tear_off_hook.rs\` | 2 | \`on_mouse_move\`, \`on_mouse_up\` (materializes HashMap from \`list_browsers\` to keep \`candidate_label_under_cursor_locked\` signature stable) |
| \`pane/callbacks.rs\` | 1 | \`resolve_pane_block_id\` |
| \`events.rs\` | 3 | \`emit_event_from_state\`, \`emit_event_all_windows\`, \`emit_event_to_window\` |
| \`ipc.rs\` | 1 | \`main_window_focus\` target lookup |
| \`srv_event_bridge.rs\` | 1 | event broadcast filter |
| \`launcher_event_bridge.rs\` | 1 | event broadcast filter |
| \`launcher_ipc.rs\` | 1 | \`compute_and_report_host_counts\` |
| \`saga_dispatch.rs\` | 1 | \`drain_pool_if_last\` |

## What's NOT in this PR (deferred to PR #4)

Three remaining \`state.browsers.lock()\` sites — all MUTATIONS in the parallel-writes step:
- \`client.rs:198\` (insert in \`on_after_created\`)
- \`client.rs:483\` (remove in \`on_before_close\`)
- \`commands/window_pool.rs:646\` (remove in \`cleanup_failed_promote_orphan\`)

PR #4 (\`agenta/h2c-panes-browsers-flip-and-delete\`) covers:
- H.1.c + H.2.c — flip reads (drop legacy fallback, reducer-only).
- H.1.d + H.2.d — drop legacy mutations (the 3 sites above).
- H.1.e + H.2.e — delete \`PaneStateMachine\` struct + \`AppState.browsers\` field.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean
- [x] \`cargo test -p agentmux-cef --bin agentmux-cef -- pane:: browser_panes:: reducer::\` → 59/59 passing
- [x] codex P2 from PR #655 addressed with regression tests
- [x] No behavior change — all reads return legacy value via fallback
- [ ] Bot review (reagentx-workflow + codex)

## Bump

Patch: \`0.33.581 → 0.33.582\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)