### PR TITLE
feat(store): command-source tagging + global dispatch log (PR-C, slice #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.622"
+version = "0.33.623"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.622"
+version = "0.33.623"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.622"
+version = "0.33.623"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.622"
+version = "0.33.623"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.622"
+version = "0.33.623"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.622"
+version = "0.33.623"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.622"
+version = "0.33.623"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.622"
+version = "0.33.623"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -23,6 +23,7 @@ import {
     AgentDocumentState,
     initialState,
 } from "./agent-document/types";
+import { type CommandSource, recordDispatch } from "./command-source";
 
 /** A pane's projection setter — typically the SignalPair[1] from createAgentAtoms. */
 type DocumentSetter = (nodes: DocumentNode[]) => void;
@@ -97,6 +98,7 @@ export function unregisterPane(blockId: string): void {
 export function dispatch(
     blockId: string,
     command: AgentDocumentCommand,
+    source: CommandSource = "system",
 ): AgentDocumentEvent[] {
     const slot = slots.get(blockId);
     if (!slot) {
@@ -113,6 +115,14 @@ export function dispatch(
         slot.setter(slot.state.nodes);
     }
     for (const ev of result.events) eventSink(blockId, ev);
+    recordDispatch({
+        slice: "agent-document",
+        key: blockId,
+        command,
+        events: result.events,
+        source,
+        at: Date.now(),
+    });
     return result.events;
 }
 

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -23,6 +23,7 @@ import {
     AgentPaneState,
     initialState,
 } from "./agent-pane-state/types";
+import { type CommandSource, recordDispatch } from "./command-source";
 
 /**
  * The set of projection setters the slot writes to. Each one corresponds
@@ -84,6 +85,7 @@ export function unregisterPane(blockId: string): void {
 export function dispatch(
     blockId: string,
     command: AgentPaneCommand,
+    source: CommandSource = "system",
 ): AgentPaneEvent[] {
     const slot = slots.get(blockId);
     if (!slot) {
@@ -106,6 +108,14 @@ export function dispatch(
     if (slot.state.pending !== prev.pending) slot.proj.pending(slot.state.pending);
 
     for (const ev of result.events) eventSink(blockId, ev);
+    recordDispatch({
+        slice: "agent-pane-state",
+        key: blockId,
+        command,
+        events: result.events,
+        source,
+        at: Date.now(),
+    });
     return result.events;
 }
 

--- a/frontend/app/store/command-source.test.ts
+++ b/frontend/app/store/command-source.test.ts
@@ -1,0 +1,92 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    __resetDispatchLog,
+    describeSource,
+    dispatchRecordsAtom,
+    getRecentDispatches,
+    recordDispatch,
+} from "./command-source";
+
+describe("command-source / dispatch log", () => {
+    beforeEach(() => {
+        __resetDispatchLog();
+    });
+
+    it("records appended in order", () => {
+        recordDispatch({
+            slice: "agent-document",
+            key: "block-a",
+            command: { type: "X" },
+            events: [],
+            source: "user",
+            at: 100,
+        });
+        recordDispatch({
+            slice: "agent-document",
+            key: "block-b",
+            command: { type: "Y" },
+            events: [],
+            source: "system",
+            at: 200,
+        });
+        const all = getRecentDispatches();
+        expect(all).toHaveLength(2);
+        expect(all[0].at).toBe(100);
+        expect(all[1].at).toBe(200);
+    });
+
+    it("trims to ring capacity (500)", () => {
+        for (let i = 0; i < 600; i++) {
+            recordDispatch({
+                slice: "test",
+                key: null,
+                command: { type: "X", i },
+                events: [],
+                source: "system",
+                at: i,
+            });
+        }
+        const all = getRecentDispatches();
+        expect(all).toHaveLength(500);
+        // Oldest 100 dropped
+        expect((all[0].command as any).i).toBe(100);
+        expect((all[499].command as any).i).toBe(599);
+    });
+
+    it("getRecentDispatches respects limit", () => {
+        for (let i = 0; i < 5; i++) {
+            recordDispatch({
+                slice: "test",
+                key: null,
+                command: { type: "X", i },
+                events: [],
+                source: "system",
+                at: i,
+            });
+        }
+        const last3 = getRecentDispatches(3);
+        expect(last3.map((r) => (r.command as any).i)).toEqual([2, 3, 4]);
+    });
+
+    it("dispatchRecordsAtom reflects writes reactively", () => {
+        expect(dispatchRecordsAtom()).toHaveLength(0);
+        recordDispatch({
+            slice: "test",
+            key: null,
+            command: {},
+            events: [],
+            source: "system",
+            at: 1,
+        });
+        expect(dispatchRecordsAtom()).toHaveLength(1);
+    });
+
+    it("describeSource handles all variants", () => {
+        expect(describeSource("system")).toBe("system");
+        expect(describeSource("user")).toBe("user");
+        expect(describeSource({ kind: "agent", agentId: "agent-1" })).toBe("agent:agent-1");
+    });
+});

--- a/frontend/app/store/command-source.ts
+++ b/frontend/app/store/command-source.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Command source-tagging + global event log (slice #3 of the frontend
+ * reducer roadmap). See docs/specs/frontend-reducer-implementation-plan-2026-05-03.md
+ * PR-C and the conventions doc §10 Q4.
+ *
+ * The reducer slices each maintain their own state. This module sits
+ * orthogonal to them and tracks WHO initiated each command (user,
+ * agent, system) plus a single global ring buffer of recent dispatches
+ * for diagnostics.
+ *
+ * Per-slice dispatch functions accept an optional `source` parameter
+ * (default `"system"`) and call `recordDispatch(...)` after applying
+ * the command. The diagnostics panel will surface `getRecentDispatches`
+ * in a follow-up PR.
+ *
+ * In-memory only — opt-in file persistence is deferred until a
+ * concrete debugging need surfaces (per the plan's lean default).
+ */
+
+import { createSignal, type Accessor } from "solid-js";
+
+/**
+ * Who initiated a command. Defaults to `"system"` when not specified
+ * (background subscriptions, lifecycle callbacks, etc.).
+ *
+ * - `"system"` — internal flow (stream tick, history load, mirror sub)
+ * - `"user"` — direct user action (click, slash command, keystroke)
+ * - `{ kind: "agent"; agentId }` — agent app-API surface (future; no
+ *   callers yet, but the type is in place for when the surface lands)
+ */
+export type CommandSource =
+    | "system"
+    | "user"
+    | { kind: "agent"; agentId: string };
+
+/**
+ * One entry in the global dispatch log. `command` and `events` are
+ * `unknown` because each slice has its own discriminated unions; the
+ * log is generic. Diagnostics surface that wants to render structured
+ * detail can downcast based on the `slice` discriminator.
+ */
+export interface DispatchRecord {
+    /** Identifier for the slice that handled the command (e.g. "agent-document"). */
+    slice: string;
+    /** Per-slot key when the slice has slots (e.g. blockId). null for global slices. */
+    key: string | null;
+    command: unknown;
+    events: ReadonlyArray<unknown>;
+    source: CommandSource;
+    /** ms epoch. */
+    at: number;
+}
+
+const RING_CAPACITY = 500;
+
+/**
+ * Ring buffer of recent dispatches. Solid signal so a diagnostics
+ * panel (PR-C follow-up) can re-render reactively. Reads are O(1)
+ * (signal getter); writes shift+push at O(n) when full but n is
+ * bounded at RING_CAPACITY so amortized cost is fine.
+ */
+const [recordsAtom, setRecordsAtom] = createSignal<ReadonlyArray<DispatchRecord>>([]);
+
+export const dispatchRecordsAtom: Accessor<ReadonlyArray<DispatchRecord>> = recordsAtom;
+
+/**
+ * Append a dispatch to the global log. Called by each slice's dispatch
+ * function. Trims to RING_CAPACITY by dropping oldest first.
+ */
+export function recordDispatch(record: DispatchRecord): void {
+    const prev = recordsAtom();
+    const next = prev.length >= RING_CAPACITY
+        ? [...prev.slice(prev.length - RING_CAPACITY + 1), record]
+        : [...prev, record];
+    setRecordsAtom(next);
+}
+
+/**
+ * Read the most recent N dispatch records, newest last. Diagnostics +
+ * tests; do NOT use for app logic.
+ */
+export function getRecentDispatches(limit?: number): ReadonlyArray<DispatchRecord> {
+    const all = recordsAtom();
+    if (limit == null || limit >= all.length) return all;
+    return all.slice(all.length - limit);
+}
+
+/** Test/dev helper — wipe the ring. Never call in production. */
+export function __resetDispatchLog(): void {
+    setRecordsAtom([]);
+}
+
+/** Convenience helpers for human-readable source descriptions. */
+export function describeSource(source: CommandSource): string {
+    if (source === "system") return "system";
+    if (source === "user") return "user";
+    return `agent:${source.agentId}`;
+}

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -43,6 +43,7 @@ import {
     LauncherEventReducerEvent,
     LauncherEventState,
 } from "./launcher-event/types";
+import { recordDispatch } from "./command-source";
 
 // Re-export the filter so existing callers (app-init.ts) don't need to
 // chase the new module path. The filter is the source of truth for
@@ -79,6 +80,16 @@ function dispatch(command: LauncherEventCommand): LauncherEventReducerEvent[] {
     state = result.state;
     if (state.instances !== prev.instances) project();
     for (const ev of result.events) onAuditEvent(ev);
+    // Source is always "system" — this slice mirrors upstream events
+    // (launcher channel) and the snapshot seed; no user-driven path.
+    recordDispatch({
+        slice: "launcher-event",
+        key: null,
+        command,
+        events: result.events,
+        source: "system",
+        at: Date.now(),
+    });
     return result.events;
 }
 

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -194,11 +194,11 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             });
         }
         if (updated.length > 0) {
-            dispatchDoc(model.blockId, {
-                type: "StreamFlush",
-                newNodes: [],
-                updatedNodes: updated,
-            });
+            dispatchDoc(
+                model.blockId,
+                { type: "StreamFlush", newNodes: [], updatedNodes: updated },
+                "user",
+            );
         }
         // Send the decision to the sidecar so it can record + audit
         // it (PR-3a). Actual delivery to the agent CLI — rules
@@ -368,7 +368,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
     // Mark turn as active when the user sends a message — TurnStart
     // also clears stale sessionStats from the prior turn.
     const handleSendMessage = (message: string): Promise<void> => {
-        dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() });
+        dispatchPane(model.blockId, { type: "TurnStart", at: Date.now() }, "user");
         return commands.sendMessage(message);
     };
 

--- a/frontend/app/view/agent/commands/global/clear.ts
+++ b/frontend/app/view/agent/commands/global/clear.ts
@@ -16,7 +16,7 @@ export const clearCommand: SlashCommand = {
     description: "Clear the visible document (frontend-only)",
     arg: { kind: "none" },
     handler: async (ctx): Promise<SlashResult> => {
-        dispatchDoc(ctx.blockId, { type: "UserClear" });
+        dispatchDoc(ctx.blockId, { type: "UserClear" }, "user");
         return { kind: "ok", message: "chat cleared" };
     },
 };

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -228,12 +228,16 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // the acceptance event promotes it. This is the architecture
         // from AGENT_PANE_QUEUED_MESSAGE_FEEDBACK_SPEC.md (two lists,
         // migration on accept).
-        dispatchPane(opts.blockId, {
-            type: "PendingMessageQueued",
-            id: messageId,
-            text: message,
-            at: Date.now(),
-        });
+        dispatchPane(
+            opts.blockId,
+            {
+                type: "PendingMessageQueued",
+                id: messageId,
+                text: message,
+                at: Date.now(),
+            },
+            "user",
+        );
 
         // Defer the scroll-to-bottom by one animation frame so the
         // pending row has a chance to mount before the scroll math runs.
@@ -288,7 +292,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // and it also runs a fallback timer that does the same cleanup
         // if `session_end` never arrives (killing a subprocess prevents
         // the CLI from emitting its own terminating result event).
-        dispatchPane(opts.blockId, { type: "RequestStop", at: Date.now() });
+        dispatchPane(opts.blockId, { type: "RequestStop", at: Date.now() }, "user");
         RpcApi.ControllerInputCommand(TabRpcClient, {
             blockid: opts.blockId,
             signame: "SIGINT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.622",
+  "version": "0.33.623",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.622",
+      "version": "0.33.623",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.622",
+  "version": "0.33.623",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

A small cross-slice helper that adds **source-tagging** to every reducer dispatch and a **global ring buffer** of recent dispatches for diagnostics. Slice #3 of the frontend reducer roadmap, descoped per conventions Q1+Q4 from the original "command bus" framing.

## What this adds

\`frontend/app/store/command-source.ts\`:
- \`CommandSource\` type: \`"system" | "user" | { kind: "agent"; agentId }\` (default \`"system"\`)
- \`recordDispatch({ slice, key, command, events, source, at })\` — append to ring buffer
- \`dispatchRecordsAtom\` — Solid signal so a future diagnostics panel renders reactively
- \`getRecentDispatches(limit?)\` and \`describeSource\` helpers

## Wiring

All three existing dispatch functions accept an optional \`source\` parameter:

| Slice | Slot key | Default source |
|---|---|---|
| agent-document | blockId | system |
| agent-pane-state | blockId | system |
| launcher-event | (global) | always system (mirror slice) |

User-driven callsites pass \`source: "user"\`:
- \`/clear\` slash command
- Composer's \`sendMessage\` (queues PendingMessageQueued)
- \`stopAgent\` (RequestStop)
- \`handleSendMessage\` (TurnStart)
- \`handleDecide\` (tool decision optimistic update)

Stream / lifecycle / mirror callsites stay implicit \`"system"\`.

## Tests

5 new command-source tests:
- Records appended in order
- Trims to ring capacity (500)
- \`getRecentDispatches\` respects limit
- \`dispatchRecordsAtom\` reflects writes reactively
- \`describeSource\` handles all variants

**66 reducer + store tests pass total** across 4 modules (20 doc + 21 pane + 20 launcher + 5 source).

## Backward compatibility

\`source\` is optional with a sensible default. Every existing dispatch callsite continues to work unchanged. New user-tagged callsites are explicit.

## Test plan (reviewer)

This is observability scaffolding — no user-facing behavior change. Smoke:
- [ ] App runs normally; \`task dev\` shows no new warnings
- [ ] In dev console: \`window.__dispatchRecords = require('@/app/store/command-source').dispatchRecordsAtom; __dispatchRecords()\` should show recent dispatches accumulating

## What's NOT in scope

- Diagnostics panel UI (~0.5 day follow-up — \`getRecentDispatches\` / \`dispatchRecordsAtom\` are ready for it)
- File persistence of the log (deferred per the plan — opt-in flag if a debugging need surfaces)
- Per-source filtering / search (depends on diagnostics UI)

## Roadmap context

- ✅ #1 (#681 — agent-document)
- ✅ #2 conventions (shipped with #683)
- ✅ PR-A (#683 — agent-pane-state)
- ✅ PR-B (#684 — launcher-event convergence)
- 🔄 **PR-C (slice #3 — this PR)**
- ⬜ PR-D (slice #7 — tab-state)
- ⬜ PR-E (slice #5 — frontend-layout, blocks on srv E.4.A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)