### PR TITLE
feat: ProviderLogo — replace Unicode glyphs with inline SVG brand marks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -92,25 +92,25 @@ export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
         if (p === "aws") {
             // stylelint-disable color-no-hex
             return (
-                <svg width={size()} height={size()} viewBox="0 0 80 50" aria-hidden="true">
+                <svg width={size()} height={size()} viewBox="0 0 24 24" aria-hidden="true">
                     <text
-                        x="40"
-                        y="28"
+                        x="12"
+                        y="14"
                         text-anchor="middle"
-                        font-size="28"
+                        font-size="9"
                         font-weight="700"
                         font-family="Arial, sans-serif"
                         fill="#FF9900"
-                        letter-spacing="-1"
+                        letter-spacing="-0.3"
                     >
                         aws
                     </text>
-                    <path d="M20 36 Q40 48 60 36" fill="none" stroke="#FF9900" stroke-width="4" stroke-linecap="round" />
+                    <path d="M6 17 Q12 21 18 17" fill="none" stroke="#FF9900" stroke-width="1.4" stroke-linecap="round" />
                     <path
-                        d="M57 33 L62 36 L57 40"
+                        d="M17 15.5 L18.5 17 L17 18.5"
                         fill="none"
                         stroke="#FF9900"
-                        stroke-width="4"
+                        stroke-width="1.4"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                     />

--- a/frontend/app/element/ProviderLogo.tsx
+++ b/frontend/app/element/ProviderLogo.tsx
@@ -1,0 +1,169 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { JSX } from "solid-js";
+
+export interface ProviderLogoProps {
+    provider: string;
+    size?: number;
+    class?: string;
+}
+
+export const ProviderLogo = (props: ProviderLogoProps): JSX.Element => {
+    const size = () => props.size ?? 24;
+
+    const svg = (): JSX.Element => {
+        const p = (props.provider ?? "").toLowerCase();
+
+        if (p === "anthropic" || p === "claude") {
+            // stylelint-disable color-no-hex
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" aria-hidden="true">
+                    <rect x="2.5" y="15" width="3" height="7" rx="1.5" fill="#d97757" />
+                    <rect x="7" y="10" width="3" height="12" rx="1.5" fill="#d97757" />
+                    <rect x="11" y="4" width="3" height="18" rx="1.5" fill="#d97757" />
+                    <rect x="15" y="10" width="3" height="12" rx="1.5" fill="#d97757" />
+                    <rect x="19.5" y="15" width="3" height="7" rx="1.5" fill="#d97757" />
+                </svg>
+            );
+            // stylelint-enable color-no-hex
+        }
+
+        if (p === "openai" || p === "codex") {
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path
+                        fill-rule="evenodd"
+                        d="M12 2a10 10 0 100 20A10 10 0 0012 2zm0 2a8 8 0 110 16A8 8 0 0112 4z"
+                    />
+                    <path d="M16.5 9.27l-4.5-2.6-4.5 2.6v5.46l4.5 2.6 4.5-2.6V9.27zm-4.5 5.73L9 13.27V10.73L12 9l3 1.73v2.54L12 15z" />
+                </svg>
+            );
+        }
+
+        if (p === "google" || p === "gemini") {
+            // stylelint-disable color-no-hex
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" aria-hidden="true">
+                    <path
+                        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                        fill="#4285F4"
+                    />
+                    <path
+                        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                        fill="#34A853"
+                    />
+                    <path
+                        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                        fill="#FBBC05"
+                    />
+                    <path
+                        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                        fill="#EA4335"
+                    />
+                </svg>
+            );
+            // stylelint-enable color-no-hex
+        }
+
+        if (p === "github") {
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+                </svg>
+            );
+        }
+
+        if (p === "copilot") {
+            // stylelint-disable color-no-hex
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" aria-hidden="true">
+                    <circle cx="12" cy="12" r="11" fill="#0078d4" />
+                    <path d="M7 14a5 5 0 0010 0" fill="none" stroke="white" stroke-width="1.6" stroke-linecap="round" />
+                    <circle cx="9" cy="11" r="1.8" fill="white" />
+                    <circle cx="15" cy="11" r="1.8" fill="white" />
+                    <circle cx="9" cy="11" r="0.8" fill="#0078d4" />
+                    <circle cx="15" cy="11" r="0.8" fill="#0078d4" />
+                </svg>
+            );
+            // stylelint-enable color-no-hex
+        }
+
+        if (p === "aws") {
+            // stylelint-disable color-no-hex
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 80 50" aria-hidden="true">
+                    <text
+                        x="40"
+                        y="28"
+                        text-anchor="middle"
+                        font-size="28"
+                        font-weight="700"
+                        font-family="Arial, sans-serif"
+                        fill="#FF9900"
+                        letter-spacing="-1"
+                    >
+                        aws
+                    </text>
+                    <path d="M20 36 Q40 48 60 36" fill="none" stroke="#FF9900" stroke-width="4" stroke-linecap="round" />
+                    <path
+                        d="M57 33 L62 36 L57 40"
+                        fill="none"
+                        stroke="#FF9900"
+                        stroke-width="4"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                    />
+                </svg>
+            );
+            // stylelint-enable color-no-hex
+        }
+
+        if (p === "kimi" || p === "moonshot") {
+            // stylelint-disable color-no-hex
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" fill="#818cf8" />
+                </svg>
+            );
+            // stylelint-enable color-no-hex
+        }
+
+        if (p === "pi" || p === "plandex") {
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <text x="12" y="18" text-anchor="middle" font-size="17" font-family="Georgia, serif" font-weight="bold">
+                        π
+                    </text>
+                </svg>
+            );
+        }
+
+        if (p === "openclaw") {
+            return (
+                <svg width={size()} height={size()} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" stroke-width="2" />
+                    <circle cx="12" cy="12" r="5" />
+                </svg>
+            );
+        }
+
+        // Default: first letter of provider name
+        const letter = (props.provider ?? "?").charAt(0).toUpperCase();
+        return (
+            <svg width={size()} height={size()} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <text x="12" y="17" text-anchor="middle" font-size="14" font-family="system-ui, sans-serif" font-weight="600">
+                    {letter}
+                </text>
+            </svg>
+        );
+    };
+
+    return (
+        <span class={`provider-logo${props.class ? ` ${props.class}` : ""}`} aria-hidden="true">
+            {svg()}
+        </span>
+    );
+};
+
+ProviderLogo.displayName = "ProviderLogo";

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -22,6 +22,7 @@
 
 import { createMemo, Show, useContext, type Component, type JSX } from "solid-js";
 import { Popover, PopoverContext, PopoverContent } from "@/element/popover";
+import { ProviderLogo } from "@/element/ProviderLogo";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 
 interface AgentCardProps {
@@ -65,7 +66,6 @@ const InfoPopoverTrigger: Component<{ ariaLabel: string }> = (props) => {
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
     const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
 
-    const icon = () => props.agent.icon || catalog()?.icon || "•";
     const title = () => catalog()?.blurb || props.agent.description || props.agent.name;
     const caption = () => catalog()?.displayName || props.agent.name;
     const popoverText = () => catalog()?.popoverMarkdown ?? props.agent.description ?? "";
@@ -100,7 +100,7 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
             aria-disabled={props.disabled}
             aria-label={`Launch ${caption()}`}
         >
-            <span class="agent-card-icon">{icon()}</span>
+            <ProviderLogo provider={props.agent.provider} size={28} class="agent-card-icon" />
             <span class="agent-card-info">
                 <span class="agent-card-title">{title()}</span>
                 <span class="agent-card-caption">{caption()}</span>

--- a/frontend/app/view/agent/components/AgentIdentityPanel.tsx
+++ b/frontend/app/view/agent/components/AgentIdentityPanel.tsx
@@ -16,6 +16,7 @@
 
 import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { AccountForm } from "@/app/view/identity/identity-view";
+import { ProviderLogo } from "@/element/ProviderLogo";
 import {
     type AccountProvider,
     type AgentAccounts,
@@ -26,13 +27,6 @@ import {
 } from "@/app/view/identity/identity-model";
 
 const ALL_PROVIDERS: AccountProvider[] = ["github", "aws", "anthropic", "custom"];
-
-const PROVIDER_ICONS: Record<AccountProvider, string> = {
-    github: "⑆",
-    aws: "☁",
-    anthropic: "◈",
-    custom: "⊞",
-};
 
 interface AgentIdentityPanelProps {
     agent: ForgeAgent;
@@ -90,9 +84,7 @@ export const AgentIdentityPanel = (props: AgentIdentityPanelProps): JSX.Element 
 
                         return (
                             <div class="agent-identity-provider-row">
-                                <span class="agent-identity-provider-icon">
-                                    {PROVIDER_ICONS[provider]}
-                                </span>
+                                <ProviderLogo provider={provider} size={16} class="agent-identity-provider-icon" />
                                 <span class="agent-identity-provider-label">
                                     {PROVIDER_LABELS[provider]}
                                 </span>

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -130,10 +130,12 @@
         }
 
         .agent-card-icon {
-            font-size: 22px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             flex-shrink: 0;
             width: 28px;
-            text-align: center;
+            height: 28px;
         }
 
         .agent-card-info {

--- a/frontend/app/view/identity/identity-view.tsx
+++ b/frontend/app/view/identity/identity-view.tsx
@@ -11,16 +11,8 @@ import type {
     SecretRef,
 } from "./identity-model";
 import { KIND_LABELS, PROVIDER_LABELS } from "./identity-model";
+import { ProviderLogo } from "@/element/ProviderLogo";
 import "./identity-view.scss";
-
-// ── Provider icons (text symbols, no extra deps) ─────────────────────────────
-
-const PROVIDER_ICON: Record<AccountProvider, string> = {
-    github: "GH",
-    aws: "AWS",
-    anthropic: "AI",
-    custom: "—",
-};
 
 const STATUS_DOT: Record<string, string> = {
     valid: "status-dot status-valid",
@@ -139,7 +131,7 @@ function AccountRow(props: { account: Account; selected: boolean; onClick: () =>
             onClick={props.onClick}
         >
             <span class={`identity-provider-badge provider-${a.provider}`}>
-                {PROVIDER_ICON[a.provider]}
+                <ProviderLogo provider={a.provider} size={16} />
             </span>
             <span class="identity-account-name">{a.name}</span>
             <div class="identity-row-meta">
@@ -162,7 +154,7 @@ function AccountDetail({ model, account }: { model: IdentityViewModel; account: 
         <div class="identity-detail">
             <div class="identity-detail-header">
                 <span class={`identity-provider-badge provider-${account.provider}`}>
-                    {PROVIDER_ICON[account.provider]}
+                    <ProviderLogo provider={account.provider} size={16} />
                 </span>
                 <div class="identity-detail-title">
                     <span class="identity-detail-name">{account.name}</span>
@@ -326,7 +318,12 @@ function AssignmentsTab({ model }: { model: IdentityViewModel }): JSX.Element {
                                                                 class={`identity-provider-badge provider-${p} matrix-badge`}
                                                                 title={acct!.name}
                                                             >
-                                                                {acct!.display_name ?? PROVIDER_ICON[p]}
+                                                                <Show
+                                                                    when={acct!.display_name}
+                                                                    fallback={<ProviderLogo provider={p} size={14} />}
+                                                                >
+                                                                    {acct!.display_name}
+                                                                </Show>
                                                             </span>
                                                             <span class={STATUS_DOT[acct!.status] ?? STATUS_DOT["unknown"]} />
                                                         </Show>

--- a/frontend/app/view/identity/styles/_provider-badge.scss
+++ b/frontend/app/view/identity/styles/_provider-badge.scss
@@ -9,12 +9,9 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 9px;
-    font-weight: 700;
     width: 26px;
-    height: 18px;
+    height: 22px;
     border-radius: 3px;
-    letter-spacing: 0;
     flex-shrink: 0;
 
     /* stylelint-disable color-no-hex --

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.625",
+      "version": "0.33.626",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Closes #679. Prerequisite for #680.

## Summary

- Adds `frontend/app/element/ProviderLogo.tsx` — single shared component with inline SVG logos for all providers (Anthropic, OpenAI/Codex, Google/Gemini, GitHub, Copilot, AWS, Kimi, Plandex/Pi, OpenClaw). Letter-initial fallback for unknown providers.
- Replaces `AgentCard.tsx` Unicode glyph (`icon()` memo) with `<ProviderLogo provider size={28} />`
- Replaces `identity-view.tsx` `PROVIDER_ICON` text map ("GH", "AWS", "AI", "—") with `<ProviderLogo size={16} />` at all three badge sites
- Replaces `AgentIdentityPanel.tsx` `PROVIDER_ICONS` Unicode map with `<ProviderLogo size={16} />`
- `_provider-badge.scss`: badge height 18→22px, removes font/letter-spacing rules
- `_picker.scss`: `.agent-card-icon` switches from text sizing to `display:flex` fixed 28×28

## Design notes

- No new dependencies — fully inline SVG, zero network requests
- Monochrome logos (`github`, `openai`, `pi`, `openclaw`, default) use `fill="currentColor"` — theme-adaptive
- Brand-color logos (`anthropic`, `google`, `aws`, `copilot`, `kimi`) use hardcoded hex — vendor identity marks, guarded with `stylelint-disable color-no-hex` in JSX

## Test plan

- [ ] Agent picker: each catalog agent shows its provider logo (Anthropic bars, OpenAI hex, Google G, etc.)
- [ ] Identity view accounts tab: provider badge shows SVG logo instead of text abbreviation
- [ ] Identity view assignments tab: matrix badge shows logo when no display name, display name when present
- [ ] AgentIdentityPanel: provider rows show SVG logo instead of Unicode glyph
- [ ] Unknown/custom provider shows letter-initial fallback
- [ ] Dark and light themes: currentColor logos adapt correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)