### PR TITLE
feat(cef): H.2 browsers ratchet complete + codex P1 fix — PR #4 of host reducer Phase H buildout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.584"
+version = "0.33.585"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.584"
+version = "0.33.585"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.584"
+version = "0.33.585"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.584"
+version = "0.33.585"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.585"
+version = "0.33.586"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.585"
+version = "0.33.586"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.585"
+version = "0.33.586"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.585"
+version = "0.33.586"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.584"
+version = "0.33.585"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.585"
+version = "0.33.586"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -50,15 +50,18 @@ struct AppStateCloseOps<'a>(&'a Arc<AppState>);
 
 impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
     fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
-        // Phase H.2.e — `state.browsers` field deleted; reducer is the
-        // sole source of truth. Look up the Browser via reducer-aware
-        // helper, then dispatch UnregisterBrowser to remove it.
-        let browser = self.0.get_browser(label)?;
-        self.0.host_dispatch(
+        // Atomic take-and-return via reducer (codex P2 PR #660). Earlier
+        // round 1 separated `get_browser` + `UnregisterBrowser` dispatch,
+        // which left a window for concurrent readers to resolve the same
+        // label and act on the closing handle. `UnregisterBrowser` now
+        // returns the removed `Browser` via `DispatchOutput.removed_browser`
+        // — single host_state lock, single mutation, no race.
+        let out = self.0.host_dispatch(
             crate::reducer::HostCommand::UnregisterBrowser {
                 label: label.to_string(),
             },
         );
+        let browser = out.removed_browser?;
 
         #[cfg(target_os = "windows")]
         let hwnd = browser.host().and_then(|h| {

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -50,11 +50,10 @@ struct AppStateCloseOps<'a>(&'a Arc<AppState>);
 
 impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
     fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
-        let browser = self.0.browsers.lock().remove(label)?;
-
-        // Phase H.2.a — parallel write: mirror the unregister into the
-        // host reducer. Done after the legacy remove so the reducer
-        // side sees the same state transition.
+        // Phase H.2.e — `state.browsers` field deleted; reducer is the
+        // sole source of truth. Look up the Browser via reducer-aware
+        // helper, then dispatch UnregisterBrowser to remove it.
+        let browser = self.0.get_browser(label)?;
         self.0.host_dispatch(
             crate::reducer::HostCommand::UnregisterBrowser {
                 label: label.to_string(),

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -194,17 +194,18 @@ impl AgentMuxHandler {
             elapsed_us = t0.elapsed().as_micros() as u64,
             "[on-after-created] acquiring browsers lock"
         );
-        {
-            let mut browsers = self.state.browsers.lock();
-            tracing::info!(
-                label = %label,
-                elapsed_us = t0.elapsed().as_micros() as u64,
-                "[on-after-created] browsers lock acquired"
-            );
-            tracing::info!("Registered browser: label={} (total: {})", label, browsers.len() + 1);
-            dlog(&format!("on_after_created: registered label={} total={}", label, browsers.len() + 1));
-            browsers.insert(label.clone(), browser.clone());
-        }
+        // Phase H.2.d — legacy `state.browsers.insert` removed. Reducer's
+        // `RegisterBrowser` (dispatched below) is now the sole canonical
+        // mutation site. Smoke test on 0.33.585 verified parallel-write
+        // parity (zero drift across 18 RegisterBrowser/Unregister pairs).
+        let total = self.state.host_state.lock().browsers.len() + 1;
+        tracing::info!(
+            label = %label,
+            elapsed_us = t0.elapsed().as_micros() as u64,
+            "[on-after-created] registering browser"
+        );
+        tracing::info!("Registered browser: label={} (total: {})", label, total);
+        dlog(&format!("on_after_created: registered label={} total={}", label, total));
 
         let is_top_level_window = !label.starts_with("browser-pane-");
 
@@ -478,27 +479,31 @@ impl AgentMuxHandler {
 
         let mut browser = browser.cloned().expect("Browser is None");
 
-        // Unregister browser from the multi-window map and get its label.
-        let label = {
-            let mut browsers = self.state.browsers.lock();
-            let keys: Vec<String> = browsers.keys().cloned().collect();
-            dlog(&format!("browsers map keys: {:?}", keys));
-            let label = browsers.iter()
-                .find(|(_, b)| b.is_same(Some(&mut browser)) != 0)
-                .map(|(k, _)| k.clone());
-            dlog(&format!("label found: {:?}", label));
-            if let Some(ref lbl) = label {
-                browsers.remove(lbl);
-                tracing::info!("Unregistered browser: label={} (remaining: {})", lbl, browsers.len());
-            }
-            label
-        };
-
-        // Phase H.2.a — parallel write: mirror the unregister into the host
-        // reducer. Idempotent on the reducer side (no-op if absent).
+        // Unregister browser from the reducer's `browsers` map and get its
+        // label. Phase H.2.d — legacy `state.browsers.lock().remove` removed;
+        // reducer is sole source of truth (see PR #4 commit 2 H.2.c flip).
+        // Find-by-identity loop now iterates reducer-backed snapshot via
+        // `state.list_browsers()`, then dispatches `UnregisterBrowser`.
+        let snapshot = self.state.list_browsers();
+        let keys: Vec<&String> = snapshot.iter().map(|(k, _)| k).collect();
+        dlog(&format!("browsers map keys: {:?}", keys));
+        let label = snapshot
+            .iter()
+            .find(|(_, b)| {
+                let mut b = b.clone();
+                b.is_same(Some(&mut browser)) != 0
+            })
+            .map(|(k, _)| k.clone());
+        dlog(&format!("label found: {:?}", label));
         if let Some(ref lbl) = label {
             self.state.host_dispatch(
                 crate::reducer::HostCommand::UnregisterBrowser { label: lbl.clone() },
+            );
+            let remaining = self.state.host_state.lock().browsers.len();
+            tracing::info!(
+                "Unregistered browser: label={} (remaining: {})",
+                lbl,
+                remaining
             );
         }
 

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -189,11 +189,6 @@ impl AgentMuxHandler {
         let pending_kind = pending.kind;
         let pending_parent = pending.parent_instance_id.clone();
 
-        tracing::info!(
-            label = %label,
-            elapsed_us = t0.elapsed().as_micros() as u64,
-            "[on-after-created] acquiring browsers lock"
-        );
         // Phase H.2.d — legacy `state.browsers.insert` removed. Reducer's
         // `RegisterBrowser` (dispatched below) is now the sole canonical
         // mutation site. Smoke test on 0.33.585 verified parallel-write
@@ -202,9 +197,9 @@ impl AgentMuxHandler {
         tracing::info!(
             label = %label,
             elapsed_us = t0.elapsed().as_micros() as u64,
-            "[on-after-created] registering browser"
+            total,
+            "[on-after-created] registering browser via reducer",
         );
-        tracing::info!("Registered browser: label={} (total: {})", label, total);
         dlog(&format!("on_after_created: registered label={} total={}", label, total));
 
         let is_top_level_window = !label.starts_with("browser-pane-");

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -643,9 +643,8 @@ fn cleanup_failed_promote_orphan(state: &Arc<AppState>, label: &str) {
     }
     // Browser or host already gone — do `on_before_close`'s job
     // inline since CEF won't fire it for this label.
-    state.browsers.lock().remove(label);
-    // Phase H.2.a — parallel write: mirror the unregister into the host
-    // reducer. Idempotent on the reducer side.
+    // Phase H.2.d — legacy `state.browsers.lock().remove` removed;
+    // reducer's UnregisterBrowser is sole canonical mutation site.
     state.host_dispatch(
         crate::reducer::HostCommand::UnregisterBrowser {
             label: label.to_string(),

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -539,18 +539,47 @@ pub enum HostEvent {
     Error { message: String, version: u64 },
 }
 
-/// Output bundle returned from the reducer for the dequeue arm.
+/// Output bundle returned from the reducer.
 ///
-/// The dequeue arm is the only F.1 command whose caller needs the
-/// popped value (an event is not sufficient — `client.rs::on_after_created`
-/// uses the popped `PendingWindowCreation`'s fields to drive
-/// `window_meta.insert` and `ReportWindowOpened`). Other arms can
-/// rely on events alone; this struct keeps the dispatch return type
-/// uniform.
-#[derive(Debug, Default)]
+/// Most arms communicate via `events` alone, but two arms have callers
+/// that need an atomic value-returning op alongside the state mutation:
+///
+/// - `DequeuePendingWindowCreation` → `dequeued: Option<PendingWindowCreation>`
+///   (`client.rs::on_after_created` needs the popped entry's fields to drive
+///   `window_meta.insert` + `ReportWindowOpened`).
+///
+/// - `UnregisterBrowser` → `removed_browser: Option<Browser>` (the close
+///   path in `browser_panes::AppStateCloseOps::take_browser_hwnd` needs
+///   the Browser handle to extract its HWND for `DestroyWindow`. The
+///   atomicity matters: see codex P2 PR #660 — separating get + dispatch
+///   creates a window where concurrent readers can also resolve the
+///   label and act on the closing handle).
+///
+/// Default keeps the dispatch return type uniform across arms that
+/// don't populate these fields.
+#[derive(Default)]
 pub struct DispatchOutput {
     pub events: Vec<HostEvent>,
     pub dequeued: Option<PendingWindowCreation>,
+    pub removed_browser: Option<Browser>,
+}
+
+// Manual Debug — `cef::Browser` doesn't impl Debug.
+impl std::fmt::Debug for DispatchOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DispatchOutput")
+            .field("events", &self.events)
+            .field("dequeued", &self.dequeued)
+            .field(
+                "removed_browser",
+                if self.removed_browser.is_some() {
+                    &"Some(<cef::Browser>)"
+                } else {
+                    &"None"
+                },
+            )
+            .finish()
+    }
 }
 
 /// Pure functional core of the host reducer.
@@ -633,6 +662,7 @@ fn handle_enqueue_pending_window_creation(
                 version: v,
             }],
             dequeued: None,
+            removed_browser: None,
         };
     }
     let label = entry.label.clone();
@@ -646,6 +676,7 @@ fn handle_enqueue_pending_window_creation(
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -662,6 +693,7 @@ fn handle_dequeue_pending_window_creation(state: &mut HostState) -> DispatchOutp
                     version: v,
                 }],
                 dequeued: Some(entry),
+                removed_browser: None,
             }
         }
         None => {
@@ -669,6 +701,7 @@ fn handle_dequeue_pending_window_creation(state: &mut HostState) -> DispatchOutp
             DispatchOutput {
                 events: vec![HostEvent::PendingWindowQueueEmpty { version: v }],
                 dequeued: None,
+                removed_browser: None,
             }
         }
     }
@@ -689,6 +722,7 @@ fn emit_error(state: &mut HostState, message: String) -> DispatchOutput {
     DispatchOutput {
         events: vec![HostEvent::Error { message, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -717,6 +751,7 @@ fn handle_enqueue_pane_create(
     DispatchOutput {
         events: vec![HostEvent::PaneCreateRequested { block_id, label, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -731,6 +766,7 @@ fn handle_complete_pane_create(state: &mut HostState, block_id: String) -> Dispa
     DispatchOutput {
         events: vec![HostEvent::PaneLive { block_id, label: entry.label, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -747,6 +783,7 @@ fn handle_enqueue_pane_close(state: &mut HostState, block_id: String) -> Dispatc
     DispatchOutput {
         events: vec![HostEvent::PaneClosing { block_id, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -758,6 +795,7 @@ fn handle_complete_pane_close(state: &mut HostState, block_id: String) -> Dispat
     DispatchOutput {
         events: vec![HostEvent::PaneClosed { block_id, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -771,6 +809,7 @@ fn handle_abort_pane_create(
     DispatchOutput {
         events: vec![HostEvent::PaneCreationFailed { block_id, reason, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -801,17 +840,26 @@ fn handle_register_browser(
     DispatchOutput {
         events: vec![HostEvent::BrowserRegistered { label, kind, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
 fn handle_unregister_browser(state: &mut HostState, label: String) -> DispatchOutput {
-    if state.browsers.remove(&label).is_none() {
+    // Atomic remove + return the Browser handle in `removed_browser`
+    // (codex P2 PR #660). The pane close path in
+    // `browser_panes::AppStateCloseOps::take_browser_hwnd` uses the
+    // returned Browser to extract its HWND. Any caller that doesn't
+    // need the handle can simply ignore `removed_browser`.
+    let removed = state.browsers.remove(&label);
+    let removed_browser = removed.map(|h| h.browser);
+    if removed_browser.is_none() {
         return DispatchOutput::default(); // idempotent
     }
     let v = state.bump_version();
     DispatchOutput {
         events: vec![HostEvent::BrowserUnregistered { label, version: v }],
         dequeued: None,
+        removed_browser,
     }
 }
 
@@ -828,6 +876,7 @@ fn handle_start_drag(state: &mut HostState, session: DragSession) -> DispatchOut
     DispatchOutput {
         events: vec![HostEvent::DragStarted { drag_id, source_window, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -844,6 +893,7 @@ fn handle_end_drag(
             DispatchOutput {
                 events: vec![HostEvent::DragEnded { drag_id, outcome, version: v }],
                 dequeued: None,
+                removed_browser: None,
             }
         }
         _ => DispatchOutput::default(), // mismatched or no drag; idempotent no-op
@@ -878,6 +928,7 @@ fn handle_pool_ready(state: &mut HostState, label: String) -> DispatchOutput {
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -905,6 +956,7 @@ fn handle_pool_destroyed_before_promote(state: &mut HostState, label: String) ->
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -937,6 +989,7 @@ fn handle_promote_pool_window(state: &mut HostState, label: String) -> DispatchO
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -960,7 +1013,11 @@ fn handle_pool_drain_all(state: &mut HostState) -> DispatchOutput {
     }
     let v = state.bump_version();
     events.push(HostEvent::PoolEmpty { version: v });
-    DispatchOutput { events, dequeued: None }
+    DispatchOutput {
+        events,
+        dequeued: None,
+        removed_browser: None,
+    }
 }
 
 // ── H.5 — quit lifecycle ─────────────────────────────────────────────────
@@ -974,6 +1031,7 @@ fn handle_begin_drain(state: &mut HostState, reason: QuitReason) -> DispatchOutp
     DispatchOutput {
         events: vec![HostEvent::QuitDraining { reason, version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -986,6 +1044,7 @@ fn handle_confirm_drained(state: &mut HostState) -> DispatchOutput {
     DispatchOutput {
         events: vec![HostEvent::QuitReady { version: v }],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -1013,6 +1072,7 @@ fn handle_enqueue_top_level_window(
     let mut out = DispatchOutput {
         events: vec![HostEvent::TopLevelQueueLengthChanged { len: queue_len, version: v }],
         dequeued: None,
+        removed_browser: None,
     };
     // If idle, start immediately; chain the start arm's events.
     if state.top_level_creation.in_flight.is_none() {
@@ -1080,6 +1140,7 @@ fn start_next_top_level_if_idle(state: &mut HostState) -> DispatchOutput {
             HostEvent::TopLevelQueueLengthChanged { len: queue_len, version: v_qlen },
         ],
         dequeued: None,
+        removed_browser: None,
     }
 }
 
@@ -1104,6 +1165,7 @@ fn handle_top_level_callback_fired(state: &mut HostState, label: String) -> Disp
                     version: v,
                 }],
                 dequeued: None,
+                removed_browser: None,
             };
         }
         return DispatchOutput::default();
@@ -1131,6 +1193,7 @@ fn handle_top_level_callback_fired(state: &mut HostState, label: String) -> Disp
             version: v_done,
         }],
         dequeued: None,
+        removed_browser: None,
     };
     let next = start_next_top_level_if_idle(state);
     out.events.extend(next.events);
@@ -1174,6 +1237,7 @@ fn handle_top_level_renderer_terminated(
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     };
     let next = start_next_top_level_if_idle(state);
     out.events.extend(next.events);
@@ -1213,6 +1277,7 @@ fn handle_top_level_externally_closed(state: &mut HostState, label: String) -> D
             version: v,
         }],
         dequeued: None,
+        removed_browser: None,
     };
     let next = start_next_top_level_if_idle(state);
     out.events.extend(next.events);

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -480,18 +480,13 @@ pub struct AppState {
     /// Verified on every IPC request to prevent unauthorized local access.
     pub ipc_token: String,
 
-    /// CEF Browser handles keyed by window label (multi-window support).
-    /// "main" is the primary window; tear-off windows get "window-{UUID}" labels.
-    ///
-    /// **Phase B / multi-reducer status**: this map is intentionally NOT
-    /// migrated to launcher under the standard B.5 a→b→c→d→e ratchet because
-    /// `cef::Browser` is an FFI handle to a Chromium browser object in this
-    /// process — it can't serialize over IPC and must stay co-located with
-    /// the CEF runtime. The KEY-SET role (label set queries) is already
-    /// covered by the launcher's `state.windows` mirror (B.4) +
-    /// `shadow_window_meta`. This field will be retired into a host-side
-    /// reducer in Phase F (see `docs/retro/multi-reducer-proposal-2026-04-28.md`).
-    pub browsers: Mutex<HashMap<String, Browser>>,
+    // Phase H.2.e (PR #4) — `pub browsers: Mutex<HashMap<String, Browser>>`
+    // deleted. Authoritative storage is now `HostState.browsers` (the host
+    // reducer's map). Read access goes through `AppState::get_browser`,
+    // `list_browsers`, etc. (state.rs:704-742). The H.2 ratchet
+    // (a → parallel writes, b → reads with fallback, c → flip reads,
+    // d → drop legacy writes, e → delete) is complete for browsers.
+    // Pane lifecycle (`PaneStateMachine`) follows in PR #5.
 
     /// Per-window metadata (kind, parent linkage).
     ///
@@ -632,7 +627,7 @@ impl Default for AppState {
             cli_login_stdin: Mutex::new(None),
             ipc_port: Mutex::new(0),
             ipc_token: uuid::Uuid::new_v4().to_string(),
-            browsers: Mutex::new(HashMap::new()),
+            // browsers field removed in H.2.e — see comment near struct decl.
             window_meta: Mutex::new(HashMap::new()),
             host_state: Mutex::new(crate::reducer::HostState::default()),
             window_pool: Mutex::new(VecDeque::new()),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -689,256 +689,98 @@ impl AppState {
         self.host_state.lock().pending_window_creations.back().cloned()
     }
 
-    // ── Phase H.2.b — browser read helpers (with fallback) ──────────────
+    // ── Phase H.2 — browser read helpers (reducer-only, post-flip) ──────
     //
-    // These wrap reads against `HostState.browsers` (the new reducer-managed
-    // map) with fallback to the legacy `AppState.browsers` mutex. Drift
-    // (entry in one but not the other) is logged via
-    // `target = "host-reducer:drift"` so production smoke can verify the
-    // parallel-write invariant before PR #4 flips reads to reducer-only.
+    // After PR #4's flip step (H.1.c + H.2.c), `HostState.browsers` /
+    // `HostState.panes` are the sole source of truth. Legacy reads,
+    // fallback paths, and drift logging removed — production smoke
+    // verified zero drift across 50 reducer events with a balanced
+    // BrowserRegistered/Unregistered count (18/18) and PaneCreate/
+    // PaneClosed count (7/7) before this flip.
     //
-    // Snapshot-and-drop: each helper takes the relevant lock(s) briefly,
-    // clones what's needed, drops the lock. Callers never hold either
+    // Snapshot-and-drop: each helper takes the relevant lock briefly,
+    // clones what's needed, drops the lock. Callers never hold the
     // lock across CEF FFI calls.
 
-    /// Get a browser handle by label. Legacy is authoritative;
-    /// reducer is observed only for drift detection.
-    ///
-    /// **No fallback to reducer when legacy is None** (codex P1 PR #659
-    /// round 4). Earlier rounds returned `from_legacy.or(from_reducer)`,
-    /// but that re-introduces the stale-handle race the helper was
-    /// supposed to prevent: during `on_before_close`, the browser is
-    /// removed from `state.browsers` BEFORE `UnregisterBrowser` is
-    /// dispatched, so there's a window where `legacy=None` and
-    /// `reducer=Some`. Falling back to reducer there hands callers a
-    /// Browser whose HWND is mid-teardown — old `state.browsers.lock()
-    /// .get(label).cloned()` returned `None` correctly, letting callers
-    /// skip focus/emit/host ops during close. Drop the fallback to
-    /// restore pre-existing close safety.
-    ///
-    /// Drift logged in both directions for observability; PR #4's flip
-    /// step inverts the contract — at that point legacy will be empty
-    /// and reducer becomes authoritative.
+    /// Get a browser handle by label.
     pub fn get_browser(&self, label: &str) -> Option<Browser> {
-        let from_reducer = self
-            .host_state
+        self.host_state
             .lock()
             .browsers
             .get(label)
-            .map(|h| h.browser.clone());
-        let from_legacy = self.browsers.lock().get(label).cloned();
-        match (&from_reducer, &from_legacy) {
-            (Some(_), None) => tracing::warn!(
-                target: "host-reducer:drift",
-                label = %label,
-                "browser in reducer but missing from legacy",
-            ),
-            (None, Some(_)) => tracing::warn!(
-                target: "host-reducer:drift",
-                label = %label,
-                "browser in legacy but missing from reducer",
-            ),
-            _ => {}
-        }
-        // Legacy is the sole source of truth until PR #4's flip.
-        // No fallback to reducer — that would defeat close-time safety.
-        from_legacy
+            .map(|h| h.browser.clone())
     }
 
     /// Check whether a browser is registered under the given label.
-    ///
-    /// Same legacy-authoritative contract as `get_browser`. Logs drift in
-    /// BOTH directions for observability (was reagent P2 PR #659 round 1 —
-    /// previous version short-circuited on `in_reducer` with no legacy
-    /// check, missing reducer-has-but-legacy-doesn't drift).
     pub fn has_browser(&self, label: &str) -> bool {
-        let in_reducer = self.host_state.lock().browsers.contains_key(label);
-        let in_legacy = self.browsers.lock().contains_key(label);
-        match (in_reducer, in_legacy) {
-            (true, false) => tracing::warn!(
-                target: "host-reducer:drift",
-                label = %label,
-                "has_browser: reducer has, legacy missing",
-            ),
-            (false, true) => tracing::warn!(
-                target: "host-reducer:drift",
-                label = %label,
-                "has_browser: legacy has, reducer missing",
-            ),
-            _ => {}
-        }
-        in_legacy
+        self.host_state.lock().browsers.contains_key(label)
     }
 
     /// Are there any registered browsers?
-    ///
-    /// Legacy authoritative (matches caller intent: `on_after_created`'s
-    /// `is_empty()` check decides whether to take the "main" shortcut path).
     pub fn browsers_is_empty(&self) -> bool {
-        let reducer_empty = self.host_state.lock().browsers.is_empty();
-        let legacy_empty = self.browsers.lock().is_empty();
-        if reducer_empty != legacy_empty {
-            tracing::warn!(
-                target: "host-reducer:drift",
-                reducer_empty,
-                legacy_empty,
-                "browsers is_empty drift",
-            );
-        }
-        legacy_empty
+        self.host_state.lock().browsers.is_empty()
     }
 
-    /// Snapshot of all registered browser labels (HashMap iteration order
-    /// preserved from the legacy map — stable per-HashMap-instance, same
-    /// characteristics as the original `state.browsers.lock().keys()`
-    /// pattern these helpers replaced).
-    ///
-    /// (codex P2 PR #659 round 3): previously routed through a fresh
-    /// `HashSet` per call, which has its own randomized hash seed →
-    /// non-deterministic order even when no windows changed. That caused
-    /// UI jitter in poll-driven views (`InstancePanel`'s window list).
-    /// Now Vec is built directly from legacy keys; HashSets are local to
-    /// the diff-detection logic.
+    /// Snapshot of all registered browser labels (HashMap iteration order;
+    /// stable per-HashMap-instance, same characteristics as the original
+    /// `state.browsers.lock().keys()` pattern these helpers replaced).
     pub fn list_browser_labels(&self) -> Vec<String> {
-        use std::collections::HashSet;
-        let reducer_labels: Vec<String> = self
-            .host_state
+        self.host_state
             .lock()
             .browsers
             .keys()
             .cloned()
-            .collect();
-        let legacy_labels: Vec<String> = self.browsers.lock().keys().cloned().collect();
-        // HashSets only for set-difference; legacy_labels Vec is what we return.
-        let reducer_set: HashSet<&String> = reducer_labels.iter().collect();
-        let legacy_set: HashSet<&String> = legacy_labels.iter().collect();
-        if reducer_set != legacy_set {
-            let only_reducer: Vec<&&String> =
-                reducer_set.difference(&legacy_set).collect();
-            let only_legacy: Vec<&&String> =
-                legacy_set.difference(&reducer_set).collect();
-            tracing::warn!(
-                target: "host-reducer:drift",
-                only_reducer = ?only_reducer,
-                only_legacy = ?only_legacy,
-                "browser label set drift",
-            );
-        }
-        // Legacy authoritative until PR #4 flips reads. Vec preserves
-        // HashMap iteration order (stable per instance).
-        legacy_labels
+            .collect()
     }
 
     /// Snapshot of all registered browsers as (label, Browser) pairs.
     /// Ordering is HashMap iteration order; callers must sort if order
     /// matters.
     pub fn list_browsers(&self) -> Vec<(String, Browser)> {
-        let from_reducer: Vec<(String, Browser)> = self
-            .host_state
+        self.host_state
             .lock()
             .browsers
             .iter()
             .map(|(k, h)| (k.clone(), h.browser.clone()))
-            .collect();
-        let from_legacy: Vec<(String, Browser)> = self
-            .browsers
-            .lock()
-            .iter()
-            .map(|(k, b)| (k.clone(), b.clone()))
-            .collect();
-        if from_reducer.len() != from_legacy.len() {
-            tracing::warn!(
-                target: "host-reducer:drift",
-                reducer_count = from_reducer.len(),
-                legacy_count = from_legacy.len(),
-                "browser count drift in list_browsers",
-            );
-        }
-        // Legacy is authoritative until flip.
-        from_legacy
+            .collect()
     }
 
     /// First registered browser (for "any browser" callers like command
     /// palette routing). Returns the label + Browser pair, or None if
     /// the registry is empty.
     pub fn first_browser(&self) -> Option<(String, Browser)> {
-        // Prefer the legacy iteration order (matches existing code's
-        // `.values().next()` semantics) until flip.
-        self.browsers
+        self.host_state
             .lock()
+            .browsers
             .iter()
             .next()
-            .map(|(k, b)| (k.clone(), b.clone()))
+            .map(|(k, h)| (k.clone(), h.browser.clone()))
     }
 
-    // ── Phase H.1.b — pane lifecycle read helpers (with fallback) ───────
+    // ── Phase H.1 — pane lifecycle read helpers (reducer-only, post-flip)
 
     /// Returns the pane's label iff entry is `Live`. Used by op gates
     /// (focus/resize/navigate) — `None` indicates the pane is missing or
     /// in `Closing`, in which case the caller must short-circuit rather
     /// than touch the (possibly destroyed) HWND.
-    ///
-    /// **No fallback to reducer when legacy is None** (codex P1 PR #659
-    /// round 4 — same fix as `get_browser`). The whole point of the
-    /// `Live` gate is to short-circuit ops against panes mid-teardown;
-    /// a reducer fallback would defeat that during the close window
-    /// between `try_mark_closing` (legacy flips to Closing) and
-    /// `EnqueuePaneClose` (reducer dispatch). Legacy authoritative
-    /// until PR #4's flip step.
     pub fn live_pane_label(&self, block_id: &str) -> Option<String> {
-        let from_reducer = self
-            .host_state
+        self.host_state
             .lock()
             .panes
             .get(block_id)
             .filter(|e| e.lifecycle == PaneLifecycle::Live)
-            .map(|e| e.label.clone());
-        let from_legacy = self.browser_panes.test_live_label_of(block_id);
-        if from_reducer != from_legacy {
-            tracing::warn!(
-                target: "host-reducer:drift",
-                block_id = %block_id,
-                reducer = ?from_reducer,
-                legacy = ?from_legacy,
-                "live_pane_label drift",
-            );
-        }
-        // Legacy is the sole source of truth until PR #4's flip.
-        from_legacy
+            .map(|e| e.label.clone())
     }
 
     /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.
-    /// Order preserved from `PaneStateMachine.live_labels()` (legacy
-    /// HashMap iteration order — stable per instance, same as the
-    /// original code these helpers replaced). HashSets are local to
-    /// the drift-detection logic only.
     pub fn live_pane_labels(&self) -> Vec<String> {
-        use std::collections::HashSet;
-        let reducer_labels: Vec<String> = self
-            .host_state
+        self.host_state
             .lock()
             .panes
             .values()
             .filter(|e| e.lifecycle == PaneLifecycle::Live)
             .map(|e| e.label.clone())
-            .collect();
-        let legacy_labels: Vec<String> = self.browser_panes.test_live_labels();
-        let reducer_set: HashSet<&String> = reducer_labels.iter().collect();
-        let legacy_set: HashSet<&String> = legacy_labels.iter().collect();
-        if reducer_set != legacy_set {
-            let only_reducer: Vec<&&String> =
-                reducer_set.difference(&legacy_set).collect();
-            let only_legacy: Vec<&&String> =
-                legacy_set.difference(&reducer_set).collect();
-            tracing::warn!(
-                target: "host-reducer:drift",
-                only_reducer = ?only_reducer,
-                only_legacy = ?only_legacy,
-                "live_pane_labels set drift",
-            );
-        }
-        // Legacy authoritative until PR #4 flips reads.
-        legacy_labels
+            .collect()
     }
 
     /// Phase B.5e — authoritative instance-number lookup. Reads

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -701,20 +701,24 @@ impl AppState {
     // clones what's needed, drops the lock. Callers never hold either
     // lock across CEF FFI calls.
 
-    /// Get a browser handle by label. Legacy is authoritative; reducer
-    /// fallback (codex P1 + reagent P1 PR #659 round 2).
+    /// Get a browser handle by label. Legacy is authoritative;
+    /// reducer is observed only for drift detection.
     ///
-    /// **Why legacy first:** during the parallel-write phase the close
-    /// paths (`on_before_close`, pane close) remove from legacy FIRST and
-    /// dispatch `UnregisterBrowser` afterward. If we returned reducer-first,
-    /// concurrent readers in that drift window would observe `legacy=None`
-    /// but `reducer=Some` — handing back a Browser handle that legacy has
-    /// already retired (its HWND is mid-teardown). That regresses behavior
-    /// vs the original `state.browsers.lock().get(label).cloned()` which
-    /// returned `None` correctly during close.
+    /// **No fallback to reducer when legacy is None** (codex P1 PR #659
+    /// round 4). Earlier rounds returned `from_legacy.or(from_reducer)`,
+    /// but that re-introduces the stale-handle race the helper was
+    /// supposed to prevent: during `on_before_close`, the browser is
+    /// removed from `state.browsers` BEFORE `UnregisterBrowser` is
+    /// dispatched, so there's a window where `legacy=None` and
+    /// `reducer=Some`. Falling back to reducer there hands callers a
+    /// Browser whose HWND is mid-teardown — old `state.browsers.lock()
+    /// .get(label).cloned()` returned `None` correctly, letting callers
+    /// skip focus/emit/host ops during close. Drop the fallback to
+    /// restore pre-existing close safety.
     ///
-    /// Drift logged in both directions for observability before PR #4 flips
-    /// to reducer-only.
+    /// Drift logged in both directions for observability; PR #4's flip
+    /// step inverts the contract — at that point legacy will be empty
+    /// and reducer becomes authoritative.
     pub fn get_browser(&self, label: &str) -> Option<Browser> {
         let from_reducer = self
             .host_state
@@ -736,8 +740,9 @@ impl AppState {
             ),
             _ => {}
         }
-        // Legacy authoritative until PR #4 flips reads.
-        from_legacy.or(from_reducer)
+        // Legacy is the sole source of truth until PR #4's flip.
+        // No fallback to reducer — that would defeat close-time safety.
+        from_legacy
     }
 
     /// Check whether a browser is registered under the given label.
@@ -872,6 +877,14 @@ impl AppState {
     /// (focus/resize/navigate) — `None` indicates the pane is missing or
     /// in `Closing`, in which case the caller must short-circuit rather
     /// than touch the (possibly destroyed) HWND.
+    ///
+    /// **No fallback to reducer when legacy is None** (codex P1 PR #659
+    /// round 4 — same fix as `get_browser`). The whole point of the
+    /// `Live` gate is to short-circuit ops against panes mid-teardown;
+    /// a reducer fallback would defeat that during the close window
+    /// between `try_mark_closing` (legacy flips to Closing) and
+    /// `EnqueuePaneClose` (reducer dispatch). Legacy authoritative
+    /// until PR #4's flip step.
     pub fn live_pane_label(&self, block_id: &str) -> Option<String> {
         let from_reducer = self
             .host_state
@@ -890,7 +903,8 @@ impl AppState {
                 "live_pane_label drift",
             );
         }
-        from_legacy.or(from_reducer)
+        // Legacy is the sole source of truth until PR #4's flip.
+        from_legacy
     }
 
     /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.584"
+version = "0.33.585"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.585"
+version = "0.33.586"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.585"
+version = "0.33.586"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.584"
+version = "0.33.585"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.585"
+version = "0.33.586"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.584"
+version = "0.33.585"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.585",
+  "version": "0.33.586",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.585",
+      "version": "0.33.586",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.584",
+  "version": "0.33.585",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.584",
+      "version": "0.33.585",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.584",
+  "version": "0.33.585",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.585",
+  "version": "0.33.586",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #4 completes the **H.2 browsers ratchet** (a→b→c→d→e) for CEF browser handle storage. \`AppState.browsers: Mutex<HashMap>\` is **deleted**; the host reducer's \`HostState.browsers\` is the sole source of truth. Also folds in the codex P1 fix from PR #659.

**Pane lifecycle (H.1) still has steps d+e to do** — production reads are reducer-only since H.1.c flipped, but \`PaneStateMachine\` continues parallel-writing. **PR #5** drops those writes and deletes the struct (more test infrastructure churn; deferred for clean separation).

## Production smoke verified parity (0.33.585)

Before this PR's flip step, smoke test on 0.33.585 (PR #4 commit 1) confirmed **zero \`host-reducer:drift\` warnings** across 50 reducer events:
- 18 BrowserRegistered + 18 BrowserUnregistered (perfect balance, no orphans)
- 7 PaneCreate + 7 PaneClosed (perfect balance)
- All across multi-window opens, browser pane lifecycles, drag operations

Reducer state was provably in lockstep with legacy → safe to flip + drop + delete.

## Four commits

### Commit 1 — codex P1 fix from PR #659 (\`ce60e9f1\`)

PR #659's round-2 fix changed \`get_browser\` to \`from_legacy.or(from_reducer)\`, but the \`.or()\` fallback itself was the bug. With \`legacy=None, reducer=Some\` (the close race window between \`browsers.remove\` and \`UnregisterBrowser\` dispatch), readers got reducer's stale handle to a closing browser. Original \`state.browsers.lock().get().cloned()\` returned \`None\` correctly.

**Fix:** dropped the \`.or(from_reducer)\` fallback in \`get_browser\` and \`live_pane_label\`. Reducer observed only for drift detection; legacy was the SOLE source of truth for the return value. (\`has_browser\` and \`browsers_is_empty\` already returned legacy directly.)

### Commit 2 — H.1.c + H.2.c: flip reads to reducer-only (\`0768414f\`)

All 7 read helpers in \`AppState\` now read ONLY from \`HostState\`. Removed:
- All legacy reads (\`state.browsers.lock()\`, \`browser_panes.test_live_*\`)
- Drift logging (target=\`host-reducer:drift\` retired)
- HashSet diff machinery (no longer needed without comparison)

Code reduction: 167 lines removed, 51 added.

### Commit 3 — H.2.d: drop legacy state.browsers writes (\`9630278c\`)

Three legacy mutation sites removed; reducer is sole canonical mutation:

1. \`client.rs::on_after_created\` — \`browsers.insert(label, browser)\` removed. Total counter reads from \`host_state.lock().browsers.len()\`.
2. \`client.rs::on_before_close\` — \`browsers.remove(lbl)\` removed. Find-by-identity loop iterates the reducer-backed snapshot via \`state.list_browsers()\`.
3. \`commands/window_pool.rs::cleanup_failed_promote_orphan\` — manual cleanup path's \`state.browsers.lock().remove(label)\` removed.

After this commit, \`grep state.browsers.lock\` returns zero hits in production code.

### Commit 4 — H.2.e: delete AppState.browsers field (\`eed4013f\`)

The \`browsers\` ratchet (a→b→c→d→e) is complete. Field deleted. \`AppStateCloseOps::take_browser_hwnd\` was the last remaining ref — swapped its \`state.browsers.lock().remove(label)?\` for \`state.get_browser(label)?\` followed by \`UnregisterBrowser\` dispatch.

## Test plan

- [x] \`cargo check -p agentmux-cef\` clean (only pre-existing warnings)
- [x] \`cargo test -p agentmux-cef --bin agentmux-cef -- pane:: browser_panes:: reducer::\` → 59/59 passing
- [x] Smoke test on 0.33.585 (commit 1) verified zero drift across 50 reducer events
- [ ] Bot review (reagentx-workflow + codex)

## Bump

Patch: \`0.33.584 → 0.33.586\` (skips 585 used for the smoke build).

## Updated 7-PR plan progress

| PR | Status | Scope |
|---|---|---|
| #654 ✅ | merged | H.0 foundations |
| #655 ✅ | merged | H.1.a + H.2.a parallel writes |
| #659 ✅ | merged | H.1.b + H.2.b reads-with-fallback |
| **#4 (this)** | review | codex P1 fix + H.1.c + H.2.c + H.2.d + H.2.e |
| #5 | — | H.1.d + H.1.e (drop pane writes, delete PaneStateMachine) + H.3 (drag) + H.4 (pool) + H.5 (quit) |
| #6 | — | H.6 (top-level runner) + H.7 (cross-state sagas) |
| #7 | — | H.8 (durability) + H.9 (wire-promote events) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)