### PR TITLE
fix(layout): TS-oracle clamp + leaf-stop in insert_node_at_index (#691 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.637"
+version = "0.33.638"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.637"
+version = "0.33.638"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.637"
+version = "0.33.638"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.637"
+version = "0.33.638"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1544,7 +1544,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2100,9 +2100,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -2271,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -2922,9 +2922,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.637"
+version = "0.33.638"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.637"
+version = "0.33.638"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.637"
+version = "0.33.638"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.637"
+version = "0.33.638"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/layout/mod.rs
+++ b/agentmux-srv/src/backend/layout/mod.rs
@@ -199,7 +199,20 @@ pub fn insert_node(root: &mut LayoutNode, node: LayoutNode) {
 /// Insert `node` at the location identified by `index_arr` — an ordered
 /// sequence of child indices (e.g. `[0, 2]` = root.children[0].children
 /// at index 3). The node is inserted AFTER the position identified by the
-/// last index. Mirrors `insertNodeAtIndex` / `findInsertLocationFromIndexArr`.
+/// last index.
+///
+/// Mirrors `findInsertLocationFromIndexArr` in
+/// `frontend/layout/lib/layoutNode.ts`:
+/// - Each segment is **clamped** to `[0, children.len() - 1]`. Out-of-range
+///   indices do NOT error — they resolve to the last child slot.
+/// - Descent **stops at a leaf**. Any remaining segments after we hit a node
+///   with no children are ignored, and the leaf becomes the insert target
+///   (where `ensure_group_node` then promotes it). This matches the TS
+///   oracle's `if (indexArr.length == 0 || !node.children) return ...`.
+///
+/// This tolerance is required for "identical state transitions" with the
+/// frontend reducer under concurrent edits — the frontend may issue a
+/// stale or over-deep `indexArr` against a tree that has since shrunk.
 pub fn insert_node_at_index(
     root: &mut LayoutNode,
     node: LayoutNode,
@@ -208,23 +221,27 @@ pub fn insert_node_at_index(
     if index_arr.is_empty() {
         return Err(LayoutError::InvalidIndexPath);
     }
-    // Navigate to the parent using all-but-last indices, then insert
-    // after last-index position.
     let mut current = root as *mut LayoutNode;
-    let split_at = index_arr.len() - 1;
-    let path = &index_arr[..split_at];
-    let last_idx = index_arr[split_at];
+    let mut clamped_idx: usize = 0;
+    let last_seg = index_arr.len() - 1;
 
-    for &idx in path {
+    for (seg_pos, &idx) in index_arr.iter().enumerate() {
         let cur = unsafe { &mut *current };
-        if idx >= cur.children.len() {
-            return Err(LayoutError::InvalidIndexPath);
+        if cur.children.is_empty() {
+            // Leaf reached early — TS treats `node.children?.length ?? 1`
+            // as 1 here, so any non-negative idx clamps to 0. Stop descent.
+            clamped_idx = 0;
+            break;
         }
-        current = &mut cur.children[idx] as *mut LayoutNode;
+        clamped_idx = idx.min(cur.children.len() - 1);
+        if seg_pos < last_seg {
+            current = &mut cur.children[clamped_idx] as *mut LayoutNode;
+        }
     }
+
     let parent = unsafe { &mut *current };
     ensure_group_node(parent);
-    let insert_at = (last_idx + 1).min(parent.children.len());
+    let insert_at = (clamped_idx + 1).min(parent.children.len());
     parent.children.insert(insert_at, node);
     Ok(())
 }

--- a/agentmux-srv/src/backend/layout/tests.rs
+++ b/agentmux-srv/src/backend/layout/tests.rs
@@ -339,6 +339,63 @@ fn insert_node_at_index_promotes_leaf_parent() {
     assert!(root.children.iter().any(|c| c.id == "root" && c.data.is_some()));
 }
 
+#[test]
+fn insert_node_at_index_clamps_out_of_range_segment() {
+    // [a, b, c], indexArr=[10] — TS oracle: clamp to lastChildIndex=2,
+    // insert at 2+1=3 → [a, b, c, new]. Rust must NOT error.
+    let a = leaf("a", "b1", 1.0);
+    let b = leaf("b", "b2", 1.0);
+    let c = leaf("c", "b3", 1.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, b, c]);
+    let new = leaf("new", "b4", 1.0);
+    insert_node_at_index(&mut root, new, &[10]).unwrap();
+    assert_eq!(root.children.len(), 4);
+    assert_eq!(root.children[3].id, "new");
+}
+
+#[test]
+fn insert_node_at_index_clamps_intermediate_segment() {
+    // root=[a, middle], middle=[m1, m2]. indexArr=[5, 0] — TS clamps
+    // first segment to lastChildIndex=1 (descends into middle), then
+    // inserts after middle.children[0] → middle = [m1, new, m2].
+    let m1 = leaf("m1", "b1", 1.0);
+    let m2 = leaf("m2", "b2", 1.0);
+    let middle = group("middle", FlexDirection::Column, 5.0, vec![m1, m2]);
+    let a = leaf("a", "b3", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a, middle]);
+    let new = leaf("new", "b4", 1.0);
+    insert_node_at_index(&mut root, new, &[5, 0]).unwrap();
+    let middle_after = find_node_by_id(&root, "middle").unwrap();
+    assert_eq!(middle_after.children.len(), 3);
+    assert_eq!(middle_after.children[0].id, "m1");
+    assert_eq!(middle_after.children[1].id, "new");
+    assert_eq!(middle_after.children[2].id, "m2");
+}
+
+#[test]
+fn insert_node_at_index_stops_descent_at_leaf_with_extra_segments() {
+    // root=[a], a is a leaf. indexArr=[0, 5] — TS hits the leaf at the
+    // first descent and stops; `normalizeIndex(5)` against a leaf
+    // (length-fallback=1) clamps to 0, so the result is "promote leaf,
+    // insert after position 0". Final: the descended-into node is
+    // promoted to a group; ensure_group_node moves the original ID
+    // ("a", with the data) onto the intermediate child and gives the
+    // wrapper a fresh UUID. So root.children[0] is the wrapper (no data,
+    // 2 children: the renamed intermediate carrying "a" + the new node).
+    let a = leaf("a", "b1", 5.0);
+    let mut root = group("root", FlexDirection::Row, 10.0, vec![a]);
+    let new = leaf("new", "b2", 1.0);
+    insert_node_at_index(&mut root, new, &[0, 5]).unwrap();
+    assert_eq!(root.children.len(), 1);
+    let wrapper = &root.children[0];
+    assert!(wrapper.data.is_none(), "wrapper should be a group");
+    assert_eq!(wrapper.children.len(), 2);
+    // Intermediate keeps the original leaf ID + data; "new" is the second.
+    let intermediate = wrapper.children.iter().find(|c| c.id == "a").expect("a-id child");
+    assert!(intermediate.data.is_some());
+    assert!(wrapper.children.iter().any(|c| c.id == "new"));
+}
+
 // ── swapNode ancestor rejection ──────────────────────────────────────────────
 
 #[test]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.637",
+  "version": "0.33.638",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Follow-up to #691 — addresses a Codex P1 that landed at 09:24:52Z (5 min before #691 was merged at 09:29:36Z) and was missed during the merge poll due to a wrong wall-clock filter cutoff. Surfacing this PR per the global \"link follow-ups to the original\" rule so reagent re-evaluates context.

## The miss

In #691 round 7 (commit \`39e07f92\`), Codex posted an inline P1 on \`mod.rs:221\`:

> \`insert_node_at_index\` currently returns \`InvalidIndexPath\` as soon as an intermediate path segment is out of bounds, but the frontend oracle (\`frontend/layout/lib/layoutNode.ts::findInsertLocationFromIndexArr\`) clamps each segment and stops descent when a leaf is reached instead of failing. This means stale or over-deep \`index_arr\` values that still succeed in the existing reducer semantics will now be rejected in srv, causing command divergence under concurrent edits and violating the \"identical state transitions\" goal for Phase 4.

Verified legit by reading the TS source.

## TS oracle (frontend/layout/lib/layoutNode.ts:259-279)

\`\`\`ts
function normalizeIndex(index: number) {
    const childrenLength = node.children?.length ?? 1;
    const lastChildIndex = childrenLength - 1;
    if (index < 0) { ... }
    return Math.min(index, lastChildIndex);  // CLAMPS, never errors
}
const nextIndex = normalizeIndex(indexArr.shift());
if (indexArr.length == 0 || !node.children) {     // STOPS at leaf
    return { node, index: nextIndex };
}
return findInsertLocationFromIndexArr(node.children[nextIndex], indexArr);
\`\`\`

## Fix

Replace the early-error loop in \`insert_node_at_index\` with clamp-and-descend that mirrors the TS algorithm step-for-step:

| TS behavior | Rust before | Rust after |
|---|---|---|
| Clamp idx to [0, len-1] | Error if idx ≥ len | Clamp same as TS |
| Stop descent at leaf | Indexing into empty children would panic | Detect leaf, stop, use clamped_idx=0 |
| Empty path returns void | Error \`InvalidIndexPath\` | (unchanged) Error |

## Tests

Adds 3 regression tests in \`backend::layout::tests\`:
- \`insert_node_at_index_clamps_out_of_range_segment\` — single-level over-range
- \`insert_node_at_index_clamps_intermediate_segment\` — multi-level, over-range mid-path resolves to last child
- \`insert_node_at_index_stops_descent_at_leaf_with_extra_segments\` — leaf hit before path exhausted; verifies \`ensure_group_node\` promotion + ID stability

Local: \`cargo test backend::layout\` → **40 passed** (was 37 after #691).

## Why merge separately

Phase 5's reducer arms will start consuming \`insert_node_at_index\` and need the TS-equivalent semantics. Cleaner to land this as a focused follow-up PR than re-open #691.

🤖 Generated with [Claude Code](https://claude.com/claude-code)