### PR TITLE
refactor(launcher): extract pool handlers into reducer/pool.rs (task #182 PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.605"
+version = "0.33.606"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.606"
+version = "0.33.607"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.606"
+version = "0.33.607"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.605"
+version = "0.33.606"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.605"
+version = "0.33.606"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.606"
+version = "0.33.607"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -76,6 +76,8 @@ pub struct Ctx {
 /// Apply one Command to State, returning the resulting Events. State
 /// is mutated in place. Total function — never panics on input
 /// (panics are reserved for internal invariant violations).
+mod pool;
+
 pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
     let _ = ctx.conn_id; // reserved for B.4 routing
     match cmd {
@@ -109,13 +111,13 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
                 return vec![err];
             }
-            handle_report_pool_window_added(state, label, saga_id)
+            pool::handle_report_pool_window_added(state, label, saga_id)
         }
         Command::ReportPoolWindowRemoved { label } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowRemoved") {
                 return vec![err];
             }
-            handle_report_pool_window_removed(state, label)
+            pool::handle_report_pool_window_removed(state, label)
         }
         // Phase F.5 — host-only signal that a pool→window promote is
         // happening. Sent BETWEEN the matching `ReportPoolWindowRemoved`
@@ -127,7 +129,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowPromoted") {
                 return vec![err];
             }
-            handle_report_pool_window_promoted(state, label)
+            pool::handle_report_pool_window_promoted(state, label)
         }
         // Phase F.5 — `SpawnPoolWindow` is a launcher→host direction
         // command, NOT a host→launcher report. If a registered client
@@ -172,7 +174,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolDrainDecision") {
                 return vec![err];
             }
-            handle_report_pool_drain_decision(state, label, was_last, saga_id)
+            pool::handle_report_pool_drain_decision(state, label, was_last, saga_id)
         }
         // Phase F.6 — `ReapPanes` and `DrainPoolIfLast` are
         // launcher→host direction commands, NOT host→launcher
@@ -218,7 +220,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportHostPoolCount") {
                 return vec![err];
             }
-            handle_report_host_pool_count(state, count)
+            pool::handle_report_host_pool_count(state, count)
         }
         Command::ReportBackendWindowIdRegistered { label, window_id } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdRegistered") {
@@ -551,23 +553,6 @@ fn handle_report_backend_window_id_unregistered(
     }]
 }
 
-/// Phase B.4 follow-up — pool-only drift check. Called from
-/// `spawn_pool_window` where the windows dimension is mid-flight
-/// (close path hasn't completed). Compares only the pool dimension;
-/// emits `DriftDetected { kind: Pool, ... }` on mismatch.
-fn handle_report_host_pool_count(state: &mut State, host_pool: u32) -> Vec<Event> {
-    let mirror_pool = state.pool.len() as u32;
-    if mirror_pool == host_pool {
-        return vec![];
-    }
-    let v = state.bump_version();
-    vec![Event::DriftDetected {
-        kind: DriftKind::Pool,
-        host_count: host_pool,
-        mirror_count: mirror_pool,
-        version: v,
-    }]
-}
 
 /// Phase B.4 follow-up — drift check. Compares host-reported counts
 /// to launcher mirror counts; emits `DriftDetected` for each
@@ -602,57 +587,6 @@ fn handle_report_host_counts(state: &mut State, host_windows: u32, host_pool: u3
     out
 }
 
-/// Phase B.4 follow-up — record pool inventory growth. Idempotent
-/// on duplicate labels (HashSet semantics) but the event still fires
-/// so subscribers can track add-attempts even if redundant.
-fn handle_report_pool_window_added(
-    state: &mut State,
-    label: String,
-    saga_id: Option<u64>,
-) -> Vec<Event> {
-    state.pool.insert(label.clone());
-    let v = state.bump_version();
-    vec![Event::PoolWindowAdded {
-        label,
-        version: v,
-        saga_id,
-    }]
-}
-
-/// Phase B.4 follow-up — record pool inventory shrink (promote or
-/// destroy). Strictly paired with `ReportPoolWindowAdded`: an
-/// unknown-label remove is a silent no-op so subscribers can rely
-/// on add/remove pairing in the broadcast stream. Same gate as
-/// `handle_report_window_closed`. (reagent P2 PR #577 round-3 —
-/// the original "idempotent" comment referenced behavior that was
-/// already removed for `ReportWindowClosed`; pool semantics now
-/// match.)
-fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
-    let was_present = state.pool.remove(&label);
-    if !was_present {
-        return vec![];
-    }
-    let v = state.bump_version();
-    vec![Event::PoolWindowRemoved { label, version: v }]
-}
-
-/// Phase F.5 — host-emitted promote signal. The reducer doesn't mutate
-/// state for this command (the windows/pool transitions are carried by
-/// the surrounding `ReportPoolWindowRemoved` + `ReportWindowOpened`
-/// pair); it just translates the wire command into the corresponding
-/// typed event so subscribers — most importantly the launcher saga
-/// coordinator — can react.
-///
-/// Idempotent / context-free: we don't validate the label is in the
-/// mirror because the host's own ordering may have the
-/// `ReportPoolWindowRemoved` arrive before this command, after this
-/// command, or in either order; the typed event is "host says a
-/// promote happened" — subscribers correlate with the surrounding
-/// add/remove pair if they need stronger invariants.
-fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
-    let v = state.bump_version();
-    vec![Event::PoolWindowPromoted { label, version: v }]
-}
 
 /// Phase F.6 — host-emitted signal that browser-pane HWNDs for a
 /// closing top-level window have been reaped. Pure pass-through:
@@ -689,47 +623,6 @@ fn handle_report_panes_reaped(
     }]
 }
 
-/// Phase F.6 — host-emitted signal carrying the result of the
-/// post-close drain-pool-if-last decision. Maps `was_last` directly
-/// to the corresponding terminal event for Step 2 of the
-/// window-cleanup-cascade saga:
-/// * `true` → `Event::PoolDrained` (last user-visible window
-///   closed; warm-pool drain initiated)
-/// * `false` → `Event::PoolNotLast` (other windows remain; pool
-///   stays warm)
-///
-/// Pure pass-through (same reasoning as `handle_report_panes_reaped`).
-fn handle_report_pool_drain_decision(
-    state: &mut State,
-    label: String,
-    was_last: bool,
-    saga_id: Option<u64>,
-) -> Vec<Event> {
-    // Same rationale as handle_report_panes_reaped: round 4's gate
-    // had an ordering bug; round 5 reverts to emit-unconditionally.
-    //
-    // CPD-1: `saga_id` flows through unchanged.
-    let v = state.bump_version();
-    if was_last {
-        vec![Event::PoolDrained {
-            label,
-            version: v,
-            saga_id,
-        }]
-    } else {
-        vec![Event::PoolNotLast {
-            label,
-            version: v,
-            saga_id,
-        }]
-    }
-}
-
-/// Phase CPD-1 — host reported a saga-issued action failed. Pure
-/// pass-through translation into `Event::SagaActionFailed`. The
-/// saga coordinator's bus loop will (CPD-3) treat the event as a
-/// terminal signal for the matching `saga_id` and emit
-/// `Event::SagaFailed`, dropping the saga from in-flight.
 fn handle_report_saga_action_failed(
     state: &mut State,
     saga_id: u64,

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -73,11 +73,11 @@ pub struct Ctx {
     pub now_ms: u64,
 }
 
+mod pool;
+
 /// Apply one Command to State, returning the resulting Events. State
 /// is mutated in place. Total function — never panics on input
 /// (panics are reserved for internal invariant violations).
-mod pool;
-
 pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
     let _ = ctx.conn_id; // reserved for B.4 routing
     match cmd {
@@ -623,6 +623,11 @@ fn handle_report_panes_reaped(
     }]
 }
 
+/// Phase CPD-1 — host reported a saga-issued action failed. Pure
+/// pass-through translation into `Event::SagaActionFailed`. The
+/// saga coordinator's bus loop will (CPD-3) treat the event as a
+/// terminal signal for the matching `saga_id` and emit
+/// `Event::SagaFailed`, dropping the saga from in-flight.
 fn handle_report_saga_action_failed(
     state: &mut State,
     saga_id: u64,

--- a/agentmux-launcher/src/reducer/pool.rs
+++ b/agentmux-launcher/src/reducer/pool.rs
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pool-related reducer handlers. Extracted from reducer/mod.rs in
+//! task #182 PR-B for navigability.
+
+use agentmux_common::ipc::{DriftKind, Event};
+
+use crate::state::State;
+
+/// Phase B.4 follow-up — pool-only drift check. Called from
+/// `spawn_pool_window` where the windows dimension is mid-flight
+/// (close path hasn't completed). Compares only the pool dimension;
+/// emits `DriftDetected { kind: Pool, ... }` on mismatch.
+pub(super) fn handle_report_host_pool_count(state: &mut State, host_pool: u32) -> Vec<Event> {
+    let mirror_pool = state.pool.len() as u32;
+    if mirror_pool == host_pool {
+        return vec![];
+    }
+    let v = state.bump_version();
+    vec![Event::DriftDetected {
+        kind: DriftKind::Pool,
+        host_count: host_pool,
+        mirror_count: mirror_pool,
+        version: v,
+    }]
+}
+
+/// Phase B.4 follow-up — record pool inventory growth. Idempotent
+/// on duplicate labels (HashSet semantics) but the event still fires
+/// so subscribers can track add-attempts even if redundant.
+pub(super) fn handle_report_pool_window_added(
+    state: &mut State,
+    label: String,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
+    state.pool.insert(label.clone());
+    let v = state.bump_version();
+    vec![Event::PoolWindowAdded {
+        label,
+        version: v,
+        saga_id,
+    }]
+}
+
+/// Phase B.4 follow-up — record pool inventory shrink (promote or
+/// destroy). Strictly paired with `ReportPoolWindowAdded`: an
+/// unknown-label remove is a silent no-op so subscribers can rely
+/// on add/remove pairing in the broadcast stream. Same gate as
+/// `handle_report_window_closed`. (reagent P2 PR #577 round-3 —
+/// the original "idempotent" comment referenced behavior that was
+/// already removed for `ReportWindowClosed`; pool semantics now
+/// match.)
+pub(super) fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
+    let was_present = state.pool.remove(&label);
+    if !was_present {
+        return vec![];
+    }
+    let v = state.bump_version();
+    vec![Event::PoolWindowRemoved { label, version: v }]
+}
+
+/// Phase F.5 — host-emitted promote signal. The reducer doesn't mutate
+/// state for this command (the windows/pool transitions are carried by
+/// the surrounding `ReportPoolWindowRemoved` + `ReportWindowOpened`
+/// pair); it just translates the wire command into the corresponding
+/// typed event so subscribers — most importantly the launcher saga
+/// coordinator — can react.
+///
+/// Idempotent / context-free: we don't validate the label is in the
+/// mirror because the host's own ordering may have the
+/// `ReportPoolWindowRemoved` arrive before this command, after this
+/// command, or in either order; the typed event is "host says a
+/// promote happened" — subscribers correlate with the surrounding
+/// add/remove pair if they need stronger invariants.
+pub(super) fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::PoolWindowPromoted { label, version: v }]
+}
+
+/// Phase F.6 — host-emitted signal carrying the result of the
+/// post-close drain-pool-if-last decision. Maps `was_last` directly
+/// to the corresponding terminal event for Step 2 of the
+/// window-cleanup-cascade saga:
+/// * `true` → `Event::PoolDrained` (last user-visible window
+///   closed; warm-pool drain initiated)
+/// * `false` → `Event::PoolNotLast` (other windows remain; pool
+///   stays warm)
+///
+/// Pure pass-through (same reasoning as `handle_report_panes_reaped`).
+pub(super) fn handle_report_pool_drain_decision(
+    state: &mut State,
+    label: String,
+    was_last: bool,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
+    // Same rationale as handle_report_panes_reaped: round 4's gate
+    // had an ordering bug; round 5 reverts to emit-unconditionally.
+    //
+    // CPD-1: `saga_id` flows through unchanged.
+    let v = state.bump_version();
+    if was_last {
+        vec![Event::PoolDrained {
+            label,
+            version: v,
+            saga_id,
+        }]
+    } else {
+        vec![Event::PoolNotLast {
+            label,
+            version: v,
+            saga_id,
+        }]
+    }
+}
+

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.605"
+version = "0.33.606"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.606"
+version = "0.33.607"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.605",
+  "version": "0.33.606",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.605",
+      "version": "0.33.606",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.606",
+  "version": "0.33.607",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.606",
+      "version": "0.33.607",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.605",
+  "version": "0.33.606",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.606",
+  "version": "0.33.607",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Stacked on PR #668** (PR-A test extraction). Extracts 5 pool-related handler functions from \`agentmux-launcher/src/reducer/mod.rs\` into a new \`reducer/pool.rs\` sub-module. Pure mechanical move; no logic changes.

## Extracted handlers

- \`handle_report_host_pool_count\`
- \`handle_report_pool_window_added\`
- \`handle_report_pool_window_removed\`
- \`handle_report_pool_window_promoted\`
- \`handle_report_pool_drain_decision\`

All marked \`pub(super)\` — only \`mod.rs\`'s \`update()\` dispatcher calls them.

## Sizes

| File | Before | After |
|---|---|---|
| \`reducer/mod.rs\` | 1114 lines | 1007 lines (-107) |
| \`reducer/pool.rs\` | NEW | 116 lines |

## Pattern for follow-ups

This establishes the template for splitting other domains:
1. Identify cohesive handler group
2. Extract to \`reducer/<domain>.rs\` with \`pub(super) fn handle_*\`
3. Add \`mod <domain>;\` to mod.rs
4. Update dispatcher arms to \`<domain>::handle_*\` calls

Future PRs in task #182:
- PR-C: extract window-lifecycle handlers (window_opened/closed, backend_window_id_*)
- PR-D: extract saga handlers (panes_reaped, saga_action_failed)
- PR-E: extract connection handlers (register, ping, goodbye + enforce_host_only + host_is_running)
- PR-F: split host reducer (per Phase-H domain)
- PR-G: split client.rs into per-callback files

## Tests

154 launcher tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)