### PR TITLE
feat(agent): document-state reducer fixes mid-session history wipe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.615"
+version = "0.33.616"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.615"
+version = "0.33.616"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.615"
+version = "0.33.616"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.615"
+version = "0.33.616"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.617"
+version = "0.33.618"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.617"
+version = "0.33.618"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.617"
+version = "0.33.618"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.617"
+version = "0.33.618"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.616"
+version = "0.33.617"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.616"
+version = "0.33.617"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.616"
+version = "0.33.617"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.616"
+version = "0.33.617"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.616"
+version = "0.33.617"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.617"
+version = "0.33.618"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.615"
+version = "0.33.616"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.617"
+version = "0.33.618"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.616"
+version = "0.33.617"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.615"
+version = "0.33.616"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.617"
+version = "0.33.618"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.616"
+version = "0.33.617"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.615"
+version = "0.33.616"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.616"
+version = "0.33.617"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.617"
+version = "0.33.618"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.615"
+version = "0.33.616"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/agent-pane-document-reducer-2026-05-03.md
+++ b/docs/specs/agent-pane-document-reducer-2026-05-03.md
@@ -1,0 +1,231 @@
+# Agent Pane Document Reducer — root-cause + architecture spec
+
+**Date:** 2026-05-03
+**Status:** Draft — awaiting review
+**Scope:** `frontend/app/view/agent/`
+**Triggering bug:** Mid-Claude-session, the agent pane chat history disappears and only a "skeleton" (empty pane shell) remains.
+
+## TL;DR
+
+The agent pane has **three independent writers** to the message-list signal (`documentAtom`) with **no serialization, invariants, or audit trail**:
+
+1. **`useAgentStream`** — appends nodes from live stdout/stderr stream
+2. **`useHistoryPagination`** — prepends nodes loaded from blockfile on mount
+3. **`/clear` command** — wipes the document on user request
+
+A fourth, unintentional writer is the **truncate fileop branch** of `useAgentStream` (`useAgentStream.ts:366–381`) which calls `setDocument([])` unconditionally. The most likely root cause of the skeleton-wipe bug is a **socket-reconnect race**: when the WebSocket reconnects, `wpsReconnectHandler()` re-issues subscriptions; if the backend has reinitialized the output blockfile in the meantime, a stale `truncate` event arrives after the resubscribe and clears the live document.
+
+This spec proposes:
+
+1. **Immediate-relief patch** (1–2h) — gate the truncate handler behind a session-active guard so a transient reconnect can't wipe a live conversation.
+2. **Architectural fix** (medium effort) — introduce a small frontend reducer (`agentDocumentReducer`) that serializes all `documentAtom` mutations and enforces invariants ("the document only goes from non-empty to empty via an explicit, user-initiated event"). Pattern follows the existing host/launcher reducers (task #182, `agentmux-cef/src/reducer/`, `agentmux-launcher/src/reducer/`).
+
+## Bug — what we know
+
+### Symptom
+
+Mid-Claude-session, the agent pane's rendered message list goes from "rich conversation history" to "empty pane shell." User has not pressed any clear/reset action. Re-opening the pane (or a hot-reload) restores the messages from the blockfile — i.e. the on-disk history is intact; the in-memory document atom was wiped.
+
+### Architecture (current state)
+
+- `documentAtom` is a Solid signal pair created per-pane by `createAgentAtoms(blockId)` (`state.ts:70–99`)
+- It holds `DocumentNode[]`, the rendered message-tree
+- Three writers (above), no coordination
+- `useAgentStream.ts:366–381` handles `fileop=truncate` events from the live file subject by calling `setDocument([])` unconditionally
+- `wpsReconnectHandler()` (`wps.ts:30–34`) re-subscribes to all `fileop` events on socket reconnect — this is where the race window opens
+
+### Ranked root-cause hypotheses
+
+| Likelihood | Cause | Evidence |
+|---|---|---|
+| **HIGH** | Socket-reconnect race delivers a stale `truncate` to a still-active session, wiping the document | `useAgentStream.ts:366–381` clears unconditionally; `wps.ts:30` resubscribes on reconnect; backend reinit between subs is the race window |
+| HIGH | `/clear` accidentally invoked (user, hotkey, MCP tool) | `commands/global/clear.ts:17–20` calls `setDocument([])`; symptomatic match but requires user action |
+| MEDIUM | `documentVersion` bump from history-load races against live stream's dedup-map rebuild | `useAgentStream.ts:329–330` resets `nodeIndexMap`/`nodeIdSet` on version bump; `useHistoryPagination.ts:155–156` calls `bumpDocumentVersion()` after prepend; if a stream batch is mid-flush during the bump, indices go stale |
+| MEDIUM | `useAgentStream` and `useHistoryPagination` race on `setDocument` — Solid batches, last-write-wins | Both hooks own the same setter with no sequencing primitive |
+| LOW | Block-meta change triggers atom factory rerun → fresh `[]` document | `agent-view.tsx:91` uses `createMemo(() => createAgentAtoms(model.blockId))`; `blockId` is stable post-create, but a future bug here would manifest exactly as the reported symptom |
+
+The HIGH/MEDIUM causes share a common shape: **multiple writers, no invariants, one of them clears state**. That's the architectural bug — the truncate-race is just the manifestation that's biting now.
+
+## Why a reducer (and which reducer)
+
+We already use the reducer pattern in three production places + one frontend instance:
+
+- `agentmux-srv/src/reducer.rs` — srv reducer (Phase E): workspaces, tabs, blocks, layouts, identity. Largest scope; serves as the canonical state.
+- `agentmux-cef/src/reducer/` — host reducer (task #182 PR-F-2): browsers, panes, drag, pool, quit, top-level
+- `agentmux-launcher/src/reducer/` — launcher reducer (task #182 PR-A through PR-E): window lifecycle
+- `frontend/app/store/launcher-event-reducer.ts` — **frontend reducer**: subscribes to launcher events, holds an in-memory `knownEntries: Map`, mirrors into store atoms, has echo-loop scaffolding (`applyingRemote`)
+
+The closest analog to this proposal is **`launcher-event-reducer.ts`** — that's the prior art for a frontend store-level reducer.
+
+The Rust reducers all follow the same shape: pure `update(&mut State, Command) → Vec<Event>`, no I/O, snapshot-and-drop the lock, sub-millisecond mutex hold. Tests assert post-conditions per command.
+
+This pattern transfers directly to the frontend with minor adjustments:
+
+- **State**: `AgentDocumentState { nodes: DocumentNode[]; sessionPhase: "loading-history" | "active" | "ended"; lastTruncateAt: number | null; ... }`
+- **Commands** (the operations that today mutate `documentAtom`):
+  - `HistoryLoaded { nodes }` — from `useHistoryPagination`
+  - `StreamAppend { nodes }` — from `useAgentStream` flush
+  - `StreamTruncate { reason }` — from `fileop=truncate` (now an explicit, contextual command)
+  - `UserClear` — from `/clear`
+  - `SessionStart`, `SessionEnd` — phase transitions
+- **Invariants enforced inside the reducer**:
+  - `StreamTruncate` is a no-op when `sessionPhase === "active"` AND the truncate isn't the first one within a small window after `SessionStart` (catches the reconnect race)
+  - `UserClear` is the only path that can take the document from non-empty to empty during an active session
+  - `HistoryLoaded` only prepends — never overwrites
+  - Stream appends are dedup-checked against existing node IDs by the reducer, not by ad-hoc maps in the hook
+- **Output**: the new state replaces `documentAtom` via a single, serialized setter
+
+Reducer ownership of dedup is also where the medium-likelihood `nodeIndexMap`-rebuild bug goes away: there's no separate dedup map to fall out of sync — the reducer is the source of truth for which IDs are present.
+
+What stays out of the reducer (per the host-reducer pattern's "snapshot-and-drop" rule):
+
+- Async I/O — `useHistoryPagination` keeps owning the fetch; it just emits the result as a command instead of calling `setDocument` directly
+- xterm scroll position, search highlight state, collapsed/pinned node sets — UI chrome, lives in `documentStateAtom` as today
+- Stream parsing — `useAgentStream` keeps the parser; it emits `StreamAppend { nodes }` after parsing
+
+## Where the reducer lives — three options
+
+The reducer logic itself is the same regardless of where it sits. The question is **scope of state owned** and **where the dispatch lives**.
+
+### Option A — View-local, agent-document only (~1 day) ← original spec
+
+`frontend/app/view/agent/document-reducer/` — per-pane state cell created alongside `createAgentAtoms`. Out-of-scope: every other agent-view atom.
+
+Pros: smallest blast radius; doesn't presume a generalization that doesn't yet have a second consumer.
+Cons: doesn't match the established frontend pattern (`launcher-event-reducer.ts` lives in `app/store/`); each future per-pane reducer would re-implement the slot/lifecycle plumbing.
+
+### Option B — Store-level, agent-document keyed by blockId (~1 day, recommended)
+
+`frontend/app/store/agent-document-store.ts` — single module owns `Map<blockId, AgentDocumentState>` and exports `dispatchFor(blockId, command)`. Pane registers a slot on mount, releases on cleanup. The per-pane `documentAtom` becomes a projection over the store.
+
+Pros: matches `launcher-event-reducer.ts` exactly (single module, in-memory mirror, atom projection); leaves the door open for cross-pane consumers (e.g. a future "agent activity feed"); centralized event log easier to surface in diagnostics.
+Cons: needs slot lifecycle (cleanup on pane close to avoid leak); marginally more wiring than Option A.
+
+### Option C — Store-level + other agent atoms (~2 days)
+
+Same as B but pulls in the other per-pane agent atoms that today have a single owner: `streamingState`, `sessionStats`, `currentTool`, `turnTokens`, `turnActive`, `stopping`. One state cell per pane, all mutations dispatch.
+
+Pros: stronger invariant surface (e.g. `turnActive` ↔ `streamingState.active` cohesion); single audit log for the whole agent-stream lifecycle.
+Cons: substantially expands the original "documentAtom only" scope; the other atoms aren't suffering the race that motivated this work.
+
+### Option D — Frontend tab/pane state mirror (~1 week, multi-PR)
+
+Build a frontend reducer mirroring srv reducer's tab/pane/block state shape (per `SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md`), with agent atoms as slices alongside tab/pane/block. Retrofits the existing wstore-driven atoms into a reducer pattern.
+
+Pros: symmetric with srv; full audit; positions the frontend for receiving srv reducer events directly (Phase E.4 layout reducer convergence).
+Cons: big project; needs its own spec; not motivated by today's bug.
+
+### Recommendation
+
+**Option B.** It addresses the architectural concern (matches the established frontend reducer pattern), keeps scope tight (still just `documentAtom`), and the relocation is mechanical from Option A. Option C and D are valuable follow-ups but should not block fixing the live bug.
+
+## Migration plan
+
+### Phase 0 — Immediate-relief patch (ship today, defends users while Phase 1 is in flight)
+
+Single edit in `useAgentStream.ts:366–381`:
+
+```ts
+// Before — unconditional wipe
+if (fileop === "truncate") {
+    setDocument([]);
+    return;
+}
+
+// After — guarded
+if (fileop === "truncate") {
+    const phase = sessionPhase();              // new accessor (see Phase 1)
+    const elapsedSinceSessionStart = ...;
+    if (phase === "active" && elapsedSinceSessionStart > GRACE_MS) {
+        log.warn("[agent-stream] suppressing late truncate during active session", {...});
+        return;
+    }
+    setDocument([]);
+}
+```
+
+Until Phase 1 lands, `sessionPhase()` can be approximated as "is `documentAtom` currently non-empty AND is the WebSocket reachable" — a coarse but effective heuristic. The exact predicate is best refined as part of Phase 1 once the reducer owns phase transitions.
+
+### Phase 1 — Introduce the reducer (single PR)
+
+1. Create `frontend/app/view/agent/document-reducer/` directory:
+   - `types.ts` — `AgentDocumentState`, `AgentDocumentCommand`, `AgentDocumentEvent`
+   - `reducer.ts` — pure `update(state, command): { state, events }` function
+   - `reducer.test.ts` — table-driven tests covering each command + invariant
+2. Wire `documentAtom` setter to a single `dispatch(command)` function exported from the reducer module. The setter wraps `update()` and applies the new `state.nodes` to the atom.
+3. Refactor `useAgentStream.ts`:
+   - On `append` fileop → `dispatch({ type: "StreamAppend", nodes })`
+   - On `truncate` fileop → `dispatch({ type: "StreamTruncate", reason: "fileop" })` (reducer decides whether it's honored)
+   - Drop the dedup `nodeIndexMap` / `nodeIdSet` — reducer owns dedup
+4. Refactor `useHistoryPagination.ts`:
+   - On fetch complete → `dispatch({ type: "HistoryLoaded", nodes })`
+   - Drop the direct `setDoc([...newNodes, ...prev])` call
+5. Refactor `commands/global/clear.ts`:
+   - Replace `setDocument([])` with `dispatch({ type: "UserClear" })`
+6. Add `SessionStart` / `SessionEnd` dispatch calls at agent-stream lifecycle boundaries.
+7. Add a debug accessor `agentDocumentEventsAtom: SignalAtom<AgentDocumentEvent[]>` (ring buffer, last N events) — surfaceable in the diagnostics panel for future bug triage.
+
+### Phase 2 — Audit + remove (follow-up PR)
+
+- grep for any remaining `setDocument(` callsite → reducer or delete
+- Add a TS exhaustiveness check: `documentAtom` setter is private to the reducer module; only `dispatch()` is exported
+- Remove the Phase 0 inline guard once the reducer's invariant covers it
+
+## Reducer scope assessment (what's NOT in scope)
+
+A common failure mode of reducer migrations is over-reach. **This spec scopes the reducer to the message document only.** Specifically NOT in scope:
+
+- The agent view's other atoms (`streamingStateAtom`, `sessionStatsAtom`, `currentToolAtom`, `stoppingAtom`, `pendingMessagesAtom`) — they have a single owner each and aren't suffering the same race
+- xterm/scroll/search/UI-chrome atoms (`documentStateAtom`)
+- AgentViewModel class itself
+- Any other view (term, swarm, etc.)
+
+If the document reducer proves out, future PRs can selectively pull additional atoms in. Don't pre-design a god-reducer.
+
+## Tests
+
+The reducer being pure is the point — it lets us assert invariants directly:
+
+| Test | Setup | Assertion |
+|---|---|---|
+| Stream append after history load preserves both | Dispatch `HistoryLoaded([h1,h2])`, then `StreamAppend([s1])` | State has `[h1, h2, s1]` |
+| Truncate during active session is suppressed | Dispatch `SessionStart`, `StreamAppend([s1])`, `StreamTruncate` | State still has `[s1]`, event log shows suppression |
+| Truncate before session start is honored | Dispatch `StreamTruncate` (no SessionStart yet) | State `nodes === []` |
+| Concurrent stream appends with duplicate IDs dedup | Dispatch `StreamAppend([s1, s1])` | State has one `s1` |
+| User clear always wipes | Dispatch any sequence ending in `UserClear` | State `nodes === []` |
+| History load after stream append prepends correctly | Stream first, then history | History nodes precede stream nodes |
+| Reducer is pure | Same input twice → same output | Property test |
+
+## Open questions
+
+| # | Question | Default |
+|---|---|---|
+| Q1 | Should `SessionStart` be auto-derived from "first stream-append" or an explicit signal from `useAgentStream`? | Explicit signal — the hook knows when subprocess spawn completed |
+| Q2 | Truncate suppression window: time-based (GRACE_MS) or event-based (next non-truncate event lifts the suppression)? | Time-based, ~5s — survives socket reconnect (~1–3s typical) without permanently blocking legitimate truncates |
+| Q3 | Persist event log across pane sessions, or in-memory ring buffer only? | In-memory ring buffer (200 events); persistence is a future feature if telemetry needs it |
+| Q4 | Reducer in `frontend/app/view/agent/document-reducer/` or in a more generic location like `frontend/app/store/`? | View-local — single consumer, follows the per-domain split established by task #182 PR-F-2 |
+| Q5 | Are there other agent-view atoms suffering similar race issues that should join this PR? (e.g. `pendingMessagesAtom` is also written by multiple hooks) | Out of scope; surface in a follow-up retro after Phase 1 ships |
+| Q6 | Should the diagnostics panel surface the event-log immediately, or in a follow-up? | Follow-up — keep Phase 1 focused |
+
+## Best-practice references
+
+The reducer/event-log pattern for chat UIs is well-trodden:
+
+- **Redux + redux-toolkit** (web standard since ~2015) — pure reducer, action log, time-travel debugging. AgentMux's existing host/launcher reducers are stylistically closer to this than to other patterns.
+- **Elm Architecture** — model/msg/update triple, the direct ancestor of Redux. Strongest invariant guarantees because messages are exhaustive sum types (which TypeScript's tagged unions approximate).
+- **Solid stores (`createStore`)** — the Solid-native option. Simpler than a reducer but has the same multi-writer race vulnerability `documentAtom` has today; doesn't solve the bug. The reducer is worth the extra layer specifically for the invariant enforcement.
+- **CRDT-based chat clients** (Slack, Linear) — overkill for our local-only document but their convergence guarantees are conceptually what we want from the reducer (mutations are commutative within a phase, late-arriving messages can't undo state).
+
+The choice here is **redux-toolkit-style reducer** over Solid store, because the value being added is the invariant ("can't accidentally wipe a live session"), not the state-shape ergonomics. A pure function with a tagged-union command type makes the invariant trivially auditable.
+
+## Estimated effort
+
+- Phase 0 (relief patch): 1–2 hours, single PR, no API change.
+- Phase 1 (reducer + refactor): ~1 day. ~200 LOC reducer + ~100 LOC tests + ~3 callsites refactored. Breaking change is internal to `frontend/app/view/agent/`.
+- Phase 2 (cleanup): 1–2 hours follow-up.
+
+## Risks
+
+- **Risk:** the reducer adds latency to high-frequency stream appends. **Mitigation:** the reducer is a pure function operating on in-memory arrays, well under 1ms per call (compare to host reducer's sub-ms target). Stream-append rate is bounded by RAF batching in `useAgentStream` (already 60Hz max).
+- **Risk:** the truncate-suppression heuristic is wrong — a legitimate user-initiated truncate gets suppressed. **Mitigation:** `UserClear` is a distinct command and is never suppressed. Backend-initiated truncates during active session are arguably always wrong (the existing code's behavior is incidental, not designed); if a legitimate use case surfaces post-Phase-1, add an explicit `BackendTruncate { authoritative: true }` command.
+- **Risk:** scope creep into a "redux for the whole agent view" rewrite. **Mitigation:** spec is explicit that scope = `documentAtom` only. Other atoms join only via follow-up PRs with their own justification.

--- a/docs/specs/frontend-reducer-architecture-2026-05-03.md
+++ b/docs/specs/frontend-reducer-architecture-2026-05-03.md
@@ -1,0 +1,125 @@
+# Frontend Reducer Architecture — spec roadmap
+
+**Date:** 2026-05-03
+**Status:** Architecture overview + spec family inventory. Each named follow-up spec needs to be written before its implementation.
+**Reads-this-first:**
+- `docs/specs/agent-pane-document-reducer-2026-05-03.md` — first slice to land (the live agent-doc bug fix)
+- `agentmux-srv/src/reducer.rs` + `SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md` — the canonical reducer pattern, server-side
+- `frontend/app/store/launcher-event-reducer.ts` — the only frontend reducer that exists today (window mirror)
+- `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` — granularity-decision precedent
+
+## What we're trying to make true
+
+Today the frontend has many state mutators with no coordinating layer. State is scattered across:
+
+- Per-pane Solid signals (`createAgentAtoms`, `createTermAtoms`, etc.) with class view-models
+- Global Solid atoms in `frontend/app/store/global.ts` (block atoms, focus, layout)
+- A wstore mirror layer (`wos.ts`) that reflects srv objects
+- `launcher-event-reducer.ts` — single store-level reducer mirroring launcher window state
+- Direct RPC calls scattered across components (`pane-actions.ts`, `command-registry.ts`, slash commands, agent app-API endpoints)
+
+Three concrete forces are pushing toward consolidation:
+
+1. **The agent-doc bug**: `documentAtom` has 3 unsynchronized writers — proven to cause a mid-session wipe. Same shape exists in other atoms.
+2. **Agent-driven UI mutations**: agents can call MCP tools / app APIs to create panes/tabs/windows. Today these go straight to srv RPCs, bypassing any frontend audit, policy, or coordination with concurrent user actions.
+3. **Symmetry with srv**: srv reducer is the source of truth for tab/pane/block state and emits versioned events. The frontend should consume those events through a coherent reducer, not a per-feature mirror.
+
+The end state is **a frontend command/event bus** that:
+- Routes all outbound mutations through one chokepoint (audit, policy, optimistic UI)
+- Routes all inbound events from srv/launcher/host through one dispatch
+- Maintains an in-memory state projection in slices (per-pane and global)
+- Preserves the per-slice reducer purity that makes the Rust reducers debuggable
+
+We will not get there in one PR. This document names the staged specs.
+
+## The spec family
+
+Each row is a separate spec to be written. They ship in order; each builds on the previous. Estimates are spec-writing + implementation, not just code.
+
+| # | Spec | Scope | Status | Effort | Depends on |
+|---|---|---|---|---|---|
+| **1** | `agent-pane-document-reducer-2026-05-03.md` | Single-slice reducer for agent `documentAtom` (Option B from spec). Lives at `frontend/app/store/agent-document-store.ts`. Per-blockId state cell. Fixes the live bug. | **Written, ready** | ~1 day | — |
+| **2** | `frontend-reducer-conventions.md` | The shared conventions: command/event types, dispatch signature, slot lifecycle, atom projection, echo-loop guard, test layout. Becomes the template every later spec follows. | **Needed before #3+** | ~1 day spec | #1 sets de facto pattern |
+| **3** | `frontend-command-bus.md` | The big one. Single outbound dispatch for user clicks + slash commands + agent app-API calls. Audits, applies policy ("agent X may not delete pane Y"), routes to srv/host/launcher RPCs. Optional optimistic-update queue for slow ops. Doesn't take ownership of state — that stays in the slice reducers. | **Needed**, biggest | 2–3 days spec, ~2 weeks impl | #2 |
+| **4** | `agent-pane-state-reducer.md` | Option C from #1. Bundles the other agent-pane atoms — `streamingState`, `sessionStats`, `currentTool`, `turnTokens`, `turnActive`, `stopping`, `pendingMessages` — into one slice with cohesive invariants (e.g. `turnActive ↔ streamingState.active`). | Needed | ~1 day spec, ~2 days impl | #1, #2 |
+| **5** | `frontend-layout-reducer.md` | Frontend mirror of srv's Phase E.4 layout reducer (focused node, magnified node, leaf order). Subscribes to srv events, projects into existing layout atoms. | Needed | ~1 day spec, ~3 days impl | #2; coordinates with srv-side `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` |
+| **6** | `launcher-event-reducer-convergence.md` | Fold the existing one-off `launcher-event-reducer.ts` into the conventions established by #2. No behavior change — purely structural alignment. | Cleanup | ~0.5 day | #2 |
+| **7** | `tab-state-reducer.md` | Frontend mirror of srv's tab state. Active tab, tab order, per-tab metadata. Subscribes to srv events. | Needed | ~1 day spec, ~3 days impl | #2 |
+| **8** | `pane-tree-reducer.md` | Frontend mirror of srv's block/layout tree per-tab. The bigger version of #5 — owns the actual tree, not just focus. Has a `rootnode` field that needs the path-representation work flagged in srv Phase E.4. | Speculative — wait for srv E.4.B | ~2 days spec | #5, #7, srv E.4.B |
+
+## Convention layer (#2) — what every slice needs
+
+Before specs #3–#8 can be written usefully, we need the shared convention. Here's the proposed shape, informed by `launcher-event-reducer.ts` and the Rust reducers:
+
+### Command / event types
+```ts
+type Command<TPayload> = { type: string; payload: TPayload };
+type Event<TPayload>   = { type: string; payload: TPayload; version: number };
+```
+Every slice declares its own discriminated-union `Command` and `Event` types. Versioning enables saga buffer ordering (matching srv's pattern).
+
+### Dispatch signature
+```ts
+type Dispatch<TCmd, TEvt> = (command: TCmd) => TEvt[];
+```
+Pure: synchronous, returns the events the command produced. No promises inside dispatch — async work happens before the dispatch (in the caller) or as a side effect after (in subscribers). Mirrors the host reducer's "snapshot-and-drop" rule.
+
+### Slot lifecycle (per-instance slices)
+For per-pane slices like #1 and #4:
+```ts
+interface Slice<TState, TCmd, TEvt> {
+  registerSlot(key: string, projection: SignalPair<…>): void;
+  unregisterSlot(key: string): void;
+  dispatchFor(key: string, command: TCmd): TEvt[];
+  snapshotFor(key: string): TState;  // diagnostics + tests
+}
+```
+Pane components register on mount, release on cleanup. Failure to release leaks a state cell — convention: a `useSlot()` hook bundles this.
+
+### Atom projection
+Each slice's authoritative state lives in the slice's internal `Map<key, State>`. The frontend's existing per-pane Solid atoms become **projections** — the slice writes through them on each command application. Components keep using `someAtom()` as before; they don't talk to the slice directly.
+
+### Echo-loop guard
+Same pattern as `launcher-event-reducer.ts:54`: an `applyingRemote` flag set during inbound-event apply. Outbound commands check the flag and skip emitting if the change is already a remote echo. Prevents double-routing.
+
+### Audit trail
+Every dispatch returns events. The bus / slice can buffer the last N (~200) events in memory for diagnostics. Surface in the existing diagnostics panel — single place to see "what mutated and why."
+
+### Tests
+- Reducer is a pure function — table-driven tests assert post-state for each command.
+- Slice (with slot lifecycle) gets integration tests for register/dispatch/unregister.
+- The bus (#3) gets routing tests + policy tests.
+
+## What this is NOT
+
+- **Not** a wholesale rewrite of `wstore` / `wos`. The wstore subscription mechanism stays — it's the inbound channel for srv events. The reducer slices subscribe to it.
+- **Not** Redux / redux-toolkit literally. The Rust reducers don't use middleware, action creators, etc. We borrow the pattern (pure update, command/event split) without the ceremony.
+- **Not** state colocation reform — atoms stay where they are; the slice writes through them. Consumers don't care that there's a reducer behind the curtain.
+- **Not** a saga framework — sagas live srv-side per `SPEC_PHASE_E_SAGAS_2026-04-30.md`. Frontend slices subscribe to terminal events; orchestration is upstream.
+
+## Sequencing rationale
+
+Why this order:
+
+- **#1 first** because the bug is real and shipping it validates the per-slice pattern in production before we generalize.
+- **#2 second** because writing more reducers without a convention guarantees inconsistency. Cheap to write; everything else depends on it.
+- **#3 next** because the agent-driven UI mutation gap is the architectural thing that the user explicitly raised and the longest-lead-time piece. Writing the spec early lets implementation parallelize with #4–#5.
+- **#4 alongside #5** because both are tightening per-pane invariants and don't compete for the same files.
+- **#6** is a small cleanup that keeps the codebase consistent; do it whenever bandwidth allows after #2.
+- **#7** before **#8** because tab state is simpler than the layout tree, and the path-representation question for `rootnode` (per srv Phase E.4 spec) needs the srv-side decision to land first.
+
+## Open architectural questions
+
+These need to be settled in #2 (conventions) before the rest can be specced cleanly:
+
+1. **Single bus vs. per-slice dispatch**: do all dispatches flow through one entry point (`bus.dispatch(slice, command)`) or do slices expose their own dispatchers (`agentDocStore.dispatch(blockId, command)`)? Single-bus is cleaner for audit; per-slice is what `launcher-event-reducer.ts` does today.
+2. **Inbound event routing**: does the bus subscribe to wstore + launcher + host once and fan out to slices, or does each slice subscribe independently? Subscribing once is the symmetric design; current code subscribes per consumer.
+3. **Async commands**: how do commands that need an RPC round-trip (e.g. "create pane") fit into a synchronous dispatch model? Likely answer: dispatch returns immediately with a "pending" event; a follow-up event lands when the RPC completes (matches srv's saga pattern).
+4. **Policy enforcement layer**: where does "this agent can/cannot do this" live? In #3 (the bus), in middleware, or in the slice? Probably the bus — single chokepoint.
+5. **Optimistic updates**: are they per-slice (slice rolls back on rejection event) or bus-level (bus tracks pending commands and rolls back if the corresponding RPC fails)? Defer until a use case actually needs it.
+
+## Next concrete action
+
+Ship spec #1 (already written and approved) so the bug stops biting users. Once that PR is open, draft spec #2 in parallel. Specs #3–#8 wait until #2 is approved.
+
+This document does not commit to implementing #2–#8 — it commits to writing the specs, then deciding which to implement based on priority and capacity.

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -1,0 +1,124 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent document store — Option B from
+ * docs/specs/agent-pane-document-reducer-2026-05-03.md.
+ *
+ * Single store-level module that owns the per-pane state cells
+ * (`Map<blockId, AgentDocumentState>`) and dispatches commands through
+ * the pure reducer. Every mutation to an agent pane's message list
+ * flows through this module — no direct setDocument calls anywhere
+ * else. The pane's `documentAtom` becomes a write-only projection.
+ *
+ * Pattern modeled on `launcher-event-reducer.ts`: single module,
+ * in-memory mirror, atom projection, audit-friendly.
+ */
+
+import type { DocumentNode } from "../view/agent/types";
+import { update } from "./agent-document/reducer";
+import {
+    AgentDocumentCommand,
+    AgentDocumentEvent,
+    AgentDocumentState,
+    initialState,
+} from "./agent-document/types";
+
+/** A pane's projection setter — typically the SignalPair[1] from createAgentAtoms. */
+type DocumentSetter = (nodes: DocumentNode[]) => void;
+
+interface Slot {
+    state: AgentDocumentState;
+    setter: DocumentSetter;
+}
+
+const slots = new Map<string, Slot>();
+
+/**
+ * Optional global event sink. The agent-view diagnostics panel can
+ * hook this to surface the reducer event stream. v1: console.warn for
+ * suppressed truncates and dropped updates.
+ */
+type EventSink = (blockId: string, event: AgentDocumentEvent) => void;
+let eventSink: EventSink = (blockId, event) => {
+    if (event.type === "truncate-suppressed") {
+        console.warn(
+            `[agent-document-store] suppressed truncate for ${blockId.slice(0, 7)}: reason=${event.reason} activeForMs=${event.activeForMs} nodeCount=${event.nodeCount}`,
+        );
+    } else if (event.type === "stream-flushed" && event.updateDropped > 0) {
+        console.warn(
+            `[agent-document-store] dropped ${event.updateDropped} stream updates for unknown ids in ${blockId.slice(0, 7)}`,
+        );
+    }
+};
+
+/** Override the event sink (tests / diagnostics panel). */
+export function setEventSink(sink: EventSink): void {
+    eventSink = sink;
+}
+
+/**
+ * Register a pane with the store. Call from the agent-view component
+ * onMount, passing the pane's documentAtom setter. The slot owns the
+ * pane's reducer state and writes through the setter on each mutation.
+ *
+ * Idempotent: re-registering a blockId resets its state to initialState
+ * and rebinds the setter. (Useful for hot-reload scenarios.)
+ */
+export function registerPane(blockId: string, setter: DocumentSetter): void {
+    slots.set(blockId, { state: initialState(), setter });
+}
+
+/**
+ * Release a pane's slot. Call from agent-view component onCleanup.
+ * Failure to release leaks a state cell — every register MUST have a
+ * matching unregister.
+ */
+export function unregisterPane(blockId: string): void {
+    slots.delete(blockId);
+}
+
+/**
+ * Apply a command to a pane's reducer state. Returns the audit events
+ * the command produced (typically zero or one event).
+ *
+ * If the blockId isn't registered, the dispatch is a no-op (logged).
+ * This shouldn't happen in normal operation — register-on-mount is the
+ * convention — but the silent fallback prevents a crash if a hook
+ * fires after unmount.
+ */
+export function dispatch(
+    blockId: string,
+    command: AgentDocumentCommand,
+): AgentDocumentEvent[] {
+    const slot = slots.get(blockId);
+    if (!slot) {
+        console.warn(
+            `[agent-document-store] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type})`,
+        );
+        return [];
+    }
+    const result = update(slot.state, command);
+    const prevNodes = slot.state.nodes;
+    slot.state = result.state;
+    // Push to atom only if nodes changed (referential equality).
+    // Avoids no-op signal writes that would still schedule a Solid effect.
+    if (slot.state.nodes !== prevNodes) {
+        slot.setter(slot.state.nodes);
+    }
+    for (const ev of result.events) eventSink(blockId, ev);
+    return result.events;
+}
+
+/** Snapshot a pane's reducer state. Diagnostics + tests only. */
+export function snapshot(blockId: string): AgentDocumentState | null {
+    return slots.get(blockId)?.state ?? null;
+}
+
+/** Test/dev helper — wipe all slots. Never call in production. */
+export function __resetAllSlots(): void {
+    slots.clear();
+}
+
+// Re-export types for ergonomic imports at the call site.
+export type { AgentDocumentCommand, AgentDocumentEvent, AgentDocumentState };

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -82,10 +82,17 @@ export function unregisterPane(blockId: string): void {
  * Apply a command to a pane's reducer state. Returns the audit events
  * the command produced (typically zero or one event).
  *
- * If the blockId isn't registered, the dispatch is a no-op (logged).
- * This shouldn't happen in normal operation — register-on-mount is the
- * convention — but the silent fallback prevents a crash if a hook
- * fires after unmount.
+ * If the blockId isn't registered the dispatch throws — silent drop is
+ * dangerous because it would mean a real reducer command (like
+ * `SessionStart` or an early `StreamFlush`) was lost, and the next
+ * `StreamTruncate` would then be honored against an uninitialized state
+ * cell, reintroducing the wipe class this whole module exists to
+ * prevent. Convention: panes call `registerPane` synchronously during
+ * component-body execution, before any hook can dispatch from its own
+ * `onMount`.
+ *
+ * The throw is structurally safe — Solid components don't unmount mid-
+ * dispatch (cleanup is synchronous and always runs after children).
  */
 export function dispatch(
     blockId: string,
@@ -93,10 +100,9 @@ export function dispatch(
 ): AgentDocumentEvent[] {
     const slot = slots.get(blockId);
     if (!slot) {
-        console.warn(
-            `[agent-document-store] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type})`,
+        throw new Error(
+            `[agent-document-store] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously in the component body.`,
         );
-        return [];
     }
     const result = update(slot.state, command);
     const prevNodes = slot.state.nodes;

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -93,13 +93,15 @@ describe("agent document reducer", () => {
         });
 
         it("drops updates targeting unknown IDs", () => {
-            const r = update(initialState(), {
+            const start = initialState();
+            const r = update(start, {
                 type: "StreamFlush",
                 newNodes: [],
                 updatedNodes: [md("ghost")],
             });
-            expect(r.state).toBe(initialState() && r.state); // structurally same
-            expect(r.events).toEqual([]); // no-op since nothing changed
+            // Reducer must return the SAME state reference when nothing changed.
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
         });
 
         it("is a no-op when both lists are empty", () => {

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -1,0 +1,231 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { DocumentNode } from "../../view/agent/types";
+import { update } from "./reducer";
+import { initialState, TRUNCATE_GRACE_MS } from "./types";
+
+const md = (id: string, content = id): DocumentNode => ({
+    type: "markdown",
+    id,
+    content,
+    timestamp: 0,
+});
+
+describe("agent document reducer", () => {
+    describe("HistoryLoaded", () => {
+        it("prepends nodes onto an empty document", () => {
+            const r = update(initialState(), { type: "HistoryLoaded", nodes: [md("h1"), md("h2")] });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["h1", "h2"]);
+            expect(r.events).toEqual([
+                { type: "history-loaded", addedCount: 2, duplicatesDropped: 0 },
+            ]);
+        });
+
+        it("dedups against existing IDs", () => {
+            const start = { ...initialState(), nodes: [md("a"), md("b")] };
+            const r = update(start, { type: "HistoryLoaded", nodes: [md("a"), md("h1")] });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["h1", "a", "b"]);
+            expect(r.events[0]).toMatchObject({ addedCount: 1, duplicatesDropped: 1 });
+        });
+
+        it("is a no-op when all incoming nodes are duplicates", () => {
+            const start = { ...initialState(), nodes: [md("a")] };
+            const r = update(start, { type: "HistoryLoaded", nodes: [md("a")] });
+            expect(r.state).toBe(start); // referentially unchanged
+        });
+    });
+
+    describe("StreamFlush", () => {
+        it("appends new nodes", () => {
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("s1"), md("s2")],
+                updatedNodes: [],
+            });
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["s1", "s2"]);
+            expect(r.events[0]).toMatchObject({ appendedNew: 2, collidedAndUpdated: 0 });
+        });
+
+        it("history then stream produces history-then-stream order", () => {
+            const s0 = update(initialState(), {
+                type: "HistoryLoaded",
+                nodes: [md("h1"), md("h2")],
+            }).state;
+            const s1 = update(s0, {
+                type: "StreamFlush",
+                newNodes: [md("s1")],
+                updatedNodes: [],
+            }).state;
+            expect(s1.nodes.map((n) => n.id)).toEqual(["h1", "h2", "s1"]);
+        });
+
+        it("routes new nodes whose ID already exists into in-place update", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a", "v1")],
+                updatedNodes: [],
+            }).state;
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [md("a", "v2")],
+                updatedNodes: [],
+            });
+            expect(r.state.nodes).toHaveLength(1);
+            expect((r.state.nodes[0] as any).content).toBe("v2");
+            expect(r.events[0]).toMatchObject({ appendedNew: 0, collidedAndUpdated: 1 });
+        });
+
+        it("merges markdown updates into existing markdown content", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a", "hello")],
+                updatedNodes: [],
+            }).state;
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [md("a", "hello world")],
+            });
+            expect((r.state.nodes[0] as any).content).toBe("hello world");
+            expect(r.events[0]).toMatchObject({ updateApplied: 1, updateDropped: 0 });
+        });
+
+        it("drops updates targeting unknown IDs", () => {
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [md("ghost")],
+            });
+            expect(r.state).toBe(initialState() && r.state); // structurally same
+            expect(r.events).toEqual([]); // no-op since nothing changed
+        });
+
+        it("is a no-op when both lists are empty", () => {
+            const start = initialState();
+            const r = update(start, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: [],
+            });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+    });
+
+    describe("StreamTruncate suppression", () => {
+        it("honors truncate when not yet started (loading-history phase)", () => {
+            const start = { ...initialState(), nodes: [md("h1")] };
+            const r = update(start, { type: "StreamTruncate", reason: "fileop" }, 1000);
+            expect(r.state.nodes).toEqual([]);
+            expect(r.events[0]).toMatchObject({ type: "truncate-applied", clearedCount: 1 });
+        });
+
+        it("honors truncate within the grace window", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 1000 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("s1")],
+                updatedNodes: [],
+            }).state;
+            const r = update(
+                withNodes,
+                { type: "StreamTruncate", reason: "fileop" },
+                1000 + TRUNCATE_GRACE_MS - 100,
+            );
+            expect(r.state.nodes).toEqual([]);
+            expect(r.events[0].type).toBe("truncate-applied");
+        });
+
+        it("suppresses truncate after grace window when active session has nodes", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 1000 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("s1")],
+                updatedNodes: [],
+            }).state;
+            const r = update(
+                withNodes,
+                { type: "StreamTruncate", reason: "fileop" },
+                1000 + TRUNCATE_GRACE_MS + 1000,
+            );
+            // The bug fix: nodes survive a late truncate.
+            expect(r.state.nodes.map((n) => n.id)).toEqual(["s1"]);
+            expect(r.events[0]).toMatchObject({
+                type: "truncate-suppressed",
+                reason: "fileop",
+                nodeCount: 1,
+            });
+        });
+
+        it("does NOT suppress truncate after grace window if document is empty", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 1000 }).state;
+            const r = update(
+                start,
+                { type: "StreamTruncate", reason: "fileop" },
+                1000 + TRUNCATE_GRACE_MS + 1000,
+            );
+            // Empty doc — no harm in honoring; nothing to lose.
+            expect(r.state.nodes).toEqual([]);
+            expect(r.events).toEqual([]); // already empty, so no truncate-applied event
+        });
+    });
+
+    describe("UserClear", () => {
+        it("always wipes regardless of session phase", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 1000 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("s1"), md("s2")],
+                updatedNodes: [],
+            }).state;
+            const r = update(
+                withNodes,
+                { type: "UserClear" },
+                1000 + TRUNCATE_GRACE_MS + 5000,
+            );
+            expect(r.state.nodes).toEqual([]);
+            expect(r.events[0]).toMatchObject({ type: "user-cleared", clearedCount: 2 });
+        });
+
+        it("emits an event even on empty doc (audit signal)", () => {
+            const r = update(initialState(), { type: "UserClear" });
+            expect(r.events[0]).toMatchObject({ type: "user-cleared", clearedCount: 0 });
+        });
+    });
+
+    describe("Session phase transitions", () => {
+        it("starts in loading-history phase", () => {
+            expect(initialState().sessionPhase).toBe("loading-history");
+        });
+
+        it("SessionStart → active", () => {
+            const r = update(initialState(), { type: "SessionStart", at: 100 });
+            expect(r.state.sessionPhase).toBe("active");
+            expect(r.state.sessionStartedAt).toBe(100);
+        });
+
+        it("SessionEnd → ended", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 100 }).state;
+            const r = update(start, { type: "SessionEnd", at: 200 });
+            expect(r.state.sessionPhase).toBe("ended");
+            expect(r.state.sessionStartedAt).toBe(100); // preserved
+        });
+    });
+
+    describe("Purity", () => {
+        it("does not mutate the input state", () => {
+            const start = { ...initialState(), nodes: [md("a")] };
+            const snapshot = JSON.parse(JSON.stringify(start));
+            update(start, { type: "StreamFlush", newNodes: [md("b")], updatedNodes: [] });
+            expect(start).toEqual(snapshot);
+        });
+
+        it("returns referentially same state when no work to do", () => {
+            const start = { ...initialState(), nodes: [md("a")] };
+            const r = update(start, { type: "StreamFlush", newNodes: [], updatedNodes: [] });
+            expect(r.state).toBe(start);
+        });
+    });
+});

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -1,0 +1,213 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure reducer for the agent pane's message document.
+ *
+ * Pattern follows the host/launcher reducers (task #182) — pure
+ * function, no I/O, snapshot input, return new state + audit events.
+ * See docs/specs/agent-pane-document-reducer-2026-05-03.md.
+ *
+ * Indices (id → position) are derived per-command, not stored.
+ * Doc sizes are bounded (~50–500 nodes typical, ~5k worst case) so
+ * the rebuild cost is negligible vs. the simplicity of immutable state.
+ */
+
+import type { DocumentNode } from "../../view/agent/types";
+import {
+    AgentDocumentCommand,
+    AgentDocumentState,
+    ReducerResult,
+    TRUNCATE_GRACE_MS,
+} from "./types";
+
+export function update(
+    state: AgentDocumentState,
+    command: AgentDocumentCommand,
+    /** Time injection for testability; defaults to Date.now(). */
+    nowMs: number = Date.now(),
+): ReducerResult {
+    switch (command.type) {
+        case "SessionStart":
+            return {
+                state: {
+                    ...state,
+                    sessionPhase: "active",
+                    sessionStartedAt: command.at,
+                },
+                events: [{ type: "session-started", at: command.at }],
+            };
+
+        case "SessionEnd":
+            return {
+                state: { ...state, sessionPhase: "ended" },
+                events: [{ type: "session-ended", at: command.at }],
+            };
+
+        case "HistoryLoaded": {
+            if (command.nodes.length === 0) {
+                return { state, events: [] };
+            }
+            const existingIds = idSet(state.nodes);
+            const fresh: DocumentNode[] = [];
+            let duplicates = 0;
+            for (const n of command.nodes) {
+                if (existingIds.has(n.id)) {
+                    duplicates++;
+                    continue;
+                }
+                existingIds.add(n.id);
+                fresh.push(n);
+            }
+            if (fresh.length === 0) {
+                return {
+                    state,
+                    events: [
+                        { type: "history-loaded", addedCount: 0, duplicatesDropped: duplicates },
+                    ],
+                };
+            }
+            return {
+                state: { ...state, nodes: [...fresh, ...state.nodes] },
+                events: [
+                    {
+                        type: "history-loaded",
+                        addedCount: fresh.length,
+                        duplicatesDropped: duplicates,
+                    },
+                ],
+            };
+        }
+
+        case "StreamFlush": {
+            const noWork = command.newNodes.length === 0 && command.updatedNodes.length === 0;
+            if (noWork) return { state, events: [] };
+
+            const indexById = new Map<string, number>();
+            for (let i = 0; i < state.nodes.length; i++) {
+                indexById.set(state.nodes[i].id, i);
+            }
+            // Lazy-clone: only allocate a new array if something changes.
+            let next: DocumentNode[] | null = null;
+            const ensureClone = () => {
+                if (!next) next = state.nodes.slice();
+                return next;
+            };
+
+            // Updates first — they target IDs that are expected to exist.
+            let updateApplied = 0;
+            let updateDropped = 0;
+            for (const upd of command.updatedNodes) {
+                const idx = indexById.get(upd.id);
+                if (idx == null) {
+                    updateDropped++;
+                    continue;
+                }
+                const arr = ensureClone();
+                const existing = arr[idx];
+                if (existing.type === "markdown" && upd.type === "markdown") {
+                    arr[idx] = { ...existing, content: upd.content };
+                } else {
+                    arr[idx] = upd;
+                }
+                updateApplied++;
+            }
+
+            // New nodes: dedup against existing IDs; collisions → in-place
+            // update (same protection the original `flushPendingNodes` had
+            // against the rebuild-while-pending race).
+            let appendedNew = 0;
+            let collidedAndUpdated = 0;
+            for (const n of command.newNodes) {
+                const idx = indexById.get(n.id);
+                if (idx != null) {
+                    const arr = ensureClone();
+                    arr[idx] = n;
+                    collidedAndUpdated++;
+                    continue;
+                }
+                const arr = ensureClone();
+                arr.push(n);
+                indexById.set(n.id, arr.length - 1);
+                appendedNew++;
+            }
+
+            if (!next) {
+                return { state, events: [] };
+            }
+            return {
+                state: { ...state, nodes: next },
+                events: [
+                    {
+                        type: "stream-flushed",
+                        appendedNew,
+                        collidedAndUpdated,
+                        updateApplied,
+                        updateDropped,
+                    },
+                ],
+            };
+        }
+
+        case "StreamTruncate": {
+            if (shouldSuppressTruncate(state, nowMs)) {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "truncate-suppressed",
+                            reason: command.reason,
+                            activeForMs: state.sessionStartedAt
+                                ? nowMs - state.sessionStartedAt
+                                : 0,
+                            nodeCount: state.nodes.length,
+                        },
+                    ],
+                };
+            }
+            const cleared = state.nodes.length;
+            if (cleared === 0) {
+                return { state, events: [] };
+            }
+            return {
+                state: { ...state, nodes: [] },
+                events: [
+                    { type: "truncate-applied", reason: command.reason, clearedCount: cleared },
+                ],
+            };
+        }
+
+        case "UserClear": {
+            const cleared = state.nodes.length;
+            return {
+                state: cleared === 0 ? state : { ...state, nodes: [] },
+                events: [{ type: "user-cleared", clearedCount: cleared }],
+            };
+        }
+    }
+}
+
+function idSet(nodes: DocumentNode[]): Set<string> {
+    const s = new Set<string>();
+    for (const n of nodes) s.add(n.id);
+    return s;
+}
+
+/**
+ * Suppress truncate when:
+ *   - we're in the active phase, AND
+ *   - the session has been running for more than the grace window, AND
+ *   - there's actual content to lose.
+ *
+ * Rationale: the dominant cause of mid-session truncate-wipe is a
+ * socket-reconnect race. A legitimate truncate during an active,
+ * established session with content is exceptionally unusual; the safe
+ * default is to ignore it and keep the conversation visible. /clear is
+ * the explicit way to wipe.
+ */
+function shouldSuppressTruncate(state: AgentDocumentState, now: number): boolean {
+    if (state.sessionPhase !== "active") return false;
+    if (state.nodes.length === 0) return false;
+    if (state.sessionStartedAt == null) return false;
+    return now - state.sessionStartedAt > TRUNCATE_GRACE_MS;
+}

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -39,9 +39,13 @@ export type AgentDocumentCommand =
     /** Persisted history (older messages from blockfile) — prepended. */
     | { type: "HistoryLoaded"; nodes: DocumentNode[] }
     /**
-     * Live stream RAF flush. `newNodes` are appends; `updatedNodes` are
-     * in-place mutations targeting existing IDs. Combined into a single
-     * command so each RAF causes exactly one atom write.
+     * Generic merge: `newNodes` are appends (with dedup against existing
+     * IDs — collisions route to in-place update), `updatedNodes` are
+     * targeted mutations against existing IDs. The primary caller is the
+     * stream's RAF flush, but any frontend-local mutation that needs to
+     * append or update document nodes (e.g. optimistic decision-update,
+     * login-success row) routes through the same command so slot.state
+     * stays authoritative.
      */
     | { type: "StreamFlush"; newNodes: DocumentNode[]; updatedNodes: DocumentNode[] }
     /**

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -1,0 +1,100 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for the agent document reducer (Option B from
+ * docs/specs/agent-pane-document-reducer-2026-05-03.md).
+ *
+ * The reducer is a single serialized writer over the agent pane's
+ * message-list state. Every mutation flows through a typed Command
+ * and produces typed Events for audit. Pure function, no I/O.
+ */
+
+import type { DocumentNode } from "../../view/agent/types";
+
+export type SessionPhase = "loading-history" | "active" | "ended";
+
+export interface AgentDocumentState {
+    nodes: DocumentNode[];
+    sessionPhase: SessionPhase;
+    /** ms epoch of the most recent SessionStart, or null if never started. */
+    sessionStartedAt: number | null;
+}
+
+export const initialState = (): AgentDocumentState => ({
+    nodes: [],
+    sessionPhase: "loading-history",
+    sessionStartedAt: null,
+});
+
+/**
+ * Hooks emit these. The reducer decides what to do based on current
+ * state + invariants.
+ */
+export type AgentDocumentCommand =
+    /** Hook signal: live stream subscription is up. */
+    | { type: "SessionStart"; at: number }
+    /** Hook signal: subscription torn down (cleanup). */
+    | { type: "SessionEnd"; at: number }
+    /** Persisted history (older messages from blockfile) — prepended. */
+    | { type: "HistoryLoaded"; nodes: DocumentNode[] }
+    /**
+     * Live stream RAF flush. `newNodes` are appends; `updatedNodes` are
+     * in-place mutations targeting existing IDs. Combined into a single
+     * command so each RAF causes exactly one atom write.
+     */
+    | { type: "StreamFlush"; newNodes: DocumentNode[]; updatedNodes: DocumentNode[] }
+    /**
+     * Backend `fileop=truncate` arrived on the file subject. The reducer
+     * decides whether to honor (initialization, legitimate clear) or
+     * suppress (stale event after socket reconnect — this is the bug we're
+     * fixing).
+     */
+    | { type: "StreamTruncate"; reason: string }
+    /** User invoked /clear — always honored. */
+    | { type: "UserClear" };
+
+/**
+ * Audit events emitted by the reducer. v1 logs them via the dispatcher's
+ * onEvent callback. The diagnostics panel surface is a follow-up.
+ */
+export type AgentDocumentEvent =
+    | { type: "session-started"; at: number }
+    | { type: "session-ended"; at: number }
+    | { type: "history-loaded"; addedCount: number; duplicatesDropped: number }
+    | {
+          type: "stream-flushed";
+          appendedNew: number;
+          /** New nodes whose ID already existed → routed to in-place update. */
+          collidedAndUpdated: number;
+          /** Updates targeting known IDs. */
+          updateApplied: number;
+          /** Updates targeting unknown IDs — dropped. */
+          updateDropped: number;
+      }
+    | { type: "truncate-applied"; reason: string; clearedCount: number }
+    | {
+          type: "truncate-suppressed";
+          reason: string;
+          /** ms since SessionStart. */
+          activeForMs: number;
+          /** Nodes that would have been wiped. */
+          nodeCount: number;
+      }
+    | { type: "user-cleared"; clearedCount: number };
+
+export interface ReducerResult {
+    state: AgentDocumentState;
+    events: AgentDocumentEvent[];
+}
+
+/**
+ * Grace window: a `StreamTruncate` arriving in the first GRACE_MS after
+ * SessionStart is honored (legitimate fresh-session reset). After that,
+ * if the document is non-empty, truncate is suppressed — the most likely
+ * source of a late truncate is a socket-reconnect race, and silently
+ * wiping a live conversation is the bug we're fixing.
+ *
+ * 5000ms covers typical socket reconnect latency (1–3s) with margin.
+ */
+export const TRUNCATE_GRACE_MS = 5000;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -6,6 +6,10 @@ import { createMemo, createSignal, onCleanup, onMount, Show, type JSX } from "so
 import type { AgentViewModel } from "./agent-model";
 import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
+import {
+    registerPane as registerAgentDocPane,
+    unregisterPane as unregisterAgentDocPane,
+} from "@/app/store/agent-document-store";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
@@ -90,6 +94,17 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
+    // Register this pane with the document store. The store holds the
+    // authoritative reducer state per blockId; the documentAtom becomes a
+    // write-only projection. Every mutation to documentAtom must flow
+    // through `dispatch(blockId, ...)` from agent-document-store. See
+    // docs/specs/agent-pane-document-reducer-2026-05-03.md.
+    onMount(() => {
+        const [, setDocument] = agentAtoms().documentAtom;
+        registerAgentDocPane(model.blockId, setDocument);
+        onCleanup(() => unregisterAgentDocPane(model.blockId));
+    });
+
     // Activity log — collects per-session diagnostic entries from launch
     // flow, subprocess lifecycle, slash commands, errors, etc. Rendered
     // in the collapsible `<ActivityLogPanel>` above the composer.
@@ -102,9 +117,8 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // always after this component body has fully run (SolidJS onMount timing).
     let onReadyFn: (() => void) | null = null;
 
-    // History pagination: owns the document slice, loadingOlder state,
-    // loadOlder handler, and documentVersion (bumped on every external
-    // document mutation so useAgentStream can rebuild its dedup index).
+    // History pagination: dispatches HistoryLoaded into the agent-document-store
+    // for the trailing 200 lines on mount + each user-triggered loadOlder.
     const history = useHistoryPagination({
         blockId: model.blockId,
         documentAtom: agentAtoms().documentAtom,
@@ -267,9 +281,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     };
 
     // Subscribe to subprocess output and parse into DocumentNodes.
-    // `documentVersion` is bumped whenever we mutate the document externally
-    // (history load / prepend), causing useAgentStream to rebuild its
-    // nodeIdSet and nodeIndexMap.
+    // Mutations dispatch through agent-document-store; the reducer there
+    // owns dedup against in-flight history loads and the truncate-suppress
+    // invariant that prevents the mid-session wipe bug.
     const stoppingAtom = agentAtoms().stoppingAtom;
     const pendingMessagesAtom = agentAtoms().pendingMessagesAtom;
     useAgentStream({
@@ -284,7 +298,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         stoppingAtom,
         pendingMessagesAtom,
         enabled: true,
-        documentVersion: history.documentVersion,
         // Provider id (lowercase catalog key) attributes completed-turn
         // tokens to the correct row in the status-bar token-usage store.
         provider: providerKey(),

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -7,6 +7,7 @@ import type { AgentViewModel } from "./agent-model";
 import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
 import {
+    dispatch as dispatchDoc,
     registerPane as registerAgentDocPane,
     unregisterPane as unregisterAgentDocPane,
 } from "@/app/store/agent-document-store";
@@ -94,16 +95,15 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     const agentAtoms = createMemo(() => createAgentAtoms(model.blockId));
 
-    // Register this pane with the document store. The store holds the
-    // authoritative reducer state per blockId; the documentAtom becomes a
-    // write-only projection. Every mutation to documentAtom must flow
-    // through `dispatch(blockId, ...)` from agent-document-store. See
+    // Register this pane with the document store SYNCHRONOUSLY during
+    // component-body execution — before any hook's onMount can dispatch
+    // (codex P1 PR #681 round 1). The store throws on dispatch to an
+    // unregistered slot to prevent silent reducer-command drops, so the
+    // slot must exist before useAgentStream / useHistoryPagination call
+    // dispatchDoc from their own onMount handlers. See
     // docs/specs/agent-pane-document-reducer-2026-05-03.md.
-    onMount(() => {
-        const [, setDocument] = agentAtoms().documentAtom;
-        registerAgentDocPane(model.blockId, setDocument);
-        onCleanup(() => unregisterAgentDocPane(model.blockId));
-    });
+    registerAgentDocPane(model.blockId, agentAtoms().documentAtom[1]);
+    onCleanup(() => unregisterAgentDocPane(model.blockId));
 
     // Activity log — collects per-session diagnostic entries from launch
     // flow, subprocess lifecycle, slash commands, errors, etc. Rendered
@@ -121,7 +121,6 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // for the trailing 200 lines on mount + each user-triggered loadOlder.
     const history = useHistoryPagination({
         blockId: model.blockId,
-        documentAtom: agentAtoms().documentAtom,
         outputFormat,
         log,
     });
@@ -131,7 +130,9 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
 
     // Auth + launch flow state and the onCleanup that kills the CLI
     // if the pane closes mid-login.
-    const [getDocument, setDocument] = agentAtoms().documentAtom;
+    // `getDocument` is read-only; for writes we MUST dispatch through
+    // agent-document-store so slot.state stays in sync (codex P1 PR #681).
+    const [getDocument] = agentAtoms().documentAtom;
 
     // Pending decision queue — every ToolNode whose
     // `status === "pending_approval"`, oldest first. The decision
@@ -156,17 +157,26 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         // advances to the next pending request). The backend write
         // happens in parallel; if it fails we log but don't try to
         // roll back the visual transition.
-        setDocument((prev) =>
-            prev.map((n) => {
-                if (n.type !== "tool" || n.status !== "pending_approval") return n;
-                if (n.pendingPermission?.request_id !== decision.request_id) return n;
-                return {
-                    ...n,
-                    status: decision.outcome === "allow" ? "running" : "denied",
-                    pendingPermission: undefined,
-                };
-            }),
-        );
+        // Dispatch through the reducer (StreamFlush.updatedNodes) so
+        // slot.state stays in sync. Find the matching pending tool node
+        // by request_id, then build the updated node.
+        const updated: import("./types").ToolNode[] = [];
+        for (const n of getDocument()) {
+            if (n.type !== "tool" || n.status !== "pending_approval") continue;
+            if (n.pendingPermission?.request_id !== decision.request_id) continue;
+            updated.push({
+                ...n,
+                status: decision.outcome === "allow" ? "running" : "denied",
+                pendingPermission: undefined,
+            });
+        }
+        if (updated.length > 0) {
+            dispatchDoc(model.blockId, {
+                type: "StreamFlush",
+                newNodes: [],
+                updatedNodes: updated,
+            });
+        }
         // Send the decision to the sidecar so it can record + audit
         // it (PR-3a). Actual delivery to the agent CLI — rules
         // persistence (path 1) or interactive subprocess stdin (path
@@ -188,14 +198,16 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         log,
         onLoginSuccess: (email) => {
             const display = email ? `Logged in as **${email}**` : "Login successful";
-            setDocument((prev) => [
-                ...prev,
-                {
-                    type: "markdown",
-                    id: `login_success_${Date.now()}`,
-                    content: `\u2713 ${display}`,
-                } as import("./types").MarkdownNode,
-            ]);
+            const node: import("./types").MarkdownNode = {
+                type: "markdown",
+                id: `login_success_${Date.now()}`,
+                content: `\u2713 ${display}`,
+            } as import("./types").MarkdownNode;
+            dispatchDoc(model.blockId, {
+                type: "StreamFlush",
+                newNodes: [node],
+                updatedNodes: [],
+            });
         },
         onReady: () => onReadyFn?.(),
     });

--- a/frontend/app/view/agent/commands/global/clear.ts
+++ b/frontend/app/view/agent/commands/global/clear.ts
@@ -8,6 +8,7 @@
  */
 
 import type { SlashCommand, SlashResult } from "../types";
+import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
 
 export const clearCommand: SlashCommand = {
     name: "clear",
@@ -15,8 +16,7 @@ export const clearCommand: SlashCommand = {
     description: "Clear the visible document (frontend-only)",
     arg: { kind: "none" },
     handler: async (ctx): Promise<SlashResult> => {
-        const [, setDocument] = ctx.documentAtom;
-        setDocument([]);
+        dispatchDoc(ctx.blockId, { type: "UserClear" });
         return { kind: "ok", message: "chat cleared" };
     },
 };

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -8,18 +8,18 @@
  * Step 5 of specs/SPEC_AGENT_VIEW_MODULARIZATION_2026_04_13.md.
  *
  * On mount the hook fires an async initial load: read `session:line_count`
- * for the block, fetch the trailing 200 lines, prepend them to the
- * document atom, and store the resulting offset for later page-up calls.
- * The hook NEVER blocks the UI — failures are non-fatal and just log a
- * warning. Live-stream events keep flowing through useAgentStream
- * regardless of whether history is loaded.
+ * for the block, fetch the trailing 200 lines, dispatch a HistoryLoaded
+ * command to the agent-document-store, and store the resulting offset
+ * for later page-up calls. The hook NEVER blocks the UI — failures are
+ * non-fatal and just log a warning. Live-stream events keep flowing
+ * through useAgentStream regardless of whether history is loaded.
  *
  * Subsequent page-up calls (the user scrolling near the top of the
  * document view) call `loadOlder()` which fetches the previous 200-line
- * page and prepends it. Each prepend bumps `documentVersion`, which
- * useAgentStream reads to rebuild its dedup set + index map so live
- * updates target the right node positions after the document is
- * re-shaped from outside.
+ * page and dispatches another HistoryLoaded. The reducer in
+ * agent-document-store owns dedup against in-flight stream nodes; the
+ * old `documentVersion` mechanism that bridged this hook and
+ * useAgentStream is no longer needed.
  *
  * Returns:
  *   - `historyOffset` — line index where the loaded slice begins
@@ -29,13 +29,12 @@
  *   - `loadingOlder`  — true while a page-up fetch is in flight
  *   - `loadOlder`     — async handler the document view calls when the
  *                       user scrolls near the top
- *   - `documentVersion` — bumped on every external document mutation;
- *                         useAgentStream subscribes to this
  */
 
 import { createSignal, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
 import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
 import { parseHistoryLines } from "../parseHistoryLines";
@@ -61,7 +60,6 @@ export interface UseHistoryPagination {
     historyTotal: Accessor<number>;
     loadingOlder: Accessor<boolean>;
     loadOlder: () => Promise<void>;
-    documentVersion: Accessor<number>;
 }
 
 const PAGE_SIZE = 200;
@@ -70,16 +68,6 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     const [historyOffset, setHistoryOffset] = createSignal(0);
     const [historyTotal, setHistoryTotal] = createSignal(0);
     const [loadingOlder, setLoadingOlder] = createSignal(false);
-
-    // Bumped on every external document mutation (initial history load +
-    // every loadOlder prepend). useAgentStream reads this and rebuilds
-    // its internal nodeIdSet + nodeIndexMap so live-stream updates
-    // continue targeting the right node indices after the document has
-    // been reshaped from outside.
-    const [documentVersion, setDocumentVersion] = createSignal(0);
-    const bumpDocumentVersion = () => setDocumentVersion((v) => v + 1);
-
-    const [doc, setDoc] = opts.documentAtom;
 
     /**
      * Load the previous page of history and prepend to the document.
@@ -106,8 +94,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
             const newNodes = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
             if (newNodes.length > 0) {
-                setDoc((prev) => [...newNodes, ...prev]);
-                bumpDocumentVersion();
+                dispatchDoc(opts.blockId, { type: "HistoryLoaded", nodes: newNodes });
             }
 
             setHistoryOffset(newOffset);
@@ -147,14 +134,8 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
                 const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                 if (nodes.length > 0) {
-                    setDoc((prev) => {
-                        if (prev.length === 0) return nodes;
-                        const seen = new Set(prev.map((n) => n.id));
-                        const historyFresh = nodes.filter((n) => !seen.has(n.id));
-                        return [...historyFresh, ...prev];
-                    });
-                    bumpDocumentVersion();
-                }
+                    dispatchDoc(opts.blockId, { type: "HistoryLoaded", nodes });
+                    }
 
                 // `resp.total` from the backend is the actual available
                 // line count clamped to the event ring buffer window —
@@ -178,6 +159,5 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
         historyTotal,
         loadingOlder,
         loadOlder,
-        documentVersion,
     };
 }

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -35,8 +35,6 @@ import { createSignal, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
-import type { SignalPair } from "../state";
-import type { DocumentNode } from "../types";
 import { parseHistoryLines } from "../parseHistoryLines";
 
 import type { LogFn } from "../types";
@@ -44,7 +42,6 @@ export type { LogFn };
 
 export interface UseHistoryPaginationOptions {
     blockId: string;
-    documentAtom: SignalPair<DocumentNode[]>;
     /**
      * Accessor for the document's stream-event format, e.g.
      * "claude-stream-json", "codex-json", etc. Passed reactively because

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -135,7 +135,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                 if (nodes.length > 0) {
                     dispatchDoc(opts.blockId, { type: "HistoryLoaded", nodes });
-                    }
+                }
 
                 // `resp.total` from the backend is the actual available
                 // line count clamped to the event ring buffer window —

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -16,6 +16,7 @@ import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { DocumentNode, SessionStats, StreamingState, TurnTokens, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
+import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
 
 const OutputFileName = "output";
 
@@ -45,13 +46,6 @@ interface UseAgentStreamOpts {
     pendingMessagesAtom?: SignalPair<PendingMessage[]>;
     enabled: boolean;
     /**
-     * Version signal bumped by external document mutations (e.g. history
-     * load or prepend). When this changes, the hook rebuilds its internal
-     * `nodeIdSet` and `nodeIndexMap` from the current documentAtom so live
-     * updates continue to target the correct nodes.
-     */
-    documentVersion?: () => number;
-    /**
      * Provider id (from CLI_CATALOG — "claude", "codex", "gemini", …).
      * Used to attribute completed-turn tokens to the right row in the
      * status-bar token-usage store. Optional for back-compat; missing
@@ -76,10 +70,8 @@ export function useAgentStream({
     stoppingAtom,
     pendingMessagesAtom,
     enabled,
-    documentVersion,
     provider,
 }: UseAgentStreamOpts): void {
-    const [, setDocument] = documentAtom;
     const [, setStreaming] = streamingStateAtom;
     const [, setSessionStats] = sessionStatsAtom;
     const [, setTurnActive] = turnActiveAtom;
@@ -92,15 +84,14 @@ export function useAgentStream({
     let lineBuffer = "";
     let translator = createTranslator(outputFormat);
     let parser = new ClaudeCodeStreamParser();
+    // nodeIdSet remains for fast in-batch dedup (the reducer also dedups,
+    // but checking here avoids enqueuing already-seen nodes into pendingNew).
     let nodeIdSet = new Set<string>();
 
     // Batching: accumulate parsed nodes between RAF flushes
     let pendingNew: DocumentNode[] = [];
     let pendingUpdates: DocumentNode[] = [];
     let flushRafId: number | null = null;
-
-    // Index for O(1) node lookups during updates
-    let nodeIndexMap = new Map<string, number>();
 
     function flushPendingNodes() {
         flushRafId = null;
@@ -111,53 +102,12 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
-        setDocument((prev) => {
-            // Only copy the array once per flush, not per WebSocket message
-            const result = prev.slice();
-            let mutated = false;
-
-            // Apply updates using index map for O(1) lookup
-            for (const updated of batchUpdates) {
-                const idx = nodeIndexMap.get(updated.id);
-                if (idx != null && idx < result.length) {
-                    const existing = result[idx];
-                    if (existing.type === "markdown" && updated.type === "markdown") {
-                        result[idx] = { ...existing, content: updated.content };
-                    } else {
-                        result[idx] = updated;
-                    }
-                    mutated = true;
-                }
-            }
-
-            // Append new nodes — but guard against the race where a
-            // documentVersion rebuild placed the node into the doc externally
-            // (e.g. history load completed between the node entering pendingNew
-            // and this RAF firing). If nodeIndexMap already has a valid entry
-            // for the node, update in-place instead of appending to prevent
-            // duplicates.
-            if (batchNew.length > 0) {
-                for (let i = 0; i < batchNew.length; i++) {
-                    const n = batchNew[i];
-                    const existingIdx = nodeIndexMap.get(n.id);
-                    if (existingIdx != null && existingIdx < result.length) {
-                        // Already in doc (placed by an external mutation while
-                        // this node was queued). Update in-place.
-                        result[existingIdx] = n;
-                    } else {
-                        nodeIndexMap.set(n.id, result.length);
-                        result.push(n);
-                    }
-                }
-                mutated = true;
-            }
-
-            // No cap on document size — `content-visibility: auto` on each
-            // node wrapper lets the browser skip layout/paint for off-screen
-            // nodes, so the DOM can grow to thousands without affecting
-            // typing smoothness. Full history is preserved.
-            // See docs/plans/agent-pane-ultra-long-sessions.md
-            return mutated ? result : prev;
+        // Single dispatch — the reducer owns dedup, in-place updates, and
+        // the markdown-content merge. See agent-document-store.ts.
+        dispatchDoc(blockId, {
+            type: "StreamFlush",
+            newNodes: batchNew,
+            updatedNodes: batchUpdates,
         });
 
         setStreaming((prev) => ({
@@ -181,7 +131,6 @@ export function useAgentStream({
         translator = createTranslator(outputFormat);
         parser = new ClaudeCodeStreamParser();
         nodeIdSet = new Set();
-        nodeIndexMap = new Map();
         pendingNew = [];
         pendingUpdates = [];
 
@@ -318,66 +267,45 @@ export function useAgentStream({
             onCleanup(() => acceptedUnsub());
         }
 
-        // Rebuild dedup set + index map from whatever is currently in the
-        // document. `doc()` is wrapped in `untrack` so the createEffect
-        // below only subscribes to documentVersion — NOT to the document
-        // signal itself. Without this, the rebuild would fire on every
-        // streaming flush (since flushPendingNodes calls setDoc), which
-        // would be O(n) per live event.
-        const rebuildIndicesFromDocument = () => {
-            const existingNodes = untrack(() => doc());
-            nodeIdSet = new Set();
-            nodeIndexMap = new Map();
-            for (let i = 0; i < existingNodes.length; i++) {
-                nodeIdSet.add(existingNodes[i].id);
-                nodeIndexMap.set(existingNodes[i].id, i);
-            }
-        };
-
-        // Initial seed — covers history nodes that were loaded before this
-        // hook mounted.
-        rebuildIndicesFromDocument();
-
-        // Reactive rebuild only when the caller bumps documentVersion after
-        // an external prepend/load. The first invocation runs immediately
-        // (SolidJS semantics) which is fine — it's idempotent.
-        if (documentVersion != null) {
-            createEffect(() => {
-                documentVersion();
-                // Re-add IDs from pending buffers AFTER rebuilding from the
-                // document so subsequent stream events for in-flight nodes are
-                // still routed as updates (not new nodes). Without this, a
-                // rebuild clears their dedup protection and the next delta
-                // creates a second entry for the same node.
-                const beforePendingNew = pendingNew.slice();
-                const beforePendingUpdates = pendingUpdates.slice();
-                rebuildIndicesFromDocument();
-                for (const n of beforePendingNew) nodeIdSet.add(n.id);
-                for (const n of beforePendingUpdates) nodeIdSet.add(n.id);
-            });
-        }
+        // Seed the local in-batch dedup set from any history that was
+        // already loaded into the document before the hook mounted. The
+        // reducer owns authoritative dedup; this set just avoids enqueuing
+        // already-known nodes into pendingNew, saving a redundant flush.
+        nodeIdSet = new Set();
+        for (const n of untrack(() => doc())) nodeIdSet.add(n.id);
 
         setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));
+        // Mark the session active in the reducer — gates the truncate-
+        // suppression invariant.
+        dispatchDoc(blockId, { type: "SessionStart", at: Date.now() });
 
         const fileSubject = getFileSubject(blockId, OutputFileName);
 
         console.debug(`[useAgentStream] subscribed blockId=${blockId} format=${outputFormat}`);
         const subscription = fileSubject.subscribe((msg: { fileop: string; data64: string }) => {
             if (msg.fileop === "truncate") {
-                // Terminal was cleared — reset document
+                // Reducer decides whether to honor — late truncates after
+                // a socket-reconnect race are suppressed. Only reset the
+                // hook-local parser/stats/etc. when the truncate is actually
+                // honored; if suppressed, the live stream is still flowing
+                // and resetting would corrupt in-flight parse state.
+                const events = dispatchDoc(blockId, {
+                    type: "StreamTruncate",
+                    reason: "fileop",
+                });
+                const honored = events.some((e) => e.type === "truncate-applied");
+                if (!honored) return;
                 if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
                 pendingNew = [];
                 pendingUpdates = [];
-                nodeIndexMap = new Map();
-                setDocument([]);
-                setSessionStats(null);
-                setCurrentTool(null);
-                setTurnTokens(null);
-                setTurnActive(false);
                 lineBuffer = "";
                 translator.reset();
                 parser.reset();
                 nodeIdSet = new Set();
+                setSessionStats(null);
+                setCurrentTool(null);
+                setTurnTokens(null);
+                setTurnActive(false);
                 return;
             }
 
@@ -507,6 +435,7 @@ export function useAgentStream({
             // Clear turn-active on teardown so a crash/exit without session_end
             // doesn't leave the status line showing "Working…" permanently.
             setTurnActive(false);
+            dispatchDoc(blockId, { type: "SessionEnd", at: Date.now() });
         });
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.617",
+  "version": "0.33.618",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.617",
+      "version": "0.33.618",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.615",
+  "version": "0.33.616",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.615",
+      "version": "0.33.616",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.616",
+  "version": "0.33.617",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.616",
+      "version": "0.33.617",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.615",
+  "version": "0.33.616",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.617",
+  "version": "0.33.618",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.616",
+  "version": "0.33.617",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Introduces a pure reducer for the agent pane's message-list state, fixing the mid-session history wipe bug. Pattern matches `frontend/app/store/launcher-event-reducer.ts` (the only existing frontend reducer): single store-level module at `frontend/app/store/agent-document-store.ts`, in-memory mirror per blockId, atom-as-projection.

**Spec:** \`docs/specs/agent-pane-document-reducer-2026-05-03.md\` (Option B)
**Roadmap:** \`docs/specs/frontend-reducer-architecture-2026-05-03.md\`

## The bug

\`documentAtom\` had **3 independent writers** (\`useAgentStream\`, \`useHistoryPagination\`, \`/clear\`) and a fourth path — the \`fileop=truncate\` branch in \`useAgentStream\` — that called \`setDocument([])\` unconditionally. On WebSocket reconnect, \`wpsReconnectHandler\` re-issues fileop subscriptions; if the backend reinitializes the output blockfile in the meantime, a stale truncate event arrives after resubscribe and wipes a live conversation.

## The fix

A pure \`update(state, command, now): { state, events }\` reducer with typed commands and audit events. The key invariant:

> \`StreamTruncate\` is suppressed when (1) session phase is \`active\`, (2) more than 5s since SessionStart, AND (3) doc is non-empty.

Catches the late-truncate-after-reconnect case without breaking legitimate truncates during initialization or on empty docs. \`UserClear\` (the \`/clear\` command) is a separate command and is always honored.

## Wiring

| File | Change |
|---|---|
| \`store/agent-document/reducer.ts\` | NEW — pure update() with all 6 command arms |
| \`store/agent-document/types.ts\` | NEW — Command/Event/State types |
| \`store/agent-document/reducer.test.ts\` | NEW — 20 table-driven tests, all passing |
| \`store/agent-document-store.ts\` | NEW — slot map (\`Map<blockId, {state, setter}>\`) + \`registerPane\` / \`unregisterPane\` / \`dispatch\` |
| \`view/agent/useAgentStream.ts\` | RAF flush dispatches \`StreamFlush\`; truncate dispatches \`StreamTruncate\` and only resets parser/stats if reducer reports honored; drops \`nodeIndexMap\` + \`rebuildIndicesFromDocument\` (reducer owns dedup); adds \`SessionStart\`/\`SessionEnd\` |
| \`view/agent/hooks/useHistoryPagination.ts\` | Dispatches \`HistoryLoaded\` instead of mutating directly; drops \`documentVersion\` bridge signal |
| \`view/agent/commands/global/clear.ts\` | Dispatches \`UserClear\` |
| \`view/agent/agent-view.tsx\` | Registers/unregisters pane on mount/cleanup |

## Tests

20 reducer tests cover: HistoryLoaded prepend+dedup, StreamFlush append/in-place-update/markdown-merge, StreamTruncate suppression scenarios (loading-history / within-grace / after-grace-with-nodes / after-grace-empty), UserClear always honored, SessionStart/End phase transitions, and reducer purity. All pass in 2.0s.

## Test plan (reviewer)

- [ ] Open an agent pane, run a Claude session, leave it running for >5s with content
- [ ] Verify the conversation persists across rapid network blips (or simulate by toggling WiFi briefly)
- [ ] \`/clear\` still wipes the doc instantly
- [ ] Page-up history load still works after the doc has live stream content
- [ ] Console shows \`[agent-document-store] suppressed truncate ...\` warning if a late truncate arrives

## What's NOT in scope

- **Other agent atoms** (\`streamingState\`, \`sessionStats\`, etc.) — single owner each today, no race; spec'd as follow-up #4 in the roadmap
- **Frontend command bus** for agent-driven UI mutations — spec'd as follow-up #3 in the roadmap

## Roadmap context

This is **slice #1 of 8** in the frontend reducer architecture roadmap. Slices #2-#8 are spec-writing commitments, not implementation commitments. The reducer/dispatch shape established here serves as de facto convention until slice #2 (\`frontend-reducer-conventions.md\`) is written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)