### PR TITLE
fix(srv): preserve unknown LayoutNode fields — codex P1 follow-up (#688)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.631"
+version = "0.33.632"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.631"
+version = "0.33.632"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.631"
+version = "0.33.632"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.631"
+version = "0.33.632"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.628"
+version = "0.33.629"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.628"
+version = "0.33.629"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.628"
+version = "0.33.629"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.628"
+version = "0.33.629"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.629"
+version = "0.33.630"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.629"
+version = "0.33.630"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.629"
+version = "0.33.630"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.629"
+version = "0.33.630"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.627"
+version = "0.33.628"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.627"
+version = "0.33.628"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.627"
+version = "0.33.628"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.627"
+version = "0.33.628"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.630"
+version = "0.33.631"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.630"
+version = "0.33.631"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.630"
+version = "0.33.631"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.630"
+version = "0.33.631"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.627"
+version = "0.33.628"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.630"
+version = "0.33.631"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.628"
+version = "0.33.629"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.629"
+version = "0.33.630"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.631"
+version = "0.33.632"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.629"
+version = "0.33.630"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.627"
+version = "0.33.628"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.631"
+version = "0.33.632"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.628"
+version = "0.33.629"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.630"
+version = "0.33.631"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.627"
+version = "0.33.628"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.628"
+version = "0.33.629"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.630"
+version = "0.33.631"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.631"
+version = "0.33.632"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.629"
+version = "0.33.630"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.630"
+version = "0.33.631"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.627"
+version = "0.33.628"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.631"
+version = "0.33.632"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.628"
+version = "0.33.629"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.629"
+version = "0.33.630"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -415,7 +415,12 @@ pub enum FlexDirection {
 /// Group nodes (those with `children`) carry no `data`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct LayoutNodeData {
-    #[serde(rename = "blockId", default)]
+    /// Required field in well-formed leaf nodes. The `#[serde(default)]`
+    /// annotation is intentionally ABSENT — a missing `blockId` in JSON
+    /// is malformed and must fail deserialization (codex P1 PR #689).
+    /// `Default` on the struct only supports `..Default::default()` at
+    /// Rust construction sites, not serde deserialization fallback.
+    #[serde(rename = "blockId")]
     pub block_id: String,
     /// Catch-all for unknown fields — preserves forward-compat with
     /// the prior `serde_json::Value` storage (codex P1 PR #688
@@ -858,6 +863,57 @@ mod tests {
         };
         let json = serde_json::to_value(&group).unwrap();
         assert!(json.get("data").is_none(), "data: None must skip-serialize");
+    }
+
+    /// Regression test: unknown fields on LayoutNode and LayoutNodeData round-
+    /// trip via the `extra: HashMap` catch-all (codex P1 PR #688 + #689).
+    /// Without this, fields the frontend writes that we don't yet model would
+    /// be silently dropped on deserialize→serialize cycles — a regression vs
+    /// the prior `serde_json::Value` storage.
+    #[test]
+    fn test_layout_node_preserves_unknown_fields() {
+        let json_with_extras = serde_json::json!({
+            "id": "n",
+            "flexDirection": "row",
+            "size": 1,
+            "backendLayoutVersion": 7,
+            "data": {
+                "blockId": "b",
+                "renderHint": "compact"
+            }
+        });
+        let node: LayoutNode = serde_json::from_value(json_with_extras).unwrap();
+        assert_eq!(node.extra.get("backendLayoutVersion"), Some(&serde_json::json!(7)));
+        assert_eq!(
+            node.data.as_ref().unwrap().extra.get("renderHint"),
+            Some(&serde_json::json!("compact"))
+        );
+        // Round-trip preserves both.
+        let reserialized = serde_json::to_value(&node).unwrap();
+        assert_eq!(reserialized.get("backendLayoutVersion"), Some(&serde_json::json!(7)));
+        assert_eq!(
+            reserialized.get("data").and_then(|d| d.get("renderHint")),
+            Some(&serde_json::json!("compact"))
+        );
+        // Empty extra → no stray "extra" key on output.
+        let no_extras = LayoutNode {
+            id: "x".into(),
+            flex_direction: FlexDirection::Row,
+            size: 1.0,
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&no_extras).unwrap();
+        assert!(json.get("extra").is_none());
+    }
+
+    /// Regression test (codex P1 PR #689): missing blockId in JSON must fail
+    /// deserialization rather than silently default to "". An empty block_id
+    /// would cause incorrect orphan handling in prune_block_from_layout.
+    #[test]
+    fn test_layout_node_data_missing_block_id_fails_deserialization() {
+        let missing_id = serde_json::json!({ "renderHint": "compact" });
+        let result = serde_json::from_value::<LayoutNodeData>(missing_id);
+        assert!(result.is_err(), "missing blockId must fail deserialization");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -445,7 +445,7 @@ pub struct LayoutNodeData {
 /// Note: `Default::size` is 0.0 (Rust default for f32), while the serde
 /// deserialization default is 1.0 (via `default_layout_size`). These differ
 /// intentionally — `Default` is used only for the `..Default::default()`
-/// struct-literal spread trick to populate `extra: HashMap::new()` without
+/// struct-literal spread trick to populate `extra: serde_json::Map::new()` without
 /// touching every construction site. Size is always set explicitly at callsites.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct LayoutNode {

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -475,8 +475,10 @@ pub struct LayoutNode {
     /// Catch-all for unknown fields — preserves forward-compat with
     /// the prior `serde_json::Value` storage (codex P1 PR #688
     /// follow-up). Without this, unknown fields are silently dropped.
-    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
-    pub extra: HashMap<String, serde_json::Value>,
+    /// Uses `serde_json::Map` (insertion-ordered) for stable round-trips
+    /// (codex P2 PR #689 — HashMap iteration order is randomized).
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 fn default_layout_size() -> f32 {

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -413,10 +413,16 @@ pub enum FlexDirection {
 
 /// Leaf-only payload — references the block this layout-leaf renders.
 /// Group nodes (those with `children`) carry no `data`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct LayoutNodeData {
-    #[serde(rename = "blockId")]
+    #[serde(rename = "blockId", default)]
     pub block_id: String,
+    /// Catch-all for unknown fields — preserves forward-compat with
+    /// the prior `serde_json::Value` storage (codex P1 PR #688
+    /// follow-up). Without this, unknown fields are silently dropped
+    /// on deserialize→serialize cycles.
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 /// One node in the layout tree. Stable UUID-keyed; size is a relative
@@ -426,7 +432,12 @@ pub struct LayoutNodeData {
 /// ```json
 /// { "id": "...", "flexDirection": "row", "size": 1, "children": [...], "data": { "blockId": "..." } }
 /// ```
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// Note: `Default::size` is 0.0 (Rust default for f32), while the serde
+/// deserialization default is 1.0 (via `default_layout_size`). These differ
+/// intentionally — `Default` is used only for the `..Default::default()`
+/// struct-literal spread trick to populate `extra: HashMap::new()` without
+/// touching every construction site. Size is always set explicitly at callsites.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct LayoutNode {
     pub id: String,
     /// Direction this node's children flow. Required in the JSON but
@@ -451,6 +462,11 @@ pub struct LayoutNode {
     /// present.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub data: Option<LayoutNodeData>,
+    /// Catch-all for unknown fields — preserves forward-compat with
+    /// the prior `serde_json::Value` storage (codex P1 PR #688
+    /// follow-up). Without this, unknown fields are silently dropped.
+    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
+    pub extra: HashMap<String, serde_json::Value>,
 }
 
 fn default_layout_size() -> f32 {
@@ -686,6 +702,7 @@ mod tests {
                 size: 1.0,
                 children: Vec::new(),
                 data: None,
+                ..Default::default()
             }),
             magnifiednodeid: "node-1".to_string(),
             ..Default::default()
@@ -804,6 +821,7 @@ mod tests {
             size: 10.0,
             children: Vec::new(),
             data: None,
+            ..Default::default()
         };
         let json = serde_json::to_string(&whole).unwrap();
         assert!(json.contains("\"size\":10"), "whole sizes should serialize as integer; got {}", json);
@@ -816,6 +834,7 @@ mod tests {
             size: 5.5,
             children: Vec::new(),
             data: None,
+            ..Default::default()
         };
         let json = serde_json::to_string(&frac).unwrap();
         assert!(json.contains("\"size\":5.5"), "fractional sizes preserve the decimal; got {}", json);
@@ -835,6 +854,7 @@ mod tests {
             size: 1.0,
             children: Vec::new(),
             data: None,
+            ..Default::default()
         };
         let json = serde_json::to_value(&group).unwrap();
         assert!(json.get("data").is_none(), "data: None must skip-serialize");

--- a/agentmux-srv/src/backend/obj.rs
+++ b/agentmux-srv/src/backend/obj.rs
@@ -426,8 +426,13 @@ pub struct LayoutNodeData {
     /// the prior `serde_json::Value` storage (codex P1 PR #688
     /// follow-up). Without this, unknown fields are silently dropped
     /// on deserialize→serialize cycles.
-    #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]
-    pub extra: HashMap<String, serde_json::Value>,
+    ///
+    /// Uses `serde_json::Map` (insertion-ordered) rather than `HashMap`
+    /// so that deserialize→serialize round-trips preserve key order
+    /// (codex P2 PR #689). HashMap iteration order is randomized per
+    /// process; reordering is observable in SQLite blob diffs.
+    #[serde(flatten, default, skip_serializing_if = "serde_json::Map::is_empty")]
+    pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
 /// One node in the layout tree. Stable UUID-keyed; size is a relative

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1609,6 +1609,7 @@ mod tests {
                 size: 1.0,
                 children: Vec::new(),
                 data: None,
+                ..Default::default()
             }),
             magnifiednodeid: "n1".to_string(),
             ..Default::default()

--- a/agentmux-srv/src/backend/wcore/block.rs
+++ b/agentmux-srv/src/backend/wcore/block.rs
@@ -241,7 +241,9 @@ mod tests {
             children: Vec::new(),
             data: Some(LayoutNodeData {
                 block_id: block_id.into(),
+                ..Default::default()
             }),
+            ..Default::default()
         }
     }
 
@@ -274,6 +276,7 @@ mod tests {
                     leaf("leaf-right", right_block, 5.0),
                 ],
                 data: None,
+                ..Default::default()
             }),
             leaforder: Some(vec![
                 LeafOrderEntry { blockid: left_block.into(), nodeid: "leaf-left".into() },

--- a/agentmux-srv/src/backend/wcore/dnd.rs
+++ b/agentmux-srv/src/backend/wcore/dnd.rs
@@ -254,7 +254,9 @@ pub fn tear_off_block(
         children: Vec::new(),
         data: Some(LayoutNodeData {
             block_id: block_id.to_string(),
+            ..Default::default()
         }),
+        ..Default::default()
     });
     layout.leaforder = Some(vec![LeafOrderEntry {
         nodeid: node_id,

--- a/agentmux-srv/src/backend/wcore/mod.rs
+++ b/agentmux-srv/src/backend/wcore/mod.rs
@@ -135,6 +135,7 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
         id: root_id,
         flex_direction: FlexDirection::Row,
         size: 10.0,
+        data: None,
         children: vec![
             LayoutNode {
                 id: agent_node_id.clone(),
@@ -143,7 +144,9 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
                 children: Vec::new(),
                 data: Some(LayoutNodeData {
                     block_id: agent_block.oid.clone(),
+                    ..Default::default()
                 }),
+                ..Default::default()
             },
             LayoutNode {
                 id: right_col_id,
@@ -157,7 +160,9 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
                         children: Vec::new(),
                         data: Some(LayoutNodeData {
                             block_id: sysinfo_block.oid.clone(),
+                            ..Default::default()
                         }),
+                        ..Default::default()
                     },
                     LayoutNode {
                         id: swarm_node_id.clone(),
@@ -166,13 +171,16 @@ pub fn ensure_initial_data(store: &WaveStore) -> Result<bool, StoreError> {
                         children: Vec::new(),
                         data: Some(LayoutNodeData {
                             block_id: swarm_block.oid.clone(),
+                            ..Default::default()
                         }),
+                        ..Default::default()
                     },
                 ],
                 data: None,
+                ..Default::default()
             },
         ],
-        data: None,
+        ..Default::default()
     };
 
     let mut layout = store.must_get::<LayoutState>(&tab.layoutstate)?;

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -2311,7 +2311,9 @@ fn setup_torn_off_block_layout(
         children: Vec::new(),
         data: Some(LayoutNodeData {
             block_id: block_id.to_string(),
+            ..Default::default()
         }),
+        ..Default::default()
     });
     layout.leaforder = Some(vec![LeafOrderEntry {
         nodeid: node_id,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.631",
+  "version": "0.33.632",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.631",
+      "version": "0.33.632",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.629",
+  "version": "0.33.630",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.629",
+      "version": "0.33.630",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.630",
+  "version": "0.33.631",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.630",
+      "version": "0.33.631",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.627",
+  "version": "0.33.628",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.627",
+      "version": "0.33.628",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.628",
+  "version": "0.33.629",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.628",
+      "version": "0.33.629",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.627",
+  "version": "0.33.628",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.628",
+  "version": "0.33.629",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.631",
+  "version": "0.33.632",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.629",
+  "version": "0.33.630",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.630",
+  "version": "0.33.631",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Codex P1 from PR #688 was not included in the squash merge (linter reverted before final push). Adds `#[serde(flatten)] extra: HashMap<String, Value>` catch-all on `LayoutNode` and `LayoutNodeData`. 784 tests pass.