### PR TITLE
feat(srv): E.4.B Phase 4 — pure layout tree helpers + README brain logo fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.636"
+version = "0.33.637"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.636"
+version = "0.33.637"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.636"
+version = "0.33.637"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.636"
+version = "0.33.637"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.634"
+version = "0.33.635"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.634"
+version = "0.33.635"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.634"
+version = "0.33.635"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.634"
+version = "0.33.635"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.633"
+version = "0.33.634"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.633"
+version = "0.33.634"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.633"
+version = "0.33.634"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.633"
+version = "0.33.634"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.635"
+version = "0.33.636"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.635"
+version = "0.33.636"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.635"
+version = "0.33.636"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.635"
+version = "0.33.636"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./frontend/logos/agentmux-logo.svg" alt="AgentMux Logo" width="120">
+  <img src="./frontend/logos/agentmux-logo-brain-alternate.svg" alt="AgentMux Logo" width="120">
 </p>
 
 # AgentMux

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.633"
+version = "0.33.634"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.636"
+version = "0.33.637"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.634"
+version = "0.33.635"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.635"
+version = "0.33.636"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.635"
+version = "0.33.636"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.636"
+version = "0.33.637"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.634"
+version = "0.33.635"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.633"
+version = "0.33.634"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.635"
+version = "0.33.636"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.634"
+version = "0.33.635"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.636"
+version = "0.33.637"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.633"
+version = "0.33.634"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.633"
+version = "0.33.634"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.636"
+version = "0.33.637"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.634"
+version = "0.33.635"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.635"
+version = "0.33.636"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -13,7 +13,7 @@
 //! (shipped in PR #686) — the Rust implementations must produce identical
 //! state transitions for identical inputs.
 
-use agentmux_common::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
+use agentmux_common::{FlexDirection, LayoutNode, ResizeOp, SplitPosition};
 use uuid::Uuid;
 
 // ── Error type ─────────────────────────────────────────────────────────────
@@ -53,6 +53,38 @@ pub const DEFAULT_MAX_CHILDREN: usize = 5;
 /// Mirrors `frontend/layout/lib/types.ts::DefaultNodeSize`.
 pub const DEFAULT_NODE_SIZE: f32 = 10.0;
 
+// ── Flex-direction utilities ───────────────────────────────────────────────
+
+/// Reverse a flex direction (Row ↔ Column).
+/// Mirrors `frontend/layout/lib/layoutNode.ts::reverseFlexDirection`.
+fn reverse_flex_direction(dir: FlexDirection) -> FlexDirection {
+    match dir {
+        FlexDirection::Row => FlexDirection::Column,
+        FlexDirection::Column => FlexDirection::Row,
+    }
+}
+
+/// If `node` is a leaf (has `data`), promote it to a group by wrapping its
+/// data in an intermediate child. Mirrors TypeScript `addIntermediateNode`.
+/// After this call, `node.data` is `None` and `node.children` is non-empty.
+/// The intermediate child receives the node's ORIGINAL ID so frontend
+/// references remain stable; the group wrapper gets a new ID.
+fn ensure_group_node(node: &mut LayoutNode) {
+    if node.data.is_some() {
+        let old_id = node.id.clone();
+        let old_flex = node.flex_direction;
+        let intermediate = LayoutNode {
+            id: old_id,
+            flex_direction: reverse_flex_direction(old_flex),
+            size: DEFAULT_NODE_SIZE,
+            data: node.data.take(),
+            ..Default::default()
+        };
+        node.id = Uuid::new_v4().to_string();
+        node.children.push(intermediate);
+    }
+}
+
 // ── Tree traversal ─────────────────────────────────────────────────────────
 
 /// Find a node by id (immutable).
@@ -81,89 +113,71 @@ pub fn find_node_by_id_mut<'a>(tree: &'a mut LayoutNode, id: &str) -> Option<&'a
     None
 }
 
-/// Find the parent of a node identified by `child_id` (mutable reference to
-/// the parent). Returns `None` if `child_id == tree.id` (root has no parent).
-pub fn find_parent_by_child_id<'a>(
-    tree: &'a mut LayoutNode,
-    child_id: &str,
-) -> Option<&'a mut LayoutNode> {
-    if tree.children.iter().any(|c| c.id == child_id) {
-        return Some(tree);
-    }
-    // Can't use iter_mut here while also holding a borrow on tree; use indices.
-    let len = tree.children.len();
-    for i in 0..len {
-        // SAFETY: we borrow one child at a time without aliasing.
-        let child = &mut tree.children[i] as *mut LayoutNode;
-        // SAFETY: child outlives tree's borrow; no aliasing.
-        let result = find_parent_by_child_id(unsafe { &mut *child }, child_id);
-        if result.is_some() {
-            return result;
-        }
-    }
-    None
-}
-
 // ── Insert-location heuristic ──────────────────────────────────────────────
 
-/// Greedy depth-first search for the first node with fewer than `max_children`
-/// children. The TypeScript oracle (`findNextInsertLocation` in layoutNode.ts)
-/// uses the same greedy-DFS descent — fill each node before going deeper.
-/// (Reagent P2 PR #691: prior doc comment incorrectly said "BFS".)
+/// Candidate for insertion location, collected during tree traversal.
+struct InsertCandidate<'a> {
+    node: &'a LayoutNode,
+    index: usize,
+    depth: usize,
+}
+
+/// Find the best insertion location using the TypeScript scoring heuristic
+/// (`Math.pow(depth, index + maxChildren)`). Collects all candidates, then
+/// sorts by ascending score. Mirrors `findNextInsertLocation` in
+/// `frontend/layout/lib/layoutNode.ts`.
 fn find_next_insert_location(
     tree: &LayoutNode,
     max_children: usize,
 ) -> (&LayoutNode, usize) {
-    find_insert_location_inner(tree, max_children, 1)
+    let mut candidates = Vec::new();
+    collect_insert_candidates(tree, max_children, 1, &mut candidates);
+    candidates.sort_by(|a, b| {
+        let a_score = (a.depth as f64).powi((a.index + max_children) as i32);
+        let b_score = (b.depth as f64).powi((b.index + max_children) as i32);
+        a_score.partial_cmp(&b_score).unwrap_or(std::cmp::Ordering::Equal)
+    });
+    candidates
+        .into_iter()
+        .next()
+        .map(|c| (c.node, c.index))
         .unwrap_or((tree, tree.children.len()))
 }
 
-fn find_insert_location_inner(
-    node: &LayoutNode,
+fn collect_insert_candidates<'a>(
+    node: &'a LayoutNode,
     max_children: usize,
-    _depth: usize,
-) -> Option<(&LayoutNode, usize)> {
-    // If this node has room, insert here.
-    if node.children.len() < max_children || node.children.is_empty() {
-        return Some((node, node.children.len()));
+    depth: usize,
+    out: &mut Vec<InsertCandidate<'a>>,
+) {
+    // Leaf node (has data but no children) — TS returns index 1.
+    if node.data.is_some() && node.children.is_empty() {
+        out.push(InsertCandidate { node, index: 1, depth });
+        return;
     }
-    // Otherwise recurse into children.
-    for child in &node.children {
-        if let Some(loc) = find_insert_location_inner(child, max_children, _depth + 1) {
-            return Some(loc);
-        }
+    if node.children.len() < max_children {
+        out.push(InsertCandidate {
+            node,
+            index: node.children.len(),
+            depth,
+        });
     }
-    None
+    // TS iterates children in REVERSE order.
+    for child in node.children.iter().rev() {
+        collect_insert_candidates(child, max_children, depth + 1, out);
+    }
 }
 
 // ── Core operations ────────────────────────────────────────────────────────
 
-/// Insert `node` using a greedy DFS heuristic (up to DEFAULT_MAX_CHILDREN
-/// per node before descending — same strategy as `findNextInsertLocation`
-/// in `frontend/layout/lib/layoutNode.ts`). If the tree is empty (called
-/// with `root = None`), the caller should set `root = Some(node)` directly.
-/// This function only operates on a non-empty tree root.
-/// (Reagent P2 PR #691 round 3: prior doc said "BFS heuristic".)
+/// Insert `node` using the TypeScript scoring heuristic (up to
+/// DEFAULT_MAX_CHILDREN per node before descending). If the target location
+/// is a leaf, it is promoted to a group first via `ensure_group_node`.
+/// Mirrors `insertNode` / `addChildAt` in `frontend/layout/lib/layoutTree.ts`.
 pub fn insert_node(root: &mut LayoutNode, node: LayoutNode) {
-    // Use raw pointer to work around borrow checker limitations with the
-    // immutable findNext + mutable insert pattern.
-    let (loc_id, loc_index) = {
-        let (loc, idx) = find_next_insert_location(root, DEFAULT_MAX_CHILDREN);
-        (loc.id.clone(), idx)
-    };
+    let loc_id = find_next_insert_location(root, DEFAULT_MAX_CHILDREN).0.id.clone();
     if let Some(target) = find_node_by_id_mut(root, &loc_id) {
-        if target.data.is_some() {
-            // Leaf node — wrap its data in a child, then append.
-            let data = target.data.take().unwrap();
-            let existing_leaf = LayoutNode {
-                id: Uuid::new_v4().to_string(),
-                flex_direction: FlexDirection::Row,
-                size: DEFAULT_NODE_SIZE,
-                data: Some(data),
-                ..Default::default()
-            };
-            target.children.push(existing_leaf);
-        }
+        ensure_group_node(target);
         target.children.push(node);
     }
 }
@@ -195,35 +209,36 @@ pub fn insert_node_at_index(
         current = &mut cur.children[idx] as *mut LayoutNode;
     }
     let parent = unsafe { &mut *current };
+    ensure_group_node(parent);
     let insert_at = (last_idx + 1).min(parent.children.len());
     parent.children.insert(insert_at, node);
     Ok(())
 }
 
-/// Remove the node with the given id from the tree. Returns whether the
-/// deleted node was the currently-focused node (callers handle clearing
-/// focusedNodeId). Collapses single-child parents.
-pub fn delete_node(root: &mut LayoutNode, node_id: &str) -> Result<bool, LayoutError> {
+/// Remove the node with the given id from the tree.
+/// Returns `Ok(())` on success, or `Err(NodeNotFound)` if `node_id` is not
+/// in the tree. Callers are responsible for clearing `focused_node_id` if
+/// needed (spec §7.1). Collapses single-child parents.
+pub fn delete_node(root: &mut LayoutNode, node_id: &str) -> Result<(), LayoutError> {
     if root.id == node_id {
         // Root deletion is handled by the caller setting root = None.
-        return Ok(false);
+        return Ok(());
     }
-    let was_focused = delete_recursive(root, node_id);
-    match was_focused {
-        Some(wf) => Ok(wf),
-        None => Err(LayoutError::NodeNotFound { id: node_id.to_string() }),
+    match delete_recursive(root, node_id) {
+        true => Ok(()),
+        false => Err(LayoutError::NodeNotFound { id: node_id.to_string() }),
     }
 }
 
-/// Recursive delete. Returns `Some(was_focused)` when the node was found
-/// and removed, `None` when not found.
-fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> Option<bool> {
+/// Recursive delete. Returns `true` when the node was found and removed,
+/// `false` when not found.
+fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> bool {
     let idx = node.children.iter().position(|c| c.id == target_id);
     if let Some(i) = idx {
         // Found target as a direct child — remove it.
         node.children.remove(i);
         // Collapse: if only one child remains, promote it.
-        // Preserve `extra` (unknown-field catch-all from #688/#689 — reagent P1 PR #691).
+        // Preserve `extra` (unknown-field catch-all from #688/#689).
         if node.children.len() == 1 {
             let sole = node.children.remove(0);
             node.id = sole.id;
@@ -233,15 +248,15 @@ fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> Option<bool> {
             node.children = sole.children;
             node.extra = sole.extra;
         }
-        return Some(false);
+        return true;
     }
     // Not a direct child — recurse.
     for child in &mut node.children {
-        if let Some(wf) = delete_recursive(child, target_id) {
-            return Some(wf);
+        if delete_recursive(child, target_id) {
+            return true;
         }
     }
-    None
+    false
 }
 
 /// Move the node identified by `node_id` to be the child at `index` under
@@ -262,8 +277,6 @@ pub fn move_node(
     }
 
     // Validate BOTH node existence AND destination BEFORE any mutation.
-    // (Reagent P1 PR #691 round 2 — prior code removed the source before
-    // checking the destination, causing silent data loss on Err paths.)
     let node_to_move = find_node_by_id(root, node_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: node_id.to_string() })?
         .clone();
@@ -272,8 +285,6 @@ pub fn move_node(
         return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() });
     }
     // Confirm destination is NOT a descendant of the node being moved.
-    // If it were, detaching the source would also remove the destination,
-    // causing an unwrap() panic at the reattach step (reagent P1 PR #691 round 3).
     if find_node_by_id(&node_to_move, new_parent_id).is_some() {
         return Err(LayoutError::NodeNotFound {
             id: format!("{} (is a descendant of the moved node {})", new_parent_id, node_id),
@@ -291,9 +302,9 @@ pub fn move_node(
         node_with_size.size = DEFAULT_NODE_SIZE;
     }
 
-    // Insert at new location (destination guaranteed to still exist since
-    // we only removed the source, not the destination).
+    // Insert at new location (destination guaranteed to still exist).
     let new_parent = find_node_by_id_mut(root, new_parent_id).unwrap();
+    ensure_group_node(new_parent);
     let insert_at = index.min(new_parent.children.len());
     new_parent.children.insert(insert_at, node_with_size);
     Ok(())
@@ -349,8 +360,7 @@ pub fn swap_nodes(
 
     // Detect ancestor/descendant relationship. If n1 is an ancestor of n2
     // (or vice versa), the first placement replaces a subtree that contains
-    // the second node's parent, making the second lookup fail (reagent P1
-    // PR #691 round 3). Return an error instead of panicking the sidecar.
+    // the second node's parent, making the second lookup fail.
     if find_node_by_id(&n1, node2_id).is_some() || find_node_by_id(&n2, node1_id).is_some() {
         return Err(LayoutError::RootCannotBeTarget);
     }
@@ -385,7 +395,7 @@ pub fn swap_nodes(
 /// if any is invalid, returns an error WITHOUT applying any ops (atomically
 /// rejected — matches the frontend's early-return semantic from PR #686).
 pub fn resize_nodes(root: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), LayoutError> {
-    // Validation pass first.
+    // Validation pass 1: sizes.
     for op in ops {
         if !(0.0..=100.0).contains(&op.size) {
             return Err(LayoutError::InvalidSize {
@@ -394,11 +404,16 @@ pub fn resize_nodes(root: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), Layou
             });
         }
     }
+    // Validation pass 2: all target nodes exist.
+    for op in ops {
+        if find_node_by_id(root, &op.node_id).is_none() {
+            return Err(LayoutError::NodeNotFound { id: op.node_id.clone() });
+        }
+    }
     // Apply pass (all valid).
     for op in ops {
-        if let Some(node) = find_node_by_id_mut(root, &op.node_id) {
-            node.size = op.size;
-        }
+        let node = find_node_by_id_mut(root, &op.node_id).unwrap();
+        node.size = op.size;
     }
     Ok(())
 }

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -259,27 +259,31 @@ pub fn move_node(
         }
     }
 
-    // Collect the node to move + its old parent id.
+    // Validate BOTH node existence AND destination BEFORE any mutation.
+    // (Reagent P1 PR #691 round 2 — prior code removed the source before
+    // checking the destination, causing silent data loss on Err paths.)
     let node_to_move = find_node_by_id(root, node_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: node_id.to_string() })?
         .clone();
-    let old_parent_id = find_parent_id(root, node_id);
+    // Confirm destination exists while tree is still intact.
+    if find_node_by_id(root, new_parent_id).is_none() {
+        return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() });
+    }
 
-    // Check same-parent case for size reset.
+    let old_parent_id = find_parent_id(root, node_id);
     let same_parent = old_parent_id.as_deref() == Some(new_parent_id);
 
-    // Remove from old location.
+    // Now it is safe to detach (both endpoints exist).
     remove_node_from_parent(root, node_id);
 
-    // Determine new size.
     let mut node_with_size = node_to_move;
     if !same_parent {
         node_with_size.size = DEFAULT_NODE_SIZE;
     }
 
-    // Insert at new location.
-    let new_parent = find_node_by_id_mut(root, new_parent_id)
-        .ok_or_else(|| LayoutError::NodeNotFound { id: new_parent_id.to_string() })?;
+    // Insert at new location (destination guaranteed to still exist since
+    // we only removed the source, not the destination).
+    let new_parent = find_node_by_id_mut(root, new_parent_id).unwrap();
     let insert_at = index.min(new_parent.children.len());
     new_parent.children.insert(insert_at, node_with_size);
     Ok(())

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -104,16 +104,16 @@ pub fn find_parent_by_child_id<'a>(
     None
 }
 
-// ── BFS insert-location heuristic ─────────────────────────────────────────
+// ── Insert-location heuristic ──────────────────────────────────────────────
 
-/// Breadth-first search for the first node with fewer than `max_children`
-/// children. Mirrors `findNextInsertLocation` in layoutNode.ts.
+/// Greedy depth-first search for the first node with fewer than `max_children`
+/// children. The TypeScript oracle (`findNextInsertLocation` in layoutNode.ts)
+/// uses the same greedy-DFS descent — fill each node before going deeper.
+/// (Reagent P2 PR #691: prior doc comment incorrectly said "BFS".)
 fn find_next_insert_location(
     tree: &LayoutNode,
     max_children: usize,
 ) -> (&LayoutNode, usize) {
-    // BFS through the tree level by level (use depth-first with level tracking
-    // as a simpler approximation that matches the test oracle).
     find_insert_location_inner(tree, max_children, 1)
         .unwrap_or((tree, tree.children.len()))
 }
@@ -221,6 +221,7 @@ fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> Option<bool> {
         // Found target as a direct child — remove it.
         node.children.remove(i);
         // Collapse: if only one child remains, promote it.
+        // Preserve `extra` (unknown-field catch-all from #688/#689 — reagent P1 PR #691).
         if node.children.len() == 1 {
             let sole = node.children.remove(0);
             node.id = sole.id;
@@ -228,6 +229,7 @@ fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> Option<bool> {
             node.data = sole.data;
             node.flex_direction = sole.flex_direction;
             node.children = sole.children;
+            node.extra = sole.extra;
         }
         return Some(false);
     }
@@ -475,13 +477,15 @@ fn split_impl(
 
     // Target IS root (no parent) — wrap root in a new group.
     // We can't replace `root` itself, so we build the group children in-place.
+    // Also take `root.extra` (unknown-field catch-all from #688/#689).
+    // `..Default::default()` would silently drop it — reagent P1 PR #691.
     let root_clone = LayoutNode {
         id: root.id.clone(),
         flex_direction: root.flex_direction,
         size: root.size,
         children: std::mem::take(&mut root.children),
         data: root.data.take(),
-        ..Default::default()
+        extra: std::mem::take(&mut root.extra),
     };
     let root_size = root_clone.size;
     let new_group_id = Uuid::new_v4().to_string();

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -65,10 +65,19 @@ fn reverse_flex_direction(dir: FlexDirection) -> FlexDirection {
 }
 
 /// If `node` is a leaf (has `data`), promote it to a group by wrapping its
-/// data in an intermediate child. Mirrors TypeScript `addIntermediateNode`.
-/// After this call, `node.data` is `None` and `node.children` is non-empty.
-/// The intermediate child receives the node's ORIGINAL ID so frontend
-/// references remain stable; the group wrapper gets a new ID.
+/// data in an intermediate child. Mirrors TypeScript `addIntermediateNode`
+/// in `frontend/layout/lib/layoutTree.ts`.
+///
+/// After this call:
+/// - `node.data` is `None` and `node.children` is non-empty.
+/// - The intermediate child receives the node's ORIGINAL ID so any
+///   frontend reference (e.g. `focusedNodeId`) still points at the
+///   leaf data after promotion.
+/// - The group wrapper gets a fresh UUID, and its flex direction is
+///   the reverse of the original leaf's so the new sibling axis is
+///   perpendicular to the parent's (matches TS layout semantics).
+///
+/// No-op when `node` is already a group (no `data`).
 fn ensure_group_node(node: &mut LayoutNode) {
     if node.data.is_some() {
         let old_id = node.id.clone();

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -87,6 +87,11 @@ fn ensure_group_node(node: &mut LayoutNode) {
             flex_direction: reverse_flex_direction(old_flex),
             size: DEFAULT_NODE_SIZE,
             data: node.data.take(),
+            // Move `extra` (forward-compat catch-all from #688/#689) to the
+            // intermediate so unknown fields the frontend wrote to the leaf
+            // travel with the data, not stay on the new group wrapper.
+            // Mirrors the same transfer in `delete_recursive` line below.
+            extra: std::mem::take(&mut node.extra),
             ..Default::default()
         };
         node.id = Uuid::new_v4().to_string();

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -1,0 +1,511 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure layout-tree helper functions for the srv E.4.B reducer.
+//!
+//! Phase 4 of docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md.
+//! Ports the 11 pure-ish action handlers from
+//! `frontend/layout/lib/layoutTree.ts` to Rust. These functions take
+//! `&mut LayoutNode` (the tree root) and operation params; they have no
+//! I/O and no side effects. The reducer arms (Phase 5) will call these.
+//!
+//! Test oracle: the 30 tests in `frontend/layout/tests/layoutTree.test.ts`
+//! (shipped in PR #686) — the Rust implementations must produce identical
+//! state transitions for identical inputs.
+
+use agentmux_common::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
+use uuid::Uuid;
+
+// ── Error type ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum LayoutError {
+    NodeNotFound { id: String },
+    /// Caller tried to swap a node with itself.
+    SelfSwap,
+    /// Caller tried to swap, move, or magnify the root node.
+    RootCannotBeTarget,
+    /// A resize op had size outside [0.0, 100.0].
+    InvalidSize { node_id: String, size: f32 },
+    /// index_arr was empty or led to a non-existent location.
+    InvalidIndexPath,
+}
+
+impl std::fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NodeNotFound { id } => write!(f, "node not found: {}", id),
+            Self::SelfSwap => write!(f, "cannot swap a node with itself"),
+            Self::RootCannotBeTarget => write!(f, "root node cannot be the target of this operation"),
+            Self::InvalidSize { node_id, size } => write!(f, "invalid size {:.2} for node {}", size, node_id),
+            Self::InvalidIndexPath => write!(f, "index_arr is empty or points to a non-existent location"),
+        }
+    }
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/// Maximum children before `insert_node`'s heuristic descends.
+/// Mirrors `frontend/layout/lib/layoutTree.ts::DEFAULT_MAX_CHILDREN`.
+pub const DEFAULT_MAX_CHILDREN: usize = 5;
+
+/// Default flex size for newly-inserted nodes.
+/// Mirrors `frontend/layout/lib/types.ts::DefaultNodeSize`.
+pub const DEFAULT_NODE_SIZE: f32 = 10.0;
+
+// ── Tree traversal ─────────────────────────────────────────────────────────
+
+/// Find a node by id (immutable).
+pub fn find_node_by_id<'a>(tree: &'a LayoutNode, id: &str) -> Option<&'a LayoutNode> {
+    if tree.id == id {
+        return Some(tree);
+    }
+    for child in &tree.children {
+        if let Some(found) = find_node_by_id(child, id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Find a node by id (mutable).
+pub fn find_node_by_id_mut<'a>(tree: &'a mut LayoutNode, id: &str) -> Option<&'a mut LayoutNode> {
+    if tree.id == id {
+        return Some(tree);
+    }
+    for child in &mut tree.children {
+        if let Some(found) = find_node_by_id_mut(child, id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Find the parent of a node identified by `child_id` (mutable reference to
+/// the parent). Returns `None` if `child_id == tree.id` (root has no parent).
+pub fn find_parent_by_child_id<'a>(
+    tree: &'a mut LayoutNode,
+    child_id: &str,
+) -> Option<&'a mut LayoutNode> {
+    if tree.children.iter().any(|c| c.id == child_id) {
+        return Some(tree);
+    }
+    // Can't use iter_mut here while also holding a borrow on tree; use indices.
+    let len = tree.children.len();
+    for i in 0..len {
+        // SAFETY: we borrow one child at a time without aliasing.
+        let child = &mut tree.children[i] as *mut LayoutNode;
+        // SAFETY: child outlives tree's borrow; no aliasing.
+        let result = find_parent_by_child_id(unsafe { &mut *child }, child_id);
+        if result.is_some() {
+            return result;
+        }
+    }
+    None
+}
+
+// ── BFS insert-location heuristic ─────────────────────────────────────────
+
+/// Breadth-first search for the first node with fewer than `max_children`
+/// children. Mirrors `findNextInsertLocation` in layoutNode.ts.
+fn find_next_insert_location(
+    tree: &LayoutNode,
+    max_children: usize,
+) -> (&LayoutNode, usize) {
+    // BFS through the tree level by level (use depth-first with level tracking
+    // as a simpler approximation that matches the test oracle).
+    find_insert_location_inner(tree, max_children, 1)
+        .unwrap_or((tree, tree.children.len()))
+}
+
+fn find_insert_location_inner(
+    node: &LayoutNode,
+    max_children: usize,
+    _depth: usize,
+) -> Option<(&LayoutNode, usize)> {
+    // If this node has room, insert here.
+    if node.children.len() < max_children || node.children.is_empty() {
+        return Some((node, node.children.len()));
+    }
+    // Otherwise recurse into children.
+    for child in &node.children {
+        if let Some(loc) = find_insert_location_inner(child, max_children, _depth + 1) {
+            return Some(loc);
+        }
+    }
+    None
+}
+
+// ── Core operations ────────────────────────────────────────────────────────
+
+/// Insert `node` using the BFS heuristic (up to DEFAULT_MAX_CHILDREN per
+/// node before descending). If the tree is empty (called with
+/// `root = None`), the caller should set `root = Some(node)` directly.
+/// This function only operates on a non-empty tree root.
+pub fn insert_node(root: &mut LayoutNode, node: LayoutNode) {
+    // Use raw pointer to work around borrow checker limitations with the
+    // immutable findNext + mutable insert pattern.
+    let (loc_id, loc_index) = {
+        let (loc, idx) = find_next_insert_location(root, DEFAULT_MAX_CHILDREN);
+        (loc.id.clone(), idx)
+    };
+    if let Some(target) = find_node_by_id_mut(root, &loc_id) {
+        if target.data.is_some() {
+            // Leaf node — wrap its data in a child, then append.
+            let data = target.data.take().unwrap();
+            let existing_leaf = LayoutNode {
+                id: Uuid::new_v4().to_string(),
+                flex_direction: FlexDirection::Row,
+                size: DEFAULT_NODE_SIZE,
+                data: Some(data),
+                ..Default::default()
+            };
+            target.children.push(existing_leaf);
+        }
+        target.children.push(node);
+    }
+}
+
+/// Insert `node` at the location identified by `index_arr` — an ordered
+/// sequence of child indices (e.g. `[0, 2]` = root.children[0].children
+/// at index 3). The node is inserted AFTER the position identified by the
+/// last index. Mirrors `insertNodeAtIndex` / `findInsertLocationFromIndexArr`.
+pub fn insert_node_at_index(
+    root: &mut LayoutNode,
+    node: LayoutNode,
+    index_arr: &[usize],
+) -> Result<(), LayoutError> {
+    if index_arr.is_empty() {
+        return Err(LayoutError::InvalidIndexPath);
+    }
+    // Navigate to the parent using all-but-last indices, then insert
+    // after last-index position.
+    let mut current = root as *mut LayoutNode;
+    let split_at = index_arr.len() - 1;
+    let path = &index_arr[..split_at];
+    let last_idx = index_arr[split_at];
+
+    for &idx in path {
+        let cur = unsafe { &mut *current };
+        if idx >= cur.children.len() {
+            return Err(LayoutError::InvalidIndexPath);
+        }
+        current = &mut cur.children[idx] as *mut LayoutNode;
+    }
+    let parent = unsafe { &mut *current };
+    let insert_at = (last_idx + 1).min(parent.children.len());
+    parent.children.insert(insert_at, node);
+    Ok(())
+}
+
+/// Remove the node with the given id from the tree. Returns whether the
+/// deleted node was the currently-focused node (callers handle clearing
+/// focusedNodeId). Collapses single-child parents.
+pub fn delete_node(root: &mut LayoutNode, node_id: &str) -> Result<bool, LayoutError> {
+    if root.id == node_id {
+        // Root deletion is handled by the caller setting root = None.
+        return Ok(false);
+    }
+    let was_focused = delete_recursive(root, node_id);
+    match was_focused {
+        Some(wf) => Ok(wf),
+        None => Err(LayoutError::NodeNotFound { id: node_id.to_string() }),
+    }
+}
+
+/// Recursive delete. Returns `Some(was_focused)` when the node was found
+/// and removed, `None` when not found.
+fn delete_recursive(node: &mut LayoutNode, target_id: &str) -> Option<bool> {
+    let idx = node.children.iter().position(|c| c.id == target_id);
+    if let Some(i) = idx {
+        // Found target as a direct child — remove it.
+        node.children.remove(i);
+        // Collapse: if only one child remains, promote it.
+        if node.children.len() == 1 {
+            let sole = node.children.remove(0);
+            node.id = sole.id;
+            node.size = sole.size;
+            node.data = sole.data;
+            node.flex_direction = sole.flex_direction;
+            node.children = sole.children;
+        }
+        return Some(false);
+    }
+    // Not a direct child — recurse.
+    for child in &mut node.children {
+        if let Some(wf) = delete_recursive(child, target_id) {
+            return Some(wf);
+        }
+    }
+    None
+}
+
+/// Move the node identified by `node_id` to be the child at `index` under
+/// the node identified by `new_parent_id`. Resets the moved node's size to
+/// DEFAULT_NODE_SIZE unless it stays under the same parent.
+pub fn move_node(
+    root: &mut LayoutNode,
+    node_id: &str,
+    new_parent_id: &str,
+    index: usize,
+) -> Result<(), LayoutError> {
+    if root.id == node_id || root.id == new_parent_id {
+        if new_parent_id == root.id && root.id != node_id {
+            // Moving a child to root-as-parent is valid; proceed.
+        } else if root.id == node_id {
+            return Err(LayoutError::RootCannotBeTarget);
+        }
+    }
+
+    // Collect the node to move + its old parent id.
+    let node_to_move = find_node_by_id(root, node_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: node_id.to_string() })?
+        .clone();
+    let old_parent_id = find_parent_id(root, node_id);
+
+    // Check same-parent case for size reset.
+    let same_parent = old_parent_id.as_deref() == Some(new_parent_id);
+
+    // Remove from old location.
+    remove_node_from_parent(root, node_id);
+
+    // Determine new size.
+    let mut node_with_size = node_to_move;
+    if !same_parent {
+        node_with_size.size = DEFAULT_NODE_SIZE;
+    }
+
+    // Insert at new location.
+    let new_parent = find_node_by_id_mut(root, new_parent_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: new_parent_id.to_string() })?;
+    let insert_at = index.min(new_parent.children.len());
+    new_parent.children.insert(insert_at, node_with_size);
+    Ok(())
+}
+
+fn find_parent_id(root: &LayoutNode, child_id: &str) -> Option<String> {
+    if root.children.iter().any(|c| c.id == child_id) {
+        return Some(root.id.clone());
+    }
+    for child in &root.children {
+        if let Some(pid) = find_parent_id(child, child_id) {
+            return Some(pid);
+        }
+    }
+    None
+}
+
+fn remove_node_from_parent(root: &mut LayoutNode, node_id: &str) {
+    if let Some(idx) = root.children.iter().position(|c| c.id == node_id) {
+        root.children.remove(idx);
+        return;
+    }
+    for child in &mut root.children {
+        remove_node_from_parent(child, node_id);
+    }
+}
+
+/// Swap two nodes (by id). Their sizes travel with them (swap positions
+/// but preserve the size each node had). Neither can be the root.
+pub fn swap_nodes(
+    root: &mut LayoutNode,
+    node1_id: &str,
+    node2_id: &str,
+) -> Result<(), LayoutError> {
+    if node1_id == node2_id {
+        return Err(LayoutError::SelfSwap);
+    }
+    if root.id == node1_id || root.id == node2_id {
+        return Err(LayoutError::RootCannotBeTarget);
+    }
+
+    // Collect both nodes + parent info.
+    let n1 = find_node_by_id(root, node1_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: node1_id.to_string() })?
+        .clone();
+    let n2 = find_node_by_id(root, node2_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: node2_id.to_string() })?
+        .clone();
+    let p1_id = find_parent_id(root, node1_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: format!("parent of {}", node1_id) })?;
+    let p2_id = find_parent_id(root, node2_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: format!("parent of {}", node2_id) })?;
+
+    // Find indices.
+    let idx1 = {
+        let p = find_node_by_id(root, &p1_id).unwrap();
+        p.children.iter().position(|c| c.id == node1_id).unwrap()
+    };
+    let idx2 = {
+        let p = find_node_by_id(root, &p2_id).unwrap();
+        p.children.iter().position(|c| c.id == node2_id).unwrap()
+    };
+
+    // Build swapped nodes: preserve sizes AT the slot, swap the nodes.
+    let mut n1_swapped = n2.clone();
+    n1_swapped.size = n1.size; // slot 1 keeps size of what was there (n1's size)
+    let mut n2_swapped = n1.clone();
+    n2_swapped.size = n2.size; // slot 2 keeps size of what was there (n2's size)
+
+    // Place them.
+    let p1 = find_node_by_id_mut(root, &p1_id).unwrap();
+    p1.children[idx1] = n1_swapped;
+
+    let p2 = find_node_by_id_mut(root, &p2_id).unwrap();
+    p2.children[idx2] = n2_swapped;
+
+    Ok(())
+}
+
+/// Apply resize operations. Validates all sizes first (0.0–100.0 range);
+/// if any is invalid, returns an error WITHOUT applying any ops (atomically
+/// rejected — matches the frontend's early-return semantic from PR #686).
+pub fn resize_nodes(root: &mut LayoutNode, ops: &[ResizeOp]) -> Result<(), LayoutError> {
+    // Validation pass first.
+    for op in ops {
+        if !(0.0..=100.0).contains(&op.size) {
+            return Err(LayoutError::InvalidSize {
+                node_id: op.node_id.clone(),
+                size: op.size,
+            });
+        }
+    }
+    // Apply pass (all valid).
+    for op in ops {
+        if let Some(node) = find_node_by_id_mut(root, &op.node_id) {
+            node.size = op.size;
+        }
+    }
+    Ok(())
+}
+
+/// Replace the node at `target_id` with `new_node`, preserving the target's
+/// `size`. If target is root, replaces root-in-place (caller's `Option<LayoutNode>`
+/// doesn't change reference — the fields are updated on the root node).
+pub fn replace_node(
+    root: &mut LayoutNode,
+    target_id: &str,
+    new_node: LayoutNode,
+) -> Result<(), LayoutError> {
+    if root.id == target_id {
+        let preserved_size = root.size;
+        *root = new_node;
+        root.size = preserved_size;
+        return Ok(());
+    }
+    let parent_id = find_parent_id(root, target_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: target_id.to_string() })?;
+    let parent = find_node_by_id_mut(root, &parent_id).unwrap();
+    let idx = parent.children.iter().position(|c| c.id == target_id).unwrap();
+    let preserved_size = parent.children[idx].size;
+    parent.children[idx] = new_node;
+    parent.children[idx].size = preserved_size;
+    Ok(())
+}
+
+/// Horizontal split: insert `new_node` before/after `target_id`.
+///
+/// - If the target's parent is a Row, splice directly.
+/// - Otherwise, wrap target + new_node in a fresh Row group.
+pub fn split_horizontal(
+    root: &mut LayoutNode,
+    target_id: &str,
+    new_node: LayoutNode,
+    position: SplitPosition,
+) -> Result<(), LayoutError> {
+    split_impl(root, target_id, new_node, position, FlexDirection::Row)
+}
+
+/// Vertical split: insert `new_node` before/after `target_id`.
+///
+/// - If the target's parent is a Column, splice directly.
+/// - Otherwise, wrap in a fresh Column group.
+pub fn split_vertical(
+    root: &mut LayoutNode,
+    target_id: &str,
+    new_node: LayoutNode,
+    position: SplitPosition,
+) -> Result<(), LayoutError> {
+    split_impl(root, target_id, new_node, position, FlexDirection::Column)
+}
+
+fn split_impl(
+    root: &mut LayoutNode,
+    target_id: &str,
+    new_node: LayoutNode,
+    position: SplitPosition,
+    direction: FlexDirection,
+) -> Result<(), LayoutError> {
+    // Find target; it must exist.
+    let _ = find_node_by_id(root, target_id)
+        .ok_or_else(|| LayoutError::NodeNotFound { id: target_id.to_string() })?;
+
+    let parent_id = find_parent_id(root, target_id);
+
+    if let Some(ref pid) = parent_id {
+        let parent = find_node_by_id_mut(root, pid).unwrap();
+        if parent.flex_direction == direction {
+            // Parent already has the matching direction — splice directly.
+            let idx = parent.children.iter().position(|c| c.id == target_id).unwrap();
+            let insert_at = match position {
+                SplitPosition::Before => idx,
+                SplitPosition::After => idx + 1,
+            };
+            parent.children.insert(insert_at, new_node);
+            return Ok(());
+        }
+        // Parent has wrong direction — wrap target in a new group.
+        let idx = parent.children.iter().position(|c| c.id == target_id).unwrap();
+        let target = parent.children.remove(idx);
+        let target_size = target.size;
+        let (children_ordered, new_flex) = match position {
+            SplitPosition::Before => (vec![new_node, target], direction),
+            SplitPosition::After => (vec![target, new_node], direction),
+        };
+        let group = LayoutNode {
+            id: Uuid::new_v4().to_string(),
+            flex_direction: new_flex,
+            size: target_size,
+            children: children_ordered,
+            ..Default::default()
+        };
+        parent.children.insert(idx, group);
+        return Ok(());
+    }
+
+    // Target IS root (no parent) — wrap root in a new group.
+    // We can't replace `root` itself, so we build the group children in-place.
+    let root_clone = LayoutNode {
+        id: root.id.clone(),
+        flex_direction: root.flex_direction,
+        size: root.size,
+        children: std::mem::take(&mut root.children),
+        data: root.data.take(),
+        ..Default::default()
+    };
+    let root_size = root_clone.size;
+    let new_group_id = Uuid::new_v4().to_string();
+    let (children_ordered, new_flex) = match position {
+        SplitPosition::Before => (vec![new_node, root_clone], direction),
+        SplitPosition::After => (vec![root_clone, new_node], direction),
+    };
+    root.id = new_group_id;
+    root.flex_direction = new_flex;
+    root.size = root_size;
+    root.children = children_ordered;
+    root.data = None;
+    Ok(())
+}
+
+// ── Clear tree ─────────────────────────────────────────────────────────────
+
+/// Clear the tree root. Callers set the `Option<LayoutNode>` to `None`.
+/// This function exists only to be referenced in the test helper pattern;
+/// actual clearing in the reducer just sets root = None.
+pub fn clear_tree_node(_root: &mut Option<LayoutNode>) {
+    *_root = None;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+#[cfg(test)]
+mod tests;

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -308,6 +308,16 @@ pub fn move_node(
     let old_parent_id = find_parent_id(root, node_id);
     let same_parent = old_parent_id.as_deref() == Some(new_parent_id);
 
+    // Capture the node's current index inside the new parent BEFORE the
+    // detach so we can compensate for the source-removal shift below.
+    // Only meaningful when same_parent (otherwise cur_idx is None).
+    let cur_idx_in_new_parent = if same_parent {
+        find_node_by_id(root, new_parent_id)
+            .and_then(|p| p.children.iter().position(|c| c.id == node_id))
+    } else {
+        None
+    };
+
     // Now it is safe to detach (both endpoints exist).
     remove_node_from_parent(root, node_id);
 
@@ -316,10 +326,22 @@ pub fn move_node(
         node_with_size.size = DEFAULT_NODE_SIZE;
     }
 
+    // Mirror the TypeScript oracle (`moveNode` in
+    // frontend/layout/lib/layoutTree.ts): TS does insert-then-remove with
+    // a `startingIndex` shift, which makes same-parent moves where the
+    // requested index is past the current position resolve to one slot
+    // earlier in the final array (because the to-be-removed source eats
+    // a slot from `index`). We do detach-then-insert here, so we apply
+    // that compensation by decrementing `index` when target > cur_idx.
+    let effective_index = match cur_idx_in_new_parent {
+        Some(ci) if index > ci => index - 1,
+        _ => index,
+    };
+
     // Insert at new location (destination guaranteed to still exist).
     let new_parent = find_node_by_id_mut(root, new_parent_id).unwrap();
     ensure_group_node(new_parent);
-    let insert_at = index.min(new_parent.children.len());
+    let insert_at = effective_index.min(new_parent.children.len());
     new_parent.children.insert(insert_at, node_with_size);
     Ok(())
 }

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -138,10 +138,12 @@ fn find_insert_location_inner(
 
 // ── Core operations ────────────────────────────────────────────────────────
 
-/// Insert `node` using the BFS heuristic (up to DEFAULT_MAX_CHILDREN per
-/// node before descending). If the tree is empty (called with
-/// `root = None`), the caller should set `root = Some(node)` directly.
+/// Insert `node` using a greedy DFS heuristic (up to DEFAULT_MAX_CHILDREN
+/// per node before descending — same strategy as `findNextInsertLocation`
+/// in `frontend/layout/lib/layoutNode.ts`). If the tree is empty (called
+/// with `root = None`), the caller should set `root = Some(node)` directly.
 /// This function only operates on a non-empty tree root.
+/// (Reagent P2 PR #691 round 3: prior doc said "BFS heuristic".)
 pub fn insert_node(root: &mut LayoutNode, node: LayoutNode) {
     // Use raw pointer to work around borrow checker limitations with the
     // immutable findNext + mutable insert pattern.
@@ -269,6 +271,14 @@ pub fn move_node(
     if find_node_by_id(root, new_parent_id).is_none() {
         return Err(LayoutError::NodeNotFound { id: new_parent_id.to_string() });
     }
+    // Confirm destination is NOT a descendant of the node being moved.
+    // If it were, detaching the source would also remove the destination,
+    // causing an unwrap() panic at the reattach step (reagent P1 PR #691 round 3).
+    if find_node_by_id(&node_to_move, new_parent_id).is_some() {
+        return Err(LayoutError::NodeNotFound {
+            id: format!("{} (is a descendant of the moved node {})", new_parent_id, node_id),
+        });
+    }
 
     let old_parent_id = find_parent_id(root, node_id);
     let same_parent = old_parent_id.as_deref() == Some(new_parent_id);
@@ -337,6 +347,14 @@ pub fn swap_nodes(
     let p2_id = find_parent_id(root, node2_id)
         .ok_or_else(|| LayoutError::NodeNotFound { id: format!("parent of {}", node2_id) })?;
 
+    // Detect ancestor/descendant relationship. If n1 is an ancestor of n2
+    // (or vice versa), the first placement replaces a subtree that contains
+    // the second node's parent, making the second lookup fail (reagent P1
+    // PR #691 round 3). Return an error instead of panicking the sidecar.
+    if find_node_by_id(&n1, node2_id).is_some() || find_node_by_id(&n2, node1_id).is_some() {
+        return Err(LayoutError::RootCannotBeTarget);
+    }
+
     // Find indices.
     let idx1 = {
         let p = find_node_by_id(root, &p1_id).unwrap();
@@ -353,7 +371,7 @@ pub fn swap_nodes(
     let mut n2_swapped = n1.clone();
     n2_swapped.size = n2.size; // slot 2 keeps size of what was there (n2's size)
 
-    // Place them.
+    // Place them. p2_id is guaranteed to still exist (ancestor check above).
     let p1 = find_node_by_id_mut(root, &p1_id).unwrap();
     p1.children[idx1] = n1_swapped;
 

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -353,12 +353,16 @@ fn swap_nodes_rejects_ancestor() {
 // ── moveNode ─────────────────────────────────────────────────────────────────
 
 #[test]
-fn move_node_to_different_parent() {
+fn move_node_same_parent_target_eq_cur_plus_one_is_no_op() {
+    // [a, b], move a to index 1 — TS oracle: no-op (cur=0, target=cur+1).
+    // The TS insert-then-remove flow inserts a copy at index 1 making
+    // [a, a, b], then removes the first a, producing [a, b] unchanged.
     let a = leaf("a", "b1", 5.0);
     let b = leaf("b", "b2", 5.0);
     let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b]);
     move_node(&mut root, "a", "root", 1).unwrap();
-    assert_eq!(root.children[1].id, "a");
+    assert_eq!(root.children[0].id, "a");
+    assert_eq!(root.children[1].id, "b");
 }
 
 #[test]
@@ -375,11 +379,32 @@ fn move_node_same_parent_earlier_index() {
 
 #[test]
 fn move_node_same_parent_later_index() {
+    // [a, b, c], move a to index 2 — TS oracle: [b, a, c].
+    // (cur=0, target=2; the TS insert-then-remove flow lands a between b
+    // and c. Detach-then-insert in Rust must compensate by inserting at
+    // index 1 to match.) See PR #691 Codex P1 + frontend layoutTree.ts:248.
     let a = leaf("a", "b1", 5.0);
     let b = leaf("b", "b2", 5.0);
     let c = leaf("c", "b3", 5.0);
     let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b, c]);
     move_node(&mut root, "a", "root", 2).unwrap();
+    assert_eq!(root.children[0].id, "b");
+    assert_eq!(root.children[1].id, "a");
+    assert_eq!(root.children[2].id, "c");
+}
+
+#[test]
+fn move_node_same_parent_target_past_end_appends() {
+    // [a, b, c], move a to index 3 — out-of-range target in same parent.
+    // TS appends after the detach: addChildAt(parent, 3, a) on [a,b,c]
+    // produces [a,b,c,a], then removeChild(parent, a, 0) removes index 0,
+    // leaving [b, c, a]. Compensation rule (target > cur → target-1) plus
+    // clamping to len gives the same result.
+    let a = leaf("a", "b1", 5.0);
+    let b = leaf("b", "b2", 5.0);
+    let c = leaf("c", "b3", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b, c]);
+    move_node(&mut root, "a", "root", 3).unwrap();
     assert_eq!(root.children[0].id, "b");
     assert_eq!(root.children[1].id, "c");
     assert_eq!(root.children[2].id, "a");

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -1,0 +1,288 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Ported tests for the Rust layout helpers. These mirror the 30 tests
+//! from `frontend/layout/tests/layoutTree.test.ts` (PR #686) — the
+//! TypeScript test suite is the behavioral oracle.
+
+use agentmux_common::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
+use uuid::Uuid;
+use super::*;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn leaf(id: &str, block_id: &str, size: f32) -> LayoutNode {
+    LayoutNode {
+        id: id.into(),
+        flex_direction: FlexDirection::Row,
+        size,
+        data: Some(LayoutNodeData {
+            block_id: block_id.into(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn group(id: &str, dir: FlexDirection, size: f32, children: Vec<LayoutNode>) -> LayoutNode {
+    LayoutNode {
+        id: id.into(),
+        flex_direction: dir,
+        size,
+        children,
+        ..Default::default()
+    }
+}
+
+fn new_id() -> String {
+    Uuid::new_v4().to_string()
+}
+
+// ── isInstanceLabel filter (JS analogue: insert location) ──────────────────
+
+#[test]
+fn insert_node_into_empty_root_promotes_to_leaf() {
+    let mut root = leaf("root", "b1", 1.0);
+    let new = leaf("new", "b2", 1.0);
+    insert_node(&mut root, new);
+    // Root should now have children.
+    assert!(!root.children.is_empty());
+}
+
+#[test]
+fn insert_node_appends_to_existing_non_full_node() {
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![
+        leaf("c1", "b1", 5.0),
+    ]);
+    let new = leaf("new", "b2", 5.0);
+    insert_node(&mut root, new.clone());
+    assert_eq!(root.children.len(), 2);
+    assert!(root.children.iter().any(|c| c.id == "new"));
+}
+
+// ── insertNodeAtIndex ────────────────────────────────────────────────────────
+
+#[test]
+fn insert_node_at_index_inserts_after_path() {
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![
+        leaf("c1", "b1", 5.0),
+        leaf("c2", "b2", 5.0),
+    ]);
+    let new = leaf("new", "b3", 5.0);
+    insert_node_at_index(&mut root, new, &[0]).unwrap();
+    // Should be inserted after index 0 (at position 1).
+    assert_eq!(root.children[1].id, "new");
+}
+
+#[test]
+fn insert_node_at_index_empty_arr_returns_error() {
+    let mut root = leaf("root", "b1", 1.0);
+    let new = leaf("new", "b2", 1.0);
+    let result = insert_node_at_index(&mut root, new, &[]);
+    assert!(matches!(result, Err(LayoutError::InvalidIndexPath)));
+}
+
+// ── swapNode ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn swap_nodes_swaps_positions_and_preserves_slot_sizes() {
+    let n1 = leaf("n1", "b1", 30.0);
+    let n2 = leaf("n2", "b2", 70.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1, n2]);
+    swap_nodes(&mut root, "n1", "n2").unwrap();
+    // n2 is now at slot 0, n1 at slot 1.
+    assert_eq!(root.children[0].id, "n2");
+    assert_eq!(root.children[1].id, "n1");
+    // Sizes stay at the slot (30 at slot 0, 70 at slot 1).
+    assert_eq!(root.children[0].size, 30.0);
+    assert_eq!(root.children[1].size, 70.0);
+}
+
+#[test]
+fn swap_nodes_rejects_root_node() {
+    let child = leaf("child", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let result = swap_nodes(&mut root, "root", "child");
+    assert!(matches!(result, Err(LayoutError::RootCannotBeTarget)));
+}
+
+#[test]
+fn swap_nodes_rejects_self_swap() {
+    let n1 = leaf("n1", "b1", 5.0);
+    let n2 = leaf("n2", "b2", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1, n2]);
+    let result = swap_nodes(&mut root, "n1", "n1");
+    assert!(matches!(result, Err(LayoutError::SelfSwap)));
+}
+
+// ── deleteNode ────────────────────────────────────────────────────────────────
+
+#[test]
+fn delete_node_removes_child() {
+    let n1 = leaf("n1", "keep", 5.0);
+    let n2 = leaf("n2", "drop", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1, n2]);
+    delete_node(&mut root, "n2").unwrap();
+    // Collapses to root being the kept leaf.
+    assert!(!root.children.iter().any(|c| c.id == "n2"));
+}
+
+#[test]
+fn delete_node_collapses_single_child_parent() {
+    let n1 = leaf("n1", "keep", 5.0);
+    let n2 = leaf("n2", "drop", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1, n2]);
+    delete_node(&mut root, "n2").unwrap();
+    // After dropping n2, only n1 remains. The group should collapse.
+    // root is now the "keep" leaf.
+    assert_eq!(root.children.len(), 0);
+    assert_eq!(root.data.as_ref().map(|d| d.block_id.as_str()), Some("keep"));
+}
+
+#[test]
+fn delete_node_unknown_id_returns_error() {
+    let child = leaf("child", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let result = delete_node(&mut root, "ghost");
+    assert!(matches!(result, Err(LayoutError::NodeNotFound { .. })));
+}
+
+#[test]
+fn delete_node_root_returns_ok_without_deleting() {
+    let mut root = leaf("root", "b1", 1.0);
+    // Caller should set Option<LayoutNode> = None; we just return Ok(false).
+    let result = delete_node(&mut root, "root");
+    assert!(result.is_ok());
+}
+
+// ── resizeNode ────────────────────────────────────────────────────────────────
+
+#[test]
+fn resize_nodes_applies_size_to_matching_node() {
+    let n1 = leaf("n1", "b1", 50.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1]);
+    resize_nodes(&mut root, &[ResizeOp { node_id: "n1".into(), size: 80.0 }]).unwrap();
+    let node = find_node_by_id(&root, "n1").unwrap();
+    assert_eq!(node.size, 80.0);
+}
+
+#[test]
+fn resize_nodes_rejects_out_of_range_and_applies_nothing() {
+    let n1 = leaf("n1", "b1", 50.0);
+    let n2 = leaf("n2", "b2", 50.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1, n2]);
+    // First op out of range → whole batch rejected.
+    let result = resize_nodes(&mut root, &[
+        ResizeOp { node_id: "n1".into(), size: 150.0 },
+        ResizeOp { node_id: "n2".into(), size: 25.0 },
+    ]);
+    assert!(matches!(result, Err(LayoutError::InvalidSize { .. })));
+    // Neither node mutated.
+    assert_eq!(find_node_by_id(&root, "n1").unwrap().size, 50.0);
+    assert_eq!(find_node_by_id(&root, "n2").unwrap().size, 50.0);
+}
+
+// ── focusNode (find_node_by_id, id lookup) ────────────────────────────────────
+
+#[test]
+fn find_node_by_id_finds_nested_node() {
+    let inner = leaf("inner", "b1", 5.0);
+    let middle = group("middle", FlexDirection::Column, 5.0, vec![inner]);
+    let root = group("root", FlexDirection::Row, 10.0, vec![middle]);
+    assert!(find_node_by_id(&root, "inner").is_some());
+    assert!(find_node_by_id(&root, "middle").is_some());
+    assert!(find_node_by_id(&root, "ghost").is_none());
+}
+
+// ── magnifyNodeToggle (via split to verify two-level structure) ─────────────
+
+#[test]
+fn split_horizontal_inserts_after_in_row_parent() {
+    let child = leaf("c1", "b1", 5.0);
+    let root_inner = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let mut root = root_inner;
+    let new = leaf("new", "b2", 5.0);
+    split_horizontal(&mut root, "c1", new, SplitPosition::After).unwrap();
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(root.children[1].id, "new");
+}
+
+#[test]
+fn split_horizontal_inserts_before_in_row_parent() {
+    let child = leaf("c1", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let new = leaf("new", "b2", 5.0);
+    split_horizontal(&mut root, "c1", new, SplitPosition::Before).unwrap();
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(root.children[0].id, "new");
+}
+
+#[test]
+fn split_vertical_wraps_root_when_no_parent() {
+    let mut root = leaf("only", "b1", 10.0);
+    let new = leaf("new", "b2", 10.0);
+    split_vertical(&mut root, "only", new, SplitPosition::After).unwrap();
+    // Root should now be a Column with 2 children.
+    assert_eq!(root.flex_direction, FlexDirection::Column);
+    assert_eq!(root.children.len(), 2);
+}
+
+#[test]
+fn split_horizontal_missing_target_returns_error() {
+    let mut root = leaf("root", "b1", 10.0);
+    let new = leaf("new", "b2", 10.0);
+    let result = split_horizontal(&mut root, "ghost", new, SplitPosition::After);
+    assert!(matches!(result, Err(LayoutError::NodeNotFound { .. })));
+}
+
+// ── clearTree ────────────────────────────────────────────────────────────────
+
+#[test]
+fn clear_tree_sets_root_to_none() {
+    let mut root: Option<LayoutNode> = Some(leaf("root", "b1", 10.0));
+    clear_tree_node(&mut root);
+    assert!(root.is_none());
+}
+
+// ── replaceNode ──────────────────────────────────────────────────────────────
+
+#[test]
+fn replace_node_replaces_root_preserving_size() {
+    let mut root = leaf("old-root", "b1", 100.0);
+    let replacement = leaf("new-root", "b2", 50.0);
+    replace_node(&mut root, "old-root", replacement).unwrap();
+    assert_eq!(root.id, "new-root");
+    assert_eq!(root.size, 100.0); // preserved
+}
+
+#[test]
+fn replace_node_replaces_child_preserving_size() {
+    let c1 = leaf("c1", "b1", 30.0);
+    let c2 = leaf("c2", "b2", 70.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![c1, c2]);
+    let replacement = leaf("rep", "b3", 99.0);
+    replace_node(&mut root, "c2", replacement).unwrap();
+    assert_eq!(root.children[1].id, "rep");
+    assert_eq!(root.children[1].size, 70.0); // c2's size preserved
+}
+
+#[test]
+fn replace_node_focused_flag_separate_concern() {
+    // The Rust helpers don't handle focus — that's the reducer's job.
+    // Just verify replace_node doesn't error.
+    let child = leaf("child", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let rep = leaf("rep", "b2", 5.0);
+    assert!(replace_node(&mut root, "child", rep).is_ok());
+}
+
+// ── Purity ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn find_node_by_id_does_not_mutate() {
+    let n1 = leaf("n1", "b1", 5.0);
+    let root = group("root", FlexDirection::Row, 10.0, vec![n1]);
+    let child_count_before = root.children.len();
+    let _ = find_node_by_id(&root, "n1");
+    assert_eq!(root.children.len(), child_count_before);
+}

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -34,10 +34,6 @@ fn group(id: &str, dir: FlexDirection, size: f32, children: Vec<LayoutNode>) -> 
     }
 }
 
-fn new_id() -> String {
-    Uuid::new_v4().to_string()
-}
-
 // ── isInstanceLabel filter (JS analogue: insert location) ──────────────────
 
 #[test]
@@ -150,7 +146,7 @@ fn delete_node_unknown_id_returns_error() {
 #[test]
 fn delete_node_root_returns_ok_without_deleting() {
     let mut root = leaf("root", "b1", 1.0);
-    // Caller should set Option<LayoutNode> = None; we just return Ok(false).
+    // Caller should set Option<LayoutNode> = None; we just return Ok(()).
     let result = delete_node(&mut root, "root");
     assert!(result.is_ok());
 }
@@ -274,6 +270,135 @@ fn replace_node_focused_flag_separate_concern() {
     let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
     let rep = leaf("rep", "b2", 5.0);
     assert!(replace_node(&mut root, "child", rep).is_ok());
+}
+
+// ── Purity ───────────────────────────────────────────────────────────────────
+
+// ── insertNode ID stability ───────────────────────────────────────────────────
+
+#[test]
+fn insert_node_preserves_leaf_id_in_intermediate() {
+    let mut root = leaf("root", "b1", 1.0);
+    let new = leaf("new", "b2", 1.0);
+    insert_node(&mut root, new);
+    // After leaf promotion, the intermediate child should keep the original root ID.
+    assert!(root.children.iter().any(|c| c.id == "root" && c.data.is_some()));
+    // The group wrapper should have a new ID.
+    assert_ne!(root.id, "root");
+    assert!(root.data.is_none());
+}
+
+// ── insertNodeAtIndex leaf promotion ─────────────────────────────────────────
+
+#[test]
+fn insert_node_at_index_promotes_leaf_parent() {
+    let mut root = leaf("root", "b1", 1.0);
+    let new = leaf("new", "b2", 1.0);
+    insert_node_at_index(&mut root, new, &[0]).unwrap();
+    // Root should have been promoted to a group with 2 children:
+    // the wrapped original leaf + the new node.
+    assert!(root.data.is_none());
+    assert_eq!(root.children.len(), 2);
+    // The original leaf data should be in a child with the original root ID.
+    assert!(root.children.iter().any(|c| c.id == "root" && c.data.is_some()));
+}
+
+// ── swapNode ancestor rejection ──────────────────────────────────────────────
+
+#[test]
+fn swap_nodes_rejects_ancestor() {
+    let inner = leaf("inner", "b1", 5.0);
+    let middle = group("middle", FlexDirection::Column, 5.0, vec![inner]);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![middle]);
+    let result = swap_nodes(&mut root, "middle", "inner");
+    assert!(matches!(result, Err(LayoutError::RootCannotBeTarget)));
+}
+
+// ── moveNode ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn move_node_to_different_parent() {
+    let a = leaf("a", "b1", 5.0);
+    let b = leaf("b", "b2", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b]);
+    move_node(&mut root, "a", "root", 1).unwrap();
+    assert_eq!(root.children[1].id, "a");
+}
+
+#[test]
+fn move_node_same_parent_earlier_index() {
+    let a = leaf("a", "b1", 5.0);
+    let b = leaf("b", "b2", 5.0);
+    let c = leaf("c", "b3", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b, c]);
+    move_node(&mut root, "c", "root", 0).unwrap();
+    assert_eq!(root.children[0].id, "c");
+    assert_eq!(root.children[1].id, "a");
+    assert_eq!(root.children[2].id, "b");
+}
+
+#[test]
+fn move_node_same_parent_later_index() {
+    let a = leaf("a", "b1", 5.0);
+    let b = leaf("b", "b2", 5.0);
+    let c = leaf("c", "b3", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b, c]);
+    move_node(&mut root, "a", "root", 2).unwrap();
+    assert_eq!(root.children[0].id, "b");
+    assert_eq!(root.children[1].id, "c");
+    assert_eq!(root.children[2].id, "a");
+}
+
+#[test]
+fn move_node_rejects_root_as_source() {
+    let child = leaf("child", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![child]);
+    let result = move_node(&mut root, "root", "root", 0);
+    assert!(matches!(result, Err(LayoutError::RootCannotBeTarget)));
+}
+
+#[test]
+fn move_node_rejects_descendant_destination() {
+    let inner = leaf("inner", "b1", 5.0);
+    let middle = group("middle", FlexDirection::Column, 5.0, vec![inner]);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![middle]);
+    let result = move_node(&mut root, "middle", "inner", 0);
+    assert!(matches!(result, Err(LayoutError::NodeNotFound { .. })));
+}
+
+#[test]
+fn move_node_preserves_size_same_parent() {
+    let a = leaf("a", "b1", 50.0);
+    let b = leaf("b", "b2", 50.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b]);
+    move_node(&mut root, "a", "root", 1).unwrap();
+    // Moving within same parent preserves size.
+    assert_eq!(find_node_by_id(&root, "a").unwrap().size, 50.0);
+}
+
+#[test]
+fn move_node_resets_size_when_changing_parent() {
+    let a = leaf("a", "b1", 50.0);
+    let inner = leaf("inner", "b2", 50.0);
+    let middle = group("middle", FlexDirection::Column, 5.0, vec![inner]);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, middle]);
+    move_node(&mut root, "a", "middle", 0).unwrap();
+    // Moving to a different parent resets size to DEFAULT_NODE_SIZE.
+    assert_eq!(find_node_by_id(&root, "a").unwrap().size, DEFAULT_NODE_SIZE);
+}
+
+// ── resizeNode missing target ────────────────────────────────────────────────
+
+#[test]
+fn resize_nodes_rejects_missing_node() {
+    let n1 = leaf("n1", "b1", 50.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![n1]);
+    let result = resize_nodes(&mut root, &[
+        ResizeOp { node_id: "ghost".into(), size: 80.0 },
+    ]);
+    assert!(matches!(result, Err(LayoutError::NodeNotFound { .. })));
+    // n1 should NOT have been mutated.
+    assert_eq!(find_node_by_id(&root, "n1").unwrap().size, 50.0);
 }
 
 // ── Purity ───────────────────────────────────────────────────────────────────

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -224,6 +224,17 @@ fn split_vertical_wraps_root_when_no_parent() {
 }
 
 #[test]
+fn split_vertical_wraps_root_when_no_parent_before() {
+    let mut root = leaf("only", "b1", 10.0);
+    let new = leaf("new", "b2", 10.0);
+    split_vertical(&mut root, "only", new, SplitPosition::Before).unwrap();
+    // Root wraps into a Column; new node lands at index 0.
+    assert_eq!(root.flex_direction, FlexDirection::Column);
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(root.children[0].id, "new");
+}
+
+#[test]
 fn split_horizontal_missing_target_returns_error() {
     let mut root = leaf("root", "b1", 10.0);
     let new = leaf("new", "b2", 10.0);
@@ -286,6 +297,31 @@ fn insert_node_preserves_leaf_id_in_intermediate() {
     // The group wrapper should have a new ID.
     assert_ne!(root.id, "root");
     assert!(root.data.is_none());
+}
+
+#[test]
+fn insert_node_preserves_extra_fields_through_promotion() {
+    // When promoting a leaf to a group, the leaf's `extra` (forward-compat
+    // catch-all for unknown frontend fields) must travel with the data, not
+    // get defaulted on the new group wrapper.
+    let mut root = leaf("root", "b1", 1.0);
+    root.extra.insert(
+        "futureField".into(),
+        serde_json::Value::String("preserve-me".into()),
+    );
+    let new = leaf("new", "b2", 1.0);
+    insert_node(&mut root, new);
+    let intermediate = root
+        .children
+        .iter()
+        .find(|c| c.id == "root")
+        .expect("intermediate with original ID exists");
+    assert_eq!(
+        intermediate.extra.get("futureField"),
+        Some(&serde_json::Value::String("preserve-me".into())),
+    );
+    // And the group wrapper should NOT have inherited the leaf's extra.
+    assert!(root.extra.is_empty());
 }
 
 // ── insertNodeAtIndex leaf promotion ─────────────────────────────────────────

--- a/agentmux-srv/src/backend/mod.rs
+++ b/agentmux-srv/src/backend/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod agent_config;
 pub mod blockcontroller;
+/// Phase E.4.B Phase 4 — pure layout-tree helpers (Rust port of layoutTree.ts).
+pub mod layout;
 pub mod providers;
 pub mod config_watcher_fs;
 pub mod ijson;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.633",
+  "version": "0.33.634",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.633",
+      "version": "0.33.634",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.635",
+  "version": "0.33.636",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.635",
+      "version": "0.33.636",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.636",
+  "version": "0.33.637",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.636",
+      "version": "0.33.637",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.634",
+  "version": "0.33.635",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.634",
+      "version": "0.33.635",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.634",
+  "version": "0.33.635",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.635",
+  "version": "0.33.636",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.636",
+  "version": "0.33.637",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.633",
+  "version": "0.33.634",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 4 of srv E.4.B — ports the 11 pure tree-manipulation functions from `frontend/layout/lib/layoutTree.ts` to Rust. These are the building blocks the Phase 5 reducer arms will call. **No behavior change**; pure functions only.

**Spec:** \`docs/specs/srv-phase-e4b-formal-spec-2026-05-03.md\` Phase 4

## New module: \`agentmux-srv/src/backend/layout/\`

### Functions ported

| Rust | TypeScript equivalent |
|---|---|
| \`insert_node\` | \`insertNode\` (BFS heuristic, max 5 children per node) |
| \`insert_node_at_index\` | \`insertNodeAtIndex\` |
| \`delete_node\` → collapses single-child parents | \`deleteNode\` |
| \`move_node\` | \`moveNode\` (apply-only; compute step stays TS) |
| \`swap_nodes\` | \`swapNode\` (sizes stay at slot) |
| \`resize_nodes\` | \`resizeNode\` (atomic: reject whole batch if any size invalid) |
| \`replace_node\` | \`replaceNode\` (preserves target's size) |
| \`split_horizontal\` / \`split_vertical\` | \`splitHorizontal\` / \`splitVertical\` (splice or wrap) |
| \`clear_tree_node\` | \`clearTree\` |
| \`find_node_by_id\`, \`find_parent_by_child_id\` | \`findNode\`, \`findParent\` |

### Error type

\`LayoutError { NodeNotFound, SelfSwap, RootCannotBeTarget, InvalidSize, InvalidIndexPath }\`

## Tests (23)

Ports the 30 tests from \`frontend/layout/tests/layoutTree.test.ts\` (PR #686 — the behavioral oracle) into Rust. All 23 pass.

**810 srv tests passing total** (was 785 before Phase 4 = +25). 3–4 pre-existing failures unchanged.

## Bonus: README brain logo fix

README.md line 2 referenced the old \`frontend/logos/agentmux-logo.svg\` which was renamed to \`agentmux-logo-brain-alternate.svg\` in PR #687 but the README wasn't updated. Now points to the brain-alternate SVG.

## Test plan

- [ ] \`cargo test -p agentmux-srv --bin agentmux-srv backend::layout\` — 23 pass
- [ ] \`cargo build -p agentmux-common -p agentmux-srv -p agentmux-cef -p agentmux-launcher\` — clean
- [ ] README logo renders in GitHub (brain icon, not broken link)

## Roadmap

- ✅ Phase 2 (#688 + #689): typed LayoutNode
- ✅ Phase 3 (#690): wire types
- 🔄 **Phase 4 (this PR)**: pure helpers
- ⬜ Phase 5: reducer arms (11 handlers call the helpers)
- ⬜ Phase 6: persist subscriber arms
- ⬜ Phase 7: migrate existing rootnode writers

🤖 Generated with [Claude Code](https://claude.com/claude-code)