### PR TITLE
fix(linux): drag + right-click coexistence on the window header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.589"
+version = "0.33.590"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.589"
+version = "0.33.590"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.589"
+version = "0.33.590"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.589"
+version = "0.33.590"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.589"
+version = "0.33.590"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -302,7 +302,7 @@ wrap_browser_process_handler! {
                 windowless_frame_rate: 60,
                 // Dark background to match app theme — prevents white bleed-through
                 // when terminal panes use transparency.
-                background_color: 0xFF000000, // ARGB: opaque black
+                background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
                 ..Default::default()
             };
 

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -219,33 +219,25 @@ impl BrowserPaneManager {
     }
 
     pub fn resize(&self, block_id: &str, rect: Rect, state: &Arc<AppState>) {
+        #[cfg(target_os = "windows")]
         if let Some(browser) = self.live_browser(state, block_id) {
             if let Some(host) = browser.host() {
                 let hwnd = host.window_handle();
                 if !hwnd.0.is_null() {
-                    #[cfg(target_os = "windows")]
                     unsafe {
-                        // HWND_TOP = 0 brings the window to the top of the Z-order
-                        // within its parent. SWP_NOACTIVATE keeps keyboard focus where
-                        // it is. We MUST keep the pane on top of the main browser's
-                        // Chrome_RenderWidgetHostHWND — otherwise mouse-wheel events
-                        // over the visible pane area hit main's widget (higher in
-                        // Z-order) instead of the pane, and scrolling is broken.
                         windows_sys::Win32::UI::WindowsAndMessaging::SetWindowPos(
                             hwnd.0 as _,
-                            std::ptr::null_mut(), // HWND_TOP
+                            std::ptr::null_mut(),
                             rect.x, rect.y, rect.width, rect.height,
                             0x0010, // SWP_NOACTIVATE
                         );
                     }
-                    // Tell Chromium the pane has been moved/resized so its cached
-                    // screen bounds are updated — without this, hit-tests on
-                    // scrollbars and drag operations use stale coordinates and
-                    // drags are rejected / misrouted.
                     host.notify_move_or_resize_started();
                 }
             }
         }
+        #[cfg(not(target_os = "windows"))]
+        { let _ = (block_id, rect, state); }
     }
 
     /// Close a pane by destroying its child HWND directly and dropping the

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1325,6 +1325,13 @@ wrap_client! {
             Some(AgentMuxRequestHandler::new(self.inner.clone()))
         }
 
+        fn drag_handler(&self) -> Option<DragHandler> {
+            if self.is_pane {
+                return None;
+            }
+            Some(AgentMuxDragHandler::new(self.inner.clone()))
+        }
+
         fn focus_handler(&self) -> Option<FocusHandler> {
             // For browser panes only: cancel CEF's auto-focus on navigation so the
             // child HWND doesn't steal keyboard focus from the main window when the
@@ -1375,6 +1382,41 @@ wrap_focus_handler! {
 }
 
 // ---------------------------------------------------------------------------
+// DragHandler — register draggable regions with the CefWindow for window drag.
+//
+// NOTE(Linux/Wayland): CEF's WindowEventFilterLinux consumes right-clicks on
+// HTCAPTION areas and shows the GNOME window menu. For local testing we binary
+// patch libcef.so (see docs/BINARY-PATCH-LINUX-DRAG.md). A production release
+// requires rebuilding CEF with the source fix.
+
+wrap_drag_handler! {
+    struct AgentMuxDragHandler {
+        inner: Arc<Mutex<AgentMuxHandler>>,
+    }
+
+    impl DragHandler {
+        fn on_draggable_regions_changed(
+            &self,
+            browser: Option<&mut Browser>,
+            _frame: Option<&mut Frame>,
+            regions: Option<&[DraggableRegion]>,
+        ) {
+            if let Some(rs) = regions {
+                let summary: Vec<String> = rs.iter().map(|r| {
+                    format!("{}x{}@{},{} drag={}", r.bounds.width, r.bounds.height, r.bounds.x, r.bounds.y, r.draggable != 0)
+                }).collect();
+                tracing::info!("[drag_handler] on_draggable_regions_changed: {} regions — {:?}", rs.len(), summary);
+            } else {
+                tracing::info!("[drag_handler] on_draggable_regions_changed: None");
+            }
+            let mut browser = browser.cloned();
+            let Some(browser_view) = browser_view_get_for_browser(browser.as_mut()) else { return };
+            let Some(window) = browser_view.window() else { return };
+            window.set_draggable_regions(regions);
+        }
+    }
+}
+
 // KeyboardHandler — intercept Ctrl+<key> shortcuts before CEF/Chromium
 // consumes them (e.g., Ctrl+P = print, Ctrl+G = find-next).
 // Returning true from on_pre_key_event tells CEF "handled" so it won't
@@ -1396,7 +1438,7 @@ wrap_keyboard_handler! {
             &self,
             _browser: Option<&mut Browser>,
             event: Option<&KeyEvent>,
-            _os_event: Option<&mut cef::sys::MSG>,
+            _os_event: Option<&mut crate::OsKeyEvent>,
             is_keyboard_shortcut: Option<&mut ::std::os::raw::c_int>,
         ) -> ::std::os::raw::c_int {
             if let Some(ev) = event {

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1382,12 +1382,17 @@ wrap_focus_handler! {
 }
 
 // ---------------------------------------------------------------------------
-// DragHandler — register draggable regions with the CefWindow for window drag.
+// DragHandler — handles `-webkit-app-region: drag` regions reported by the
+// renderer (used on macOS/Windows where native draggable regions work).
 //
-// NOTE(Linux/Wayland): CEF's WindowEventFilterLinux consumes right-clicks on
-// HTCAPTION areas and shows the GNOME window menu. For local testing we binary
-// patch libcef.so (see docs/BINARY-PATCH-LINUX-DRAG.md). A production release
-// requires rebuilding CEF with the source fix.
+// NOTE(Linux): On Linux/Wayland we do NOT use -webkit-app-region: drag for
+// window-move because Chromium suppresses ALL events on drag regions before
+// they reach the renderer (verified empirically), making drag mutually
+// exclusive with right-click contextmenu on the same element. Linux drag is
+// JS-driven instead — see frontend/app/hook/useWindowDrag.linux.ts and
+// the start_window_drag IPC → CefWindow::BeginWindowDrag() (CEF source
+// patch in agentmux/7680-... branch). Retro:
+// docs/retros/2026-05-02-drag-and-rightclick-coexistence.md.
 
 wrap_drag_handler! {
     struct AgentMuxDragHandler {

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -622,6 +622,7 @@ pub fn tear_off_sc_move_handshake(
 /// or the deadline elapses. Returns the HWND as a raw pointer.
 /// Releases the browsers mutex between polls so on_after_created can
 /// register on the UI thread.
+#[cfg(target_os = "windows")]
 fn wait_for_browser_hwnd(
     state: &Arc<AppState>,
     label: &str,

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -47,10 +47,17 @@ use std::sync::Arc;
 use cef::*;
 
 /// Platform-specific type for OS key events in KeyboardHandler.
+/// Matches `cef_event_handle_t` after deref:
+///   - Windows:  *mut MSG          → MSG
+///   - Linux:    *mut XEvent       → _XEvent (libX11)
+///   - macOS:    *mut c_void       → c_void  (NSEvent-backed; cef-dll-sys
+///                                            uses an opaque pointer here)
 #[cfg(target_os = "windows")]
 pub type OsKeyEvent = cef::sys::MSG;
-#[cfg(not(target_os = "windows"))]
+#[cfg(target_os = "linux")]
 pub type OsKeyEvent = cef::sys::_XEvent;
+#[cfg(target_os = "macos")]
+pub type OsKeyEvent = std::ffi::c_void;
 
 fn main() {
     // Set the DLL search path so CEF's runtime LoadLibrary calls (chrome_elf,

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -46,6 +46,12 @@ use std::sync::Arc;
 
 use cef::*;
 
+/// Platform-specific type for OS key events in KeyboardHandler.
+#[cfg(target_os = "windows")]
+pub type OsKeyEvent = cef::sys::MSG;
+#[cfg(not(target_os = "windows"))]
+pub type OsKeyEvent = cef::sys::_XEvent;
+
 fn main() {
     // Set the DLL search path so CEF's runtime LoadLibrary calls (chrome_elf,
     // libEGL, libGLESv2, d3dcompiler_47, …) resolve against the directory that
@@ -406,7 +412,7 @@ fn main() {
 
     let settings = Settings {
         no_sandbox: 1,
-        background_color: 0xFF000000,
+        background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
         remote_debugging_port: debug_port as i32,
         root_cache_path: cache_dir,
         resources_dir_path: resources_dir,

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -145,8 +145,59 @@ pub fn post_focus_window(state: &Arc<AppState>, label: &str) {
 
 // ── Drag ─────────────────────────────────────────────────────────────────
 // CEF Views does not expose a programmatic drag-initiation API.
-// Window dragging on Linux/macOS uses the WindowDelegate draggable regions.
-// TODO: implement via X11 _NET_WM_MOVERESIZE for programmatic drag.
+// Begin a native window-move via the underlying CefWindow's BeginWindowDrag().
+// Posted on the CEF UI thread (RunMoveLoop must be called there). On
+// Linux/Wayland this issues xdg_toplevel.move with the most recent input
+// serial; on X11 it dispatches an XEvent for _NET_WM_MOVERESIZE; on macOS
+// it begins a system move loop. The compositor handles the drag until the
+// user releases the mouse button.
+//
+// Triggered by `start_window_drag` IPC from the renderer (useWindowDrag.linux.ts).
+// The renderer detects a left-button-down + threshold-crossing motion on a
+// HTCLIENT header element (NOT -webkit-app-region: drag — that suppresses
+// renderer events) and sends this IPC to initiate native drag.
+//
+// Requires CEF Patch: BeginWindowDrag added to CefWindow API (libcef/browser/views/window_impl.cc).
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct StartWindowDragTask {
+        state: Arc<AppState>,
+        label: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Call CefWindow::BeginWindowDrag via raw FFI. The cef Rust
+            // crate doesn't have a typed wrapper for our extension method
+            // (it's appended to _cef_window_t after get_runtime_style),
+            // so we get the raw *mut _cef_window_t and invoke the function
+            // pointer directly. cef-dll-sys's binding has been patched to
+            // include the begin_window_drag field at the end of the struct.
+            use cef::ImplWindow;
+            if let Some(window) = get_window_on_ui(&self.state, &self.label) {
+                let raw_ptr = <cef::Window as ImplWindow>::get_raw(&window);
+                unsafe {
+                    if let Some(f) = (*raw_ptr).begin_window_drag {
+                        let result = f(raw_ptr);
+                        tracing::info!("[start_window_drag] BeginWindowDrag returned {} label={}", result, self.label);
+                    } else {
+                        tracing::warn!("[start_window_drag] BeginWindowDrag fn ptr is null (libcef.so doesn't have AgentMux patch?) label={}", self.label);
+                    }
+                }
+            } else {
+                tracing::warn!("[start_window_drag] no window for label={}", self.label);
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn post_start_drag(state: &Arc<AppState>, label: &str) {
+    let mut task = StartWindowDragTask::new(state.clone(), label.to_string());
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+#[cfg(target_os = "windows")]
 pub fn post_start_drag(_state: &Arc<AppState>, _label: &str) {}
 
 // ── Move window ───────────────────────────────────────────────────────────
@@ -275,7 +326,7 @@ wrap_task! {
             tracing::info!(label = %self.label, "[create-window] task entered UI thread");
 
             let settings = BrowserSettings {
-                background_color: 0xFF000000,
+                background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
                 ..Default::default()
             };
             let cef_url = CefString::from(self.url.as_str());

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -146,11 +146,13 @@ pub fn post_focus_window(state: &Arc<AppState>, label: &str) {
 // ── Drag ─────────────────────────────────────────────────────────────────
 // CEF Views does not expose a programmatic drag-initiation API.
 // Begin a native window-move via the underlying CefWindow's BeginWindowDrag().
-// Posted on the CEF UI thread (RunMoveLoop must be called there). On
-// Linux/Wayland this issues xdg_toplevel.move with the most recent input
-// serial; on X11 it dispatches an XEvent for _NET_WM_MOVERESIZE; on macOS
-// it begins a system move loop. The compositor handles the drag until the
-// user releases the mouse button.
+// Posted on the CEF UI thread (BeginWindowDrag must be called there). On
+// Linux/Wayland this dispatches WmMoveResizeHandler::DispatchHostWindowDragMovement
+// → xdg_toplevel.move with the most recent input serial; on X11 it dispatches
+// an XEvent for _NET_WM_MOVERESIZE; on macOS it begins a system move loop.
+// The compositor handles the drag until the user releases the mouse button.
+// Note: views::Widget::RunMoveLoop() is the wrong API on Wayland (returns
+// immediately with a non-zero result) — see retro for details.
 //
 // Triggered by `start_window_drag` IPC from the renderer (useWindowDrag.linux.ts).
 // The renderer detects a left-button-down + threshold-crossing motion on a

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -173,15 +173,32 @@ wrap_task! {
             // so we get the raw *mut _cef_window_t and invoke the function
             // pointer directly. cef-dll-sys's binding has been patched to
             // include the begin_window_drag field at the end of the struct.
+            //
+            // Runtime ABI guard: every CEF struct begins with a size field
+            // (cef_base_ref_counted_t.size) populated by libcef itself. If
+            // libcef wasn't built from the AgentMux a5af/cef branch, the
+            // size will be the upstream value (≠ size_of::<_cef_window_t>()
+            // here, since our cef-dll-sys binding has begin_window_drag
+            // appended) and reading the extension slot would be UB. Bail
+            // out cleanly when sizes diverge.
             use cef::ImplWindow;
             if let Some(window) = get_window_on_ui(&self.state, &self.label) {
                 let raw_ptr = <cef::Window as ImplWindow>::get_raw(&window);
                 unsafe {
+                    let runtime_size = (*raw_ptr).base.base.base.size;
+                    let expected_size = std::mem::size_of::<cef::sys::_cef_window_t>();
+                    if runtime_size != expected_size {
+                        tracing::warn!(
+                            "[start_window_drag] libcef.so ABI mismatch — runtime _cef_window_t.size={} expected={} (libcef.so was not built from agentmux/7680-...; skipping native drag) label={}",
+                            runtime_size, expected_size, self.label
+                        );
+                        return;
+                    }
                     if let Some(f) = (*raw_ptr).begin_window_drag {
                         let result = f(raw_ptr);
                         tracing::info!("[start_window_drag] BeginWindowDrag returned {} label={}", result, self.label);
                     } else {
-                        tracing::warn!("[start_window_drag] BeginWindowDrag fn ptr is null (libcef.so doesn't have AgentMux patch?) label={}", self.label);
+                        tracing::warn!("[start_window_drag] BeginWindowDrag fn ptr is null label={}", self.label);
                     }
                 }
             } else {

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.589"
+version = "0.33.590"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.589"
+version = "0.33.590"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.589"
+version = "0.33.590"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retros/2026-05-02-drag-and-rightclick-coexistence.md
+++ b/docs/retros/2026-05-02-drag-and-rightclick-coexistence.md
@@ -1,0 +1,162 @@
+# Retro: Left-Click Drag + Right-Click Context Menu Coexistence on CEF/Wayland
+
+**Date:** 2026-05-02
+**Outcome:** Both work. Native window drag from any HTCLIENT header element + standard contextmenu on the same element.
+
+---
+
+## The original problem
+
+On Ubuntu/GNOME/Wayland (Mutter), AgentMux's window header needed two things at once:
+- **Left-click drag** anywhere in the empty middle of the title bar should move the window.
+- **Right-click** anywhere in the same area should fire the window-header context menu.
+
+The Linux SCSS already had this comment, predating us:
+
+> NOTE: do NOT set `-webkit-app-region: drag` on the whole header. That makes
+> the header HTCAPTION on Wayland, and right-click on HTCAPTION is consumed
+> by the compositor — the renderer never sees `contextmenu`, so the app
+> header menu can't open.
+
+CEF Patch A (`41802fe60`, "Patch A: Let right-clicks on HTCAPTION fall through to renderer") was added to libcef.so to fix the right-click side. The intent: in `WindowEventFilterLinux::HandleMouseEventWithHitTest`, return `false` for right-click on HTCAPTION instead of consuming it, so the event would propagate through the handler chain to the renderer's `contextmenu` pipeline.
+
+## What we found
+
+### Diagnosis #1 — empirical confirmation that Patch A is incomplete
+
+I added `-webkit-app-region: drag` to `.tab-bar-fill` (the wide gap between tabs and right-side buttons). Result:
+- ✅ Drag worked end-to-end. Window moved.
+- ❌ Right-click on the same area showed no menu (not even the tab/widget contextmenu — nothing).
+
+To prove the renderer wasn't seeing the events, I injected a document-level **capture-phase** listener via DevTools `Runtime.evaluate`:
+
+```javascript
+document.addEventListener('mousedown', e => window.__amxctlEvents.push({...}), true);
+document.addEventListener('contextmenu', e => window.__amxctlEvents.push({...}), true);
+```
+
+User did three right-clicks: tab, drag area, widget. Captured events:
+- Right-click on tab (`HTCLIENT`): `mousedown(button=2)` + `contextmenu` ✓
+- Right-click on widget (`HTCLIENT`): `mousedown(button=2)` + `contextmenu` ✓
+- Right-click on drag area (`HTCAPTION`): **zero events**
+
+Verdict: **Chromium architecturally suppresses ALL events on `-webkit-app-region: drag` elements before they reach the renderer process.** Capture phase, JS handlers, none of it matters — the events don't enter the renderer's input pipeline at all. Patch A's `return false` from `WindowEventFilterLinux` is *necessary but not sufficient*; the events are gone before they reach that handler in the renderer-targeted path. So `-webkit-app-region: drag` and `contextmenu` are **mutually exclusive** on the same element.
+
+### Diagnosis #2 — the dock occlusion red herring
+
+Earlier sessions blamed Ubuntu's left-edge dock for occluding the existing `.window-drag.left` strip (60×27 at window x=0–60). That was a real issue (and the dock does cover that strip), but it explained "user can't drag from the visible header" — not the deeper question of "why does drag preclude right-click." The dock was a separate issue we eventually moved past once we made the wider `.tab-bar-fill` draggable.
+
+### Diagnosis #3 — false starts on the FFI
+
+Once I committed to the proper fix (JS-driven drag calling a new CEF API), I added a `BeginWindowDrag` method to `CefWindow`. First impl used `views::Widget::RunMoveLoop` (the documented public API for window move). Returned `2` from Rust's perspective.
+
+I spent half an hour chasing struct-layout / ABI / cef-dll-sys version mismatch theories. After verifying:
+- Field counts in cef_window_capi.h matched cef-dll-sys binding (43 methods + 1 `base`)
+- Field ORDER matched
+- Sizes matched (post my +896 byte patch from 888)
+- Cef-dll-sys 146.7 + libcef.so 146.0.7680.179 + my appended `begin_window_drag` field
+
+…I temporarily replaced the impl with `return true;` to isolate the FFI plumbing. Got `1` back — FFI was fine. So `RunMoveLoop` was returning some value I just didn't expect, and the real question was whether RunMoveLoop is even the right API on Wayland.
+
+It isn't. On Aura/Wayland, the right path is `WmMoveResizeHandler::DispatchHostWindowDragMovement(HTCAPTION, point)`, which dispatches `xdg_toplevel.move` directly. RunMoveLoop is a synchronous nested message loop intended primarily for X11 (`_NET_WM_MOVERESIZE` initiated synchronously). On Wayland it apparently completes immediately with some unhelpful status.
+
+## The fix that worked
+
+### CEF source patch (`libcef/include/views/cef_window.h` + `window_impl.{h,cc}`)
+
+Added `bool BeginWindowDrag()` as a new public method on `CefWindow`. Crucially, **placed at the end of the class** so the generated C struct (`_cef_window_t`) gets the new function pointer appended at the end of its vtable — this preserves all existing field offsets and keeps ABI compatibility with the downstream `cef-dll-sys` Rust bindings.
+
+```cpp
+bool CefWindowImpl::BeginWindowDrag() {
+  CEF_REQUIRE_VALID_RETURN(false);
+  if (!widget_) return false;
+#if BUILDFLAG(IS_OZONE)
+  auto* native_view = widget_->GetNativeView();
+  if (!native_view) return false;
+  auto* host = native_view->GetHost();
+  if (!host) return false;
+  auto* platform_host = static_cast<aura::WindowTreeHostPlatform*>(host);
+  auto* platform_window = platform_host->platform_window();
+  if (!platform_window) return false;
+  auto* handler = ui::GetWmMoveResizeHandler(*platform_window);
+  if (!handler) return false;
+  handler->DispatchHostWindowDragMovement(HTCAPTION, gfx::Point());
+  return true;
+#else
+  return false;
+#endif
+}
+```
+
+The trick was finding `aura::WindowTreeHostPlatform::platform_window()` — public accessor (unlike `views::DesktopWindowTreeHostPlatform::platform_window()` which is protected). Static-cast from `aura::WindowTreeHost*` to `aura::WindowTreeHostPlatform*` is safe on Linux/Ozone because the host always *is* WindowTreeHostPlatform there.
+
+### Translator + Rust binding patches
+
+Ran `tools/translator.py` to regenerate the C API headers + cpptoc/ctocpp wrappers.
+
+The `cef` Rust crate has hardcoded bindings (NOT generated from headers — they ship pre-baked in `src/bindings/x86_64_unknown_linux_gnu.rs`). And `cef-dll-sys` has hardcoded bindings too plus compile-time size asserts. Two manual patches needed:
+
+1. **`cef-dll-sys` `_cef_window_t`** — append `pub begin_window_drag` field at the end, mirroring the C struct. Done via a Python script (`/tmp/patch_cef_dllsys.py`) so it patches all 5 cached versions.
+2. **`cef-dll-sys` size assert** — bumped `888` → `896` (one extra `*const fn` = 8 bytes).
+
+The `cef` crate doesn't have a typed wrapper for our extension method, so the call goes through raw FFI on `*mut _cef_window_t`:
+
+```rust
+let raw_ptr = <cef::Window as ImplWindow>::get_raw(&window);
+unsafe {
+    if let Some(f) = (*raw_ptr).begin_window_drag {
+        f(raw_ptr);
+    }
+}
+```
+
+(Disambiguating `get_raw` is needed because `Window` implements `ImplView`, `ImplPanel`, AND `ImplWindow`, all with their own `get_raw`.)
+
+### Rust IPC + UI-thread task
+
+`agentmux-cef/src/ui_tasks.rs` got a `StartWindowDragTask` that runs on the CEF UI thread. The IPC handler `start_window_drag` (already wired in `ipc.rs`) posts this task. Nothing fancy — single task, single FFI call, no state.
+
+### Frontend (`useWindowDrag.linux.ts`)
+
+The header element gets `data-drag-region="true"` (a marker, NOT `-webkit-app-region: drag`). Document-level mousedown listener:
+- Left button (button === 0) only — right-click is left to standard `contextmenu` propagation
+- Records press position
+- On `mousemove` exceeding 4-pixel threshold (matches Chrome's drag threshold + Mutter's input-gesture threshold), sends ONE IPC `start_window_drag` and stops listening
+- Compositor handles the rest of the drag until mouseup
+- Double-click on drag region toggles maximize via existing IPC
+
+The element stays `HTCLIENT` so right-click `contextmenu` propagates normally to `.window-header`'s `handleContextMenu` handler.
+
+## Lessons
+
+1. **`-webkit-app-region: drag` is total**. Don't trust upstream comments / patches that promise "events will fall through" without verifying with a capture-phase listener in DevTools. Chromium's drag region implementation suppresses events at the input-routing layer, well before any handler can intercept them.
+2. **The right Wayland API is `DispatchHostWindowDragMovement`, not `RunMoveLoop`.** Aura's `RunMoveLoop` is X11-flavored — it kind of works but doesn't do the right thing on Wayland for our use case. The handler-based path is non-blocking and goes directly to `xdg_toplevel.move`.
+3. **When extending CEF's vtable, append at the end of the class.** Never insert in the middle. Field offsets in the generated C struct match declaration order, and downstream Rust bindings (`cef-dll-sys`, `cef`) hardcode those offsets via field positions and size asserts. End-only growth = ABI-compatible extension.
+4. **`aura::WindowTreeHostPlatform::platform_window()` is public.** I wasted time digging through `views::DesktopWindowTreeHost*` looking for protected accessors. The aura layer below has the public method we wanted.
+5. **Capture-phase document listener is the gold-standard diagnostic** for "is this event reaching the renderer at all." Three lines of `Runtime.evaluate` answered a question that two days of speculation couldn't.
+6. **When debugging unexpected FFI return values, hardcode the C++ side first.** I burned time speculating about ABI mismatches when the simplest experiment (`return true;`) would have isolated the FFI vs. impl in 2 minutes. (And it did — `RunMoveLoop` was just behaving weirdly, not the FFI.)
+
+## Files changed
+
+CEF fork (`agentmux/7680-drag-rightclick-and-transparency` branch on `github.com/a5af/cef.git`):
+- `include/views/cef_window.h` — add `BeginWindowDrag()` at end of `CefWindow` class
+- `libcef/browser/views/window_impl.{h,cc}` — implementation calling `WmMoveResizeHandler::DispatchHostWindowDragMovement`
+- Auto-generated: `include/capi/views/cef_window_capi.h`, `cef_window_capi_versions.h`, `libcef_dll/cpptoc/views/window_cpptoc.cc`, `libcef_dll/ctocpp/views/window_ctocpp.{h,cc}`
+
+`cef-dll-sys` cargo cache (one-time edit, 5 versions in registry):
+- Append `pub begin_window_drag` field to `_cef_window_t` struct
+- Bump `Size of _cef_window_t` assert from 888 → 896
+- Patch script: `/tmp/patch_cef_dllsys.py`
+
+agentmux:
+- `agentmux-cef/src/ui_tasks.rs` — `StartWindowDragTask` + `post_start_drag` (Linux/macOS)
+- `frontend/app/hook/useWindowDrag.linux.ts` — JS-driven mousedown threshold + IPC dispatch
+- `frontend/app/window/window-header.linux.scss` — removed `.tab-bar-fill { -webkit-app-region: drag }`, replaced with explanatory comment pointing to this approach
+
+## Next steps
+
+- The cef-dll-sys cache patch is ephemeral (will be wiped by `cargo update` or registry refresh). Two long-term options:
+  - Vendor the modified cef-dll-sys (`[patch.crates-io]` in workspace `Cargo.toml`)
+  - Upstream the BeginWindowDrag API to chromiumembedded/cef so the `cef` crate eventually picks it up natively
+- The `widget_->IsMoveLoopSupported()` check we tried was a red herring; not needed for the WmMoveResizeHandler path.
+- Consider exposing X11/Windows pointer location for the `DispatchHostWindowDragMovement` call. Currently passes `gfx::Point()` which Wayland ignores but X11 may use for `_NET_WM_MOVERESIZE`. Forward the renderer's `mousedown.screenX/screenY` through the IPC if X11 reliability proves insufficient.

--- a/frontend/app/hook/useWindowDrag.linux.ts
+++ b/frontend/app/hook/useWindowDrag.linux.ts
@@ -2,10 +2,104 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // Linux-specific window drag hook.
-// On Linux, drag is handled natively by drag.rs (GTK motion detection).
-// data-drag-region triggers an immediate Wayland compositor pointer
-// grab that swallows button clicks, so no drag attributes are set.
+//
+// Why JS-driven drag instead of `-webkit-app-region: drag`:
+// Chromium architecturally suppresses ALL events on drag regions before
+// they enter the renderer (verified 2026-05-02 via document capture-phase
+// listener: zero mousedown / contextmenu fires on drag elements). That
+// makes drag and right-click contextmenu mutually exclusive on the same
+// element when using `-webkit-app-region: drag`.
+//
+// Workaround: keep the header HTCLIENT (so contextmenu fires normally)
+// and detect drag in JS. On mousedown + threshold-crossing motion, send
+// `start_window_drag` IPC to the Rust host. The host calls into the new
+// CefWindow::BeginWindowDrag() (CEF patch) which dispatches the
+// compositor-driven move (xdg_toplevel.move on Wayland, _NET_WM_MOVERESIZE
+// on X11). The compositor handles the rest of the drag until the user
+// releases the mouse button.
+//
+// Required CEF patch: BeginWindowDrag added to CefWindow API (commit
+// associated with the agentmux/7680-... branch).
+// Required Rust IPC: `start_window_drag` -> ui_tasks::post_start_drag.
+
+import { detectHost, invokeCommand } from "@/app/platform/ipc";
+
+let cefDragListenerInstalled = false;
+
+// Threshold in CSS pixels before we initiate a window drag. Below this
+// the click is treated as a normal click (e.g. for buttons that happen
+// to be inside a drag-region container). 4px matches Chrome's default
+// drag threshold and Mutter's input gesture threshold.
+const DRAG_THRESHOLD_PX = 4;
+
+function isInDragRegion(target: HTMLElement | null): boolean {
+    let el = target;
+    while (el) {
+        const attr = el.getAttribute("data-drag-region");
+        if (attr === "false") return false;
+        if (attr === "true" || attr === "") return true;
+        el = el.parentElement;
+    }
+    return false;
+}
+
+function installCefDragListener() {
+    if (cefDragListenerInstalled || detectHost() !== "cef") return;
+    cefDragListenerInstalled = true;
+
+    let pressX = 0;
+    let pressY = 0;
+    let pressArmed = false; // mousedown registered, waiting for threshold-crossing motion
+    let dragInitiated = false; // start_window_drag IPC has been sent
+
+    document.addEventListener("mousedown", (e: MouseEvent) => {
+        // Left button only; right-click and middle-click pass through to
+        // standard renderer event handling (contextmenu etc).
+        if (e.button !== 0) return;
+        if (!isInDragRegion(e.target as HTMLElement)) return;
+        pressX = e.clientX;
+        pressY = e.clientY;
+        pressArmed = true;
+        dragInitiated = false;
+        // No preventDefault — we want the click to still work for any
+        // child handler if it doesn't reach the threshold.
+    }, true);
+
+    document.addEventListener("mousemove", (e: MouseEvent) => {
+        if (!pressArmed || dragInitiated) return;
+        const dx = Math.abs(e.clientX - pressX);
+        const dy = Math.abs(e.clientY - pressY);
+        if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return;
+        // Threshold crossed — initiate native window drag. This sends
+        // ONE IPC; the compositor takes over until mouseup. JS doesn't
+        // track further motion (would race with Mutter anyway).
+        dragInitiated = true;
+        pressArmed = false;
+        invokeCommand("start_window_drag").catch(() => {
+            dragInitiated = false;
+        });
+    }, true);
+
+    document.addEventListener("mouseup", () => {
+        pressArmed = false;
+        dragInitiated = false;
+    }, true);
+
+    // Double-click on drag region toggles maximize.
+    document.addEventListener("dblclick", (e: MouseEvent) => {
+        if (e.button !== 0) return;
+        if (!isInDragRegion(e.target as HTMLElement)) return;
+        e.preventDefault();
+        pressArmed = false;
+        dragInitiated = false;
+        invokeCommand("maximize_window").catch(() => {});
+    }, true);
+}
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {
-    return { dragProps: {} };
+    installCefDragListener();
+    // The drag-target elements need data-drag-region="true" so the
+    // mousedown listener picks them up. Tabs/buttons inside the header
+    // already have data-drag-region="false" via tabbar.tsx etc.
+    return { dragProps: { "data-drag-region": true } };
 }

--- a/frontend/app/hook/useWindowDrag.linux.ts
+++ b/frontend/app/hook/useWindowDrag.linux.ts
@@ -67,6 +67,15 @@ function installCefDragListener() {
 
     document.addEventListener("mousemove", (e: MouseEvent) => {
         if (!pressArmed || dragInitiated) return;
+        // If the primary button is no longer pressed, the user must have
+        // released outside the webview (Wayland/X11 don't always deliver
+        // a renderer-side mouseup in that case). Disarm so we don't fire
+        // start_window_drag on a stray hover after an interrupted press.
+        // e.buttons bit 0 = primary button currently held.
+        if ((e.buttons & 1) === 0) {
+            pressArmed = false;
+            return;
+        }
         const dx = Math.abs(e.clientX - pressX);
         const dy = Math.abs(e.clientY - pressY);
         if (dx < DRAG_THRESHOLD_PX && dy < DRAG_THRESHOLD_PX) return;

--- a/frontend/app/hook/useWindowDrag.linux.ts
+++ b/frontend/app/hook/useWindowDrag.linux.ts
@@ -98,8 +98,13 @@ function installCefDragListener() {
 
 export function useWindowDrag(): { dragProps: Record<string, unknown> } {
     installCefDragListener();
-    // The drag-target elements need data-drag-region="true" so the
-    // mousedown listener picks them up. Tabs/buttons inside the header
-    // already have data-drag-region="false" via tabbar.tsx etc.
+    // The drag-region marker drives the JS-driven drag listener, which is
+    // only installed for CEF (see installCefDragListener). On non-CEF
+    // Linux hosts the marker has no listener attached, so emit no
+    // attribute — keeps the element strictly HTCLIENT and avoids any
+    // future hook from misinterpreting it.
+    if (detectHost() !== "cef") return { dragProps: {} };
+    // Tabs/buttons inside the header already have data-drag-region="false"
+    // via tabbar.tsx etc., so they opt out individually.
     return { dragProps: { "data-drag-region": true } };
 }

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -131,6 +131,10 @@
         flex: 1 1 auto;
         min-width: 0;
         height: 100%;
+        // NOTE: intentionally HTCLIENT (not drag). Making this drag would
+        // cover ~670px of header width with HTCAPTION, absorbing right-clicks.
+        // Window drag happens via the narrow .window-drag strip on the left
+        // of the header.
     }
 
 }

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -131,10 +131,14 @@
         flex: 1 1 auto;
         min-width: 0;
         height: 100%;
-        // NOTE: intentionally HTCLIENT (not drag). Making this drag would
-        // cover ~670px of header width with HTCAPTION, absorbing right-clicks.
-        // Window drag happens via the narrow .window-drag strip on the left
-        // of the header.
+        // NOTE: intentionally HTCLIENT (not -webkit-app-region: drag).
+        // Chromium suppresses ALL events on drag elements before the renderer
+        // sees them, so contextmenu wouldn't fire. Window drag is JS-driven
+        // (see frontend/app/hook/useWindowDrag.linux.ts) — a 4px-threshold
+        // mousedown handler sends start_window_drag IPC →
+        // CefWindow::BeginWindowDrag(), which dispatches xdg_toplevel.move
+        // (Wayland) / _NET_WM_MOVERESIZE (X11). Right-click reaches the
+        // renderer normally.
     }
 
 }

--- a/frontend/app/window/window-header.linux.scss
+++ b/frontend/app/window/window-header.linux.scss
@@ -34,30 +34,23 @@
     height: 33px;
     zoom: var(--zoomfactor);
     cursor: default;
-    // Drag is on the explicit .window-drag strip AND the .tab-bar-fill gap.
-    // Previously only .window-drag was drag because right-click on HTCAPTION
-    // was being consumed by the compositor (no contextmenu reached the
-    // renderer). With CEF Patch A (views_caption_rightclick_passthrough,
-    // commit 41802fe60 on agentmux/7680-...) right-clicks on HTCAPTION fall
-    // through to the renderer, so .tab-bar-fill can safely be draggable too.
-    //
-    // This matters on Ubuntu/GNOME because the sidebar dock occludes the
-    // leftmost ~60 logical px — the same area the .window-drag strip lives in.
-    // Without an additional drag area, the user has no clickable drag zone.
+    // Window drag is JS-driven (NOT -webkit-app-region: drag). Chromium
+    // architecturally suppresses ALL events on drag regions before they
+    // enter the renderer (verified 2026-05-02 via document capture-phase
+    // listener), so right-click contextmenu would not fire on the same
+    // element. Instead, .tab-bar-fill stays HTCLIENT and a 4px-threshold
+    // mousedown handler in useWindowDrag.linux.ts sends start_window_drag
+    // IPC → CefWindow::BeginWindowDrag() → xdg_toplevel.move (Wayland) /
+    // _NET_WM_MOVERESIZE (X11). This is the only known way to coexist
+    // drag + contextmenu on the same Chromium element.
 
     .window-drag {
+        // Legacy left-edge drag strip. --default-indent is 0px on Linux
+        // (set above) so this renders as zero width. Kept in the DOM only
+        // because the cross-platform window-header.tsx still mounts it;
+        // platform-specific markup would require structural changes.
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
-        -webkit-app-region: drag;
     }
-
-    // Inter-tab gap — DO NOT mark as -webkit-app-region: drag here.
-    // Chromium architecturally suppresses ALL events on drag regions
-    // before they enter the renderer (verified 2026-05-02 via document
-    // capture-phase listener), so right-click contextmenu would not fire.
-    // Instead, JS-driven drag via mousedown threshold + start_window_drag
-    // IPC handles native window-move; the area stays HTCLIENT so
-    // contextmenu fires normally on right-click.
-    // See: useWindowDrag.linux.ts + agentmux-cef IPC start_window_drag.
 }

--- a/frontend/app/window/window-header.linux.scss
+++ b/frontend/app/window/window-header.linux.scss
@@ -6,7 +6,10 @@
 // so no width compensation is needed — 100vw is correct.
 
 .window-header {
-    --default-indent: 10px;
+    // Was 60px for a dedicated left drag strip; drag now lives on .tab-bar-fill
+    // (JS-driven via useWindowDrag.linux.ts), so the strip is redundant and the
+    // gap on the left of the + add-tab button is removed.
+    --default-indent: 0px;
 }
 
 .config-error-message {
@@ -31,10 +34,30 @@
     height: 33px;
     zoom: var(--zoomfactor);
     cursor: default;
+    // Drag is on the explicit .window-drag strip AND the .tab-bar-fill gap.
+    // Previously only .window-drag was drag because right-click on HTCAPTION
+    // was being consumed by the compositor (no contextmenu reached the
+    // renderer). With CEF Patch A (views_caption_rightclick_passthrough,
+    // commit 41802fe60 on agentmux/7680-...) right-clicks on HTCAPTION fall
+    // through to the renderer, so .tab-bar-fill can safely be draggable too.
+    //
+    // This matters on Ubuntu/GNOME because the sidebar dock occludes the
+    // leftmost ~60 logical px — the same area the .window-drag strip lives in.
+    // Without an additional drag area, the user has no clickable drag zone.
 
     .window-drag {
         height: 100%;
         width: var(--default-indent);
         flex-shrink: 0;
+        -webkit-app-region: drag;
     }
+
+    // Inter-tab gap — DO NOT mark as -webkit-app-region: drag here.
+    // Chromium architecturally suppresses ALL events on drag regions
+    // before they enter the renderer (verified 2026-05-02 via document
+    // capture-phase listener), so right-click contextmenu would not fire.
+    // Instead, JS-driven drag via mousedown threshold + start_window_drag
+    // IPC handles native window-move; the area stays HTCLIENT so
+    // contextmenu fires normally on right-click.
+    // See: useWindowDrag.linux.ts + agentmux-cef IPC start_window_drag.
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.589",
+  "version": "0.33.590",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.589",
+      "version": "0.33.590",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -661,16 +661,6 @@
         "keyv": "^5.6.0"
       }
     },
-    "node_modules/@cacheable/memory/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
     "node_modules/@cacheable/utils": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
@@ -680,16 +670,6 @@
       "dependencies": {
         "hashery": "^1.5.1",
         "keyv": "^5.6.0"
-      }
-    },
-    "node_modules/@cacheable/utils/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
@@ -1158,7 +1138,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,7 +1154,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,7 +1170,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1209,7 +1186,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1226,7 +1202,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,7 +1218,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,7 +1234,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,7 +1250,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,7 +1266,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,7 +1282,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,7 +1298,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,7 +1314,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,7 +1330,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,7 +1346,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,7 +1362,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,7 +1378,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,7 +1394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1447,7 +1410,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1464,7 +1426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1481,7 +1442,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1498,7 +1458,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1515,7 +1474,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1532,7 +1490,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1549,7 +1506,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1566,7 +1522,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1583,7 +1538,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2090,7 +2044,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2130,7 +2083,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2151,7 +2103,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2172,7 +2123,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2193,7 +2143,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2214,7 +2163,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2235,7 +2183,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2256,7 +2203,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2277,7 +2223,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,7 +2243,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2319,7 +2263,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2340,7 +2283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,7 +2303,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2382,7 +2323,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2597,7 +2537,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2611,7 +2550,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2625,7 +2563,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2639,7 +2576,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2653,7 +2589,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2667,7 +2602,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2681,7 +2615,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2695,7 +2628,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,7 +2641,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2723,7 +2654,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2737,7 +2667,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2751,7 +2680,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2765,7 +2693,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2779,7 +2706,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,7 +2719,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2807,7 +2732,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,7 +2745,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2835,7 +2758,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2849,7 +2771,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2863,7 +2784,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2877,7 +2797,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2891,7 +2810,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2905,7 +2823,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2919,7 +2836,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2933,7 +2849,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4376,7 +4291,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4403,7 +4318,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4413,7 +4327,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -5339,16 +5253,6 @@
         "qified": "^0.9.0"
       }
     },
-    "node_modules/cacheable/node_modules/keyv": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
-      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@keyv/serialize": "^1.1.1"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5499,7 +5403,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -6363,7 +6267,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6505,7 +6409,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6904,7 +6808,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6976,6 +6879,16 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -7011,7 +6924,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7057,7 +6969,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7765,7 +7677,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7917,7 +7829,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7937,7 +7849,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -8128,7 +8040,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -8337,13 +8249,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/khroma": {
@@ -8409,7 +8321,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -8442,7 +8354,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8463,7 +8374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8484,7 +8394,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8505,7 +8414,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8526,7 +8434,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8547,7 +8454,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8568,7 +8474,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8589,7 +8494,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8610,7 +8514,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8631,7 +8534,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8652,7 +8554,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9976,7 +9877,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10026,7 +9926,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10334,7 +10233,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -10389,7 +10287,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10776,7 +10673,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -11115,7 +11012,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -11181,7 +11078,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -11283,7 +11179,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -12351,7 +12247,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -12580,7 +12475,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -12600,7 +12495,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12672,7 +12566,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -12921,7 +12815,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -13088,7 +12981,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13105,7 +12997,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13122,7 +13013,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13139,7 +13029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13156,7 +13045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13173,7 +13061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13190,7 +13077,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13207,7 +13093,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13224,7 +13109,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13241,7 +13125,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13258,7 +13141,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13275,7 +13157,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13292,7 +13173,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13309,7 +13189,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13326,7 +13205,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13343,7 +13221,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13360,7 +13237,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13377,7 +13253,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13394,7 +13269,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13411,7 +13285,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13428,7 +13301,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13445,7 +13317,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13462,7 +13333,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13479,7 +13349,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13496,7 +13365,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13513,7 +13381,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13527,7 +13394,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -13569,7 +13435,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.589",
+  "version": "0.33.590",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Header tabs/widgets now show their context menus while the empty header area is draggable — both work simultaneously, no more `-webkit-app-region` mutual exclusion.
- Drag uses a document-level mousedown listener (4px threshold) → `start_window_drag` IPC → new `CefWindow::BeginWindowDrag()` API → `WmMoveResizeHandler::DispatchHostWindowDragMovement(HTCAPTION)` → `xdg_toplevel.move` on Wayland (or `_NET_WM_MOVERESIZE` on X11). Non-blocking; compositor takes over until mouseup.
- Removes the 60px `.window-drag` strip on the left (`--default-indent: 0`) — now redundant and was leaving a visible gap to the left of the `+` add-tab button.

## Why `-webkit-app-region: drag` was the wrong primitive

Verified empirically (DevTools capture-phase listener, 2026-05-02): Chromium suppresses ALL events on drag elements before they reach the renderer, so `contextmenu` cannot fire on the same element. JS-driven drag with HTCLIENT preservation is the only way to get both.

## Requires (CEF runtime)

`libcef.so` must be built from [`agentmux/7680-drag-rightclick-and-transparency`](https://github.com/a5af/cef/tree/agentmux/7680-drag-rightclick-and-transparency) (a5af/cef PR #1 — **merged**) which adds `CefWindow::BeginWindowDrag()` at the END of the `CefWindow` class to preserve ABI for downstream `cef-dll-sys` bindings. The `cef-dll-sys` registry binding also needs the `begin_window_drag` fn pointer appended to `_cef_window_t` and the size assert bumped 888→896.

## What's in this PR

- `agentmux-cef/src/ui_tasks.rs` — `StartWindowDragTask`, raw FFI to `BeginWindowDrag`
- `agentmux-cef/src/main.rs` / `client.rs` / `browser_panes.rs` — IPC wiring
- `agentmux-cef/src/commands/drag.rs` — gate Windows-only helper behind `#[cfg(target_os = "windows")]`
- `agentmux-cef/src/app.rs` — clarify `background_color` comment (no behavior change; stays 0xFF000000 opaque black)
- `frontend/app/hook/useWindowDrag.linux.ts` — JS-driven drag with 4px threshold, HTCLIENT preservation
- `frontend/app/tab/tabbar.scss` — drag-region marker + add-tab button styling
- `frontend/app/window/window-header.linux.scss` — `--default-indent: 0`, drag region notes
- `docs/retros/2026-05-02-drag-and-rightclick-coexistence.md` — full retro

## Test plan

- [ ] On Linux/Wayland (Mutter/GNOME):
  - [ ] Right-click a tab → tab context menu appears
  - [ ] Right-click a widget icon → widget context menu appears
  - [ ] Right-click the empty header area between tabs and the right edge → window-header context menu appears
  - [ ] Left-click + drag in that same empty area → window moves natively (no input lag, no nested message loop)
  - [ ] Double-click the empty area → maximize toggles
  - [ ] No visible gap to the left of the `+` add-tab button
- [ ] macOS / Windows builds still compile (drag.rs `wait_for_browser_hwnd` cfg-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)