### PR TITLE
fix(linux): embedded browser panes via CEF Views (AddOverlayView + CUSTOM)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -17,12 +17,23 @@ use crate::state::AppState;
 // Window & BrowserView delegates (CEF Views framework)
 // ---------------------------------------------------------------------------
 
+// Linux/macOS only: when `Some((state, window_label))`, `on_window_created`
+// inserts the Window into `state.windows[window_label]` and
+// `on_window_destroyed` removes it. Browser-pane creation
+// (`browser_pane/creation_views.rs`) looks up the parent Window by label
+// to call `add_overlay_view` on. Without this, panes opened from a
+// non-main window were silently routed to the main window. Popup
+// delegates (DevTools etc.) pass `None` and don't register because they
+// shouldn't host user-facing panes.
+// (kept as a regular comment — wrap_window_delegate! doesn't accept
+// doc-comments on struct fields.)
 wrap_window_delegate! {
     pub struct AgentMuxWindowDelegate {
         browser_view: RefCell<Option<BrowserView>>,
         initial_bounds: Option<(i32, i32, i32, i32)>,
         frameless: bool,
         runtime_style: RuntimeStyle,
+        window_registration: Option<(Arc<AppState>, String)>,
     }
 
     impl ViewDelegate {
@@ -52,6 +63,19 @@ wrap_window_delegate! {
                 window.set_bounds(Some(&Rect { x, y, width: w, height: h }));
             }
 
+            // Linux/macOS only — register this Window in state.windows
+            // keyed by label, so the browser-pane Views path can attach
+            // pane overlays to the right window. Popup delegates pass
+            // `None` and don't register (they shouldn't host panes).
+            #[cfg(not(target_os = "windows"))]
+            if let Some((state, label)) = self.window_registration.as_ref() {
+                state.windows.lock().insert(label.clone(), window.clone());
+                tracing::info!(
+                    window_label = %label,
+                    "[browser-pane] registered Window in state.windows for pane attachment"
+                );
+            }
+
             // Chrome-style windows (DevTools popups) are shown immediately.
             // Alloy-style windows defer to on_load_end in client.rs to avoid
             // the DWM white flash on startup.
@@ -63,6 +87,18 @@ wrap_window_delegate! {
         fn on_window_destroyed(&self, _window: Option<&mut Window>) {
             let mut browser_view = self.browser_view.borrow_mut();
             *browser_view = None;
+
+            // Linux/macOS — un-register this Window from state.windows.
+            // Stale entries would cause subsequent pane creates targeting
+            // a destroyed window to silently no-op or worse.
+            #[cfg(not(target_os = "windows"))]
+            if let Some((state, label)) = self.window_registration.as_ref() {
+                state.windows.lock().remove(label);
+                tracing::info!(
+                    window_label = %label,
+                    "[browser-pane] unregistered Window on destroy"
+                );
+            }
         }
 
         fn can_close(&self, _window: Option<&mut Window>) -> i32 {
@@ -265,6 +301,7 @@ wrap_browser_view_delegate! {
                 None,
                 frameless,
                 runtime_style,
+                None, // popup (DevTools etc.) — don't register; not pane-host
             );
             #[cfg(target_os = "linux")]
             install_linux_window_properties_override(&window_delegate);
@@ -437,6 +474,7 @@ wrap_browser_process_handler! {
                     None,
                     true, // frameless — main window uses custom title bar
                     RuntimeStyle::ALLOY,
+                    Some((self.state.clone(), "main".to_string())),
                 );
                 #[cfg(target_os = "linux")]
                 install_linux_window_properties_override(&window_delegate);

--- a/agentmux-cef/src/browser_pane/creation.rs
+++ b/agentmux-cef/src/browser_pane/creation.rs
@@ -34,67 +34,82 @@ wrap_task! {
         label: String,
         url: String,
         rect: Rect,
+        // Linux/macOS only: which top-level CefWindow to attach the pane
+        // overlay to (looked up in `state.windows`). Windows path doesn't
+        // read this field — `find_own_top_level_window` resolves the
+        // calling window's HWND directly.
+        window_label: String,
     }
 
     impl Task {
         fn execute(&self) {
             // Running on the CEF UI thread.
+            //
+            // Two completely separate paths by platform:
+            //   - Windows: native child window via WindowInfo::set_as_child +
+            //     browser_host_create_browser. Requires the parent HWND from
+            //     find_own_top_level_window.
+            //   - Linux / macOS: CEF Views via browser_view_create +
+            //     Window::add_overlay_view. The Windows native-child path does
+            //     not work on Wayland (cef#2804) and is officially unsupported
+            //     on macOS. We use AddOverlayView (not AddChildView) so the
+            //     pane cohabits cleanly with the host UI's full-window
+            //     BrowserView. See
+            //     `docs/specs/embedded-browser-panes-linux-macos-2026-05-03.md`.
 
-            // Get parent HWND via Win32 enumeration (CEF Views returns null).
-            #[cfg(target_os = "windows")]
-            let parent_hwnd_raw = unsafe {
-                crate::commands::window::find_own_top_level_window()
-            };
             #[cfg(not(target_os = "windows"))]
-            let parent_hwnd_raw: *mut std::ffi::c_void = std::ptr::null_mut();
-
-            if parent_hwnd_raw.is_null() {
-                tracing::error!(block_id = %self.block_id, "cannot find main window HWND — aborting browser pane creation");
+            {
+                crate::browser_pane::creation_views::create_browser_pane_view(
+                    self.state.clone(),
+                    self.block_id.clone(),
+                    self.label.clone(),
+                    self.url.clone(),
+                    self.rect.clone(),
+                    self.window_label.clone(),
+                );
                 return;
             }
 
-            // Phase B.5 (window_meta step d) — pre-create handoff.
-            // Browser panes are not top-level windows; the kind
-            // value here is irrelevant (on_after_created skips the
-            // taskbar/report-open logic for browser-pane-* labels).
-            //
-            // Phase F.1 — routed through the host reducer.
-            self.state.host_dispatch(
-                crate::reducer::HostCommand::EnqueuePendingWindowCreation {
-                    entry: crate::state::PendingWindowCreation {
-                        label: self.label.clone(),
-                        kind: crate::state::WindowKind::FullInstance,
-                        parent_instance_id: None,
-                    },
-                },
-            );
-
-            let handler = crate::client::AgentMuxHandler::new_with_browser_pane(self.state.clone(), 0, true);
-            let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
-
-            let url_cef = CefString::from(self.url.as_str());
-            let settings = BrowserSettings::default();
-
             #[cfg(target_os = "windows")]
-            let window_info = {
+            {
+                // Get parent HWND via Win32 enumeration (CEF Views returns null).
+                let parent_hwnd_raw = unsafe {
+                    crate::commands::window::find_own_top_level_window()
+                };
+                if parent_hwnd_raw.is_null() {
+                    tracing::error!(block_id = %self.block_id, "cannot find main window HWND — aborting browser pane creation");
+                    return;
+                }
+
+                // Phase B.5 (window_meta step d) — pre-create handoff.
+                // Browser panes are not top-level windows; the kind value here
+                // is irrelevant (on_after_created skips the taskbar/report-open
+                // logic for browser-pane-* labels).
+                // Phase F.1 — routed through the host reducer.
+                self.state.host_dispatch(
+                    crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+                        entry: crate::state::PendingWindowCreation {
+                            label: self.label.clone(),
+                            kind: crate::state::WindowKind::FullInstance,
+                            parent_instance_id: None,
+                        },
+                    },
+                );
+
+                let handler = crate::client::AgentMuxHandler::new_with_browser_pane(self.state.clone(), 0, true);
+                let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
+
+                let url_cef = CefString::from(self.url.as_str());
+                let settings = BrowserSettings::default();
+
                 let parent_hwnd = sys::HWND(parent_hwnd_raw as *mut _);
                 // Use the clean set_as_child helper — it fills style/parent/bounds
                 // correctly and leaves other fields zeroed (in particular `window`
                 // which is an OUTPUT field filled by CEF).
-                let mut wi = WindowInfo::default().set_as_child(parent_hwnd, &self.rect);
+                let mut window_info = WindowInfo::default().set_as_child(parent_hwnd, &self.rect);
                 // Match the main process runtime style (ALLOY throughout the app).
-                wi.runtime_style = RuntimeStyle::ALLOY;
-                wi
-            };
+                window_info.runtime_style = RuntimeStyle::ALLOY;
 
-            #[cfg(not(target_os = "windows"))]
-            {
-                tracing::warn!(block_id = %self.block_id, "browser panes not yet implemented on this platform");
-                return;
-            }
-
-            #[cfg(target_os = "windows")]
-            {
                 let result = browser_host_create_browser(
                     Some(&window_info),
                     client.as_mut(),

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -1,0 +1,324 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Linux/macOS browser-pane creation via the CEF Views framework.
+//!
+//! On Linux Wayland the Windows-style `WindowInfo::set_as_child(parent_hwnd, rect)`
+//! path doesn't work (cef#2804 — embedded Wayland subsurfaces aren't upstreamed,
+//! and even when they ship the API is too constrained for our use case). On
+//! macOS NSView embedding is officially unsupported by the CEF maintainer for
+//! new code (cef-forum t=19688). The recommended path for both platforms is the
+//! Views framework.
+//!
+//! ## Embedding mechanism: AddOverlayView, not AddChildView
+//!
+//! We tried `Window::add_child_view + View::set_bounds` first (PR #669 design
+//! spec called for it) and the result was: pane rendered at full window size,
+//! "flashing" on every Wayland frame, because CEF's Window has a default
+//! FillLayout that re-asserts "fill parent" on every layout pass and clobbers
+//! the explicit `set_bounds` we wrote. With multiple FillLayout children both
+//! get full-parent-size bounds, so the pane stacked on top of the host UI at
+//! full size.
+//!
+//! `Window::add_overlay_view(view, docking_mode, can_activate)` is the API
+//! designed for the "view at arbitrary position above other children" case.
+//! The returned `CefOverlayController` exposes `set_size(Size)` /
+//! `set_position(Point)` / `set_visible(bool)` / `destroy()` that aren't
+//! subject to the parent's auto-layout. We pass `DockingMode::CUSTOM` to
+//! opt out of corner-docking — every other DockingMode forces auto-positioning
+//! and silently ignores `set_size` / `set_position` / `set_bounds` calls.
+//! Verified empirically during the spike: with TOP_LEFT the overlay filled
+//! the whole window; with CUSTOM and just `set_bounds(rect)` the overlay
+//! was 0×0; only the `set_size + set_position + window.layout()` triplet
+//! reads back as the requested rect.
+//!
+//! Risks (see PR #669 spec §"Risks"):
+//!   - cef#3790 — overlay BrowserView display regressions in CEF 125. Our
+//!     libcef.so is 146.0.179, post-fix.
+//!   - cef#4035 — transparent overlay BrowserViews not yet supported. We use
+//!     opaque background, so this isn't a blocker.
+//!
+//! ## Lifecycle
+//!
+//! 1. `browser_view_create(client, url, settings, ..., delegate)` constructs
+//!    a `CefBrowserView`. The underlying `CefBrowser` is created lazily —
+//!    only after the view is added to a Widget hierarchy via `AddedToWidget`.
+//! 2. Look up the cached primary `CefWindow` from `state.windows`
+//!    (populated by `AgentMuxWindowDelegate::on_window_created`).
+//! 3. `window.add_overlay_view(view, DockingMode::CUSTOM, can_activate=1)`
+//!    returns an `OverlayController`. CEF then creates the underlying
+//!    Browser, which fires `on_after_created` on our existing handler — same
+//!    callback path as the Windows pane (`callbacks::on_after_created_browser_pane`).
+//! 4. `controller.set_bounds(rect)` positions + sizes the pane within the
+//!    window's content area. Bounds are in DIP relative to the window.
+//! 5. Stash the `OverlayController` in `state.browser_pane_overlays` keyed by
+//!    label, so subsequent `BrowserPaneManager::resize` / `close` can locate it.
+//!
+//! The host reducer's `RegisterBrowser` command fires from `client.rs::on_after_created`
+//! (existing code) and registers the underlying `Browser` in `state.browsers`, so
+//! the rest of the pane API (`navigate`, frame access, etc.) works through the
+//! same Browser-handle path as on Windows.
+
+use std::sync::Arc;
+
+use cef::{
+    browser_view_create, BrowserSettings, CefString, DockingMode, ImplBrowser, ImplBrowserHost,
+    ImplOverlayController, ImplPanel, ImplView, ImplWindow, Point, Rect, RuntimeStyle, Size, View,
+};
+
+use crate::state::AppState;
+
+/// Create a Views-based browser pane on the CEF UI thread.
+///
+/// Caller is `CreateBrowserPaneTask::execute` (`browser_pane/creation.rs`),
+/// which is itself posted via `post_task(ThreadId::UI, ...)` from
+/// `BrowserPaneManager::create`. So this function runs on the UI thread.
+pub fn create_browser_pane_view(
+    state: Arc<AppState>,
+    block_id: String,
+    label: String,
+    url: String,
+    rect: Rect,
+    window_label: String,
+) {
+    tracing::info!(
+        block_id = %block_id,
+        label = %label,
+        url = %url,
+        window_label = %window_label,
+        x = rect.x, y = rect.y, w = rect.width, h = rect.height,
+        "[browser-pane] views: create_browser_pane_view begin"
+    );
+
+    // 1. Locate the parent CefWindow by its label.
+    let parent_window = {
+        let guard = state.windows.lock();
+        guard.get(&window_label).cloned()
+    };
+    let parent_window = match parent_window {
+        Some(w) => w,
+        None => {
+            tracing::error!(
+                block_id = %block_id, label = %label, window_label = %window_label,
+                "[browser-pane] views: no Window registered for this window_label — pane creation aborted"
+            );
+            return;
+        }
+    };
+
+    // 2. Pre-create handoff to the host reducer — same as Windows path. on_after_created
+    //    uses this to look up the pane's intended kind / parent linkage from the
+    //    pending-creations queue.
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: label.clone(),
+                kind: crate::state::WindowKind::FullInstance,
+                parent_instance_id: None,
+            },
+        },
+    );
+
+    // 3. Build the per-pane CEF Client (handler with is_browser_pane = true).
+    let handler = crate::client::AgentMuxHandler::new_with_browser_pane(state.clone(), 0, true);
+    let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
+
+    // 4. BrowserViewDelegate. Reuse the same delegate as the main browser —
+    //    its on_popup_browser_view_created behavior (popups → new top-level
+    //    windows) is what we want for panes too.
+    let mut view_delegate =
+        crate::app::AgentMuxBrowserViewDelegate::new(RuntimeStyle::ALLOY);
+
+    let settings = BrowserSettings {
+        windowless_frame_rate: 60,
+        background_color: 0xFF000000, // opaque black baseline
+        ..Default::default()
+    };
+
+    let url_cef = CefString::from(url.as_str());
+
+    // 5. Create the BrowserView. Underlying Browser is constructed lazily on
+    //    AddedToWidget below.
+    let pane_view = match browser_view_create(
+        client.as_mut(),
+        Some(&url_cef),
+        Some(&settings),
+        None,
+        None,
+        Some(&mut view_delegate),
+    ) {
+        Some(v) => v,
+        None => {
+            tracing::error!(
+                block_id = %block_id, label = %label,
+                "[browser-pane] views: browser_view_create returned None"
+            );
+            return;
+        }
+    };
+    tracing::info!(
+        block_id = %block_id, label = %label,
+        "[browser-pane] views: browser_view_create succeeded"
+    );
+
+    // 6. Add as an OVERLAY (not a regular child). Overlays are positioned
+    //    via OverlayController::set_bounds rather than the parent's layout,
+    //    so they cohabit cleanly with the host UI's full-window BrowserView.
+    //    DockingMode::CUSTOM tells CEF "don't auto-dock, I'll set bounds
+    //    myself" — the corner modes (TOP_LEFT etc.) IGNORE subsequent
+    //    set_bounds calls (verified empirically: spike with TOP_LEFT showed
+    //    set_bounds returning success but bounds() reading back as 0,0,0,0).
+    //    can_activate=1 — pane should be able to receive keyboard focus
+    //    (clicking inside the pane focuses it).
+    let mut view = View::from(&pane_view);
+    let overlay_controller = parent_window.add_overlay_view(
+        Some(&mut view),
+        DockingMode::CUSTOM,
+        1, // can_activate
+    );
+
+    let overlay_controller = match overlay_controller {
+        Some(oc) => oc,
+        None => {
+            tracing::error!(
+                block_id = %block_id, label = %label,
+                "[browser-pane] views: add_overlay_view returned None — pane lost"
+            );
+            return;
+        }
+    };
+    tracing::info!(
+        block_id = %block_id, label = %label,
+        "[browser-pane] views: add_overlay_view returned OverlayController"
+    );
+
+    // 7. Position the overlay. We tried `set_bounds(rect)` directly: silently
+    //    ignored — readback shows 0,0,0,0. Trying separate set_size + set_position
+    //    and explicit window.layout() to force a layout pass.
+    overlay_controller.set_size(Some(&Size { width: rect.width, height: rect.height }));
+    overlay_controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
+    overlay_controller.set_visible(1);
+    parent_window.layout();
+    tracing::info!(
+        block_id = %block_id, label = %label,
+        x = rect.x, y = rect.y, w = rect.width, h = rect.height,
+        "[browser-pane] views: overlay set_size + set_position + set_visible + layout() applied"
+    );
+
+    // 8. Diagnostic: read back what CEF thinks of the overlay state.
+    //    If is_drawn=0 or is_visible=0 with our settings, something below
+    //    Views is rejecting the layout. If bounds are 0,0,0,0 the set_bounds
+    //    didn't take. If bounds match our request but user sees black, the
+    //    Wayland sub-surface compositing for AddOverlayView is broken.
+    let oc_visible = overlay_controller.is_visible();
+    let oc_drawn = overlay_controller.is_drawn();
+    let oc_bounds = overlay_controller.bounds();
+    // BrowserView's view methods come via the View facade.
+    let pane_as_view = View::from(&pane_view);
+    let view_bounds = pane_as_view.bounds();
+    let view_drawn = pane_as_view.is_drawn();
+    let view_attached = pane_as_view.is_attached();
+    tracing::info!(
+        block_id = %block_id, label = %label,
+        oc_visible, oc_drawn,
+        oc_x = oc_bounds.x, oc_y = oc_bounds.y, oc_w = oc_bounds.width, oc_h = oc_bounds.height,
+        view_x = view_bounds.x, view_y = view_bounds.y, view_w = view_bounds.width, view_h = view_bounds.height,
+        view_drawn, view_attached,
+        "[browser-pane] views: post-create diagnostic readback"
+    );
+
+    // 9. Stash the controller AND the parent window's label for later
+    //    resize/close lookups (so they can find the right Window for
+    //    `layout()` calls without re-deriving from the pane name).
+    state
+        .browser_pane_overlays
+        .lock()
+        .insert(label.clone(), (window_label.clone(), overlay_controller));
+    tracing::info!(
+        block_id = %block_id, label = %label, window_label = %window_label,
+        "[browser-pane] views: OverlayController stashed in state.browser_pane_overlays"
+    );
+}
+
+/// Resize a Views-based browser pane (Linux/macOS only).
+///
+/// Called from `BrowserPaneManager::resize` on non-Windows. Looks up the
+/// cached OverlayController by label and calls `set_bounds`.
+///
+/// Must run on the CEF UI thread. Caller is responsible for the
+/// `post_task(ThreadId::UI, ...)` marshalling.
+pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) {
+    let entry = state.browser_pane_overlays.lock().get(label).cloned();
+    let Some((window_label, controller)) = entry else {
+        tracing::debug!(
+            label = %label,
+            "[browser-pane] views: resize requested but no OverlayController found (already closed?)"
+        );
+        return;
+    };
+    // OverlayController::set_bounds is silently ignored even with
+    // DockingMode::CUSTOM (verified during initial spike — readback
+    // showed bounds stayed 0,0,0,0 after set_bounds calls). The
+    // working pattern is set_size + set_position separately, then
+    // a window.layout() on the OWNING window to force the layout pass.
+    controller.set_size(Some(&Size { width: rect.width, height: rect.height }));
+    controller.set_position(Some(&Point { x: rect.x, y: rect.y }));
+    if let Some(window) = state.windows.lock().get(&window_label).cloned() {
+        window.layout();
+    }
+    tracing::debug!(
+        label = %label, window_label = %window_label,
+        x = rect.x, y = rect.y, w = rect.width, h = rect.height,
+        "[browser-pane] views: resize applied (set_size + set_position + layout)"
+    );
+}
+
+/// Detach + drop a Views-based browser pane (Linux/macOS only).
+///
+/// Called from `BrowserPaneManager::close` on non-Windows. Order matters:
+///
+///   1. Look up the underlying `Browser` for this label and call
+///      `BrowserHost::close_browser(force=1)`. Empirically `OverlayController::destroy`
+///      DOES eventually trigger `on_before_close`, but per CEF's documentation
+///      the destroy path is layout-tracking only and the Browser's lifecycle
+///      is independent — without the explicit close request a Browser can
+///      survive its overlay's destruction and stay registered in `state.browsers`
+///      with stale callbacks (PR #682 codex P2).
+///   2. Destroy the OverlayController to remove the overlay from the parent.
+///   3. Drop the cached handle. `on_before_close` fires asynchronously on the
+///      Browser and the existing `callbacks::on_before_close_browser_pane`
+///      drains state.browsers + the reducer's pane map. If close_browser
+///      fails (already-gone race), the destroy still cleans up the overlay.
+///
+/// Must run on the CEF UI thread.
+pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
+    let entry = state.browser_pane_overlays.lock().remove(label);
+    let Some((_window_label, controller)) = entry else {
+        tracing::debug!(
+            label = %label,
+            "[browser-pane] views: detach requested but no OverlayController found"
+        );
+        return;
+    };
+
+    // Step 1: ask the Browser to close BEFORE destroying its overlay.
+    if let Some(browser) = state.get_browser(label) {
+        if let Some(host) = browser.host() {
+            host.close_browser(1); // force=1 — pane is going away regardless
+            tracing::debug!(label = %label, "[browser-pane] views: close_browser(force=1) requested");
+        }
+    } else {
+        tracing::debug!(
+            label = %label,
+            "[browser-pane] views: no Browser registered at detach (already drained?)"
+        );
+    }
+
+    // Step 2: destroy the overlay.
+    controller.destroy();
+    tracing::info!(
+        label = %label,
+        "[browser-pane] views: OverlayController destroyed"
+    );
+    drop(controller);
+}

--- a/agentmux-cef/src/browser_pane/mod.rs
+++ b/agentmux-cef/src/browser_pane/mod.rs
@@ -11,6 +11,8 @@ pub mod callbacks;
 pub mod creation;
 #[cfg(target_os = "windows")]
 pub mod hwnd;
+#[cfg(not(target_os = "windows"))]
+pub mod creation_views;
 
 pub use creation::CreateBrowserPaneTask;
 

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -160,6 +160,7 @@ impl BrowserPaneManager {
         block_id: &str,
         url: &str,
         rect: Rect,
+        window_label: &str,
     ) -> Result<(), String> {
         // Phase H.1.d (PR #5) — sole pane-registration entry point. The
         // reducer atomically generates the label and inserts the entry,
@@ -202,6 +203,7 @@ impl BrowserPaneManager {
                     label,
                     url.to_string(),
                     rect,
+                    window_label.to_string(),
                 );
                 post_task(ThreadId::UI, Some(&mut task));
                 Ok(())
@@ -236,8 +238,18 @@ impl BrowserPaneManager {
                 }
             }
         }
+        // Linux/macOS — Views path. The pane is a CefBrowserView in the main
+        // window's view hierarchy; resizing is `View::set_bounds` in DIP. Must
+        // run on the CEF UI thread (set_bounds is UI-thread-only).
         #[cfg(not(target_os = "windows"))]
-        { let _ = (block_id, rect, state); }
+        {
+            let label = match state.live_browser_pane_label(block_id) {
+                Some(l) => l,
+                None => return, // pane already closed or never created
+            };
+            let mut task = ResizeBrowserPaneViewTask::new(state.clone(), label, rect);
+            cef::post_task(cef::ThreadId::UI, Some(&mut task));
+        }
     }
 
     /// Close a pane by destroying its child HWND directly and dropping the
@@ -281,8 +293,20 @@ impl BrowserPaneManager {
             Some(l) => l,
             None => return,
         };
-        let ops = AppStateCloseOps(state);
-        Self::close_with(&label, &ops);
+        #[cfg(target_os = "windows")]
+        {
+            let ops = AppStateCloseOps(state);
+            Self::close_with(&label, &ops);
+        }
+        // Linux/macOS — Views path. Marshal the BrowserView detach onto the
+        // CEF UI thread (remove_child_view is UI-thread-only); the underlying
+        // Browser's on_before_close fires asynchronously and clears
+        // state.browsers via the existing callback (callbacks::on_before_close_browser_pane).
+        #[cfg(not(target_os = "windows"))]
+        {
+            let mut task = DetachBrowserPaneViewTask::new(state.clone(), label.clone());
+            cef::post_task(cef::ThreadId::UI, Some(&mut task));
+        }
         state.host_dispatch(
             crate::reducer::HostCommand::CompleteBrowserPaneClose {
                 block_id: block_id.to_string(),
@@ -509,13 +533,48 @@ impl BrowserPaneManager {
             "[pane-airspace] applied overlay clip to pane HWNDs",
         );
     }
+    /// Linux/macOS — equivalent of the Windows SetWindowRgn airspace
+    /// workaround, but built on Views instead of HWND clip regions.
+    ///
+    /// `add_overlay_view` puts the pane on a higher z-layer than the host UI
+    /// BrowserView, so any host-side modal/dropdown/contextmenu that overlaps
+    /// a pane rect renders UNDERNEATH the pane and becomes unclickable. We
+    /// can't punch a clip hole through an Aura View the way Win32 SetWindowRgn
+    /// does on an HWND. The pragmatic workaround: when ANY overlay rect
+    /// overlaps a pane's bounds, hide that pane (`set_visible(false)`); when
+    /// no overlay rect intersects, show it again. The DOM modal renders in
+    /// the host UI BrowserView underneath, becomes the topmost paint at that
+    /// rect, and the pane's content briefly disappears — same UX trade-off
+    /// the Windows path makes (Win32 punches a hole; we hide the whole pane).
+    /// (Codex P1 on PR #682.)
+    ///
+    /// Future improvement: only hide the overlapping fraction of the pane
+    /// (would need a per-overlay set_size + position trick or a custom Layout).
+    /// Hiding the whole pane is acceptable for now — the airspace problem only
+    /// arises when modals open over panes, which is a transient case.
+    ///
+    /// `_window_label` is currently ignored on this path because we only
+    /// support a single primary window for panes (sub-window panes are a
+    /// follow-up — see PR #682's "Risks / follow-ups" section).
+    /// (See doc comment for the cfg(target_os = "windows") variant.)
+    /// Linux/macOS body — marshalled to the CEF UI thread because
+    /// `OverlayController::set_visible` and `bounds()` are UI-thread-only.
+    /// IPC handler runs on tokio so we post a task and return immediately.
+    /// `window_label` filters which panes get visibility-managed: only those
+    /// attached to the requesting window are affected.
     #[cfg(not(target_os = "windows"))]
     pub fn set_pane_overlay_clip(
         &self,
-        _state: &Arc<AppState>,
-        _window_label: &str,
-        _overlay_rects: &[(i32, i32, i32, i32)],
+        state: &Arc<AppState>,
+        window_label: &str,
+        overlay_rects: &[(i32, i32, i32, i32)],
     ) {
+        let mut task = SetPaneOverlayClipViewsTask::new(
+            state.clone(),
+            window_label.to_string(),
+            overlay_rects.to_vec(),
+        );
+        cef::post_task(cef::ThreadId::UI, Some(&mut task));
     }
 
     /// Give keyboard focus to the pane's child HWND so keystrokes reach the
@@ -552,6 +611,117 @@ impl BrowserPaneManager {
 }
 
 // `CreateBrowserPaneTask` moved to `crate::browser_pane::creation` in Phase 3.
+
+/// Two axis-aligned rects intersect iff neither is fully to one side of the
+/// other. Coordinates: (x, y, width, height). Used by the Linux/macOS
+/// pane-airspace logic to decide whether an overlay rect from the frontend
+/// covers any part of a pane's bounds.
+#[cfg(not(target_os = "windows"))]
+fn rects_intersect(a: (i32, i32, i32, i32), b: (i32, i32, i32, i32)) -> bool {
+    let (ax, ay, aw, ah) = a;
+    let (bx, by, bw, bh) = b;
+    let a_right = ax + aw;
+    let a_bottom = ay + ah;
+    let b_right = bx + bw;
+    let b_bottom = by + bh;
+    !(a_right <= bx || b_right <= ax || a_bottom <= by || b_bottom <= ay)
+}
+
+// ── Linux/macOS UI-thread marshalling tasks ────────────────────────────────
+//
+// `View::set_bounds` and `Window::remove_child_view` must run on the CEF UI
+// thread. Both `BrowserPaneManager::resize` and `::close` are called from IPC
+// handler tasks on tokio threads, so we wrap the UI-thread bodies in
+// `wrap_task!` structs and post them via `post_task(ThreadId::UI, ...)` —
+// same pattern as `ui_tasks::CloseWindowTask` / `MaximizeWindowTask` / etc.
+
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct ResizeBrowserPaneViewTask {
+        state: Arc<AppState>,
+        label: String,
+        rect: Rect,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            crate::browser_pane::creation_views::resize_browser_pane_view(
+                &self.state, &self.label, self.rect.clone(),
+            );
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct DetachBrowserPaneViewTask {
+        state: Arc<AppState>,
+        label: String,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            crate::browser_pane::creation_views::detach_browser_pane_view(
+                &self.state, &self.label,
+            );
+        }
+    }
+}
+
+/// Linux/macOS pane-airspace task — fired by `set_pane_overlay_clip` for the
+/// non-Windows code path. For each live OverlayController, hide it when any
+/// overlay rect intersects its current bounds; show it otherwise. See the
+/// doc comment on `set_pane_overlay_clip` (non-Windows variant) for why this
+/// is the equivalent of the Windows SetWindowRgn airspace dance.
+#[cfg(not(target_os = "windows"))]
+wrap_task! {
+    pub struct SetPaneOverlayClipViewsTask {
+        state: Arc<AppState>,
+        // Only panes attached to this window get visibility-managed; panes
+        // in other windows are unaffected by overlay rects from this window.
+        // Mirrors the window_label filtering in the Windows path.
+        window_label: String,
+        overlay_rects: Vec<(i32, i32, i32, i32)>,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Snapshot the (pane label, parent window label, controller) tuples,
+            // filter by parent-window-label matching the requesting window,
+            // drop the mutex before any FFI call (snapshot-and-drop discipline
+            // per docs/specs/SPEC_PHASE_F_HOST_REDUCER §6).
+            let live: Vec<(String, cef::OverlayController)> = self
+                .state
+                .browser_pane_overlays
+                .lock()
+                .iter()
+                .filter(|(_, (win_label, _))| win_label == &self.window_label)
+                .map(|(k, (_, c))| (k.clone(), c.clone()))
+                .collect();
+            if live.is_empty() {
+                return;
+            }
+            for (label, controller) in live {
+                use cef::ImplOverlayController;
+                let pb = controller.bounds();
+                let pane_rect = (pb.x, pb.y, pb.width, pb.height);
+                let intersects_any = self
+                    .overlay_rects
+                    .iter()
+                    .any(|or| rects_intersect(*or, pane_rect));
+                controller.set_visible(if intersects_any { 0 } else { 1 });
+                tracing::debug!(
+                    label = %label,
+                    window_label = %self.window_label,
+                    hidden = intersects_any,
+                    pane_x = pb.x, pane_y = pb.y, pane_w = pb.width, pane_h = pb.height,
+                    overlay_count = self.overlay_rects.len(),
+                    "[pane-airspace] views: applied visibility"
+                );
+            }
+        }
+    }
+}
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 //

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -317,7 +317,16 @@ async fn route_command(
             let w = args.get("width").and_then(|v| v.as_i64()).unwrap_or(800) as i32;
             let h = args.get("height").and_then(|v| v.as_i64()).unwrap_or(600) as i32;
             let rect = cef::Rect { x, y, width: w, height: h };
-            state.browser_panes.create(state, block_id, url, rect)?;
+            // window_label: which window the pane should be attached to
+            // (Linux/macOS Views path looks this up in state.windows). Default
+            // to "main" for backward compat with frontends that don't send it.
+            // Windows path ignores it (find_own_top_level_window resolves the
+            // calling window's HWND directly).
+            let window_label = args
+                .get("window_label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("main");
+            state.browser_panes.create(state, block_id, url, rect, window_label)?;
             Ok(serde_json::json!(true))
         }
         "browser_pane_navigate" => {

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -512,6 +512,42 @@ pub struct AppState {
     /// `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`.
     pub host_state: Mutex<crate::reducer::HostState>,
 
+    /// Linux/macOS only — registry of live top-level `CefWindow` handles,
+    /// keyed by window label ("main" for the primary, otherwise the label
+    /// CreateWindowTask assigns to a sub-window). Populated by
+    /// `AgentMuxWindowDelegate::on_window_created` and cleared by
+    /// `on_window_destroyed`. Used by the browser-pane Views path to find
+    /// the right parent Window when attaching a pane via
+    /// `Window::add_overlay_view` — without this map, panes opened from a
+    /// non-main window were silently routed to the main window (PR #682
+    /// follow-up: "the browser opens in the wrong window" bug).
+    /// The Windows pane path uses native HWND lookup instead and never
+    /// reads this field, so it is cfg-gated to avoid carrying unused
+    /// state on Windows.
+    #[cfg(not(target_os = "windows"))]
+    pub windows: Mutex<std::collections::HashMap<String, cef::Window>>,
+
+    /// Linux/macOS only — `CefOverlayController` handles for live browser
+    /// panes, keyed by pane label (the same label used in `host_state.browsers`).
+    /// Each entry pairs the controller with the `window_label` of the
+    /// parent CefWindow it was attached to (looked up from `state.windows`
+    /// at create time), so resize / detach / overlay-clip calls can find
+    /// the right Window for `layout()` / `remove_child_view`.
+    ///
+    /// Populated by `browser_pane/creation_views.rs` after the BrowserView
+    /// has been added to its parent Window via `add_overlay_view`. We use
+    /// AddOverlayView (not AddChildView) because AddChildView cohabitates
+    /// poorly with the host UI's BrowserView under the Window's default
+    /// FillLayout — both children get full-parent-size bounds and the pane
+    /// stacks on top of the host UI at full size with per-frame redraw
+    /// flashing (verified empirically during the spike). OverlayController
+    /// has its own explicit `set_size` / `set_position` / `set_visible`
+    /// /`destroy` that aren't subject to the parent's auto-layout.
+    /// Windows panes use HWND ops instead and never touch this map.
+    #[cfg(not(target_os = "windows"))]
+    pub browser_pane_overlays:
+        Mutex<std::collections::HashMap<String, (String, cef::OverlayController)>>,
+
     /// Tear-off Phase 6 — pre-warmed pool of hidden CEF windows ready for
     /// instant promotion on tear-off. Each entry is a label of a window
     /// that's already painted, has its renderer connected, and is sitting
@@ -604,6 +640,10 @@ impl Default for AppState {
             // browsers field removed in H.2.e — see comment near struct decl.
             window_meta: Mutex::new(HashMap::new()),
             host_state: Mutex::new(crate::reducer::HostState::default()),
+            #[cfg(not(target_os = "windows"))]
+            windows: Mutex::new(HashMap::new()),
+            #[cfg(not(target_os = "windows"))]
+            browser_pane_overlays: Mutex::new(HashMap::new()),
             // window_pool / unpromoted_pool_labels / window_pool_respawn_in_flight
             // deleted (PR #5 H.4) — see HostState.pool.
             // is_quitting deleted (PR #5 H.5) — see HostState.quit_state.

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -394,6 +394,7 @@ wrap_task! {
                 Some((self.x, self.y, self.w, self.h)),
                 self.frameless,
                 RuntimeStyle::ALLOY,
+                Some((self.state.clone(), self.label.clone())),
             );
             #[cfg(target_os = "linux")]
             crate::app::install_linux_window_properties_override(&wd);

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/research/cef-pane-research-2026-05-03.md
+++ b/docs/research/cef-pane-research-2026-05-03.md
@@ -1,0 +1,270 @@
+# CEF Embedded Browser Pane Research — Linux & macOS
+
+Research date: 2026-05-02. Target: AgentMux's port of the Windows native-child-window pane mechanism (`browser_pane/creation.rs`) to Linux (Ozone-Wayland on GNOME/Mutter) and macOS, against a frameless ALLOY-style main window that already uses `browser_view_create` + `add_child_view` for the primary browser.
+
+---
+
+## TL;DR
+
+- **The native-child-window path (`WindowInfo::set_as_child(parent, rect)`) does not work on Linux Wayland and is officially unsupported on macOS.** It works on Linux X11 and on Windows. ([cef#2804](https://github.com/chromiumembedded/cef/issues/2804), [cef#3294](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19688))
+- **CEF maintainer (`magreenblatt`) explicitly recommends the Views framework for new code**, and confirms multiple `CefBrowserView` instances may be added to a single `CefWindow` under the **Alloy** style. ([forum t=19718](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718), [cef#3681](https://github.com/chromiumembedded/cef/issues/3681))
+- **AgentMux's existing ALLOY + `browser_view_create` infra is exactly the right substrate** to add multi-pane support on Linux/macOS by adding additional `CefBrowserView` children to the main `CefWindow` and positioning them with `View::set_bounds`.
+- **macOS native NSView embedding with `set_as_child` does work in a single process**, but the CEF maintainer states embedded non-Views windows are not supported on macOS upstream and the recommended path is Views. ([forum t=19593](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19593), [forum t=19688](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=19688))
+
+---
+
+## 1. CEF's two embedding paradigms for sub-browsers
+
+### 1a. Native child window approach — `WindowInfo::set_as_child(parent_handle, rect)` + `browser_host_create_browser`
+
+This is the Windows path AgentMux already uses (`browser_pane/creation.rs:84`).
+
+| Platform | Parent handle type | Status |
+| --- | --- | --- |
+| Windows | HWND | Fully supported. AgentMux already uses this. |
+| Linux X11 | X11 Window XID (cast to `CefWindowHandle`) | Supported with caveats. ([forum t=18048](https://magpcss.org/ceforum/viewtopic.php?t=18048)) |
+| Linux Wayland | wl_surface + wl_display (proposed) | **Not implemented in upstream stable CEF.** ([cef#2804](https://github.com/chromiumembedded/cef/issues/2804)) |
+| macOS | NSView* (cast to `CefWindowHandle`) | Works in-process; officially "not supported" upstream for new code. ([forum t=12727](https://magpcss.org/ceforum/viewtopic.php?f=6&t=12727), [t=19688](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=19688)) |
+
+**Linux X11 (forum t=18048)**: "The parent value is used to identify monitor info and to act as the parent window for dialogs, context menus, etc." Pattern is:
+
+```c
+GdkWindow* gdk_window = gtk_widget_get_window(gtk_handle);
+Window x_window = GDK_WINDOW_XID(gdk_window);
+// pass x_window as CefWindowHandle to SetAsChild
+```
+
+**Linux Wayland — the blocker** ([cef#2804](https://github.com/chromiumembedded/cef/issues/2804)):
+
+> "Ozone/Wayland/X11 can only be used with views framework now, but it does not allow to embed host windows into client windows."
+
+> "wl_subsurface is the way to go for supporting embedded Wayland windows. Clients should take a wl_surface they created and a wl_display and pass them to CEF. Depending on whether a parent wl_surface is passed or not, the CEF either will create a toplevel window or a subsurface that it will parent with the passed parent wl_surface."
+
+This proposed mechanism is **not yet upstreamed**. As of January 2025 the only upstream Wayland progress is Toyota's ANGLE Wayland work for top-level windows ([Phoronix Jan 2025](https://www.phoronix.com/news/Chromium-CEF-Wayland-Progress)); embedded sub-surfaces remain a future item. Even when implemented, the constraints are sharp:
+
+> "Calls that manipulate the window state (such as SetBounds(), Hide(), Show()) may not result in actual Wayland calls, as a subsurface is treated as an overlay above a parent surface that cannot be hidden, shown or placed to arbitrary areas."
+
+In other words: even hypothetically, a Wayland subsurface is a constrained overlay, not a free-floating child window like an HWND.
+
+**Interpretation for AgentMux**: a `set_as_child`-equivalent on Wayland does not exist today. Even on X11, the agentmux runtime is launched with native Wayland (Ozone-Wayland, per the user's MEMORY note about CEF Wayland) — so an X11-XID approach would require a deliberate `--ozone-platform=x11` regression. We should treat the native-child-window path as unavailable on Linux for our deployment target.
+
+### 1b. Views-based approach — `browser_view_create` + `Panel::add_child_view`
+
+AgentMux's main browser already uses this path: `browser_view_create()` returns a `CefBrowserView`; `WindowDelegate::on_window_created` adds it via `window.add_child_view(view)`.
+
+Key facts from primary sources:
+
+- `CefView::SetBounds(...)` "sets the bounds (size and position) of a View, where bounds are in parent coordinates, or DIP screen coordinates if there is no parent." ([CefView API docs](https://magpcss.org/ceforum/apidocs3/projects/(default)/CefView.html))
+- `CefBrowserView` inherits from `CefView`; it is created without a backing `CefBrowser`. **The browser instance is only created when the view is added to a Widget hierarchy** via `AddedToWidget()` ([cef/libcef/browser/views/browser_view_impl.cc](https://github.com/chromiumembedded/cef/blob/master/libcef/browser/views/browser_view_impl.cc)).
+- A `CefPanel` (which `CefWindow` subclasses) supports `AddChildView`, `RemoveChildView`, `Layout` and child enumeration. ([CefPanel API](https://magpcss.org/ceforum/apidocs3/projects/(default)/CefPanel.html))
+- **Multi-browser per window is officially confirmed**: "You can add multiple `CefBrowserView` instances in the same `CefWindow` (with Alloy runtime). You can implement a tab strip using `CefButton` (e.g. clicking a button swaps the visible `CefBrowserView`)." — magreenblatt, [forum t=19718](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718).
+- The Alloy/Chrome-style constraint (from `browser_view_impl.cc`):
+  > "Cannot add Chrome style BrowserView to Alloy style Window"
+  > "Cannot add multiple Chrome style BrowserViews"
+  
+  AgentMux uses Alloy throughout, so neither limit applies.
+- BrowserView positioning at runtime is performed by calling `set_bounds(CefRect)` on the BrowserView (or by giving the parent panel a custom layout). Bounds change triggers a callback in `CefBrowserViewImpl` so the underlying browser resizes correctly.
+
+**Interpretation for AgentMux**: this is the supported, cross-platform, future-proof path. With Alloy throughout, our main window can host the primary browser-view *and* N pane browser-views as siblings, each positioned by `set_bounds`.
+
+---
+
+## 2. What does cefclient do for embedded sub-browsers?
+
+[`tests/cefclient/browser/views_window.cc`](https://github.com/chromiumembedded/cef/blob/master/tests/cefclient/browser/views_window.cc) is the reference. Behavior:
+
+- **One primary `CefBrowserView` per `CefWindow`.** It is added via `window->AddChildView(browser_view_)` in `OnWindowCreated`.
+- Layout uses `CefWindow::SizeToPreferredSize()` for the overall window, with the BrowserView occupying the "main" slot via the default fill layout.
+- **Popups are sent to new top-level windows** by default. `OnPopupBrowserViewCreated` returns `false` so CEF wraps the popup in its own `CefWindow::CreateTopLevelWindow`. The sample notes that returning `true` after adding the popup BrowserView yourself is fine — that is the hook for in-window popup embedding, but cefclient itself does not exercise it.
+- cefclient does **not** demonstrate multi-pane-per-window in its default flow. The maintainer's guidance for that pattern is "use a `CefButton` to swap visible BrowserView" ([forum t=19718](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718)).
+- On Linux specifically, the upstream cefclient native (non-Views) build is **not available in Ozone builds** ([Collabora 2019 upstream](https://www.collabora.com/news-and-blog/blog/2019/05/08/cef-on-wayland-upstreamed/) — "cefclient is not available in Ozone build"). Only the Views path is exercised.
+
+**Interpretation**: cefclient's example doesn't cover our case directly. The primitives we need (multiple BrowserView siblings; `set_bounds`) are well-defined and work, but the reference sample only shows one BrowserView per window plus popups-as-new-windows.
+
+---
+
+## 3. Best-known CEF apps and how they embed sub-browsers
+
+### Steam
+Steam's UI uses CEF with a `BrowserView` JS API exposed through `SteamClient.BrowserView`:
+
+> "BrowserView is a subpage embedded in the original webpage, similar to an iframe in a normal web page, but interaction with this object is implemented by Steam itself." ([SteamBrew docs](https://docs.steambrew.app/developers/environment))
+
+Steam's `BrowserView.Create / LoadURL / SetBounds / SetVisible` is **a JS-level abstraction over native CEF BrowserViews** — i.e. they expose the same semantic to their JS layer that we'd be using natively. This is strong evidence that the multi-BrowserView-per-Window pattern scales to a complex production app. The DARKNAVY exploit writeup ([darknavy.org](https://www.darknavy.org/blog/exploiting_steam_usual_and_unusual_ways_in_the_cef_framework/)) corroborates the architecture.
+
+### Spotify
+Spotify uses CEF (since 2011, [Spotify Engineering](https://engineering.atspotify.com/2019/3/building-spotifys-new-web-player)) and runs the [`cef-builds.spotifycdn.com`](https://cef-builds.spotifycdn.com/index.html) public binary distribution. No public detail on multi-pane internal architecture.
+
+### 1Password
+1Password 8 on Linux uses **Electron**, not raw CEF ([1Password 8 blog](https://blog.1password.com/1password-8-the-story-so-far/)). Not relevant precedent for our problem.
+
+**Interpretation**: Steam is the closest in-the-wild precedent and validates the Views + multiple BrowserViews approach as production-grade.
+
+---
+
+## 4. GTK / Qt CEF integration libraries
+
+- **cefcapi** ([cztomczak/cefcapi](https://github.com/cztomczak/cefcapi)) — C-API example; uses GTK+X11 XID + `SetAsChild`. Pre-Views era.
+- **cefpython** ([cztomczak/cefpython, WindowInfo.md](https://github.com/cztomczak/cefpython/blob/master/api/WindowInfo.md)) — `SetAsChild` on Linux requires an X11 XID extracted from a GTK widget. Pre-Wayland.
+- **Qt + CEF on Linux** ([Qt forum t=74647](https://forum.qt.io/topic/74647/qt-cef-integration-on-linux)) — "CEF is built on Gtk2, so it requires gtk handle, not the winId()." Pattern is: create a GTK toplevel via `gtk_window_new`, pull its `XID` with `gdk_x11_drawable_get_xid`, hand to `SetAsChild`. **No Wayland path discussed.**
+- **cef Rust crate** ([docs.rs/cef v147.1.0](https://docs.rs/cef)) — Tauri-stewarded bindings. Exposes `BrowserView`, `Panel`, `Window`, `BrowserViewDelegate`, `PanelDelegate`. The crate at v147 supports x86_64 + aarch64 on Linux/macOS/Windows. AgentMux already uses this crate (Cargo.lock shows `cef = "...147..."` per the codebase).
+- **cef-ui** ([hytopiagg/cef-ui](https://github.com/hytopiagg/cef-ui)) — alternative Rust bindings via bindgen.
+- **browser-window** ([bamidev/browser-window](https://github.com/bamidev/browser-window)) — high-level Rust toolkit; uses CEF as a backend; abstracts away direct CEF view APIs.
+
+**Interpretation**: every GTK/Qt integration library targets the X11-XID path. None has a documented Wayland-subsurface path. The Rust `cef` crate AgentMux already uses exposes the Views API surface we need (`BrowserView`, `Window::add_child_view`, `View::set_bounds`).
+
+---
+
+## 5. macOS specifics
+
+### 5a. NSView-based `set_as_child`
+
+`SetAsChild` on macOS takes an NSView pointer cast to `CefWindowHandle` ([forum t=12727](https://magpcss.org/ceforum/viewtopic.php?f=6&t=12727)):
+
+```objc
+window_info.SetAsChild(self, 20, 20,
+                       self.frame.size.width - 40,
+                       self.frame.size.height - 40);
+```
+
+Same-process embedding works. Cross-process embedding does not ([forum t=19593](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19593)). Cocoa's "single key window per app" model is cited as the underlying reason ([forum t=19688](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=19688)):
+
+> "macOS can only have one key window at a time, which makes it impossible for the Chromium window to receive focus at the same time as the app window."
+
+### 5b. Maintainer's stance on macOS embedding
+
+[cef#3294](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19688) and forum t=19688 establish that **embedded non-Views windows on macOS are explicitly not supported**:
+
+> "I've been reading up on the progress... and am happy to see that this is already supported in windows and linux." (about Linux X11; macOS still missing)
+
+The recommended path on macOS is again Views. Same-process NSView embedding is a "works but unsupported" tier: focus/activation glitches are likely with custom title bars and frameless windows.
+
+**Interpretation for AgentMux**: doing `set_as_child(NSView, rect)` would be a fragile parallel to the Windows code. Given AgentMux is single-process for the host UI, it would *technically* work, but the maintainer's guidance plus our existing ALLOY+Views infrastructure point firmly at the Views approach for macOS as well.
+
+---
+
+## 6. Wayland-specific considerations
+
+1. **Sub-surfaces of a parent xdg_toplevel**: theoretically possible via `wl_subsurface` once CEF exposes the API ([cef#2804](https://github.com/chromiumembedded/cef/issues/2804)). Today, no upstream CEF binary supports this.
+
+2. **Nested top-level windows from same client**: Wayland allows multiple top-levels per client (no protocol prohibition). What it forbids is **arbitrary X11-style reparenting** — there is no equivalent to "embed window A inside window B's coordinate system" except via `wl_subsurface`.
+
+3. **What does Chromium-Ozone do for its DevTools window?** DevTools in Chromium is a separate top-level window when undocked, and an internally-rendered iframe-like region (using Chromium's own Views/Aura) when docked. Crucially, **docked DevTools uses Chromium's internal Views layout system, not OS-level child window embedding** — exactly the model CEF's Views framework exposes.
+
+4. **AgentMux's patched libcef.so** (HEAD `5ab41b6` on `agentmux/7680-drag-rightclick-and-transparency`, per MEMORY): the patches are about transparency (`SetBackgroundOpaque(false)`) and drag (`CefWindow::BeginWindowDrag` -> `WmMoveResizeHandler::DispatchHostWindowDragMovement`). **None of the agentmux patches add the cef#2804 Wayland subsurface API**. Our libcef.so does not bypass the Wayland embedding limitation.
+
+**Interpretation**: on Wayland, child-window embedding for sub-browsers is structurally unavailable; the only viable embedded-pane mechanism is the Views path.
+
+---
+
+## 7. Coordinate / DPI / overlay clipping
+
+The Windows AgentMux pane mechanism uses `SetWindowRgn` to cut transparent holes through the pane HWND so DOM popovers, modals and dropdown menus paint through (`frontend/app/platform/pane-overlay.ts`, lines 1-16). This is the classic "airspace" workaround required because native HWNDs composite above the WebView regardless of CSS z-index.
+
+### Native-child-window approach (Windows / X11):
+- The pane window is a separate OS-level surface, composited above the host window content.
+- Z-order is controlled at the OS level. CSS z-index has no effect.
+- **Clipping must be explicit** (Win32 `SetWindowRgn`; X11 SHAPE extension). `pane-overlay.ts` exists exactly for this.
+- DPI: each platform's per-monitor DPI rules apply directly to the pane window.
+
+### Views approach:
+- The BrowserView is a `views::View` inside Chromium's Aura/Views compositor — same compositor as the host window.
+- **Z-order is controlled via the Views hierarchy and `CefWindow::AddOverlayView`**. ([CefWindow API](https://cef-builds.spotifycdn.com/docs/120.1/classCefWindow.html)) Overlay views are drawn at higher z than regular child views and support docking modes.
+- **No airspace problem** — a sibling BrowserView and a sibling label/UI view share one compositor. CSS z-index (within a single browser) plus Views z-order (across browsers) is the entire model.
+- DPI: CEF Views use DIP coordinates throughout ([CEF general usage docs](https://chromiumembedded.github.io/cef/general_usage.html)): "Screen/window coordinates are generally represented as density independent pixel (DIP) coordinates with upper-left origin. These DIP coordinates will be passed to Views APIs and browser callbacks." This is much simpler than the Windows pane-overlay flow, which currently does manual integer rounding in `pane-overlay.ts:53-60`.
+
+### Relevant gotchas in Views overlays:
+- [cef#3790](https://github.com/chromiumembedded/cef/issues/3790): regression in CEF 125 where overlay BrowserViews didn't display (closed-but-imperfect).
+- [cef#4035](https://github.com/chromiumembedded/cef/issues/4035): transparent overlay BrowserViews not yet supported (`GetColor` enforces opaque). Open enhancement.
+- AddOverlayView is hidden by default; you must call `CefOverlayController::SetVisible(true)`.
+
+**Interpretation**: switching to Views *eliminates* the airspace problem, so `pane-overlay.ts`'s `SetWindowRgn` workaround can be retired on Linux/macOS — DOM modals naturally paint above sibling BrowserViews via Views z-order. We don't need region-clipping at all in the Views model. (This is a significant complexity reduction.)
+
+---
+
+## 8. Trade-off summary: Views vs Native-child-window for Linux/macOS
+
+| Dimension | Views (`browser_view_create` + `add_child_view`) | Native child window (`set_as_child`) |
+| --- | --- | --- |
+| **Linux Wayland** | Works (current AgentMux deployment target) | **Does not work** — cef#2804 unimplemented |
+| **Linux X11** | Works | Works (with GTK XID extraction) |
+| **macOS** | Works, recommended | Works in-process, "not supported" upstream |
+| **Windows** | Works | Works (current AgentMux pane path) |
+| **Multi-pane per window** | Yes, with Alloy style — confirmed by maintainer | Yes |
+| **Z-order vs DOM (airspace)** | No problem — single compositor | Major problem — requires region clipping (`pane-overlay.ts`) |
+| **Resize lag** | maintainer: "substantially improved" with Views ([forum t=19718](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718)) | Visible lag in CEF 88+ |
+| **DPI handling** | DIP everywhere | Per-platform raw pixel quirks |
+| **Frameless / custom title bar** | `CefWindowDelegate::IsFrameless()` (already used for main window) | Manual per-platform |
+| **Off-screen rendering compat** | Incompatible | Compatible |
+| **Future direction (CEF 126+)** | Recommended; Chrome bootstrap defaults to Alloy style ([cef#3681](https://github.com/chromiumembedded/cef/issues/3681)) | Maintenance-mode for native; Wayland never coming on this path |
+| **Cross-platform code** | Single path | Three platform-specific paths |
+
+The maintainer's stance, repeated across multiple threads:
+> "This is substantially improved if you use the CEF Views framework. ... The only known way to resolve this issue is by using the Views framework." — magreenblatt, [forum t=19718](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718)
+
+---
+
+## Recommendation
+
+**For AgentMux's Linux + macOS embedded browser pane port: use the Views framework. Add each pane as a sibling `CefBrowserView` child of the existing main `CefWindow`, position it via `View::set_bounds(rect)`, and retire the `pane-overlay.ts` SetWindowRgn clipping mechanism on Linux/macOS.**
+
+### Concrete justification
+
+1. **Linux Wayland forces the decision.** The native-child-window path that powers `browser_pane/creation.rs:84` on Windows has no functional equivalent on Wayland today, and even the proposed `wl_subsurface` mechanism in [cef#2804](https://github.com/chromiumembedded/cef/issues/2804) is constrained (no Hide/Show/SetBounds in the usual sense). Our patched libcef.so does not implement the proposed Wayland API.
+2. **AgentMux is already on the Views path for the main browser.** Adding additional `CefBrowserView` children is incremental — same `add_child_view`, same `WindowDelegate`, same Alloy runtime style. No new CEF subsystem to learn.
+3. **The Alloy runtime allows N BrowserViews per Window.** The only constraint (from `browser_view_impl.cc`) is "no multiple Chrome-style BrowserViews per Widget" — we use Alloy.
+4. **macOS gets the same code path for free.** No NSView swizzling, no Cocoa key-window dance, no maintainer-warning tier.
+5. **The airspace / pane-overlay problem disappears.** A sibling BrowserView shares the Aura compositor with the host browser-view; DOM modals in either pane natively respect Views z-order. `pane-overlay.ts`'s SetWindowRgn dance can be skipped on Linux/macOS (it must remain for Windows).
+6. **Steam validates the architecture.** Steam's `SteamClient.BrowserView` is a JS facade over the same multi-BrowserView-per-Window primitive.
+7. **Resize, DPI, and frameless concerns are all handled better by Views.** Our existing `IsFrameless` delegate already proves this works for the host window.
+
+### Architectural sketch (no code, just shape)
+
+- A new task analogous to `CreateBrowserPaneTask` runs on the CEF UI thread.
+- Instead of `WindowInfo::set_as_child + browser_host_create_browser`, it calls `browser_view_create(client, url, settings, None, None, Some(delegate))`.
+- The returned `CefBrowserView` is added to the main window via the existing `WindowDelegate` plumbing — with a hook on the host window to call `window.add_child_view(pane_view)` from the UI thread (a thread-marshalled call analogous to today's `post_task(ThreadId::UI, ...)`).
+- Position is set via `pane_view.set_bounds(CefRect { x, y, w, h })` in DIP, derived from the same frontend `getBoundingClientRect` flow that already exists.
+- Resizes/visibility changes from the frontend translate to `pane_view.set_bounds` and `pane_view.set_visible` calls instead of HWND moves and SetWindowRgn updates.
+- For pane-on-top-of-everything cases (modals over a pane), DOM modals just work — Views z-order is automatic for siblings; for cases needing absolute z-elevation, `CefWindow::AddOverlayView` is the escape hatch (with the cef#4035 transparent-overlay limitation noted).
+- The Windows path remains as-is. A `cfg!(target_os)` switch in `BrowserPaneManager::create` selects native-child-window on Windows and Views on Linux/macOS. Once the Views path is proven, Windows can migrate too — at which point `pane-overlay.ts` can be retired entirely.
+
+### Risks to monitor
+
+- [cef#3790](https://github.com/chromiumembedded/cef/issues/3790) (overlay BrowserView display regressions) — only a risk if we use `AddOverlayView`; sibling `add_child_view` is the safer base.
+- [cef#4035](https://github.com/chromiumembedded/cef/issues/4035) (transparent overlay BrowserViews not yet supported) — if we need transparent panes on top of other panes, this is a future enhancement to track. AgentMux's current usage doesn't require this.
+- DPI rounding when translating from frontend pixel coords to CEF DIPs — Views uses DIP natively, so this is mostly handled, but cross-monitor moves on Linux multi-DPI setups should be tested.
+- Frontend coordinate system change: the Windows path uses raw screen pixels relative to the parent HWND; the Views path uses DIP relative to the host window's content area. The pane-positioning frontend code needs a small abstraction layer.
+
+---
+
+## Source index (primary)
+
+- [chromiumembedded/cef issue #2804 — Add support for embedded Ozone/Wayland windows](https://github.com/chromiumembedded/cef/issues/2804)
+- [chromiumembedded/cef issue #3681 — Lightweight Alloy-style windows in Chrome runtime](https://github.com/chromiumembedded/cef/issues/3681)
+- [chromiumembedded/cef issue #3790 — Overlay browser view not shown when using AddOverlayView](https://github.com/chromiumembedded/cef/issues/3790)
+- [chromiumembedded/cef issue #4035 — views: Support transparent overlay BrowserViews](https://github.com/chromiumembedded/cef/issues/4035)
+- [cef/libcef/browser/views/browser_view_impl.cc — multi-BrowserView constraints](https://github.com/chromiumembedded/cef/blob/master/libcef/browser/views/browser_view_impl.cc)
+- [cef/include/views/cef_window.h](https://github.com/chromiumembedded/cef/blob/master/include/views/cef_window.h)
+- [cef/tests/cefclient/browser/views_window.cc](https://github.com/chromiumembedded/cef/blob/master/tests/cefclient/browser/views_window.cc)
+- [cef/tests/cefsimple/simple_app.cc](https://github.com/chromiumembedded/cef/blob/master/tests/cefsimple/simple_app.cc)
+- [CEF general usage — DIP coordinates](https://chromiumembedded.github.io/cef/general_usage.html)
+- [CefView API reference (SetBounds)](https://magpcss.org/ceforum/apidocs3/projects/(default)/CefView.html)
+- [CefPanel API reference (AddChildView)](https://magpcss.org/ceforum/apidocs3/projects/(default)/CefPanel.html)
+- [CefBrowserView API reference (v120)](https://cef-builds.spotifycdn.com/docs/120.0/classCefBrowserView.html)
+- [CEF Forum t=19718 — view lag, multi-BrowserView per window confirmation](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718)
+- [CEF Forum t=19688 — macOS embedded non-Views support status](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=19688)
+- [CEF Forum t=19593 — embedding cefsimple in NSWindow](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19593)
+- [CEF Forum t=12727 — CEF browser inside NSWindow on macOS](https://magpcss.org/ceforum/viewtopic.php?f=6&t=12727)
+- [CEF Forum t=18048 — embedding CEF into GTK on Linux](https://magpcss.org/ceforum/viewtopic.php?t=18048)
+- [CEF Forum t=18750 — Chrome runtime vs Alloy runtime](https://magpcss.org/ceforum/viewtopic.php?f=17&t=18750)
+- [CEF Forum t=19186 — managing AddOverlayView BrowserViews](https://magpcss.org/ceforum/viewtopic.php?f=6&t=19186)
+- [Qt forum t=74647 — Qt+CEF integration on Linux (X11 XID via GTK)](https://forum.qt.io/topic/74647/qt-cef-integration-on-linux)
+- [Collabora 2019 — CEF on Wayland upstreamed (Views-only)](https://www.collabora.com/news-and-blog/blog/2019/05/08/cef-on-wayland-upstreamed/)
+- [Phoronix Jan 2025 — CEF Wayland progress (Toyota / ANGLE)](https://www.phoronix.com/news/Chromium-CEF-Wayland-Progress)
+- [SteamBrew docs — SteamClient.BrowserView](https://docs.steambrew.app/developers/environment)
+- [DARKNAVY — Steam CEF exploitation writeup](https://www.darknavy.org/blog/exploiting_steam_usual_and_unusual_ways_in_the_cef_framework/)
+- [docs.rs cef v147.1.0+147.0.10 — Rust bindings (Views API exposed)](https://docs.rs/cef)
+- [tauri-apps/cef-rs](https://github.com/tauri-apps/cef-rs)
+- [cefpython WindowInfo (X11 XID pattern)](https://github.com/cztomczak/cefpython/blob/master/api/WindowInfo.md)
+- [1Password 8 architecture (uses Electron, not raw CEF)](https://blog.1password.com/1password-8-the-story-so-far/)
+- [Spotify Engineering — Building Spotify's New Web Player (CEF since 2011)](https://engineering.atspotify.com/2019/3/building-spotifys-new-web-player)

--- a/docs/specs/embedded-browser-panes-linux-macos-2026-05-03.md
+++ b/docs/specs/embedded-browser-panes-linux-macos-2026-05-03.md
@@ -1,0 +1,338 @@
+# Embedded Browser Panes — Linux & macOS Port
+
+**Date:** 2026-05-03
+**Status:** Spec / Proposal
+**Repo state:** main @ `1d887341`, AgentMux v0.33.612
+**Author:** AgentC (research delegated to a subagent; full source-cited research at `/tmp/cef-pane-research.md` — keep that file alongside review of this spec)
+
+---
+
+## Problem
+
+`defwidget@browser` (the embedded-webpage pane) renders a black screen on Linux. The cause is structural: `agentmux-cef/src/browser_pane/creation.rs:90-94` short-circuits with a warning on every non-Windows platform:
+
+```rust
+#[cfg(not(target_os = "windows"))]
+{
+    tracing::warn!(block_id = %self.block_id, "browser panes not yet implemented on this platform");
+    return;
+}
+```
+
+The frontend creates the pane DIV and fires the `browser_pane_create` IPC; the Rust side returns without creating a CEF browser; the DIV stays empty. Same code path will black-screen on macOS when that build target is enabled.
+
+The Windows implementation uses **native child windows**: `find_own_top_level_window()` → `WindowInfo::set_as_child(parent_hwnd, &rect)` → `browser_host_create_browser`. That paradigm has no working analogue on Wayland and is officially unsupported on macOS (see Research §1, §5, §6). The port has to choose a different mechanism.
+
+---
+
+## TL;DR
+
+- **Use the CEF Views framework** for Linux + macOS pane creation: `browser_view_create(...)` returns a `CefBrowserView` that we add as a sibling child of the existing main `CefWindow` via `add_child_view`, and position with `view.set_bounds(rect)` in DIP.
+- **Drives the decision: Wayland.** `WindowInfo::set_as_child` does not work on Wayland (cef#2804 unimplemented; even the proposed `wl_subsurface` mechanism is sharply constrained — no Hide/Show/SetBounds in the usual sense). Our patched `libcef.so` on `agentmux/7680-...` does not add this API.
+- **Substrate is already in place.** AgentMux's main browser already uses `browser_view_create + add_child_view` (`agentmux-cef/src/app.rs:426` and `WindowDelegate::on_window_created`). Pane creation becomes "do the same thing, but for an additional view, and `set_bounds` it where the frontend pane lives."
+- **`pane-overlay.ts` SetWindowRgn airspace dance becomes obsolete on Linux/macOS.** Sibling BrowserViews share Aura's compositor with the host UI, so DOM modals naturally sort by Views z-order — no region clipping needed. Eventually Windows can migrate too and `pane-overlay.ts` retires entirely.
+- **Estimated change**: 1 new ~150-line module (`browser_pane/creation_views.rs`), 4-line `cfg!(target_os)` switch in the existing creation entry point, ~30-line frontend coordinate-system shim, ~50 lines added to `WindowDelegate` for the "add this view to the window when ready" plumbing, no changes to `pane-overlay.ts` for now (only Linux/macOS skip it). One bump, one binary patch to the host. No CEF source changes; the Views API we need is already exported by cef-dll-sys / cef 146.7.
+
+---
+
+## Why Views, not native-child-window — the hard constraints
+
+Three independent reasons make the native-child-window path unusable for our deployment target. Any one of them would suffice; together they're decisive.
+
+### 1. Wayland forbids OS-level child-window embedding (Research §1, §6)
+
+From the CEF maintainer on cef#2804 about Ozone-Wayland:
+
+> "Ozone/Wayland/X11 can only be used with views framework now, but it does not allow to embed host windows into client windows."
+
+The proposed `wl_subsurface` API in the same issue is **not upstreamed** as of 2026-05. Even if it were, sub-surfaces are constrained to be passive overlays of the parent surface — they can't be hidden/shown/moved with the same freedom as an HWND. AgentMux deploys natively on Wayland (per the `cef_wayland.md` MEMORY note); a pane that can't be hidden/shown is unusable.
+
+X11 fallback (`--ozone-platform=x11`) would technically work via GTK XID extraction + `set_as_child`, but regressing AgentMux to XWayland on Linux just to support panes is a non-starter.
+
+### 2. macOS embedded non-Views windows are explicitly unsupported (Research §5)
+
+Maintainer guidance on cef-forum t=19688:
+
+> "macOS can only have one key window at a time, which makes it impossible for the Chromium window to receive focus at the same time as the app window."
+
+Same-process NSView embedding works in practice but lives in a "works but unsupported" tier — focus and activation glitches are likely with our frameless ALLOY-style window and custom title bar. Views is the recommended path for macOS for the same reason as Linux.
+
+### 3. The native path requires a per-platform code branch we'd own forever
+
+Three platforms × the existing Windows code = three independent integrations to maintain (HWND, X11 XID via GTK, NSView). Each has subtle DPI rules and focus quirks. The Views path collapses this to one cross-platform code path per the CEF maintainer's repeated guidance (cef-forum t=19718):
+
+> "This is substantially improved if you use the CEF Views framework. ... The only known way to resolve this issue is by using the Views framework."
+
+---
+
+## Why Views works for AgentMux specifically
+
+Five things have to be true for the Views approach to fit. All five are.
+
+1. **The Alloy runtime style allows multiple `CefBrowserView` siblings per `CefWindow`.** The constraint in `libcef/browser/views/browser_view_impl.cc` ("Cannot add multiple Chrome style BrowserViews") only applies to Chrome-style, which AgentMux does not use. Maintainer confirms on cef-forum t=19718: "You can add multiple CefBrowserView instances in the same CefWindow (with Alloy runtime)."
+
+2. **Our main window is already a `CefWindow` hosting a `CefBrowserView` via `add_child_view`.** See `agentmux-cef/src/app.rs:426-437` and `WindowDelegate::on_window_created`. Pane addition is the same primitive a second time.
+
+3. **`CefView::SetBounds` lets a child be positioned anywhere within the parent's coordinate space, in DIP.** From the CefView API docs: "Sets the bounds (size and position) of a View, where bounds are in parent coordinates, or DIP screen coordinates if there is no parent." Resize, move, and visibility changes from the frontend become single calls.
+
+4. **Z-order between siblings is handled by Views, not by the OS compositor.** A pane BrowserView and a host BrowserView share Aura's compositor. DOM modals in the host paint above the pane naturally; the existing `pane-overlay.ts` SetWindowRgn workaround is unnecessary on this path. (The airspace problem only exists when native OS surfaces composite outside the WebView's compositor.)
+
+5. **Steam validates the architecture in production.** Steam's `SteamClient.BrowserView.Create / LoadURL / SetBounds / SetVisible` JS API is a thin facade over exactly this multi-`CefBrowserView`-per-Window primitive. SteamBrew docs explicitly compare it to "an iframe in a normal web page." Production-scale precedent.
+
+---
+
+## Design
+
+### Architecture
+
+```
+┌──────────────────────── CefWindow (main, frameless ALLOY) ───────────────┐
+│                                                                          │
+│  ┌─────────── BrowserView (host UI — current main browser) ──────────┐   │
+│  │  set_bounds(0, 0, win_w, win_h)  — fills the window               │   │
+│  │  Renders the SolidJS frontend, which contains pane DIVs and       │   │
+│  │  reports their on-screen rects to Rust via IPC.                   │   │
+│  └───────────────────────────────────────────────────────────────────┘   │
+│                                                                          │
+│  ┌─────── BrowserView (pane #1, label="browser-pane-<block_id>") ────┐   │
+│  │  set_bounds(pane_x, pane_y, pane_w, pane_h)                       │   │
+│  │  Loads the user's URL; sized to match the frontend pane DIV.      │   │
+│  └───────────────────────────────────────────────────────────────────┘   │
+│                                                                          │
+│  ┌─────── BrowserView (pane #N) ──────────────────────────────────────┐  │
+│  │  ... etc ...                                                       │  │
+│  └────────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Key invariant:** the host UI BrowserView occupies the full window. Pane BrowserViews are added on top of (z-order: later siblings) the host UI BrowserView and positioned to cover specific rects. Because Views composites them in one pipeline, the frontend's CSS-positioned pane DIV is conceptually a "hole" through which the pane BrowserView shows — but at the OS level it's just two siblings, no clipping, no airspace.
+
+### Module layout
+
+| File | Purpose | Status |
+|---|---|---|
+| `agentmux-cef/src/browser_pane/creation.rs` | Existing entry point. Add a `cfg(target_os = "windows")` switch at line 78ish: Windows path stays as-is; Linux/macOS path delegates to the new `creation_views` module. | Edit |
+| `agentmux-cef/src/browser_pane/creation_views.rs` | New module. Implements `create_browser_pane_view(state, block_id, label, url, rect)` running on the CEF UI thread. Calls `browser_view_create(client, url, settings, None, None, Some(view_delegate))`, hands the resulting `CefBrowserView` to the main `WindowDelegate` via a thread-marshalled `add_child_view + set_bounds` call. | New |
+| `agentmux-cef/src/app.rs` | `AgentMuxWindowDelegate` gains a method to host pane BrowserViews. Two options below in "Open question 1"; pick after a quick spike. | Edit |
+| `agentmux-cef/src/browser_pane/callbacks.rs` | The existing `on_after_created_browser_pane` / `on_before_close_browser_pane` / `on_load_end_browser_pane` callbacks already work generically over the `Browser` handle and don't depend on HWND. They should fire for Views-created panes too — but verify by tracing. | Verify, no change expected |
+| `agentmux-cef/src/browser_pane/hwnd.rs` (379 lines) | Windows-specific HWND management for native pane windows. Untouched on this PR. (When Windows eventually migrates to Views, this whole file can be deleted.) | Untouched |
+| `frontend/app/platform/pane-overlay.ts` | The SetWindowRgn-equivalent clipping mechanism. Skip its work on Linux/macOS — Views z-order handles it. **Today's pane-overlay.ts only fires `browser_panes_set_overlay_clip` IPC; that IPC's Rust handler should no-op on non-Windows.** | Edit (Rust handler), maybe edit (frontend) |
+| `agentmux-cef/src/ipc.rs` | The five `browser_pane_*` IPCs (`create`, `navigate`, `resize`, `close`, `go_back`, `go_forward`) keep their current dispatch shape. `BrowserPaneManager::resize` switches on cfg to use `view.set_bounds` on Linux/macOS instead of HWND `SetWindowPos`. | Edit (small) |
+
+### Data flow — pane creation, end-to-end
+
+1. **Frontend:** user opens `defwidget@browser` widget. `BrowserViewModel` (`frontend/app/view/browser/browser-model.ts`) renders a pane DIV with a `block_id`. After mount, it measures the DIV's screen rect and fires `browser_pane_create` IPC with `{ block_id, url, rect: {x, y, w, h} }`.
+
+2. **Rust IPC dispatcher** (`agentmux-cef/src/ipc.rs:312`): unchanged, calls `state.browser_panes.create(state, block_id, url, rect)`.
+
+3. **`BrowserPaneManager::create`** (`agentmux-cef/src/browser_panes.rs:157`): unchanged. Reducer-routed `TryRegisterBrowserPaneLive` returns `Fresh(label)` (or `AlreadyLive`/`Closing`). Posts `CreateBrowserPaneTask` to `ThreadId::UI`.
+
+4. **`CreateBrowserPaneTask::execute`** (`agentmux-cef/src/browser_pane/creation.rs:30`-ish): NEW switch at the top:
+   ```
+   #[cfg(target_os = "windows")]    →  existing HWND path
+   #[cfg(not(target_os = "windows"))] →  delegate to creation_views::create_browser_pane_view
+   ```
+
+5. **`create_browser_pane_view` (NEW, `creation_views.rs`):**
+   - Build `client = AgentMuxClient::new(handler, true)` (same handler-with-pane setup as Windows).
+   - Build `view_delegate = AgentMuxBrowserViewDelegate::new(RuntimeStyle::ALLOY)` (the same delegate type already used for the main browser at `app.rs:172`).
+   - Call `browser_view_create(client, &CefString::from(url), &BrowserSettings::default(), None, None, Some(view_delegate))` → returns `Option<BrowserView>`.
+   - Stash the `BrowserView` in `state.browser_panes` keyed by `label` (so subsequent `resize`/`close`/`navigate` can find it).
+   - Marshal an "add this view to the main window at this rect" call to the WindowDelegate (see Open question 1).
+
+6. **WindowDelegate** (on the same UI thread): `window.add_child_view(&mut View::from(&pane_view))` and `pane_view.as_view().set_bounds(rect)`.
+
+7. **CEF internally:** `CefBrowserViewImpl::AddedToWidget()` fires, which actually creates the underlying `CefBrowser`. Our `Client::on_after_created` runs (existing handler), our `on_load_end_browser_pane` runs when the URL finishes loading.
+
+8. **Resize flow:** frontend observes its DIV's rect via `ResizeObserver`, fires `browser_pane_resize` IPC. Rust looks up `BrowserView` by label and calls `pane_view.as_view().set_bounds(new_rect)`. No HWND `SetWindowPos`, no `pane-overlay.ts` clip update needed on Linux/macOS.
+
+9. **Close flow:** `browser_pane_close` IPC → Rust calls `pane_view.as_view().parent_view()?.remove_child_view(pane_view.as_view())` (or directly via the cached parent panel handle). The browser's `on_before_close` cleans up state via the existing reducer path.
+
+### Coordinate model
+
+| Surface | Coordinate system | Origin | Unit |
+|---|---|---|---|
+| Frontend pane DIV's `getBoundingClientRect()` | CSS pixels relative to the document's viewport | Top-left of viewport | CSS pixel |
+| Today's Windows path | Screen pixels relative to parent HWND content area | Top-left of HWND client area | Raw pixel (DPI-scaled separately) |
+| Views path (Linux/macOS) | DIP relative to parent View's bounds | Top-left of parent View | DIP |
+
+The frontend already sends pane rects in CSS pixels relative to the viewport. The viewport in our model = the host BrowserView's content area = the parent of the pane BrowserView in the Views hierarchy. So **CSS pixels → DIPs is essentially identity at zoom factor 1.0**; if the user has set a CEF zoom factor, we multiply by it.
+
+This is *simpler* than the Windows path (which has to deal with per-monitor DPI scaling separately from zoom). One conversion in the Rust resize handler:
+```
+dip_rect.x = (css_rect.x * zoom_factor) as i32;
+... etc.
+```
+
+The zoom factor is queryable via `host.zoom_level()` on the host browser; cache and update via the existing `set_zoom_factor` IPC.
+
+---
+
+## Design decisions
+
+### D1. Sibling BrowserView, not OverlayView
+
+`CefWindow::AddOverlayView` is the alternative entry point — it adds a BrowserView at higher z than regular child views, with an `OverlayController` for visibility and docking modes. Why not use it?
+
+- **Open issues:** cef#3790 (overlay BrowserView display regressions in some CEF versions), cef#4035 (transparent overlay BrowserViews not yet supported — the GetColor enforces opaque). Adding panes via the overlay path inherits these.
+- **Z-order overkill:** OverlayView guarantees "above all regular children." We don't need that — a pane should be sandwiched between the host UI's background and the host UI's modals. Sibling z-order via `add_child_view` order is exactly what we want.
+- **Layout coupling:** Overlay views have docking modes (`TopLeft`, `TopRight`, etc.) that conflict with pane positioning by absolute rect.
+
+**Decision:** plain `add_child_view` + `set_bounds`. AddOverlayView is reserved as the escape hatch if we later need a pane to genuinely float above modals.
+
+### D2. One BrowserView per pane, not one BrowserView reused via reload
+
+Steam's BrowserView abstraction is per-pane and they don't reuse views across navigations. Reuse-with-reload is feasible (call `frame.load_url(new)` on the existing view) and we already use it in `BrowserPaneManager::create`'s `RegisterResult::AlreadyLive` branch. Keep that as-is for navigations within an existing pane; **create a fresh view only when a pane block-id is newly registered.**
+
+### D3. Pane lifecycle tracked in state.browser_panes (existing), keyed by label
+
+`BrowserPaneManager` (`browser_panes.rs`) already keys live panes by label. The Windows path stores the `Browser` handle there for IPC lookup. The Views path stores `BrowserView` (which has its own `Browser` accessor via `pane_view.browser()`). Same key, different value type. Use `enum PaneHandle { Native(Browser), View(BrowserView) }` (or platform-cfg the type) — the latter is cleaner because no other code needs to discriminate at runtime.
+
+**Decision:** platform-cfg the stored type. `PaneHandle = Browser` on Windows, `PaneHandle = BrowserView` on Linux/macOS. Methods that need a `Browser` go through `pane_handle.browser()` (Windows: identity; Linux/macOS: the BrowserView's accessor).
+
+### D4. `pane-overlay.ts` SetWindowRgn dance: skip on Linux/macOS, leave Windows alone
+
+The clipping IPC `browser_panes_set_overlay_clip` (called from `pane-overlay.ts:50`) is Windows-specific: it cuts transparent regions through a native HWND. On Linux/macOS the pane is a sibling Views child — DOM modals in the host UI naturally cover it via Views z-order. Make the Rust handler a no-op on non-Windows. The frontend can keep firing the IPC; the handler just returns `Null`.
+
+**Optimization (later):** the frontend can also stop computing/sending overlay clip rects on non-Windows once the Rust no-op is confirmed in production. Defer; it's free perf only when CPU is contended.
+
+### D5. The Views resize path runs on the UI thread; resize IPCs marshal there
+
+Today's `BrowserPaneManager::resize` calls into Windows APIs that must run on a specific thread (the UI thread). The Views path has the same constraint — `View::set_bounds` must run on the CEF UI thread. Use the same `post_task(ThreadId::UI, ...)` pattern. No new infra.
+
+### D6. macOS uses the same code path as Linux
+
+The Views API works identically on macOS, and the Cocoa key-window concern that affects native-child embedding doesn't apply to Views (the BrowserView lives inside the host's NSWindow, not as a separate top-level). One `cfg(not(target_os = "windows"))` branch covers both. Test on macOS once we have a build target; no separate code path expected.
+
+### D7. Don't migrate Windows yet
+
+The Windows native-child path works, ships, and doesn't bottleneck Linux/macOS work. Migrating it to Views would mean retiring `pane-overlay.ts` and `browser_pane/hwnd.rs` (379 lines), validating that resize behavior is identical, and re-testing all the multi-window taskbar grouping logic that interacts with HWNDs. That's a separate PR.
+
+**This PR's scope:** Linux + macOS via Views. Windows untouched. A follow-up PR can converge.
+
+---
+
+## Open questions / verification before implementation
+
+### 1. How does the WindowDelegate "host this new pane view" call get marshalled?
+
+Two options:
+
+**(a)** The `AgentMuxWindowDelegate` keeps a list of pending pane views (`RefCell<Vec<BrowserView>>`). After delegate construction, before window mount, the pane creation task pushes views in. `on_window_created` adds them. **Problem:** panes can be created long after the main window has been created (a user clicks "open browser pane" mid-session). We need a hook for late additions.
+
+**(b)** Cache a handle to the main `Window` itself in `AppState` (e.g. `state.main_window: Mutex<Option<Window>>`) — populated by `WindowDelegate::on_window_created`. The pane creation task reads the handle on the UI thread and calls `window.add_child_view(view)` directly.
+
+**Decision needed in spike:** (b) is cleaner but requires storing a `cef::Window` (refcounted via `RefGuard`) in `AppState` — verify the type is `Send + Sync` enough or wrap appropriately. The cef Rust crate's `Rc` trait already supports cross-thread refcounting; should be fine.
+
+### 2. What `BrowserViewDelegate` fields are required?
+
+Today's `AgentMuxBrowserViewDelegate` (`app.rs:172`) overrides `on_popup_browser_view_created` to wrap popups in their own top-level windows. For pane BrowserViews, popup behavior should match (a popup in a pane → new top-level window, not embedded in the pane). Reuse the existing delegate type; no new override needed. Confirm via spike.
+
+### 3. Click + focus routing
+
+When the user clicks inside a pane BrowserView, it should get focus. CEF Views handles this automatically via the Aura focus manager — clicks on a child view focus that view. Confirm: clicking the host UI again returns focus to the host. No special code expected; verify via manual test.
+
+### 4. Pane ordering when multiple panes overlap
+
+If two panes overlap (two BrowserViews with overlapping bounds in the same parent), the later-added one is on top. Match this to the frontend's z-order intent. Frontend likely doesn't expect overlapping panes today, but confirm and document.
+
+### 5. Hidden / minimized panes
+
+Frontend sometimes hides a pane (e.g. tab not active). On Windows we use `ShowWindow(hwnd, SW_HIDE)`. On Views: `view.set_visible(false)` or `view.set_bounds({0, 0, 0, 0})`. The first is cleaner; verify the BrowserView pauses rendering when `set_visible(false)` (it should; that's the Views contract).
+
+---
+
+## Implementation plan
+
+1. **Spike (1-2 hours):** in a throwaway branch, hard-code a single pane creation in `WindowDelegate::on_window_created` to validate that:
+   - `browser_view_create` returns a usable view on Linux.
+   - `window.add_child_view(view)` plus `view.set_bounds(rect)` displays the URL at the right rect.
+   - Click-to-focus and resize-to-bounds work.
+   - DOM modals in the host UI render above the pane.
+
+2. **Resolve open question 1** (WindowDelegate handle storage). Pick (a) or (b) based on the spike.
+
+3. **Implement** `agentmux-cef/src/browser_pane/creation_views.rs` with `create_browser_pane_view(state, block_id, label, url, rect)`.
+
+4. **Edit** `agentmux-cef/src/browser_pane/creation.rs` to delegate non-Windows to the new module.
+
+5. **Edit** `BrowserPaneManager::resize / close / navigate` to take the Views path on Linux/macOS. Likely a `match` on the cfg-typed `PaneHandle` enum.
+
+6. **Edit** `pane_overlay`'s Rust handler in `ipc.rs` to no-op on non-Windows.
+
+7. **Frontend coordinate-system shim:** verify the existing `getBoundingClientRect`-derived rect can pass directly to the IPC. If yes, no frontend change. If no, wrap the rect with a zoom-factor multiplier.
+
+8. **Test plan** below.
+
+9. **Bump patch + build AppImage + open PR.** AppImage build flow already in place from PR #669.
+
+---
+
+## Test plan
+
+On Linux/Wayland (GNOME/Mutter):
+
+- [ ] Open `defwidget@browser`. Pane shows the URL (was black before).
+- [ ] Resize the pane (drag the splitter). BrowserView resizes to match.
+- [ ] Resize the main window. Pane BrowserView reflows correctly.
+- [ ] Open a second browser pane in the same tab. Both render correctly side-by-side.
+- [ ] Open a DOM modal (e.g. an agent picker overlay). Modal renders above the pane.
+- [ ] Click inside the pane → pane gets focus, scrolling works.
+- [ ] Click outside (host UI) → focus returns to host UI.
+- [ ] Right-click in the pane → pane's contextmenu fires (not the host's).
+- [ ] Right-click on the host UI header → host's contextmenu fires (not the pane's).
+- [ ] Navigate within the pane (URL bar). Pane navigates; host doesn't.
+- [ ] Close the pane (X button). Pane disappears; host BrowserView still works; no zombie BrowserView in `state.browser_panes`.
+- [ ] Open a second window from the status bar (PR #666 fix). Open a pane in the second window. Both windows have independent panes.
+- [ ] Close the second window with a pane open. No host crash; no zombie state.
+
+When macOS becomes a build target:
+
+- [ ] Same tests pass on macOS.
+
+---
+
+## Risks / non-goals
+
+- **Risk: cef#3790 / cef#4035** — overlay-related regressions in some CEF versions. Mitigation: we use `add_child_view`, not `AddOverlayView`. If we later need true overlay behavior, watch those issues.
+- **Risk: BrowserView lifecycle subtleties** — Views creates the underlying `CefBrowser` only on `AddedToWidget`. If we cache the `BrowserView` before adding it to the window, calling `browser()` on it returns `None` until the add. Order operations carefully (add to window first, then cache).
+- **Non-goal: migrating Windows.** Out of scope. Windows native-child path stays. `pane-overlay.ts` stays for Windows.
+- **Non-goal: transparent panes overlapping other panes.** cef#4035 limitation. Not currently used.
+- **Non-goal: cross-process panes.** All panes live in the host process, same as Windows today.
+
+---
+
+## File-by-file change summary
+
+**New:**
+- `agentmux-cef/src/browser_pane/creation_views.rs` (~150 lines)
+
+**Edited:**
+- `agentmux-cef/src/browser_pane/creation.rs` — add `cfg(target_os = "windows")` switch at the top of `CreateBrowserPaneTask::execute`; delegate non-Windows to `creation_views`.
+- `agentmux-cef/src/browser_pane/mod.rs` — re-export the new module.
+- `agentmux-cef/src/browser_panes.rs` — `PaneHandle` enum or platform-cfg type alias; resize/close/navigate methods updated to use Views API on non-Windows.
+- `agentmux-cef/src/app.rs` — `AgentMuxWindowDelegate` plumbing per Open Question 1; or `AppState` gains a `main_window` handle.
+- `agentmux-cef/src/ipc.rs` — `browser_panes_set_overlay_clip` handler no-ops on non-Windows.
+
+**Untouched:**
+- `agentmux-cef/src/browser_pane/hwnd.rs` (Windows-only).
+- `agentmux-cef/src/browser_pane/callbacks.rs` (works generically over `Browser`).
+- `frontend/app/platform/pane-overlay.ts` (kept as-is; Rust handler ignores its IPC on non-Windows).
+- macOS / Windows packaging.
+
+---
+
+## Source references
+
+The full source-cited research backing this spec lives at `/tmp/cef-pane-research.md` (also archive at `docs/research/cef-pane-research-2026-05-03.md` if needed). Primary sources:
+
+- [chromiumembedded/cef issue #2804 — embedded Ozone/Wayland windows](https://github.com/chromiumembedded/cef/issues/2804)
+- [chromiumembedded/cef issue #3681 — Lightweight Alloy-style windows in Chrome runtime](https://github.com/chromiumembedded/cef/issues/3681)
+- [CEF Forum t=19718 — multi-BrowserView per window confirmation by maintainer](https://www.magpcss.org/ceforum/viewtopic.php?f=10&t=19718)
+- [CEF Forum t=19688 — macOS embedded non-Views support status](https://www.magpcss.org/ceforum/viewtopic.php?f=6&t=19688)
+- [Collabora 2019 — CEF on Wayland upstreamed (Views-only)](https://www.collabora.com/news-and-blog/blog/2019/05/08/cef-on-wayland-upstreamed/)
+- [SteamBrew docs — SteamClient.BrowserView](https://docs.steambrew.app/developers/environment)
+- [cef/libcef/browser/views/browser_view_impl.cc — multi-BrowserView constraints](https://github.com/chromiumembedded/cef/blob/master/libcef/browser/views/browser_view_impl.cc)
+- [cef/tests/cefclient/browser/views_window.cc](https://github.com/chromiumembedded/cef/blob/master/tests/cefclient/browser/views_window.cc)
+- [CefView::SetBounds docs](https://magpcss.org/ceforum/apidocs3/projects/(default)/CefView.html)
+- [CefBrowserView API reference](https://cef-builds.spotifycdn.com/docs/120.0/classCefBrowserView.html)

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -56,9 +56,17 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     const createPane = async (url: string) => {
         if (!placeholderRef) return;
         try {
+            // window_label tells the Rust Views path which CefWindow to attach
+            // the pane overlay to. Without it, panes opened in a non-main
+            // window were silently routed to the main window. Same
+            // ?windowLabel=… URL convention as cef-api.ts (defaults to "main"
+            // for the primary window).
+            const windowLabel =
+                new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
             await invokeCommand("browser_pane_create", {
                 block_id: model.blockId,
                 url: url || "about:blank",
+                window_label: windowLabel,
                 ...paneRect(),
             });
             setPaneCreated(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.625",
+      "version": "0.33.626",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1022,7 +1022,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1039,7 +1038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,7 +1054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1073,7 +1070,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1090,7 +1086,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1107,7 +1102,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,7 +1118,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1141,7 +1134,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1158,7 +1150,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1175,7 +1166,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1192,7 +1182,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1209,7 +1198,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1226,7 +1214,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1243,7 +1230,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1260,7 +1246,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1277,7 +1262,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,7 +1278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1311,7 +1294,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,7 +1310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,7 +1326,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,7 +1342,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,7 +1358,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,7 +1374,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1413,7 +1390,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,7 +1406,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1447,7 +1422,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,6 +1649,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1830,6 +1816,21 @@
         "langium": "^4.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1886,7 +1887,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1926,7 +1926,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1947,7 +1946,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1968,7 +1966,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,7 +1986,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,7 +2006,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,7 +2026,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2052,7 +2046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2073,7 +2066,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2094,7 +2086,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2115,7 +2106,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2136,7 +2126,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2157,7 +2146,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2178,7 +2166,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2258,7 +2245,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2272,7 +2258,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2286,7 +2271,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2300,7 +2284,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2314,7 +2297,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2328,7 +2310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2342,7 +2323,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,7 +2336,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,7 +2349,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,7 +2362,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,7 +2375,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,7 +2388,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,7 +2401,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2440,7 +2414,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2454,7 +2427,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2468,7 +2440,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2482,7 +2453,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,7 +2466,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2510,7 +2479,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2524,7 +2492,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,7 +2505,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,7 +2518,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,7 +2531,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2580,7 +2544,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2594,7 +2557,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3702,7 +3664,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4532,6 +4494,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4723,7 +4693,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5575,7 +5545,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5694,7 +5664,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6059,7 +6029,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6176,7 +6145,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6222,7 +6190,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6905,7 +6873,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7057,7 +7025,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7077,7 +7045,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7268,7 +7236,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7514,7 +7482,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7547,7 +7515,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7568,7 +7535,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7589,7 +7555,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7610,7 +7575,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7631,7 +7595,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7652,7 +7615,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7673,7 +7635,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7694,7 +7655,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7715,7 +7675,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7736,7 +7695,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7757,7 +7715,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7822,6 +7779,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9069,7 +9039,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9119,7 +9088,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9408,7 +9376,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9454,7 +9421,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9696,11 +9662,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10015,7 +9994,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10081,7 +10060,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10183,7 +10161,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10392,6 +10370,29 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11106,6 +11107,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/terser": {
+      "version": "5.46.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11196,7 +11225,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11425,7 +11453,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11445,7 +11473,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11517,7 +11544,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11748,7 +11775,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11915,7 +11941,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11932,7 +11957,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11949,7 +11973,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11966,7 +11989,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11983,7 +12005,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12000,7 +12021,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12017,7 +12037,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12034,7 +12053,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12051,7 +12069,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12068,7 +12085,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,7 +12101,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12102,7 +12117,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12119,7 +12133,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12136,7 +12149,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12153,7 +12165,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12170,7 +12181,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12187,7 +12197,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12204,7 +12213,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12221,7 +12229,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12238,7 +12245,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12255,7 +12261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12272,7 +12277,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12289,7 +12293,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12306,7 +12309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12323,7 +12325,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12340,7 +12341,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,7 +12354,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12396,7 +12395,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12835,6 +12833,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Linux/macOS embedded browser panes (`defwidget@browser`) showed a black screen because the non-Windows code path in `browser_pane/creation.rs` was a stubbed `tracing::warn! + return`. This implements the Views-based pane creation per the design spec / research doc committed alongside this PR.

## Architecture

The Windows native-child-window path (`WindowInfo::set_as_child(parent_hwnd, rect)`) doesn't work on Linux Wayland (cef#2804 — the proposed `wl_subsurface` API isn't upstreamed and even when it ships is too constrained for hide/show/move). macOS embedded non-Views is officially unsupported by the CEF maintainer (cef-forum t=19688). The Views framework is the only viable cross-platform path.

Pane creation now uses **`Window::add_overlay_view`** (returning a `CefOverlayController`) rather than `add_child_view`. The host UI's main BrowserView fills the window via the existing FillLayout; pane BrowserViews are added as sibling overlays positioned via the controller. **Overlays don't participate in the parent's auto-layout** so multi-pane works without the FillLayout-stacking problem `add_child_view` exhibits.

## Two non-obvious findings during the spike

Both ended up driving the implementation; full notes in the spec's postscript section.

1. **`OverlayController::set_bounds(rect)` is silently ignored** under every `DockingMode` the cef Rust binding exposes — `TOP_LEFT` made the overlay fill the whole window, `CUSTOM` made it 0×0. The post-create diagnostic readback (`oc_w=0 oc_h=0`) caught this in one round-trip via the spike. The working pattern is `set_size(Size) + set_position(Point) + window.layout()`. We use `DockingMode::CUSTOM` to opt out of corner-docking altogether.

2. **`add_child_view` is the wrong primitive** even when paired with explicit `set_bounds`: the Window's default FillLayout reasserts "fill parent" on every layout pass and clobbers explicit bounds. With two FillLayout children both get full-parent-size bounds and the pane stacks on top of the host UI (we observed exactly this — full-window flashing pane). `AddOverlayView` avoids that entirely — overlays live outside the auto-layout system.

## Files

- `agentmux-cef/src/browser_pane/creation_views.rs` (new) — runs on the CEF UI thread. `browser_view_create + add_overlay_view(CUSTOM) + set_size + set_position + set_visible + window.layout()`. Stashes the OverlayController in `state.browser_pane_overlays`. Diagnostic readback of is_visible / is_drawn / bounds — kept post-merge to make future regressions debuggable from the host log alone.
- `agentmux-cef/src/browser_pane/creation.rs` — restructured: Windows native-child path stays inside `cfg(target_os = "windows")` unchanged; non-Windows delegates to `creation_views`. Removed the premature null-HWND check that was hard-aborting all non-Windows pane creates.
- `agentmux-cef/src/state.rs` — `main_window: Mutex<Option<cef::Window>>` and `browser_pane_overlays: Mutex<HashMap<String, OverlayController>>`, both `cfg(not(target_os = "windows"))`. Snapshot-and-drop at every read site (per Phase F.1 reducer discipline).
- `agentmux-cef/src/app.rs` — `AgentMuxWindowDelegate` gains `primary_window_state: Option<Arc<AppState>>`. Main window passes `Some(state)` to cache its handle for pane attach; popups + sub-windows pass `None`.
- `agentmux-cef/src/browser_panes.rs` — resize and close paths split by cfg. Linux/macOS post `ResizeBrowserPaneViewTask` / `DetachBrowserPaneViewTask` to the UI thread (View ops are UI-thread-only). Windows path unchanged.
- `docs/specs/embedded-browser-panes-linux-macos-2026-05-03.md` — full design spec.
- `docs/research/cef-pane-research-2026-05-03.md` — source-cited research backing the Views decision (CEF maintainer quotes, Wayland forum threads, Steam BrowserView precedent, etc.).

The host reducer state machine is unchanged across both paths — `on_after_created` still routes through the existing `client.rs` handler and dispatches `RegisterBrowser` to the reducer's `browsers` map. Pane lifecycle (Live/Closing/Closed) is identical.

## Verified empirically

Drove via the IPC `browser_pane_create` (port + token from the host log; same shape as the frontend's `invokeCommand` call) with `url=https://example.com, rect=(300,150,700,500)`.

Diagnostic readback:
```
oc_x=300 oc_y=150 oc_w=700 oc_h=500 oc_drawn=1 view_attached=1
```

`[pane-load-end]` fired. Two simultaneous panes (the frontend's github pane at its own rect plus the spike example.com pane at this rect) both rendered. Detach via `browser_pane_close` fired `OverlayController destroyed` and the example.com overlay disappeared.

## Risks / follow-ups

- **cef#3790** (overlay regressions in CEF 125) — our libcef is 146.0.179, post-fix.
- **cef#4035** (transparent overlay BrowserViews unsupported) — we use opaque background, not affected.
- **Multi-window panes** — main window only for now. Sub-windows pass `None` for `primary_window_state`. Generalizing needs a per-window-label store; follow-up PR.
- **Windows is untouched** — the existing native-child-window path stays. When Views is proven across more environments, Windows can migrate too and `pane-overlay.ts` (the SetWindowRgn airspace dance) can retire entirely.

## Test plan

- [ ] On Linux/Wayland, open the `defwidget@browser` widget → URL renders at the correct rect (no black screen, no full-window-flashing).
- [ ] Resize the pane via the splitter → BrowserView resizes to match (resize path uses the same set_size + set_position + layout pattern).
- [ ] Open multiple panes simultaneously → all render at their distinct rects.
- [ ] Close a pane → `OverlayController destroyed` fires; the BrowserView disappears.
- [ ] Right-click in the pane → page contextmenu fires.
- [ ] Right-click on host UI header → host context menu fires (no longer suppressed by full-window pane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)