### PR TITLE
test(layout): backfill reducer test coverage + session docs + AM/PM tweak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.623"
+version = "0.33.624"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.623"
+version = "0.33.624"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.623"
+version = "0.33.624"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.623"
+version = "0.33.624"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1493,11 +1493,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.624"
+version = "0.33.625"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.624"
+version = "0.33.625"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.624"
+version = "0.33.625"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.624"
+version = "0.33.625"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.624 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |
 | 0.33.614 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |
 | 0.33.592 | 2026-05-02 | 161.9 MiB | 339.0 MiB | |
 | 0.33.591 | 2026-05-02 | 161.9 MiB | 339.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.623"
+version = "0.33.624"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.624"
+version = "0.33.625"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.623"
+version = "0.33.624"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.624"
+version = "0.33.625"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.624"
+version = "0.33.625"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.623"
+version = "0.33.624"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.623"
+version = "0.33.624"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.624"
+version = "0.33.625"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/analysis/sysinfo-architecture-assessment-2026-05-03.md
+++ b/docs/analysis/sysinfo-architecture-assessment-2026-05-03.md
@@ -1,0 +1,82 @@
+# Sysinfo Architecture Assessment
+
+**Date:** 2026-05-03
+**Files reviewed:**
+- `frontend/app/view/sysinfo/sysinfo-plot.tsx` (159 LOC)
+- `frontend/app/view/sysinfo/sysinfo-model.ts` (259 LOC)
+- `frontend/app/view/sysinfo/sysinfo-view.tsx` (108 LOC)
+- `frontend/app/view/sysinfo/sysinfo-types.ts` (113 LOC)
+- `frontend/app/view/sysinfo/sysinfo-util.ts` (36 LOC)
+- `frontend/app/view/sysinfo/sysinfo.tsx` (17 LOC)
+- **Total: 692 LOC**
+
+**Triggering question:** is the original sysinfo architecture worth improving or replacing?
+
+## TL;DR
+
+Mid-tier code. Works fine, has the smell of "feature shipped, never came back to." **Do not replace** — the cost-to-value ratio is bad. **Improve selectively** — three high-value moves listed below; everything else can stay.
+
+## What's good
+
+- Clean module separation: model / view / plot / types / util — small focused files
+- Solid migration done properly: ViewModel class, signal atoms, `createMemo` for derived state, `onCleanup` everywhere
+- Uses `@observablehq/plot` (Mike Bostock's library — D3 author) — legitimate dependency, not a homegrown wheel
+- `DataItem` index-signature shape (`[k: string]: number`) is extensible without schema changes
+- `PlotTypes` lookup table is data-driven; adding a new plot view is one entry
+- Gap-detection logic (blank-item insertion in `addInitialData`/`addContinuousData`) is thoughtful
+- Resize observer + reactive plumbing has nothing janky
+
+## What's not good (concrete issues)
+
+| # | Issue | Location | Severity |
+|---|---|---|---|
+| 1 | Destroy-and-recreate hot path: `createEffect` wipes containerRef and calls `Plot.plot()` from scratch on every data change (~1Hz per pane) | sysinfo-plot.tsx:42–154 | Medium (perf concern at scale; root of why animation is hard) |
+| 2 | `try/catch` with `console.log` swallows errors silently | sysinfo-model.ts:73, 88 | Low (should be `console.error`) |
+| 3 | `model: any` to dodge circular dep | sysinfo-types.ts:16 | Low (fixable with `import type`) |
+| 4 | `data.push(newPoint)` mutates atom's underlying array before filter | sysinfo-model.ts:84 | Low (referential checks downstream could mislead) |
+| 5 | `_set` on the atom — internal API leaking | sysinfo-model.ts:71, 86 | Low (smell) |
+| 6 | Hardcoded 32-CPU loop | sysinfo-types.ts:111 | Low (silently broken for 64+ core machines like Threadripper Pro) |
+| 7 | `htl.svg` template literal mixes raw HTML strings into a Solid component | sysinfo-plot.tsx:61–67 | Low (off-grain but works) |
+| 8 | `SingleLinePlot` renders 6 marks (line + area + gradient + tooltip + dot + rules) | sysinfo-plot.tsx:25 | Trivial (naming) |
+
+The destroy-and-recreate pattern (#1) is the only structural issue. The rest are surface smells.
+
+## Big picture comparison
+
+Compare to what we shipped in the reducer migration (slices #1, #4, #6 — explicit invariants, immutable state, audit events, table-driven tests). Sysinfo doesn't show that level of consideration. It feels like a sprint-shipped feature that got parked. **That's not damning — most code in any sufficiently large codebase looks like this.** It just means the bar set elsewhere in this project is higher.
+
+## Replace vs. improve
+
+### Replace? **No.**
+
+Replacement options I considered:
+
+- **Migrate to a different chart library** (chart.js, uplot, lightweight d3): 3–5 days; throw away ~500 LOC of working code; revisit visual correctness across 9 plot types and many CPU configs; high risk of subtle regressions. **Marginal user-visible benefit.**
+- **Custom canvas/WebGL renderer**: 1–2 weeks; fundamentally different code path; future maintainers need WebGL knowledge. **Out of proportion to benefit.**
+- **Rewrite the destroy-and-recreate effect to use Plot's update API**: doesn't exist — `@observablehq/plot` doesn't expose in-place updates. Would require switching libs.
+
+None of these clear the bar.
+
+### Improve? **Yes — selectively.**
+
+Three high-value moves, in priority order:
+
+| Improvement | Effort | Value | Status |
+|---|---|---|---|
+| 1. Continuous-monitor animation | 1–1.5d | High visual quality bump; restructures the destroy-and-recreate hot path | Spec written: `sysinfo-continuous-monitor-animation-2026-05-03.md` |
+| 2. Cleanup pass: `console.error`, `model: any`, `data.push` mutation, dynamic CPU count | ~1h | Removes the smells; trivially safe | Not started |
+| 3. Cache the Plot instance + only re-render when the data domain actually changes (vs. on every signal change) | 0.5d | Real CPU win on machines with many sysinfo panes; speculative until measured | Not started |
+
+### Skip
+
+| Idea | Why not |
+|---|---|
+| Migrate off `@observablehq/plot` | Cost ≫ benefit; current lib is reasonable |
+| Rewrite the model in the reducer pattern | Sysinfo state is per-pane and read-mostly; no multi-writer hazard. Reducer pattern's value prop is invariant enforcement against multiple writers — doesn't fit here. |
+| Add tests retroactively | Data-handling logic is small; visual surface is hard to test meaningfully. ROI is low. |
+
+## Net call
+
+If the user wants monitoring polish, do the animation (improvement #1). The 1-hour cleanup pass (#2) is worth doing whenever bandwidth allows. The plot-instance caching (#3) is speculative — defer until perf is actually measured to be a problem.
+
+The architecture is **good enough to leave alone for now** unless one of these three pulls is taken on. Anything beyond is gold-plating.

--- a/docs/retro/pr-d-tab-state-reducer-not-applicable-2026-05-03.md
+++ b/docs/retro/pr-d-tab-state-reducer-not-applicable-2026-05-03.md
@@ -1,0 +1,101 @@
+# Retro: PR-D (tab-state-reducer) — premise doesn't fit the actual frontend
+
+**Date:** 2026-05-03
+**Status:** Plan stop-condition triggered. Writing this BEFORE proceeding so the architecture decision is captured.
+**Plan reference:** `docs/specs/frontend-reducer-implementation-plan-2026-05-03.md` PR-D (slice #7)
+
+## What the plan said
+
+> **PR-D — Slice #7: tab-state-reducer**
+> Goal: frontend mirror of srv tab state (active tab, tab order, per-tab metadata). First pure mirror slice; validates §6 echo-loop guard.
+> Effort: ~3 days.
+
+The plan assumed there was tab-related state on the frontend that needed to be mirrored from srv via a reducer with an echo-loop guard.
+
+## What I actually found
+
+After ~10 minutes of code inspection (`frontend/app/store/global.ts:40–110`, `command-registry.ts`, `keymodel.ts`, `layoutModel.ts`):
+
+1. **There are no local tab atoms.** All tab/workspace/window state is derived via `createMemo` over `WOS.getObjectValue`. Wstore already does the mirror.
+   ```ts
+   export const tabAtom = createMemo<Tab>(() => {
+       return WOS.getObjectValue(WOS.makeORef("tab", staticTabId()));
+   });
+   export const activeTabId = createMemo<string>(() => {
+       const ws = workspace();
+       return ws?.activetabid || ...;
+   });
+   ```
+2. **`setActiveTab` is a one-line RPC wrapper** (`global.ts:866`): `WorkspaceService.SetActiveTab(ws.oid, tabId)`. The result lands back in wstore, which reactively updates `activeTabId` automatically. Single chokepoint already exists.
+3. **`pendingbackendactions` is part of the LAYOUT slice**, not tab state — it lives in `frontend/layout/lib/layoutModel.ts` + `layoutPersistence.ts`. The plan flagged this as a decision point (lean: tab-state) but the answer is now obvious: it's already in the layout module.
+
+## Why a tab-state reducer would be wrong
+
+If I built it as planned, the resulting module would:
+
+- **Duplicate state**: hold a `Map<tabId, TabSnapshot>` that's already in wstore
+- **Duplicate subscriptions**: subscribe to wstore `tab:*` updates that consumers already subscribe to via `tabAtom`
+- **Add a pass-through dispatch**: `dispatchTab(SetActive, ...)` that just calls `setActiveTab` which already exists
+- **Add an echo-loop guard** for an echo that doesn't exist (no local→srv→back loop because the local "set" path IS the srv RPC)
+
+Net effect: ~600 LOC of new code that adds zero invariants and zero auditing value the existing event log (PR-C `command-source.ts`) doesn't already provide for the existing dispatch path.
+
+## What changed about the plan's reasoning
+
+The plan was written without inspecting the existing tab-state surface. It assumed a launcher-event-style scenario (local mirror, multiple writers, async upstream events). The reality is that tab state was always wstore-mirrored — there's no architectural problem to solve.
+
+## Comparison to slices that DID fit
+
+| Slice | Local writers? | Multi-writer race? | Reducer added value? |
+|---|---|---|---|
+| #1 agent-document | Yes (3) | Yes (truncate-wipe bug) | Big — fixed live bug |
+| #4 agent-pane-state | Yes (~14) | Latent (turnActive ↔ streamingState cohesion) | Real — invariants now enforced |
+| #6 launcher-event | Yes (1, but with seed-vs-close race) | Yes (codex P1/P2 fixes) | Real — invariants now in tests |
+| #3 source-tagging | N/A (cross-cutting) | N/A | Real — audit trail |
+| **#7 tab-state (this)** | **No** | **No** | **None** |
+
+The pattern: reducers add value when frontend state has multiple writers OR when invariants need formal enforcement. Tab state has neither.
+
+## Decision
+
+**Cancel PR-D as planned. Do not implement.**
+
+Three options for what to do instead:
+
+### Option 1 — Skip to PR-E (frontend-layout) ← recommended
+
+Layout state DOES have local multi-writer patterns (drag-resize ticks, focus changes, magnify toggles, leaf-order updates). It's the original target spec'd by srv-side `SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md`. The frontend mirror is genuinely useful here.
+
+**Caveat per the plan**: PR-E "blocks on srv E.4.A landing first." Need to check srv status. If srv E.4.A is in flight, this is the next move.
+
+### Option 2 — Find a different real target
+
+Search for any frontend state that DOES have a multi-writer pattern. Candidates worth a 30-min investigation:
+- The activity log (per-pane diagnostic entries) — multiple hooks append
+- Token usage store (`@/store/token-usage`) — turn-aggregation
+- Focus manager (per-block focus tracking)
+
+If any of these have race-prone patterns, they'd be a better fit than tab-state.
+
+### Option 3 — Stop the slice migration here
+
+We've shipped 4 slices (agent-doc, agent-pane-state, launcher-event convergence, source-tagging). The pattern is established. Layout (PR-E) is the only remaining one with a clear value prop. If srv E.4.A isn't ready, we could pause the migration and pivot to other work until it is.
+
+## Updated roadmap
+
+| # | Slice | Status |
+|---|---|---|
+| #1 | agent-document | ✅ Shipped |
+| #2 | conventions | ✅ Shipped |
+| #3 | source-tagging | ✅ Shipped (PR-C) |
+| #4 | agent-pane-state | ✅ Shipped (PR-A) |
+| #5 | frontend-layout | ⬜ PR-E — blocks on srv E.4.A |
+| #6 | launcher-event convergence | ✅ Shipped (PR-B) |
+| #7 | **tab-state** | **❌ Cancelled — see this retro** |
+| #8 | pane-tree | ⬜ Deferred (waits for srv E.4.B) |
+
+## Lessons for future planning
+
+The plan was written in one pass without code inspection per slice. Doing the inspection during implementation caught the mismatch — but ideally the spec phase for each slice should include "verify the premise by reading the current code" as a checklist item before estimating.
+
+Should add to the conventions doc §10: **"Before specifying a new mirror slice, read the existing wstore-derived atoms for the domain. If everything's already a `createMemo` over `WOS.getObjectValue` with no local writers, the mirror reducer adds nothing — skip it."**

--- a/docs/retro/pr-e1-layout-reducer-already-exists-2026-05-03.md
+++ b/docs/retro/pr-e1-layout-reducer-already-exists-2026-05-03.md
@@ -1,0 +1,114 @@
+# Retro: PR-E1 (layout focus/magnify reducer) — already exists
+
+**Date:** 2026-05-03
+**Status:** Stop-condition triggered (second time today). Writing this BEFORE any more code.
+**Plan reference:** `docs/specs/frontend-reducer-implementation-plan-2026-05-03.md` PR-E
+**Decision context:** User picked E1 (refactor-only) over E2 (refactor + srv sync) for smaller blast radius
+
+## What I assumed for PR-E1
+
+A clean greenfield reducer for local focused/magnified state, similar in shape to PR-A (agent-pane-state). One day of work.
+
+## What's actually there
+
+`frontend/layout/` has a **complete tree reducer architecture already**:
+
+| Component | Where | What |
+|---|---|---|
+| Action types enum | `frontend/layout/lib/types.ts` | 15+ types: FocusNode, MagnifyNodeToggle, Move, Insert, Delete, Resize, Swap, ComputeMove, ResizeNode, etc. |
+| Action dispatcher | `layoutModel.ts:486 (treeReducer)` | Switch-by-action-type, ~75 LOC |
+| Pure-ish action handlers | `layoutTree.ts` | 544 LOC, 11 functions, e.g. `focusNode(state, action)` mutates passed-in state |
+| Projection | `layoutModel.ts:571` | `localTreeStateAtom._set({ ...this.treeState })` after each reducer run |
+| Validators (the multi-writer surface) | `layoutFocus.ts:15 (validateFocusedNode)`, `layoutMagnify.ts:166 (validateMagnifiedNode)` | Called from `layoutGeometry.ts:65–66` after geometry recompute; also mutate `treeState.focusedNodeId` directly |
+
+The "mutations" in `layoutFocus.ts:21,22,34,38–45` are inside `validateFocusedNode` — a **post-geometry repair function**, not a parallel reducer pathway. It runs sequentially after the tree reducer (when `computeAdditionalProps` re-derives geometry). They don't race; they're stages of one pipeline.
+
+## The two writers question
+
+Strictly speaking, `treeState.focusedNodeId` IS written from two places:
+1. Via `treeReducer` action `FocusNode`
+2. Via `validateFocusedNode` direct assignment
+
+But they execute **sequentially** in the same call stack:
+```
+user click
+  → focusNode(model, nodeId)
+    → model.treeReducer({type: FocusNode, ...})
+      → layoutTree.focusNode(treeState, action)  // sets focusedNodeId
+    → updateTree()
+      → computeAdditionalProps()
+        → validateFocusedNode(model, leafOrder)  // may rewrite focusedNodeId for stale-stack case
+    → localTreeStateAtom._set({ ...treeState })  // single projection
+```
+
+No concurrent writers. No async race. No network event interleaving. The validator sees the post-reducer state and either confirms it or repairs it before projection.
+
+This is **not the multi-writer pattern** the convention is designed to fix.
+
+## Value assessment
+
+A convergence PR (folding `validateFocusedNode` and `validateMagnifiedNode` into reducer arms, replacing in-place mutation with immutable updates, adding audit events + tests) would:
+
+| Pro | Con |
+|---|---|
+| Validators become pure + testable | ~1 week of work for the focused/magnified slice alone (layoutTree + layoutFocus + layoutMagnify + tests) |
+| Audit log captures geometry-driven repair events | Layout is the most-touched UI surface; regressions affect everything |
+| Explicit "RepairFocus" / "RepairMagnify" commands surface invariants | No known bug or race motivates the work — pure consistency-with-conventions |
+| Eventual srv sync (E2) needs a frontend reducer anyway | Could just write the reducer as part of E2 instead of a separate refactor |
+
+The two real action items I see are:
+- "We need to enforce focus repair invariants" — yes, but they're already encoded in the validator functions; the existing tests aren't bad; rewriting just to use a different pattern is gold-plating.
+- "We need cross-window focus sync (E2)" — yes, but that's E2 territory, and doing E1 first as scaffolding doesn't reduce E2's risk meaningfully.
+
+## Decision
+
+**Cancel PR-E1 as planned. Do not implement.**
+
+The layout system already has a reducer. It uses an older convention (in-place mutation, no audit events, no slot abstraction) but it works. Converging it to the new conventions is a multi-day investment with no known correctness benefit.
+
+## Updated roadmap
+
+| # | Slice | Status | Notes |
+|---|---|---|---|
+| #1 | agent-document | ✅ Shipped | |
+| #2 | conventions | ✅ Shipped | |
+| #3 | source-tagging | ✅ Shipped | |
+| #4 | agent-pane-state | ✅ Shipped | |
+| #5 / E1 | frontend-layout (refactor-only) | ❌ Cancelled — see this retro | Existing reducer is good enough |
+| #5 / E2 | frontend-layout + srv sync | 🟨 **Real work, real value** — write spec when needed | Multi-window focus sync is the user-visible feature |
+| #6 | launcher-event convergence | ✅ Shipped | |
+| #7 | tab-state | ❌ Cancelled (PR-D retro) | No multi-writer; wstore-derived |
+| #8 | pane-tree | ⬜ Deferred (waits srv E.4.B) | |
+
+## Lessons (compounded with PR-D retro)
+
+The implementation plan's per-slice descriptions were written without code inspection. Two of three remaining slices (D + E1) turned out to be premised on assumptions that don't hold. **The conventions work was right** — it set the bar. **The existing-code inventory was wrong** — it assumed reducer-shaped code was either absent (D, where wstore already mirrors) or unreducer-shaped (E, where there's already a reducer).
+
+**Add to conventions §10 / planning checklist:**
+
+> Before writing a "new reducer slice" spec, do a 30-minute code inspection:
+> 1. Is the state already wstore-mirrored? (If yes, no slice needed.)
+> 2. Is there already a reducer or reducer-shaped code? (If yes, the slice is convergence-only — assess vs. gold-plating.)
+> 3. Is there a known bug or invariant violation? (If no, the slice is consistency-only — assess vs. gold-plating.)
+
+## What's actually left to ship
+
+Looking at the 8 slices honestly:
+
+- **3 high-value PRs already shipped** (#1 fixed a live bug; #4 + #6 added real invariants + testability)
+- **1 cross-cutting helper shipped** (#3 source-tagging)
+- **2 slices cancelled** (#7 tab-state, #5 E1 layout-refactor — not applicable)
+- **1 slice has real future value but needs a spec** (#5 E2 layout + srv sync — multi-window focus sync feature)
+- **1 slice deferred indefinitely** (#8 pane-tree — waits on srv E.4.B)
+
+**The frontend reducer migration is essentially done.** Further slices either don't fit (D, E1) or wait on upstream work (E2 needs a real spec; #8 needs srv E.4.B).
+
+## Recommended next move
+
+Three options:
+
+1. **Stop the slice migration here.** Pivot to other work. Pick up E2 when multi-window focus sync becomes a user-visible priority (or when the user explicitly asks for it).
+2. **Write the E2 spec now.** ~1 day of design work; doesn't commit to implementing. Captures the multi-window focus-sync design while context is fresh.
+3. **Pivot to one of the other named follow-ups** from the implementation plan: diagnostics panel surface (PR-C follow-up, ~0.5d) or the README/architecture docs for `frontend/app/store/`.
+
+My recommendation: **option 1 (stop)** + **option 3's diagnostics panel** as a small completion. Stops the migration cleanly with a tangible user-visible feature (the audit log surface) and avoids the trap of inventing more work to keep the queue moving.

--- a/docs/specs/sysinfo-continuous-monitor-animation-2026-05-03.md
+++ b/docs/specs/sysinfo-continuous-monitor-animation-2026-05-03.md
@@ -1,0 +1,179 @@
+# Sysinfo Plot — Continuous-Monitor Animation
+
+**Date:** 2026-05-03
+**Status:** Analysis + spec draft. Brittleness assessment in §5 — read that first before deciding to build.
+**Scope:** `frontend/app/view/sysinfo/sysinfo-plot.tsx`
+
+## Problem
+
+The sysinfo plot today re-renders on each new sample. Samples arrive at the configured interval (typically 1s), so the chart **snaps** rather than glides. Users watching the chart for "is the CPU still pegged?" want the visual continuity of a real monitoring tool — the line should feel like it's flowing in from the right, not punching in once a second.
+
+## Goal
+
+Between samples, the plot slides left at a rate that makes the next sample arrival feel continuous. On sample arrival, the plot rebases to the new data without visible discontinuity.
+
+This is a **visual** improvement only — the underlying data and sample rate don't change.
+
+## The math (linear)
+
+Given:
+- `intervalMs` — configured sample interval (e.g. 1000)
+- `lastSampleTs` — backend timestamp of the most recent sample
+- `lastSampleArrivalT` — wall-clock time we received that sample (`Date.now()`)
+- `visibleSpanMs` — total time span the chart shows
+- `chartWidth` — pixels available for the data area
+
+Then at any wall-clock time `T`:
+
+```
+elapsed   = T - lastSampleArrivalT
+progress  = min(elapsed / intervalMs, 1.0)           // 0..1, capped
+rightEdge = lastSampleTs + intervalMs * progress     // virtual right-edge time
+
+# Pixel-shift form (for CSS transform):
+pxPerMs    = chartWidth / visibleSpanMs
+shiftPx    = (rightEdge - lastSampleTs) * pxPerMs    // = pxPerMs * intervalMs * progress
+```
+
+Apply each frame as `transform: translateX(-shiftPx + 'px')` on the SVG/canvas data layer.
+
+The `min(..., 1.0)` cap matters: if the next sample is late (network jitter, backend hiccup), the chart "stalls" at the next-expected position rather than sliding off into space. When the late sample arrives, we reset and slide the new amount — the user sees a brief pause but no glitch.
+
+## Smoothing options
+
+Linear works. If a smoother feel is wanted, replace `progress` with an easing curve:
+
+```
+linear:    progress
+ease-out:  1 - (1 - progress)^2          # slows near sample boundary
+ease-in:   progress^2                    # accelerates into the boundary
+spring:    requires a spring system, two params (stiffness, damping)
+```
+
+**Recommendation: linear.** At 1Hz the easing window is the entire second; non-linear curves make the chart feel "rubbery" or "laggy" because the eye perceives the speed change. Linear matches what users expect from `top`/`htop`/Activity Monitor.
+
+## Implementation sketch
+
+Two viable architectures:
+
+### A. CSS transform on the SVG (recommended)
+
+1. Render the plot once per sample at its true position (existing `Plot.plot()` call).
+2. Wrap the plot's data layer (SVG `<g>` or canvas) in a div with `overflow: hidden`.
+3. Each frame (RAF), compute `shiftPx` and apply `transform: translateX(-shiftPx)` to the data layer.
+4. On new sample arrival: stop the RAF, re-render with new data, reset transform to 0, restart RAF.
+5. Axis ticks/labels: leave them as-is (snap on re-render). The slight mismatch between sliding line + snapping axis ticks is invisible at 1s intervals.
+
+**Pros:** GPU-accelerated transform, near-zero CPU per frame. Re-render frequency unchanged (1Hz).
+**Cons:** transform clipping requires the wrapper `overflow: hidden` to be precise; the slid pixels need to come from somewhere — either we render the plot wider than visible (1 sample's worth of buffer on the right), OR the rightmost edge appears empty as the chart slides.
+
+The "render wider, clip to visible" approach is cleanest. Add `intervalMs` worth of pixels to the right of the visible domain when calling `Plot.plot()`; the wrapper masks them; sliding reveals them progressively.
+
+### B. Re-render every RAF tick
+
+Simply call `Plot.plot()` 60 times per second with an updated x-domain. No transform tricks.
+
+**Pros:** simpler. Axis ticks slide too (no snap mismatch).
+**Cons:** ~60× CPU cost vs. today. At 8 sysinfo panes open this is noticeable. `Plot.plot()` recreates DOM nodes; not designed for high-frequency re-render.
+
+A is better. Build A.
+
+## Edge cases to design for
+
+| Case | Handling |
+|---|---|
+| Tab inactive (browser pauses RAF) | On `visibilitychange` → visible: snap transform to truth (compute `shiftPx` at current wall-clock; instantly apply). Resume RAF. |
+| Window resize during animation | Recompute `pxPerMs` from new `chartWidth`; current frame's `shiftPx` recalculates naturally next tick. Visual hiccup of one frame, acceptable. |
+| Sample arrives early (rare) | Reset baseline as usual; `progress` jumps from <1.0 back to 0; no visual artifact because `rightEdge` always lands at `lastSampleTs`. |
+| Sample arrives very late (>2× intervalMs) | Stalled chart; on arrival, reset baseline. User sees a stutter — accurately reflects that a sample was late. Don't try to hide this. |
+| Pane closed mid-animation | `onCleanup` cancels the RAF. Standard. |
+| Multiple plots in same pane (CPU + mem + net) | Each owns its own RAF loop. At 60Hz with ~5 plots, cost is 300 transform updates/sec — still trivial because transform doesn't trigger layout. |
+| Sample interval changes mid-stream | Stop animation, re-render plot at new domain width, restart with new `intervalMs`. |
+| User scrolls the plot back in time (history view) | Animation only applies in "live" mode (data continues to scroll in from the right). If a "frozen" mode exists for historical inspection, animation is disabled there. |
+
+## Brittleness assessment — honest
+
+**The animation itself is not brittle.** The math is bounded (`min(..., 1.0)` cap), the transform is decoupled from re-rendering, and edge cases reset to truth on each new sample.
+
+**Three real risks:**
+
+1. **Sample timing assumptions.** The animation assumes samples arrive at roughly `intervalMs` cadence. In practice samples have jitter from:
+   - Backend cron tick (sysinfo subscription is on the srv side, fires every 2s per logs)
+   - WebSocket latency
+   - Frontend event-loop pressure
+
+   If average jitter exceeds ~10% of `intervalMs`, the animation will frequently hit the `min(..., 1.0)` cap and stall briefly before each sample. At 1s intervals with 100ms jitter, this is invisible. At 200ms intervals with 100ms jitter, it's distracting.
+
+   **Mitigation:** measure actual inter-sample arrival distribution before shipping. If P95 jitter > 15% of interval, consider a small "look-ahead" (animate to 95% of next position; the last 5% snaps on actual arrival).
+
+2. **Plot library re-render cost stays the same.** The animation only smooths between samples — each sample still triggers a full `Plot.plot()` rebuild. If the user has many sysinfo plots open and the underlying re-render is already a perf concern, the animation doesn't help (and the per-frame transform adds a small constant cost on top).
+
+   **Mitigation:** if perf becomes a problem, the bigger fix is moving off `@observablehq/plot` to a canvas renderer, which is a much larger undertaking. Don't tie that to this PR.
+
+3. **Visual mismatch between sliding data and snapping axis.** Acceptable at 1s intervals; might be jarring at faster rates (e.g., a 200ms sample interval where axis ticks would visibly snap every 5 ticks). Can be addressed by rendering axis ticks at 0.5× sample frequency so each tick lasts longer.
+
+   **Mitigation:** if axis snap becomes an issue, manually re-render the axis on each RAF (Plot exposes the axis component). Skip until/unless reported.
+
+**Three risks I'd dismiss:**
+
+- **DPR / zoom changes**: handled naturally by `pxPerMs = chartWidth / visibleSpanMs` since chartWidth comes from `getBoundingClientRect()` each tick.
+- **CSS transform compositing layer leaks**: SVG wrappers are well-trodden territory in chart libraries; no real risk.
+- **Memory growth from running RAF**: bounded — single closure per plot; no allocation per tick if `shiftPx` is set via `style.transform = 'translateX(' + n + 'px)'`.
+
+**Net call:** moderately brittle if rolled out without measurement; robust if you measure jitter first and accept the perf cost stays as-is. The math is the safe part. **Build it.**
+
+## Spec
+
+### Files affected
+
+| File | Change |
+|---|---|
+| `frontend/app/view/sysinfo/sysinfo-plot.tsx` | Wrap data layer in masked div; add RAF loop with transform updates; reset on new sample |
+| `frontend/app/view/sysinfo/sysinfo-plot.scss` (new) | Mask wrapper styling (`overflow: hidden`, fixed width) |
+| `frontend/app/view/sysinfo/sysinfo-model.ts` | (No change — already exposes `intervalSecs`) |
+
+### Behavior change
+
+- Plot data slides smoothly from right to left between samples.
+- On new sample arrival: imperceptible reset (transform → 0, plot re-renders with new data).
+- Tooltip + hover behavior: unchanged (hover position is in screen space, transform doesn't affect it).
+
+### Configuration
+
+Add a single user-toggleable setting (default ON) in case the animation causes issues for some users:
+
+```
+sysinfo:smooth-animation = true | false   (block meta)
+```
+
+Off → today's behavior verbatim. On → animation enabled.
+
+### Tests
+
+Hard to unit-test animation behavior — rely on:
+- A storybook-style demo page where the dev can see various `intervalMs` values rendering correctly.
+- Smoke checklist:
+  - 1s sample interval → smooth slide
+  - Tab away for 30s, return → no glitch on resume
+  - Window resize during animation → no glitch
+  - Open 5 sysinfo panes simultaneously → no perceptible CPU bump in Task Manager
+
+## Out of scope
+
+- Migration off `@observablehq/plot` to a canvas/WebGL renderer (separate spec, much larger).
+- Animation for non-time-series plots in the app (the sparkline mode in `sysinfo-plot.tsx` could use the same treatment but is rendered without axes — defer until requested).
+- Predictive rendering (linear extrapolation past the last sample). Honest > smooth; we shouldn't draw what we don't know.
+- Pause / resume controls in the UI.
+
+## Estimated effort
+
+~1–1.5 days:
+- 0.5d: implement the RAF loop + transform plumbing + mask wrapper
+- 0.25d: handle the 8 edge cases in the table above
+- 0.25d: setting + meta plumbing
+- 0.25d: smoke + tuning
+
+## Decision needed before implementing
+
+1. Measure actual sample jitter first (10 minutes of work — log inter-arrival times in `sysinfo-model.ts` and inspect the distribution). If P95 > 15% of interval, iterate on the spec before building.
+2. Accept that this is visual polish, not a correctness fix. The right call if you want monitoring-tool-quality feel; the wrong call if perf is already tight.

--- a/frontend/app/view/sysinfo/sysinfo-plot.tsx
+++ b/frontend/app/view/sysinfo/sysinfo-plot.tsx
@@ -116,7 +116,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
                     anchor: "middle",
                     dy: -30,
                     title: (d: any) =>
-                        `${dayjs.unix(d.ts / 1000).format("HH:mm:ss")} ${Number(d[yval]).toFixed(decimalPlaces)}${labelY}`,
+                        `${dayjs.unix(d.ts / 1000).format("h:mm:ss A")} ${Number(d[yval]).toFixed(decimalPlaces)}${labelY}`,
                     textPadding: 3,
                 })
             )
@@ -138,7 +138,7 @@ function SingleLinePlot(props: SingleLinePlotProps): JSX.Element {
             x: {
                 grid: true,
                 label: "time",
-                tickFormat: (d: number) => `${dayjs.unix(d / 1000).format("HH:mm:ss")}`,
+                tickFormat: (d: number) => `${dayjs.unix(d / 1000).format("h:mm:ss A")}`,
                 domain: [minX, maxX],
             },
             y: { label: labelY, domain: [minY, maxY] },

--- a/frontend/layout/tests/layoutTree.test.ts
+++ b/frontend/layout/tests/layoutTree.test.ts
@@ -3,9 +3,24 @@
 
 import { assert, test } from "vitest";
 import { newLayoutNode } from "../lib/layoutNode";
-import { computeMoveNode, moveNode } from "../lib/layoutTree";
+import {
+    clearTree,
+    computeMoveNode,
+    deleteNode,
+    focusNode,
+    insertNode,
+    insertNodeAtIndex,
+    magnifyNodeToggle,
+    moveNode,
+    replaceNode,
+    resizeNode,
+    splitHorizontal,
+    splitVertical,
+    swapNode,
+} from "../lib/layoutTree";
 import {
     DropDirection,
+    FlexDirection,
     LayoutTreeActionType,
     LayoutTreeComputeMoveNodeAction,
     LayoutTreeMoveNodeAction,
@@ -81,4 +96,370 @@ test("computeMove - noop action", () => {
 
     pendingAction = computeMoveNode(treeState, moveAction);
     assert(pendingAction === undefined, "inserting a node to the right of itself should not produce a pendingAction");
+});
+
+// ── insertNode ────────────────────────────────────────────────────────────────
+
+test("insertNode - empty tree promotes node to root", () => {
+    const treeState = newLayoutTreeState(undefined as any);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "first" });
+    insertNode(treeState, { type: LayoutTreeActionType.InsertNode, node: newNode });
+    assert(treeState.rootNode === newNode, "inserting into empty tree sets the node as root");
+});
+
+test("insertNode - existing tree appends via findNextInsertLocation", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "second" });
+    insertNode(treeState, { type: LayoutTreeActionType.InsertNode, node: newNode });
+    assert(treeState.rootNode.children!.some((c) => c.id === newNode.id), "new node should be inserted into the tree");
+});
+
+test("insertNode - magnified flag also focuses the node", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "magnified" });
+    insertNode(treeState, {
+        type: LayoutTreeActionType.InsertNode,
+        node: newNode,
+        magnified: true,
+    });
+    assert(treeState.magnifiedNodeId === newNode.id, "magnified flag sets magnifiedNodeId");
+    assert(treeState.focusedNodeId === newNode.id, "magnified flag also sets focusedNodeId (cohesion)");
+});
+
+test("insertNode - focused-only flag", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "focused" });
+    insertNode(treeState, {
+        type: LayoutTreeActionType.InsertNode,
+        node: newNode,
+        focused: true,
+    });
+    assert(treeState.focusedNodeId === newNode.id);
+    assert(treeState.magnifiedNodeId === undefined, "focused alone does not magnify");
+});
+
+test("insertNode - missing node is a no-op (logs error, does not crash)", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    const before = JSON.stringify(treeState);
+    insertNode(treeState, { type: LayoutTreeActionType.InsertNode, node: undefined as any });
+    assert(JSON.stringify(treeState) === before, "missing node should leave state unchanged");
+});
+
+// ── insertNodeAtIndex ─────────────────────────────────────────────────────────
+
+test("insertNodeAtIndex - missing indexArr is a no-op", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "n" });
+    const before = JSON.stringify(treeState);
+    insertNodeAtIndex(treeState, {
+        type: LayoutTreeActionType.InsertNodeAtIndex,
+        node: newNode,
+        indexArr: undefined as any,
+    });
+    assert(JSON.stringify(treeState) === before, "missing indexArr should leave state unchanged");
+});
+
+test("insertNodeAtIndex - empty tree promotes node to root", () => {
+    const treeState = newLayoutTreeState(undefined as any);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "first" });
+    insertNodeAtIndex(treeState, {
+        type: LayoutTreeActionType.InsertNodeAtIndex,
+        node: newNode,
+        indexArr: [0],
+    });
+    assert(treeState.rootNode === newNode);
+});
+
+// ── swapNode ──────────────────────────────────────────────────────────────────
+
+test("swapNode - swaps two siblings (positions and sizes)", () => {
+    const node1 = newLayoutNode(undefined, 30, undefined, { blockId: "n1" });
+    const node2 = newLayoutNode(undefined, 70, undefined, { blockId: "n2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    swapNode(treeState, {
+        type: LayoutTreeActionType.Swap,
+        node1Id: node1.id,
+        node2Id: node2.id,
+    });
+    assert(treeState.rootNode.children![0].id === node2.id, "node2 takes node1's slot");
+    assert(treeState.rootNode.children![1].id === node1.id, "node1 takes node2's slot");
+    assert(treeState.rootNode.children![0].size === 30, "size at slot 0 stays 30 (sizes swap with the nodes)");
+    assert(treeState.rootNode.children![1].size === 70, "size at slot 1 stays 70");
+});
+
+test("swapNode - rejects swapping the root node", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    const before = JSON.stringify(treeState);
+    swapNode(treeState, {
+        type: LayoutTreeActionType.Swap,
+        node1Id: treeState.rootNode.id,
+        node2Id: child.id,
+    });
+    assert(JSON.stringify(treeState) === before, "cannot swap root; state unchanged");
+});
+
+test("swapNode - rejects swapping a node with itself", () => {
+    const node1 = newLayoutNode(undefined, undefined, undefined, { blockId: "n1" });
+    const node2 = newLayoutNode(undefined, undefined, undefined, { blockId: "n2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    const before = JSON.stringify(treeState);
+    swapNode(treeState, {
+        type: LayoutTreeActionType.Swap,
+        node1Id: node1.id,
+        node2Id: node1.id,
+    });
+    assert(JSON.stringify(treeState) === before, "self-swap is a no-op");
+});
+
+// ── deleteNode ────────────────────────────────────────────────────────────────
+
+test("deleteNode - removes a child", () => {
+    const node1 = newLayoutNode(undefined, undefined, undefined, { blockId: "keep" });
+    const node2 = newLayoutNode(undefined, undefined, undefined, { blockId: "drop" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    deleteNode(treeState, { type: LayoutTreeActionType.DeleteNode, nodeId: node2.id });
+    assert(treeState.rootNode.children!.length === 1);
+    assert(treeState.rootNode.children![0].id === node1.id);
+});
+
+test("deleteNode - clears focusedNodeId when the focused node is deleted", () => {
+    const node1 = newLayoutNode(undefined, undefined, undefined, { blockId: "n1" });
+    const node2 = newLayoutNode(undefined, undefined, undefined, { blockId: "n2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    treeState.focusedNodeId = node2.id;
+    deleteNode(treeState, { type: LayoutTreeActionType.DeleteNode, nodeId: node2.id });
+    assert(treeState.focusedNodeId === undefined, "deleting the focused node clears focus");
+});
+
+test("deleteNode - deleting non-focused node leaves focus intact", () => {
+    const node1 = newLayoutNode(undefined, undefined, undefined, { blockId: "n1" });
+    const node2 = newLayoutNode(undefined, undefined, undefined, { blockId: "n2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    treeState.focusedNodeId = node1.id;
+    deleteNode(treeState, { type: LayoutTreeActionType.DeleteNode, nodeId: node2.id });
+    assert(treeState.focusedNodeId === node1.id);
+});
+
+test("deleteNode - deleting the root sets rootNode to undefined", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    deleteNode(treeState, {
+        type: LayoutTreeActionType.DeleteNode,
+        nodeId: treeState.rootNode.id,
+    });
+    assert(treeState.rootNode === undefined);
+});
+
+// ── resizeNode ────────────────────────────────────────────────────────────────
+
+test("resizeNode - applies size to the matching node", () => {
+    const node1 = newLayoutNode(undefined, 50, undefined, { blockId: "n1" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1]));
+    resizeNode(treeState, {
+        type: LayoutTreeActionType.ResizeNode,
+        resizeOperations: [{ nodeId: node1.id, size: 80 }],
+    });
+    assert(treeState.rootNode.children![0].size === 80);
+});
+
+test("resizeNode - rejects size out of bounds (early return at first invalid op)", () => {
+    const node1 = newLayoutNode(undefined, 50, undefined, { blockId: "n1" });
+    const node2 = newLayoutNode(undefined, 50, undefined, { blockId: "n2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1, node2]));
+    resizeNode(treeState, {
+        type: LayoutTreeActionType.ResizeNode,
+        resizeOperations: [
+            { nodeId: node1.id, size: 150 }, // invalid → bails before touching either node
+            { nodeId: node2.id, size: 25 },
+        ],
+    });
+    // No mutation: the first invalid op causes an early return BEFORE applying.
+    assert(node1.size === 50, "n1 should be untouched (out-of-range guard ran first)");
+    assert(node2.size === 50, "n2 should be untouched (loop bailed)");
+});
+
+// ── focusNode ────────────────────────────────────────────────────────────────
+
+test("focusNode - sets focusedNodeId", () => {
+    const node1 = newLayoutNode(undefined, undefined, undefined, { blockId: "n1" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [node1]));
+    focusNode(treeState, { type: LayoutTreeActionType.FocusNode, nodeId: node1.id });
+    assert(treeState.focusedNodeId === node1.id);
+});
+
+test("focusNode - missing nodeId is a no-op", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    treeState.focusedNodeId = "preexisting";
+    focusNode(treeState, { type: LayoutTreeActionType.FocusNode, nodeId: undefined as any });
+    assert(treeState.focusedNodeId === "preexisting", "missing nodeId leaves state unchanged");
+});
+
+// ── magnifyNodeToggle ────────────────────────────────────────────────────────
+
+test("magnifyNodeToggle - toggles a node ON, also focuses it", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    magnifyNodeToggle(treeState, {
+        type: LayoutTreeActionType.MagnifyNodeToggle,
+        nodeId: child.id,
+    });
+    assert(treeState.magnifiedNodeId === child.id);
+    assert(treeState.focusedNodeId === child.id, "magnify toggle ON also sets focus (cohesion)");
+});
+
+test("magnifyNodeToggle - second toggle clears (does NOT clear focus)", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    magnifyNodeToggle(treeState, {
+        type: LayoutTreeActionType.MagnifyNodeToggle,
+        nodeId: child.id,
+    });
+    magnifyNodeToggle(treeState, {
+        type: LayoutTreeActionType.MagnifyNodeToggle,
+        nodeId: child.id,
+    });
+    assert(treeState.magnifiedNodeId === undefined);
+    // Subtle: the OFF branch doesn't touch focusedNodeId — focus persists from the ON branch.
+    assert(treeState.focusedNodeId === child.id, "OFF branch preserves focus from ON branch");
+});
+
+test("magnifyNodeToggle - rejects magnifying the root node", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    magnifyNodeToggle(treeState, {
+        type: LayoutTreeActionType.MagnifyNodeToggle,
+        nodeId: treeState.rootNode.id,
+    });
+    assert(treeState.magnifiedNodeId === undefined, "root cannot be magnified");
+});
+
+test("magnifyNodeToggle - missing nodeId is a no-op", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    treeState.magnifiedNodeId = "preexisting";
+    magnifyNodeToggle(treeState, {
+        type: LayoutTreeActionType.MagnifyNodeToggle,
+        nodeId: undefined as any,
+    });
+    assert(treeState.magnifiedNodeId === "preexisting");
+});
+
+// ── clearTree ────────────────────────────────────────────────────────────────
+
+test("clearTree - resets all four fields", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    treeState.focusedNodeId = child.id;
+    treeState.magnifiedNodeId = child.id;
+    treeState.leafOrder = [{ nodeid: child.id, blockid: "child" }];
+    clearTree(treeState);
+    assert(treeState.rootNode === undefined);
+    assert(treeState.focusedNodeId === undefined);
+    assert(treeState.magnifiedNodeId === undefined);
+    assert(treeState.leafOrder === undefined);
+});
+
+// ── replaceNode ──────────────────────────────────────────────────────────────
+
+test("replaceNode - replaces root, preserving size", () => {
+    const root = newLayoutNode(undefined, 100, undefined, { blockId: "old-root" });
+    root.size = 100;
+    const treeState = newLayoutTreeState(root);
+    const newRoot = newLayoutNode(undefined, 50, undefined, { blockId: "new-root" });
+    replaceNode(treeState, {
+        type: LayoutTreeActionType.ReplaceNode,
+        targetNodeId: root.id,
+        newNode: newRoot,
+    });
+    assert(treeState.rootNode === newRoot);
+    assert(treeState.rootNode.size === 100, "replaceNode preserves the old node's size");
+});
+
+test("replaceNode - replaces a child in-place, preserving size", () => {
+    const child1 = newLayoutNode(undefined, 30, undefined, { blockId: "c1" });
+    const child2 = newLayoutNode(undefined, 70, undefined, { blockId: "c2" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child1, child2]));
+    const replacement = newLayoutNode(undefined, 99, undefined, { blockId: "replacement" });
+    replaceNode(treeState, {
+        type: LayoutTreeActionType.ReplaceNode,
+        targetNodeId: child2.id,
+        newNode: replacement,
+    });
+    assert(treeState.rootNode.children![1].id === replacement.id);
+    assert(treeState.rootNode.children![1].size === 70, "replacement inherits child2's size");
+});
+
+test("replaceNode - focused flag updates focusedNodeId", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "child" });
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, [child]));
+    const replacement = newLayoutNode(undefined, undefined, undefined, { blockId: "rep" });
+    replaceNode(treeState, {
+        type: LayoutTreeActionType.ReplaceNode,
+        targetNodeId: child.id,
+        newNode: replacement,
+        focused: true,
+    });
+    assert(treeState.focusedNodeId === replacement.id);
+});
+
+// ── splitHorizontal / splitVertical ──────────────────────────────────────────
+
+test("splitHorizontal - inserts after the target in a Row parent", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "c1" });
+    // Row parent
+    const root = newLayoutNode(FlexDirection.Row, undefined, [child]);
+    const treeState = newLayoutTreeState(root);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+    splitHorizontal(treeState, {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: child.id,
+        newNode,
+        position: "after",
+    });
+    assert(treeState.rootNode.children!.length === 2);
+    assert(treeState.rootNode.children![1].id === newNode.id, "new node inserted after target");
+});
+
+test("splitHorizontal - inserts before the target in a Row parent", () => {
+    const child = newLayoutNode(undefined, undefined, undefined, { blockId: "c1" });
+    const root = newLayoutNode(FlexDirection.Row, undefined, [child]);
+    const treeState = newLayoutTreeState(root);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+    splitHorizontal(treeState, {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: child.id,
+        newNode,
+        position: "before",
+    });
+    assert(treeState.rootNode.children![0].id === newNode.id);
+});
+
+test("splitVertical - wraps target when parent is not Column", () => {
+    // Root has no parent and is the leaf itself — splitVertical should wrap.
+    const leaf = newLayoutNode(undefined, undefined, undefined, { blockId: "only" });
+    const treeState = newLayoutTreeState(leaf);
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+    splitVertical(treeState, {
+        type: LayoutTreeActionType.SplitVertical,
+        targetNodeId: leaf.id,
+        newNode,
+        position: "after",
+    });
+    // Root should now be a wrapping Column with the original leaf + newNode as children.
+    assert(treeState.rootNode.flexDirection === FlexDirection.Column, "root wrapped in Column");
+    assert(treeState.rootNode.children!.length === 2);
+});
+
+test("splitHorizontal - missing target is a no-op (logs error)", () => {
+    const treeState = newLayoutTreeState(newLayoutNode(undefined, undefined, undefined, { blockId: "root" }));
+    const newNode = newLayoutNode(undefined, undefined, undefined, { blockId: "new" });
+    const before = JSON.stringify(treeState);
+    splitHorizontal(treeState, {
+        type: LayoutTreeActionType.SplitHorizontal,
+        targetNodeId: "ghost-id",
+        newNode,
+        position: "after",
+    });
+    assert(JSON.stringify(treeState) === before);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1022,6 +1022,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,6 +1039,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,6 +1056,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,6 +1073,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,6 +1090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,6 +1107,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,6 +1124,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1141,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,6 +1158,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,6 +1175,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,6 +1192,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1198,6 +1209,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,6 +1226,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,6 +1243,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,6 +1260,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1277,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,6 +1294,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,6 +1311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,6 +1328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,6 +1345,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,6 +1362,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,6 +1379,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,6 +1396,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,6 +1413,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1406,6 +1430,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,6 +1447,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1649,18 +1675,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1816,21 +1830,6 @@
         "langium": "^4.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1887,6 +1886,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1926,6 +1926,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1946,6 +1947,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,6 +1968,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1986,6 +1989,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,6 +2010,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2026,6 +2031,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2046,6 +2052,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2066,6 +2073,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2086,6 +2094,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,6 +2115,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2126,6 +2136,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,6 +2157,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,6 +2178,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2245,6 +2258,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2258,6 +2272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,6 +2286,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,6 +2300,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,6 +2314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2310,6 +2328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2323,6 +2342,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,6 +2356,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2349,6 +2370,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2362,6 +2384,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,6 +2398,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,6 +2412,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,6 +2426,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2414,6 +2440,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,6 +2454,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2440,6 +2468,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,6 +2482,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,6 +2496,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,6 +2510,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2492,6 +2524,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2505,6 +2538,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,6 +2552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2531,6 +2566,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2544,6 +2580,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2557,6 +2594,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3664,7 +3702,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4494,14 +4532,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4693,7 +4723,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5545,7 +5575,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5664,7 +5694,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6029,6 +6059,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6145,6 +6176,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6190,7 +6222,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6873,7 +6905,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7025,7 +7057,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7045,7 +7077,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7236,7 +7268,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7482,7 +7514,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7515,6 +7547,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7535,6 +7568,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7555,6 +7589,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7575,6 +7610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7595,6 +7631,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7615,6 +7652,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7635,6 +7673,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7655,6 +7694,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7675,6 +7715,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7695,6 +7736,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7715,6 +7757,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7779,19 +7822,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9039,6 +9069,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9088,6 +9119,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9376,6 +9408,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9421,6 +9454,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9662,24 +9696,11 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9994,7 +10015,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10060,6 +10081,7 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10161,7 +10183,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10370,29 +10392,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11107,34 +11106,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11225,6 +11196,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11453,7 +11425,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11473,6 +11445,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11544,7 +11517,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11775,6 +11748,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11941,6 +11915,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11957,6 +11932,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11973,6 +11949,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11989,6 +11966,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12005,6 +11983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12021,6 +12000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12037,6 +12017,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12053,6 +12034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12069,6 +12051,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,6 +12068,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12101,6 +12085,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12117,6 +12102,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12133,6 +12119,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12149,6 +12136,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12165,6 +12153,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12181,6 +12170,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12197,6 +12187,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12213,6 +12204,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12229,6 +12221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12245,6 +12238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12261,6 +12255,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12277,6 +12272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12293,6 +12289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12309,6 +12306,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12325,6 +12323,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12341,6 +12340,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,6 +12354,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12395,6 +12396,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12833,23 +12835,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.624",
+  "version": "0.33.625",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.624",
+      "version": "0.33.625",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.623",
+  "version": "0.33.624",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.623",
+      "version": "0.33.624",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.624",
+  "version": "0.33.625",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.623",
+  "version": "0.33.624",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the frontend-reducer-migration session with three artifacts:

1. **Layout reducer test coverage** — 30 new tests covering 9 untested action handlers in \`layoutTree.ts\`. Pure additions; no production code touched. Decision context: the retro for cancelled PR-E1 recommended this as the highest-value move (path 1 — de-risk any future migration).
2. **Session retros + analysis docs** — captures why PR-D and PR-E1 were cancelled, the sysinfo architecture quality assessment, and the sliding-line animation spec.
3. **Bonus UX**: sysinfo plot tooltip + x-axis labels switch from 24-hour \`HH:mm:ss\` to 12-hour \`h:mm:ss A\` (user-requested).

## Test coverage

Pre-PR: 2 tests in \`layoutTree.test.ts\` (computeMoveNode + moveNode happy paths). Post-PR: 32 tests covering all 11 action handlers.

| Handler | Tests | Notable invariants captured |
|---|---|---|
| \`insertNode\` | 5 | Empty-tree → root promotion; magnified flag also focuses |
| \`insertNodeAtIndex\` | 2 | Missing-indexArr no-op |
| \`swapNode\` | 3 | Sibling positions+sizes swap; root rejected; self-swap rejected |
| \`deleteNode\` | 4 | Focus-clearing on focused-node delete; root-delete sets undefined |
| \`resizeNode\` | 2 | **Out-of-range guard short-circuits the entire op array** (not just the bad op) |
| \`focusNode\` | 2 | Missing-nodeId no-op |
| \`magnifyNodeToggle\` | 4 | **ON also focuses (cohesion); OFF preserves focus from prior ON** |
| \`clearTree\` | 1 | Resets all four fields |
| \`replaceNode\` | 3 | Replace preserves size; focused flag updates focus |
| \`splitHorizontal/splitVertical\` | 4 | Insert in same-direction parent; wrap when direction mismatches |

The bolded ones are non-obvious behavioral invariants that future refactors need to preserve.

## Session retros included

- \`docs/retro/pr-d-tab-state-reducer-not-applicable-2026-05-03.md\` — why slice #7 was cancelled (frontend tab state is wstore-derived)
- \`docs/retro/pr-e1-layout-reducer-already-exists-2026-05-03.md\` — why slice #5 E1 was cancelled (layout-tree reducer already exists)
- \`docs/analysis/sysinfo-architecture-assessment-2026-05-03.md\` — quality assessment: do not replace, selectively improve
- \`docs/specs/sysinfo-continuous-monitor-animation-2026-05-03.md\` — sliding-line animation spec + brittleness analysis

## Test plan (reviewer)

- [ ] \`npx vitest run frontend/layout/tests/layoutTree.test.ts\` — 32 pass
- [ ] Open a sysinfo pane → verify AM/PM in tooltip + x-axis (single-pane smoke)
- [ ] Optional read of the retros to understand why migration paused here

## Frontend reducer migration — final state

| Status | Slices |
|---|---|
| ✅ Shipped | #1 agent-document, #2 conventions, #3 source-tagging, #4 agent-pane-state, #6 launcher-event convergence |
| ❌ Cancelled (retros) | #7 tab-state, #5 E1 layout-refactor |
| 🟨 Real future value, needs spec | #5 E2 layout + srv sync (multi-window focus sync) |
| ⬜ Deferred | #8 pane-tree (waits srv E.4.B) |

Five slices shipped (the high-value ones). Two cancelled with retros. Two on the back burner. **Migration is essentially done.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)