### PR TITLE
refactor(cef): rename Pane → BrowserPane in reducer/state types (task #181)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.600"
+version = "0.33.601"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.600"
+version = "0.33.601"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.600"
+version = "0.33.601"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.600"
+version = "0.33.601"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.601"
+version = "0.33.602"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.601"
+version = "0.33.602"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.601"
+version = "0.33.602"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.601"
+version = "0.33.602"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.603"
+version = "0.33.604"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.603"
+version = "0.33.604"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.603"
+version = "0.33.604"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.603"
+version = "0.33.604"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.599"
+version = "0.33.600"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.599"
+version = "0.33.600"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.599"
+version = "0.33.600"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.599"
+version = "0.33.600"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.602"
+version = "0.33.603"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.602"
+version = "0.33.603"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.602"
+version = "0.33.603"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.602"
+version = "0.33.603"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.602"
+version = "0.33.603"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.601"
+version = "0.33.602"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.603"
+version = "0.33.604"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.600"
+version = "0.33.601"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.599"
+version = "0.33.600"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -293,7 +293,7 @@ wrap_browser_process_handler! {
                 let mut client = self.client.borrow_mut();
                 *client = Some(AgentMuxClient::new(
                     AgentMuxHandler::new(self.state.clone(), self.ipc_port),
-                    false, // is_pane = false — main browser takes focus normally
+                    false, // is_browser_pane = false — main browser takes focus normally
                 ));
             }
 

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -9,10 +9,10 @@
 //! bodies so pane-specific logic lives in one place instead of threaded
 //! through `if self.is_pane` branches in `client.rs`.
 //!
-//! Notable: this is where `install_pane_focus_redirect` actually gets wired
+//! Notable: this is where `install_browser_pane_focus_redirect` actually gets wired
 //! in. Before this phase the function existed in `pane::hwnd` but had zero
 //! callers (see `SPEC_BROWSER_PANE_LIFECYCLE.md` §5 race #5). Now
-//! `on_after_created_pane` and `on_load_end_pane` both reinstall the focus
+//! `on_after_created_browser_pane` and `on_load_end_pane` both reinstall the focus
 //! subclass — required because Chromium recreates the
 //! `Chrome_RenderWidgetHostHWND` child on every navigation, stranding the
 //! old subclass on a destroyed HWND.
@@ -32,7 +32,7 @@ use crate::state::AppState;
 /// 2. Install the WM_SETFOCUS redirect subclass on the pane's HWND tree so
 ///    Chromium's internal focus-steals on page load don't yank keyboard
 ///    focus away from the main window.
-pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
+pub fn on_after_created_browser_pane(state: &Arc<AppState>, browser: &Browser) {
     #[cfg(target_os = "windows")]
     {
         if let Some(host) = browser.host() {
@@ -59,7 +59,7 @@ pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
                 // focused pane).
                 let block_id = resolve_pane_block_id(state, browser).unwrap_or_default();
                 unsafe {
-                    crate::pane::hwnd::install_pane_focus_redirect(
+                    crate::browser_pane::hwnd::install_browser_pane_focus_redirect(
                         hwnd,
                         state.clone(),
                         block_id,
@@ -81,7 +81,7 @@ pub fn on_after_created_pane(state: &Arc<AppState>, browser: &Browser) {
 /// Drains the lifecycle entry from `BrowserPaneManager` so a re-create
 /// with the same block_id gets a fresh Live state. Idempotent — if the
 /// explicit `close()` path already drained it, this is a no-op.
-pub fn on_before_close_pane(state: &Arc<AppState>, label: &str) {
+pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
     state.browser_panes.drain_closed_label(state, label);
 
     // Labels are `browser-pane-<uuid>-<seq>`; strip prefix + trailing `-<seq>`
@@ -92,7 +92,7 @@ pub fn on_before_close_pane(state: &Arc<AppState>, label: &str) {
         if let Some(rest) = label.strip_prefix("browser-pane-") {
             if let Some(dash) = rest.rfind('-') {
                 let block_id = &rest[..dash];
-                crate::pane::hwnd::remove_contexts_for_block(block_id);
+                crate::browser_pane::hwnd::remove_contexts_for_block(block_id);
             }
         }
     }
@@ -120,7 +120,7 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
             if !wh.0.is_null() {
                 let block_id = resolve_pane_block_id(state, browser).unwrap_or_default();
                 unsafe {
-                    crate::pane::hwnd::install_pane_focus_redirect(
+                    crate::browser_pane::hwnd::install_browser_pane_focus_redirect(
                         wh.0 as *mut std::ffi::c_void,
                         state.clone(),
                         block_id,

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -12,7 +12,7 @@
 //! Notable: this is where `install_browser_pane_focus_redirect` actually gets wired
 //! in. Before this phase the function existed in `pane::hwnd` but had zero
 //! callers (see `SPEC_BROWSER_PANE_LIFECYCLE.md` §5 race #5). Now
-//! `on_after_created_browser_pane` and `on_load_end_pane` both reinstall the focus
+//! `on_after_created_browser_pane` and `on_load_end_browser_pane` both reinstall the focus
 //! subclass — required because Chromium recreates the
 //! `Chrome_RenderWidgetHostHWND` child on every navigation, stranding the
 //! old subclass on a destroyed HWND.
@@ -110,7 +110,7 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
 /// focused HWND; stealing focus away from the pane breaks scrolling.
 /// The FocusHandler cancel + WndProc redirect already keep focus off
 /// the pane during the *initial* navigation focus steal.
-pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
+pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
     tracing::info!("[pane-load-end] pane page loaded; reinstalling focus subclass");
 
     #[cfg(target_os = "windows")]
@@ -136,7 +136,7 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
     // `on_load_end` fires before the navigation controller commits the
     // history entry, so calling `browser.can_go_back()` from this hook
     // can return the pre-navigation state. Those flags flow through the
-    // dedicated `on_loading_state_change_pane` callback below, which CEF
+    // dedicated `on_loading_state_change_browser_pane` callback below, which CEF
     // provides with correct values as direct parameters.
     if let Some(block_id) = resolve_pane_block_id(state, browser) {
         let url = {
@@ -175,7 +175,7 @@ pub fn on_load_end_pane(state: &Arc<AppState>, browser: &Browser) {
 /// back/forward. `can_go_back` / `can_go_forward` are provided as direct
 /// parameters (not queried after the fact), so they're guaranteed to reflect
 /// the real committed state rather than the pre-commit race window.
-pub fn on_loading_state_change_pane(
+pub fn on_loading_state_change_browser_pane(
     state: &Arc<AppState>,
     browser: &Browser,
     can_go_back: bool,

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -10,7 +10,7 @@
 //! through `if self.is_browser_pane` branches in `client.rs`.
 //!
 //! Notable: this is where `install_browser_pane_focus_redirect` actually gets wired
-//! in. Before this phase the function existed in `pane::hwnd` but had zero
+//! in. Before this phase the function existed in `browser_pane::hwnd` but had zero
 //! callers (see `SPEC_BROWSER_PANE_LIFECYCLE.md` §5 race #5). Now
 //! `on_after_created_browser_pane` and `on_load_end_browser_pane` both reinstall the focus
 //! subclass — required because Chromium recreates the

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -7,7 +7,7 @@
 //! (see `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md` §6). `AgentMuxHandler`
 //! still owns the CEF callback plumbing; this module holds the pane-branch
 //! bodies so pane-specific logic lives in one place instead of threaded
-//! through `if self.is_pane` branches in `client.rs`.
+//! through `if self.is_browser_pane` branches in `client.rs`.
 //!
 //! Notable: this is where `install_browser_pane_focus_redirect` actually gets wired
 //! in. Before this phase the function existed in `pane::hwnd` but had zero
@@ -98,7 +98,7 @@ pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
     }
 }
 
-/// Called from `AgentMuxHandler::on_load_end` when `is_pane` is true.
+/// Called from `AgentMuxHandler::on_load_end` when `is_browser_pane` is true.
 ///
 /// Chromium creates a fresh `Chrome_RenderWidgetHostHWND` on every
 /// navigation. The subclass installed at `on_after_created` is on the
@@ -168,7 +168,7 @@ pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
 }
 
 /// Pane-specific `on_loading_state_change` body. Called from
-/// `AgentMuxHandler::on_loading_state_change` when `is_pane == true`.
+/// `AgentMuxHandler::on_loading_state_change` when `is_browser_pane == true`.
 ///
 /// CEF invokes `on_loading_state_change` whenever the navigation controller's
 /// history state changes — navigation start, navigation commit, and after

--- a/agentmux-cef/src/browser_pane/creation.rs
+++ b/agentmux-cef/src/browser_pane/creation.rs
@@ -28,7 +28,7 @@ use cef::*;
 use crate::state::AppState;
 
 wrap_task! {
-    pub struct CreatePaneTask {
+    pub struct CreateBrowserPaneTask {
         state: Arc<AppState>,
         block_id: String,
         label: String,

--- a/agentmux-cef/src/browser_pane/creation.rs
+++ b/agentmux-cef/src/browser_pane/creation.rs
@@ -69,7 +69,7 @@ wrap_task! {
                 },
             );
 
-            let handler = crate::client::AgentMuxHandler::new_with_pane(self.state.clone(), 0, true);
+            let handler = crate::client::AgentMuxHandler::new_with_browser_pane(self.state.clone(), 0, true);
             let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
 
             let url_cef = CefString::from(self.url.as_str());

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -6,7 +6,7 @@
 //!
 //! Moved out of `client.rs` during Phase 2 of the pane modularization split
 //! (see `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md` §6). `client.rs`
-//! still uses `ALLOW_PANE_FOCUS_ONCE` at a distance (nothing there imports
+//! still uses `ALLOW_BROWSER_PANE_FOCUS_ONCE` at a distance (nothing there imports
 //! the function directly), but `install_browser_pane_focus_redirect` is the home
 //! for pane-focused Win32 subclass logic and future phases can wire it up
 //! to pane `on_after_created` / `on_load_end` without touching `client.rs`.
@@ -21,7 +21,7 @@ use std::sync::{Arc, Weak};
 /// to the real handler after running its interception logic. The mutex is
 /// held only while mutating the map — hooks that read on the UI thread
 /// copy out the pointer quickly.
-static PANE_WNDPROCS: std::sync::LazyLock<
+static BROWSER_PANE_WNDPROCS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, isize>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
@@ -31,23 +31,23 @@ static PANE_WNDPROCS: std::sync::LazyLock<
 /// round-trip through CEF callbacks — only the outer HWND is keyed here;
 /// descendants walk up via `GetParent` to find their context.
 #[derive(Clone)]
-struct PaneContext {
+struct BrowserPaneContext {
     state: Weak<crate::state::AppState>,
     block_id: String,
 }
 
-static PANE_HWND_CONTEXT: std::sync::LazyLock<
-    std::sync::Mutex<std::collections::HashMap<usize, PaneContext>>,
+static BROWSER_PANE_HWND_CONTEXT: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<usize, BrowserPaneContext>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
-/// Remove every `PANE_HWND_CONTEXT` entry whose context refers to the given
-/// `block_id`. Called from `on_before_close_pane` so the map doesn't grow
+/// Remove every `BROWSER_PANE_HWND_CONTEXT` entry whose context refers to the given
+/// `block_id`. Called from `on_before_close_browser_pane` so the map doesn't grow
 /// unbounded as panes are opened and closed over the session. Keyed by
 /// block_id (not HWND) because the close path has the label/block_id
 /// immediately but not the HWND — by the time CEF fires on_before_close,
 /// the browser's HWND may already be invalid.
 pub fn remove_contexts_for_block(block_id: &str) {
-    if let Ok(mut map) = PANE_HWND_CONTEXT.lock() {
+    if let Ok(mut map) = BROWSER_PANE_HWND_CONTEXT.lock() {
         let before = map.len();
         map.retain(|_hwnd, ctx| ctx.block_id != block_id);
         let removed = before - map.len();
@@ -68,7 +68,7 @@ pub fn remove_contexts_for_block(block_id: &str) {
 /// The frontend's `giveFocus()` -> `browser_pane_focus` IPC sets this flag
 /// before calling `SetFocus` on the pane, so user-initiated focus works
 /// even though Chromium's internal focus-steal on navigation is blocked.
-pub static ALLOW_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
+pub static ALLOW_BROWSER_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 /// Last-redirect timestamp per root HWND, used by
@@ -78,7 +78,7 @@ pub static ALLOW_PANE_FOCUS_ONCE: std::sync::atomic::AtomicBool =
 /// HWND cast to `usize`. Entries are overwritten on each pass and never
 /// explicitly removed — the map is bounded by the count of distinct
 /// top-level AgentMux windows seen in a session, which is small.
-static PANE_REDIRECT_LAST_AT: std::sync::LazyLock<
+static BROWSER_PANE_REDIRECT_LAST_AT: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, std::time::Instant>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
@@ -112,7 +112,7 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 
     let key = root as usize;
     let now = std::time::Instant::now();
-    if let Ok(mut map) = PANE_REDIRECT_LAST_AT.lock() {
+    if let Ok(mut map) = BROWSER_PANE_REDIRECT_LAST_AT.lock() {
         if let Some(last) = map.get(&key) {
             if now.duration_since(*last) < std::time::Duration::from_millis(100) {
                 return false;
@@ -126,7 +126,7 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 /// Subclass a browser pane's outer HWND (and every descendant HWND Chromium
 /// has already created) so `WM_SETFOCUS` is redirected back to the parent
 /// top-level window unless the focus change is user-initiated (see
-/// `ALLOW_PANE_FOCUS_ONCE`).
+/// `ALLOW_BROWSER_PANE_FOCUS_ONCE`).
 ///
 /// Without this, Chromium's internal SetFocus on the pane HWND (page load,
 /// JS `window.focus()`, etc.) steals the Windows-level keyboard focus —
@@ -134,7 +134,7 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 /// window, so terminals, URL bars, and other inputs in the main UI stop
 /// responding.
 ///
-/// Wired in by `browser_pane::callbacks::on_after_created_pane` at create time and
+/// Wired in by `browser_pane::callbacks::on_after_created_browser_pane` at create time and
 /// by `browser_pane::callbacks::on_load_end_browser_pane` after every navigation — Chromium
 /// recreates the `Chrome_RenderWidgetHostHWND` on every page load, so the
 /// subclass has to follow along or it ends up stranded on a destroyed HWND.
@@ -154,8 +154,8 @@ pub unsafe fn install_browser_pane_focus_redirect(
     // the click event without going through CEF callbacks (which only
     // fire on Windows-level focus CHANGE — clicks inside an already-
     // focused pane wouldn't produce a CEF focus callback at all).
-    if let Ok(mut map) = PANE_HWND_CONTEXT.lock() {
-        map.insert(hwnd as usize, PaneContext {
+    if let Ok(mut map) = BROWSER_PANE_HWND_CONTEXT.lock() {
+        map.insert(hwnd as usize, BrowserPaneContext {
             state: Arc::downgrade(&state),
             block_id: block_id.clone(),
         });
@@ -165,10 +165,10 @@ pub unsafe fn install_browser_pane_focus_redirect(
     /// context. Child HWNDs (Chrome_WidgetWin_1, Chrome_RenderWidgetHostHWND)
     /// aren't themselves in the map — the outer pane HWND is. Safety bound
     /// of 8 jumps is plenty; Chromium's pane hierarchy is only 2-3 deep.
-    unsafe fn find_context(mut hwnd: *mut std::ffi::c_void) -> Option<PaneContext> {
+    unsafe fn find_context(mut hwnd: *mut std::ffi::c_void) -> Option<BrowserPaneContext> {
         use windows_sys::Win32::UI::WindowsAndMessaging::GetParent;
         for _ in 0..8 {
-            if let Ok(map) = PANE_HWND_CONTEXT.lock() {
+            if let Ok(map) = BROWSER_PANE_HWND_CONTEXT.lock() {
                 if let Some(ctx) = map.get(&(hwnd as usize)) {
                     return Some(ctx.clone());
                 }
@@ -210,7 +210,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
 
         // A click inside the pane HWND is the explicit "user wants to
         // interact with the embedded page" signal. Chromium's own handler
-        // will call SetFocus(pane) next — arm ALLOW_PANE_FOCUS_ONCE so
+        // will call SetFocus(pane) next — arm ALLOW_BROWSER_PANE_FOCUS_ONCE so
         // the WM_SETFOCUS branch below doesn't redirect it. Without this,
         // clicks on the pane never transfer keyboard focus to Chromium
         // (cursor works, typing goes nowhere — reported by user after
@@ -218,7 +218,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
         // the DOM-level mousedown never fires because the pane HWND
         // intercepts the click at Win32 level, not DOM level).
         if msg == WM_LBUTTONDOWN {
-            ALLOW_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
+            ALLOW_BROWSER_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
             // Emit the click event directly from the WndProc. We can't
             // rely on CEF's FocusHandler::on_set_focus to emit, because
             // CEF only fires that callback when Windows-level focus
@@ -248,7 +248,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
         if msg == WM_SETFOCUS {
             // Intentional focus from the frontend's giveFocus() IPC: honor it
             // once, then revert to redirect-mode for subsequent events.
-            if ALLOW_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed) {
+            if ALLOW_BROWSER_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed) {
                 tracing::info!("[pane-wndproc] WM_SETFOCUS allowed (intentional)");
                 // Fall through to the original WndProc.
             } else {
@@ -276,7 +276,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
             }
         }
 
-        let original = PANE_WNDPROCS
+        let original = BROWSER_PANE_WNDPROCS
             .lock()
             .ok()
             .and_then(|m| m.get(&(hwnd as usize)).copied())
@@ -292,8 +292,8 @@ pub unsafe fn install_browser_pane_focus_redirect(
     }
 
     // Subclass the outer HWND — but only once. Re-calling SetWindowLongPtrW
-    // would replace our hook with itself and poison PANE_WNDPROCS.
-    let already_hooked = PANE_WNDPROCS
+    // would replace our hook with itself and poison BROWSER_PANE_WNDPROCS.
+    let already_hooked = BROWSER_PANE_WNDPROCS
         .lock()
         .ok()
         .map(|m| m.contains_key(&(hwnd as usize)))
@@ -301,7 +301,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
     if !already_hooked {
         let original = SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wndproc_hook as *const () as isize);
         if original != 0 {
-            if let Ok(mut map) = PANE_WNDPROCS.lock() {
+            if let Ok(mut map) = BROWSER_PANE_WNDPROCS.lock() {
                 map.insert(hwnd as usize, original);
             }
             tracing::info!("[pane-subclass] installed focus-redirect WndProc on pane HWND {:p}", hwnd);
@@ -315,7 +315,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
         child: *mut std::ffi::c_void,
         _lparam: isize,
     ) -> i32 {
-        let already = PANE_WNDPROCS
+        let already = BROWSER_PANE_WNDPROCS
             .lock()
             .ok()
             .map(|m| m.contains_key(&(child as usize)))
@@ -325,7 +325,7 @@ pub unsafe fn install_browser_pane_focus_redirect(
         }
         let orig = SetWindowLongPtrW(child, GWLP_WNDPROC, wndproc_hook as *const () as isize);
         if orig != 0 {
-            if let Ok(mut map) = PANE_WNDPROCS.lock() {
+            if let Ok(mut map) = BROWSER_PANE_WNDPROCS.lock() {
                 map.insert(child as usize, orig);
             }
             let mut class_buf = [0u16; 64];
@@ -358,22 +358,22 @@ mod tests {
     fn allow_pane_focus_once_starts_false() {
         // Note: this static is global to the process, so other tests can
         // have modified it. Read-only assertion before mutation.
-        let _ = ALLOW_PANE_FOCUS_ONCE.load(Ordering::Relaxed);
+        let _ = ALLOW_BROWSER_PANE_FOCUS_ONCE.load(Ordering::Relaxed);
     }
 
     #[test]
     fn allow_pane_focus_once_swap_returns_prev_and_clears() {
-        ALLOW_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
-        let prev = ALLOW_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed);
+        ALLOW_BROWSER_PANE_FOCUS_ONCE.store(true, Ordering::Relaxed);
+        let prev = ALLOW_BROWSER_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed);
         assert!(prev, "swap should return the prior true value");
-        assert!(!ALLOW_PANE_FOCUS_ONCE.load(Ordering::Relaxed),
+        assert!(!ALLOW_BROWSER_PANE_FOCUS_ONCE.load(Ordering::Relaxed),
             "after swap(false), flag must be cleared");
     }
 
     #[test]
     fn allow_pane_focus_once_swap_when_false_returns_false() {
-        ALLOW_PANE_FOCUS_ONCE.store(false, Ordering::Relaxed);
-        let prev = ALLOW_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed);
+        ALLOW_BROWSER_PANE_FOCUS_ONCE.store(false, Ordering::Relaxed);
+        let prev = ALLOW_BROWSER_PANE_FOCUS_ONCE.swap(false, Ordering::Relaxed);
         assert!(!prev, "swap on cleared flag should return false");
     }
 }

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -7,7 +7,7 @@
 //! Moved out of `client.rs` during Phase 2 of the pane modularization split
 //! (see `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md` §6). `client.rs`
 //! still uses `ALLOW_PANE_FOCUS_ONCE` at a distance (nothing there imports
-//! the function directly), but `install_pane_focus_redirect` is the home
+//! the function directly), but `install_browser_pane_focus_redirect` is the home
 //! for pane-focused Win32 subclass logic and future phases can wire it up
 //! to pane `on_after_created` / `on_load_end` without touching `client.rs`.
 //!
@@ -26,7 +26,7 @@ static PANE_WNDPROCS: std::sync::LazyLock<
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 /// Per-pane context, keyed by the pane's outer HWND. Populated by
-/// `install_pane_focus_redirect`. The WndProc hook uses it to emit the
+/// `install_browser_pane_focus_redirect`. The WndProc hook uses it to emit the
 /// `browser-pane-clicked` event on `WM_LBUTTONDOWN` without needing to
 /// round-trip through CEF callbacks — only the outer HWND is keyed here;
 /// descendants walk up via `GetParent` to find their context.
@@ -138,7 +138,7 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 /// by `pane::callbacks::on_load_end_pane` after every navigation — Chromium
 /// recreates the `Chrome_RenderWidgetHostHWND` on every page load, so the
 /// subclass has to follow along or it ends up stranded on a destroyed HWND.
-pub unsafe fn install_pane_focus_redirect(
+pub unsafe fn install_browser_pane_focus_redirect(
     hwnd: *mut std::ffi::c_void,
     state: Arc<crate::state::AppState>,
     block_id: String,

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -135,7 +135,7 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 /// responding.
 ///
 /// Wired in by `pane::callbacks::on_after_created_pane` at create time and
-/// by `pane::callbacks::on_load_end_pane` after every navigation — Chromium
+/// by `pane::callbacks::on_load_end_browser_pane` after every navigation — Chromium
 /// recreates the `Chrome_RenderWidgetHostHWND` on every page load, so the
 /// subclass has to follow along or it ends up stranded on a destroyed HWND.
 pub unsafe fn install_browser_pane_focus_redirect(

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -134,8 +134,8 @@ unsafe fn should_redirect_pane_focus_to_root(root: *mut std::ffi::c_void) -> boo
 /// window, so terminals, URL bars, and other inputs in the main UI stop
 /// responding.
 ///
-/// Wired in by `pane::callbacks::on_after_created_pane` at create time and
-/// by `pane::callbacks::on_load_end_browser_pane` after every navigation — Chromium
+/// Wired in by `browser_pane::callbacks::on_after_created_pane` at create time and
+/// by `browser_pane::callbacks::on_load_end_browser_pane` after every navigation — Chromium
 /// recreates the `Chrome_RenderWidgetHostHWND` on every page load, so the
 /// subclass has to follow along or it ends up stranded on a destroyed HWND.
 pub unsafe fn install_browser_pane_focus_redirect(

--- a/agentmux-cef/src/browser_pane/mod.rs
+++ b/agentmux-cef/src/browser_pane/mod.rs
@@ -4,7 +4,7 @@
 //! Browser-pane module.
 //!
 //! Phase H.1.d/e (PR #5) deleted the in-memory `PaneStateMachine`; pane
-//! lifecycle now lives only in the host reducer (`HostState.panes`).
+//! lifecycle now lives only in the host reducer (`HostState.browser_panes`).
 //! `RegisterResult` moved to `crate::reducer`.
 
 pub mod callbacks;
@@ -18,4 +18,4 @@ pub use creation::CreatePaneTask;
 pub use hwnd::ALLOW_PANE_FOCUS_ONCE;
 
 #[cfg(target_os = "windows")]
-pub use hwnd::install_pane_focus_redirect;
+pub use hwnd::install_browser_pane_focus_redirect;

--- a/agentmux-cef/src/browser_pane/mod.rs
+++ b/agentmux-cef/src/browser_pane/mod.rs
@@ -12,10 +12,10 @@ pub mod creation;
 #[cfg(target_os = "windows")]
 pub mod hwnd;
 
-pub use creation::CreatePaneTask;
+pub use creation::CreateBrowserPaneTask;
 
 #[cfg(target_os = "windows")]
-pub use hwnd::ALLOW_PANE_FOCUS_ONCE;
+pub use hwnd::ALLOW_BROWSER_PANE_FOCUS_ONCE;
 
 #[cfg(target_os = "windows")]
 pub use hwnd::install_browser_pane_focus_redirect;

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -8,7 +8,7 @@
 //! by label, accessed via `AppState::get_browser` etc). We only need the
 //! block_id → label mapping, which also lives in the reducer's `panes` map.
 //!
-//! Lifecycle states are tracked explicitly via the reducer's `PaneLifecycle`:
+//! Lifecycle states are tracked explicitly via the reducer's `BrowserPaneLifecycle`:
 //!   Created → Closing → Closed (removed from `panes`)
 //! Every pane-facing op (focus/resize/navigate/…) short-circuits when the
 //! entry is already in `Closing`. This drops late IPC that the frontend
@@ -17,16 +17,16 @@
 //! the crash described in `docs/specs/SPEC_BROWSER_PANE_LIFECYCLE.md` §4c.
 //!
 //! **Phase H.1.d/e (PR #5):** The legacy `pane::lifecycle::PaneStateMachine`
-//! is gone; pane state lives only in `HostState.panes`. All mutations go
-//! through `HostCommand::TryRegisterPaneLive` / `EnqueuePaneClose` /
-//! `CompletePaneClose` / `DrainPaneByLabel` and read back via the reducer's
+//! is gone; pane state lives only in `HostState.browser_panes`. All mutations go
+//! through `HostCommand::TryRegisterBrowserPaneLive` / `EnqueueBrowserPaneClose` /
+//! `CompleteBrowserPaneClose` / `DrainBrowserPaneByLabel` and read back via the reducer's
 //! atomic `DispatchOutput` fields.
 
 use std::sync::Arc;
 
 use cef::*;
 
-use crate::pane::CreatePaneTask;
+use crate::browser_pane::CreatePaneTask;
 use crate::reducer::RegisterResult;
 use crate::state::AppState;
 
@@ -139,7 +139,7 @@ impl BrowserPaneManager {
     /// Look up the Browser iff the pane is Live. Returns None when closing
     /// so all ops short-circuit uniformly.
     fn live_browser(&self, state: &Arc<AppState>, block_id: &str) -> Option<Browser> {
-        let label = state.live_pane_label(block_id)?;
+        let label = state.live_browser_pane_label(block_id)?;
         state.get_browser(&label)
     }
 
@@ -165,11 +165,11 @@ impl BrowserPaneManager {
         // reducer atomically generates the label and inserts the entry,
         // returning Fresh / AlreadyLive / Closing via DispatchOutput.
         let out = state.host_dispatch(
-            crate::reducer::HostCommand::TryRegisterPaneLive {
+            crate::reducer::HostCommand::TryRegisterBrowserPaneLive {
                 block_id: block_id.to_string(),
             },
         );
-        let result = out.pane_register_result.ok_or_else(|| {
+        let result = out.browser_pane_register_result.ok_or_else(|| {
             format!(
                 "try_register_pane_live returned no result (block_id={}); host shutting down?",
                 block_id
@@ -188,7 +188,7 @@ impl BrowserPaneManager {
             RegisterResult::Closing => {
                 // Reject rather than overwrite: the old CEF Browser is
                 // mid-teardown and its on_before_close will call
-                // DrainPaneByLabel — if we let create overwrite, drain
+                // DrainBrowserPaneByLabel — if we let create overwrite, drain
                 // would evict the NEW entry. Frontend retries on next tick.
                 Err(format!(
                     "browser pane for block_id={} is still closing; retry after on_before_close",
@@ -269,29 +269,29 @@ impl BrowserPaneManager {
         // Phase H.1.d (PR #5) — sole pane-close entry point. The reducer
         // flips Live→Closing atomically and returns the entry's label iff
         // the transition fired. None means missing or already-Closing —
-        // both idempotent no-ops; we don't dispatch CompletePaneClose in
+        // both idempotent no-ops; we don't dispatch CompleteBrowserPaneClose in
         // those cases (codex P2 PR #655 race), avoiding the entry removal
         // while another in-flight close is still tearing down the HWND.
         let close_out = state.host_dispatch(
-            crate::reducer::HostCommand::EnqueuePaneClose {
+            crate::reducer::HostCommand::EnqueueBrowserPaneClose {
                 block_id: block_id.to_string(),
             },
         );
-        let label = match close_out.closed_pane_label {
+        let label = match close_out.closed_browser_pane_label {
             Some(l) => l,
             None => return,
         };
         let ops = AppStateCloseOps(state);
         Self::close_with(&label, &ops);
         state.host_dispatch(
-            crate::reducer::HostCommand::CompletePaneClose {
+            crate::reducer::HostCommand::CompleteBrowserPaneClose {
                 block_id: block_id.to_string(),
             },
         );
         tracing::info!(block_id, label, "browser pane closed");
 
         // PR #6 H.7 kick — the pane is fully closed; if any pool refill
-        // was deferred by `any_pane_closing()` while we were mid-close,
+        // was deferred by `any_browser_pane_closing()` while we were mid-close,
         // top up now. `spawn_pool_window` is internally idempotent
         // (single-flight semaphore + below-target check via reducer), so
         // calling it always-on-pane-close is safe even when no refill is
@@ -301,7 +301,7 @@ impl BrowserPaneManager {
 
     /// The testable side-effect body of `close()`. Given a pane's `label`,
     /// remove its Browser handle and destroy its HWND. The state-machine
-    /// transition (Live→Closing) and the entry removal (CompletePaneClose)
+    /// transition (Live→Closing) and the entry removal (CompleteBrowserPaneClose)
     /// happen in `close()` via reducer dispatch — `close_with` is purely
     /// the FFI side-effects that follow.
     fn close_with(label: &str, ops: &dyn PaneCloseOps) {
@@ -314,15 +314,15 @@ impl BrowserPaneManager {
     /// Called from CEF's `on_before_close` if/when it fires for a pane
     /// browser. The explicit `close()` path usually clears the entry first,
     /// so this is a no-op in that case — but `on_before_close` may still
-    /// fire async as Chromium's refcount hits zero, and `DrainPaneByLabel`
+    /// fire async as Chromium's refcount hits zero, and `DrainBrowserPaneByLabel`
     /// is idempotent so the callback is safe.
     pub fn drain_closed_label(&self, state: &Arc<AppState>, label: &str) {
         let out = state.host_dispatch(
-            crate::reducer::HostCommand::DrainPaneByLabel {
+            crate::reducer::HostCommand::DrainBrowserPaneByLabel {
                 label: label.to_string(),
             },
         );
-        if let Some(block_id) = out.drained_block_id {
+        if let Some(block_id) = out.drained_browser_pane_block_id {
             tracing::info!(label, block_id = %block_id, "browser pane drained via on_before_close");
             // PR #6 H.7 kick — see `close()` for rationale. The
             // on_before_close path is the async drain; pool refill that
@@ -348,7 +348,7 @@ impl BrowserPaneManager {
         // Phase H.1.b + H.2.b — read live labels via reducer-aware helper,
         // then look up each browser via reducer-aware helper. Both with
         // fallback + drift logging.
-        let labels = state.live_pane_labels();
+        let labels = state.live_browser_pane_labels();
         for label in &labels {
             if let Some(browser) = state.get_browser(label) {
                 if let Some(host) = browser.host() {
@@ -418,7 +418,7 @@ impl BrowserPaneManager {
         // Phase H.1.b + H.2.b — labels via reducer-aware helper; per-label
         // browser lookup via reducer-aware helper. Drops the held-across-loop
         // legacy lock; each iteration now snapshots independently.
-        let labels = state.live_pane_labels();
+        let labels = state.live_browser_pane_labels();
         for label in &labels {
             let browser = match state.get_browser(label) {
                 Some(b) => b,
@@ -537,7 +537,7 @@ impl BrowserPaneManager {
                         // Tell the subclass this focus request is intentional
                         // (not Chromium's on-load focus steal) so it won't be
                         // redirected back to the parent.
-                        crate::pane::ALLOW_PANE_FOCUS_ONCE.store(
+                        crate::browser_pane::ALLOW_PANE_FOCUS_ONCE.store(
                             true,
                             std::sync::atomic::Ordering::Relaxed,
                         );
@@ -551,12 +551,12 @@ impl BrowserPaneManager {
     }
 }
 
-// `CreatePaneTask` moved to `crate::pane::creation` in Phase 3.
+// `CreatePaneTask` moved to `crate::browser_pane::creation` in Phase 3.
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 //
 // Phase H.1.d/e (PR #5): The pane state machine lives in the host reducer
-// (`HostState.panes`). Lifecycle transition tests — Live→Closing, idempotent
+// (`HostState.browser_panes`). Lifecycle transition tests — Live→Closing, idempotent
 // no-ops for missing or already-Closing entries, label sequence monotonicity,
 // drain-by-label — are now in `crate::reducer::tests`.
 //

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 
 use cef::*;
 
-use crate::browser_pane::CreatePaneTask;
+use crate::browser_pane::CreateBrowserPaneTask;
 use crate::reducer::RegisterResult;
 use crate::state::AppState;
 
@@ -38,8 +38,8 @@ use crate::state::AppState;
 /// Kept minimal (just two methods) to avoid a dependency graph that has to
 /// be updated every time `close()` grows. Other ops (`focus`, `resize`, …)
 /// can gain their own traits when they need testing, or graduate to a
-/// unified `PaneCefBridge` once the shape is stable.
-pub trait PaneCloseOps {
+/// unified `BrowserPaneCefBridge` once the shape is stable.
+pub trait BrowserPaneCloseOps {
     /// Remove the Browser for this label from the registry. Return its
     /// outer HWND as a pointer-sized value, or `None` if there is no
     /// Browser or no HWND. Dropping the Browser Arc is the implementation's
@@ -52,11 +52,11 @@ pub trait PaneCloseOps {
     fn destroy_hwnd(&self, hwnd: usize);
 }
 
-/// Production implementation of `PaneCloseOps` backed by `AppState.browsers`
+/// Production implementation of `BrowserPaneCloseOps` backed by `AppState.browsers`
 /// and Win32 `DestroyWindow`.
 struct AppStateCloseOps<'a>(&'a Arc<AppState>);
 
-impl<'a> PaneCloseOps for AppStateCloseOps<'a> {
+impl<'a> BrowserPaneCloseOps for AppStateCloseOps<'a> {
     fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
         // Atomic take-and-return via reducer (codex P2 PR #660). Earlier
         // round 1 separated `get_browser` + `UnregisterBrowser` dispatch,
@@ -196,7 +196,7 @@ impl BrowserPaneManager {
                 ))
             }
             RegisterResult::Fresh(label) => {
-                let mut task = CreatePaneTask::new(
+                let mut task = CreateBrowserPaneTask::new(
                     state.clone(),
                     block_id.to_string(),
                     label,
@@ -304,7 +304,7 @@ impl BrowserPaneManager {
     /// transition (Live→Closing) and the entry removal (CompleteBrowserPaneClose)
     /// happen in `close()` via reducer dispatch — `close_with` is purely
     /// the FFI side-effects that follow.
-    fn close_with(label: &str, ops: &dyn PaneCloseOps) {
+    fn close_with(label: &str, ops: &dyn BrowserPaneCloseOps) {
         if let Some(hwnd) = ops.take_browser_hwnd(label) {
             ops.destroy_hwnd(hwnd);
             tracing::info!(label, "pane HWND destroyed");
@@ -537,7 +537,7 @@ impl BrowserPaneManager {
                         // Tell the subclass this focus request is intentional
                         // (not Chromium's on-load focus steal) so it won't be
                         // redirected back to the parent.
-                        crate::browser_pane::ALLOW_PANE_FOCUS_ONCE.store(
+                        crate::browser_pane::ALLOW_BROWSER_PANE_FOCUS_ONCE.store(
                             true,
                             std::sync::atomic::Ordering::Relaxed,
                         );
@@ -551,7 +551,7 @@ impl BrowserPaneManager {
     }
 }
 
-// `CreatePaneTask` moved to `crate::browser_pane::creation` in Phase 3.
+// `CreateBrowserPaneTask` moved to `crate::browser_pane::creation` in Phase 3.
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 //
@@ -561,7 +561,7 @@ impl BrowserPaneManager {
 // drain-by-label — are now in `crate::reducer::tests`.
 //
 // What remains here: the FFI seam. `close_with` only takes a label and
-// drives `PaneCloseOps`; tests verify it forwards label → take → destroy
+// drives `BrowserPaneCloseOps`; tests verify it forwards label → take → destroy
 // in order, with a None-returning `take` short-circuiting the destroy.
 
 #[cfg(test)]
@@ -569,7 +569,7 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    /// Recording mock for `PaneCloseOps`. Tests inspect `taken` and
+    /// Recording mock for `BrowserPaneCloseOps`. Tests inspect `taken` and
     /// `destroyed` to assert what close_with did.
     struct MockCloseOps {
         registered: parking_lot::Mutex<HashMap<String, usize>>,
@@ -599,7 +599,7 @@ mod tests {
         }
     }
 
-    impl PaneCloseOps for MockCloseOps {
+    impl BrowserPaneCloseOps for MockCloseOps {
         fn take_browser_hwnd(&self, label: &str) -> Option<usize> {
             self.taken.lock().push(label.to_string());
             self.registered.lock().remove(label)

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -171,7 +171,7 @@ impl BrowserPaneManager {
         );
         let result = out.browser_pane_register_result.ok_or_else(|| {
             format!(
-                "try_register_pane_live returned no result (block_id={}); host shutting down?",
+                "try_register_browser_pane_live returned no result (block_id={}); host shutting down?",
                 block_id
             )
         })?;

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -80,10 +80,10 @@ pub struct AgentMuxHandler {
 
 impl AgentMuxHandler {
     pub fn new(state: Arc<AppState>, ipc_port: u16) -> Arc<Mutex<Self>> {
-        Self::new_with_pane(state, ipc_port, false)
+        Self::new_with_browser_pane(state, ipc_port, false)
     }
 
-    pub fn new_with_pane(state: Arc<AppState>, ipc_port: u16, is_pane: bool) -> Arc<Mutex<Self>> {
+    pub fn new_with_browser_pane(state: Arc<AppState>, ipc_port: u16, is_pane: bool) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             browser_list: Vec::new(),
             is_closing: false,
@@ -321,10 +321,10 @@ impl AgentMuxHandler {
         }
 
         // Pane-specific on_after_created work (Z-order raise + Win32 focus
-        // subclass install) lives in `crate::pane::callbacks` after Phase 4
+        // subclass install) lives in `crate::browser_pane::callbacks` after Phase 4
         // of the modularization split.
         if self.is_pane {
-            crate::pane::callbacks::on_after_created_pane(&self.state, &browser);
+            crate::browser_pane::callbacks::on_after_created_browser_pane(&self.state, &browser);
         }
 
         // Phase B.4 — report top-level windows to the launcher's
@@ -541,10 +541,10 @@ impl AgentMuxHandler {
         }
 
         // Pane-specific on_before_close work (drain lifecycle entry) lives
-        // in `crate::pane::callbacks` after Phase 4.
+        // in `crate::browser_pane::callbacks` after Phase 4.
         if let Some(ref lbl) = label {
             if lbl.starts_with("browser-pane-") {
-                crate::pane::callbacks::on_before_close_pane(&self.state, lbl);
+                crate::browser_pane::callbacks::on_before_close_browser_pane(&self.state, lbl);
             }
             // Pool-window cleanup — release the respawn semaphore +
             // drop the label from the queue if the window died before
@@ -616,7 +616,7 @@ impl AgentMuxHandler {
 
         // Phase F.6 — narrate the pane-reap step for the launcher's
         // window-cleanup-cascade saga. By the time we reach here, the
-        // pane lifecycle drain (`on_before_close_pane` for browser-
+        // pane lifecycle drain (`on_before_close_browser_pane` for browser-
         // pane labels) and the subwindow cascade above have run for
         // this label. The saga uses this signal as the Step 1
         // terminal so it can advance to Step 2 (drain-pool decision).
@@ -905,7 +905,7 @@ impl AgentMuxHandler {
             return;
         }
         if let Some(b) = browser.as_deref() {
-            crate::pane::callbacks::on_loading_state_change_pane(
+            crate::browser_pane::callbacks::on_loading_state_change_pane(
                 &self.state,
                 b,
                 can_go_back != 0,
@@ -930,11 +930,11 @@ impl AgentMuxHandler {
 
         // Pane-specific on_load_end work (focus subclass re-install after
         // Chromium rebuilds Chrome_RenderWidgetHostHWND on navigation)
-        // lives in `crate::pane::callbacks` after Phase 4. Returning early
+        // lives in `crate::browser_pane::callbacks` after Phase 4. Returning early
         // skips main-only IPC-port injection below.
         if self.is_pane {
             if let Some(b) = browser.as_deref() {
-                crate::pane::callbacks::on_load_end_pane(&self.state, b);
+                crate::browser_pane::callbacks::on_load_end_pane(&self.state, b);
             }
             return;
         }
@@ -1381,7 +1381,7 @@ wrap_client! {
 // focus during the very first navigation of a newly-created pane fires
 // CEF's `on_before_close` on that pane ~10ms later. Focus-steal
 // protection lives entirely in the Win32 `WndProc` subclass below
-// (`pane::hwnd::install_pane_focus_redirect`), which redirects programmatic
+// (`pane::hwnd::install_browser_pane_focus_redirect`), which redirects programmatic
 // `WM_SETFOCUS` back to the top-level window. User clicks are let through
 // because `WM_LBUTTONDOWN` in the subclass arms `ALLOW_PANE_FOCUS_ONCE`.
 wrap_focus_handler! {
@@ -1401,7 +1401,7 @@ wrap_focus_handler! {
             // reliably reproducible when creating a 2nd browser pane.
             // The Win32 WndProc subclass below already redirects
             // page-load SetFocus to the top-level window (see
-            // `pane::hwnd::install_pane_focus_redirect`), which
+            // `pane::hwnd::install_browser_pane_focus_redirect`), which
             // handles the original focus-steal concern. Returning 0
             // here so CEF proceeds with normal focus handling at the
             // Chromium level; Win32 subclass continues to redirect
@@ -1672,7 +1672,7 @@ static ORIGINAL_WNDPROCS: std::sync::LazyLock<
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
 // Pane Win32 focus-redirect subclass + ALLOW_PANE_FOCUS_ONCE flag moved to
-// `crate::pane::hwnd` in Phase 2 of the modularization split. See
+// `crate::browser_pane::hwnd` in Phase 2 of the modularization split. See
 // `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md`.
 
 /// Install a WndProc hook on a SECONDARY window that handles:

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1383,7 +1383,7 @@ wrap_client! {
 // protection lives entirely in the Win32 `WndProc` subclass below
 // (`browser_pane::hwnd::install_browser_pane_focus_redirect`), which redirects programmatic
 // `WM_SETFOCUS` back to the top-level window. User clicks are let through
-// because `WM_LBUTTONDOWN` in the subclass arms `ALLOW_PANE_FOCUS_ONCE`.
+// because `WM_LBUTTONDOWN` in the subclass arms `ALLOW_BROWSER_PANE_FOCUS_ONCE`.
 wrap_focus_handler! {
     struct AgentMuxPaneFocusHandler;
 
@@ -1671,7 +1671,7 @@ static ORIGINAL_WNDPROCS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<usize, isize>>,
 > = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
 
-// Pane Win32 focus-redirect subclass + ALLOW_PANE_FOCUS_ONCE flag moved to
+// Pane Win32 focus-redirect subclass + ALLOW_BROWSER_PANE_FOCUS_ONCE flag moved to
 // `crate::browser_pane::hwnd` in Phase 2 of the modularization split. See
 // `docs/specs/SPEC_BROWSER_PANE_MODULARIZATION.md`.
 

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -1381,7 +1381,7 @@ wrap_client! {
 // focus during the very first navigation of a newly-created pane fires
 // CEF's `on_before_close` on that pane ~10ms later. Focus-steal
 // protection lives entirely in the Win32 `WndProc` subclass below
-// (`pane::hwnd::install_browser_pane_focus_redirect`), which redirects programmatic
+// (`browser_pane::hwnd::install_browser_pane_focus_redirect`), which redirects programmatic
 // `WM_SETFOCUS` back to the top-level window. User clicks are let through
 // because `WM_LBUTTONDOWN` in the subclass arms `ALLOW_PANE_FOCUS_ONCE`.
 wrap_focus_handler! {
@@ -1401,7 +1401,7 @@ wrap_focus_handler! {
             // reliably reproducible when creating a 2nd browser pane.
             // The Win32 WndProc subclass below already redirects
             // page-load SetFocus to the top-level window (see
-            // `pane::hwnd::install_browser_pane_focus_redirect`), which
+            // `browser_pane::hwnd::install_browser_pane_focus_redirect`), which
             // handles the original focus-steal concern. Returning 0
             // here so CEF proceeds with normal focus handling at the
             // Chromium level; Win32 subclass continues to redirect

--- a/agentmux-cef/src/client.rs
+++ b/agentmux-cef/src/client.rs
@@ -75,7 +75,7 @@ pub struct AgentMuxHandler {
     is_closing: bool,
     state: Arc<AppState>,
     ipc_port: u16,
-    is_pane: bool,
+    is_browser_pane: bool,
 }
 
 impl AgentMuxHandler {
@@ -83,13 +83,13 @@ impl AgentMuxHandler {
         Self::new_with_browser_pane(state, ipc_port, false)
     }
 
-    pub fn new_with_browser_pane(state: Arc<AppState>, ipc_port: u16, is_pane: bool) -> Arc<Mutex<Self>> {
+    pub fn new_with_browser_pane(state: Arc<AppState>, ipc_port: u16, is_browser_pane: bool) -> Arc<Mutex<Self>> {
         Arc::new(Mutex::new(Self {
             browser_list: Vec::new(),
             is_closing: false,
             state,
             ipc_port,
-            is_pane,
+            is_browser_pane,
         }))
     }
 
@@ -205,11 +205,11 @@ impl AgentMuxHandler {
         let is_top_level_window = !label.starts_with("browser-pane-");
 
         // Determine BrowserKind from the LABEL prefix, not the
-        // AgentMuxClient `is_pane` flag. Smoke test on 0.33.586 found
+        // AgentMuxClient `is_browser_pane` flag. Smoke test on 0.33.586 found
         // top-level windows misclassified as `Pane { block_id: "" }`
         // because `CreateWindowTask::execute` reuses an existing
         // browser's CEF Client via `first_browser()` — if the iteration
-        // happens to pick a pane, the new window inherits `is_pane=true`
+        // happens to pick a pane, the new window inherits `is_browser_pane=true`
         // and the label-stripping in this branch produces an empty
         // block_id (since the label starts with `window-` not
         // `browser-pane-`). LABEL is the source of truth. See
@@ -323,7 +323,7 @@ impl AgentMuxHandler {
         // Pane-specific on_after_created work (Z-order raise + Win32 focus
         // subclass install) lives in `crate::browser_pane::callbacks` after Phase 4
         // of the modularization split.
-        if self.is_pane {
+        if self.is_browser_pane {
             crate::browser_pane::callbacks::on_after_created_browser_pane(&self.state, &browser);
         }
 
@@ -489,7 +489,7 @@ impl AgentMuxHandler {
             cef::post_task(cef::ThreadId::UI, Some(&mut task));
         }
         tracing::info!(
-            is_pane = %self.is_pane,
+            is_browser_pane = %self.is_browser_pane,
             url = %url,
             "popup intercepted — deferred navigation of current frame",
         );
@@ -505,8 +505,8 @@ impl AgentMuxHandler {
         // close-cascade issues.
         tracing::debug!(
             target: "wrr-trace",
-            "[trace] on_before_close ENTER; self.browser_list.len()={} is_pane={}",
-            self.browser_list.len(), self.is_pane
+            "[trace] on_before_close ENTER; self.browser_list.len()={} is_browser_pane={}",
+            self.browser_list.len(), self.is_browser_pane
         );
         dlog(&format!("on_before_close fired; browser_list.len()={}", self.browser_list.len()));
 
@@ -687,8 +687,8 @@ impl AgentMuxHandler {
         // gate input when investigating close-cascade issues.
         tracing::debug!(
             target: "wrr-trace",
-            "[trace] app-exit gate: closing_label={:?} user_count={} is_pane={} browsers={:?} unpromoted_pool={:?}",
-            label, user_browser_count, self.is_pane, browsers_keys, pool_keys
+            "[trace] app-exit gate: closing_label={:?} user_count={} is_browser_pane={} browsers={:?} unpromoted_pool={:?}",
+            label, user_browser_count, self.is_browser_pane, browsers_keys, pool_keys
         );
 
         // Phase F.6 — narrate the post-close pool-drain decision for
@@ -717,7 +717,7 @@ impl AgentMuxHandler {
             // browser-pane-* only. window-pool-* labels (promoted)
             // are tracked windows and need their cleanup events.
             if !lbl.starts_with("browser-pane-") {
-                let was_last = user_browser_count == 0 && !self.is_pane;
+                let was_last = user_browser_count == 0 && !self.is_browser_pane;
                 crate::launcher_ipc::report_pool_drain_decision(lbl.clone(), was_last);
             }
         }
@@ -746,7 +746,7 @@ impl AgentMuxHandler {
         // Windows path. macOS uses NSWindow.performClose:; Linux
         // uses X11 WM_DELETE_WINDOW. Same async-close-cascade
         // semantics on all platforms; only the OS API differs.
-        if user_browser_count == 0 && !self.is_pane {
+        if user_browser_count == 0 && !self.is_browser_pane {
             // PR #5 H.5 — flip QuitState Running → Draining via reducer.
             // Mirrors the pre-PR Phase B.9.3 drain flag: spawn_pool_window
             // checks `quit_state != Running` (in the reducer's spawn arm)
@@ -845,7 +845,7 @@ impl AgentMuxHandler {
         // Stage 2: every browser this handler ever managed is now
         // gone. Safe to call quit_message_loop — no other CEF
         // lifecycle is in flight that could deadlock with it.
-        if self.browser_list.is_empty() && !self.is_pane {
+        if self.browser_list.is_empty() && !self.is_browser_pane {
             tracing::warn!(
                 target: "wrr",
                 "[wrr] stage 2: self.browser_list.is_empty() — calling quit_message_loop"
@@ -901,11 +901,11 @@ impl AgentMuxHandler {
         can_go_back: i32,
         can_go_forward: i32,
     ) {
-        if !self.is_pane {
+        if !self.is_browser_pane {
             return;
         }
         if let Some(b) = browser.as_deref() {
-            crate::browser_pane::callbacks::on_loading_state_change_pane(
+            crate::browser_pane::callbacks::on_loading_state_change_browser_pane(
                 &self.state,
                 b,
                 can_go_back != 0,
@@ -932,9 +932,9 @@ impl AgentMuxHandler {
         // Chromium rebuilds Chrome_RenderWidgetHostHWND on navigation)
         // lives in `crate::browser_pane::callbacks` after Phase 4. Returning early
         // skips main-only IPC-port injection below.
-        if self.is_pane {
+        if self.is_browser_pane {
             if let Some(b) = browser.as_deref() {
-                crate::browser_pane::callbacks::on_load_end_pane(&self.state, b);
+                crate::browser_pane::callbacks::on_load_end_browser_pane(&self.state, b);
             }
             return;
         }
@@ -1332,7 +1332,7 @@ fn html_escape(s: &str) -> String {
 wrap_client! {
     pub struct AgentMuxClient {
         inner: Arc<Mutex<AgentMuxHandler>>,
-        is_pane: bool,
+        is_browser_pane: bool,
     }
 
     impl Client {
@@ -1357,7 +1357,7 @@ wrap_client! {
         }
 
         fn drag_handler(&self) -> Option<DragHandler> {
-            if self.is_pane {
+            if self.is_browser_pane {
                 return None;
             }
             Some(AgentMuxDragHandler::new(self.inner.clone()))
@@ -1367,7 +1367,7 @@ wrap_client! {
             // For browser panes only: cancel CEF's auto-focus on navigation so the
             // child HWND doesn't steal keyboard focus from the main window when the
             // page finishes loading. The user can still click into the pane to focus it.
-            if self.is_pane {
+            if self.is_browser_pane {
                 Some(AgentMuxPaneFocusHandler::new())
             } else {
                 None

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -344,7 +344,7 @@ pub fn tear_off_pool_promote(
 pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     // PR #6 H.7 — refuse top-level creation while any pane is mid-close.
     // See `commands/window.rs::open_window_with_kind` for rationale.
-    if state.any_pane_closing() {
+    if state.any_browser_pane_closing() {
         tracing::warn!(
             target: "wfr:gate",
             "[wfr:gate] open_window_at_position refused — pane is mid-close (H.7 invariant)"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -626,7 +626,7 @@ fn open_window_with_kind(
     // creating a top-level CEF window while a pane is in `Closing` hits
     // a Chromium v146 deadlock (HiddenSinceOpen + IPC backpressure)
     // that wedges the message loop. Frontend should retry on next tick.
-    if state.any_pane_closing() {
+    if state.any_browser_pane_closing() {
         tracing::warn!(
             target: "wfr:gate",
             "[wfr:gate] open_window refused — pane is mid-close (H.7 invariant)"

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -74,7 +74,7 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
     // windows are CEF top-levels just like user-visible ones; the v146
     // deadlock fires regardless of whether the new window is on-screen.
     // See `commands/window.rs::open_window_with_kind` for rationale.
-    if state.any_pane_closing() {
+    if state.any_browser_pane_closing() {
         tracing::warn!(
             target: "wfr:gate",
             "[wfr:gate] spawn_pool_window deferred — pane is mid-close (H.7 invariant)"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -34,7 +34,7 @@ mod launcher_ipc;
 mod srv_event_bridge;
 mod srv_ipc;
 mod memory_heartbeat;
-mod pane;
+mod browser_pane;
 mod reducer;
 mod saga_dispatch;
 mod sidecar;

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -35,7 +35,7 @@ use cef::Browser;
 
 use crate::state::{
     BrowserHandle, BrowserKind, CompletedCreation, CreationPhase, DragSession, EffectKind,
-    InFlightCreation, PaneEntry, PaneLifecycle, PendingWindowCreation, PoolState, QuitReason,
+    InFlightCreation, BrowserPaneEntry, BrowserPaneLifecycle, PendingWindowCreation, PoolState, QuitReason,
     QuitState, TopLevelCreationOutcome, TopLevelCreationRequest, TopLevelCreationState,
     TopLevelSource,
 };
@@ -86,7 +86,7 @@ pub struct HostState {
     /// H.1 — pane lifecycle map. Replaces `BrowserPaneManager::PaneStateMachine`
     /// (pane/lifecycle.rs:60). Keyed by `block_id`.
     #[allow(dead_code)]
-    pub panes: HashMap<String, PaneEntry>,
+    pub browser_panes: HashMap<String, BrowserPaneEntry>,
 
     /// H.2 — browser handle registry. Replaces `AppState.browsers:
     /// Mutex<HashMap<String, Browser>>` (state.rs:210). Keyed by label
@@ -128,7 +128,7 @@ impl Default for HostState {
             pending_window_creations: VecDeque::new(),
             // Phase H foundations (PR #1) — empty defaults; populated as
             // PRs #2-#5 wire callers through the reducer.
-            panes: HashMap::new(),
+            browser_panes: HashMap::new(),
             browsers: HashMap::new(),
             active_drag: None,
             pool: PoolState::default(),
@@ -156,17 +156,17 @@ impl HostState {
 //
 // Monotonic counter appended to every pane label so a close-then-recreate of
 // the same block_id doesn't collide: if the old browser's `on_before_close`
-// fires after the new pane's create has already run, `DrainPaneByLabel`
+// fires after the new pane's create has already run, `DrainBrowserPaneByLabel`
 // would otherwise find and wipe the NEW entry.
 static PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
 
-fn next_pane_label(block_id: &str) -> String {
+fn next_browser_pane_label(block_id: &str) -> String {
     let seq = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
     format!("browser-pane-{}-{}", block_id, seq)
 }
 
-/// Outcome of `TryRegisterPaneLive`. Returned via
-/// `DispatchOutput::pane_register_result`. Same three-way semantics as the
+/// Outcome of `TryRegisterBrowserPaneLive`. Returned via
+/// `DispatchOutput::browser_pane_register_result`. Same three-way semantics as the
 /// pre-Phase-H `pane::lifecycle::PaneStateMachine::try_register_live` returned
 /// — caller decides whether to start a fresh CEF create, re-navigate the
 /// existing browser, or reject.
@@ -206,31 +206,31 @@ pub enum HostCommand {
 
     /// Caller (pane create code) requests a new pane lifecycle entry.
     /// Reducer inserts with `Live`. Reject if `block_id` already present.
-    EnqueuePaneCreate { block_id: String, label: String },
+    EnqueueBrowserPaneCreate { block_id: String, label: String },
 
     /// PR #5 — sole pane registration entry point post-H.1.d.
     ///
     /// Replaces `pane::lifecycle::PaneStateMachine::try_register_live`.
-    /// Reducer generates the label internally (via `next_pane_label`) so
+    /// Reducer generates the label internally (via `next_browser_pane_label`) so
     /// label assignment is atomic with the entry insert. Returns the
-    /// outcome via `DispatchOutput::pane_register_result`:
+    /// outcome via `DispatchOutput::browser_pane_register_result`:
     ///   - `Fresh(label)`: new `Live` entry inserted; caller posts CreatePaneTask
     ///   - `AlreadyLive(label)`: caller should re-navigate existing browser
     ///   - `Closing`: caller must reject (old teardown still in flight)
-    TryRegisterPaneLive { block_id: String },
+    TryRegisterBrowserPaneLive { block_id: String },
 
     /// CEF on_after_created fired for a pane browser; confirm it's Live.
     /// No-op if already Live or absent (idempotent against late callbacks).
-    CompletePaneCreate { block_id: String },
+    CompleteBrowserPaneCreate { block_id: String },
 
     /// Caller requests pane close. Reducer flips entry to `Closing` and
-    /// returns the entry's label via `DispatchOutput::closed_pane_label`
+    /// returns the entry's label via `DispatchOutput::closed_browser_pane_label`
     /// iff the transition actually fired (was `Live`). Returns `None` for
     /// missing or already-Closing entries (idempotent).
-    EnqueuePaneClose { block_id: String },
+    EnqueueBrowserPaneClose { block_id: String },
 
     /// CEF on_before_close fired for a pane; remove entry from map.
-    CompletePaneClose { block_id: String },
+    CompleteBrowserPaneClose { block_id: String },
 
     /// PR #5 — sole label-keyed drain entry point post-H.1.d.
     ///
@@ -238,13 +238,13 @@ pub enum HostCommand {
     /// by `BrowserPaneManager::drain_closed_label` when CEF's
     /// `on_before_close` fires for a pane. Removes the entry whose `label`
     /// matches; returns the drained `block_id` via
-    /// `DispatchOutput::drained_block_id` so the caller can also dispatch
+    /// `DispatchOutput::drained_browser_pane_block_id` so the caller can also dispatch
     /// any block_id-keyed cleanup. Idempotent (None if no match).
-    DrainPaneByLabel { label: String },
+    DrainBrowserPaneByLabel { label: String },
 
     /// Pane creation failed before reaching Live (e.g., CEF callback
     /// never fired, browser host returned 0). Reducer removes entry.
-    AbortPaneCreate { block_id: String, reason: String },
+    AbortBrowserPaneCreate { block_id: String, reason: String },
 
     // ── H.2 — browser handle registry ───────────────────────────────────
 
@@ -343,33 +343,33 @@ impl std::fmt::Debug for HostCommand {
             HostCommand::DequeuePendingWindowCreation => {
                 f.write_str("DequeuePendingWindowCreation")
             }
-            HostCommand::EnqueuePaneCreate { block_id, label } => f
-                .debug_struct("EnqueuePaneCreate")
+            HostCommand::EnqueueBrowserPaneCreate { block_id, label } => f
+                .debug_struct("EnqueueBrowserPaneCreate")
                 .field("block_id", block_id)
                 .field("label", label)
                 .finish(),
-            HostCommand::TryRegisterPaneLive { block_id } => f
-                .debug_struct("TryRegisterPaneLive")
+            HostCommand::TryRegisterBrowserPaneLive { block_id } => f
+                .debug_struct("TryRegisterBrowserPaneLive")
                 .field("block_id", block_id)
                 .finish(),
-            HostCommand::CompletePaneCreate { block_id } => f
-                .debug_struct("CompletePaneCreate")
+            HostCommand::CompleteBrowserPaneCreate { block_id } => f
+                .debug_struct("CompleteBrowserPaneCreate")
                 .field("block_id", block_id)
                 .finish(),
-            HostCommand::EnqueuePaneClose { block_id } => f
-                .debug_struct("EnqueuePaneClose")
+            HostCommand::EnqueueBrowserPaneClose { block_id } => f
+                .debug_struct("EnqueueBrowserPaneClose")
                 .field("block_id", block_id)
                 .finish(),
-            HostCommand::CompletePaneClose { block_id } => f
-                .debug_struct("CompletePaneClose")
+            HostCommand::CompleteBrowserPaneClose { block_id } => f
+                .debug_struct("CompleteBrowserPaneClose")
                 .field("block_id", block_id)
                 .finish(),
-            HostCommand::DrainPaneByLabel { label } => f
-                .debug_struct("DrainPaneByLabel")
+            HostCommand::DrainBrowserPaneByLabel { label } => f
+                .debug_struct("DrainBrowserPaneByLabel")
                 .field("label", label)
                 .finish(),
-            HostCommand::AbortPaneCreate { block_id, reason } => f
-                .debug_struct("AbortPaneCreate")
+            HostCommand::AbortBrowserPaneCreate { block_id, reason } => f
+                .debug_struct("AbortBrowserPaneCreate")
                 .field("block_id", block_id)
                 .field("reason", reason)
                 .finish(),
@@ -495,25 +495,25 @@ pub enum HostEvent {
 
     // ── H.1 — pane lifecycle events ─────────────────────────────────────
 
-    PaneCreateRequested {
+    BrowserPaneCreateRequested {
         block_id: String,
         label: String,
         version: u64,
     },
-    PaneLive {
+    BrowserPaneLive {
         block_id: String,
         label: String,
         version: u64,
     },
-    PaneClosing {
+    BrowserPaneClosing {
         block_id: String,
         version: u64,
     },
-    PaneClosed {
+    BrowserPaneClosed {
         block_id: String,
         version: u64,
     },
-    PaneCreationFailed {
+    BrowserPaneCreationFailed {
         block_id: String,
         reason: String,
         version: u64,
@@ -628,17 +628,17 @@ pub enum HostEvent {
 ///   creates a window where concurrent readers can also resolve the
 ///   label and act on the closing handle).
 ///
-/// - `TryRegisterPaneLive` → `pane_register_result: Option<RegisterResult>`
+/// - `TryRegisterBrowserPaneLive` → `browser_pane_register_result: Option<RegisterResult>`
 ///   (PR #5 H.1.d: `BrowserPaneManager::create` branches on
 ///   Fresh/AlreadyLive/Closing).
 ///
-/// - `EnqueuePaneClose` → `closed_pane_label: Option<String>` (PR #5
+/// - `EnqueueBrowserPaneClose` → `closed_browser_pane_label: Option<String>` (PR #5
 ///   H.1.d: the close path needs the label to call `take_browser_hwnd`
-///   without a separate `live_pane_label` query that could race).
+///   without a separate `live_browser_pane_label` query that could race).
 ///
-/// - `DrainPaneByLabel` → `drained_block_id: Option<String>` (PR #5
+/// - `DrainBrowserPaneByLabel` → `drained_browser_pane_block_id: Option<String>` (PR #5
 ///   H.1.d: `drain_closed_label` needs the block_id to dispatch
-///   `CompletePaneClose`).
+///   `CompleteBrowserPaneClose`).
 ///
 /// - `EndDrag` → `ended_drag_session: Option<DragSession>` (PR #5
 ///   H.3: `complete_cross_drag` / `cancel_cross_drag` need the
@@ -671,9 +671,9 @@ pub struct DispatchOutput {
     pub events: Vec<HostEvent>,
     pub dequeued: Option<PendingWindowCreation>,
     pub removed_browser: Option<Browser>,
-    pub pane_register_result: Option<RegisterResult>,
-    pub closed_pane_label: Option<String>,
-    pub drained_block_id: Option<String>,
+    pub browser_pane_register_result: Option<RegisterResult>,
+    pub closed_browser_pane_label: Option<String>,
+    pub drained_browser_pane_block_id: Option<String>,
     pub ended_drag_session: Option<DragSession>,
     pub pool_spawn_proceeding: bool,
     pub pool_size_after: Option<usize>,
@@ -695,9 +695,9 @@ impl std::fmt::Debug for DispatchOutput {
                     &"None"
                 },
             )
-            .field("pane_register_result", &self.pane_register_result)
-            .field("closed_pane_label", &self.closed_pane_label)
-            .field("drained_block_id", &self.drained_block_id)
+            .field("browser_pane_register_result", &self.browser_pane_register_result)
+            .field("closed_browser_pane_label", &self.closed_browser_pane_label)
+            .field("drained_browser_pane_block_id", &self.drained_browser_pane_block_id)
             .field("ended_drag_session", &self.ended_drag_session)
             .field("pool_spawn_proceeding", &self.pool_spawn_proceeding)
             .field("pool_size_after", &self.pool_size_after)
@@ -721,26 +721,26 @@ pub fn update(state: &mut HostState, cmd: HostCommand) -> DispatchOutput {
             handle_dequeue_pending_window_creation(state)
         }
         // H.1 panes
-        HostCommand::EnqueuePaneCreate { block_id, label } => {
-            handle_enqueue_pane_create(state, block_id, label)
+        HostCommand::EnqueueBrowserPaneCreate { block_id, label } => {
+            handle_enqueue_browser_pane_create(state, block_id, label)
         }
-        HostCommand::TryRegisterPaneLive { block_id } => {
-            handle_try_register_pane_live(state, block_id)
+        HostCommand::TryRegisterBrowserPaneLive { block_id } => {
+            handle_try_register_browser_pane_live(state, block_id)
         }
-        HostCommand::CompletePaneCreate { block_id } => {
-            handle_complete_pane_create(state, block_id)
+        HostCommand::CompleteBrowserPaneCreate { block_id } => {
+            handle_complete_browser_pane_create(state, block_id)
         }
-        HostCommand::EnqueuePaneClose { block_id } => {
-            handle_enqueue_pane_close(state, block_id)
+        HostCommand::EnqueueBrowserPaneClose { block_id } => {
+            handle_enqueue_browser_pane_close(state, block_id)
         }
-        HostCommand::CompletePaneClose { block_id } => {
-            handle_complete_pane_close(state, block_id)
+        HostCommand::CompleteBrowserPaneClose { block_id } => {
+            handle_complete_browser_pane_close(state, block_id)
         }
-        HostCommand::DrainPaneByLabel { label } => {
-            handle_drain_pane_by_label(state, label)
+        HostCommand::DrainBrowserPaneByLabel { label } => {
+            handle_drain_browser_pane_by_label(state, label)
         }
-        HostCommand::AbortPaneCreate { block_id, reason } => {
-            handle_abort_pane_create(state, block_id, reason)
+        HostCommand::AbortBrowserPaneCreate { block_id, reason } => {
+            handle_abort_browser_pane_create(state, block_id, reason)
         }
         // H.2 browsers
         HostCommand::RegisterBrowser { label, browser, kind } => {
@@ -856,7 +856,7 @@ fn emit_error(state: &mut HostState, message: String) -> DispatchOutput {
 
 // ── H.1 — pane lifecycle ─────────────────────────────────────────────────
 
-fn handle_enqueue_pane_create(
+fn handle_enqueue_browser_pane_create(
     state: &mut HostState,
     block_id: String,
     label: String,
@@ -864,52 +864,52 @@ fn handle_enqueue_pane_create(
     if state.lifecycle == HostLifecyclePhase::ShuttingDown {
         return emit_error(state, format!("enqueue_pane_create: shutting down (block_id={})", block_id));
     }
-    if state.panes.contains_key(&block_id) {
+    if state.browser_panes.contains_key(&block_id) {
         return emit_error(state, format!("enqueue_pane_create: block_id {} already has a pane", block_id));
     }
-    state.panes.insert(
+    state.browser_panes.insert(
         block_id.clone(),
-        PaneEntry {
+        BrowserPaneEntry {
             block_id: block_id.clone(),
             label: label.clone(),
-            lifecycle: PaneLifecycle::Live,
+            lifecycle: BrowserPaneLifecycle::Live,
         },
     );
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneCreateRequested { block_id, label, version: v }],
+        events: vec![HostEvent::BrowserPaneCreateRequested { block_id, label, version: v }],
         ..Default::default()
     }
 }
 
-fn handle_complete_pane_create(state: &mut HostState, block_id: String) -> DispatchOutput {
-    let entry = match state.panes.get(&block_id) {
+fn handle_complete_browser_pane_create(state: &mut HostState, block_id: String) -> DispatchOutput {
+    let entry = match state.browser_panes.get(&block_id) {
         Some(e) => e.clone(),
         None => return DispatchOutput::default(), // late callback for already-removed pane; idempotent no-op
     };
-    // Already Live by EnqueuePaneCreate's invariant; this is a no-op
+    // Already Live by EnqueueBrowserPaneCreate's invariant; this is a no-op
     // confirmation event for observers.
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneLive { block_id, label: entry.label, version: v }],
+        events: vec![HostEvent::BrowserPaneLive { block_id, label: entry.label, version: v }],
         ..Default::default()
     }
 }
 
-fn handle_enqueue_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
-    let entry = match state.panes.get_mut(&block_id) {
+fn handle_enqueue_browser_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
+    let entry = match state.browser_panes.get_mut(&block_id) {
         Some(e) => e,
         None => return DispatchOutput::default(), // close request for already-gone pane; idempotent
     };
-    if matches!(entry.lifecycle, PaneLifecycle::Closing { .. }) {
+    if matches!(entry.lifecycle, BrowserPaneLifecycle::Closing { .. }) {
         return DispatchOutput::default(); // already Closing; idempotent
     }
-    entry.lifecycle = PaneLifecycle::Closing { since: Instant::now() };
+    entry.lifecycle = BrowserPaneLifecycle::Closing { since: Instant::now() };
     let label = entry.label.clone();
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneClosing { block_id, version: v }],
-        closed_pane_label: Some(label),
+        events: vec![HostEvent::BrowserPaneClosing { block_id, version: v }],
+        closed_browser_pane_label: Some(label),
         ..Default::default()
     }
 }
@@ -920,41 +920,41 @@ fn handle_enqueue_pane_close(state: &mut HostState, block_id: String) -> Dispatc
 /// - Live entry exists → `AlreadyLive(label)`
 /// - Closing entry exists → `Closing`
 /// - No entry → generate label, insert Live, `Fresh(label)` + emit
-///   `PaneCreateRequested`
-fn handle_try_register_pane_live(state: &mut HostState, block_id: String) -> DispatchOutput {
+///   `BrowserPaneCreateRequested`
+fn handle_try_register_browser_pane_live(state: &mut HostState, block_id: String) -> DispatchOutput {
     if state.lifecycle == HostLifecyclePhase::ShuttingDown {
         return emit_error(
             state,
             format!("try_register_pane_live: shutting down (block_id={})", block_id),
         );
     }
-    if let Some(entry) = state.panes.get(&block_id) {
+    if let Some(entry) = state.browser_panes.get(&block_id) {
         let result = match entry.lifecycle {
-            PaneLifecycle::Live => RegisterResult::AlreadyLive(entry.label.clone()),
-            PaneLifecycle::Closing { .. } => RegisterResult::Closing,
+            BrowserPaneLifecycle::Live => RegisterResult::AlreadyLive(entry.label.clone()),
+            BrowserPaneLifecycle::Closing { .. } => RegisterResult::Closing,
         };
         return DispatchOutput {
-            pane_register_result: Some(result),
+            browser_pane_register_result: Some(result),
             ..Default::default()
         };
     }
-    let label = next_pane_label(&block_id);
-    state.panes.insert(
+    let label = next_browser_pane_label(&block_id);
+    state.browser_panes.insert(
         block_id.clone(),
-        PaneEntry {
+        BrowserPaneEntry {
             block_id: block_id.clone(),
             label: label.clone(),
-            lifecycle: PaneLifecycle::Live,
+            lifecycle: BrowserPaneLifecycle::Live,
         },
     );
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneCreateRequested {
+        events: vec![HostEvent::BrowserPaneCreateRequested {
             block_id,
             label: label.clone(),
             version: v,
         }],
-        pane_register_result: Some(RegisterResult::Fresh(label)),
+        browser_pane_register_result: Some(RegisterResult::Fresh(label)),
         ..Default::default()
     }
 }
@@ -963,12 +963,12 @@ fn handle_try_register_pane_live(state: &mut HostState, block_id: String) -> Dis
 /// `pane::lifecycle::PaneStateMachine::drain_by_label`.
 ///
 /// Removes whichever pane entry has `label`. Returns the drained block_id
-/// in `drained_block_id`. Idempotent — `None` if no entry has that label
+/// in `drained_browser_pane_block_id`. Idempotent — `None` if no entry has that label
 /// (e.g., explicit `close()` already cleared it; `on_before_close` arrives
 /// later).
-fn handle_drain_pane_by_label(state: &mut HostState, label: String) -> DispatchOutput {
+fn handle_drain_browser_pane_by_label(state: &mut HostState, label: String) -> DispatchOutput {
     let victim = state
-        .panes
+        .browser_panes
         .iter()
         .find(|(_, e)| e.label == label)
         .map(|(k, _)| k.clone());
@@ -976,38 +976,38 @@ fn handle_drain_pane_by_label(state: &mut HostState, label: String) -> DispatchO
         Some(b) => b,
         None => return DispatchOutput::default(),
     };
-    state.panes.remove(&block_id);
+    state.browser_panes.remove(&block_id);
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneClosed {
+        events: vec![HostEvent::BrowserPaneClosed {
             block_id: block_id.clone(),
             version: v,
         }],
-        drained_block_id: Some(block_id),
+        drained_browser_pane_block_id: Some(block_id),
         ..Default::default()
     }
 }
 
-fn handle_complete_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
-    if state.panes.remove(&block_id).is_none() {
+fn handle_complete_browser_pane_close(state: &mut HostState, block_id: String) -> DispatchOutput {
+    if state.browser_panes.remove(&block_id).is_none() {
         return DispatchOutput::default(); // idempotent
     }
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneClosed { block_id, version: v }],
+        events: vec![HostEvent::BrowserPaneClosed { block_id, version: v }],
         ..Default::default()
     }
 }
 
-fn handle_abort_pane_create(
+fn handle_abort_browser_pane_create(
     state: &mut HostState,
     block_id: String,
     reason: String,
 ) -> DispatchOutput {
-    state.panes.remove(&block_id);
+    state.browser_panes.remove(&block_id);
     let v = state.bump_version();
     DispatchOutput {
-        events: vec![HostEvent::PaneCreationFailed { block_id, reason, version: v }],
+        events: vec![HostEvent::BrowserPaneCreationFailed { block_id, reason, version: v }],
         ..Default::default()
     }
 }
@@ -1624,11 +1624,11 @@ mod tests {
             HostEvent::PendingWindowEnqueued { version, .. } => *version,
             HostEvent::PendingWindowDequeued { version, .. } => *version,
             HostEvent::PendingWindowQueueEmpty { version } => *version,
-            HostEvent::PaneCreateRequested { version, .. } => *version,
-            HostEvent::PaneLive { version, .. } => *version,
-            HostEvent::PaneClosing { version, .. } => *version,
-            HostEvent::PaneClosed { version, .. } => *version,
-            HostEvent::PaneCreationFailed { version, .. } => *version,
+            HostEvent::BrowserPaneCreateRequested { version, .. } => *version,
+            HostEvent::BrowserPaneLive { version, .. } => *version,
+            HostEvent::BrowserPaneClosing { version, .. } => *version,
+            HostEvent::BrowserPaneClosed { version, .. } => *version,
+            HostEvent::BrowserPaneCreationFailed { version, .. } => *version,
             HostEvent::BrowserRegistered { version, .. } => *version,
             HostEvent::BrowserUnregistered { version, .. } => *version,
             HostEvent::DragStarted { version, .. } => *version,
@@ -1655,8 +1655,8 @@ mod tests {
 
     // ── Phase H foundations tests ───────────────────────────────────────
 
-    fn pane_request(block_id: &str, label: &str) -> HostCommand {
-        HostCommand::EnqueuePaneCreate {
+    fn browser_pane_request(block_id: &str, label: &str) -> HostCommand {
+        HostCommand::EnqueueBrowserPaneCreate {
             block_id: block_id.to_string(),
             label: label.to_string(),
         }
@@ -1678,94 +1678,94 @@ mod tests {
     // ── H.1 panes ────────────────────────────────────────────────────────
 
     #[test]
-    fn enqueue_pane_create_inserts_live() {
+    fn enqueue_browser_pane_create_inserts_live() {
         let mut state = HostState::default();
-        let out = update(&mut state, pane_request("b1", "browser-pane-b1-1"));
-        assert!(state.panes.contains_key("b1"));
-        assert!(matches!(state.panes["b1"].lifecycle, PaneLifecycle::Live));
-        assert!(matches!(out.events[0], HostEvent::PaneCreateRequested { .. }));
+        let out = update(&mut state, browser_pane_request("b1", "browser-pane-b1-1"));
+        assert!(state.browser_panes.contains_key("b1"));
+        assert!(matches!(state.browser_panes["b1"].lifecycle, BrowserPaneLifecycle::Live));
+        assert!(matches!(out.events[0], HostEvent::BrowserPaneCreateRequested { .. }));
     }
 
     #[test]
-    fn enqueue_pane_create_duplicate_rejected() {
+    fn enqueue_browser_pane_create_duplicate_rejected() {
         let mut state = HostState::default();
-        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
-        let out = update(&mut state, pane_request("b1", "browser-pane-b1-2"));
+        update(&mut state, browser_pane_request("b1", "browser-pane-b1-1"));
+        let out = update(&mut state, browser_pane_request("b1", "browser-pane-b1-2"));
         assert!(matches!(out.events[0], HostEvent::Error { .. }));
-        assert_eq!(state.panes.len(), 1);
+        assert_eq!(state.browser_panes.len(), 1);
     }
 
     #[test]
     fn pane_close_lifecycle() {
         let mut state = HostState::default();
-        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
-        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
+        update(&mut state, browser_pane_request("b1", "browser-pane-b1-1"));
+        update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() });
         assert!(matches!(
-            state.panes["b1"].lifecycle,
-            PaneLifecycle::Closing { .. }
+            state.browser_panes["b1"].lifecycle,
+            BrowserPaneLifecycle::Closing { .. }
         ));
-        update(&mut state, HostCommand::CompletePaneClose { block_id: "b1".into() });
-        assert!(!state.panes.contains_key("b1"));
+        update(&mut state, HostCommand::CompleteBrowserPaneClose { block_id: "b1".into() });
+        assert!(!state.browser_panes.contains_key("b1"));
     }
 
     #[test]
     fn pane_abort_removes_entry() {
         let mut state = HostState::default();
-        update(&mut state, pane_request("b1", "browser-pane-b1-1"));
+        update(&mut state, browser_pane_request("b1", "browser-pane-b1-1"));
         let out = update(
             &mut state,
-            HostCommand::AbortPaneCreate {
+            HostCommand::AbortBrowserPaneCreate {
                 block_id: "b1".into(),
                 reason: "test".into(),
             },
         );
-        assert!(!state.panes.contains_key("b1"));
-        assert!(matches!(out.events[0], HostEvent::PaneCreationFailed { .. }));
+        assert!(!state.browser_panes.contains_key("b1"));
+        assert!(matches!(out.events[0], HostEvent::BrowserPaneCreationFailed { .. }));
     }
 
     #[test]
     fn pane_close_idempotent_for_missing() {
         let mut state = HostState::default();
-        let out = update(&mut state, HostCommand::EnqueuePaneClose { block_id: "missing".into() });
+        let out = update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "missing".into() });
         assert!(out.events.is_empty()); // idempotent no-op
     }
 
-    // ── H.1.d (PR #5) — TryRegisterPaneLive / EnqueuePaneClose return-values
-    //   / DrainPaneByLabel ────────────────────────────────────────────────
+    // ── H.1.d (PR #5) — TryRegisterBrowserPaneLive / EnqueueBrowserPaneClose return-values
+    //   / DrainBrowserPaneByLabel ────────────────────────────────────────────────
 
     #[test]
-    fn try_register_pane_live_fresh_returns_label_and_inserts_live() {
+    fn try_register_browser_pane_live_fresh_returns_label_and_inserts_live() {
         let mut state = HostState::default();
         let out = update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
         );
-        let label = match out.pane_register_result {
+        let label = match out.browser_pane_register_result {
             Some(RegisterResult::Fresh(l)) => l,
             other => panic!("expected Fresh(_), got {:?}", other),
         };
         assert!(label.starts_with("browser-pane-b1-"));
-        assert_eq!(state.panes["b1"].label, label);
-        assert!(matches!(state.panes["b1"].lifecycle, PaneLifecycle::Live));
-        assert!(matches!(out.events[0], HostEvent::PaneCreateRequested { .. }));
+        assert_eq!(state.browser_panes["b1"].label, label);
+        assert!(matches!(state.browser_panes["b1"].lifecycle, BrowserPaneLifecycle::Live));
+        assert!(matches!(out.events[0], HostEvent::BrowserPaneCreateRequested { .. }));
     }
 
     #[test]
-    fn try_register_pane_live_already_live_returns_existing_label() {
+    fn try_register_browser_pane_live_already_live_returns_existing_label() {
         let mut state = HostState::default();
         let first = match update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
-        ).pane_register_result
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
+        ).browser_pane_register_result
         {
             Some(RegisterResult::Fresh(l)) => l,
             _ => unreachable!(),
         };
         let out = update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
         );
-        match out.pane_register_result {
+        match out.browser_pane_register_result {
             Some(RegisterResult::AlreadyLive(l)) => assert_eq!(l, first),
             other => panic!("expected AlreadyLive, got {:?}", other),
         }
@@ -1773,111 +1773,111 @@ mod tests {
     }
 
     #[test]
-    fn try_register_pane_live_closing_returns_closing() {
+    fn try_register_browser_pane_live_closing_returns_closing() {
         let mut state = HostState::default();
-        update(&mut state, HostCommand::TryRegisterPaneLive { block_id: "b1".into() });
-        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
+        update(&mut state, HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() });
+        update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() });
         let out = update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
         );
-        assert!(matches!(out.pane_register_result, Some(RegisterResult::Closing)));
+        assert!(matches!(out.browser_pane_register_result, Some(RegisterResult::Closing)));
     }
 
     #[test]
-    fn try_register_pane_live_during_shutdown_errors() {
+    fn try_register_browser_pane_live_during_shutdown_errors() {
         let mut state = HostState::default();
         state.lifecycle = HostLifecyclePhase::ShuttingDown;
         let out = update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
         );
-        assert!(out.pane_register_result.is_none());
+        assert!(out.browser_pane_register_result.is_none());
         assert!(matches!(out.events[0], HostEvent::Error { .. }));
-        assert!(!state.panes.contains_key("b1"));
+        assert!(!state.browser_panes.contains_key("b1"));
     }
 
     #[test]
-    fn enqueue_pane_close_returns_label_for_live_entry() {
+    fn enqueue_browser_pane_close_returns_label_for_live_entry() {
         let mut state = HostState::default();
         let label = match update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
-        ).pane_register_result
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
+        ).browser_pane_register_result
         {
             Some(RegisterResult::Fresh(l)) => l,
             _ => unreachable!(),
         };
         let out = update(
             &mut state,
-            HostCommand::EnqueuePaneClose { block_id: "b1".into() },
+            HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() },
         );
-        assert_eq!(out.closed_pane_label, Some(label));
+        assert_eq!(out.closed_browser_pane_label, Some(label));
     }
 
     #[test]
-    fn enqueue_pane_close_returns_none_for_already_closing() {
+    fn enqueue_browser_pane_close_returns_none_for_already_closing() {
         let mut state = HostState::default();
-        update(&mut state, HostCommand::TryRegisterPaneLive { block_id: "b1".into() });
-        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
+        update(&mut state, HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() });
+        update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() });
         let out = update(
             &mut state,
-            HostCommand::EnqueuePaneClose { block_id: "b1".into() },
+            HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() },
         );
-        assert!(out.closed_pane_label.is_none());
+        assert!(out.closed_browser_pane_label.is_none());
     }
 
     #[test]
-    fn drain_pane_by_label_removes_entry_and_returns_block_id() {
+    fn drain_browser_pane_by_label_removes_entry_and_returns_block_id() {
         let mut state = HostState::default();
         let label = match update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
-        ).pane_register_result
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
+        ).browser_pane_register_result
         {
             Some(RegisterResult::Fresh(l)) => l,
             _ => unreachable!(),
         };
-        let out = update(&mut state, HostCommand::DrainPaneByLabel { label });
-        assert_eq!(out.drained_block_id, Some("b1".to_string()));
-        assert!(!state.panes.contains_key("b1"));
-        assert!(matches!(out.events[0], HostEvent::PaneClosed { .. }));
+        let out = update(&mut state, HostCommand::DrainBrowserPaneByLabel { label });
+        assert_eq!(out.drained_browser_pane_block_id, Some("b1".to_string()));
+        assert!(!state.browser_panes.contains_key("b1"));
+        assert!(matches!(out.events[0], HostEvent::BrowserPaneClosed { .. }));
     }
 
     #[test]
-    fn drain_pane_by_label_idempotent_on_miss() {
+    fn drain_browser_pane_by_label_idempotent_on_miss() {
         let mut state = HostState::default();
         let out = update(
             &mut state,
-            HostCommand::DrainPaneByLabel { label: "no-such-label".into() },
+            HostCommand::DrainBrowserPaneByLabel { label: "no-such-label".into() },
         );
-        assert!(out.drained_block_id.is_none());
+        assert!(out.drained_browser_pane_block_id.is_none());
         assert!(out.events.is_empty());
     }
 
     #[test]
     fn pane_lifecycle_supports_h7_invariant_check() {
-        // PR #6 H.7 — `AppState::any_pane_closing()` reads
-        // `state.panes.values()` and matches `PaneLifecycle::Closing`.
+        // PR #6 H.7 — `AppState::any_browser_pane_closing()` reads
+        // `state.browser_panes.values()` and matches `BrowserPaneLifecycle::Closing`.
         // This test verifies the reducer's pane state transitions in
         // the way that helper relies on: Live entries don't trip the
         // gate; Closing entries do; drained (removed) entries don't.
         let mut state = HostState::default();
 
         // baseline: no panes → no closing
-        assert!(!state.panes.values().any(|e| matches!(e.lifecycle, PaneLifecycle::Closing { .. })));
+        assert!(!state.browser_panes.values().any(|e| matches!(e.lifecycle, BrowserPaneLifecycle::Closing { .. })));
 
-        update(&mut state, HostCommand::TryRegisterPaneLive { block_id: "b1".into() });
+        update(&mut state, HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() });
         // Live pane present → gate is OPEN (not closing)
-        assert!(!state.panes.values().any(|e| matches!(e.lifecycle, PaneLifecycle::Closing { .. })));
+        assert!(!state.browser_panes.values().any(|e| matches!(e.lifecycle, BrowserPaneLifecycle::Closing { .. })));
 
-        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
+        update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() });
         // Closing pane present → gate is CLOSED
-        assert!(state.panes.values().any(|e| matches!(e.lifecycle, PaneLifecycle::Closing { .. })));
+        assert!(state.browser_panes.values().any(|e| matches!(e.lifecycle, BrowserPaneLifecycle::Closing { .. })));
 
-        update(&mut state, HostCommand::CompletePaneClose { block_id: "b1".into() });
+        update(&mut state, HostCommand::CompleteBrowserPaneClose { block_id: "b1".into() });
         // Drained → gate is OPEN again
-        assert!(!state.panes.values().any(|e| matches!(e.lifecycle, PaneLifecycle::Closing { .. })));
+        assert!(!state.browser_panes.values().any(|e| matches!(e.lifecycle, BrowserPaneLifecycle::Closing { .. })));
     }
 
     #[test]
@@ -1888,20 +1888,20 @@ mod tests {
         let mut state = HostState::default();
         let first = match update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
-        ).pane_register_result
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
+        ).browser_pane_register_result
         {
             Some(RegisterResult::Fresh(l)) => l,
             _ => unreachable!(),
         };
-        update(&mut state, HostCommand::EnqueuePaneClose { block_id: "b1".into() });
-        update(&mut state, HostCommand::DrainPaneByLabel { label: first.clone() });
+        update(&mut state, HostCommand::EnqueueBrowserPaneClose { block_id: "b1".into() });
+        update(&mut state, HostCommand::DrainBrowserPaneByLabel { label: first.clone() });
 
         // re-register — gets a different label
         let second = match update(
             &mut state,
-            HostCommand::TryRegisterPaneLive { block_id: "b1".into() },
-        ).pane_register_result
+            HostCommand::TryRegisterBrowserPaneLive { block_id: "b1".into() },
+        ).browser_pane_register_result
         {
             Some(RegisterResult::Fresh(l)) => l,
             _ => unreachable!(),
@@ -1909,10 +1909,10 @@ mod tests {
         assert_ne!(first, second);
 
         // late on_before_close for the OLD browser tries to drain by old label
-        let stale = update(&mut state, HostCommand::DrainPaneByLabel { label: first });
-        assert!(stale.drained_block_id.is_none(), "stale drain must not evict the new entry");
-        assert!(state.panes.contains_key("b1"), "new entry must survive stale drain");
-        assert_eq!(state.panes["b1"].label, second);
+        let stale = update(&mut state, HostCommand::DrainBrowserPaneByLabel { label: first });
+        assert!(stale.drained_browser_pane_block_id.is_none(), "stale drain must not evict the new entry");
+        assert!(state.browser_panes.contains_key("b1"), "new entry must survive stale drain");
+        assert_eq!(state.browser_panes["b1"].label, second);
     }
 
     // ── H.3 drag (singleton invariant) ───────────────────────────────────

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -152,16 +152,16 @@ impl HostState {
     }
 }
 
-// ── Pane label generator (replaces pane/lifecycle.rs::PANE_LABEL_SEQ) ──────
+// ── Pane label generator (replaces pane/lifecycle.rs::BROWSER_PANE_LABEL_SEQ) ──────
 //
 // Monotonic counter appended to every pane label so a close-then-recreate of
 // the same block_id doesn't collide: if the old browser's `on_before_close`
 // fires after the new pane's create has already run, `DrainBrowserPaneByLabel`
 // would otherwise find and wipe the NEW entry.
-static PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
+static BROWSER_PANE_LABEL_SEQ: AtomicU64 = AtomicU64::new(1);
 
 fn next_browser_pane_label(block_id: &str) -> String {
-    let seq = PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
+    let seq = BROWSER_PANE_LABEL_SEQ.fetch_add(1, Ordering::Relaxed);
     format!("browser-pane-{}-{}", block_id, seq)
 }
 
@@ -173,7 +173,7 @@ fn next_browser_pane_label(block_id: &str) -> String {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RegisterResult {
     /// No prior entry; reducer inserted a new `Live` pane under `label`.
-    /// Caller should post `CreatePaneTask` for this label.
+    /// Caller should post `CreateBrowserPaneTask` for this label.
     Fresh(String),
     /// Entry already existed and is `Live`; caller should re-navigate the
     /// existing browser at `label`.
@@ -214,7 +214,7 @@ pub enum HostCommand {
     /// Reducer generates the label internally (via `next_browser_pane_label`) so
     /// label assignment is atomic with the entry insert. Returns the
     /// outcome via `DispatchOutput::browser_pane_register_result`:
-    ///   - `Fresh(label)`: new `Live` entry inserted; caller posts CreatePaneTask
+    ///   - `Fresh(label)`: new `Live` entry inserted; caller posts CreateBrowserPaneTask
     ///   - `AlreadyLive(label)`: caller should re-navigate existing browser
     ///   - `Closing`: caller must reject (old teardown still in flight)
     TryRegisterBrowserPaneLive { block_id: String },
@@ -1882,7 +1882,7 @@ mod tests {
 
     #[test]
     fn drain_after_close_recreate_does_not_evict_new_entry() {
-        // The exact bug PANE_LABEL_SEQ defends against: register → close →
+        // The exact bug BROWSER_PANE_LABEL_SEQ defends against: register → close →
         // drain by OLD label → register again → drain by OLD label must
         // NOT evict the new entry.
         let mut state = HostState::default();

--- a/agentmux-cef/src/reducer.rs
+++ b/agentmux-cef/src/reducer.rs
@@ -862,10 +862,10 @@ fn handle_enqueue_browser_pane_create(
     label: String,
 ) -> DispatchOutput {
     if state.lifecycle == HostLifecyclePhase::ShuttingDown {
-        return emit_error(state, format!("enqueue_pane_create: shutting down (block_id={})", block_id));
+        return emit_error(state, format!("enqueue_browser_pane_create: shutting down (block_id={})", block_id));
     }
     if state.browser_panes.contains_key(&block_id) {
-        return emit_error(state, format!("enqueue_pane_create: block_id {} already has a pane", block_id));
+        return emit_error(state, format!("enqueue_browser_pane_create: block_id {} already has a pane", block_id));
     }
     state.browser_panes.insert(
         block_id.clone(),
@@ -925,7 +925,7 @@ fn handle_try_register_browser_pane_live(state: &mut HostState, block_id: String
     if state.lifecycle == HostLifecyclePhase::ShuttingDown {
         return emit_error(
             state,
-            format!("try_register_pane_live: shutting down (block_id={})", block_id),
+            format!("try_register_browser_pane_live: shutting down (block_id={})", block_id),
         );
     }
     if let Some(entry) = state.browser_panes.get(&block_id) {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -123,13 +123,13 @@ pub struct PendingWindowCreation {
 // ── Pane lifecycle (H.1) ─────────────────────────────────────────────────
 
 /// Lifecycle state of a browser pane (the `defwidget@browser` widget). Held
-/// inside `HostState.panes` keyed by `block_id`. Mirrors the existing
-/// `PaneStateMachine::PaneLifecycle` (pane/lifecycle.rs:28); the existing
+/// inside `HostState.browser_panes` keyed by `block_id`. Mirrors the existing
+/// `PaneStateMachine::BrowserPaneLifecycle` (pane/lifecycle.rs:28); the existing
 /// type stays during PR #2's a→e migration. PR #2 step e deletes the
 /// pane/lifecycle.rs version and migrates all readers to this one.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(dead_code)]
-pub enum PaneLifecycle {
+pub enum BrowserPaneLifecycle {
     /// Pane is alive and accepting operations (focus, resize, navigate).
     Live,
     /// Close requested; awaiting CEF on_before_close to fully tear down.
@@ -138,14 +138,14 @@ pub enum PaneLifecycle {
     Closing { since: std::time::Instant },
 }
 
-/// Per-pane reducer-managed entry. Replaces `pane::lifecycle::PaneEntry`
+/// Per-pane reducer-managed entry. Replaces `pane::lifecycle::BrowserPaneEntry`
 /// (lifecycle.rs:42) at PR #2 step e.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
-pub struct PaneEntry {
+pub struct BrowserPaneEntry {
     pub block_id: String,
     pub label: String,
-    pub lifecycle: PaneLifecycle,
+    pub lifecycle: BrowserPaneLifecycle,
 }
 
 // ── Browser handle registry (H.2) ────────────────────────────────────────
@@ -187,7 +187,7 @@ pub enum BrowserKind {
     /// pool; cleared on promote.
     TopLevel { is_pool: bool },
     /// Browser pane child window. `block_id` correlates with the
-    /// `HostState.panes` entry.
+    /// `HostState.browser_panes` entry.
     Pane { block_id: String },
 }
 
@@ -660,11 +660,11 @@ impl AppState {
     // ── Phase H.2 — browser read helpers (reducer-only, post-flip) ──────
     //
     // After PR #4's flip step (H.1.c + H.2.c), `HostState.browsers` /
-    // `HostState.panes` are the sole source of truth. Legacy reads,
+    // `HostState.browser_panes` are the sole source of truth. Legacy reads,
     // fallback paths, and drift logging removed — production smoke
     // verified zero drift across 50 reducer events with a balanced
     // BrowserRegistered/Unregistered count (18/18) and PaneCreate/
-    // PaneClosed count (7/7) before this flip.
+    // BrowserPaneClosed count (7/7) before this flip.
     //
     // Snapshot-and-drop: each helper takes the relevant lock briefly,
     // clones what's needed, drops the lock. Callers never hold the
@@ -731,22 +731,22 @@ impl AppState {
     /// (focus/resize/navigate) — `None` indicates the pane is missing or
     /// in `Closing`, in which case the caller must short-circuit rather
     /// than touch the (possibly destroyed) HWND.
-    pub fn live_pane_label(&self, block_id: &str) -> Option<String> {
+    pub fn live_browser_pane_label(&self, block_id: &str) -> Option<String> {
         self.host_state
             .lock()
-            .panes
+            .browser_panes
             .get(block_id)
-            .filter(|e| e.lifecycle == PaneLifecycle::Live)
+            .filter(|e| e.lifecycle == BrowserPaneLifecycle::Live)
             .map(|e| e.label.clone())
     }
 
     /// Snapshot of all `Live` pane labels. Used by `defocus_all` etc.
-    pub fn live_pane_labels(&self) -> Vec<String> {
+    pub fn live_browser_pane_labels(&self) -> Vec<String> {
         self.host_state
             .lock()
-            .panes
+            .browser_panes
             .values()
-            .filter(|e| e.lifecycle == PaneLifecycle::Live)
+            .filter(|e| e.lifecycle == BrowserPaneLifecycle::Live)
             .map(|e| e.label.clone())
             .collect()
     }
@@ -820,12 +820,12 @@ impl AppState {
     /// async surface. If it turns out the gate needs to widen
     /// ("any pane present" rather than "any pane Closing"), that's a
     /// one-line edit. Spec §5 escape hatch.
-    pub fn any_pane_closing(&self) -> bool {
+    pub fn any_browser_pane_closing(&self) -> bool {
         self.host_state
             .lock()
-            .panes
+            .browser_panes
             .values()
-            .any(|e| matches!(e.lifecycle, PaneLifecycle::Closing { .. }))
+            .any(|e| matches!(e.lifecycle, BrowserPaneLifecycle::Closing { .. }))
     }
 
     /// Phase B.5e — authoritative instance-number lookup. Reads
@@ -946,29 +946,29 @@ fn log_host_event(ev: &crate::reducer::HostEvent) {
             "[host-reducer] dequeue on empty queue — caller will fall back",
         ),
         // ── H.1 panes ────────────────────────────────────────────────────
-        HostEvent::PaneCreateRequested { block_id, label, version } => tracing::info!(
+        HostEvent::BrowserPaneCreateRequested { block_id, label, version } => tracing::info!(
             target: "host-reducer",
-            event = "PaneCreateRequested",
+            event = "BrowserPaneCreateRequested",
             block_id = %block_id, label = %label, version,
         ),
-        HostEvent::PaneLive { block_id, label, version } => tracing::info!(
+        HostEvent::BrowserPaneLive { block_id, label, version } => tracing::info!(
             target: "host-reducer",
-            event = "PaneLive",
+            event = "BrowserPaneLive",
             block_id = %block_id, label = %label, version,
         ),
-        HostEvent::PaneClosing { block_id, version } => tracing::info!(
+        HostEvent::BrowserPaneClosing { block_id, version } => tracing::info!(
             target: "host-reducer",
-            event = "PaneClosing",
+            event = "BrowserPaneClosing",
             block_id = %block_id, version,
         ),
-        HostEvent::PaneClosed { block_id, version } => tracing::info!(
+        HostEvent::BrowserPaneClosed { block_id, version } => tracing::info!(
             target: "host-reducer",
-            event = "PaneClosed",
+            event = "BrowserPaneClosed",
             block_id = %block_id, version,
         ),
-        HostEvent::PaneCreationFailed { block_id, reason, version } => tracing::warn!(
+        HostEvent::BrowserPaneCreationFailed { block_id, reason, version } => tracing::warn!(
             target: "host-reducer",
-            event = "PaneCreationFailed",
+            event = "BrowserPaneCreationFailed",
             block_id = %block_id, reason = %reason, version,
         ),
         // ── H.2 browsers ─────────────────────────────────────────────────

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -663,7 +663,7 @@ impl AppState {
     // `HostState.browser_panes` are the sole source of truth. Legacy reads,
     // fallback paths, and drift logging removed — production smoke
     // verified zero drift across 50 reducer events with a balanced
-    // BrowserRegistered/Unregistered count (18/18) and PaneCreate/
+    // BrowserRegistered/Unregistered count (18/18) and BrowserPaneCreate/
     // BrowserPaneClosed count (7/7) before this flip.
     //
     // Snapshot-and-drop: each helper takes the relevant lock briefly,

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.599"
+version = "0.33.600"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.602"
+version = "0.33.603"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.603"
+version = "0.33.604"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.600"
+version = "0.33.601"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.601"
+version = "0.33.602"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.603"
+version = "0.33.604"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.601"
+version = "0.33.602"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.600"
+version = "0.33.601"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.602"
+version = "0.33.603"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.599"
+version = "0.33.600"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.599"
+version = "0.33.600"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.601"
+version = "0.33.602"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.602"
+version = "0.33.603"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.603"
+version = "0.33.604"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.600"
+version = "0.33.601"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.599",
+  "version": "0.33.600",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.599",
+      "version": "0.33.600",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.600",
+  "version": "0.33.601",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.600",
+      "version": "0.33.601",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.602",
+  "version": "0.33.603",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.602",
+      "version": "0.33.603",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.603",
+  "version": "0.33.604",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.603",
+      "version": "0.33.604",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.601",
+  "version": "0.33.602",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.601",
+      "version": "0.33.602",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.599",
+  "version": "0.33.600",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.602",
+  "version": "0.33.603",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.601",
+  "version": "0.33.602",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.603",
+  "version": "0.33.604",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.600",
+  "version": "0.33.601",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Resolves the long-standing ambiguity where reducer.rs / state.rs used bare \`Pane\` to mean specifically embedded-browser child windows (\`defwidget@browser\`). The IPC commands (\`browser_pane_*\`) and \`BrowserPaneManager\` were already explicit; only the host-internal types were abbreviated. A first-time reader of the reducer code would reasonably wonder if \`Pane\` meant terminals, agent panes, or browser panes — see the PR #664 retro session, 2026-05-02:

> \"is the pane terminology PaneCreate .. is that a terminal, agent pane, created by widgets?\"

Pure mechanical rename. Zero behavior changes. All 63 host tests pass.

## Renames

### Host-internal (renamed)

| Category | Before | After |
|---|---|---|
| HostCommand variants | \`TryRegisterPaneLive\`, \`EnqueuePaneCreate\`, etc. (7 total) | \`TryRegisterBrowserPaneLive\`, etc. |
| HostEvent variants | \`PaneCreateRequested\`, \`PaneLive\`, etc. (5 total) | \`BrowserPaneCreateRequested\`, etc. |
| State types | \`PaneEntry\`, \`PaneLifecycle\` | \`BrowserPaneEntry\`, \`BrowserPaneLifecycle\` |
| HostState field | \`panes\` | \`browser_panes\` |
| DispatchOutput fields | \`pane_register_result\`, \`closed_pane_label\`, \`drained_block_id\` | \`browser_pane_register_result\`, etc. |
| AppState helpers | \`live_pane_label\`, \`live_pane_labels\`, \`any_pane_closing\` | \`live_browser_pane_label\`, etc. |
| Reducer handler fns | \`handle_enqueue_pane_create\`, etc. (8 total) | \`handle_enqueue_browser_pane_create\`, etc. |
| Pane callbacks | \`on_before_close_pane\`, \`on_after_created_pane\` | \`on_before_close_browser_pane\`, etc. |
| Module dir | \`src/pane/\` (4 files) | \`src/browser_pane/\` (git mv preserves history) |

### NOT renamed (still bare \"pane\" — intentional)

- \`BrowserPaneManager\` (already explicit)
- IPC command names: \`browser_pane_create\` / \`navigate\` / \`focus\` (already explicit)
- Label format: \`browser-pane-<id>-<seq>\` (already explicit)
- \`launcher_ipc::report_panes_reaped\` (cross-process wire protocol — separate rename PR if desired)

## Tests

63 host tests pass. No new tests — pure rename has no new semantics to verify.

## Unblocks

**Task #182** (modularize large reducer + client files) — the per-domain split for the host reducer can now use \`browser_pane\` consistently in submodule names rather than the ambiguous \`pane\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)