### PR TITLE
refactor(launcher): extract saga handlers into reducer/saga.rs (task #182 PR-D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.606"
+version = "0.33.607"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.606"
+version = "0.33.607"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.606"
+version = "0.33.607"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.606"
+version = "0.33.607"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -75,6 +75,7 @@ pub struct Ctx {
 
 mod pool;
 mod window;
+mod saga;
 
 /// Apply one Command to State, returning the resulting Events. State
 /// is mutated in place. Total function — never panics on input
@@ -160,7 +161,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportPanesReaped") {
                 return vec![err];
             }
-            handle_report_panes_reaped(state, label, saga_id)
+            saga::handle_report_panes_reaped(state, label, saga_id)
         }
         // Phase F.6 — host reports the result of the post-close
         // drain-pool-if-last decision. `was_last == true` →
@@ -209,7 +210,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = enforce_host_only(state, ctx, "ReportSagaActionFailed") {
                 return vec![err];
             }
-            handle_report_saga_action_failed(state, saga_id, reason)
+            saga::handle_report_saga_action_failed(state, saga_id, reason)
         }
         Command::ReportHostCounts { windows, pool } => {
             if let Some(err) = enforce_host_only(state, ctx, "ReportHostCounts") {
@@ -550,58 +551,7 @@ fn handle_report_host_counts(state: &mut State, host_windows: u32, host_pool: u3
 }
 
 
-/// Phase F.6 — host-emitted signal that browser-pane HWNDs for a
-/// closing top-level window have been reaped. Pure pass-through:
-/// state stays untouched (the host owns pane bookkeeping); the
-/// reducer just translates the wire command into the typed event so
-/// the window-cleanup-cascade saga can advance.
-///
-/// Idempotent / context-free: the saga matches the `label` against
-/// its own `closed_label`, so a stray report for a label that no
-/// in-flight saga is tracking is a harmless broadcast.
-fn handle_report_panes_reaped(
-    state: &mut State,
-    label: String,
-    saga_id: Option<u64>,
-) -> Vec<Event> {
-    // No state.windows gate — round 4's gate had an ordering bug:
-    // host sends ReportWindowClosed BEFORE ReportPanesReaped on the
-    // same channel, so by the time the reducer processes this, the
-    // label is already gone from state.windows (closed by the prior
-    // command's reducer arm). The gate then dropped EVERY
-    // PanesReaped, leaving the F.6 saga stuck in WaitingForPanesReaped
-    // indefinitely. Round 5 reversal: emit unconditionally; for
-    // unpromoted-pool drains where no saga is in flight, the event
-    // appears stray on the bus but is harmless (no subscriber acts
-    // on it). Cosmetic only; correct saga lifecycle restored.
-    //
-    // CPD-1: `saga_id` flows through unchanged (None for organic
-    // reports, Some(N) once CPD-3 hosts echo back the saga's id).
-    let v = state.bump_version();
-    vec![Event::PanesReaped {
-        label,
-        version: v,
-        saga_id,
-    }]
-}
 
-/// Phase CPD-1 — host reported a saga-issued action failed. Pure
-/// pass-through translation into `Event::SagaActionFailed`. The
-/// saga coordinator's bus loop will (CPD-3) treat the event as a
-/// terminal signal for the matching `saga_id` and emit
-/// `Event::SagaFailed`, dropping the saga from in-flight.
-fn handle_report_saga_action_failed(
-    state: &mut State,
-    saga_id: u64,
-    reason: String,
-) -> Vec<Event> {
-    let v = state.bump_version();
-    vec![Event::SagaActionFailed {
-        saga_id,
-        reason,
-        version: v,
-    }]
-}
 
 /// Phase B.4 — gate window-mirror reports to Host clients only. The
 /// host is the only source of truth about its own window lifecycle;

--- a/agentmux-launcher/src/reducer/saga.rs
+++ b/agentmux-launcher/src/reducer/saga.rs
@@ -1,0 +1,66 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Saga-related reducer handlers. Extracted from reducer/mod.rs
+//! in task #182 PR-D for navigability.
+//!
+//! Both handlers are pure pass-through: state is untouched, the
+//! reducer just translates the wire command into the typed event
+//! so saga subscribers (in the saga coordinator's bus loop) can react.
+
+use agentmux_common::ipc::Event;
+
+use crate::state::State;
+
+/// Phase F.6 — host-emitted signal that browser-pane HWNDs for a
+/// closing top-level window have been reaped. Pure pass-through:
+/// state stays untouched (the host owns pane bookkeeping); the
+/// reducer just translates the wire command into the typed event so
+/// the window-cleanup-cascade saga can advance.
+///
+/// Idempotent / context-free: the saga matches the `label` against
+/// its own `closed_label`, so a stray report for a label that no
+/// in-flight saga is tracking is a harmless broadcast.
+pub(super) fn handle_report_panes_reaped(
+    state: &mut State,
+    label: String,
+    saga_id: Option<u64>,
+) -> Vec<Event> {
+    // No state.windows gate — round 4's gate had an ordering bug:
+    // host sends ReportWindowClosed BEFORE ReportPanesReaped on the
+    // same channel, so by the time the reducer processes this, the
+    // label is already gone from state.windows (closed by the prior
+    // command's reducer arm). The gate then dropped EVERY
+    // PanesReaped, leaving the F.6 saga stuck in WaitingForPanesReaped
+    // indefinitely. Round 5 reversal: emit unconditionally; for
+    // unpromoted-pool drains where no saga is in flight, the event
+    // appears stray on the bus but is harmless (no subscriber acts
+    // on it). Cosmetic only; correct saga lifecycle restored.
+    //
+    // CPD-1: `saga_id` flows through unchanged (None for organic
+    // reports, Some(N) once CPD-3 hosts echo back the saga's id).
+    let v = state.bump_version();
+    vec![Event::PanesReaped {
+        label,
+        version: v,
+        saga_id,
+    }]
+}
+
+/// Phase CPD-1 — host reported a saga-issued action failed. Pure
+/// pass-through translation into `Event::SagaActionFailed`. The
+/// saga coordinator's bus loop will (CPD-3) treat the event as a
+/// terminal signal for the matching `saga_id` and emit
+/// `Event::SagaFailed`, dropping the saga from in-flight.
+pub(super) fn handle_report_saga_action_failed(
+    state: &mut State,
+    saga_id: u64,
+    reason: String,
+) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::SagaActionFailed {
+        saga_id,
+        reason,
+        version: v,
+    }]
+}

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.606"
+version = "0.33.607"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.606",
+  "version": "0.33.607",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.606",
+      "version": "0.33.607",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.606",
+  "version": "0.33.607",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Continues the per-domain reducer split. Extracts the 2 saga-related handlers from \`reducer/mod.rs\` into \`reducer/saga.rs\`. Both are pure pass-through (state untouched; just translates the wire command into a typed event for the saga coordinator's bus loop subscribers).

## Extracted

- \`handle_report_panes_reaped\` (~33 lines incl. doc)
- \`handle_report_saga_action_failed\` (~17 lines incl. doc)

Both marked \`pub(super)\` — only mod.rs's dispatcher calls them.

## Sizes

| File | Before | After |
|---|---|---|
| \`reducer/mod.rs\` | 815 lines | 765 lines (-50) |
| \`reducer/saga.rs\` | NEW | 66 lines |

## Tests

154 launcher tests pass. No behavior change.

## Next in task #182

- **PR-E**: extract connection handlers (register, ping, goodbye, enforce_host_only, host_is_running)
- **PR-F**: split host reducer per Phase-H domain
- **PR-G**: split client.rs per-callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)