### PR TITLE
feat(agent): agent-pane-state reducer (PR-A, slice #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.619"
+version = "0.33.620"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.619"
+version = "0.33.620"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.619"
+version = "0.33.620"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.619"
+version = "0.33.620"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.618"
+version = "0.33.619"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.618"
+version = "0.33.619"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.618"
+version = "0.33.619"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.618"
+version = "0.33.619"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.618"
+version = "0.33.619"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.619"
+version = "0.33.620"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.618"
+version = "0.33.619"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.619"
+version = "0.33.620"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.619"
+version = "0.33.620"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.618"
+version = "0.33.619"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.619"
+version = "0.33.620"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.618"
+version = "0.33.619"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/frontend-reducer-conventions-2026-05-03.md
+++ b/docs/specs/frontend-reducer-conventions-2026-05-03.md
@@ -1,0 +1,265 @@
+# Frontend Reducer Conventions
+
+**Date:** 2026-05-03
+**Status:** Draft — answers needed on §10 open questions before any new slice is built.
+**Reads-this-first:**
+- `docs/specs/frontend-reducer-architecture-2026-05-03.md` — the spec roadmap; this is spec #2 of 8
+- `docs/specs/agent-pane-document-reducer-2026-05-03.md` — slice #1, shipped as PR #681; serves as the de facto template
+- `frontend/app/store/launcher-event-reducer.ts` — the only pre-existing frontend reducer, single-file pattern
+- `agentmux-srv/src/reducer.rs` — canonical Rust reducer style we're echoing
+
+## Purpose
+
+Define the shared shape every frontend reducer slice follows so we don't accumulate inconsistencies as slices #3–#8 are written. This document is **prescriptive** (when you write a new slice, do it like this) but does NOT mandate retroactive uniformity — `launcher-event-reducer.ts` predates this spec and gets harmonized in slice #6.
+
+This is a conventions spec. No code lands from this doc directly. Code lands from the slices that follow it.
+
+## 1. The reducer function
+
+A reducer slice exports a single pure function:
+
+```ts
+function update(
+    state: SliceState,
+    command: SliceCommand,
+    nowMs?: number,                    // optional time injection for tests
+): { state: SliceState; events: SliceEvent[] };
+```
+
+**Rules:**
+- Pure: no I/O, no async, no global side effects, no console.log inside the reducer.
+- Snapshot-and-drop: never holds a reference to the input state after returning. The returned state is either a new object or — for true no-ops — the same reference.
+- Returns the new state plus an array of events the command produced (typically 0 or 1 event).
+- `nowMs` parameter for time-dependent logic (suppression windows etc.) so tests can deterministically advance time. Defaults to `Date.now()`.
+
+**Why pure:** matches the Rust reducers' contract. A pure function is trivially auditable, replayable, and testable. Side-effects move OUT to the dispatch layer.
+
+## 2. Command and event types
+
+Every slice defines two discriminated unions:
+
+```ts
+type SliceCommand =
+    | { type: "DoX"; payload: ... }
+    | { type: "DoY"; payload: ... };
+
+type SliceEvent =
+    | { type: "x-applied"; ... }
+    | { type: "x-suppressed"; reason: string; ... }
+    | { type: "y-completed"; ... };
+```
+
+**Rules:**
+- Command names use **PascalCase verb-phrases** (`SessionStart`, `StreamFlush`, `UserClear`)
+- Event names use **kebab-case past-tense facts** (`session-started`, `stream-flushed`, `truncate-suppressed`)
+- The split mirrors how the Rust reducers express `Command` vs `Event`. The asymmetry is intentional: commands describe intent ("do X"), events describe outcome ("X happened" / "X was suppressed").
+- Suppressed/dropped commands MUST emit a "negative" event (e.g. `truncate-suppressed`, `update-dropped`) so audit logs reflect the decision, not just successful mutations.
+
+## 3. State shape
+
+```ts
+interface SliceState {
+    // ... domain fields
+}
+
+const initialState = (): SliceState => ({ ... });
+```
+
+**Rules:**
+- `initialState()` is a factory function, not a frozen const — Solid signals don't enjoy shared frozen objects, and tests want fresh state per case.
+- State is **immutable**: each command application returns a new object (or the same reference if nothing changed).
+- Indices/derived data (Map<id, position>, etc.) generally **not** stored — derived per-command from the source-of-truth fields. Storing them invites the index-out-of-sync class of bugs we just fixed in agent-document. Only store when the rebuild cost is genuinely a problem (typically when state has thousands of items).
+
+## 4. The dispatch layer
+
+For per-instance slices (one cell per blockId, paneId, etc.):
+
+```ts
+// Per-key state cell, holding both the reducer state and the projection
+// setter that the cell owns.
+interface Slot {
+    state: SliceState;
+    project: (next: SliceState) => void;   // typically writes to a Solid signal
+}
+
+const slots = new Map<string, Slot>();
+
+export function registerSlot(key: string, project: (s: SliceState) => void): void;
+export function unregisterSlot(key: string): void;
+export function dispatch(key: string, command: SliceCommand): SliceEvent[];
+export function snapshot(key: string): SliceState | null;       // diagnostics + tests
+```
+
+For **global slices** (no key — one state cell for the whole app), drop the Map and key parameter.
+
+**Rules:**
+- `registerSlot` is called **synchronously during component-body execution**, not in `onMount`. Reason: hooks dispatching from their own `onMount` would race the registration. This is a hard rule — codex P1 on PR #681 caught the violation.
+- `unregisterSlot` is called from `onCleanup`. Failure to unregister leaks a state cell.
+- `dispatch` **throws** on unregistered key. Silent drops are the bug we just spent two PRs preventing.
+- `snapshot` is a window for tests + the diagnostics panel. Don't use it for app logic — it bypasses reactivity.
+
+## 5. Atom projection
+
+Components keep using their existing Solid signals. The slot's `project` callback writes through them on each command application. Components don't talk to the slot directly:
+
+```ts
+// OK — component reads the projection
+const [doc] = agentAtoms().documentAtom;
+return <For each={doc()}>{...}</For>;
+
+// OK — hook dispatches a command
+dispatch(blockId, { type: "StreamFlush", ... });
+
+// NOT OK — component writes the projection directly, bypassing slot.state
+setDocument([...]);  // reducer's slot.state is now stale
+```
+
+The projection is **write-only from the slot's perspective**: nothing else writes the atom. Slice #1 (PR #681) caught two violations of this rule (handleDecide, onLoginSuccess) and migrated them to dispatch. Future PRs that introduce new mutators must dispatch.
+
+**Read-only access to a per-slot projection from outside is fine** — components rendering the doc, hooks computing derived values from the doc, etc. Only writes need to go through dispatch.
+
+## 6. Echo-loop guard (inbound events)
+
+For slices that mirror an upstream reducer (srv, launcher, host), the dispatch layer needs an `applyingRemote` flag pattern (modeled on `launcher-event-reducer.ts:54`):
+
+```ts
+let applyingRemote = false;
+
+export function applyRemoteEvent(event: RemoteEvent): void {
+    applyingRemote = true;
+    try {
+        dispatch(event.key, translateRemoteEvent(event));
+    } finally {
+        applyingRemote = false;
+    }
+}
+
+export function isApplyingRemoteEvent(): boolean {
+    return applyingRemote;
+}
+```
+
+Outbound command paths check the flag before re-emitting the change upstream. Without this, a state change from srv triggers a frontend command which sends back to srv which echoes another event which triggers another command — infinite loop.
+
+**Slices that don't mirror upstream state can skip this** (the agent-document slice has no upstream — the document IS frontend-only).
+
+## 7. Audit log
+
+Each slice keeps a ring buffer of the last N events (default 200, per slice). Emitted via the dispatch layer's `onEvent` sink. The diagnostics panel will surface these in a future PR.
+
+```ts
+const eventLog: { key: string; event: SliceEvent; at: number }[] = [];
+
+function recordEvent(key: string, event: SliceEvent) {
+    eventLog.push({ key, event, at: Date.now() });
+    if (eventLog.length > 200) eventLog.shift();
+}
+```
+
+The agent-document slice currently logs significant events to `console.warn` (suppressed truncates, dropped updates) but doesn't ring-buffer. Adding the buffer is a follow-up.
+
+## 8. Tests
+
+Three layers:
+
+### Reducer tests (the primary safety net)
+- Pure, table-driven.
+- One file per slice: `<slice>/reducer.test.ts`.
+- Cover: each command's happy path; each invariant (suppression, dedup, dropped); purity (input not mutated, no-op returns same reference).
+- Should run in <5 seconds per slice.
+
+### Dispatch tests
+- Optional but recommended for slices with non-trivial slot lifecycle.
+- Cover: register/dispatch/unregister cycle; throw-on-unregistered-dispatch; project callback called with new state.
+
+### Slice-specific tests
+- For mirror slices: echo-loop guard works (dispatches inside `applyRemoteEvent` don't re-emit upstream).
+- For async-coordinated slices: pending command tracking + rollback (deferred until any slice actually needs this).
+
+## 9. File layout
+
+```
+frontend/app/store/<slice-name>/
+    reducer.ts               # pure update() + helpers
+    types.ts                 # State, Command, Event, initialState
+    reducer.test.ts          # table-driven reducer tests
+frontend/app/store/<slice-name>-store.ts   # dispatch layer, slot map, public API
+```
+
+The split between `<slice>/` (the pure core) and `<slice>-store.ts` (the dispatch layer) lets tests import the pure reducer without dragging in atom dependencies.
+
+For tiny slices (no slot map, single global state), the store file may be redundant — collapse the dispatch into the reducer module's index.
+
+## 10. Open architectural questions — answers proposed
+
+### Q1. Single bus vs. per-slice dispatch?
+
+**Proposed answer:** **per-slice dispatch.** Each slice exports its own `dispatch(key, command)` function. The agent-document slice does this; launcher-event-reducer does this; new slices follow suit.
+
+**Rationale:** A single bus would force every command into a discriminated union spanning all slices, which adds friction without adding value — slices have no need to coordinate at the dispatch layer. The audit log can be made global by sharing a recordEvent function across slices. We keep the dispatch shape symmetric with the Rust reducers (each crate has its own dispatch, no super-bus).
+
+**Reconsider when:** slices need to dispatch atomically across each other (e.g. "select tab AND focus pane" as one transactional unit). Today no use case for this.
+
+### Q2. Inbound event routing — single subscription or per-slice?
+
+**Proposed answer:** **per-slice subscription.** Each mirror-slice subscribes to its own upstream channel (wstore for srv-state slices; launcher-events signal for launcher-state slices).
+
+**Rationale:** Mirrors what `launcher-event-reducer.ts` already does. A single subscription router would need to know which events route to which slice, duplicating the slice's own knowledge of its concern. Per-slice keeps slices independent.
+
+**Reconsider when:** event ordering across slices becomes load-bearing (e.g. tab-switch must apply before pane-focus to avoid flicker). Solvable with explicit ordering hints if needed.
+
+### Q3. Async commands — how do they fit a synchronous dispatch model?
+
+**Proposed answer:** **synchronous dispatch always; async work happens before or after.**
+
+For "create pane" (which needs an srv RPC):
+1. Caller dispatches a local command if optimistic UI is needed (e.g. `PaneCreatePending { localId, blockDef }`)
+2. Caller fires the srv RPC
+3. On srv response (async), caller dispatches a confirm command (`PaneCreateConfirmed { localId, srvId }`) or a rollback (`PaneCreateRejected { localId, error }`)
+
+The reducer never sees promises. The `localId` correlates the optimistic and confirming commands.
+
+**Rationale:** Mirrors the Rust reducer pattern (sagas live outside the reducer). Keeps the reducer pure. Optimistic-UI is opt-in per command, not framework-level.
+
+**Reconsider when:** this rollback boilerplate becomes painful in practice — could justify a small "pending command tracker" helper. Defer until 2+ slices need it.
+
+### Q4. Where does policy enforcement live (e.g. "this agent may not delete that pane")?
+
+**Proposed answer:** **in the slice that owns the resource, not in a shared bus.**
+
+A slice that owns "panes" (per spec #8) gates `PaneDelete` based on policy in its reducer. The reducer can read a permission table from state (which itself was populated via another command). No middleware, no AOP magic.
+
+**Rationale:** Policy is domain-specific. Putting it in the reducer makes it auditable + testable like any other invariant. Spec #3 (frontend-command-bus) was originally framed as a chokepoint for policy; on reflection the chokepoint is the dispatch function itself, not a separate bus layer.
+
+**Reconsider when:** policy genuinely cuts across slices (e.g. "this agent is sandboxed; deny all UI mutations from it"). At that point, an outer wrapper around dispatch (a true middleware) might be warranted. Today no slice has cross-cutting policy.
+
+### Q5. Optimistic updates — per-slice or framework-level?
+
+**Proposed answer:** **per-slice, opt-in.**
+
+Slices that need optimistic UI implement it via the pending-command pattern (Q3). No framework support today.
+
+**Rationale:** Most slices won't need optimistic updates (srv is local, latency is small). Building a framework feature for a non-pressing problem is over-design.
+
+**Reconsider when:** 2+ slices need optimistic + rollback and the duplication becomes obvious.
+
+## 11. What this spec does NOT establish
+
+- A central frontend store object. Slices are independent modules; no `appStore.subscribe()` etc.
+- Middleware / interceptors / decorators around dispatch. No use case yet.
+- Time-travel debugging. Audit log gives us the data; UI is a future feature.
+- Type-level enforcement that "all writes go through dispatch" (no compile-time guarantee — relies on convention + code review).
+
+## 12. Sequencing impact on slices #3–#8
+
+With these conventions in place:
+- **Slice #3** (frontend-command-bus): partly DESCOPED. Per Q1+Q4, no separate bus is needed — each slice's `dispatch` is the chokepoint for its domain. The remaining concern in #3 (audit + cross-cutting agent-action attribution) shrinks to "global event log helper" + "command-source tagging" (`{ source: 'user' | 'agent:<id>' | 'system' }`). Will rewrite spec #3 once #2 is approved.
+- **Slice #4** (agent-pane-state-reducer): straightforwardly follows §1–§9.
+- **Slice #5** (frontend-layout-reducer): mirror slice; uses the echo-loop guard from §6.
+- **Slice #6** (launcher-event-reducer convergence): mostly already follows the conventions; tightens slot lifecycle + audit log.
+- **Slice #7** (tab-state-reducer): mirror slice; same as #5.
+- **Slice #8** (pane-tree-reducer): wait for srv E.4.B as before.
+
+## 13. Decision log
+
+This section will accumulate decisions made in subsequent slices that affect the conventions. (Empty at draft time.)

--- a/docs/specs/frontend-reducer-implementation-plan-2026-05-03.md
+++ b/docs/specs/frontend-reducer-implementation-plan-2026-05-03.md
@@ -1,0 +1,257 @@
+# Frontend Reducer Implementation Plan
+
+**Date:** 2026-05-03
+**Status:** Draft. Each PR section needs a quick "go" before its code lands.
+**Reads-this-first:**
+- `frontend-reducer-architecture-2026-05-03.md` — the spec roadmap (slices #1–#8)
+- `frontend-reducer-conventions-2026-05-03.md` — shape every slice follows
+- `agent-pane-document-reducer-2026-05-03.md` — slice #1, shipped as PR #681
+
+## Status snapshot
+
+| Slice | Status | PR | Notes |
+|---|---|---|---|
+| #1 agent-document | **Shipped** | #681 (0.33.618) | Bug fix; established the pattern |
+| #2 conventions | **Spec approved** | — (doc only) | Now drives all later slices |
+| #3 source-tagging + global event log | **Spec needs rewrite** | — | Descoped per conventions Q1+Q4 |
+| #4 agent-pane-state | Spec pending | — | Highest value, no deps |
+| #5 frontend-layout | Spec pending | — | Depends on srv E.4 |
+| #6 launcher-event-reducer convergence | Spec pending | — | Cleanup; validates conventions retroactively |
+| #7 tab-state | Spec pending | — | Mirror slice |
+| #8 pane-tree | **Deferred** | — | Wait for srv E.4.B |
+
+## Sequencing rationale
+
+Dependencies:
+
+```
+#1 (shipped) ──────────┐
+                       │
+#2 (approved) ─────────┼──→ #4 ──→ #6 ──→ #3 ──→ #7 ──→ #5 ──→ (#8 — wait)
+                       │       \                           ↑
+srv E.4 (in flight) ───┴───────────────────────────────────┘
+```
+
+The order is chosen for:
+
+1. **#4 first** — per-pane slice, no upstream dependency, immediate value (cleans up the other multi-writer agent atoms before they bite).
+2. **#6 second** — convergence of `launcher-event-reducer.ts` to the conventions. Small. Validates that the conventions actually fit a real pre-existing reducer; surfaces gaps before they multiply.
+3. **#3 third** — source-tagging + global event log. Now small (per Q1+Q4). Valuable as a debuggability feature; lights up the audit story for #1, #4, #6.
+4. **#7 fourth** — tab-state mirror slice. First pure mirror; exercises §6 echo-loop guard end-to-end.
+5. **#5 fifth** — layout mirror, depends on srv E.4.A landing first. If srv E.4.A delays, swap with #7 or pull forward a smaller mirror.
+6. **#8 deferred** — needs srv E.4.B to settle the rootnode path-representation question.
+
+## Concrete PRs
+
+Each section below specifies what the PR ships. Effort estimates assume contiguous focus, no surprise blockers.
+
+---
+
+### PR-A — Slice #4: agent-pane-state-reducer
+
+**Goal:** bundle the remaining per-pane agent atoms (`streamingState`, `sessionStats`, `currentTool`, `turnTokens`, `turnActive`, `stopping`, `pendingMessages`) into one slot-keyed reducer that enforces cross-atom invariants.
+
+**Why now:** Same architectural problem as agent-document but smaller blast radius. Multiple writers across `useAgentStream` (lifecycle), `agent-model.ts` (composer/decision flow), and possibly slash commands. No single bug observed yet, but the cohesion `turnActive ↔ streamingState.active ↔ stoppingAtom` is fragile and a future race waits to land.
+
+**Scope:**
+
+| File | Change |
+|---|---|
+| `frontend/app/store/agent-pane-state/types.ts` | NEW — `AgentPaneState`, `Command`, `Event` |
+| `frontend/app/store/agent-pane-state/reducer.ts` | NEW — pure update() |
+| `frontend/app/store/agent-pane-state/reducer.test.ts` | NEW — table-driven tests |
+| `frontend/app/store/agent-pane-state-store.ts` | NEW — slot map + dispatch (mirrors agent-document-store) |
+| `frontend/app/view/agent/state.ts` | Atoms become projections; factory still creates them but readers don't change |
+| `frontend/app/view/agent/agent-view.tsx` | Register slot synchronously alongside agent-document slot |
+| `frontend/app/view/agent/useAgentStream.ts` | All `setStreaming`, `setSessionStats`, `setCurrentTool`, `setTurnTokens`, `setTurnActive` → dispatch |
+| `frontend/app/view/agent/agent-model.ts` | All composer/decision-flow writes to these atoms → dispatch |
+
+**Commands** (proposed):
+- `SessionLifecycle { action: "subscribe-up" \| "subscribe-down" }` — toggles `streamingState.active`
+- `TurnStart { at }` — `turnActive = true`
+- `TurnEnd { stats? }` — `turnActive = false`, optional stats merge
+- `RequestStop { at }` — `stopping = true`
+- `StopApplied { at }` — clears `stopping`
+- `ToolStart { name }` / `ToolEnd` — `currentTool` setter
+- `TokenDelta { input?, output? }` — `turnTokens` increment
+- `PendingMessageQueued { id, text }` / `PendingMessageAccepted { id }` — pending FIFO
+
+**Invariants the reducer enforces** (the value-add over scattered atoms):
+- `turnActive` cannot be true while `streamingState.active` is false
+- `stopping` clears automatically on any `TurnEnd`
+- `currentTool` and `turnTokens` clear on `TurnEnd`
+- `pendingMessages` is a strict FIFO; accepting an id removes it (idempotent for unknown ids)
+
+**Tests:** ~20 reducer tests (one per invariant, plus happy paths).
+
+**Effort:** ~1.5 days. Mostly mechanical migration; the design work is small.
+
+**Risk:** medium — touches the agent view's lifecycle code which is the most-watched code path in the app. Mitigations: ship behind a fresh patch version; smoke-test in `task dev` before merging; keep the reducer's behavior semantically identical to today's atom mutations (only tighten the cohesion).
+
+**Open question:** does `pendingMessagesAtom` belong with the lifecycle atoms or in its own slice? Today it's coupled to the composer + agent-message-accepted event handler; I lean toward keeping it here but could justify a separate composer slice.
+
+---
+
+### PR-B — Slice #6: launcher-event-reducer convergence
+
+**Goal:** harmonize the existing `frontend/app/store/launcher-event-reducer.ts` into the conventions established in spec #2.
+
+**Why now:** Validates the conventions retroactively. If something in the conventions doesn't fit the launcher reducer, that's a sign the conventions need a tweak — better to learn this with a small known-good reducer than mid-way through a bigger slice.
+
+**Scope:**
+
+| File | Change |
+|---|---|
+| `frontend/app/store/launcher-event-reducer.ts` | Extract pure `update()` to `launcher-event/reducer.ts`; current file becomes the dispatch + slot layer |
+| `frontend/app/store/launcher-event/types.ts` | NEW — extracted Command/Event types (from existing inline types) |
+| `frontend/app/store/launcher-event/reducer.test.ts` | NEW — backfill table-driven tests for the existing arms |
+| `frontend/util/launcher-events.ts` | Wire to the new dispatch (no logic change) |
+
+**No behavior change.** Pure refactor + test backfill. Echo-loop guard (`applyingRemote`) stays exactly as is — it was the model for the convention.
+
+**Effort:** 0.5 day.
+
+**Risk:** low — refactor of code that already works.
+
+**Decision point:** does the launcher-event-reducer's seed mechanism (`seedKnownEntriesFromSnapshot`) generalize to a conventions feature, or stay launcher-specific? Lean toward launcher-specific until a second slice needs it.
+
+---
+
+### PR-C — Slice #3 (revised): source-tagging + global event log
+
+**Goal:** add a small cross-slice helper that tracks WHO initiated each command (user, agent:<id>, system) and aggregates events into a single ring buffer for the diagnostics panel.
+
+**Why now:** Cheap but high-value once enough slices exist. Lights up the audit story — you can ask "what did agent X do in the last hour?" and get a real answer.
+
+**Why this is much smaller than the original spec #3:**
+Per conventions Q1+Q4, there's no command bus chokepoint to build. The chokepoint is each slice's `dispatch`. This PR adds two things on top of dispatch:
+
+1. **`CommandSource` type + threading.** Every `dispatch(key, command)` callsite gets an optional `source: CommandSource` parameter. Defaults to `"system"`. Slash commands set `"user"`. Future agent-API surface sets `{ kind: "agent", agentId }`.
+
+2. **Global event log.** A single ring buffer (~500 entries) collects `{slice, key, command, source, events, at}` records. Diagnostics panel surfaces it.
+
+**Scope:**
+
+| File | Change |
+|---|---|
+| `frontend/app/store/command-source.ts` | NEW — `CommandSource` type + global event log + helpers |
+| `frontend/app/store/agent-document-store.ts` | Accept optional `source` parameter on dispatch; record to global log |
+| `frontend/app/store/agent-pane-state-store.ts` | Same |
+| `frontend/app/store/launcher-event-reducer.ts` | Same |
+| All dispatch callsites | Pass `source` where known; default unchanged |
+
+**Effort:** 1 day.
+
+**Risk:** low. Backward-compatible — `source` is optional with a sensible default.
+
+**Decision point:** does the global event log live in memory only, or also write to a file (debug.log)? Default in spec: memory only; opt-in file flag.
+
+---
+
+### PR-D — Slice #7: tab-state-reducer
+
+**Goal:** frontend mirror of srv tab state (active tab, tab order, per-tab metadata). First pure mirror slice; validates §6 echo-loop guard.
+
+**Why now:** After #6 has converged the existing mirror, this is the second mirror — pattern is proven. Tabs are a high-frequency mutation site (new tabs, drags, closes) so the audit log immediately gives value.
+
+**Scope:**
+
+| File | Change |
+|---|---|
+| `frontend/app/store/tab-state/types.ts` | NEW — TabState, Command (local), Event |
+| `frontend/app/store/tab-state/reducer.ts` | NEW — pure update() |
+| `frontend/app/store/tab-state/reducer.test.ts` | NEW |
+| `frontend/app/store/tab-state-store.ts` | NEW — dispatch + wstore subscription + echo-loop guard |
+| `frontend/app/store/global.ts` | Existing tab atoms become projections; factories untouched |
+| `frontend/app/tab/*.tsx` | Local UI commands dispatch through the store (no longer write atoms directly) |
+
+**Mirror semantics:**
+- Wstore objects update → `applyRemoteEvent({ type: 'TabUpdated', tab })` → dispatch echoes to local atoms
+- Local UI commands (e.g. user clicks a tab) → dispatch → emits the command upstream via existing RPC; the echo-loop guard prevents the resulting wstore event from re-emitting
+
+**Effort:** ~3 days (more careful than per-pane slices because mirror semantics are subtler).
+
+**Risk:** medium — touches global tab atoms used in many places. Mitigations: read-side projection means consumers don't change; only mutation sites move.
+
+**Decision point:** does `pendingbackendactions` (per-tab queue of pending layout ops; see srv `LayoutState`) belong here or in slice #5? Lean toward keeping in this slice since it's per-tab.
+
+---
+
+### PR-E — Slice #5: frontend-layout-reducer
+
+**Goal:** frontend mirror of srv Phase E.4 layout reducer (focused node, magnified node, leaf order). Coordinates with srv-side `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`.
+
+**Why this comes after #7:** layout mirror semantics are the same as tab mirror semantics, but layout has thornier per-pane state (focused/magnified vary per-tab). Better to bake the mirror pattern on tab first, then extend to layout.
+
+**Blocking dependency:** srv E.4.A (focused/magnified PR) must ship first. If srv E.4.A is delayed, this PR slot can be filled by another non-blocking slice.
+
+**Scope:**
+
+| File | Change |
+|---|---|
+| `frontend/app/store/layout-state/types.ts` | NEW |
+| `frontend/app/store/layout-state/reducer.ts` | NEW — `SetFocusedNode`, `SetMagnifiedNode`, `RebuildLeafOrder` |
+| `frontend/app/store/layout-state/reducer.test.ts` | NEW |
+| `frontend/app/store/layout-state-store.ts` | NEW — dispatch + wstore sub + echo-loop guard |
+| `frontend/layout/*.ts` | Existing focus/magnify atoms become projections |
+
+**Out of scope** (pending srv E.4.B): `rootnode` path-representation. The current `rootnode` JSON-blob path stays as-is until srv decides on the path representation.
+
+**Effort:** ~3 days (assumes srv E.4.A is in main).
+
+**Risk:** medium — layout state is the most-touched per-frame state in the app. Mirror pattern means reads don't change, but bugs would manifest as visual glitches.
+
+**Decision point:** none new (srv E.4 spec already settled the granularity question for the srv side).
+
+---
+
+### Slice #8 — pane-tree-reducer (deferred)
+
+Wait for srv E.4.B (path representation for rootnode). Until that lands, frontend keeps shipping rootnode mutations directly to the wstore meta path.
+
+---
+
+## Cross-cutting work
+
+Two things outside any specific slice that should land alongside the work above:
+
+### Diagnostics panel surface
+
+After PR-C ships, build a simple diagnostics panel that shows the global event log. Probably a new tab in the existing diagnostics surface, or a slash command (`/events`) that opens a modal. **Effort: 0.5 day.** Punt to whenever bandwidth allows after PR-C.
+
+### Documentation
+
+Each slice's PR includes a short README in its directory linking back to the conventions doc + the slice's own decisions. After all slices land, write a single `frontend/app/store/README.md` summarizing the architecture for new contributors. **Effort: 1 hour at the end.**
+
+## Total effort + calendar
+
+| PR | Effort | Cumulative |
+|---|---|---|
+| PR-A (#4 agent-pane-state) | 1.5d | 1.5d |
+| PR-B (#6 launcher convergence) | 0.5d | 2d |
+| PR-C (#3 source-tagging + log) | 1d | 3d |
+| PR-D (#7 tab-state) | 3d | 6d |
+| PR-E (#5 layout) | 3d (after srv E.4.A) | 9d |
+| Diagnostics panel | 0.5d | 9.5d |
+| README | 0.1d | ~10d |
+
+**~10 working days of focused work** to converge most of the frontend mutation surface. Some PRs can parallelize if more than one person works the queue (PR-B and PR-C don't depend on each other; PR-D and PR-E are independent of the others once #6 is in).
+
+## Decision points (one-line summary)
+
+1. **PR-A**: pendingMessages in the agent-pane-state slice or its own slice? (lean: same slice)
+2. **PR-B**: generalize the seed mechanism, or keep it launcher-specific? (lean: launcher-specific)
+3. **PR-C**: global event log in memory only, or also written to debug.log? (lean: memory only, opt-in file)
+4. **PR-D**: pendingbackendactions in tab-state slice or layout slice? (lean: tab-state)
+5. **Slice #5 timing**: do we hold for srv E.4.A or rearrange? (depends on srv schedule)
+
+## What this plan does NOT commit to
+
+- Replacing the wstore subscription mechanism. wstore stays — it's the inbound event channel for mirror slices.
+- Component-level state migration. Per-component `createSignal` for UI chrome (open/closed, hover, etc.) stays as-is.
+- Backward-compatibility shims. Each slice migration is a clean cutover; consumers reading projection atoms don't change, but writers must move to dispatch in the same PR.
+- A "frontend redux store" object. Slices remain independent modules.
+
+## Stop conditions
+
+If at any point in the plan it becomes clear that an unforeseen architectural concern requires a re-spec, **pause and write a retro before continuing**. Better to absorb the new constraint into the conventions than to ship two slices that disagree on a fundamental.

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -1,0 +1,122 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent pane state store — slice #4 of the frontend reducer roadmap.
+ * Bundles the per-pane lifecycle/turn/tool/tokens/stop/pending atoms.
+ *
+ * Pattern matches agent-document-store.ts: per-blockId slot, atoms as
+ * write-only projections, throw on unregistered dispatch. Conventions
+ * §4–§5 (frontend-reducer-conventions-2026-05-03.md).
+ */
+
+import type { PendingMessage } from "../view/agent/state";
+import type {
+    SessionStats,
+    StreamingState,
+    TurnTokens,
+} from "../view/agent/types";
+import { update } from "./agent-pane-state/reducer";
+import {
+    AgentPaneCommand,
+    AgentPaneEvent,
+    AgentPaneState,
+    initialState,
+} from "./agent-pane-state/types";
+
+/**
+ * The set of projection setters the slot writes to. Each one corresponds
+ * to a pre-existing per-pane Solid signal in `createAgentAtoms`. Readers
+ * keep using the existing accessors; only writes are routed through this
+ * store.
+ */
+export interface AgentPaneProjections {
+    streaming: (next: StreamingState) => void;
+    sessionStats: (next: SessionStats | null) => void;
+    currentTool: (next: string | null) => void;
+    turnTokens: (next: TurnTokens | null) => void;
+    turnActive: (next: boolean) => void;
+    stopping: (next: boolean) => void;
+    pending: (next: PendingMessage[]) => void;
+}
+
+interface Slot {
+    state: AgentPaneState;
+    proj: AgentPaneProjections;
+}
+
+const slots = new Map<string, Slot>();
+
+type EventSink = (blockId: string, event: AgentPaneEvent) => void;
+let eventSink: EventSink = (blockId, event) => {
+    if (event.type === "turn-start-suppressed") {
+        console.warn(
+            `[agent-pane-state] turn-start suppressed for ${blockId.slice(0, 7)}: ${event.reason}`,
+        );
+    }
+};
+
+export function setEventSink(sink: EventSink): void {
+    eventSink = sink;
+}
+
+/**
+ * Register a pane. Call SYNCHRONOUSLY from the component body, before
+ * any hook can dispatch. Re-registering a blockId resets the state cell
+ * to initialState (useful for hot-reload).
+ */
+export function registerPane(
+    blockId: string,
+    agentId: string,
+    proj: AgentPaneProjections,
+): void {
+    slots.set(blockId, { state: initialState(agentId), proj });
+}
+
+export function unregisterPane(blockId: string): void {
+    slots.delete(blockId);
+}
+
+/**
+ * Apply a command. Throws on unregistered blockId — silent drops would
+ * defeat the point of the reducer (same rule as agent-document-store).
+ */
+export function dispatch(
+    blockId: string,
+    command: AgentPaneCommand,
+): AgentPaneEvent[] {
+    const slot = slots.get(blockId);
+    if (!slot) {
+        throw new Error(
+            `[agent-pane-state] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously in the component body.`,
+        );
+    }
+    const prev = slot.state;
+    const result = update(prev, command);
+    slot.state = result.state;
+
+    // Project changes — only call setters for fields that actually
+    // changed (referential equality). Avoids redundant signal writes.
+    if (slot.state.streaming !== prev.streaming) slot.proj.streaming(slot.state.streaming);
+    if (slot.state.sessionStats !== prev.sessionStats) slot.proj.sessionStats(slot.state.sessionStats);
+    if (slot.state.currentTool !== prev.currentTool) slot.proj.currentTool(slot.state.currentTool);
+    if (slot.state.turnTokens !== prev.turnTokens) slot.proj.turnTokens(slot.state.turnTokens);
+    if (slot.state.turnActive !== prev.turnActive) slot.proj.turnActive(slot.state.turnActive);
+    if (slot.state.stopping !== prev.stopping) slot.proj.stopping(slot.state.stopping);
+    if (slot.state.pending !== prev.pending) slot.proj.pending(slot.state.pending);
+
+    for (const ev of result.events) eventSink(blockId, ev);
+    return result.events;
+}
+
+/** Snapshot — diagnostics + tests only. */
+export function snapshot(blockId: string): AgentPaneState | null {
+    return slots.get(blockId)?.state ?? null;
+}
+
+/** Test/dev helper. */
+export function __resetAllSlots(): void {
+    slots.clear();
+}
+
+export type { AgentPaneCommand, AgentPaneEvent, AgentPaneState };

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -33,8 +33,10 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("StreamFlushObserved is no-op when stream inactive", () => {
-            const r = update(mk(), { type: "StreamFlushObserved", addedCount: 3, at: 110 });
-            expect(r.state).toBe(mk() && r.state); // unchanged
+            const start = mk();
+            const r = update(start, { type: "StreamFlushObserved", addedCount: 3, at: 110 });
+            // Reducer must return SAME reference when no work was done.
+            expect(r.state).toBe(start);
             expect(r.events).toEqual([]);
         });
     });

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -1,0 +1,229 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { update } from "./reducer";
+import { initialState } from "./types";
+
+const mk = () => initialState("test-agent");
+
+describe("agent-pane-state reducer", () => {
+    describe("Stream lifecycle", () => {
+        it("StreamSubscribe sets active + lastEventTime", () => {
+            const r = update(mk(), { type: "StreamSubscribe", at: 100 });
+            expect(r.state.streaming.active).toBe(true);
+            expect(r.state.streaming.lastEventTime).toBe(100);
+            expect(r.events[0]).toMatchObject({ type: "stream-subscribed", at: 100 });
+        });
+
+        it("StreamUnsubscribe clears active and force-clears turnActive", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            expect(s1.turnActive).toBe(true);
+            const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
+            expect(r.state.streaming.active).toBe(false);
+            expect(r.state.turnActive).toBe(false);
+        });
+
+        it("StreamFlushObserved bumps bufferSize when active", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const r = update(s0, { type: "StreamFlushObserved", addedCount: 3, at: 110 });
+            expect(r.state.streaming.bufferSize).toBe(3);
+            expect(r.state.streaming.lastEventTime).toBe(110);
+        });
+
+        it("StreamFlushObserved is no-op when stream inactive", () => {
+            const r = update(mk(), { type: "StreamFlushObserved", addedCount: 3, at: 110 });
+            expect(r.state).toBe(mk() && r.state); // unchanged
+            expect(r.events).toEqual([]);
+        });
+    });
+
+    describe("Turn lifecycle invariants", () => {
+        it("TurnStart while stream inactive is suppressed", () => {
+            const start = mk();
+            const r = update(start, { type: "TurnStart", at: 100 });
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state).toBe(start);
+            expect(r.events[0]).toMatchObject({ type: "turn-start-suppressed" });
+        });
+
+        it("TurnStart while active sets turnActive + clears stale stats", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const sWithStats = { ...s0, sessionStats: { input_tokens: 50, output_tokens: 100 } };
+            const r = update(sWithStats, { type: "TurnStart", at: 110 });
+            expect(r.state.turnActive).toBe(true);
+            expect(r.state.sessionStats).toBe(null);
+        });
+
+        it("TurnEnd clears tool/tokens/turnActive AND stopping in one shot", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "ToolStart", name: "Read" }).state;
+            const s3 = update(s2, { type: "TokensIn", input: 50 }).state;
+            const s4 = update(s3, { type: "TokensOut", output: 200 }).state;
+            const s5 = update(s4, { type: "RequestStop", at: 120 }).state;
+            const r = update(s5, {
+                type: "TurnEnd",
+                stats: null,
+            });
+            expect(r.state.turnActive).toBe(false);
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnTokens).toBe(null);
+            expect(r.state.stopping).toBe(false);
+            // Stats merged from live tokens (mergeStats fallback path).
+            expect(r.state.sessionStats).toEqual({ input_tokens: 50, output_tokens: 200 });
+            expect(r.events[0]).toMatchObject({
+                type: "turn-ended",
+                statsMerged: true,
+                stoppingCleared: true,
+            });
+        });
+
+        it("TurnEnd with explicit stats merges live token totals", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "TokensIn", input: 80 }).state;
+            const r = update(s2, {
+                type: "TurnEnd",
+                stats: { input_tokens: 0, output_tokens: 0, total_cost_usd: 0.05 } as any,
+            });
+            expect(r.state.sessionStats).toMatchObject({
+                input_tokens: 80,
+                output_tokens: 0,
+                total_cost_usd: 0.05,
+            });
+        });
+
+        it("TurnReset clears turn-scoped state but keeps streaming + pending", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s1 = update(s0, {
+                type: "PendingMessageQueued",
+                id: "p1",
+                text: "hello",
+                at: 105,
+            }).state;
+            const s2 = update(s1, { type: "TurnStart", at: 110 }).state;
+            const s3 = update(s2, { type: "ToolStart", name: "Edit" }).state;
+            const r = update(s3, { type: "TurnReset" });
+            expect(r.state.streaming.active).toBe(true); // preserved
+            expect(r.state.pending).toHaveLength(1); // preserved
+            expect(r.state.currentTool).toBe(null);
+            expect(r.state.turnActive).toBe(false);
+        });
+    });
+
+    describe("Tool", () => {
+        it("ToolStart sets currentTool", () => {
+            const r = update(mk(), { type: "ToolStart", name: "Bash" });
+            expect(r.state.currentTool).toBe("Bash");
+        });
+
+        it("ToolEnd clears", () => {
+            const s0 = update(mk(), { type: "ToolStart", name: "Bash" }).state;
+            const r = update(s0, { type: "ToolEnd" });
+            expect(r.state.currentTool).toBe(null);
+        });
+    });
+
+    describe("Tokens", () => {
+        it("TokensIn / TokensOut accumulate independently", () => {
+            const s0 = update(mk(), { type: "TokensIn", input: 50 }).state;
+            const s1 = update(s0, { type: "TokensOut", output: 100 }).state;
+            expect(s1.turnTokens).toEqual({ input: 50, output: 100 });
+        });
+
+        it("TokensIn preserves prior output", () => {
+            const s0 = update(mk(), { type: "TokensOut", output: 100 }).state;
+            const s1 = update(s0, { type: "TokensIn", input: 50 }).state;
+            expect(s1.turnTokens).toEqual({ input: 50, output: 100 });
+        });
+    });
+
+    describe("Stop flow", () => {
+        it("RequestStop sets stopping", () => {
+            const r = update(mk(), { type: "RequestStop", at: 100 });
+            expect(r.state.stopping).toBe(true);
+        });
+
+        it("StopFailed clears stopping", () => {
+            const s0 = update(mk(), { type: "RequestStop", at: 100 }).state;
+            const r = update(s0, { type: "StopFailed" });
+            expect(r.state.stopping).toBe(false);
+        });
+
+        it("TurnEnd clears stopping (the normal path — no explicit StopApplied needed)", () => {
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
+            const s2 = update(s1, { type: "RequestStop", at: 120 }).state;
+            const r = update(s2, { type: "TurnEnd", stats: null });
+            expect(r.state.stopping).toBe(false);
+        });
+    });
+
+    describe("Pending message FIFO", () => {
+        it("Queue then accept removes the entry", () => {
+            const s0 = update(mk(), {
+                type: "PendingMessageQueued",
+                id: "m1",
+                text: "hi",
+                at: 100,
+            }).state;
+            expect(s0.pending).toHaveLength(1);
+            const r = update(s0, { type: "PendingMessageAccepted", id: "m1" });
+            expect(r.state.pending).toHaveLength(0);
+            expect(r.events[0]).toMatchObject({ type: "pending-accepted", wasPresent: true });
+        });
+
+        it("Accepting unknown id is idempotent no-op (with audit event)", () => {
+            const start = mk();
+            const r = update(start, { type: "PendingMessageAccepted", id: "ghost" });
+            expect(r.state).toBe(start);
+            expect(r.events[0]).toMatchObject({ type: "pending-accepted", wasPresent: false });
+        });
+
+        it("Reject removes the entry", () => {
+            const s0 = update(mk(), {
+                type: "PendingMessageQueued",
+                id: "m1",
+                text: "hi",
+                at: 100,
+            }).state;
+            const r = update(s0, { type: "PendingMessageRejected", id: "m1" });
+            expect(r.state.pending).toHaveLength(0);
+        });
+
+        it("Preserves FIFO order across multiple queues", () => {
+            const s0 = update(mk(), {
+                type: "PendingMessageQueued",
+                id: "a",
+                text: "1",
+                at: 100,
+            }).state;
+            const s1 = update(s0, {
+                type: "PendingMessageQueued",
+                id: "b",
+                text: "2",
+                at: 110,
+            }).state;
+            const s2 = update(s1, {
+                type: "PendingMessageQueued",
+                id: "c",
+                text: "3",
+                at: 120,
+            }).state;
+            expect(s2.pending.map((m) => m.id)).toEqual(["a", "b", "c"]);
+            const r = update(s2, { type: "PendingMessageAccepted", id: "b" });
+            expect(r.state.pending.map((m) => m.id)).toEqual(["a", "c"]);
+        });
+    });
+
+    describe("Purity", () => {
+        it("does not mutate input state", () => {
+            const start = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const snapshot = JSON.parse(JSON.stringify(start));
+            update(start, { type: "TurnStart", at: 110 });
+            expect(start).toEqual(snapshot);
+        });
+    });
+});

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -1,0 +1,242 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure reducer for the agent pane's lifecycle/turn/tool/tokens/stopping/
+ * pending state. See docs/specs/agent-pane-document-reducer-2026-05-03.md
+ * (slice #1 — pattern reference) and frontend-reducer-conventions-2026-05-03.md.
+ *
+ * Invariants enforced:
+ *   1. turnActive cannot be set while streaming inactive (suppressed).
+ *   2. stopping clears automatically on TurnEnd / TurnReset.
+ *   3. currentTool and turnTokens clear on TurnEnd / TurnReset.
+ *   4. pending FIFO; accepting/rejecting unknown ids is idempotent no-op.
+ *   5. StreamFlushObserved is a no-op when streaming inactive.
+ */
+
+import {
+    AgentPaneCommand,
+    AgentPaneState,
+    ReducerResult,
+} from "./types";
+
+export function update(
+    state: AgentPaneState,
+    command: AgentPaneCommand,
+): ReducerResult {
+    switch (command.type) {
+        case "StreamSubscribe":
+            return {
+                state: {
+                    ...state,
+                    streaming: {
+                        ...state.streaming,
+                        active: true,
+                        lastEventTime: command.at,
+                    },
+                },
+                events: [{ type: "stream-subscribed", at: command.at }],
+            };
+
+        case "StreamUnsubscribe":
+            return {
+                state: {
+                    ...state,
+                    streaming: { ...state.streaming, active: false },
+                    // Defensive: subscription gone → no turn can be active.
+                    turnActive: false,
+                },
+                events: [{ type: "stream-unsubscribed", at: command.at }],
+            };
+
+        case "StreamFlushObserved": {
+            if (!state.streaming.active) {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    streaming: {
+                        ...state.streaming,
+                        bufferSize: state.streaming.bufferSize + command.addedCount,
+                        lastEventTime: command.at,
+                    },
+                },
+                events: [
+                    { type: "stream-flush-observed", addedCount: command.addedCount },
+                ],
+            };
+        }
+
+        case "TurnStart": {
+            // Invariant 1: can't start a turn without an active stream.
+            if (!state.streaming.active) {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "turn-start-suppressed",
+                            reason: "stream not active",
+                        },
+                    ],
+                };
+            }
+            return {
+                state: {
+                    ...state,
+                    turnActive: true,
+                    sessionStats: null, // clear stale stats from prior turn
+                },
+                events: [{ type: "turn-started", at: command.at }],
+            };
+        }
+
+        case "TurnEnd": {
+            const stoppingWasSet = state.stopping;
+            // Merge stats with live turn-tokens (mirrors prior finalizeTurn
+            // logic — see PR #549 reagent/codex P1 reference).
+            const merged = mergeStats(command.stats, state.turnTokens);
+            return {
+                state: {
+                    ...state,
+                    sessionStats: merged,
+                    currentTool: null,
+                    turnTokens: null,
+                    turnActive: false,
+                    stopping: false,
+                },
+                events: [
+                    {
+                        type: "turn-ended",
+                        statsMerged: merged != null,
+                        stoppingCleared: stoppingWasSet,
+                    },
+                ],
+            };
+        }
+
+        case "TurnReset":
+            return {
+                state: {
+                    ...state,
+                    sessionStats: null,
+                    currentTool: null,
+                    turnTokens: null,
+                    turnActive: false,
+                    // stopping is part of turn state — clear it too.
+                    stopping: false,
+                },
+                events: [{ type: "turn-reset" }],
+            };
+
+        case "ToolStart":
+            return {
+                state: { ...state, currentTool: command.name },
+                events: [{ type: "tool-started", name: command.name }],
+            };
+
+        case "ToolEnd":
+            return {
+                state: { ...state, currentTool: null },
+                events: [{ type: "tool-ended" }],
+            };
+
+        case "TokensIn": {
+            const next = {
+                input: command.input,
+                output: state.turnTokens?.output ?? 0,
+            };
+            return {
+                state: { ...state, turnTokens: next },
+                events: [{ type: "tokens-updated", input: command.input, output: null }],
+            };
+        }
+
+        case "TokensOut": {
+            const next = {
+                input: state.turnTokens?.input ?? 0,
+                output: command.output,
+            };
+            return {
+                state: { ...state, turnTokens: next },
+                events: [{ type: "tokens-updated", input: null, output: command.output }],
+            };
+        }
+
+        case "RequestStop":
+            return {
+                state: { ...state, stopping: true },
+                events: [{ type: "stop-requested", at: command.at }],
+            };
+
+        case "StopFailed":
+            return {
+                state: { ...state, stopping: false },
+                events: [{ type: "stop-failed" }],
+            };
+
+        case "PendingMessageQueued":
+            return {
+                state: {
+                    ...state,
+                    pending: [
+                        ...state.pending,
+                        { id: command.id, text: command.text, createdAt: command.at },
+                    ],
+                },
+                events: [{ type: "pending-queued", id: command.id }],
+            };
+
+        case "PendingMessageAccepted": {
+            const wasPresent = state.pending.some((m) => m.id === command.id);
+            if (!wasPresent) {
+                return {
+                    state,
+                    events: [{ type: "pending-accepted", id: command.id, wasPresent: false }],
+                };
+            }
+            return {
+                state: {
+                    ...state,
+                    pending: state.pending.filter((m) => m.id !== command.id),
+                },
+                events: [{ type: "pending-accepted", id: command.id, wasPresent: true }],
+            };
+        }
+
+        case "PendingMessageRejected": {
+            const wasPresent = state.pending.some((m) => m.id === command.id);
+            if (!wasPresent) {
+                return {
+                    state,
+                    events: [{ type: "pending-rejected", id: command.id, wasPresent: false }],
+                };
+            }
+            return {
+                state: {
+                    ...state,
+                    pending: state.pending.filter((m) => m.id !== command.id),
+                },
+                events: [{ type: "pending-rejected", id: command.id, wasPresent: true }],
+            };
+        }
+    }
+}
+
+/**
+ * Mirror of the prior finalizeTurn merge: prefer the explicit stats from
+ * the result event, but inject live turn-token totals because the result
+ * event sometimes lacks them.
+ */
+function mergeStats(
+    stats: AgentPaneState["sessionStats"],
+    tokens: AgentPaneState["turnTokens"],
+): AgentPaneState["sessionStats"] {
+    if (stats) {
+        return { ...stats, input_tokens: tokens?.input, output_tokens: tokens?.output };
+    }
+    if (tokens) {
+        return { input_tokens: tokens.input, output_tokens: tokens.output };
+    }
+    return null;
+}

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -1,0 +1,126 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for the agent-pane-state reducer (slice #4 in
+ * docs/specs/frontend-reducer-architecture-2026-05-03.md).
+ *
+ * Bundles the per-pane atoms that have cohesive cross-atom invariants:
+ *   streaming, sessionStats, currentTool, turnTokens, turnActive,
+ *   stopping, pendingMessages.
+ *
+ * The agent document (message list) lives in its own slice
+ * (`agent-document/`); reducer scope is intentionally separate per the
+ * conventions doc §11 ("no god-reducer").
+ */
+
+import type { PendingMessage } from "../../view/agent/state";
+import type {
+    SessionStats,
+    StreamingState,
+    TurnTokens,
+} from "../../view/agent/types";
+
+/**
+ * The reducer's state. Each field maps 1:1 to a Solid signal that the
+ * agent pane projects from. The reducer enforces invariants ACROSS
+ * fields (e.g. turnActive can't be true while streaming inactive).
+ */
+export interface AgentPaneState {
+    streaming: StreamingState;
+    sessionStats: SessionStats | null;
+    currentTool: string | null;
+    turnTokens: TurnTokens | null;
+    turnActive: boolean;
+    stopping: boolean;
+    pending: PendingMessage[];
+}
+
+export const initialState = (agentId: string): AgentPaneState => ({
+    streaming: { active: false, agentId, bufferSize: 0, lastEventTime: 0 },
+    sessionStats: null,
+    currentTool: null,
+    turnTokens: null,
+    turnActive: false,
+    stopping: false,
+    pending: [],
+});
+
+export type AgentPaneCommand =
+    // ── Stream lifecycle ───────────────────────────────────────────
+    /** Hook signal: subscription is up. */
+    | { type: "StreamSubscribe"; at: number }
+    /** Hook signal: subscription torn down. */
+    | { type: "StreamUnsubscribe"; at: number }
+    /**
+     * RAF flush observed by useAgentStream — bumps bufferSize +
+     * lastEventTime. No state change beyond those counters.
+     */
+    | { type: "StreamFlushObserved"; addedCount: number; at: number }
+
+    // ── Turn lifecycle ─────────────────────────────────────────────
+    /**
+     * User pressed send — turn becomes active. Also clears stale
+     * sessionStats from the previous turn.
+     */
+    | { type: "TurnStart"; at: number }
+    /**
+     * Stream produced session_end (or fallback timer fired). Final
+     * stats merged with current turn-tokens. Clears currentTool,
+     * turnTokens, turnActive, AND stopping (the latter cascades to
+     * "stop applied" without a separate command).
+     */
+    | { type: "TurnEnd"; stats: SessionStats | null }
+    /**
+     * Truncate path: the doc was reset (or whatever caused the local
+     * stream-restart). Clears all per-turn state but does NOT touch
+     * pending or streaming.
+     */
+    | { type: "TurnReset" }
+
+    // ── Tool ───────────────────────────────────────────────────────
+    | { type: "ToolStart"; name: string }
+    | { type: "ToolEnd" }
+
+    // ── Tokens (live deltas during a turn) ────────────────────────
+    | { type: "TokensIn"; input: number }
+    | { type: "TokensOut"; output: number }
+
+    // ── Stop flow ──────────────────────────────────────────────────
+    /** User pressed Esc / clicked Stop. */
+    | { type: "RequestStop"; at: number }
+    /** Stop RPC failed — bail on the stopping state. */
+    | { type: "StopFailed" }
+
+    // ── Pending message queue (composer side) ─────────────────────
+    | { type: "PendingMessageQueued"; id: string; text: string; at: number }
+    /** Backend acknowledged the message — remove from pending. */
+    | { type: "PendingMessageAccepted"; id: string }
+    /** RPC failed — remove the entry so user doesn't see a ghost row. */
+    | { type: "PendingMessageRejected"; id: string };
+
+export type AgentPaneEvent =
+    | { type: "stream-subscribed"; at: number }
+    | { type: "stream-unsubscribed"; at: number }
+    | { type: "stream-flush-observed"; addedCount: number }
+    | { type: "turn-started"; at: number }
+    | { type: "turn-ended"; statsMerged: boolean; stoppingCleared: boolean }
+    | { type: "turn-reset" }
+    | {
+          /** Invariant fire: TurnStart while streaming inactive — dropped. */
+          type: "turn-start-suppressed";
+          reason: string;
+      }
+    | { type: "tool-started"; name: string }
+    | { type: "tool-ended" }
+    | { type: "tokens-updated"; input: number | null; output: number | null }
+    | { type: "stop-requested"; at: number }
+    | { type: "stop-failed" }
+    | { type: "pending-queued"; id: string }
+    | { type: "pending-accepted"; id: string; wasPresent: boolean }
+    | { type: "pending-rejected"; id: string; wasPresent: boolean };
+
+export interface ReducerResult {
+    state: AgentPaneState;
+    events: AgentPaneEvent[];
+}

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -11,6 +11,11 @@ import {
     registerPane as registerAgentDocPane,
     unregisterPane as unregisterAgentDocPane,
 } from "@/app/store/agent-document-store";
+import {
+    dispatch as dispatchPane,
+    registerPane as registerAgentPaneStatePane,
+    unregisterPane as unregisterAgentPaneStatePane,
+} from "@/app/store/agent-pane-state-store";
 import type { SubagentLinkNode } from "./types";
 import { openSubagentPane, isSubagentPaneOpen } from "@/app/store/subagent-pane-manager";
 import { useAgentStream } from "./useAgentStream";
@@ -104,6 +109,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // docs/specs/agent-pane-document-reducer-2026-05-03.md.
     registerAgentDocPane(model.blockId, agentAtoms().documentAtom[1]);
     onCleanup(() => unregisterAgentDocPane(model.blockId));
+
+    // Slice #4 — agent-pane-state slot: bundles streaming/sessionStats/
+    // currentTool/turnTokens/turnActive/stopping/pending atoms behind a
+    // single reducer with cross-atom invariants. Same synchronous-register
+    // rule as the agent-document slot.
+    {
+        const a = agentAtoms();
+        registerAgentPaneStatePane(model.blockId, agentId, {
+            streaming: a.streamingStateAtom[1],
+            sessionStats: a.sessionStatsAtom[1],
+            currentTool: a.currentToolAtom[1],
+            turnTokens: a.turnTokensAtom[1],
+            turnActive: a.turnActiveAtom[1],
+            stopping: a.stoppingAtom[1],
+            pending: a.pendingMessagesAtom[1],
+        });
+        onCleanup(() => unregisterAgentPaneStatePane(model.blockId));
+    }
 
     // Activity log — collects per-session diagnostic entries from launch
     // flow, subprocess lifecycle, slash commands, errors, etc. Rendered
@@ -342,12 +365,10 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         pendingMessagesAtom,
     });
 
-    // Clear session stats and mark turn as active when the user sends a message.
-    const [, setSessionStats] = agentAtoms().sessionStatsAtom;
-    const [, setTurnActive] = agentAtoms().turnActiveAtom;
+    // Mark turn as active when the user sends a message — TurnStart
+    // also clears stale sessionStats from the prior turn.
     const handleSendMessage = (message: string): Promise<void> => {
-        setSessionStats(null);
-        setTurnActive(true);
+        dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() });
         return commands.sendMessage(message);
     };
 

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -27,6 +27,7 @@ import { type Accessor, createMemo, createSignal } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
+import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
@@ -227,13 +228,12 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // the acceptance event promotes it. This is the architecture
         // from AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md (two lists,
         // migration on accept).
-        const setPending = opts.pendingMessagesAtom?.[1];
-        if (setPending) {
-            setPending((prev) => [
-                ...prev,
-                { id: messageId, text: message, createdAt: Date.now() },
-            ]);
-        }
+        dispatchPane(opts.blockId, {
+            type: "PendingMessageQueued",
+            id: messageId,
+            text: message,
+            at: Date.now(),
+        });
 
         // Defer the scroll-to-bottom by one animation frame so the
         // pending row has a chance to mount before the scroll math runs.
@@ -268,7 +268,10 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             // RPC outright failed — remove the pending entry so the user
             // doesn't see a ghost row for a message the backend never
             // received. Log already surfaces the error elsewhere.
-            setPending?.((prev) => prev.filter((m) => m.id !== messageId));
+            dispatchPane(opts.blockId, {
+                type: "PendingMessageRejected",
+                id: messageId,
+            });
         });
     };
 
@@ -285,13 +288,13 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // and it also runs a fallback timer that does the same cleanup
         // if `session_end` never arrives (killing a subprocess prevents
         // the CLI from emitting its own terminating result event).
-        opts.stoppingAtom?.[1](true);
+        dispatchPane(opts.blockId, { type: "RequestStop", at: Date.now() });
         RpcApi.ControllerInputCommand(TabRpcClient, {
             blockid: opts.blockId,
             signame: "SIGINT",
         }).catch((err) => {
             opts.log("warn", `stop failed: ${err?.message ?? String(err)}`, "warn");
-            opts.stoppingAtom?.[1](false);
+            dispatchPane(opts.blockId, { type: "StopFailed" });
         });
     };
 

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -398,10 +398,15 @@ export function useAgentStream({
                     }
                     // Track the currently-running tool for the status line
                     if (event.type === "tool_call") {
-                        dispatchPane(blockId, {
-                            type: "ToolStart",
-                            name: event.tool ?? "",
-                        });
+                        // Preserve prior semantic: missing tool name means
+                        // "no tool" (currentTool=null), NOT "tool with empty
+                        // name". Pre-reducer code did setCurrentTool(event.tool ?? null);
+                        // route through ToolEnd in the missing-name case.
+                        if (event.tool) {
+                            dispatchPane(blockId, { type: "ToolStart", name: event.tool });
+                        } else {
+                            dispatchPane(blockId, { type: "ToolEnd" });
+                        }
                     } else if (event.type === "tool_result") {
                         dispatchPane(blockId, { type: "ToolEnd" });
                     }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -17,6 +17,7 @@ import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { DocumentNode, SessionStats, StreamingState, TurnTokens, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
 import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
+import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
 
 const OutputFileName = "output";
 
@@ -72,13 +73,9 @@ export function useAgentStream({
     enabled,
     provider,
 }: UseAgentStreamOpts): void {
-    const [, setStreaming] = streamingStateAtom;
-    const [, setSessionStats] = sessionStatsAtom;
-    const [, setTurnActive] = turnActiveAtom;
-    const [, setCurrentTool] = currentToolAtom;
-    const [getTurnTokens, setTurnTokens] = turnTokensAtom;
+    // Read-side accessors only — all writes route through dispatchPane.
+    const [getTurnTokens] = turnTokensAtom;
     const getStopping = stoppingAtom?.[0];
-    const setStopping = stoppingAtom?.[1];
 
     // Mutable state that doesn't trigger re-renders
     let lineBuffer = "";
@@ -102,19 +99,20 @@ export function useAgentStream({
         pendingNew = [];
         pendingUpdates = [];
 
-        // Single dispatch — the reducer owns dedup, in-place updates, and
-        // the markdown-content merge. See agent-document-store.ts.
+        // Document mutation — the reducer owns dedup, in-place updates,
+        // and the markdown-content merge. See agent-document-store.ts.
         dispatchDoc(blockId, {
             type: "StreamFlush",
             newNodes: batchNew,
             updatedNodes: batchUpdates,
         });
-
-        setStreaming((prev) => ({
-            ...prev,
-            lastEventTime: Date.now(),
-            bufferSize: prev.bufferSize + batchNew.length,
-        }));
+        // Lifecycle counter bump — agent-pane-state owns streaming
+        // metadata (active flag + bufferSize + lastEventTime).
+        dispatchPane(blockId, {
+            type: "StreamFlushObserved",
+            addedCount: batchNew.length,
+            at: Date.now(),
+        });
     }
 
     function scheduleFlush() {
@@ -155,12 +153,6 @@ export function useAgentStream({
             // merge the headline tokens-in-Worked feature shows nothing.
             // Per PR #549 reagent/codex P1.
             const tokens = getTurnTokens();
-            const mergedStats: SessionStats | null = stats
-                ? { ...stats, input_tokens: tokens?.input, output_tokens: tokens?.output }
-                : tokens
-                    ? { input_tokens: tokens.input, output_tokens: tokens.output }
-                    : null;
-            setSessionStats(mergedStats);
             // Aggregate the completed turn's tokens into the global
             // session-local token-usage store so the status bar's
             // indicator + breakdown popover stay up to date. Guarded
@@ -169,10 +161,13 @@ export function useAgentStream({
             if (provider && tokens) {
                 recordTurn(provider, tokens);
             }
-            setCurrentTool(null);
-            setTurnTokens(null);
-            setTurnActive(false);
-            if (getStopping?.()) {
+            // The reducer's TurnEnd handler does the cross-atom cleanup
+            // in one shot: merges live tokens into stats, clears tool/
+            // tokens/turnActive, AND clears stopping (the latter cascade
+            // replaces the explicit setStopping(false) below).
+            const wasStopping = getStopping?.() === true;
+            dispatchPane(blockId, { type: "TurnEnd", stats });
+            if (wasStopping) {
                 const interruptedNode: DocumentNode = {
                     type: "markdown",
                     id: `interrupted-${Date.now()}`,
@@ -184,7 +179,6 @@ export function useAgentStream({
                     pendingNew.push(interruptedNode);
                     scheduleFlush();
                 }
-                setStopping?.(false);
             }
         };
 
@@ -193,7 +187,7 @@ export function useAgentStream({
         // — TerminateProcess skips any final output), run the same
         // finalization locally so the UI doesn't hang on "Stopping…".
         let stopFallbackTimer: number | null = null;
-        if (getStopping && setStopping) {
+        if (getStopping) {
             createEffect(() => {
                 const stopping = getStopping();
                 if (stopFallbackTimer != null) {
@@ -221,7 +215,7 @@ export function useAgentStream({
         // color shift (amber → accent blue) is the user's visible
         // "accepted" signal — the spec's core requirement.
         if (pendingMessagesAtom) {
-            const [getPending, setPending] = pendingMessagesAtom;
+            const [getPending] = pendingMessagesAtom;
             const acceptedUnsub = waveEventSubscribe({
                 eventType: "agent-message-accepted",
                 scope: WOS.makeORef("block", blockId),
@@ -237,7 +231,11 @@ export function useAgentStream({
                         // promoted or the pane was re-mounted mid-queue.
                         return;
                     }
-                    setPending((prev) => prev.filter((m) => m.id !== messageId));
+                    // Reducer removes the entry + emits pending-accepted.
+                    dispatchPane(blockId, {
+                        type: "PendingMessageAccepted",
+                        id: messageId,
+                    });
                     // A new turn is now running (either the first one,
                     // which already flipped turnActive via handleSendMessage,
                     // or one drained from the queue — in that case
@@ -245,7 +243,7 @@ export function useAgentStream({
                     // and nothing else flips it back, leaving the status
                     // line stuck on "Worked" with no running animation
                     // even though the CLI is processing the next message).
-                    setTurnActive(true);
+                    dispatchPane(blockId, { type: "TurnStart", at: Date.now() });
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
                     // node ties back to the pending entry 1:1.
@@ -274,10 +272,12 @@ export function useAgentStream({
         nodeIdSet = new Set();
         for (const n of untrack(() => doc())) nodeIdSet.add(n.id);
 
-        setStreaming((prev) => ({ ...prev, active: true, lastEventTime: Date.now() }));
-        // Mark the session active in the reducer — gates the truncate-
-        // suppression invariant.
-        dispatchDoc(blockId, { type: "SessionStart", at: Date.now() });
+        // Two reducers signaled in lockstep: pane-state owns the streaming
+        // metadata (active flag), agent-document owns the session phase
+        // gate that drives truncate suppression.
+        const subscribedAt = Date.now();
+        dispatchPane(blockId, { type: "StreamSubscribe", at: subscribedAt });
+        dispatchDoc(blockId, { type: "SessionStart", at: subscribedAt });
 
         const fileSubject = getFileSubject(blockId, OutputFileName);
 
@@ -302,10 +302,9 @@ export function useAgentStream({
                 translator.reset();
                 parser.reset();
                 nodeIdSet = new Set();
-                setSessionStats(null);
-                setCurrentTool(null);
-                setTurnTokens(null);
-                setTurnActive(false);
+                // Reducer clears sessionStats/currentTool/turnTokens/
+                // turnActive/stopping in one shot.
+                dispatchPane(blockId, { type: "TurnReset" });
                 return;
             }
 
@@ -374,12 +373,12 @@ export function useAgentStream({
                     if (inner?.type === "message_start") {
                         const inputTok = inner.message?.usage?.input_tokens as number | undefined;
                         if (inputTok != null) {
-                            setTurnTokens((prev) => ({ input: inputTok, output: prev?.output ?? 0 }));
+                            dispatchPane(blockId, { type: "TokensIn", input: inputTok });
                         }
                     } else if (inner?.type === "message_delta") {
                         const outputTok = inner.usage?.output_tokens as number | undefined;
                         if (outputTok != null) {
-                            setTurnTokens((prev) => ({ input: prev?.input ?? 0, output: outputTok }));
+                            dispatchPane(blockId, { type: "TokensOut", output: outputTok });
                         }
                     }
                 }
@@ -399,9 +398,12 @@ export function useAgentStream({
                     }
                     // Track the currently-running tool for the status line
                     if (event.type === "tool_call") {
-                        setCurrentTool(event.tool ?? null);
+                        dispatchPane(blockId, {
+                            type: "ToolStart",
+                            name: event.tool ?? "",
+                        });
                     } else if (event.type === "tool_result") {
-                        setCurrentTool(null);
+                        dispatchPane(blockId, { type: "ToolEnd" });
                     }
                     const node = parser.parseLine(JSON.stringify(event));
                     if (!node) continue;
@@ -431,11 +433,11 @@ export function useAgentStream({
         onCleanup(() => {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
-            setStreaming((prev) => ({ ...prev, active: false }));
-            // Clear turn-active on teardown so a crash/exit without session_end
-            // doesn't leave the status line showing "Working…" permanently.
-            setTurnActive(false);
-            dispatchDoc(blockId, { type: "SessionEnd", at: Date.now() });
+            // StreamUnsubscribe also force-clears turnActive (so a crash
+            // or exit without session_end doesn't leave "Working…" stuck).
+            const at = Date.now();
+            dispatchPane(blockId, { type: "StreamUnsubscribe", at });
+            dispatchDoc(blockId, { type: "SessionEnd", at });
         });
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.619",
+  "version": "0.33.620",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.619",
+      "version": "0.33.620",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.618",
+  "version": "0.33.619",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.618",
+      "version": "0.33.619",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.618",
+  "version": "0.33.619",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.619",
+  "version": "0.33.620",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Bundles the per-pane lifecycle/turn/tool/tokens/stop/pending atoms behind a single reducer with cross-atom invariants. **Slice #4 of the frontend reducer roadmap** (PR-A in the implementation plan).

**Specs included in this PR** (so reviewers have full design context):
- \`docs/specs/frontend-reducer-conventions-2026-05-03.md\` — spec #2, the conventions every slice follows
- \`docs/specs/frontend-reducer-implementation-plan-2026-05-03.md\` — the 5-PR sequencing plan

## What this changes

7 atoms (\`streaming\`, \`sessionStats\`, \`currentTool\`, \`turnTokens\`, \`turnActive\`, \`stopping\`, \`pending\`) move from scattered \`setX\` writes across 3 files into one reducer with **5 enforced invariants**:

1. \`turnActive\` cannot be set while streaming inactive — TurnStart suppressed
2. \`stopping\` clears automatically on TurnEnd / TurnReset
3. \`currentTool\` and \`turnTokens\` clear on TurnEnd / TurnReset
4. \`pending\` is FIFO; accept/reject for unknown ids is idempotent
5. StreamFlushObserved is a no-op when streaming inactive

Net diff: +87 / −61 in modified files. The reducer absorbs the cross-atom cleanup that was previously 4–5 separate \`setX\` calls per finalize/truncate path.

## Files

| File | Change |
|---|---|
| \`store/agent-pane-state/types.ts\` | NEW — State, Command, Event |
| \`store/agent-pane-state/reducer.ts\` | NEW — pure update() with all 13 command arms |
| \`store/agent-pane-state/reducer.test.ts\` | NEW — 21 table-driven tests |
| \`store/agent-pane-state-store.ts\` | NEW — slot map + dispatch (matches \`agent-document-store\`) |
| \`view/agent/agent-view.tsx\` | Registers slot; handleSendMessage dispatches TurnStart |
| \`view/agent/useAgentStream.ts\` | All 14 prior atom writes → dispatchPane |
| \`view/agent/hooks/useAgentCommands.ts\` | Pending queue + stop flow → dispatch |

## Tests

21 reducer tests + the 20 from the doc-reducer slice = **41 total**, all passing in 2.2s. Table-driven, covers each invariant + happy paths + purity.

## Test plan (reviewer)

- [ ] Open an agent pane, send a message, verify status line shows "Working…"
- [ ] Press Esc — status flips to "Stopping…"; on session_end the "⏹ Interrupted" row appears and stopping clears
- [ ] Queue 2 messages while one is running — pending zone shows both, each promotes correctly on accept
- [ ] /clear — pending preserved (TurnReset doesn't touch pending), stats/tool/tokens/turnActive all clear
- [ ] Token counter in the Worked footer still updates during streaming and persists post-turn

## What's NOT in scope

- Diagnostics panel surface for the audit events (deferred to after PR-C ships the global event log)
- Cross-slice coordination (e.g., "did stream subscribe before doc session start?") — both dispatched in lockstep but not transactional. Acceptable per conventions Q1.

## Roadmap context

This is **PR-A of 5 in the implementation plan**:
- ✅ Slice #1 (PR #681 — agent-document) — shipped
- ✅ Spec #2 (conventions) — shipped (in this PR's docs)
- 🔄 PR-A (slice #4 — agent-pane-state) — this PR
- ⬜ PR-B (slice #6 — launcher-event convergence)
- ⬜ PR-C (slice #3 — source-tagging + global event log)
- ⬜ PR-D (slice #7 — tab-state)
- ⬜ PR-E (slice #5 — frontend-layout, blocks on srv E.4.A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)