### PR TITLE
refactor(launcher): re-apply pool + extract window-lifecycle handlers (task #182 PR-B+C consolidated)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.605"
+version = "0.33.606"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.605"
+version = "0.33.606"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.605"
+version = "0.33.606"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.605"
+version = "0.33.606"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -73,6 +73,8 @@ pub struct Ctx {
     pub now_ms: u64,
 }
 
+mod pool;
+
 /// Apply one Command to State, returning the resulting Events. State
 /// is mutated in place. Total function — never panics on input
 /// (panics are reserved for internal invariant violations).
@@ -109,13 +111,13 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
                 return vec![err];
             }
-            handle_report_pool_window_added(state, label, saga_id)
+            pool::handle_report_pool_window_added(state, label, saga_id)
         }
         Command::ReportPoolWindowRemoved { label } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowRemoved") {
                 return vec![err];
             }
-            handle_report_pool_window_removed(state, label)
+            pool::handle_report_pool_window_removed(state, label)
         }
         // Phase F.5 — host-only signal that a pool→window promote is
         // happening. Sent BETWEEN the matching `ReportPoolWindowRemoved`
@@ -127,7 +129,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowPromoted") {
                 return vec![err];
             }
-            handle_report_pool_window_promoted(state, label)
+            pool::handle_report_pool_window_promoted(state, label)
         }
         // Phase F.5 — `SpawnPoolWindow` is a launcher→host direction
         // command, NOT a host→launcher report. If a registered client
@@ -172,7 +174,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolDrainDecision") {
                 return vec![err];
             }
-            handle_report_pool_drain_decision(state, label, was_last, saga_id)
+            pool::handle_report_pool_drain_decision(state, label, was_last, saga_id)
         }
         // Phase F.6 — `ReapPanes` and `DrainPoolIfLast` are
         // launcher→host direction commands, NOT host→launcher
@@ -218,7 +220,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportHostPoolCount") {
                 return vec![err];
             }
-            handle_report_host_pool_count(state, count)
+            pool::handle_report_host_pool_count(state, count)
         }
         Command::ReportBackendWindowIdRegistered { label, window_id } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdRegistered") {
@@ -551,23 +553,6 @@ fn handle_report_backend_window_id_unregistered(
     }]
 }
 
-/// Phase B.4 follow-up — pool-only drift check. Called from
-/// `spawn_pool_window` where the windows dimension is mid-flight
-/// (close path hasn't completed). Compares only the pool dimension;
-/// emits `DriftDetected { kind: Pool, ... }` on mismatch.
-fn handle_report_host_pool_count(state: &mut State, host_pool: u32) -> Vec<Event> {
-    let mirror_pool = state.pool.len() as u32;
-    if mirror_pool == host_pool {
-        return vec![];
-    }
-    let v = state.bump_version();
-    vec![Event::DriftDetected {
-        kind: DriftKind::Pool,
-        host_count: host_pool,
-        mirror_count: mirror_pool,
-        version: v,
-    }]
-}
 
 /// Phase B.4 follow-up — drift check. Compares host-reported counts
 /// to launcher mirror counts; emits `DriftDetected` for each
@@ -602,57 +587,6 @@ fn handle_report_host_counts(state: &mut State, host_windows: u32, host_pool: u3
     out
 }
 
-/// Phase B.4 follow-up — record pool inventory growth. Idempotent
-/// on duplicate labels (HashSet semantics) but the event still fires
-/// so subscribers can track add-attempts even if redundant.
-fn handle_report_pool_window_added(
-    state: &mut State,
-    label: String,
-    saga_id: Option<u64>,
-) -> Vec<Event> {
-    state.pool.insert(label.clone());
-    let v = state.bump_version();
-    vec![Event::PoolWindowAdded {
-        label,
-        version: v,
-        saga_id,
-    }]
-}
-
-/// Phase B.4 follow-up — record pool inventory shrink (promote or
-/// destroy). Strictly paired with `ReportPoolWindowAdded`: an
-/// unknown-label remove is a silent no-op so subscribers can rely
-/// on add/remove pairing in the broadcast stream. Same gate as
-/// `handle_report_window_closed`. (reagent P2 PR #577 round-3 —
-/// the original "idempotent" comment referenced behavior that was
-/// already removed for `ReportWindowClosed`; pool semantics now
-/// match.)
-fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
-    let was_present = state.pool.remove(&label);
-    if !was_present {
-        return vec![];
-    }
-    let v = state.bump_version();
-    vec![Event::PoolWindowRemoved { label, version: v }]
-}
-
-/// Phase F.5 — host-emitted promote signal. The reducer doesn't mutate
-/// state for this command (the windows/pool transitions are carried by
-/// the surrounding `ReportPoolWindowRemoved` + `ReportWindowOpened`
-/// pair); it just translates the wire command into the corresponding
-/// typed event so subscribers — most importantly the launcher saga
-/// coordinator — can react.
-///
-/// Idempotent / context-free: we don't validate the label is in the
-/// mirror because the host's own ordering may have the
-/// `ReportPoolWindowRemoved` arrive before this command, after this
-/// command, or in either order; the typed event is "host says a
-/// promote happened" — subscribers correlate with the surrounding
-/// add/remove pair if they need stronger invariants.
-fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
-    let v = state.bump_version();
-    vec![Event::PoolWindowPromoted { label, version: v }]
-}
 
 /// Phase F.6 — host-emitted signal that browser-pane HWNDs for a
 /// closing top-level window have been reaped. Pure pass-through:
@@ -687,42 +621,6 @@ fn handle_report_panes_reaped(
         version: v,
         saga_id,
     }]
-}
-
-/// Phase F.6 — host-emitted signal carrying the result of the
-/// post-close drain-pool-if-last decision. Maps `was_last` directly
-/// to the corresponding terminal event for Step 2 of the
-/// window-cleanup-cascade saga:
-/// * `true` → `Event::PoolDrained` (last user-visible window
-///   closed; warm-pool drain initiated)
-/// * `false` → `Event::PoolNotLast` (other windows remain; pool
-///   stays warm)
-///
-/// Pure pass-through (same reasoning as `handle_report_panes_reaped`).
-fn handle_report_pool_drain_decision(
-    state: &mut State,
-    label: String,
-    was_last: bool,
-    saga_id: Option<u64>,
-) -> Vec<Event> {
-    // Same rationale as handle_report_panes_reaped: round 4's gate
-    // had an ordering bug; round 5 reverts to emit-unconditionally.
-    //
-    // CPD-1: `saga_id` flows through unchanged.
-    let v = state.bump_version();
-    if was_last {
-        vec![Event::PoolDrained {
-            label,
-            version: v,
-            saga_id,
-        }]
-    } else {
-        vec![Event::PoolNotLast {
-            label,
-            version: v,
-            saga_id,
-        }]
-    }
 }
 
 /// Phase CPD-1 — host reported a saga-issued action failed. Pure

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -41,9 +41,9 @@
 //     register. Running → Quitting on Quit (B.3 placeholder).
 //     Quitting → Dead on cleanup-done (B.3 placeholder). No skipping.
 
-use agentmux_common::ipc::{ClientKind, Command, DriftKind, ErrorCode, Event, HwndDriftKind, WindowKind};
+use agentmux_common::ipc::{ClientKind, Command, DriftKind, ErrorCode, Event};
 
-use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State, WindowMirror};
+use crate::state::{LifecyclePhase, ProcessRecord, ProcessState, State};
 
 /// Context the reducer needs but can't read from State (clocks,
 /// connection identity). Passed in per-call so update remains pure.
@@ -74,6 +74,7 @@ pub struct Ctx {
 }
 
 mod pool;
+mod window;
 
 /// Apply one Command to State, returning the resulting Events. State
 /// is mutated in place. Total function — never panics on input
@@ -99,13 +100,13 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportWindowOpened") {
                 return vec![err];
             }
-            handle_report_window_opened(state, ctx, label, kind, parent_label)
+            window::handle_report_window_opened(state, ctx, label, kind, parent_label)
         }
         Command::ReportWindowClosed { label } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportWindowClosed") {
                 return vec![err];
             }
-            handle_report_window_closed(state, label)
+            window::handle_report_window_closed(state, label)
         }
         Command::ReportPoolWindowAdded { label, saga_id } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPoolWindowAdded") {
@@ -226,13 +227,13 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdRegistered") {
                 return vec![err];
             }
-            handle_report_backend_window_id_registered(state, label, window_id)
+            window::handle_report_backend_window_id_registered(state, label, window_id)
         }
         Command::ReportBackendWindowIdUnregistered { label } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportBackendWindowIdUnregistered") {
                 return vec![err];
             }
-            handle_report_backend_window_id_unregistered(state, label)
+            window::handle_report_backend_window_id_unregistered(state, label)
         }
         // Phase B.9.1 (WRR) — Win32 reality events. Host-only
         // because only the host installs the SetWinEventHook /
@@ -513,45 +514,6 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
     }
 }
 
-/// Phase B.5 (window_id_map step a) — record the host-reported
-/// label → backend_window_id mapping. Idempotent on duplicate
-/// label (overwrites with the new ID and emits a fresh event so
-/// subscribers see the latest mapping).
-fn handle_report_backend_window_id_registered(
-    state: &mut State,
-    label: String,
-    window_id: String,
-) -> Vec<Event> {
-    state
-        .backend_window_ids
-        .insert(label.clone(), window_id.clone());
-    let v = state.bump_version();
-    vec![Event::BackendWindowIdRegistered {
-        label,
-        window_id,
-        version: v,
-    }]
-}
-
-/// Phase B.5 (window_id_map step a) — drop the host-reported label
-/// from the map. Strict pairing: emits `BackendWindowIdUnregistered`
-/// only when the label was present (mirrors `WindowClosed` and
-/// `PoolWindowRemoved` semantics — codex P2 PR #577 round-2).
-fn handle_report_backend_window_id_unregistered(
-    state: &mut State,
-    label: String,
-) -> Vec<Event> {
-    let removed = state.backend_window_ids.remove(&label);
-    let Some(window_id) = removed else {
-        return vec![];
-    };
-    let v = state.bump_version();
-    vec![Event::BackendWindowIdUnregistered {
-        label,
-        window_id,
-        version: v,
-    }]
-}
 
 
 /// Phase B.4 follow-up — drift check. Compares host-reported counts
@@ -671,165 +633,6 @@ fn enforce_host_only(state: &mut State, ctx: &Ctx, op: &'static str) -> Option<E
     })
 }
 
-/// Phase B.4 — record a host-reported window opening in the launcher's
-/// read-only mirror. Idempotent on duplicate opens (same label twice
-/// in a row): the second insert overwrites with fresh metadata and
-/// emits a fresh event. Subscribers must tolerate seeing the same
-/// label twice; cleaner once B.5 makes the launcher authoritative.
-///
-/// Phase B.5: also assigns an authoritative instance number from
-/// `state.instance_registry` and emits `WindowInstanceAssigned`.
-/// "main" is pre-seeded with 1; other labels get the next value of
-/// `next_instance_num`. Re-opens of an existing label preserve the
-/// original number — instance numbers are stable per-label-per-run.
-fn handle_report_window_opened(
-    state: &mut State,
-    ctx: &Ctx,
-    label: String,
-    kind: WindowKind,
-    parent_label: Option<String>,
-) -> Vec<Event> {
-    // PR #664 codex P1 round 2 — drain-on-WindowOpened RESTORED as
-    // best-effort fallback. The explicit `ReportHwndOpened(Some(label))`
-    // from `client.rs::on_after_created` remains the AUTHORITATIVE
-    // link, and `apply_hwnd_opened` REPAIRS stale links it finds.
-    // But that explicit dispatch is gated on `hwnd_val != 0` host-side;
-    // if the HWND can't be resolved at on_after_created time from
-    // either of the 2 sources (Views, host), the explicit dispatch
-    // is skipped and the mirror would otherwise stay permanently
-    // unlinked, breaking WRR drift detection AND orphan-destroy
-    // reconciliation (no WindowClosed when OS destroys the HWND →
-    // permanent ghost InstancePanel rows).
-    //
-    // (PR #664 round 4 dropped a 3rd fallback `find_own_top_level_window`
-    // because it returns the FIRST visible window in the process —
-    // some other window's HWND in a multi-window session — which
-    // would corrupt other labels' mirrors via the `Repaired` arm.
-    // See client.rs::on_after_created comment for details.)
-    //
-    // The drain provides a fallback link from `pending_hwnds`. If the
-    // drain picks the WRONG HWND (the original burst-create race), the
-    // subsequent `apply_hwnd_opened` call from on_after_created will
-    // detect the mismatch and REPAIR — see the `Repaired` arm there.
-    // Net: best-effort link via drain, authoritative repair via
-    // explicit dispatch. The combination addresses both the
-    // hwnd_val=0 case and the burst-create race.
-    const PENDING_AGE_LIMIT_MS: u64 = 2_000;
-    let drained_hwnd: Option<u64> = state
-        .pending_hwnds
-        .iter()
-        .filter(|(_, p)| p.label_hint.is_none())
-        .filter(|(_, p)| ctx.now_ms.saturating_sub(p.arrived_at_ms) <= PENDING_AGE_LIMIT_MS)
-        .max_by_key(|(_, p)| p.arrived_at_ms)
-        .map(|(hwnd, _)| *hwnd);
-    if let Some(hwnd) = drained_hwnd {
-        state.pending_hwnds.remove(&hwnd);
-    }
-
-    state.windows.insert(
-        label.clone(),
-        WindowMirror {
-            label: label.clone(),
-            kind,
-            parent_label: parent_label.clone(),
-            opened_at: ctx.now_rfc3339.clone(),
-            // Best-effort drain above; authoritative explicit
-            // ReportHwndOpened from on_after_created arrives a few
-            // ms later via `apply_hwnd_opened` and REPAIRS any wrong
-            // link the drain picked.
-            hwnd: drained_hwnd,
-            visible: false,
-            iconic: false,
-            last_rect: None,
-            last_foreground_at_ms: None,
-            foregrounded_since_open: false,
-        },
-    );
-    let mut out = Vec::with_capacity(2);
-    let v = state.bump_version();
-    out.push(Event::WindowOpened {
-        label: label.clone(),
-        kind,
-        parent_label,
-        version: v,
-    });
-
-    // Assign instance number if this label isn't already in the
-    // registry. Re-opens of an existing label keep the original
-    // number — matches host's `WindowInstanceRegistry` semantics
-    // where a label is only registered once per session.
-    let num = if let Some(existing) = state.instance_registry.get(&label).copied() {
-        existing
-    } else {
-        let n = state.next_instance_num;
-        state.instance_registry.insert(label.clone(), n);
-        state.next_instance_num += 1;
-        n
-    };
-    let v = state.bump_version();
-    out.push(Event::WindowInstanceAssigned { label, num, version: v });
-    out
-}
-
-/// Phase B.4 — drop a host-reported window from the mirror. Returns
-/// `Event::WindowClosed` only when the label was actually in the
-/// mirror; an unknown-label close is a silent no-op (codex P2 PR
-/// #577 round-2). Without this gate, a `ReportWindowClosed` for a
-/// label the launcher never saw (e.g. a pool window that was popped
-/// from the queue but failed HWND validation in
-/// `promote_pool_window` — the orphan window's eventual
-/// `on_before_close` reaches us without a matching open) would
-/// emit an unpaired `WindowClosed` broadcast and break subscribers
-/// that assume open/close pairing.
-///
-/// Phase B.5 — also drops the label from `instance_registry` and
-/// emits `WindowInstanceReleased` if a number was assigned.
-/// `next_instance_num` is NOT decremented — instance numbers are
-/// monotonic per-launcher-run.
-fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
-    let was_present = state.windows.remove(&label).is_some();
-    if !was_present {
-        // Silent: only emit when the close pairs with a known open.
-        return vec![];
-    }
-    let mut out = Vec::with_capacity(4);
-    let v = state.bump_version();
-    out.push(Event::WindowClosed {
-        label: label.clone(),
-        version: v,
-        // Clean close — host ran on_before_close before sending
-        // ReportWindowClosed. F.6 saga is safe to trigger.
-        crash_detected: false,
-    });
-    if let Some(num) = state.instance_registry.remove(&label) {
-        let v = state.bump_version();
-        out.push(Event::WindowInstanceReleased { label: label.clone(), num, version: v });
-    }
-
-    // Phase B.9.3 — OrphanInstance transition. The label we just
-    // removed was the LAST user-visible window (state.windows is
-    // now empty). If a Host is still registered as Running, its
-    // own close path won't quit_message_loop because the warm
-    // pool is keeping state.browsers non-empty. Emit drift +
-    // saga-style HostShouldQuit so the host can reap pool and
-    // quit cleanly. See B.9.3 in
-    // docs/retro/next-steps-2026-04-29.md.
-    if state.windows.is_empty() && host_is_running(state) {
-        let v_drift = state.bump_version();
-        out.push(Event::HwndDriftDetected {
-            kind: HwndDriftKind::OrphanInstance,
-            label: Some(label),
-            hwnd: None,
-            detail: "Last user-visible window closed; host still alive (likely holding warm pool)"
-                .to_string(),
-            severity: agentmux_common::ipc::Severity::Warn,
-            version: v_drift,
-        });
-        let v_quit = state.bump_version();
-        out.push(Event::HostShouldQuit { version: v_quit });
-    }
-    out
-}
 
 /// Phase B.9.3 — does state.processes contain a Host in the
 /// `Running` lifecycle? Used by the OrphanInstance transition
@@ -837,7 +640,7 @@ fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
 /// HostShouldQuit on every benign close. Tool-only sessions
 /// (`agentmux.exe --diag`) also correctly skip the saga because
 /// they never register a Host.
-fn host_is_running(state: &State) -> bool {
+pub(super) fn host_is_running(state: &State) -> bool {
     use crate::state::ProcessState;
     state.processes.values().any(|r| {
         r.kind == ClientKind::Host && matches!(r.state, ProcessState::Running)

--- a/agentmux-launcher/src/reducer/pool.rs
+++ b/agentmux-launcher/src/reducer/pool.rs
@@ -1,0 +1,116 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pool-related reducer handlers. Extracted from reducer/mod.rs in
+//! task #182 PR-B for navigability.
+
+use agentmux_common::ipc::{DriftKind, Event};
+
+use crate::state::State;
+
+/// Phase B.4 follow-up — pool-only drift check. Called from
+/// `spawn_pool_window` where the windows dimension is mid-flight
+/// (close path hasn't completed). Compares only the pool dimension;
+/// emits `DriftDetected { kind: Pool, ... }` on mismatch.
+pub(super) fn handle_report_host_pool_count(state: &mut State, host_pool: u32) -> Vec<Event> {
+    let mirror_pool = state.pool.len() as u32;
+    if mirror_pool == host_pool {
+        return vec![];
+    }
+    let v = state.bump_version();
+    vec![Event::DriftDetected {
+        kind: DriftKind::Pool,
+        host_count: host_pool,
+        mirror_count: mirror_pool,
+        version: v,
+    }]
+}
+
+/// Phase B.4 follow-up — record pool inventory growth. Idempotent
+/// on duplicate labels (HashSet semantics) but the event still fires
+/// so subscribers can track add-attempts even if redundant.
+pub(super) fn handle_report_pool_window_added(
+    state: &mut State,
+    label: String,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
+    state.pool.insert(label.clone());
+    let v = state.bump_version();
+    vec![Event::PoolWindowAdded {
+        label,
+        version: v,
+        saga_id,
+    }]
+}
+
+/// Phase B.4 follow-up — record pool inventory shrink (promote or
+/// destroy). Strictly paired with `ReportPoolWindowAdded`: an
+/// unknown-label remove is a silent no-op so subscribers can rely
+/// on add/remove pairing in the broadcast stream. Same gate as
+/// `handle_report_window_closed`. (reagent P2 PR #577 round-3 —
+/// the original "idempotent" comment referenced behavior that was
+/// already removed for `ReportWindowClosed`; pool semantics now
+/// match.)
+pub(super) fn handle_report_pool_window_removed(state: &mut State, label: String) -> Vec<Event> {
+    let was_present = state.pool.remove(&label);
+    if !was_present {
+        return vec![];
+    }
+    let v = state.bump_version();
+    vec![Event::PoolWindowRemoved { label, version: v }]
+}
+
+/// Phase F.5 — host-emitted promote signal. The reducer doesn't mutate
+/// state for this command (the windows/pool transitions are carried by
+/// the surrounding `ReportPoolWindowRemoved` + `ReportWindowOpened`
+/// pair); it just translates the wire command into the corresponding
+/// typed event so subscribers — most importantly the launcher saga
+/// coordinator — can react.
+///
+/// Idempotent / context-free: we don't validate the label is in the
+/// mirror because the host's own ordering may have the
+/// `ReportPoolWindowRemoved` arrive before this command, after this
+/// command, or in either order; the typed event is "host says a
+/// promote happened" — subscribers correlate with the surrounding
+/// add/remove pair if they need stronger invariants.
+pub(super) fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::PoolWindowPromoted { label, version: v }]
+}
+
+/// Phase F.6 — host-emitted signal carrying the result of the
+/// post-close drain-pool-if-last decision. Maps `was_last` directly
+/// to the corresponding terminal event for Step 2 of the
+/// window-cleanup-cascade saga:
+/// * `true` → `Event::PoolDrained` (last user-visible window
+///   closed; warm-pool drain initiated)
+/// * `false` → `Event::PoolNotLast` (other windows remain; pool
+///   stays warm)
+///
+/// Pure pass-through (same reasoning as `handle_report_panes_reaped`).
+pub(super) fn handle_report_pool_drain_decision(
+    state: &mut State,
+    label: String,
+    was_last: bool,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
+    // Same rationale as handle_report_panes_reaped: round 4's gate
+    // had an ordering bug; round 5 reverts to emit-unconditionally.
+    //
+    // CPD-1: `saga_id` flows through unchanged.
+    let v = state.bump_version();
+    if was_last {
+        vec![Event::PoolDrained {
+            label,
+            version: v,
+            saga_id,
+        }]
+    } else {
+        vec![Event::PoolNotLast {
+            label,
+            version: v,
+            saga_id,
+        }]
+    }
+}
+

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use agentmux_common::ipc::{HwndDriftKind, WindowKind};
+use crate::state::WindowMirror;
 
 fn ctx(conn_id: u64) -> Ctx {
     Ctx {
@@ -1272,7 +1274,7 @@ fn arb_window_cmd() -> impl proptest::strategy::Strategy<Value = Command> {
 // Phase B.9 (WRR) — reducer arm tests
 // -----------------------------------------------------------
 
-use agentmux_common::ipc::{HwndDriftKind, Rect};
+use agentmux_common::ipc::Rect;
 
 /// Helper: drive the reducer through a host Register so
 /// subsequent host-only WRR commands are accepted. Returns the
@@ -1644,7 +1646,7 @@ fn b9_3_orphan_instance_does_not_fire_after_host_goodbye() {
     // is no longer Running, but that rejection happens
     // BEFORE reaching the predicate; we want to prove the
     // predicate itself is correct.)
-    let evs = handle_report_window_closed(&mut state, "w1".into());
+    let evs = super::window::handle_report_window_closed(&mut state, "w1".into());
     assert!(
         evs.iter().any(|e| matches!(e, Event::WindowClosed { .. })),
         "WindowClosed should still emit, got {:?}", evs

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -1,0 +1,215 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Window lifecycle reducer handlers. Extracted from reducer/mod.rs
+//! in task #182 PR-C for navigability.
+//!
+//! Handles ReportWindowOpened, ReportWindowClosed, and the
+//! ReportBackendWindowId{Registered,Unregistered} pair.
+
+use agentmux_common::ipc::{Event, WindowKind};
+
+use crate::reducer::Ctx;
+use crate::state::{State, WindowMirror};
+
+use agentmux_common::ipc::HwndDriftKind;
+
+/// Phase B.5 (window_id_map step a) — record the host-reported
+/// label → backend_window_id mapping. Idempotent on duplicate
+/// label (overwrites with the new ID and emits a fresh event so
+/// subscribers see the latest mapping).
+pub(super) fn handle_report_backend_window_id_registered(
+    state: &mut State,
+    label: String,
+    window_id: String,
+) -> Vec<Event> {
+    state
+        .backend_window_ids
+        .insert(label.clone(), window_id.clone());
+    let v = state.bump_version();
+    vec![Event::BackendWindowIdRegistered {
+        label,
+        window_id,
+        version: v,
+    }]
+}
+
+/// Phase B.5 (window_id_map step a) — drop the host-reported label
+/// from the map. Strict pairing: emits `BackendWindowIdUnregistered`
+/// only when the label was present (mirrors `WindowClosed` and
+/// `PoolWindowRemoved` semantics — codex P2 PR #577 round-2).
+pub(super) fn handle_report_backend_window_id_unregistered(
+    state: &mut State,
+    label: String,
+) -> Vec<Event> {
+    let removed = state.backend_window_ids.remove(&label);
+    let Some(window_id) = removed else {
+        return vec![];
+    };
+    let v = state.bump_version();
+    vec![Event::BackendWindowIdUnregistered {
+        label,
+        window_id,
+        version: v,
+    }]
+}
+
+/// Phase B.4 — record a host-reported window opening in the launcher's
+/// read-only mirror. Idempotent on duplicate opens (same label twice
+/// in a row): the second insert overwrites with fresh metadata and
+/// emits a fresh event. Subscribers must tolerate seeing the same
+/// label twice; cleaner once B.5 makes the launcher authoritative.
+///
+/// Phase B.5: also assigns an authoritative instance number from
+/// `state.instance_registry` and emits `WindowInstanceAssigned`.
+/// "main" is pre-seeded with 1; other labels get the next value of
+/// `next_instance_num`. Re-opens of an existing label preserve the
+/// original number — instance numbers are stable per-label-per-run.
+pub(super) fn handle_report_window_opened(
+    state: &mut State,
+    ctx: &Ctx,
+    label: String,
+    kind: WindowKind,
+    parent_label: Option<String>,
+) -> Vec<Event> {
+    // PR #664 codex P1 round 2 — drain-on-WindowOpened RESTORED as
+    // best-effort fallback. The explicit `ReportHwndOpened(Some(label))`
+    // from `client.rs::on_after_created` remains the AUTHORITATIVE
+    // link, and `apply_hwnd_opened` REPAIRS stale links it finds.
+    // But that explicit dispatch is gated on `hwnd_val != 0` host-side;
+    // if the HWND can't be resolved at on_after_created time from
+    // either of the 2 sources (Views, host), the explicit dispatch
+    // is skipped and the mirror would otherwise stay permanently
+    // unlinked, breaking WRR drift detection AND orphan-destroy
+    // reconciliation (no WindowClosed when OS destroys the HWND →
+    // permanent ghost InstancePanel rows).
+    //
+    // (PR #664 round 4 dropped a 3rd fallback `find_own_top_level_window`
+    // because it returns the FIRST visible window in the process —
+    // some other window's HWND in a multi-window session — which
+    // would corrupt other labels' mirrors via the `Repaired` arm.
+    // See client.rs::on_after_created comment for details.)
+    //
+    // The drain provides a fallback link from `pending_hwnds`. If the
+    // drain picks the WRONG HWND (the original burst-create race), the
+    // subsequent `apply_hwnd_opened` call from on_after_created will
+    // detect the mismatch and REPAIR — see the `Repaired` arm there.
+    // Net: best-effort link via drain, authoritative repair via
+    // explicit dispatch. The combination addresses both the
+    // hwnd_val=0 case and the burst-create race.
+    const PENDING_AGE_LIMIT_MS: u64 = 2_000;
+    let drained_hwnd: Option<u64> = state
+        .pending_hwnds
+        .iter()
+        .filter(|(_, p)| p.label_hint.is_none())
+        .filter(|(_, p)| ctx.now_ms.saturating_sub(p.arrived_at_ms) <= PENDING_AGE_LIMIT_MS)
+        .max_by_key(|(_, p)| p.arrived_at_ms)
+        .map(|(hwnd, _)| *hwnd);
+    if let Some(hwnd) = drained_hwnd {
+        state.pending_hwnds.remove(&hwnd);
+    }
+
+    state.windows.insert(
+        label.clone(),
+        WindowMirror {
+            label: label.clone(),
+            kind,
+            parent_label: parent_label.clone(),
+            opened_at: ctx.now_rfc3339.clone(),
+            // Best-effort drain above; authoritative explicit
+            // ReportHwndOpened from on_after_created arrives a few
+            // ms later via `apply_hwnd_opened` and REPAIRS any wrong
+            // link the drain picked.
+            hwnd: drained_hwnd,
+            visible: false,
+            iconic: false,
+            last_rect: None,
+            last_foreground_at_ms: None,
+            foregrounded_since_open: false,
+        },
+    );
+    let mut out = Vec::with_capacity(2);
+    let v = state.bump_version();
+    out.push(Event::WindowOpened {
+        label: label.clone(),
+        kind,
+        parent_label,
+        version: v,
+    });
+
+    // Assign instance number if this label isn't already in the
+    // registry. Re-opens of an existing label keep the original
+    // number — matches host's `WindowInstanceRegistry` semantics
+    // where a label is only registered once per session.
+    let num = if let Some(existing) = state.instance_registry.get(&label).copied() {
+        existing
+    } else {
+        let n = state.next_instance_num;
+        state.instance_registry.insert(label.clone(), n);
+        state.next_instance_num += 1;
+        n
+    };
+    let v = state.bump_version();
+    out.push(Event::WindowInstanceAssigned { label, num, version: v });
+    out
+}
+
+/// Phase B.4 — drop a host-reported window from the mirror. Returns
+/// `Event::WindowClosed` only when the label was actually in the
+/// mirror; an unknown-label close is a silent no-op (codex P2 PR
+/// #577 round-2). Without this gate, a `ReportWindowClosed` for a
+/// label the launcher never saw (e.g. a pool window that was popped
+/// from the queue but failed HWND validation in
+/// `promote_pool_window` — the orphan window's eventual
+/// `on_before_close` reaches us without a matching open) would
+/// emit an unpaired `WindowClosed` broadcast and break subscribers
+/// that assume open/close pairing.
+///
+/// Phase B.5 — also drops the label from `instance_registry` and
+/// emits `WindowInstanceReleased` if a number was assigned.
+/// `next_instance_num` is NOT decremented — instance numbers are
+/// monotonic per-launcher-run.
+pub(super) fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
+    let was_present = state.windows.remove(&label).is_some();
+    if !was_present {
+        // Silent: only emit when the close pairs with a known open.
+        return vec![];
+    }
+    let mut out = Vec::with_capacity(4);
+    let v = state.bump_version();
+    out.push(Event::WindowClosed {
+        label: label.clone(),
+        version: v,
+        // Clean close — host ran on_before_close before sending
+        // ReportWindowClosed. F.6 saga is safe to trigger.
+        crash_detected: false,
+    });
+    if let Some(num) = state.instance_registry.remove(&label) {
+        let v = state.bump_version();
+        out.push(Event::WindowInstanceReleased { label: label.clone(), num, version: v });
+    }
+
+    // Phase B.9.3 — OrphanInstance transition. The label we just
+    // removed was the LAST user-visible window (state.windows is
+    // now empty). If a Host is still registered as Running, its
+    // own close path won't quit_message_loop because the warm
+    // pool is keeping state.browsers non-empty. Emit drift +
+    // saga-style HostShouldQuit so the host can reap pool and
+    // quit cleanly. See B.9.3 in
+    // docs/retro/next-steps-2026-04-29.md.
+    if state.windows.is_empty() && super::host_is_running(state) {
+        let v_drift = state.bump_version();
+        out.push(Event::HwndDriftDetected {
+            kind: HwndDriftKind::OrphanInstance,
+            label: Some(label),
+            hwnd: None,
+            detail: "Last user-visible window closed; host still alive (likely holding warm pool)"
+                .to_string(),
+            severity: agentmux_common::ipc::Severity::Warn,
+            version: v_drift,
+        });
+        let v_quit = state.bump_version();
+        out.push(Event::HostShouldQuit { version: v_quit });
+    }
+    out
+}

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.605"
+version = "0.33.606"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.605",
+  "version": "0.33.606",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.605",
+      "version": "0.33.606",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.605",
+  "version": "0.33.606",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Bundles **PR-B (pool extraction)** + **PR-C (window-lifecycle extraction)** into one PR off main. PR-B's content needs re-applying because PR #670 was merged into the wrong base (\`agenta/modularize-launcher-reducer-tests\` instead of main), so the pool extraction never reached main.

| File | Before this PR | After |
|---|---|---|
| \`reducer/mod.rs\` | 1114 lines | 815 lines (-299) |
| \`reducer/pool.rs\` | NEW | 116 lines (re-applied from PR #670) |
| \`reducer/window.rs\` | NEW | 213 lines |

## Extracted

### Pool (re-applied — same content as merged PR #670)
- handle_report_host_pool_count
- handle_report_pool_window_added/removed/promoted
- handle_report_pool_drain_decision

### Window lifecycle (PR-C, new)
- handle_report_window_opened
- handle_report_window_closed
- handle_report_backend_window_id_registered
- handle_report_backend_window_id_unregistered

## Cross-module wiring changes

- All extracted handlers marked \`pub(super)\` (only \`mod.rs\`'s dispatcher calls them)
- \`host_is_running\` made \`pub(super)\` so window.rs can call it via \`super::\` for OrphanInstance drift detection
- Imports relocated: \`WindowKind\`, \`HwndDriftKind\`, \`WindowMirror\` moved from mod.rs to window.rs
- tests.rs gets explicit imports for those types (was relying on mod.rs re-exports via super::*)

## Note on stack mishap

PR #670's content is on the \`agenta/modularize-launcher-reducer-tests\` remote branch (now stale) but never reached main. This PR cherry-picks the same pool extraction onto main, then layers window-lifecycle on top. Once this merges, the stale PR #670 branch can be deleted.

## Tests

154 launcher tests pass.

## Future PRs in task #182

- **PR-D**: extract saga handlers (panes_reaped, saga_action_failed)
- **PR-E**: extract connection handlers (register, ping, goodbye, enforce_host_only)
- **PR-F**: split host reducer per Phase-H domain
- **PR-G**: split client.rs per-callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)