### PR TITLE
feat(srv): typed LayoutNode struct (E.4.B Phase 2) + tabN naming fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.626"
+version = "0.33.627"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.626"
+version = "0.33.627"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.626"
+version = "0.33.627"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.626"
+version = "0.33.627"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.626"
+version = "0.33.627"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.626"
+version = "0.33.627"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.626"
+version = "0.33.627"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.625"
+version = "0.33.626"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.626"
+version = "0.33.627"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.625"
+version = "0.33.626"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -386,13 +386,80 @@ pub struct Tab {
 
 impl_wave_obj!(Tab, OTYPE_TAB);
 
+// ====================================================================
+// Phase E.4.B Phase 2 — typed LayoutNode tree
+// ====================================================================
+//
+// `LayoutState.rootnode` was `Option<serde_json::Value>` (opaque blob)
+// pre-E.4.B. This phase replaces it with a typed Rust struct that
+// deserializes from the same JSON shape the frontend produces.
+//
+// Wire-compat goal: bytes produced by serializing a `LayoutNode` must
+// match what `Option<serde_json::Value>` would have produced for the
+// equivalent shape. See `tests::layout_node_roundtrip` (in this file).
+//
+// See `docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md` §4.1.
+
+/// Direction children flow within a layout node (row = horizontal split,
+/// column = vertical split). Always present in production JSON; defaults
+/// to `Row` if absent on deserialization for forward-compat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum FlexDirection {
+    #[default]
+    Row,
+    Column,
+}
+
+/// Leaf-only payload — references the block this layout-leaf renders.
+/// Group nodes (those with `children`) carry no `data`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LayoutNodeData {
+    #[serde(rename = "blockId")]
+    pub block_id: String,
+}
+
+/// One node in the layout tree. Stable UUID-keyed; size is a relative
+/// flex unit; children form the recursive structure (empty for leaves).
+///
+/// JSON shape (matches frontend `LayoutNode` in `frontend/layout/lib/types.ts`):
+/// ```json
+/// { "id": "...", "flexDirection": "row", "size": 1, "children": [...], "data": { "blockId": "..." } }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutNode {
+    pub id: String,
+    /// Direction this node's children flow. Required in the JSON but
+    /// defaulted on deserialization to be tolerant of older blobs.
+    #[serde(rename = "flexDirection", default)]
+    pub flex_direction: FlexDirection,
+    /// Flex size — relative units within the parent's children array.
+    /// Default 1.0 if missing on the wire.
+    #[serde(default = "default_layout_size")]
+    pub size: f32,
+    /// Child nodes. Empty for leaves; serialized as `[]` (preserved by
+    /// default) — frontend tolerates either omitted or empty array.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<LayoutNode>,
+    /// Leaf-only payload. None for group nodes; serialized only when
+    /// present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<LayoutNodeData>,
+}
+
+fn default_layout_size() -> f32 {
+    1.0
+}
+
 /// Go: `LayoutState` in pkg/obj/wtype.go
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct LayoutState {
     pub oid: String,
     pub version: i64,
+    /// Phase E.4.B Phase 2 — typed; was `Option<serde_json::Value>`.
+    /// Wire format unchanged (serde-compat with the prior JSON shape).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub rootnode: Option<serde_json::Value>,
+    pub rootnode: Option<LayoutNode>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub magnifiednodeid: String,
     #[serde(default, skip_serializing_if = "String::is_empty")]
@@ -580,10 +647,17 @@ mod tests {
 
     #[test]
     fn test_layout_state_roundtrip() {
+        // Phase E.4.B Phase 2 — uses typed LayoutNode (was a junk JSON blob).
         let ls = LayoutState {
             oid: "ls-oid".to_string(),
             version: 1,
-            rootnode: Some(serde_json::json!({"type": "split", "children": []})),
+            rootnode: Some(LayoutNode {
+                id: "node-1".into(),
+                flex_direction: FlexDirection::Row,
+                size: 1.0,
+                children: Vec::new(),
+                data: None,
+            }),
             magnifiednodeid: "node-1".to_string(),
             ..Default::default()
         };
@@ -591,6 +665,117 @@ mod tests {
         let parsed: LayoutState = wave_obj_from_json(&json).unwrap();
         assert_eq!(parsed.magnifiednodeid, "node-1");
         assert!(parsed.rootnode.is_some());
+        assert_eq!(parsed.rootnode.as_ref().unwrap().id, "node-1");
+    }
+
+    /// Phase E.4.B Phase 2 acceptance gate: deserializing the JSON shape
+    /// the frontend produces today MUST yield the typed LayoutNode, and
+    /// reserializing MUST produce equivalent JSON. The shapes here cover:
+    ///   1. Single-leaf root (dnd / tear-off shape)
+    ///   2. The first-launch three-pane shape (deep nesting + mixed
+    ///      group/leaf nodes)
+    ///   3. Edge: missing `children` array for leaves
+    #[test]
+    fn test_layout_node_serde_compat_with_frontend_shapes() {
+        // Shape 1 — single leaf (matches dnd.rs / service.rs writers).
+        let leaf_json = serde_json::json!({
+            "id": "node-uuid-1",
+            "data": { "blockId": "block-uuid-1" },
+            "flexDirection": "row",
+            "size": 1
+        });
+        let leaf: LayoutNode = serde_json::from_value(leaf_json).unwrap();
+        assert_eq!(leaf.id, "node-uuid-1");
+        assert_eq!(leaf.flex_direction, FlexDirection::Row);
+        assert_eq!(leaf.size, 1.0);
+        assert!(leaf.children.is_empty());
+        assert_eq!(leaf.data.as_ref().unwrap().block_id, "block-uuid-1");
+        // Round-trip preserves shape.
+        let reserialized = serde_json::to_value(&leaf).unwrap();
+        let reparsed: LayoutNode = serde_json::from_value(reserialized).unwrap();
+        assert_eq!(leaf, reparsed);
+
+        // Shape 2 — first-launch three-pane (matches wcore::mod.rs).
+        let three_pane_json = serde_json::json!({
+            "id": "root-id",
+            "flexDirection": "row",
+            "size": 10,
+            "children": [
+                {
+                    "id": "agent-id",
+                    "flexDirection": "column",
+                    "size": 5,
+                    "data": { "blockId": "agent-block" }
+                },
+                {
+                    "id": "right-col-id",
+                    "flexDirection": "column",
+                    "size": 5,
+                    "children": [
+                        {
+                            "id": "sysinfo-id",
+                            "flexDirection": "row",
+                            "size": 2,
+                            "data": { "blockId": "sysinfo-block" }
+                        },
+                        {
+                            "id": "swarm-id",
+                            "flexDirection": "row",
+                            "size": 8,
+                            "data": { "blockId": "swarm-block" }
+                        }
+                    ]
+                }
+            ]
+        });
+        let root: LayoutNode = serde_json::from_value(three_pane_json).unwrap();
+        assert_eq!(root.id, "root-id");
+        assert_eq!(root.children.len(), 2);
+        assert_eq!(root.children[0].id, "agent-id");
+        assert_eq!(root.children[0].flex_direction, FlexDirection::Column);
+        assert_eq!(root.children[0].data.as_ref().unwrap().block_id, "agent-block");
+        let right_col = &root.children[1];
+        assert_eq!(right_col.children.len(), 2);
+        assert_eq!(right_col.data, None); // group node, no leaf data
+        assert_eq!(right_col.children[1].data.as_ref().unwrap().block_id, "swarm-block");
+        let reserialized = serde_json::to_value(&root).unwrap();
+        let reparsed: LayoutNode = serde_json::from_value(reserialized).unwrap();
+        assert_eq!(root, reparsed);
+
+        // Shape 3 — leaf without `children` array (real on-disk blobs may
+        // or may not have `"children": []`; deserializer must tolerate either).
+        let leaf_no_children = serde_json::json!({
+            "id": "loner",
+            "flexDirection": "column",
+            "size": 5,
+            "data": { "blockId": "b" }
+        });
+        let parsed: LayoutNode = serde_json::from_value(leaf_no_children).unwrap();
+        assert!(parsed.children.is_empty());
+    }
+
+    /// Phase E.4.B Phase 2 — deserializing a node WITHOUT `flexDirection`
+    /// falls back to `Row` default. Defensive against older blobs.
+    #[test]
+    fn test_layout_node_defaults_flex_direction_to_row() {
+        let no_dir = serde_json::json!({"id": "x", "size": 1});
+        let parsed: LayoutNode = serde_json::from_value(no_dir).unwrap();
+        assert_eq!(parsed.flex_direction, FlexDirection::Row);
+    }
+
+    /// Phase E.4.B Phase 2 — `data: None` serializes ABSENT (not `"data": null`).
+    /// Frontend tolerates either, but absent matches the pre-typed JSON shape.
+    #[test]
+    fn test_layout_node_data_skipped_when_none() {
+        let group = LayoutNode {
+            id: "g".into(),
+            flex_direction: FlexDirection::Row,
+            size: 1.0,
+            children: Vec::new(),
+            data: None,
+        };
+        let json = serde_json::to_value(&group).unwrap();
+        assert!(json.get("data").is_none(), "data: None must skip-serialize");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -434,8 +434,14 @@ pub struct LayoutNode {
     #[serde(rename = "flexDirection", default)]
     pub flex_direction: FlexDirection,
     /// Flex size — relative units within the parent's children array.
-    /// Default 1.0 if missing on the wire.
-    #[serde(default = "default_layout_size")]
+    /// Default 1.0 if missing on the wire. Custom serializer emits
+    /// whole-number sizes as integers (`10` not `10.0`) to preserve
+    /// byte-equal compatibility with the prior `serde_json::json!()`-
+    /// produced JSON, which used integer literals (reagent P2 PR #688).
+    #[serde(
+        default = "default_layout_size",
+        serialize_with = "serialize_size_smallest",
+    )]
     pub size: f32,
     /// Child nodes. Empty for leaves; serialized as `[]` (preserved by
     /// default) — frontend tolerates either omitted or empty array.
@@ -449,6 +455,29 @@ pub struct LayoutNode {
 
 fn default_layout_size() -> f32 {
     1.0
+}
+
+/// Serialize a layout `size` as the smallest representation that
+/// round-trips faithfully:
+/// - Whole numbers (5.0) → integer JSON (`5`) — matches the prior
+///   `serde_json::json!()` writers which used integer literals
+/// - Fractional numbers (5.5) → float JSON (`5.5`)
+///
+/// JSON `number` is the same type either way, but byte-level diffs
+/// matter for downstream consumers that do string-equality on stored
+/// blobs (and for clarity in debug logs).
+fn serialize_size_smallest<S>(value: &f32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    if value.fract() == 0.0
+        && value.is_finite()
+        && (i64::MIN as f32..=i64::MAX as f32).contains(value)
+    {
+        serializer.serialize_i64(*value as i64)
+    } else {
+        serializer.serialize_f32(*value)
+    }
 }
 
 /// Go: `LayoutState` in pkg/obj/wtype.go
@@ -761,6 +790,39 @@ mod tests {
         let no_dir = serde_json::json!({"id": "x", "size": 1});
         let parsed: LayoutNode = serde_json::from_value(no_dir).unwrap();
         assert_eq!(parsed.flex_direction, FlexDirection::Row);
+    }
+
+    /// Phase E.4.B Phase 2 (reagent P2 PR #688) — whole-number sizes
+    /// serialize as integer JSON literals, not float (`10` not `10.0`).
+    /// This preserves byte-equal compatibility with the prior
+    /// `serde_json::json!()`-produced JSON which used integer literals.
+    #[test]
+    fn test_layout_node_size_serializes_as_integer_when_whole() {
+        let whole = LayoutNode {
+            id: "x".into(),
+            flex_direction: FlexDirection::Row,
+            size: 10.0,
+            children: Vec::new(),
+            data: None,
+        };
+        let json = serde_json::to_string(&whole).unwrap();
+        assert!(json.contains("\"size\":10"), "whole sizes should serialize as integer; got {}", json);
+        assert!(!json.contains("\"size\":10.0"), "whole sizes should NOT include the decimal; got {}", json);
+
+        // Fractional sizes still serialize with the decimal.
+        let frac = LayoutNode {
+            id: "y".into(),
+            flex_direction: FlexDirection::Row,
+            size: 5.5,
+            children: Vec::new(),
+            data: None,
+        };
+        let json = serde_json::to_string(&frac).unwrap();
+        assert!(json.contains("\"size\":5.5"), "fractional sizes preserve the decimal; got {}", json);
+
+        // Round-trip works either way.
+        let reparsed: LayoutNode = serde_json::from_str(&serde_json::to_string(&whole).unwrap()).unwrap();
+        assert_eq!(reparsed.size, 10.0);
     }
 
     /// Phase E.4.B Phase 2 — `data: None` serializes ABSENT (not `"data": null`).

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1600,9 +1600,16 @@ mod tests {
     #[test]
     fn test_insert_and_get_layout_state() {
         let store = make_store();
+        // Phase E.4.B Phase 2 — uses typed LayoutNode (was a junk JSON blob).
         let mut ls = LayoutState {
             oid: "ls-1".to_string(),
-            rootnode: Some(serde_json::json!({"type": "split"})),
+            rootnode: Some(crate::backend::obj::LayoutNode {
+                id: "n1".into(),
+                flex_direction: crate::backend::obj::FlexDirection::Row,
+                size: 1.0,
+                children: Vec::new(),
+                data: None,
+            }),
             magnifiednodeid: "n1".to_string(),
             ..Default::default()
         };
@@ -1720,7 +1727,8 @@ mod tests {
 
                 let mut tab = Tab {
                     oid: "tab-tx".to_string(),
-                    name: "Untitled1".to_string(),
+                    // tabN naming convention per SPEC_TAB_GAPS_AND_NAMING_2026_04_25.
+                    name: "tab1".to_string(),
                     layoutstate: "ls-tx".to_string(),
                     meta: MetaMapType::new(),
                     ..Default::default()
@@ -1742,7 +1750,7 @@ mod tests {
         assert_eq!(ws.version, 2); // insert=v1, update=v2
 
         let tab = store.must_get::<Tab>("tab-tx").unwrap();
-        assert_eq!(tab.name, "Untitled1");
+        assert_eq!(tab.name, "tab1");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -72,12 +72,12 @@ fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
     // leaf (no `children` array, just `data.blockId`). `prune_node` only
     // touches the `children` array, so a rootnode-leaf orphan would
     // otherwise persist forever. See SPEC_LAYOUT_HEAL_ROOTNODE_ORPHAN.md.
+    //
+    // Phase E.4.B Phase 2 — operates on typed LayoutNode (was JSON walks).
     let root_is_orphan = layout.rootnode
         .as_ref()
-        .and_then(|r| r.get("data"))
-        .and_then(|d| d.get("blockId"))
-        .and_then(|id| id.as_str())
-        .map(|id| id == block_id)
+        .and_then(|r| r.data.as_ref())
+        .map(|d| d.block_id == block_id)
         .unwrap_or(false);
     if root_is_orphan {
         layout.rootnode = None;
@@ -86,47 +86,34 @@ fn prune_block_from_layout(layout: &mut LayoutState, block_id: &str) {
     }
 }
 
-/// Recursively remove child nodes whose `data.blockId` matches `block_id`.
+/// Recursively remove child nodes whose `data.block_id` matches `block_id`.
 /// If removing a child leaves a parent with only one child, collapse by
 /// promoting the sole child to replace the parent node.
-fn prune_node(node: &mut serde_json::Value, block_id: &str) {
-    if let Some(children) = node.get_mut("children").and_then(|c| c.as_array_mut()) {
-        // Remove children that are leaves matching block_id
-        children.retain(|child| {
-            child.get("data")
-                .and_then(|d| d.get("blockId"))
-                .and_then(|id| id.as_str())
-                .map(|id| id != block_id)
-                .unwrap_or(true) // keep non-leaf nodes
-        });
-        // Recurse into remaining children
-        for child in children.iter_mut() {
-            prune_node(child, block_id);
-        }
+///
+/// Phase E.4.B Phase 2 — operates on typed LayoutNode (was JSON walks).
+fn prune_node(node: &mut LayoutNode, block_id: &str) {
+    // Remove children whose leaf data references the doomed block.
+    node.children.retain(|child| {
+        child
+            .data
+            .as_ref()
+            .map(|d| d.block_id != block_id)
+            .unwrap_or(true) // keep group nodes (no leaf data)
+    });
+    // Recurse into remaining children
+    for child in node.children.iter_mut() {
+        prune_node(child, block_id);
     }
     // If only one child remains, promote it to replace this split node.
     // This avoids degenerate single-child splits in the layout tree.
-    let should_collapse = node.get("children")
-        .and_then(|c| c.as_array())
-        .map(|c| c.len() == 1)
-        .unwrap_or(false);
-    if should_collapse {
-        if let Some(sole_child) = node.get("children")
-            .and_then(|c| c.as_array())
-            .and_then(|c| c.first())
-            .cloned()
-        {
-            // Preserve the parent's id and size, replace everything else
-            let parent_id = node.get("id").cloned();
-            let parent_size = node.get("size").cloned();
-            *node = sole_child;
-            if let Some(id) = parent_id {
-                node["id"] = id;
-            }
-            if let Some(size) = parent_size {
-                node["size"] = size;
-            }
-        }
+    if node.children.len() == 1 {
+        let parent_id = node.id.clone();
+        let parent_size = node.size;
+        let sole_child = node.children.remove(0);
+        *node = sole_child;
+        // Preserve the parent's id and size, replace everything else.
+        node.id = parent_id;
+        node.size = parent_size;
     }
 }
 
@@ -212,20 +199,17 @@ fn heal_layout_body(
     (true, orphans)
 }
 
-/// Walk a layout-tree node, calling `sink` once per leaf `data.blockId`.
-fn collect_leaf_block_ids(node: &serde_json::Value, sink: &mut dyn FnMut(&str)) {
-    if let Some(children) = node.get("children").and_then(|c| c.as_array()) {
-        for child in children {
+/// Walk a layout-tree node, calling `sink` once per leaf `data.block_id`.
+/// Phase E.4.B Phase 2 — typed traversal (was JSON walks).
+fn collect_leaf_block_ids(node: &LayoutNode, sink: &mut dyn FnMut(&str)) {
+    if !node.children.is_empty() {
+        for child in &node.children {
             collect_leaf_block_ids(child, sink);
         }
         return;
     }
-    if let Some(id) = node
-        .get("data")
-        .and_then(|d| d.get("blockId"))
-        .and_then(|id| id.as_str())
-    {
-        sink(id);
+    if let Some(data) = &node.data {
+        sink(&data.block_id);
     }
 }
 
@@ -249,16 +233,23 @@ mod tests {
         }
     }
 
+    fn leaf(id: &str, block_id: &str, size: f32) -> LayoutNode {
+        LayoutNode {
+            id: id.into(),
+            flex_direction: FlexDirection::Row,
+            size,
+            children: Vec::new(),
+            data: Some(LayoutNodeData {
+                block_id: block_id.into(),
+            }),
+        }
+    }
+
     fn single_leaf_layout(block_id: &str, node_id: &str) -> LayoutState {
         LayoutState {
             oid: "layout-1".into(),
             version: 1,
-            rootnode: Some(json!({
-                "data": { "blockId": block_id },
-                "flexDirection": "row",
-                "id": node_id,
-                "size": 10,
-            })),
+            rootnode: Some(leaf(node_id, block_id, 10.0)),
             leaforder: Some(vec![LeafOrderEntry {
                 blockid: block_id.into(),
                 nodeid: node_id.into(),
@@ -274,25 +265,16 @@ mod tests {
         LayoutState {
             oid: "layout-1".into(),
             version: 1,
-            rootnode: Some(json!({
-                "id": "split-1",
-                "flexDirection": "row",
-                "size": 10,
-                "children": [
-                    {
-                        "id": "leaf-left",
-                        "flexDirection": "row",
-                        "size": 5,
-                        "data": { "blockId": left_block }
-                    },
-                    {
-                        "id": "leaf-right",
-                        "flexDirection": "row",
-                        "size": 5,
-                        "data": { "blockId": right_block }
-                    }
-                ]
-            })),
+            rootnode: Some(LayoutNode {
+                id: "split-1".into(),
+                flex_direction: FlexDirection::Row,
+                size: 10.0,
+                children: vec![
+                    leaf("leaf-left", left_block, 5.0),
+                    leaf("leaf-right", right_block, 5.0),
+                ],
+                data: None,
+            }),
             leaforder: Some(vec![
                 LeafOrderEntry { blockid: left_block.into(), nodeid: "leaf-left".into() },
                 LeafOrderEntry { blockid: right_block.into(), nodeid: "leaf-right".into() },
@@ -333,10 +315,9 @@ mod tests {
 
         assert!(layout.rootnode.is_some(), "rootnode should survive");
         // The split should collapse to just the "keep" leaf.
+        // Phase E.4.B Phase 2 — typed access (was JSON walks).
         let root = layout.rootnode.as_ref().unwrap();
-        let kept_block = root.get("data")
-            .and_then(|d| d.get("blockId"))
-            .and_then(|id| id.as_str());
+        let kept_block = root.data.as_ref().map(|d| d.block_id.as_str());
         assert_eq!(kept_block, Some("keep"),
             "after pruning 'drop' and collapsing, rootnode should be the 'keep' leaf");
     }

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -244,15 +244,20 @@ pub fn tear_off_block(
 
     // Set up the layout tree for the new tab with the block as the single root node.
     // Without this, the frontend renders an empty layout (rootnode: null).
+    // Phase E.4.B Phase 2 — typed LayoutNode (was inline JSON).
     let mut layout = store.must_get::<LayoutState>(&new_tab.layoutstate)?;
-    layout.rootnode = Some(serde_json::json!({
-        "id": Uuid::new_v4().to_string(),
-        "data": { "blockId": block_id },
-        "flexDirection": "row",
-        "size": 1
-    }));
+    let node_id = Uuid::new_v4().to_string();
+    layout.rootnode = Some(LayoutNode {
+        id: node_id.clone(),
+        flex_direction: FlexDirection::Row,
+        size: 1.0,
+        children: Vec::new(),
+        data: Some(LayoutNodeData {
+            block_id: block_id.to_string(),
+        }),
+    });
     layout.leaforder = Some(vec![LeafOrderEntry {
-        nodeid: layout.rootnode.as_ref().unwrap()["id"].as_str().unwrap().to_string(),
+        nodeid: node_id,
         blockid: block_id.to_string(),
     }]);
     store.update(&mut layout)?;

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -130,38 +130,50 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
     let right_col_id = Uuid::new_v4().to_string();
     let root_id = Uuid::new_v4().to_string();
 
-    let rootnode = serde_json::json!({
-        "id": root_id,
-        "flexDirection": "row",
-        "size": 10,
-        "children": [
-            {
-                "id": agent_node_id,
-                "flexDirection": "column",
-                "size": 5,
-                "data": { "blockId": agent_block.oid },
+    // Phase E.4.B Phase 2 — typed LayoutNode (was inline JSON).
+    let rootnode = LayoutNode {
+        id: root_id,
+        flex_direction: FlexDirection::Row,
+        size: 10.0,
+        children: vec![
+            LayoutNode {
+                id: agent_node_id.clone(),
+                flex_direction: FlexDirection::Column,
+                size: 5.0,
+                children: Vec::new(),
+                data: Some(LayoutNodeData {
+                    block_id: agent_block.oid.clone(),
+                }),
             },
-            {
-                "id": right_col_id,
-                "flexDirection": "column",
-                "size": 5,
-                "children": [
-                    {
-                        "id": sysinfo_node_id,
-                        "flexDirection": "row",
-                        "size": 2,
-                        "data": { "blockId": sysinfo_block.oid },
+            LayoutNode {
+                id: right_col_id,
+                flex_direction: FlexDirection::Column,
+                size: 5.0,
+                children: vec![
+                    LayoutNode {
+                        id: sysinfo_node_id.clone(),
+                        flex_direction: FlexDirection::Row,
+                        size: 2.0,
+                        children: Vec::new(),
+                        data: Some(LayoutNodeData {
+                            block_id: sysinfo_block.oid.clone(),
+                        }),
                     },
-                    {
-                        "id": swarm_node_id,
-                        "flexDirection": "row",
-                        "size": 8,
-                        "data": { "blockId": swarm_block.oid },
+                    LayoutNode {
+                        id: swarm_node_id.clone(),
+                        flex_direction: FlexDirection::Row,
+                        size: 8.0,
+                        children: Vec::new(),
+                        data: Some(LayoutNodeData {
+                            block_id: swarm_block.oid.clone(),
+                        }),
                     },
                 ],
+                data: None,
             },
         ],
-    });
+        data: None,
+    };
 
     let mut layout = store.must_get::<LayoutState>(&tab.layoutstate)?;
     layout.rootnode = Some(rootnode);
@@ -223,8 +235,10 @@ mod tests {
 
         let tabs = store.get_all::<Tab>().unwrap();
         assert_eq!(tabs.len(), 1);
-        // Tab should be named "Untitled1"
-        assert_eq!(tabs[0].name, "Untitled1");
+        // Tab should be named "tab1" (per SPEC_TAB_GAPS_AND_NAMING_2026_04_25 —
+        // auto-generated tabs use the `tabN` convention, not the older
+        // `Untitled1` name. The test was asserting against stale-spec naming).
+        assert_eq!(tabs[0].name, "tab1");
     }
 
     #[test]

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2303,12 +2303,16 @@ fn setup_torn_off_block_layout(
     let new_tab = store.must_get::<Tab>(new_tab_id)?;
     let mut layout = store.must_get::<LayoutState>(&new_tab.layoutstate)?;
     let node_id = uuid::Uuid::new_v4().to_string();
-    layout.rootnode = Some(serde_json::json!({
-        "id": node_id,
-        "data": { "blockId": block_id },
-        "flexDirection": "row",
-        "size": 1
-    }));
+    // Phase E.4.B Phase 2 — construct typed LayoutNode (was inline JSON).
+    layout.rootnode = Some(LayoutNode {
+        id: node_id.clone(),
+        flex_direction: FlexDirection::Row,
+        size: 1.0,
+        children: Vec::new(),
+        data: Some(LayoutNodeData {
+            block_id: block_id.to_string(),
+        }),
+    });
     layout.leaforder = Some(vec![LeafOrderEntry {
         nodeid: node_id,
         blockid: block_id.to_string(),

--- a/docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md
+++ b/docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md
@@ -1,0 +1,707 @@
+# SPEC: srv Phase E.4.B — Layout Tree as Reducer State
+
+**Date:** 2026-05-03
+**Status:** Formal implementation spec. Final answers to all open questions; ready to drive PRs.
+**Decision context:** Full E.4.B committed (~4–5 weeks) for **multi-window robust operation**. The half-version (typed tree only) is rejected — it doesn't fix the drag-resize-clobber and concurrent-split-data-loss bugs that motivate the project.
+**Reads-this-first:**
+- `docs/specs/SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` — original Phase E.4 spec; deferred E.4.B as "the hard part"
+- `docs/specs/srv-phase-e4b-implementation-plan-2026-05-03.md` — the planning doc this formalizes
+- `agentmux-srv/src/reducer.rs:655–700` — E.4.A handlers (the pattern)
+- `agentmux-srv/src/state.rs:69–88` — `TabRecord` struct (extended in this spec)
+- `frontend/layout/lib/layoutTree.ts` — the 11 pure-ish tree mutators to port
+- `frontend/layout/tests/layoutTree.test.ts` — test oracle from PR #686
+
+## 1. Goals
+
+This spec covers the work to:
+
+1. **Replace `LayoutState.rootnode: Option<serde_json::Value>` with a typed Rust `Option<LayoutNode>` struct** (`agentmux-srv/src/backend/obj.rs:391–406`). Removes the opaque-blob smell on the most-touched UI surface.
+2. **Add 11 reducer commands + 11 events** for tree mutations (Move, Swap, Resize, Insert×2, Delete, Replace, SplitH, SplitV, Clear, plus E.4.A's already-shipped Focus/Magnify which stay).
+3. **Migrate the 5 existing rootnode writers** to dispatch through the reducer.
+4. **Wire the frontend** to subscribe to `Layout*` events + apply granular mutations to its local state instead of replacing the whole tree on every wstore update (slice #8 of the frontend reducer roadmap).
+
+The user-visible payoff is multi-window robust operation. Concretely:
+
+| Scenario | Today | After E.4.B |
+|---|---|---|
+| Drag-resize in window B while window A flushes a tree change | Window B's drag clobbered | Window B's drag continues; remote command applies to non-overlapping subtree |
+| Both windows split different panes simultaneously | Last writer wins; one user's split silently disappears | srv serializes both commands; both splits land |
+| Tear off a tab from window A | Window B re-renders entire layout from blob | Window B applies a typed `LayoutTabReplaced` event |
+| Audit "what tree mutations happened in the last 5 min?" | Invisible | Captured in the global event log (PR-C) per-command |
+
+## 2. Non-goals
+
+- **No migration of `leaforder` to the reducer.** It's a derived view of `rootnode`; let the existing computation stay wcore-side.
+- **No migration of `pendingbackendactions`.** Re-evaluate after E.4.B has soaked. Likely subsumed by command-level events; defer the call.
+- **No change to the frontend's local-first reducer** (`frontend/layout/lib/layoutTree.ts`). It keeps its existing 15 actions as the local optimistic-update path. Slice #8 only adds an srv-event subscription on top.
+- **No multi-window state sync for state OUTSIDE the layout tree** (e.g. agent-pane state, tab-bar state). Those are separate concerns.
+- **No collaborative-editing-style conflict resolution** (CRDT, OT, etc.). srv is the serializing authority; conflicts are resolved by who-arrived-first ordering at the reducer mutex.
+- **No change to the wstore (SQLite) schema for `LayoutState`.** Existing columns suffice. The persisted JSON shape stays compatible with the typed Rust struct via serde.
+
+## 3. Architecture
+
+### 3.1 The two reducers
+
+| Reducer | Where | Owns | Role in E.4.B |
+|---|---|---|---|
+| **Frontend layout reducer** | `frontend/layout/lib/layoutTree.ts` + `layoutModel.ts` | Local treeState; 15 actions; pure-ish handlers | UNCHANGED. Stays the primary local-write path for optimistic UI. Slice #8 adds an srv-event subscription that applies remote mutations as additional reducer dispatches. |
+| **srv reducer** | `agentmux-srv/src/reducer.rs` | Workspaces, tabs, blocks, windows, focus/magnify | EXTENDED. Gains 11 new `Command::Layout*` arms operating on `TabRecord.layout_tree: Option<LayoutNode>` (new field). |
+
+### 3.2 Sync shape (Q2 from prior plan — finalized)
+
+**Optimistic-local-apply with srv serialization.** Each tree mutation:
+
+```
+[user clicks pane in window A]
+  → A's frontend layoutTree reducer dispatches Move action (LOCAL, sub-ms)
+  → A's UI updates immediately (no waiting on srv)
+  → A's persistence layer dispatches Command::LayoutMoveNode to srv (debounced 100ms)
+  → srv reducer arm validates + applies the command authoritatively
+  → srv emits Event::LayoutNodeMoved with version
+  → All connected windows (including A) receive the event via wstore subscription
+  → Each window's slice-#8 subscriber:
+       - if event matches a pending local optimistic-apply → confirm (no-op)
+       - if event differs → apply the command to local treeState (granular!)
+```
+
+This preserves the optimistic-UI feel (no srv round-trip on user actions) while making srv the source of truth for the persistent tree.
+
+### 3.3 Conflict resolution
+
+Conflicts are resolved at the reducer mutex by arrival order:
+
+1. Window A and B both dispatch overlapping commands (e.g. both delete the same node).
+2. srv reducer mutex serializes them — first command applies, second command's invariant check (`find_node_by_id`) fails → second command emits `Event::Error { code: NodeNotFound, fatal: false }` instead of mutating.
+3. Both windows receive the success event for command 1 and the error event for command 2; the error window can no-op or display a brief toast.
+
+No CRDT, no rollback. The reducer's "validate then apply" pattern handles this naturally.
+
+### 3.4 Optimistic apply discrepancy detection (slice #8 concern)
+
+When window A applies an optimistic Move locally THEN dispatches to srv THEN receives the matching event back, the slice-#8 subscriber needs to detect "this event corresponds to my own optimistic apply" and no-op. Two options:
+
+- **Option α — Echo-loop guard pattern** (matches `launcher-event-reducer.ts`): set `applyingRemote = true` while dispatching the local `Move` action that came from a remote event; the persistence layer checks this flag and skips the outbound RPC. Simple but doesn't distinguish "my own command echo" from "your command that I should apply."
+- **Option β — Command correlation IDs** (matches saga pattern): each outbound command carries a `correlation_id`; events reference it; subscriber checks "did I issue this command?" If yes, no-op (already applied locally); if no, apply.
+
+**Decision: Option β.** Echo-loop guard works for single-window mirror but in multi-window it's ambiguous. Correlation IDs scale cleanly. ~10 LOC overhead per command.
+
+## 4. Data model
+
+### 4.1 The typed `LayoutNode` struct
+
+New types in `agentmux-srv/src/backend/obj.rs` (alongside the existing `LayoutState`):
+
+```rust
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutNode {
+    /// UUID, generated on creation. Stable for the lifetime of this node.
+    pub id: String,
+    /// Direction children flow within this node. None for leaves.
+    #[serde(rename = "flexDirection", skip_serializing_if = "Option::is_none")]
+    pub flex_direction: Option<FlexDirection>,
+    /// Flex size; relative units. Default 1.0.
+    #[serde(default = "default_size")]
+    pub size: f32,
+    /// Children nodes. Empty for leaves.
+    #[serde(default)]
+    pub children: Vec<LayoutNode>,
+    /// Leaf-only payload (block reference). None for groups.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<LayoutNodeData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FlexDirection { Row, Column }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LayoutNodeData {
+    #[serde(rename = "blockId")]
+    pub block_id: String,
+}
+
+fn default_size() -> f32 { 1.0 }
+```
+
+`LayoutState.rootnode` becomes:
+```rust
+pub rootnode: Option<LayoutNode>,
+```
+
+Wire compat: serde-derived (de)serialization produces the same JSON the frontend already consumes (camelCase fields, optional skip-serialize). Round-trip tests against production tree blobs ensure compat (Phase 2 acceptance criterion).
+
+### 4.2 `TabRecord` extension (`agentmux-srv/src/state.rs`)
+
+Add one field:
+
+```rust
+pub struct TabRecord {
+    // ... existing fields
+    /// Phase E.4.B — the layout tree owned by this tab. `None` when the
+    /// tab has no panes (initial state or last-pane closed). Bootstrap-
+    /// loaded from `LayoutState.rootnode` at startup; mutated by the 11
+    /// `Command::Layout*` arms.
+    pub layout_tree: Option<LayoutNode>,
+}
+```
+
+Bootstrap from SQLite: `state.rs` startup load reads `LayoutState.rootnode` per tab and clones into the in-memory `TabRecord.layout_tree`.
+
+### 4.3 Pure helper functions
+
+In `agentmux-srv/src/backend/layout/mod.rs` (new file):
+
+```rust
+pub fn find_node_by_id(tree: &LayoutNode, id: &str) -> Option<&LayoutNode>;
+pub fn find_node_by_id_mut(tree: &mut LayoutNode, id: &str) -> Option<&mut LayoutNode>;
+pub fn find_parent_by_child_id(tree: &mut LayoutNode, child_id: &str) -> Option<&mut LayoutNode>;
+
+pub fn insert_node(tree: &mut LayoutNode, node: LayoutNode);
+pub fn insert_node_at_index(tree: &mut LayoutNode, node: LayoutNode, index_arr: &[usize]) -> Result<(), LayoutError>;
+pub fn delete_node(tree: &mut LayoutNode, node_id: &str) -> Result<bool, LayoutError>;  // returns whether-was-focused
+pub fn move_node(tree: &mut LayoutNode, node_id: &str, new_parent_id: &str, index: usize) -> Result<(), LayoutError>;
+pub fn swap_nodes(tree: &mut LayoutNode, node1_id: &str, node2_id: &str) -> Result<(), LayoutError>;
+pub fn resize_nodes(tree: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), LayoutError>;
+pub fn replace_node(tree: &mut LayoutNode, target_id: &str, new_node: LayoutNode) -> Result<(), LayoutError>;
+pub fn split_horizontal(tree: &mut LayoutNode, target_id: &str, new_node: LayoutNode, position: SplitPosition) -> Result<(), LayoutError>;
+pub fn split_vertical(tree: &mut LayoutNode, target_id: &str, new_node: LayoutNode, position: SplitPosition) -> Result<(), LayoutError>;
+
+pub enum LayoutError { NodeNotFound { id: String }, RootCannotBeMagnified, RootCannotBeSwapped, SelfSwap, InvalidSize { size: f32 } }
+pub struct ResizeOp { pub node_id: String, pub size: f32 }
+pub enum SplitPosition { Before, After }
+```
+
+These mirror `frontend/layout/lib/layoutTree.ts` semantics 1:1. Test oracle: port the 30 tests from `frontend/layout/tests/layoutTree.test.ts` (PR #686).
+
+## 5. Command surface
+
+All 11 new commands in `agentmux-common/src/ipc.rs` Command enum:
+
+```rust
+LayoutInsertNode {
+    tab_id: String,
+    node: LayoutNode,
+    /// Insert at root (None) or as child of a specific parent (Some).
+    parent_id: Option<String>,
+    /// Position within parent's children. None = append.
+    index: Option<usize>,
+    /// If true, sets focused_node_id to this node's id after insert.
+    focus_after: bool,
+    /// If true, sets magnified_node_id to this node's id after insert.
+    magnify_after: bool,
+    correlation_id: Uuid,
+},
+LayoutInsertNodeAtIndex {
+    tab_id: String,
+    node: LayoutNode,
+    /// Index path through the tree. e.g. [0, 2] = root.children[0].children[2].
+    index_arr: Vec<usize>,
+    focus_after: bool,
+    magnify_after: bool,
+    correlation_id: Uuid,
+},
+LayoutDeleteNode {
+    tab_id: String,
+    node_id: String,
+    correlation_id: Uuid,
+},
+LayoutMoveNode {
+    tab_id: String,
+    node_id: String,
+    new_parent_id: String,
+    index: usize,
+    correlation_id: Uuid,
+},
+LayoutSwapNodes {
+    tab_id: String,
+    node1_id: String,
+    node2_id: String,
+    correlation_id: Uuid,
+},
+LayoutResizeNodes {
+    tab_id: String,
+    ops: Vec<ResizeOp>,
+    correlation_id: Uuid,
+},
+LayoutReplaceNode {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    focus_after: bool,
+    correlation_id: Uuid,
+},
+LayoutSplitHorizontal {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    position: SplitPosition,
+    focus_after: bool,
+    correlation_id: Uuid,
+},
+LayoutSplitVertical {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    position: SplitPosition,
+    focus_after: bool,
+    correlation_id: Uuid,
+},
+LayoutClear {
+    tab_id: String,
+    correlation_id: Uuid,
+},
+LayoutSetTree {
+    /// Bulk replace the tree. Used during migration period and for tear-off
+    /// where the whole subtree changes atomically.
+    tab_id: String,
+    new_tree: Option<LayoutNode>,
+    correlation_id: Uuid,
+},
+```
+
+All commands carry `tab_id` (selects the slot) and `correlation_id` (for slice #8's optimistic-confirm logic).
+
+## 6. Event surface
+
+Mirror commands 1:1 in `agentmux-common/src/ipc.rs` Event enum:
+
+```rust
+LayoutNodeInserted {
+    tab_id: String,
+    node: LayoutNode,
+    parent_id: Option<String>,
+    index: Option<usize>,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodeInsertedAtIndex {
+    tab_id: String,
+    node: LayoutNode,
+    index_arr: Vec<usize>,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodeDeleted {
+    tab_id: String,
+    node_id: String,
+    /// True if the deleted node was the focused one (subscribers may need to refocus).
+    was_focused: bool,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodeMoved {
+    tab_id: String,
+    node_id: String,
+    new_parent_id: String,
+    index: usize,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodesSwapped {
+    tab_id: String,
+    node1_id: String,
+    node2_id: String,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodesResized {
+    tab_id: String,
+    ops: Vec<ResizeOp>,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutNodeReplaced {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutSplitHorizontal {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    position: SplitPosition,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutSplitVertical {
+    tab_id: String,
+    target_id: String,
+    new_node: LayoutNode,
+    position: SplitPosition,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutCleared {
+    tab_id: String,
+    correlation_id: Uuid,
+    version: u64,
+},
+LayoutTreeReplaced {
+    tab_id: String,
+    new_tree: Option<LayoutNode>,
+    correlation_id: Uuid,
+    version: u64,
+},
+```
+
+Errors flow through the existing `Event::Error { code, message, fatal: false, version }` shape — same as E.4.A.
+
+## 7. Reducer arm semantics
+
+Each handler follows the E.4.A template (`reducer.rs:655–700`):
+
+```rust
+fn handle_layout_<verb>(state: &mut State, ...args) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error { code: ErrorCode::InvalidCommand, message: format!("LayoutXxx: unknown tab {}", tab_id), fatal: false, version: v }];
+    };
+    // 1. Validate (find target nodes, check invariants)
+    // 2. If invariant violated: return typed Error event (non-fatal)
+    // 3. Apply pure helper to tab.layout_tree
+    // 4. Update tab.focused_node_id / magnified_node_id if command requested it
+    // 5. bump_version
+    // 6. Return Vec<Event> with the success event
+}
+```
+
+### 7.1 Per-handler specifications
+
+#### `handle_layout_insert_node`
+- If `tab.layout_tree.is_none()`: validate `parent_id.is_none()` AND `index.is_none()`; promote `node` to root.
+- Else: find parent by id (O(n) walk). If `parent_id.is_none()`, use `findNextInsertLocation` heuristic (port from frontend). If parent not found → Error event.
+- Insert node at parent.children[index] (or append if index None).
+- If `focus_after`: tab.focused_node_id = node.id.
+- If `magnify_after`: tab.magnified_node_id = node.id (also focused per cohesion rule).
+- Emit `LayoutNodeInserted`.
+
+#### `handle_layout_delete_node`
+- Find node by id; not found → Error.
+- If node IS root: tab.layout_tree = None.
+- Else: find parent, remove from children. Collapse-empty-parents pass.
+- Track `was_focused = (tab.focused_node_id == node_id)`. If true: tab.focused_node_id = "" (clear).
+- Emit `LayoutNodeDeleted { was_focused }`.
+
+#### `handle_layout_move_node`
+- Find node by id; not found → Error.
+- Find new_parent by id; not found → Error.
+- Detach node from old parent. Insert at new_parent.children[index].
+- Edge: moving node into its own descendant → reject (Error: InvalidMove).
+- Emit `LayoutNodeMoved`.
+
+#### `handle_layout_swap_nodes`
+- Find both nodes; either missing → Error.
+- Reject if either is root → Error.
+- Reject if same id → Error.
+- Swap positions in their respective parents (sizes swap with the nodes — matches existing semantic).
+- Emit `LayoutNodesSwapped`.
+
+#### `handle_layout_resize_nodes`
+- For each op: validate `0.0 <= size <= 100.0`. If any invalid → Error (and reject the entire op array atomically — match the existing "first invalid op causes early return" semantic from PR #686 tests).
+- For each op: find node, set size.
+- Emit `LayoutNodesResized`.
+
+#### `handle_layout_replace_node`
+- Find target_id; not found → Error.
+- If target is root: replace root, preserving size.
+- Else: find parent, replace at index, preserving size.
+- If `focus_after`: tab.focused_node_id = new_node.id.
+- Emit `LayoutNodeReplaced`.
+
+#### `handle_layout_split_horizontal` / `handle_layout_split_vertical`
+- Find target; not found → Error.
+- If target's parent has matching flex_direction (Row/Column): splice new_node before/after target. (No new group needed.)
+- Else: wrap target + new_node in a fresh group node with the requested direction; replace target with the group in the grandparent (or root).
+- If `focus_after`: tab.focused_node_id = new_node.id.
+- Emit corresponding event.
+
+#### `handle_layout_clear`
+- tab.layout_tree = None.
+- tab.focused_node_id = ""; tab.magnified_node_id = "".
+- Emit `LayoutCleared`.
+
+#### `handle_layout_set_tree` (bulk replace)
+- tab.layout_tree = new_tree.
+- If new_tree is None: also clear focused/magnified.
+- Used by migration period + tear-off (see §10).
+- Emit `LayoutTreeReplaced`.
+
+## 8. Persist subscriber arms
+
+For each `Event::Layout*`, an apply function in `persist_subscriber.rs`:
+
+```rust
+fn apply_layout_node_inserted(wstore: &WaveStore, tab_id: &str, node: &LayoutNode, parent_id: Option<&str>, index: Option<usize>) -> Result<...> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else { return Ok(()); };
+    if tab.layoutstate.is_empty() { return Ok(()); }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else { return Ok(()); };
+    // Apply the same helper the reducer used — idempotent because the same pure function.
+    if layout.rootnode.is_none() {
+        layout.rootnode = Some(node.clone());
+    } else {
+        let mut tree = layout.rootnode.as_mut().unwrap();
+        backend::layout::insert_node_at_parent(tree, node.clone(), parent_id, index)?;
+    }
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+```
+
+Idempotency rationale: same pure helpers as the reducer mean re-applying produces the same result. If wstore state diverges from reducer state (shouldn't happen post-migration), the next persist roundtrips back to the reducer's truth.
+
+11 apply functions, ~25 LOC each = ~280 LOC.
+
+## 9. serde compatibility
+
+The current `rootnode: Option<serde_json::Value>` produces JSON like:
+
+```json
+{
+  "id": "...",
+  "data": { "blockId": "..." },
+  "flexDirection": "row",
+  "size": 1
+}
+```
+
+The new typed `LayoutNode` must produce byte-identical JSON to maintain wire compat (frontend consumes the same shape).
+
+**Key serde annotations** (per §4.1):
+- `#[serde(rename = "flexDirection", skip_serializing_if = "Option::is_none")]`
+- `#[serde(rename = "blockId")]` on `LayoutNodeData.block_id`
+- `#[serde(rename_all = "lowercase")]` on `FlexDirection`
+- `#[serde(default = "default_size")]` on size to match frontend's "missing → 1.0" default
+
+**Round-trip test** (Phase 2 gate): seed a SQLite DB with 50+ real production layouts; deserialize each into `LayoutNode`; reserialize; compare bytes (modulo whitespace). Difference fails the build.
+
+**Bootstrap migration**: on srv startup, the existing `LayoutState.rootnode: Option<serde_json::Value>` rows already in SQLite deserialize transparently into `Option<LayoutNode>`. No data migration script needed — just a serde-compat win.
+
+## 10. Migration of the 5 existing writers
+
+Before any new commands flow, **each existing writer must dispatch through the reducer** (§7) instead of writing the wstore directly. Done as Phase 7.
+
+| Writer | Today | After migration |
+|---|---|---|
+| `service.rs:2306` (tear-off) | `layout.rootnode = Some(serde_json::json!({...}))` then `store.update(&mut layout)` | `dispatch(Command::LayoutSetTree { tab_id, new_tree: Some(node), correlation_id })` |
+| `dnd.rs:248` (DnD consolidation) | Same direct write | Dispatch `LayoutSetTree` |
+| `mod.rs:167` (first launch) | Same | Dispatch `LayoutSetTree` |
+| `block.rs:83` (last-pane close) | `layout.rootnode = None` then `store.update` | Dispatch `LayoutClear` |
+| Frontend persist via waveObject subscriber (`service.rs:240–290`) | Detects rootnode change → writes blob | Detects rootnode change → diffs against prior tree → dispatches granular `LayoutMoveNode` / `LayoutResizeNodes` / etc. — see §10.1 |
+
+### 10.1 Frontend-flush migration (the trickiest sub-step)
+
+Today the persist subscriber sees `rootnode` changed and writes the blob. Post-E.4.B it needs to translate "the tree changed from old to new" into a sequence of granular commands.
+
+Two options:
+
+**Option X — Diff-based dispatch on srv side.** Subscriber computes a tree-diff (old → new) and emits commands for each delta. Pros: no frontend change. Cons: tree-diff is itself non-trivial (~200 LOC).
+
+**Option Y — Frontend dispatches commands directly.** Refactor `persistToBackend()` to enumerate the actions taken since the last flush (the frontend reducer ALREADY knows what actions ran) and dispatch those commands. Pros: no diff; trivial mapping (frontend action → srv command). Cons: requires frontend persistence-layer rewrite.
+
+**Decision: Y.** The frontend reducer already has the action log; reusing it eliminates the diff. Frontend persistence layer change is ~150 LOC. Phase 7's frontend-side scope.
+
+### 10.2 Migration sequencing within Phase 7
+
+To keep the migration safe:
+
+1. Land the typed tree (Phase 2) — no behavior change.
+2. Land the command surface + reducer arms + persist subscribers (Phases 3–6) — commands DEFINED but not DISPATCHED from the existing writers yet. Tests pass; production behavior unchanged.
+3. Phase 7a: migrate the 4 wcore-direct writers ONE at a time. Each is a small PR. After each, smoke that path (tear-off / DnD / first-launch / last-pane-close).
+4. Phase 7b: migrate the frontend-flush subscriber. Single big PR. Feature flag.
+5. Once 7b is stable for 1–2 versions: delete the wcore-direct rootnode write path entirely.
+
+## 11. Tests
+
+### 11.1 Pure helper tests (Phase 4)
+
+Port the 30 tests from `frontend/layout/tests/layoutTree.test.ts` (PR #686) to Rust. Each frontend `test()` becomes a `#[test]` in `agentmux-srv/src/backend/layout/tests.rs`. Same scenarios, same assertions. The frontend test suite is the **behavioral oracle** — Rust pure helpers MUST produce identical state transitions for identical inputs.
+
+### 11.2 Reducer arm tests (Phase 5)
+
+Per command, test:
+- Happy path (round-trip: dispatch → state mutated → event emitted with correct fields)
+- Unknown tab → Error event, no state change
+- Unknown target node → Error event, no state change
+- No-op short-circuit where applicable (e.g. setting a value that's already current)
+- Invariant violation (e.g. swap-with-root) → Error event
+- Correlation ID round-trips into the event
+
+11 commands × ~3 tests each = ~35 reducer tests.
+
+### 11.3 Persist subscriber tests (Phase 6)
+
+Per event:
+- SQL round-trip: dispatch event → wstore row updated correctly
+- Idempotent re-apply: dispatch same event twice → second is no-op
+- Missing tab → silent no-op (matches E.4.A pattern)
+
+11 events × ~3 tests each = ~35 subscriber tests.
+
+### 11.4 Integration tests (Phase 7)
+
+End-to-end through the dispatch + persist path. Frontend-driven scenarios:
+- Tear-off path: dispatch from `service.rs:2306` site → reducer updates state → subscriber writes wstore → next read returns the new tree.
+- Multi-window mirror: simulate two clients; client A dispatches Move; verify client B receives the event with the same correlation ID and applies it.
+- Concurrent splits: clients A and B dispatch Splits to different targets simultaneously; verify both land.
+
+## 12. Frontend slice #8 (Phase 9)
+
+After srv E.4.B is stable in main, slice #8 wires the frontend mirror.
+
+### 12.1 Scope
+
+`frontend/app/store/layout-tree-store.ts` (new module, ~250 LOC):
+- Subscribes to wstore `Layout*` events via the existing wstore subscription mechanism.
+- For each inbound event:
+  - Check correlation ID against `pendingOptimisticDispatches` map (set by frontend reducer's persistence layer when it dispatched this command).
+  - If matched (own echo): clear the pending entry and no-op.
+  - If unmatched (remote command): dispatch the equivalent local action to `frontend/layout/lib/layoutTree.ts` reducer.
+- The local reducer applies the action via the existing pure helpers (no separate code path).
+
+### 12.2 Conflict scenarios
+
+When window B receives a remote event for a node it just optimistically modified locally:
+
+- If B's optimistic modification matched the eventual srv outcome (most common case): no observable conflict.
+- If B's modification was rejected by srv (lost the race): B receives no matching success event, but does receive an Error event. B rolls back the optimistic apply.
+  - Rollback strategy: keep a small stack of "optimistic deltas" per pending dispatch. On Error, pop the top delta and apply its inverse.
+
+### 12.3 Drag-resize specifically
+
+Drag-resize is the most-frequent multi-window pain point. With slice #8:
+- Window A user drags a resize handle.
+- Frontend treeReducer applies `SetPendingAction` locally (already happens today).
+- On `CommitPendingAction` (mouseup): dispatch `Command::LayoutResizeNodes` to srv.
+- srv emits `LayoutNodesResized`.
+- Window B receives the event; applies via local reducer; tree updates without re-rendering from blob.
+- If window B was mid-drag of a different handle: only the affected nodes update; B's drag state is preserved.
+
+This is the user-visible payoff.
+
+## 13. Phase-by-phase plan (PRs in order)
+
+| # | Phase | LOC | Days | PR scope | Acceptance |
+|---|---|---|---|---|---|
+| 1 | Spec finalization | (this doc) | 2 | Doc only — this spec | All open questions answered (§14) |
+| 2 | Typed `LayoutNode` | ~250 + ~150 tests | 3 | `obj.rs` types + serde impls + round-trip tests against 50+ production blobs | Existing tests still pass; no behavior change |
+| 3 | Command + Event types | ~200 | 1 | `agentmux-common/src/ipc.rs` additions; `LayoutError`, `ResizeOp`, `SplitPosition` helpers | Compiles; no runtime effect |
+| 4 | Pure helpers in `agentmux-srv/src/backend/layout/` | ~700 + ~400 tests | 4 | New module; 11 helper functions; 30 ported tests from PR #686 | All ported tests pass; identical output to frontend |
+| 5 | Reducer arms | ~400 + ~300 tests | 3 | 11 `handle_layout_*` functions + dispatch entries; 35 reducer tests | Each command round-trips; correlation IDs preserved |
+| 6 | Persist subscriber arms | ~280 + ~200 tests | 3 | 11 `apply_layout_*` functions; subscriber dispatch; 35 SQL round-trip tests | Idempotent; no schema migration |
+| 7a | Migrate 4 wcore-direct writers (one PR each) | ~50 each | 3 | tear-off, DnD, first-launch, last-pane-close — each PR is one writer | Smoke each path; behavior unchanged from user perspective |
+| 7b | Frontend-flush migration | ~150 + ~100 tests | 3 | `persistToBackend()` rewrite to dispatch granular commands; feature-flagged | Multi-window smoke shows no clobber |
+| 8 | Correctness pass | varies | 3–5 | Bug-fix PRs surfacing from real usage of 7a + 7b | No multi-window state-divergence reports |
+| 9 | Frontend slice #8 | ~250 + ~150 tests | 5 | `layout-tree-store.ts` + correlation-ID logic + rollback | Drag-resize in window B not clobbered by window A's flush |
+
+**srv-side total (1–8): 16–22 days = ~3–4 weeks.**
+**Frontend (9): ~1 week.**
+**Combined: 4–5 weeks of focused work.**
+
+## 14. Open questions — answered
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| Q1 | Typed tree vs `serde_json::Value`? | Typed (Option A) | Bounded migration cost; safety compounds over 11 handlers |
+| Q2 | Sync shape (frontend-waits vs optimistic-local) | Optimistic-local (Shape B) | Preserves UX; reducer value (audit + invariants + mirror) achieved either way |
+| Q3 | Error semantics for unknown node-id | Typed `Event::Error { code: NodeNotFound, fatal: false }` | Match E.4.A pattern; subscribers can react |
+| Q4 | Migrate `pendingbackendactions`? | No (re-eval after E.4.B soaks) | Likely subsumed by command-level events; defer the call |
+| Q5 | Migrate `leaforder`? | No | Derived from rootnode; stays wcore-side |
+| Q6 | Feature flag the migration in Phase 7? | Yes; default-on after one minor version | Risk floor for the most-touched UI surface |
+| Q7 | Drop frontend's per-action `treeReducer`? | No | Frontend reducer stays as the primary local-write path |
+| Q8 | Echo-loop guard vs correlation IDs? | **Correlation IDs** | Multi-window scales cleanly; ~10 LOC overhead per command |
+| Q9 | Diff-based subscriber dispatch vs frontend-direct? | **Frontend-direct (Option Y)** | No diff complexity; reuses frontend reducer's action log |
+
+## 15. Risks (concrete)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| serde compat issues with existing JSON shape | Medium | Phase 2 round-trip tests against 50+ production blobs (gate before Phase 3) |
+| Subtle behavioral divergence between Rust port and frontend `layoutTree.ts` | Medium-High | Port the 30 PR #686 tests verbatim; run against both implementations during Phase 7 to catch drift |
+| Phase 7a breaks tear-off / DnD / first-launch | High | One writer per PR; smoke each before next; keep direct path as fallback during Phase 7a; remove only after Phase 7b stable |
+| Phase 7b multi-window flush race | High | Feature flag; rollout to 1 version with default-off; flip to default-on only after 0 regressions |
+| Correlation ID overhead pessimizes the dispatch path | Low | UUID generation is sub-µs; not a perf concern |
+| Drag-resize edge cases not covered by current frontend tests | Medium | Add multi-window-specific integration tests in Phase 7 |
+| Effort estimate underruns reality by 2× | Medium | Plan assumes contiguous focus; real schedule needs 30% buffer |
+
+## 16. Rollout plan
+
+### Phase 7 feature flag
+
+Add `AGENTMUX_LAYOUT_REDUCER_E4B=1` env var. Default-off until proven; default-on after one minor version with no regression reports.
+
+When off: existing wcore-direct writers run; no commands dispatched.
+When on: writers dispatch commands; subscriber writes via reducer event path.
+
+### Smoke checklist (Phase 7 readiness)
+
+Before flipping default-on:
+- [ ] Tear-off pane to new tab: tree replicated correctly to new window
+- [ ] DnD pane within tab: new positioning persists
+- [ ] First-launch fresh install: initial three-pane tree appears
+- [ ] Close last pane: tree clears
+- [ ] Drag-resize across multiple panes
+- [ ] Multi-window same-tab: split in window A appears in window B without clobbering window B's drag
+- [ ] Two-window race: simultaneous splits both land
+- [ ] Restart srv: tree round-trips through SQLite intact
+
+### Rollback strategy
+
+If a critical bug surfaces post-flip:
+1. Revert to default-off via env or code change.
+2. Wcore-direct writers continue to function (kept as fallback during Phase 7a).
+3. Only after E.4.B is stable for 2+ versions does the wcore-direct code get deleted.
+
+## 17. Slice #8 spec teaser
+
+This spec covers srv E.4.B in full. Slice #8 (frontend wire-up) gets its own spec written when E.4.B is in Phase 6 stable. The teaser covers:
+
+- `layout-tree-store.ts` shape
+- Correlation ID tracking
+- Rollback-on-Error
+- Subscription wiring
+- Drag-resize specific handling
+
+Estimated frontend spec writing: 1 day, in parallel with srv Phases 5–6.
+
+## 18. What changes about the architecture roadmap
+
+After E.4.B + slice #8 ship:
+
+| # | Slice | Status |
+|---|---|---|
+| #1 | agent-document | ✅ Shipped |
+| #2 | conventions | ✅ Shipped |
+| #3 | source-tagging | ✅ Shipped |
+| #4 | agent-pane-state | ✅ Shipped |
+| #5 / E1 | frontend-layout (refactor-only) | ❌ Cancelled |
+| #5 / E2 | frontend-layout + srv sync (focus/magnify) | 🟨 Subsumed by E.4.B + slice #8 |
+| #6 | launcher-event convergence | ✅ Shipped |
+| #7 | tab-state | ❌ Cancelled |
+| **#8** | **pane-tree** | **✅ Shipped (was deferred; unblocked by E.4.B)** |
+
+The frontend reducer migration becomes complete. All slices either shipped or explicitly cancelled with retros.
+
+## 19. Definition of done
+
+E.4.B is "done" when:
+
+1. All 11 commands implemented + tested + dispatched
+2. All 5 wcore-direct writers migrated (Phase 7a + 7b)
+3. Slice #8 frontend mirror shipped
+4. Multi-window drag-resize works without clobber (smoke verified)
+5. Concurrent splits in two windows both land (smoke verified)
+6. wstore JSON shape unchanged (production layouts still load on old + new)
+7. Feature flag flipped to default-on for one minor version with no regressions
+8. wcore-direct rootnode write path deleted
+
+## 20. Reading order for implementers
+
+1. This spec (you're here)
+2. `docs/specs/SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` — context for why E.4.B was deferred from E.4.A
+3. `agentmux-srv/src/reducer.rs:655–700` — the E.4.A pattern this mirrors
+4. `agentmux-srv/src/persist_subscriber.rs:666–707` — the E.4.A persist pattern
+5. `frontend/layout/lib/layoutTree.ts` — the helper functions to port
+6. `frontend/layout/tests/layoutTree.test.ts` — the test oracle
+7. `agentmux-srv/src/state.rs:69–88` — `TabRecord` (will be extended)

--- a/docs/specs/srv-phase-e4b-implementation-plan-2026-05-03.md
+++ b/docs/specs/srv-phase-e4b-implementation-plan-2026-05-03.md
@@ -1,0 +1,365 @@
+# srv Phase E.4.B — Implementation Plan
+
+**Date:** 2026-05-03
+**Status:** Plan with grounded analysis. Forensic findings citations throughout.
+**Scope:** `agentmux-srv/` — make `LayoutState.rootnode` reducer-shaped on the Rust side
+**Reads-this-first:**
+- `docs/specs/SPEC_PHASE_E4_LAYOUT_REDUCER_2026-05-01.md` — original spec; deferred E.4.B as "the hard part"
+- `agentmux-srv/src/reducer.rs:655–700` — E.4.A handlers (the pattern to mirror)
+- `frontend/layout/lib/layoutTree.ts` — the 11 pure-ish tree mutators that already encode the operations we'd port
+
+## Two surprises from the forensic pass that change the math
+
+The original Phase E.4 spec framed E.4.B as urgent for perf reasons:
+
+> *"every drag-resize tick allocates a JSON blob, hits the mutex, and emits an event — that's 60Hz of churn for what is logically one ongoing user gesture."*
+
+**The forensic pass invalidated both halves:**
+
+1. **Not 60Hz.** Frontend resizes call `treeReducer(SetPendingAction)` locally, then `persistToBackend()` debounces 100ms (`frontend/layout/lib/layoutPersistence.ts:261–279`). One drag gesture produces ~1 backend update, not 60.
+2. **Nodes already have UUIDs.** `service.rs:2305` and `dnd.rs` both `Uuid::new_v4()` when building tree nodes; the JSON shape preserves them. Path representation isn't blocked on schema work — by-ID addressing is already the natural fit.
+
+**Consequence for the plan:** E.4.B is **not** an urgent perf project. It's a correctness/architecture project. That changes the right framing from "fix this hot path" to "decide whether the audit + invariants + multi-window-sync benefits are worth the migration cost." The cost is real; the perf benefit is small.
+
+## What's actually there today
+
+### `LayoutState` shape (`agentmux-srv/src/backend/obj.rs:391–406`)
+
+```rust
+pub struct LayoutState {
+    pub oid: String,
+    pub version: i64,
+    pub rootnode: Option<serde_json::Value>,        // ← OPAQUE — the E.4.B target
+    pub magnifiednodeid: String,                    // ← Reducer-shaped (E.4.A)
+    pub focusednodeid: String,                      // ← Reducer-shaped (E.4.A)
+    pub leaforder: Option<Vec<LeafOrderEntry>>,     // ← Wcore-direct
+    pub pendingbackendactions: Option<Vec<LayoutActionData>>,  // ← Wcore-direct
+    pub meta: Option<MetaMapType>,
+}
+```
+
+### Existing `rootnode` writers (4 sites)
+
+| Site | What it does | When |
+|---|---|---|
+| `agentmux-srv/src/server/service.rs:2306` | Builds a fresh single-node tree on tab tear-off | User drags pane out to new tab |
+| `agentmux-srv/src/backend/wcore/dnd.rs:248` | Builds new tree after drag-drop consolidation | Mid-DnD reparenting |
+| `agentmux-srv/src/backend/wcore/mod.rs:167` | Initial three-pane tree on first launch | App first run |
+| `agentmux-srv/src/backend/wcore/block.rs:83` | Sets `rootnode = None` when last block removed | Last-pane close |
+
+All four use `store.update(&mut layout)` directly — no reducer dispatch.
+
+The frontend's debounced flush (`layoutPersistence.ts:261–279`) is the **fifth and most frequent** writer in practice — it overwrites the entire `rootnode` blob via the waveObject update subscriber path on every tree mutation that survives the 100ms debounce.
+
+### The pattern E.4.A established (`reducer.rs:655–700`)
+
+E.4.A handlers are tiny and uniform:
+
+```rust
+fn handle_set_focused_node(state: &mut State, tab_id: String, node_id: String) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        return vec![Event::Error { ... }];   // unknown tab → typed error
+    };
+    if tab.focused_node_id == node_id {
+        return Vec::new();                    // no-op short-circuit
+    }
+    tab.focused_node_id = node_id.clone();
+    let v = state.bump_version();
+    vec![Event::FocusedNodeChanged { tab_id, node_id, version: v }]
+}
+```
+
+~25 LOC. Unknown-target errors typed. No-op short-circuit. Single event on real change. Tests at `reducer.rs:1500+` cover happy-path / no-op / unknown-target.
+
+Persist subscriber arm (`persist_subscriber.rs:666–686`):
+
+```rust
+fn apply_focused_node_changed(wstore: &WaveStore, tab_id: &str, node_id: &str) -> Result<...> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else { return Ok(()); };
+    if tab.layoutstate.is_empty() { return Ok(()); }
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else { return Ok(()); };
+    if layout.focusednodeid == node_id { return Ok(()); }
+    layout.focusednodeid = node_id.to_string();
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+```
+
+Idempotent. Single SQL UPDATE. Schema columns already exist.
+
+## The 15 frontend operations to port
+
+`frontend/layout/lib/types.ts:65–82` defines the action surface. Each becomes a candidate srv command:
+
+| Frontend action | Mutation shape | E.4.B command target |
+|---|---|---|
+| `Move` | reparent subtree (target by UUID) | `Command::LayoutMoveNode { tab_id, node_id, new_parent_id, index }` |
+| `Swap` | swap two siblings | `Command::LayoutSwapNodes { tab_id, node1_id, node2_id }` |
+| `ResizeNode` | apply N size deltas | `Command::LayoutResizeNodes { tab_id, ops: Vec<ResizeOp> }` |
+| `InsertNode` | add via `findNextInsertLocation` heuristic | `Command::LayoutInsertNode { tab_id, node }` |
+| `InsertNodeAtIndex` | add at exact index path | `Command::LayoutInsertNodeAtIndex { tab_id, node, index_arr }` |
+| `DeleteNode` | remove + collapse empty parents | `Command::LayoutDeleteNode { tab_id, node_id }` |
+| `ReplaceNode` | swap one node for another, preserve size | `Command::LayoutReplaceNode { tab_id, target_id, new_node }` |
+| `SplitHorizontal` | wrap-or-splice in Row group | `Command::LayoutSplitHorizontal { tab_id, target_id, new_node, position }` |
+| `SplitVertical` | wrap-or-splice in Column group | `Command::LayoutSplitVertical { tab_id, target_id, new_node, position }` |
+| `ClearTree` | wipe rootnode + focused + magnified + leaforder | `Command::LayoutClear { tab_id }` |
+| `FocusNode` | set focused | **Already exists (E.4.A)** |
+| `MagnifyNodeToggle` | toggle magnified | **Already exists (E.4.A)** |
+| `ComputeMove` | pure compute — returns a pending Move | **Stays frontend-side** (no state mutation; just produces a Move command) |
+| `SetPendingAction` | stage a pending tree change | **Stays frontend-side** (transient UI state during drag) |
+| `CommitPendingAction` / `ClearPendingAction` | commit/cancel the staged change | **Stays frontend-side** (or maps to the underlying Move/Resize) |
+
+**11 commands** to add (the first 10 + ClearTree). Three actions stay client-side.
+
+## Two design questions that drive the rest
+
+### Q1 — Typed Rust tree, or keep `serde_json::Value`?
+
+**Option A — Typed tree (recommended).** Replace `Option<serde_json::Value>` with a Rust struct:
+
+```rust
+pub struct LayoutNode {
+    pub id: String,                    // UUID
+    pub flex_direction: FlexDirection, // Row / Column
+    pub size: f32,
+    pub children: Vec<LayoutNode>,
+    pub data: Option<LayoutNodeData>,  // blockId etc.
+}
+```
+
+Pros: handlers operate on a typed structure (compile-time safety); can reuse Rust enum exhaustiveness checks; serde-derived (de)serialization handles wire compat.
+
+Cons: serde compat with the existing JSON shape needs careful test coverage. One-time write of the type definitions + (de)serializer.
+
+**Option B — Keep `serde_json::Value`, add path-walk helpers.** Each command operates on the JSON tree via path-by-id traversal helpers.
+
+Pros: zero migration risk; existing JSON shape unchanged; old wcore code keeps compiling.
+
+Cons: handlers manipulate untyped JSON; runtime errors instead of compile-time; duplicates the shape definition (already implicit in the JSON serializer on the frontend).
+
+**Recommendation: Option A.** The migration cost is bounded (one-shot typing exercise, not architecture-wide), and the safety benefits compound as the 11 handlers land. Frontend already has the typed shape; mirroring it in Rust closes a long-standing semantic gap.
+
+### Q2 — How does srv apply a command and report it back to frontend?
+
+Two roundtrip shapes:
+
+**Shape A — Frontend dispatches granular command, srv applies authoritatively, srv emits authoritative event:**
+
+```
+[user clicks pane] → frontend treeReducer (locally apply)
+                  → frontend dispatches RPC LayoutMoveNode
+                  → srv reducer LayoutMoveNode
+                  → srv emits LayoutNodeMoved event
+                  → frontend receives event, reconciles local state if differs
+```
+
+**Shape B — Frontend stays authoritative, srv mirrors:**
+
+```
+[user clicks pane] → frontend treeReducer (locally apply)
+                  → frontend persists via existing waveObject path
+                  → srv subscriber detects change
+                  → srv reducer dispatches LayoutMoveNode synthetically
+                  → srv emits LayoutNodeMoved
+                  → other frontend windows receive event
+```
+
+Shape A is the redux-correct version. Shape B is the migration-friendly version that preserves the existing frontend code path.
+
+**Recommendation: Shape B for the migration**, with a future flip to Shape A once tests prove the round-trip.
+
+Why: Shape A requires synchronous waiting on srv before applying user actions locally — adds latency on every focus/click/drag. Shape B preserves the optimistic-local-apply UX. The reducer's value (audit + invariants + multi-window mirror) is achieved either way.
+
+## Implementation phases
+
+Total: ~3–4 weeks of focused work, broken into 8 phases. Ship phase by phase with main-merges between each.
+
+### Phase 1 — Spec finalization + design decisions (2 days, doc-only)
+
+- Lock in Q1 + Q2 above
+- Decide handling of `pendingbackendactions` field (likely subsumed; needs a call)
+- Decide `leaforder` migration (probably stays wcore-direct; it's derived from rootnode)
+- Decide error semantics for unknown node-id targets (typed error vs silent no-op — match E.4.A's typed-error pattern)
+- Define exact wire protocol for each of the 11 commands
+
+**Deliverable:** updated spec doc, no code.
+
+### Phase 2 — Typed `LayoutNode` Rust struct (~3 days)
+
+- Define `LayoutNode`, `LayoutNodeData`, `FlexDirection` in `agentmux-srv/src/backend/obj.rs`
+- Serde-compat layer with current JSON shape (round-trip tests against real tree blobs from production data)
+- `LayoutState.rootnode` field migrates from `Option<serde_json::Value>` to `Option<LayoutNode>`
+- 4 wcore-direct writers (service.rs:2306, dnd.rs:248, mod.rs:167, block.rs:83) update their construction to use the new type
+- Frontend (de)serialization unchanged (still consumes/produces the same JSON shape via serde)
+
+**Deliverable:** typed tree on srv, no behavior change. Single PR. Zero new commands yet.
+
+### Phase 3 — Reducer command + event types (~1 day, all in `agentmux-common/src/ipc.rs`)
+
+- Add 11 `Command::Layout*` variants
+- Add 11 corresponding `Event::Layout*` variants
+- Add helper types: `ResizeOp`, `SplitPosition` etc.
+- No handlers yet — just the wire types
+
+**Deliverable:** types compile; no runtime behavior change.
+
+### Phase 4 — Pure helper functions (~3 days, in `agentmux-srv/src/backend/`)
+
+Port the frontend `layoutTree.ts` mutators to Rust as pure helper functions on `LayoutNode`:
+
+- `find_node_by_id(&LayoutNode, id) -> Option<&LayoutNode>`
+- `find_parent_by_child_id(&LayoutNode, child_id) -> Option<&LayoutNode>`
+- `insert_node`, `delete_node`, `move_node`, `swap_nodes`, `resize_nodes`, `replace_node`, `split_horizontal`, `split_vertical`, `clear_tree`
+- Each takes `&mut LayoutNode` (or `&mut Option<LayoutNode>` for clear) and the operation parameters
+
+These are **pure functions** — no SQL, no events, no I/O. Mirror the shape of `frontend/layout/lib/layoutTree.ts`.
+
+**Tests for each** — table-driven, mirror the test suite I just shipped for the frontend (PR #686). The frontend tests act as the **behavioral oracle** — port them.
+
+**Deliverable:** ~700 LOC of pure mutators + ~400 LOC of tests. Coverage matches what the frontend already has.
+
+### Phase 5 — Reducer arms (~2 days)
+
+For each of the 11 commands, write a reducer handler in `reducer.rs` mirroring the E.4.A shape:
+
+```rust
+fn handle_layout_insert_node(state: &mut State, tab_id: String, node: LayoutNode) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        return vec![Event::Error { ... }];
+    };
+    let Some(rootnode) = tab.rootnode.as_mut() else {
+        // Empty tree — promote to root
+        tab.rootnode = Some(node.clone());
+        let v = state.bump_version();
+        return vec![Event::LayoutNodeInserted { tab_id, node, version: v }];
+    };
+    backend::layout::insert_node(rootnode, node.clone());  // pure helper
+    let v = state.bump_version();
+    vec![Event::LayoutNodeInserted { tab_id, node, version: v }]
+}
+```
+
+~25–40 LOC per handler × 11 = ~350 LOC. **Tests at the reducer level** — round-trip tests for each command (mirror E.4.A's test patterns).
+
+**Deliverable:** all 11 handlers + tests. No persistence yet.
+
+### Phase 6 — Persist subscriber arms (~2 days)
+
+For each `Event::Layout*`, add an apply function in `persist_subscriber.rs`:
+
+```rust
+fn apply_layout_node_inserted(wstore: &WaveStore, tab_id: &str, node: &LayoutNode) -> Result<...> {
+    let Some(tab) = wstore.get::<Tab>(tab_id)? else { return Ok(()); };
+    let Some(mut layout) = wstore.get::<PersistedLayoutState>(&tab.layoutstate)? else { return Ok(()); };
+    // Apply the same mutation the reducer applied (idempotent because both paths use the same helper)
+    if let Some(root) = layout.rootnode.as_mut() {
+        backend::layout::insert_node(root, node.clone());
+    } else {
+        layout.rootnode = Some(node.clone());
+    }
+    wstore.update(&mut layout)?;
+    Ok(())
+}
+```
+
+11 apply functions, ~20 LOC each = ~220 LOC. Idempotent by design (same pure helper as the reducer).
+
+**Deliverable:** events round-trip through SQLite.
+
+### Phase 7 — Migrate the existing 5 writers (3 days, the risky one)
+
+This is where behavior actually changes.
+
+| Writer | Migration |
+|---|---|
+| `service.rs:2306` (tear-off) | Replaces direct `store.update` with `dispatch(Command::LayoutInsertNode { ... })` (or a tear-off-specific composite command) |
+| `dnd.rs:248` (DnD consolidation) | Same — dispatch instead of direct write |
+| `mod.rs:167` (first-launch) | Initial tree built then dispatched as a single LayoutInsertNode |
+| `block.rs:83` (last-pane close) | Dispatch `LayoutClear` |
+| Frontend persist via waveObject subscriber | This is the big one — see below |
+
+**Frontend-flush migration** (the trickiest sub-step): the existing waveObject subscriber detects rootnode changes and writes them directly. Two options:
+
+- **Drop-in replacement**: subscriber detects what changed and dispatches the corresponding granular Layout commands. Requires a diff against the prior tree state. Complex — but preserves the existing frontend code path entirely (Shape B from Q2).
+- **Frontend dispatches directly**: refactor `persistToBackend()` to enumerate the actions taken since the last flush and dispatch them as commands. Requires a frontend code change (new RPC paths) but is cleaner long-term.
+
+Recommended: drop-in replacement first (no frontend changes, lowest blast radius), then frontend-dispatches-directly as a follow-up.
+
+**Risk profile:** highest of any phase. Layout is the most-touched UI surface. Mitigations:
+- Keep the wcore-direct path as a fallback behind a feature flag during the rollout
+- Heavy test coverage from Phase 4–6 already in place
+- Smoke before merge (multi-window, drag-resize, tear-off, all the gestures)
+
+### Phase 8 — Reducer-side correctness fixes that surface during migration (~3 days)
+
+Once the migration is in main, real-world usage will surface:
+- Edge cases in tree mutations the frontend tests didn't cover (you can't write a frontend test for "what happens when wcore-direct write races a reducer dispatch")
+- Subtle behavioral differences between the frontend's pure-mutation tree code and the Rust port (off-by-one, child-collapse semantics, etc.)
+- Drift detection — events emitted vs. SQL state
+
+Budget for this is the honest part — it's never zero.
+
+### Phase 9 — Frontend slice #8 (~1 week, separate spec)
+
+Once srv E.4.B is stable, slice #8 (frontend-pane-tree-reducer) becomes implementable. The frontend already has `frontend/layout/lib/layoutTree.ts` as its own reducer; the slice #8 work is wiring it to subscribe to srv's `LayoutNode*` events for the multi-window mirror case. **This is a separate spec.**
+
+## Total effort
+
+| Phase | LOC | Days |
+|---|---|---|
+| 1 — Spec finalization | (doc) | 2 |
+| 2 — Typed `LayoutNode` | ~200 | 3 |
+| 3 — Wire types | ~150 | 1 |
+| 4 — Pure helpers | ~700 + ~400 tests | 3 |
+| 5 — Reducer arms | ~350 + ~300 tests | 2 |
+| 6 — Persist arms | ~220 | 2 |
+| 7 — Migration (risky) | ~300 | 3 |
+| 8 — Correctness pass | varies | 3 |
+| **srv-side total** | **~1900 LOC + ~700 LOC tests** | **~3 weeks** |
+| Phase 9 — Frontend #8 | (separate spec) | ~1 week |
+
+## What this plan deliberately does NOT do
+
+- **Doesn't change the wire format.** `rootnode` JSON shape stays compatible — typed Rust struct serializes/deserializes to the same bytes.
+- **Doesn't change debouncing strategy.** Frontend keeps the 100ms debounce.
+- **Doesn't change `leaforder` or `pendingbackendactions`.** Both stay wcore-direct (decided in Phase 1; flagged for re-eval if a real bug appears).
+- **Doesn't migrate the frontend tree reducer.** Frontend `layoutTree.ts` keeps its existing shape; Phase 9 only adds the srv-event subscription.
+- **Doesn't add multi-window focus sync.** That's slice #5/E2 territory; orthogonal to E.4.B.
+
+## Open questions for product/architecture review
+
+| # | Question | Default proposed |
+|---|---|---|
+| Q1 | Typed tree vs `serde_json::Value`? | Typed (Option A) |
+| Q2 | Sync shape (A frontend-waits, B optimistic-local) | B (optimistic-local) |
+| Q3 | Error semantics for unknown node-id | Typed error (match E.4.A) |
+| Q4 | Migrate `pendingbackendactions`? | No — re-eval if needed |
+| Q5 | Migrate `leaforder`? | No — derive-only, stays wcore |
+| Q6 | Feature flag the migration in Phase 7? | Yes, default-on after one minor version |
+| Q7 | Drop the frontend's per-action `treeReducer` once srv is authoritative? | No — frontend reducer stays; just adds srv subscription |
+
+## Risks (honest)
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Subtle behavioral divergence between Rust port of `layoutTree.ts` and the original | Medium-High | Use frontend tests as oracle; port them; run in parallel during Phase 7 |
+| Migration of the 5 write sites breaks tear-off / first-launch / DnD | High (this IS the most-touched UI surface) | Feature flag; smoke each gesture before merge; keep wcore-direct fallback |
+| serde compat issues with existing JSON shape | Medium | Round-trip tests against production tree blobs |
+| Effort estimate underruns reality by 2× | Medium | Plan assumes contiguous focus; budget buffer |
+| Plan reveals Q1 (typed tree) was wrong call mid-Phase 2 | Low | Phase 2 is small and reversible |
+
+## Three honest paths forward
+
+| Path | When to pick | Cost |
+|---|---|---|
+| **Don't do E.4.B** | If the perf framing was the only motivation, and we now know it's debounced | $0 — but slice #8 stays blocked |
+| **Do E.4.B as planned** | If audit + invariants + multi-window mirror have value worth the work | ~3–4 weeks srv-side + ~1 week frontend |
+| **Do half of E.4.B (typed tree only)** | If we want the type safety without the reducer command surface | ~5 days; lets future commands land incrementally |
+
+The half-version (typed tree only — phases 1+2 of this plan) is the **Pareto-best** option if you're not committed to multi-window state sync. It eliminates the opaque `serde_json::Value` (which is the ugliest single thing on the srv side) without committing to the 11-command surface.
+
+## Recommendation
+
+**Do phases 1+2 ("typed tree only") first as a discrete project.** Single PR. Low risk. Removes the opaque-blob smell. Doesn't commit to the rest. After that lands, re-decide whether to continue with phases 3–8 based on whether multi-window state mirroring becomes a real priority. If it does, the typed tree is exactly the foundation those phases need; if it doesn't, we got a real architecture improvement for ~5 days of work and stopped at a coherent point.
+
+Don't commit to the full ~4-week project until the value is concrete. The forensic pass already invalidated half the original motivation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.625",
+      "version": "0.33.626",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.626",
+  "version": "0.33.627",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.626",
+      "version": "0.33.627",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.625",
+  "version": "0.33.626",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.626",
+  "version": "0.33.627",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 2 of srv E.4.B — replaces \`LayoutState.rootnode: Option<serde_json::Value>\` with a typed Rust \`Option<LayoutNode>\` struct. **No behavior change.** JSON wire format preserved by serde annotations matching the existing shape.

This is the foundation phase for the rest of E.4.B (the 11-command reducer surface in phases 3–8). Lands as a discrete, low-risk PR; doesn't add commands or events yet.

**Spec:** \`docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md\` Phase 2

## Drive-by fix

The \`test_ensure_initial_data_first_launch\` test was failing on main: actual tab name is \`tab1\` (per \`SPEC_TAB_GAPS_AND_NAMING_2026_04_25\` which renamed auto-generated tabs to the \`tabN\` convention) but the test was asserting against the older \`Untitled1\` naming. Fixed both this test and the wstore tx-test fixture to use \`tab1\` consistently. Per user request: "tab1 across the board (tabN)".

## Files

| File | Change |
|---|---|
| \`obj.rs\` | NEW: \`LayoutNode\`, \`LayoutNodeData\`, \`FlexDirection\` types + serde compat + 4 round-trip tests |
| \`server/service.rs\` | \`setup_torn_off_block_layout\` constructs typed LayoutNode |
| \`wcore/dnd.rs\` | DnD consolidation constructs typed LayoutNode |
| \`wcore/mod.rs\` | First-launch three-pane tree typed; \`Untitled1\` → \`tab1\` test fix |
| \`wcore/block.rs\` | \`prune_block_from_layout\`, \`prune_node\`, \`collect_leaf_block_ids\` walk typed LayoutNode (was JSON \`.get()\` walks) |
| \`storage/wstore.rs\` | Test fixture uses typed LayoutNode + \`Untitled1\` → \`tab1\` |

## Tests

**4 new round-trip tests** in obj.rs cover the Phase 2 acceptance gate:
- Single-leaf root (dnd/tear-off shape)
- First-launch three-pane shape (deep nesting + mixed group/leaf)
- Edge: leaf without children array (deserializer tolerance)
- \`flexDirection\` defaults to \`Row\` when absent
- \`data: None\` skip-serializes (no \`"data": null\` on the wire)

Existing layout state roundtrip + 30 prune/heal tests in block.rs still pass (helpers ported from JSON walks to typed access).

**Net: 783 passing, 4 failing** (was 779/5 on main). +1 test fixed, +4 new tests, 4 pre-existing failures unchanged.

## What this does NOT do (per spec)

- No new reducer commands (Phase 3+)
- No persist subscriber arms for layout events (Phase 6)
- No migration of the 5 wcore-direct writers TO dispatch through the reducer (Phase 7)
- No frontend changes

## Test plan (reviewer)

- [ ] \`cargo test -p agentmux-srv --bin agentmux-srv\` — 783 pass; 4 pre-existing failures unchanged
- [ ] \`cargo build -p agentmux-srv\` — clean
- [ ] Smoke: tear-off pane to new tab, DnD pane within tab, first-launch fresh install, last-pane close — all behaviors unchanged
- [ ] Restart srv: existing on-disk LayoutState rows deserialize cleanly (serde compat)

## Roadmap context

- ✅ Spec phase 1 (formal spec written)
- ✅ Phase 2 (this PR)
- ⬜ Phase 3 (Command + Event types)
- ⬜ Phase 4 (Pure helper functions — port \`layoutTree.ts\`)
- ⬜ Phase 5 (Reducer arms)
- ⬜ Phase 6 (Persist subscriber arms)
- ⬜ Phase 7 (Migrate writers — risky; feature-flagged)
- ⬜ Phase 8 (Correctness pass)
- ⬜ Phase 9 (Frontend slice #8 — multi-window mirror)

🤖 Generated with [Claude Code](https://claude.com/claude-code)