### PR TITLE
feat(common): RuntimeMode + DataPaths primitives (#694 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,8 +39,10 @@ dependencies = [
 name = "agentmux-common"
 version = "0.33.639"
 dependencies = [
+ "dirs",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.638"
+version = "0.33.639"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.638"
+version = "0.33.639"
 dependencies = [
  "serde",
  "serde_json",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.638"
+version = "0.33.639"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.638"
+version = "0.33.639"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.639"
+version = "0.33.640"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.639"
+version = "0.33.640"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.639"
+version = "0.33.640"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.639"
+version = "0.33.640"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.639"
+version = "0.33.640"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.638"
+version = "0.33.639"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -13,3 +13,9 @@ tracing = "0.1"
 # skew release. JSON over newline-delimited frames.
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Cross-platform home/data/config-dir lookup for the unified data-dir
+# layout (see docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md).
+dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.638"
+version = "0.33.639"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.639"
+version = "0.33.640"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -61,13 +61,28 @@ pub struct DataPaths {
 impl DataPaths {
     /// Resolve all paths for the given version + mode. Honors
     /// `AGENTMUX_HOME_OVERRIDE` for tests (replaces `~/.agentmux` root).
+    ///
+    /// Returns `Err` if the input contains values that cannot be
+    /// represented as a safe single-segment subpath — e.g. `..` in the
+    /// version string, or a Dev branch that sanitizes to empty. This
+    /// is belt-and-braces safety: parse-time sanitization in
+    /// [`crate::RuntimeMode`] should already have caught these, but a
+    /// `RuntimeMode::Dev { branch }` constructed directly (e.g. by a
+    /// test or future caller) is also rejected here.
     pub fn resolve(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
         let root = resolve_root()?;
+        let safe_version = sanitize_path_segment(version)
+            .ok_or_else(|| format!("invalid version string for path: {:?}", version))?;
         let instance_dir = match mode {
             RuntimeMode::Installed | RuntimeMode::Portable => {
-                root.join("versions").join(version)
+                root.join("versions").join(&safe_version)
             }
-            RuntimeMode::Dev { branch } => root.join("dev").join(branch),
+            RuntimeMode::Dev { branch } => {
+                let safe_branch = sanitize_path_segment(branch).ok_or_else(|| {
+                    format!("invalid dev branch for path: {:?}", branch)
+                })?;
+                root.join("dev").join(safe_branch)
+            }
         };
 
         let data_dir = instance_dir.join("data");
@@ -184,11 +199,38 @@ fn resolve_root() -> Result<PathBuf, String> {
     Ok(home.join(".agentmux"))
 }
 
-/// Helper: is `target` inside or equal to `parent`?
-pub fn path_contains(parent: &Path, target: &Path) -> bool {
-    let parent = parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf());
-    let target = target.canonicalize().unwrap_or_else(|_| target.to_path_buf());
-    target.starts_with(&parent)
+/// Helper: is `target` inside or equal to `parent`? Returns `Err` if
+/// either path cannot be canonicalized — callers that ask "is target
+/// inside parent" before the target exists need the precondition
+/// (target on disk) before invoking.
+///
+/// (We canonicalize both sides so that symlinks, `..`, and case
+/// differences resolve before the prefix check; mixing canonicalized
+/// and raw values silently produced incorrect results in earlier
+/// drafts. Claude P2 on PR #695.)
+pub fn path_contains(parent: &Path, target: &Path) -> std::io::Result<bool> {
+    let parent = parent.canonicalize()?;
+    let target = target.canonicalize()?;
+    Ok(target.starts_with(&parent))
+}
+
+/// Sanitize a string for use as a single filesystem path segment.
+/// Rejects empty, `.`, `..`, and segments that contain path separators
+/// or other unsafe chars. Used as belt-and-braces protection in
+/// `DataPaths::resolve` to prevent traversal even when callers pass a
+/// directly-constructed `RuntimeMode::Dev` or odd version string.
+fn sanitize_path_segment(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty()
+        || trimmed == "."
+        || trimmed == ".."
+        || trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains('\0')
+    {
+        return None;
+    }
+    Some(trimmed.to_string())
 }
 
 #[cfg(test)]
@@ -297,6 +339,35 @@ mod tests {
             for (k, _) in p1.to_env_vars() {
                 std::env::remove_var(k);
             }
+        });
+    }
+
+    #[test]
+    fn resolve_rejects_dev_branch_traversal() {
+        // Even if a caller manages to construct a Dev variant with an
+        // unsafe branch (bypassing parse_mode_string sanitization),
+        // resolve() must catch it.
+        with_home_override(|_root| {
+            let mode = RuntimeMode::Dev {
+                branch: "..".into(),
+            };
+            assert!(DataPaths::resolve("0.33.639", &mode).is_err());
+            let mode = RuntimeMode::Dev {
+                branch: "foo/bar".into(),
+            };
+            assert!(DataPaths::resolve("0.33.639", &mode).is_err());
+        });
+    }
+
+    #[test]
+    fn resolve_rejects_traversal_version() {
+        with_home_override(|_root| {
+            assert!(DataPaths::resolve("..", &RuntimeMode::Installed).is_err());
+            assert!(DataPaths::resolve(
+                "0.33.639/etc",
+                &RuntimeMode::Installed
+            )
+            .is_err());
         });
     }
 

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -228,13 +228,31 @@ mod tests {
     use crate::TEST_ENV_LOCK;
     use tempfile::TempDir;
 
+    /// RAII guard that restores process state on drop, even if the
+    /// test panics. Without Drop-based cleanup, a panic inside `f`
+    /// would leave AGENTMUX_HOME_OVERRIDE set with a stale tempdir
+    /// path AND poison the mutex; subsequent tests recover from poison
+    /// but inherit the wrong env value.
+    struct HomeOverrideGuard {
+        _tmp: TempDir,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl Drop for HomeOverrideGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        }
+    }
+
     fn with_home_override<F: FnOnce(&Path)>(f: F) {
-        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let lock = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = TempDir::new().expect("tempdir");
-        let path_str = tmp.path().display().to_string();
-        std::env::set_var("AGENTMUX_HOME_OVERRIDE", &path_str);
-        f(tmp.path());
-        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        let path = tmp.path().to_path_buf();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", &path);
+        let _guard = HomeOverrideGuard { _tmp: tmp, _lock: lock };
+        f(&path);
+        // _guard drops here, removing the env var even if f panicked
+        // (the panic still propagates after Drop runs).
     }
 
     #[test]

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -1,0 +1,322 @@
+//! Unified data-path resolution for AgentMux.
+//!
+//! Single source of truth for where state lives on disk. Replaces the
+//! launcher / host / sidecar trio of independent path computations
+//! (see docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md §3).
+//!
+//! Layout:
+//!
+//! ```text
+//! ~/.agentmux/
+//! ├── shared/                       (cookies, credentials, account-wide)
+//! ├── versions/<v>/                 (installed + portable; one running instance)
+//! │   ├── data/, config/, logs/, cef-cache/, agents/
+//! │   └── runtime/                  (lock + IPC, single set per version)
+//! └── dev/<branch>/                 (per-branch dev isolation)
+//!     └── (same children as versions/<v>/)
+//! ```
+
+use crate::RuntimeMode;
+use std::path::{Path, PathBuf};
+
+/// All paths a launcher / host / srv needs. Computed once by the
+/// launcher; downstream binaries read paths from env vars set by the
+/// launcher rather than recomputing (avoids the legacy desync risk
+/// where each binary made its own portable / dev-mode determination).
+#[derive(Debug, Clone)]
+pub struct DataPaths {
+    /// Top-level dir for this version+mode. All version-keyed paths
+    /// below are children. Either `~/.agentmux/versions/<v>/` (installed/
+    /// portable) or `~/.agentmux/dev/<branch>/` (dev).
+    pub instance_dir: PathBuf,
+
+    /// `instance_dir/data/` — srv DB (objects.db, sagas.db, …).
+    pub data_dir: PathBuf,
+
+    /// `instance_dir/config/` — settings.json, repos.json, etc.
+    pub config_dir: PathBuf,
+
+    /// `instance_dir/logs/` — host + srv + launcher logs (rotated).
+    pub logs_dir: PathBuf,
+
+    /// `instance_dir/cef-cache/` — Chromium runtime cache (regenerable).
+    pub cef_cache_dir: PathBuf,
+
+    /// `instance_dir/agents/` — agent workspace state.
+    pub agents_dir: PathBuf,
+
+    /// `instance_dir/runtime/` — single-instance lock + IPC (pid,
+    /// lockfile, ipc-port, named-pipe). One set per version+mode.
+    pub instance_runtime_dir: PathBuf,
+
+    /// `~/.agentmux/shared/` — version-independent, account-wide
+    /// state (cookies, OAuth tokens, API keys, dictionary downloads).
+    pub shared_dir: PathBuf,
+
+    /// Snapshot of the [`RuntimeMode`] this resolution used. Helpful
+    /// for logging and feature gates.
+    pub mode: RuntimeMode,
+}
+
+impl DataPaths {
+    /// Resolve all paths for the given version + mode. Honors
+    /// `AGENTMUX_HOME_OVERRIDE` for tests (replaces `~/.agentmux` root).
+    pub fn resolve(version: &str, mode: &RuntimeMode) -> Result<Self, String> {
+        let root = resolve_root()?;
+        let instance_dir = match mode {
+            RuntimeMode::Installed | RuntimeMode::Portable => {
+                root.join("versions").join(version)
+            }
+            RuntimeMode::Dev { branch } => root.join("dev").join(branch),
+        };
+
+        let data_dir = instance_dir.join("data");
+        let config_dir = instance_dir.join("config");
+        let logs_dir = instance_dir.join("logs");
+        let cef_cache_dir = instance_dir.join("cef-cache");
+        let agents_dir = instance_dir.join("agents");
+        let instance_runtime_dir = instance_dir.join("runtime");
+        let shared_dir = root.join("shared");
+
+        Ok(Self {
+            instance_dir,
+            data_dir,
+            config_dir,
+            logs_dir,
+            cef_cache_dir,
+            agents_dir,
+            instance_runtime_dir,
+            shared_dir,
+            mode: mode.clone(),
+        })
+    }
+
+    /// Create every directory that may be written to. Idempotent.
+    /// Safe to call on every launch.
+    pub fn ensure_dirs(&self) -> Result<(), String> {
+        for d in [
+            &self.instance_dir,
+            &self.data_dir,
+            &self.config_dir,
+            &self.logs_dir,
+            &self.cef_cache_dir,
+            &self.agents_dir,
+            &self.instance_runtime_dir,
+            &self.shared_dir,
+        ] {
+            std::fs::create_dir_all(d)
+                .map_err(|e| format!("failed to create {}: {}", d.display(), e))?;
+        }
+        // The data dir's `db/` subdir is the canonical srv DB home;
+        // mirrors legacy ensure_dirs() and lets srv unconditionally
+        // open `data_dir/db/objects.db`.
+        std::fs::create_dir_all(self.data_dir.join("db"))
+            .map_err(|e| format!("failed to create db dir: {}", e))?;
+        Ok(())
+    }
+
+    /// Env vars to pass to host + srv subprocesses. The launcher
+    /// computes `DataPaths` once and exports these; downstream
+    /// binaries read them via [`Self::from_env`] instead of
+    /// recomputing.
+    pub fn to_env_vars(&self) -> Vec<(&'static str, String)> {
+        vec![
+            (
+                "AGENTMUX_INSTANCE_DIR",
+                self.instance_dir.display().to_string(),
+            ),
+            ("AGENTMUX_DATA_DIR", self.data_dir.display().to_string()),
+            ("AGENTMUX_CONFIG_DIR", self.config_dir.display().to_string()),
+            ("AGENTMUX_LOG_DIR", self.logs_dir.display().to_string()),
+            (
+                "AGENTMUX_CEF_CACHE_DIR",
+                self.cef_cache_dir.display().to_string(),
+            ),
+            ("AGENTMUX_AGENTS_DIR", self.agents_dir.display().to_string()),
+            (
+                "AGENTMUX_INSTANCE_RUNTIME_DIR",
+                self.instance_runtime_dir.display().to_string(),
+            ),
+            ("AGENTMUX_SHARED_DIR", self.shared_dir.display().to_string()),
+            ("AGENTMUX_RUNTIME_MODE", self.mode.to_env_string()),
+        ]
+    }
+
+    /// Reconstruct from env vars set by the launcher. Returns
+    /// `None` if any required var is missing — fail-fast vs.
+    /// silently falling back to legacy paths the way the old
+    /// sidecar.rs did.
+    pub fn from_env() -> Option<Self> {
+        let instance_dir = std::env::var("AGENTMUX_INSTANCE_DIR").ok()?;
+        let data_dir = std::env::var("AGENTMUX_DATA_DIR").ok()?;
+        let config_dir = std::env::var("AGENTMUX_CONFIG_DIR").ok()?;
+        let logs_dir = std::env::var("AGENTMUX_LOG_DIR").ok()?;
+        let cef_cache_dir = std::env::var("AGENTMUX_CEF_CACHE_DIR").ok()?;
+        let agents_dir = std::env::var("AGENTMUX_AGENTS_DIR").ok()?;
+        let instance_runtime_dir = std::env::var("AGENTMUX_INSTANCE_RUNTIME_DIR").ok()?;
+        let shared_dir = std::env::var("AGENTMUX_SHARED_DIR").ok()?;
+        let mode = RuntimeMode::from_env()?;
+
+        Some(Self {
+            instance_dir: PathBuf::from(instance_dir),
+            data_dir: PathBuf::from(data_dir),
+            config_dir: PathBuf::from(config_dir),
+            logs_dir: PathBuf::from(logs_dir),
+            cef_cache_dir: PathBuf::from(cef_cache_dir),
+            agents_dir: PathBuf::from(agents_dir),
+            instance_runtime_dir: PathBuf::from(instance_runtime_dir),
+            shared_dir: PathBuf::from(shared_dir),
+            mode,
+        })
+    }
+}
+
+/// `~/.agentmux/` root, or the test override via
+/// `AGENTMUX_HOME_OVERRIDE`. Falls back to error if no home dir
+/// can be resolved (rare — should only happen in stripped CI envs).
+fn resolve_root() -> Result<PathBuf, String> {
+    if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
+        if !s.is_empty() {
+            return Ok(PathBuf::from(s));
+        }
+    }
+    let home = dirs::home_dir().ok_or_else(|| "dirs::home_dir() returned None".to_string())?;
+    Ok(home.join(".agentmux"))
+}
+
+/// Helper: is `target` inside or equal to `parent`?
+pub fn path_contains(parent: &Path, target: &Path) -> bool {
+    let parent = parent.canonicalize().unwrap_or_else(|_| parent.to_path_buf());
+    let target = target.canonicalize().unwrap_or_else(|_| target.to_path_buf());
+    target.starts_with(&parent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    /// All tests in this module touch process-global env vars
+    /// (`AGENTMUX_HOME_OVERRIDE` plus the eight `AGENTMUX_*` vars in
+    /// the round-trip test). cargo test runs tests in parallel by
+    /// default, so without serialization the env state visible inside
+    /// one test gets clobbered by another. Lock at module scope.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_home_override<F: FnOnce(&Path)>(f: F) {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().expect("tempdir");
+        let path_str = tmp.path().display().to_string();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", &path_str);
+        f(tmp.path());
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+    }
+
+    #[test]
+    fn installed_paths_under_versions() {
+        with_home_override(|root| {
+            let p = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
+            assert_eq!(p.instance_dir, root.join("versions").join("0.33.639"));
+            assert_eq!(p.data_dir, p.instance_dir.join("data"));
+            assert_eq!(p.config_dir, p.instance_dir.join("config"));
+            assert_eq!(p.logs_dir, p.instance_dir.join("logs"));
+            assert_eq!(p.cef_cache_dir, p.instance_dir.join("cef-cache"));
+            assert_eq!(p.agents_dir, p.instance_dir.join("agents"));
+            assert_eq!(p.instance_runtime_dir, p.instance_dir.join("runtime"));
+            assert_eq!(p.shared_dir, root.join("shared"));
+        });
+    }
+
+    #[test]
+    fn portable_paths_match_installed() {
+        with_home_override(|root| {
+            let inst = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
+            let port = DataPaths::resolve("0.33.639", &RuntimeMode::Portable).unwrap();
+            // §3 design: portable + installed share the same data dir
+            // (per the user's multi-instance decision in §5.5).
+            assert_eq!(inst.instance_dir, port.instance_dir);
+            assert_eq!(inst.data_dir, port.data_dir);
+            // shared/ is mode-independent.
+            assert_eq!(inst.shared_dir, root.join("shared"));
+            assert_eq!(port.shared_dir, root.join("shared"));
+        });
+    }
+
+    #[test]
+    fn dev_paths_under_dev_branch() {
+        with_home_override(|root| {
+            let mode = RuntimeMode::Dev {
+                branch: "main".into(),
+            };
+            let p = DataPaths::resolve("0.33.639", &mode).unwrap();
+            // Dev mode does NOT use the version — branches isolate.
+            assert_eq!(p.instance_dir, root.join("dev").join("main"));
+            assert_eq!(p.data_dir, root.join("dev").join("main").join("data"));
+            assert_eq!(p.shared_dir, root.join("shared"));
+        });
+    }
+
+    #[test]
+    fn ensure_dirs_creates_everything() {
+        with_home_override(|_root| {
+            let p = DataPaths::resolve("0.33.639", &RuntimeMode::Installed).unwrap();
+            p.ensure_dirs().unwrap();
+            assert!(p.instance_dir.is_dir());
+            assert!(p.data_dir.is_dir());
+            assert!(p.data_dir.join("db").is_dir());
+            assert!(p.config_dir.is_dir());
+            assert!(p.logs_dir.is_dir());
+            assert!(p.cef_cache_dir.is_dir());
+            assert!(p.agents_dir.is_dir());
+            assert!(p.instance_runtime_dir.is_dir());
+            assert!(p.shared_dir.is_dir());
+        });
+    }
+
+    #[test]
+    fn env_vars_round_trip() {
+        with_home_override(|_root| {
+            let p1 = DataPaths::resolve(
+                "0.33.639",
+                &RuntimeMode::Dev {
+                    branch: "main".into(),
+                },
+            )
+            .unwrap();
+            // Apply each env var, then read back.
+            for (k, v) in p1.to_env_vars() {
+                std::env::set_var(k, v);
+            }
+            let p2 = DataPaths::from_env().expect("round-trip");
+            assert_eq!(p1.instance_dir, p2.instance_dir);
+            assert_eq!(p1.data_dir, p2.data_dir);
+            assert_eq!(p1.shared_dir, p2.shared_dir);
+            assert_eq!(p1.mode, p2.mode);
+            // Cleanup
+            for (k, _) in p1.to_env_vars() {
+                std::env::remove_var(k);
+            }
+        });
+    }
+
+    #[test]
+    fn from_env_fails_fast_on_missing_vars() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Clear all expected vars.
+        for k in [
+            "AGENTMUX_INSTANCE_DIR",
+            "AGENTMUX_DATA_DIR",
+            "AGENTMUX_CONFIG_DIR",
+            "AGENTMUX_LOG_DIR",
+            "AGENTMUX_CEF_CACHE_DIR",
+            "AGENTMUX_AGENTS_DIR",
+            "AGENTMUX_INSTANCE_RUNTIME_DIR",
+            "AGENTMUX_SHARED_DIR",
+            "AGENTMUX_RUNTIME_MODE",
+        ] {
+            std::env::remove_var(k);
+        }
+        assert!(DataPaths::from_env().is_none());
+    }
+}

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -199,21 +199,6 @@ fn resolve_root() -> Result<PathBuf, String> {
     Ok(home.join(".agentmux"))
 }
 
-/// Helper: is `target` inside or equal to `parent`? Returns `Err` if
-/// either path cannot be canonicalized — callers that ask "is target
-/// inside parent" before the target exists need the precondition
-/// (target on disk) before invoking.
-///
-/// (We canonicalize both sides so that symlinks, `..`, and case
-/// differences resolve before the prefix check; mixing canonicalized
-/// and raw values silently produced incorrect results in earlier
-/// drafts. Claude P2 on PR #695.)
-pub fn path_contains(parent: &Path, target: &Path) -> std::io::Result<bool> {
-    let parent = parent.canonicalize()?;
-    let target = target.canonicalize()?;
-    Ok(target.starts_with(&parent))
-}
-
 /// Sanitize a string for use as a single filesystem path segment.
 /// Rejects empty, `.`, `..`, and segments that contain path separators
 /// or other unsafe chars. Used as belt-and-braces protection in

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -134,26 +134,28 @@ impl DataPaths {
     /// computes `DataPaths` once and exports these; downstream
     /// binaries read them via [`Self::from_env`] instead of
     /// recomputing.
-    pub fn to_env_vars(&self) -> Vec<(&'static str, String)> {
+    ///
+    /// Returns `OsString` (not `String`) so paths with non-UTF-8 bytes
+    /// — possible on Linux/macOS for users with exotic home dirs —
+    /// round-trip losslessly. `Command::env(k, v)` accepts any
+    /// `AsRef<OsStr>`, so the OsString flows through to children
+    /// unchanged. The mode value is the only `String`-typed entry
+    /// (it's a fixed ASCII vocabulary). Claude P2 round-7 PR #695.
+    pub fn to_env_vars(&self) -> Vec<(&'static str, std::ffi::OsString)> {
+        use std::ffi::OsString;
         vec![
-            (
-                "AGENTMUX_INSTANCE_DIR",
-                self.instance_dir.display().to_string(),
-            ),
-            ("AGENTMUX_DATA_DIR", self.data_dir.display().to_string()),
-            ("AGENTMUX_CONFIG_DIR", self.config_dir.display().to_string()),
-            ("AGENTMUX_LOG_DIR", self.logs_dir.display().to_string()),
-            (
-                "AGENTMUX_CEF_CACHE_DIR",
-                self.cef_cache_dir.display().to_string(),
-            ),
-            ("AGENTMUX_AGENTS_DIR", self.agents_dir.display().to_string()),
+            ("AGENTMUX_INSTANCE_DIR", self.instance_dir.clone().into_os_string()),
+            ("AGENTMUX_DATA_DIR", self.data_dir.clone().into_os_string()),
+            ("AGENTMUX_CONFIG_DIR", self.config_dir.clone().into_os_string()),
+            ("AGENTMUX_LOG_DIR", self.logs_dir.clone().into_os_string()),
+            ("AGENTMUX_CEF_CACHE_DIR", self.cef_cache_dir.clone().into_os_string()),
+            ("AGENTMUX_AGENTS_DIR", self.agents_dir.clone().into_os_string()),
             (
                 "AGENTMUX_INSTANCE_RUNTIME_DIR",
-                self.instance_runtime_dir.display().to_string(),
+                self.instance_runtime_dir.clone().into_os_string(),
             ),
-            ("AGENTMUX_SHARED_DIR", self.shared_dir.display().to_string()),
-            ("AGENTMUX_RUNTIME_MODE", self.mode.to_env_string()),
+            ("AGENTMUX_SHARED_DIR", self.shared_dir.clone().into_os_string()),
+            ("AGENTMUX_RUNTIME_MODE", OsString::from(self.mode.to_env_string())),
         ]
     }
 
@@ -161,15 +163,17 @@ impl DataPaths {
     /// `None` if any required var is missing — fail-fast vs.
     /// silently falling back to legacy paths the way the old
     /// sidecar.rs did.
+    ///
+    /// Uses `var_os` (not `var`) so non-UTF-8 path bytes survive.
     pub fn from_env() -> Option<Self> {
-        let instance_dir = std::env::var("AGENTMUX_INSTANCE_DIR").ok()?;
-        let data_dir = std::env::var("AGENTMUX_DATA_DIR").ok()?;
-        let config_dir = std::env::var("AGENTMUX_CONFIG_DIR").ok()?;
-        let logs_dir = std::env::var("AGENTMUX_LOG_DIR").ok()?;
-        let cef_cache_dir = std::env::var("AGENTMUX_CEF_CACHE_DIR").ok()?;
-        let agents_dir = std::env::var("AGENTMUX_AGENTS_DIR").ok()?;
-        let instance_runtime_dir = std::env::var("AGENTMUX_INSTANCE_RUNTIME_DIR").ok()?;
-        let shared_dir = std::env::var("AGENTMUX_SHARED_DIR").ok()?;
+        let instance_dir = std::env::var_os("AGENTMUX_INSTANCE_DIR")?;
+        let data_dir = std::env::var_os("AGENTMUX_DATA_DIR")?;
+        let config_dir = std::env::var_os("AGENTMUX_CONFIG_DIR")?;
+        let logs_dir = std::env::var_os("AGENTMUX_LOG_DIR")?;
+        let cef_cache_dir = std::env::var_os("AGENTMUX_CEF_CACHE_DIR")?;
+        let agents_dir = std::env::var_os("AGENTMUX_AGENTS_DIR")?;
+        let instance_runtime_dir = std::env::var_os("AGENTMUX_INSTANCE_RUNTIME_DIR")?;
+        let shared_dir = std::env::var_os("AGENTMUX_SHARED_DIR")?;
         let mode = RuntimeMode::from_env()?;
 
         Some(Self {

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -236,18 +236,11 @@ fn sanitize_path_segment(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use crate::TEST_ENV_LOCK;
     use tempfile::TempDir;
 
-    /// All tests in this module touch process-global env vars
-    /// (`AGENTMUX_HOME_OVERRIDE` plus the eight `AGENTMUX_*` vars in
-    /// the round-trip test). cargo test runs tests in parallel by
-    /// default, so without serialization the env state visible inside
-    /// one test gets clobbered by another. Lock at module scope.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
     fn with_home_override<F: FnOnce(&Path)>(f: F) {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = TempDir::new().expect("tempdir");
         let path_str = tmp.path().display().to_string();
         std::env::set_var("AGENTMUX_HOME_OVERRIDE", &path_str);
@@ -373,7 +366,7 @@ mod tests {
 
     #[test]
     fn from_env_fails_fast_on_missing_vars() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Clear all expected vars.
         for k in [
             "AGENTMUX_INSTANCE_DIR",

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -140,7 +140,7 @@ impl DataPaths {
     /// round-trip losslessly. `Command::env(k, v)` accepts any
     /// `AsRef<OsStr>`, so the OsString flows through to children
     /// unchanged. The mode value is the only `String`-typed entry
-    /// (it's a fixed ASCII vocabulary). Claude P2 round-7 PR #695.
+    /// (it's a fixed ASCII vocabulary).
     pub fn to_env_vars(&self) -> Vec<(&'static str, std::ffi::OsString)> {
         use std::ffi::OsString;
         vec![

--- a/agentmux-common/src/data_paths.rs
+++ b/agentmux-common/src/data_paths.rs
@@ -204,18 +204,25 @@ fn resolve_root() -> Result<PathBuf, String> {
 }
 
 /// Sanitize a string for use as a single filesystem path segment.
-/// Rejects empty, `.`, `..`, and segments that contain path separators
-/// or other unsafe chars. Used as belt-and-braces protection in
-/// `DataPaths::resolve` to prevent traversal even when callers pass a
-/// directly-constructed `RuntimeMode::Dev` or odd version string.
+/// Rejects empty, `.`, `..`, segments containing path separators, and
+/// any character that has filesystem-special meaning on Windows (which
+/// is the most restrictive of the platforms we target). Used as belt-
+/// and-braces protection in `DataPaths::resolve` to prevent traversal
+/// even when callers pass a directly-constructed `RuntimeMode::Dev` or
+/// odd version string.
+///
+/// Why `:` is rejected: on Windows `C:temp` is a drive-relative path,
+/// not a literal filename, so `PathBuf::join("versions").join("C:temp")`
+/// would resolve OUTSIDE the intended `~/.agentmux/versions/` subtree.
 fn sanitize_path_segment(s: &str) -> Option<String> {
     let trimmed = s.trim();
-    if trimmed.is_empty()
-        || trimmed == "."
-        || trimmed == ".."
-        || trimmed.contains('/')
-        || trimmed.contains('\\')
-        || trimmed.contains('\0')
+    if trimmed.is_empty() || trimmed == "." || trimmed == ".." {
+        return None;
+    }
+    // Filesystem separators + Windows-reserved characters + NUL.
+    if trimmed
+        .chars()
+        .any(|c| matches!(c, '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' | '\0'))
     {
         return None;
     }
@@ -368,6 +375,19 @@ mod tests {
                 &RuntimeMode::Installed
             )
             .is_err());
+            // Drive-relative on Windows: `PathBuf::join("versions")
+            // .join("C:temp")` would resolve outside the intended
+            // ~/.agentmux/versions/ subtree because `C:temp` is a
+            // drive-relative path, not a literal filename.
+            assert!(DataPaths::resolve("C:temp", &RuntimeMode::Installed).is_err());
+            // Other Windows-reserved chars also rejected.
+            for v in ["a*b", "a?b", "a|b", "a<b", "a>b", "a\"b"] {
+                assert!(
+                    DataPaths::resolve(v, &RuntimeMode::Installed).is_err(),
+                    "should reject version with reserved char: {:?}",
+                    v
+                );
+            }
         });
     }
 

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -1,8 +1,12 @@
 //! Shared utilities for AgentMux crates.
 
 mod cli;
+pub mod data_paths;
 pub mod ipc;
 pub mod layout_types;
+pub mod runtime_mode;
 
 pub use cli::make_cli_cmd;
+pub use data_paths::DataPaths;
 pub use layout_types::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
+pub use runtime_mode::RuntimeMode;

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -10,3 +10,13 @@ pub use cli::make_cli_cmd;
 pub use data_paths::DataPaths;
 pub use layout_types::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
 pub use runtime_mode::RuntimeMode;
+
+/// Crate-wide test-only lock for env-var-touching tests. Both
+/// `runtime_mode::tests` and `data_paths::tests` mutate process-global
+/// env vars (`AGENTMUX_RUNTIME_MODE`, `AGENTMUX_HOME_OVERRIDE`, etc.);
+/// without a lock that's shared ACROSS modules, cargo's parallel test
+/// runner can race a setter in one module against a reader in the
+/// other. A per-module `static Mutex<()>` was insufficient — they
+/// need to share the same Mutex instance.
+#[cfg(test)]
+pub(crate) static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -81,9 +81,19 @@ impl RuntimeMode {
 
         // 4. AGENTMUX_DEV_BRANCH env override (CI override for dev mode
         //    when the binary isn't in a recognised build dir).
-        if std::env::var("AGENTMUX_DEV_BRANCH").is_ok() {
-            let branch = detect_branch(exe_dir);
-            return Self::Dev { branch };
+        //
+        //    `is_ok()` would be true for an empty string too — same
+        //    anti-pattern as the legacy `AGENTMUX_DEV` flag we're
+        //    replacing. CI/shell environments sometimes export empty
+        //    placeholders (`AGENTMUX_DEV_BRANCH=`); those should not
+        //    coerce installed/portable into Dev. Only treat the var as
+        //    set when it has non-empty content. Codex P2 round-5 on PR
+        //    #695.
+        if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
+            if !b.trim().is_empty() {
+                let branch = detect_branch(exe_dir);
+                return Self::Dev { branch };
+            }
         }
 
         // 5. Default.

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -49,7 +49,7 @@ impl RuntimeMode {
     /// `exe_dir` should be `current_exe().parent()` of the binary
     /// doing the detection (typically the launcher).
     pub fn current(exe_dir: &Path) -> Self {
-        // 1. Explicit override always wins (used by tests, CI, ops).
+        // 1. Explicit AGENTMUX_RUNTIME_MODE override (tests, CI, ops).
         if let Ok(s) = std::env::var("AGENTMUX_RUNTIME_MODE") {
             if let Some(mode) = parse_mode_string(&s) {
                 return mode;
@@ -62,14 +62,22 @@ impl RuntimeMode {
             return Self::Portable;
         }
 
-        // 3. Dev: exe lives under a known build-output dir. We check
-        //    by walking parents and matching path components.
-        if exe_dir_is_dev_build(exe_dir) || std::env::var("AGENTMUX_DEV_BRANCH").is_ok() {
+        // 3. Path-based dev detection: exe lives under a known
+        //    build-output dir. We check by walking parents and
+        //    matching path components.
+        if exe_dir_is_dev_build(exe_dir) {
             let branch = detect_branch(exe_dir);
             return Self::Dev { branch };
         }
 
-        // 4. Default.
+        // 4. AGENTMUX_DEV_BRANCH env override (CI override for dev mode
+        //    when the binary isn't in a recognised build dir).
+        if std::env::var("AGENTMUX_DEV_BRANCH").is_ok() {
+            let branch = detect_branch(exe_dir);
+            return Self::Dev { branch };
+        }
+
+        // 5. Default.
         Self::Installed
     }
 
@@ -101,7 +109,12 @@ impl RuntimeMode {
             // appended separately in DataPaths so callers can re-use
             // RuntimeMode across version queries.
             Self::Installed | Self::Portable => "versions".to_string(),
-            Self::Dev { branch } => format!("dev/{}", slugify_branch(branch)),
+            // Defense in depth: branch is sanitized at parse time, but
+            // a Dev variant constructed directly (e.g. via tests) might
+            // still hold an unsafe value. Slug-on-format ensures the
+            // path produced here is always a single-segment subdir of
+            // dev/.
+            Self::Dev { branch } => format!("dev/{}", sanitize_branch_slug(branch)),
         }
     }
 }
@@ -114,10 +127,17 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
     if trimmed.eq_ignore_ascii_case("portable") {
         return Some(RuntimeMode::Portable);
     }
-    if let Some(branch) = trimmed.strip_prefix("dev:") {
-        return Some(RuntimeMode::Dev {
-            branch: branch.to_string(),
-        });
+    if let Some(raw_branch) = trimmed.strip_prefix("dev:") {
+        // Slugify at parse time — the branch then flows through
+        // DataPaths::resolve into a `~/.agentmux/dev/<branch>/` path,
+        // and we must not let `/`, `..`, or shell-meta chars in the
+        // env override (`AGENTMUX_RUNTIME_MODE=dev:../versions/x`)
+        // escape the dev/ subtree. Codex P1 + Claude P1 on PR #695.
+        let slug = sanitize_branch_slug(raw_branch);
+        if slug.is_empty() {
+            return None;
+        }
+        return Some(RuntimeMode::Dev { branch: slug });
     }
     if trimmed.eq_ignore_ascii_case("dev") {
         return Some(RuntimeMode::Dev {
@@ -158,8 +178,9 @@ fn exe_dir_is_dev_build(exe_dir: &Path) -> bool {
 /// `AGENTMUX_DEV_BRANCH` env override always wins.
 fn detect_branch(exe_dir: &Path) -> String {
     if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
-        if !b.is_empty() {
-            return slugify_branch(&b);
+        let slug = sanitize_branch_slug(&b);
+        if !slug.is_empty() {
+            return slug;
         }
     }
     // Find a git repo by walking up from exe_dir.
@@ -193,8 +214,34 @@ fn run_git_branch(repo_dir: &Path) -> Option<String> {
 
 /// Convert a git branch into a filesystem-safe slug.
 /// `agenta/feature-x` → `agenta-feature-x`.
+///
+/// Use [`sanitize_branch_slug`] for any value that originates from an
+/// env var or other untrusted source — it additionally strips `..` and
+/// leading dots that could escape the dev/ subtree.
 fn slugify_branch(b: &str) -> String {
     b.replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "-")
+}
+
+/// Stricter sanitization for branch values that came from outside the
+/// trusted slugify path (env overrides, CI inputs). Strips parent-dir
+/// segments, leading dots, and any whitespace that survived earlier
+/// trimming. Returns an empty string if nothing usable remains, which
+/// callers should treat as "reject this input."
+fn sanitize_branch_slug(b: &str) -> String {
+    // Step 1: replace shell + filesystem-meta characters (same as
+    // slugify_branch — git-valid chars get a "-").
+    let replaced = slugify_branch(b);
+    // Step 2: drop `..` segments (now dash-separated, so "-..-"-style
+    // sequences too) and any leading/trailing dots/dashes/whitespace
+    // that would resolve up out of the dev/ subdir.
+    let cleaned: String = replaced
+        .split('-')
+        .filter(|seg| !seg.is_empty() && *seg != "." && *seg != "..")
+        .collect::<Vec<_>>()
+        .join("-");
+    cleaned
+        .trim_matches(|c: char| c == '.' || c == '-' || c.is_whitespace())
+        .to_string()
 }
 
 #[cfg(test)]
@@ -333,5 +380,35 @@ mod tests {
     fn invalid_env_string_falls_through() {
         assert!(parse_mode_string("garbage").is_none());
         assert!(parse_mode_string("").is_none());
+    }
+
+    #[test]
+    fn parse_dev_branch_rejects_traversal_attempts() {
+        // `..` resolves out of the dev/ subdir on disk — the slug must
+        // either reject it or strip it. We choose strip; if nothing
+        // usable remains, parse fails (returns None).
+        assert_eq!(parse_mode_string("dev:.."), None);
+        assert_eq!(parse_mode_string("dev:."), None);
+        assert_eq!(parse_mode_string("dev:"), None);
+        // `dev:../versions/x` slugifies to `versions-x` (the slashes
+        // are replaced and `..` segment is dropped).
+        let m = parse_mode_string("dev:../versions/x").expect("parses");
+        match m {
+            RuntimeMode::Dev { branch } => {
+                assert!(!branch.contains(".."));
+                assert!(!branch.contains('/'));
+                assert!(!branch.contains('\\'));
+            }
+            _ => panic!("expected Dev variant"),
+        }
+    }
+
+    #[test]
+    fn sanitize_branch_slug_strips_traversal() {
+        assert_eq!(sanitize_branch_slug(".."), "");
+        assert_eq!(sanitize_branch_slug("../foo"), "foo");
+        assert_eq!(sanitize_branch_slug("foo/../bar"), "foo-bar");
+        assert_eq!(sanitize_branch_slug(".hidden"), "hidden");
+        assert_eq!(sanitize_branch_slug("ok-branch"), "ok-branch");
     }
 }

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -15,7 +15,9 @@
 //! # Detection priority
 //!
 //! 1. `AGENTMUX_RUNTIME_MODE` env override (testing, CI).
-//! 2. Path-based portable detection: `<exe-dir>/runtime/` exists.
+//! 2. Marker-based portable detection: `<exe-dir>/.agentmux-portable`
+//!    exists (also looks two levels up for macOS .app bundles). Written
+//!    by `scripts/package-cef-portable.sh` at packaging time.
 //! 3. Path-based dev detection: exe is under a known dev-build dir
 //!    (`dist/cef-dev/`, `target/debug/`, `target/release/`).
 //! 4. `AGENTMUX_DEV_BRANCH` env override (CI override for dev mode).
@@ -56,9 +58,16 @@ impl RuntimeMode {
             }
         }
 
-        // 2. Portable: a `runtime/` subdir is bundled next to the
-        //    launcher binary in our portable ZIPs.
-        if exe_dir.join("runtime").is_dir() {
+        // 2. Portable: marker file written next to the launcher by the
+        //    portable-package script. See `is_portable_marker_present`.
+        //
+        //    An earlier draft used `<exe-dir>/runtime/.is_dir()` as
+        //    the test, but installed builds ALSO co-locate `runtime/`
+        //    (the launcher's main.rs:40 expects it unconditionally and
+        //    aborts if missing). So `runtime/` is universal across
+        //    portable + installed; only a marker file distinguishes
+        //    them. Claude P1 round-3 on PR #695.
+        if is_portable_marker_present(exe_dir) {
             return Self::Portable;
         }
 
@@ -147,6 +156,27 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
         });
     }
     None
+}
+
+/// True when `exe_dir` (or its parent on macOS app bundles) contains
+/// the `.agentmux-portable` marker file written by the
+/// portable-package script. Installed builds NEVER write this marker.
+///
+/// Falls back to `false` (i.e., not portable) if the dir isn't readable
+/// — installed-mode default is the safer guess when unsure.
+fn is_portable_marker_present(exe_dir: &Path) -> bool {
+    if exe_dir.join(".agentmux-portable").is_file() {
+        return true;
+    }
+    // On macOS the launcher exe is at <Bundle>.app/Contents/MacOS/<exe>;
+    // a portable .app would put the marker at the bundle root, two
+    // levels up.
+    if let Some(bundle_root) = exe_dir.parent().and_then(|p| p.parent()) {
+        if bundle_root.join(".agentmux-portable").is_file() {
+            return true;
+        }
+    }
+    false
 }
 
 /// True when `exe_dir` is one of our known dev-build output dirs.
@@ -251,6 +281,7 @@ mod tests {
     use super::*;
     use crate::TEST_ENV_LOCK;
     use std::path::PathBuf;
+    // tempfile is a dev-dep used here for the marker-detection test.
 
     /// `with_env` does NOT take `TEST_ENV_LOCK` — callers must hold
     /// it. This avoids the re-entrant-locking problem when a test
@@ -400,6 +431,48 @@ mod tests {
             }
             _ => panic!("expected Dev variant"),
         }
+    }
+
+    #[test]
+    fn portable_marker_detection() {
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let exe_dir = tmp.path();
+
+        // No marker → not portable.
+        assert!(!is_portable_marker_present(exe_dir));
+
+        // With marker → portable.
+        std::fs::write(exe_dir.join(".agentmux-portable"), b"").unwrap();
+        assert!(is_portable_marker_present(exe_dir));
+
+        // Marker two levels up (macOS .app bundle case).
+        let nested = exe_dir.join("Contents/MacOS");
+        std::fs::create_dir_all(&nested).unwrap();
+        // Removing top-level marker would still allow detection via the
+        // bundle-root walk-up.
+        std::fs::remove_file(exe_dir.join(".agentmux-portable")).unwrap();
+        assert!(!is_portable_marker_present(&nested));
+        std::fs::write(exe_dir.join(".agentmux-portable"), b"").unwrap();
+        assert!(is_portable_marker_present(&nested));
+    }
+
+    #[test]
+    fn current_with_only_runtime_subdir_is_not_portable() {
+        // Regression for Claude P1 round-3 PR #695: prior implementation
+        // returned Portable whenever <exe>/runtime/ existed, but
+        // installed builds also co-locate runtime/ (per launcher
+        // main.rs:40). Without a marker, we must NOT classify as Portable.
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let exe_dir = tmp.path();
+        std::fs::create_dir_all(exe_dir.join("runtime")).unwrap();
+        // No .agentmux-portable marker — must be Installed (or whatever
+        // the fall-through is, but specifically NOT Portable).
+        std::env::remove_var("AGENTMUX_RUNTIME_MODE");
+        std::env::remove_var("AGENTMUX_DEV_BRANCH");
+        let mode = RuntimeMode::current(exe_dir);
+        assert_ne!(mode, RuntimeMode::Portable);
     }
 
     #[test]

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -17,7 +17,8 @@
 //! 1. `AGENTMUX_RUNTIME_MODE` env override (testing, CI).
 //! 2. Marker-based portable detection: `<exe-dir>/.agentmux-portable`
 //!    exists (also looks two levels up for macOS .app bundles). Written
-//!    by `scripts/package-cef-portable.sh` at packaging time.
+//!    by `scripts/package-portable.sh` at packaging time (see the
+//!    `printf '...' > "$PORTABLE/.agentmux-portable"` line).
 //! 3. Path-based dev detection: exe is under a known dev-build dir
 //!    (`dist/cef-dev/`, `target/debug/`, `target/release/`).
 //! 4. `AGENTMUX_DEV_BRANCH` env override (CI override for dev mode).
@@ -169,8 +170,9 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
 }
 
 /// True when `exe_dir` (or its parent on macOS app bundles) contains
-/// the `.agentmux-portable` marker file written by the
-/// portable-package script. Installed builds NEVER write this marker.
+/// the `.agentmux-portable` marker file written by
+/// `scripts/package-portable.sh` at packaging time. Installed builds
+/// NEVER write this marker.
 ///
 /// Falls back to `false` (i.e., not portable) if the dir isn't readable
 /// — installed-mode default is the safer guess when unsure.

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -59,41 +59,37 @@ impl RuntimeMode {
             }
         }
 
-        // 2. Portable: marker file written next to the launcher by the
-        //    portable-package script. See `is_portable_marker_present`.
-        //
-        //    An earlier draft used `<exe-dir>/runtime/.is_dir()` as
-        //    the test, but installed builds ALSO co-locate `runtime/`
-        //    (the launcher's main.rs:40 expects it unconditionally and
-        //    aborts if missing). So `runtime/` is universal across
-        //    portable + installed; only a marker file distinguishes
-        //    them. Claude P1 round-3 on PR #695.
+        // 2. Portable: marker file written next to the launcher by
+        //    `scripts/package-portable.sh`. The presence of a
+        //    `runtime/` subdir is NOT a discriminator — installed
+        //    builds ship it too — so we require the explicit marker.
         if is_portable_marker_present(exe_dir) {
             return Self::Portable;
         }
 
         // 3. Path-based dev detection: exe lives under a known
-        //    build-output dir. We check by walking parents and
-        //    matching path components.
+        //    build-output dir.
         if exe_dir_is_dev_build(exe_dir) {
             let branch = detect_branch(exe_dir);
             return Self::Dev { branch };
         }
 
-        // 4. AGENTMUX_DEV_BRANCH env override (CI override for dev mode
-        //    when the binary isn't in a recognised build dir).
-        //
-        //    `is_ok()` would be true for an empty string too — same
-        //    anti-pattern as the legacy `AGENTMUX_DEV` flag we're
-        //    replacing. CI/shell environments sometimes export empty
-        //    placeholders (`AGENTMUX_DEV_BRANCH=`); those should not
-        //    coerce installed/portable into Dev. Only treat the var as
-        //    set when it has non-empty content. Codex P2 round-5 on PR
-        //    #695.
+        // 4. AGENTMUX_DEV_BRANCH override. Treat the env var as set
+        //    only when it has non-empty content AFTER detect_branch
+        //    sanitizes it — a malformed value like `..` sanitizes to
+        //    empty and should fall through to Installed rather than
+        //    silently routing into `dev/default/`.
         if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
             if !b.trim().is_empty() {
                 let branch = detect_branch(exe_dir);
-                return Self::Dev { branch };
+                if !branch.is_empty() && branch != "default" {
+                    return Self::Dev { branch };
+                }
+                // The env var was set but unusable AND we're not in
+                // a known dev-build dir. detect_branch's "default"
+                // fallback is for legitimate dev-build cases (covered
+                // by step 3 above), not for accidental env-var leaks
+                // out of a bash shell. Fall through.
             }
         }
 
@@ -154,7 +150,7 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
         // DataPaths::resolve into a `~/.agentmux/dev/<branch>/` path,
         // and we must not let `/`, `..`, or shell-meta chars in the
         // env override (`AGENTMUX_RUNTIME_MODE=dev:../versions/x`)
-        // escape the dev/ subtree. Codex P1 + Claude P1 on PR #695.
+        // escape the dev/ subtree.
         let slug = sanitize_branch_slug(raw_branch);
         if slug.is_empty() {
             return None;
@@ -446,6 +442,27 @@ mod tests {
     }
 
     #[test]
+    fn dev_branch_env_with_unusable_value_falls_through() {
+        // AGENTMUX_DEV_BRANCH=`..` sanitizes to empty inside
+        // detect_branch and would previously have routed an installed
+        // process into `dev/default/` (a real bug because it'd silently
+        // change where state lives). With the fix, an unusable value
+        // falls through to Installed when no other dev signal applies.
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Use a path nowhere near a build dir or a marker.
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        std::env::remove_var("AGENTMUX_RUNTIME_MODE");
+        std::env::set_var("AGENTMUX_DEV_BRANCH", "..");
+        let mode = RuntimeMode::current(tmp.path());
+        std::env::remove_var("AGENTMUX_DEV_BRANCH");
+        // The "..": ancestor-traversal value sanitizes to empty;
+        // detect_branch falls back to "default" because there's no
+        // .git in the temp dir. Both signals are unsafe-to-trust, so
+        // we fall through to Installed.
+        assert_eq!(mode, RuntimeMode::Installed);
+    }
+
+    #[test]
     fn portable_marker_detection() {
         let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::TempDir::new().expect("tempdir");
@@ -471,10 +488,10 @@ mod tests {
 
     #[test]
     fn current_with_only_runtime_subdir_is_not_portable() {
-        // Regression for Claude P1 round-3 PR #695: prior implementation
-        // returned Portable whenever <exe>/runtime/ existed, but
-        // installed builds also co-locate runtime/ (per launcher
-        // main.rs:40). Without a marker, we must NOT classify as Portable.
+        // Regression: prior implementation returned Portable whenever
+        // <exe>/runtime/ existed, but installed builds also co-locate
+        // runtime/ (per the launcher unconditionally requiring it).
+        // Without a marker, we must NOT classify as Portable.
         let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let exe_dir = tmp.path();

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -112,8 +112,10 @@ impl RuntimeMode {
             // Defense in depth: branch is sanitized at parse time, but
             // a Dev variant constructed directly (e.g. via tests) might
             // still hold an unsafe value. Slug-on-format ensures the
-            // path produced here is always a single-segment subdir of
-            // dev/.
+            // returned string is always exactly two segments — `dev/`
+            // followed by a single-segment branch slug — so callers
+            // splitting on `/` see the expected shape and the resulting
+            // filesystem path is always a child of `dev/`.
             Self::Dev { branch } => format!("dev/{}", sanitize_branch_slug(branch)),
         }
     }
@@ -247,18 +249,15 @@ fn sanitize_branch_slug(b: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::TEST_ENV_LOCK;
     use std::path::PathBuf;
-    use std::sync::Mutex;
 
-    /// Tests in this module touch process-global env vars; cargo
-    /// test runs tests in parallel so without serialization one
-    /// test's set_var can be visible to another test's lookup.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// `with_env` does NOT take ENV_LOCK — callers must hold it.
-    /// This avoids the re-entrant-locking problem when a test nests
-    /// `with_env` calls (both would try to acquire the same Mutex
-    /// and deadlock).
+    /// `with_env` does NOT take `TEST_ENV_LOCK` — callers must hold
+    /// it. This avoids the re-entrant-locking problem when a test
+    /// nests `with_env` calls. The lock is shared across the whole
+    /// crate (defined in lib.rs) so tests in this module also
+    /// serialize against `data_paths::tests` which touches the same
+    /// process-global env vars.
     fn with_env<F: FnOnce()>(key: &str, val: Option<&str>, f: F) {
         let prev = std::env::var(key).ok();
         match val {
@@ -308,7 +307,7 @@ mod tests {
 
     #[test]
     fn env_override_wins_over_path_detection() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Even if exe_dir looks portable (has `runtime/`), env override wins.
         // We simulate by passing a path that doesn't exist (so .is_dir()
         // returns false), but we also force the env override.

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -1,0 +1,337 @@
+//! Runtime mode detection — single source of truth.
+//!
+//! The launcher computes [`RuntimeMode::current`] once at startup and
+//! propagates the result to host + srv via the `AGENTMUX_RUNTIME_MODE`
+//! environment variable. No binary should call [`current`] more than
+//! once per process; downstream binaries read the env var via
+//! [`from_env`] instead.
+//!
+//! Replaces the legacy mix of `cfg!(debug_assertions)`, `env::var
+//! ("AGENTMUX_DEV").is_ok()`, and `== Ok("1")` checks across launcher,
+//! host, and sidecar — which were each correct in isolation but
+//! desynchronized in combination (see docs/specs/
+//! SPEC_DATA_DIR_UNIFICATION_2026-05-05.md §2.1).
+//!
+//! # Detection priority
+//!
+//! 1. `AGENTMUX_RUNTIME_MODE` env override (testing, CI).
+//! 2. Path-based portable detection: `<exe-dir>/runtime/` exists.
+//! 3. Path-based dev detection: exe is under a known dev-build dir
+//!    (`dist/cef-dev/`, `target/debug/`, `target/release/`).
+//! 4. `AGENTMUX_DEV_BRANCH` env override (CI override for dev mode).
+//! 5. Default: `Installed`.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Where this AgentMux binary is running from. Determines data path
+/// layout (see [`crate::DataPaths`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeMode {
+    /// Installed via the platform installer (msi/dmg/deb). State lives
+    /// in `~/.agentmux/versions/<v>/`.
+    Installed,
+    /// Running from an extracted portable ZIP. State STILL lives in
+    /// `~/.agentmux/versions/<v>/` (not under the portable folder) —
+    /// portable binaries are stateless on disk.
+    Portable,
+    /// Running from a source-tree build. State lives in
+    /// `~/.agentmux/dev/<branch>/` so different branches don't share
+    /// state.
+    Dev { branch: String },
+}
+
+impl RuntimeMode {
+    /// Detect runtime mode from the launcher's vantage point. Call
+    /// ONCE at process startup. Subsequent processes read the
+    /// `AGENTMUX_RUNTIME_MODE` env var via [`Self::from_env`].
+    ///
+    /// `exe_dir` should be `current_exe().parent()` of the binary
+    /// doing the detection (typically the launcher).
+    pub fn current(exe_dir: &Path) -> Self {
+        // 1. Explicit override always wins (used by tests, CI, ops).
+        if let Ok(s) = std::env::var("AGENTMUX_RUNTIME_MODE") {
+            if let Some(mode) = parse_mode_string(&s) {
+                return mode;
+            }
+        }
+
+        // 2. Portable: a `runtime/` subdir is bundled next to the
+        //    launcher binary in our portable ZIPs.
+        if exe_dir.join("runtime").is_dir() {
+            return Self::Portable;
+        }
+
+        // 3. Dev: exe lives under a known build-output dir. We check
+        //    by walking parents and matching path components.
+        if exe_dir_is_dev_build(exe_dir) || std::env::var("AGENTMUX_DEV_BRANCH").is_ok() {
+            let branch = detect_branch(exe_dir);
+            return Self::Dev { branch };
+        }
+
+        // 4. Default.
+        Self::Installed
+    }
+
+    /// Read mode from the `AGENTMUX_RUNTIME_MODE` env var the launcher
+    /// set. Used by host + srv to consume the launcher's decision
+    /// without re-detecting (which would re-introduce the desync risk
+    /// the legacy code had).
+    pub fn from_env() -> Option<Self> {
+        std::env::var("AGENTMUX_RUNTIME_MODE")
+            .ok()
+            .and_then(|s| parse_mode_string(&s))
+    }
+
+    /// Encode for the `AGENTMUX_RUNTIME_MODE` env var. Round-trips
+    /// with [`parse_mode_string`].
+    pub fn to_env_string(&self) -> String {
+        match self {
+            Self::Installed => "installed".to_string(),
+            Self::Portable => "portable".to_string(),
+            Self::Dev { branch } => format!("dev:{}", branch),
+        }
+    }
+
+    /// Slug used inside `~/.agentmux/` to separate state by mode.
+    /// Stable across releases of the same major mode + branch.
+    pub fn dir_slug(&self) -> String {
+        match self {
+            // Versioned modes don't include the version here — that's
+            // appended separately in DataPaths so callers can re-use
+            // RuntimeMode across version queries.
+            Self::Installed | Self::Portable => "versions".to_string(),
+            Self::Dev { branch } => format!("dev/{}", slugify_branch(branch)),
+        }
+    }
+}
+
+fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
+    let trimmed = s.trim();
+    if trimmed.eq_ignore_ascii_case("installed") {
+        return Some(RuntimeMode::Installed);
+    }
+    if trimmed.eq_ignore_ascii_case("portable") {
+        return Some(RuntimeMode::Portable);
+    }
+    if let Some(branch) = trimmed.strip_prefix("dev:") {
+        return Some(RuntimeMode::Dev {
+            branch: branch.to_string(),
+        });
+    }
+    if trimmed.eq_ignore_ascii_case("dev") {
+        return Some(RuntimeMode::Dev {
+            branch: "default".to_string(),
+        });
+    }
+    None
+}
+
+/// True when `exe_dir` is one of our known dev-build output dirs.
+/// Walks parents to handle nested cases (CEF subprocesses run from
+/// `runtime/` even in dev).
+fn exe_dir_is_dev_build(exe_dir: &Path) -> bool {
+    // Match any ancestor of exe_dir that ends in a known build dir name.
+    // We accept: dist/cef-dev/<...>, target/debug/<...>, target/release/<...>
+    let mut cur = Some(exe_dir);
+    while let Some(p) = cur {
+        let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let parent_name = p
+            .parent()
+            .and_then(|pp| pp.file_name())
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+
+        if (parent_name == "dist" && name == "cef-dev")
+            || (parent_name == "target" && (name == "debug" || name == "release"))
+        {
+            return true;
+        }
+        cur = p.parent();
+    }
+    false
+}
+
+/// Detect the current git branch slug for dev mode. Walks up from
+/// `exe_dir` to find a git repo, runs `git rev-parse --abbrev-ref
+/// HEAD`, and slugifies. Falls back to `"default"` if anything fails.
+/// `AGENTMUX_DEV_BRANCH` env override always wins.
+fn detect_branch(exe_dir: &Path) -> String {
+    if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
+        if !b.is_empty() {
+            return slugify_branch(&b);
+        }
+    }
+    // Find a git repo by walking up from exe_dir.
+    let mut cur = Some(exe_dir);
+    while let Some(p) = cur {
+        if p.join(".git").exists() {
+            return run_git_branch(p).unwrap_or_else(|| "default".to_string());
+        }
+        cur = p.parent();
+    }
+    "default".to_string()
+}
+
+fn run_git_branch(repo_dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(repo_dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(output.stdout).ok()?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed == "HEAD" {
+        // Detached state; not useful for branch keying.
+        return None;
+    }
+    Some(slugify_branch(trimmed))
+}
+
+/// Convert a git branch into a filesystem-safe slug.
+/// `agenta/feature-x` → `agenta-feature-x`.
+fn slugify_branch(b: &str) -> String {
+    b.replace(['/', '\\', ':', '*', '?', '"', '<', '>', '|'], "-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    /// Tests in this module touch process-global env vars; cargo
+    /// test runs tests in parallel so without serialization one
+    /// test's set_var can be visible to another test's lookup.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// `with_env` does NOT take ENV_LOCK — callers must hold it.
+    /// This avoids the re-entrant-locking problem when a test nests
+    /// `with_env` calls (both would try to acquire the same Mutex
+    /// and deadlock).
+    fn with_env<F: FnOnce()>(key: &str, val: Option<&str>, f: F) {
+        let prev = std::env::var(key).ok();
+        match val {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+        f();
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn parses_env_strings_round_trip() {
+        for mode in [
+            RuntimeMode::Installed,
+            RuntimeMode::Portable,
+            RuntimeMode::Dev {
+                branch: "main".into(),
+            },
+            RuntimeMode::Dev {
+                branch: "agenta-feature-x".into(),
+            },
+        ] {
+            let s = mode.to_env_string();
+            let back = parse_mode_string(&s).expect("round-trip");
+            assert_eq!(back, mode);
+        }
+    }
+
+    #[test]
+    fn parse_accepts_bare_dev() {
+        assert_eq!(
+            parse_mode_string("dev"),
+            Some(RuntimeMode::Dev {
+                branch: "default".into()
+            })
+        );
+        assert_eq!(
+            parse_mode_string("DEV"),
+            Some(RuntimeMode::Dev {
+                branch: "default".into()
+            })
+        );
+    }
+
+    #[test]
+    fn env_override_wins_over_path_detection() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Even if exe_dir looks portable (has `runtime/`), env override wins.
+        // We simulate by passing a path that doesn't exist (so .is_dir()
+        // returns false), but we also force the env override.
+        with_env("AGENTMUX_RUNTIME_MODE", Some("dev:main"), || {
+            with_env("AGENTMUX_DEV_BRANCH", None, || {
+                let mode = RuntimeMode::current(&PathBuf::from("/nonexistent"));
+                assert_eq!(
+                    mode,
+                    RuntimeMode::Dev {
+                        branch: "main".into()
+                    }
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn dev_build_path_pattern() {
+        // Match dist/cef-dev/...
+        assert!(exe_dir_is_dev_build(&PathBuf::from(
+            "/c/Systems/agentmux/dist/cef-dev"
+        )));
+        // Match target/debug/...
+        assert!(exe_dir_is_dev_build(&PathBuf::from(
+            "/c/Systems/agentmux/target/debug"
+        )));
+        // Match target/release/...
+        assert!(exe_dir_is_dev_build(&PathBuf::from(
+            "/c/Systems/agentmux/target/release"
+        )));
+        // Don't match an installed path.
+        assert!(!exe_dir_is_dev_build(&PathBuf::from(
+            "/c/Program Files/AgentMux"
+        )));
+        // Don't match a portable path.
+        assert!(!exe_dir_is_dev_build(&PathBuf::from(
+            "/Users/me/Desktop/agentmux-portable"
+        )));
+    }
+
+    #[test]
+    fn slugify_branch_replaces_unsafe_chars() {
+        assert_eq!(slugify_branch("agenta/feature-x"), "agenta-feature-x");
+        assert_eq!(slugify_branch("feat:foo*bar"), "feat-foo-bar");
+        assert_eq!(slugify_branch("plain"), "plain");
+    }
+
+    #[test]
+    fn dir_slug_per_mode() {
+        assert_eq!(RuntimeMode::Installed.dir_slug(), "versions");
+        assert_eq!(RuntimeMode::Portable.dir_slug(), "versions");
+        assert_eq!(
+            RuntimeMode::Dev {
+                branch: "main".into()
+            }
+            .dir_slug(),
+            "dev/main"
+        );
+        assert_eq!(
+            RuntimeMode::Dev {
+                branch: "agenta/x".into()
+            }
+            .dir_slug(),
+            "dev/agenta-x"
+        );
+    }
+
+    #[test]
+    fn invalid_env_string_falls_through() {
+        assert!(parse_mode_string("garbage").is_none());
+        assert!(parse_mode_string("").is_none());
+    }
+}

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -15,10 +15,10 @@
 //! # Detection priority
 //!
 //! 1. `AGENTMUX_RUNTIME_MODE` env override (testing, CI).
-//! 2. Marker-based portable detection: `<exe-dir>/.agentmux-portable`
+//! 2. Marker-based portable detection: `<exe-dir>/agentmux-portable.marker`
 //!    exists (also looks two levels up for macOS .app bundles). Written
 //!    by `scripts/package-portable.sh` at packaging time (see the
-//!    `printf '...' > "$PORTABLE/.agentmux-portable"` line).
+//!    `printf '...' > "$PORTABLE/agentmux-portable.marker"` line).
 //! 3. Path-based dev detection: exe is under a known dev-build dir
 //!    (`dist/cef-dev/`, `target/debug/`, `target/release/`).
 //! 4. `AGENTMUX_DEV_BRANCH` env override (CI override for dev mode).
@@ -165,21 +165,21 @@ fn parse_mode_string(s: &str) -> Option<RuntimeMode> {
 }
 
 /// True when `exe_dir` (or its parent on macOS app bundles) contains
-/// the `.agentmux-portable` marker file written by
+/// the `agentmux-portable.marker` marker file written by
 /// `scripts/package-portable.sh` at packaging time. Installed builds
 /// NEVER write this marker.
 ///
 /// Falls back to `false` (i.e., not portable) if the dir isn't readable
 /// — installed-mode default is the safer guess when unsure.
 fn is_portable_marker_present(exe_dir: &Path) -> bool {
-    if exe_dir.join(".agentmux-portable").is_file() {
+    if exe_dir.join("agentmux-portable.marker").is_file() {
         return true;
     }
     // On macOS the launcher exe is at <Bundle>.app/Contents/MacOS/<exe>;
     // a portable .app would put the marker at the bundle root, two
     // levels up.
     if let Some(bundle_root) = exe_dir.parent().and_then(|p| p.parent()) {
-        if bundle_root.join(".agentmux-portable").is_file() {
+        if bundle_root.join("agentmux-portable.marker").is_file() {
             return true;
         }
     }
@@ -296,17 +296,36 @@ mod tests {
     /// crate (defined in lib.rs) so tests in this module also
     /// serialize against `data_paths::tests` which touches the same
     /// process-global env vars.
+    ///
+    /// Uses a Drop guard so the previous env value is restored even
+    /// if `f` panics — without it, a panicking test would leave the
+    /// env var modified and any subsequent test in the same process
+    /// would see the wrong value.
     fn with_env<F: FnOnce()>(key: &str, val: Option<&str>, f: F) {
+        struct EnvGuard {
+            key: String,
+            prev: Option<String>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => std::env::set_var(&self.key, v),
+                    None => std::env::remove_var(&self.key),
+                }
+            }
+        }
+
         let prev = std::env::var(key).ok();
+        let _guard = EnvGuard {
+            key: key.to_string(),
+            prev,
+        };
         match val {
             Some(v) => std::env::set_var(key, v),
             None => std::env::remove_var(key),
         }
         f();
-        match prev {
-            Some(v) => std::env::set_var(key, v),
-            None => std::env::remove_var(key),
-        }
+        // _guard drops here (also runs on panic).
     }
 
     #[test]
@@ -477,7 +496,7 @@ mod tests {
         assert!(!is_portable_marker_present(exe_dir));
 
         // With marker → portable.
-        std::fs::write(exe_dir.join(".agentmux-portable"), b"").unwrap();
+        std::fs::write(exe_dir.join("agentmux-portable.marker"), b"").unwrap();
         assert!(is_portable_marker_present(exe_dir));
 
         // Marker two levels up (macOS .app bundle case).
@@ -485,9 +504,9 @@ mod tests {
         std::fs::create_dir_all(&nested).unwrap();
         // Removing top-level marker would still allow detection via the
         // bundle-root walk-up.
-        std::fs::remove_file(exe_dir.join(".agentmux-portable")).unwrap();
+        std::fs::remove_file(exe_dir.join("agentmux-portable.marker")).unwrap();
         assert!(!is_portable_marker_present(&nested));
-        std::fs::write(exe_dir.join(".agentmux-portable"), b"").unwrap();
+        std::fs::write(exe_dir.join("agentmux-portable.marker"), b"").unwrap();
         assert!(is_portable_marker_present(&nested));
     }
 
@@ -501,7 +520,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().expect("tempdir");
         let exe_dir = tmp.path();
         std::fs::create_dir_all(exe_dir.join("runtime")).unwrap();
-        // No .agentmux-portable marker — must be Installed (or whatever
+        // No agentmux-portable.marker marker — must be Installed (or whatever
         // the fall-through is, but specifically NOT Portable).
         std::env::remove_var("AGENTMUX_RUNTIME_MODE");
         std::env::remove_var("AGENTMUX_DEV_BRANCH");

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -74,22 +74,21 @@ impl RuntimeMode {
             return Self::Dev { branch };
         }
 
-        // 4. AGENTMUX_DEV_BRANCH override. Treat the env var as set
-        //    only when it has non-empty content AFTER detect_branch
-        //    sanitizes it — a malformed value like `..` sanitizes to
-        //    empty and should fall through to Installed rather than
-        //    silently routing into `dev/default/`.
+        // 4. AGENTMUX_DEV_BRANCH override. The env-var IS the branch
+        //    source at this step; sanitize it directly, do NOT call
+        //    detect_branch (which has its own git fallback that would
+        //    take over when the env-var sanitizes to empty — and could
+        //    then return a real branch name from an unrelated .git
+        //    ancestor of `exe_dir`, silently routing installed runs
+        //    into Dev when the user only had a typo'd env var).
+        //
+        //    If the env value is unusable (empty after trim, or
+        //    sanitizes to empty via path-traversal stripping), fall
+        //    through to Installed instead of inventing a branch.
         if let Ok(b) = std::env::var("AGENTMUX_DEV_BRANCH") {
-            if !b.trim().is_empty() {
-                let branch = detect_branch(exe_dir);
-                if !branch.is_empty() && branch != "default" {
-                    return Self::Dev { branch };
-                }
-                // The env var was set but unusable AND we're not in
-                // a known dev-build dir. detect_branch's "default"
-                // fallback is for legitimate dev-build cases (covered
-                // by step 3 above), not for accidental env-var leaks
-                // out of a bash shell. Fall through.
+            let slug = sanitize_branch_slug(&b);
+            if !slug.is_empty() {
+                return Self::Dev { branch: slug };
             }
         }
 
@@ -443,22 +442,28 @@ mod tests {
 
     #[test]
     fn dev_branch_env_with_unusable_value_falls_through() {
-        // AGENTMUX_DEV_BRANCH=`..` sanitizes to empty inside
-        // detect_branch and would previously have routed an installed
-        // process into `dev/default/` (a real bug because it'd silently
-        // change where state lives). With the fix, an unusable value
-        // falls through to Installed when no other dev signal applies.
+        // AGENTMUX_DEV_BRANCH=`..` sanitizes to empty.
+        // With the fix, an unusable value falls through to Installed
+        // when no other dev signal applies — even when exe_dir has
+        // a .git ancestor that detect_branch could have grabbed.
         let _g = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        // Use a path nowhere near a build dir or a marker.
         let tmp = tempfile::TempDir::new().expect("tempdir");
+        // Plant a .git directory so a buggy implementation that called
+        // detect_branch as a fallback would find a real branch name and
+        // wrongly classify as Dev. Step 4 now sanitizes the env var
+        // directly without invoking the git lookup — verifying that.
+        std::fs::create_dir_all(tmp.path().join(".git")).unwrap();
+        let exe_dir = tmp.path().join("subdir");
+        std::fs::create_dir_all(&exe_dir).unwrap();
+
         std::env::remove_var("AGENTMUX_RUNTIME_MODE");
         std::env::set_var("AGENTMUX_DEV_BRANCH", "..");
-        let mode = RuntimeMode::current(tmp.path());
+        let mode = RuntimeMode::current(&exe_dir);
         std::env::remove_var("AGENTMUX_DEV_BRANCH");
-        // The "..": ancestor-traversal value sanitizes to empty;
-        // detect_branch falls back to "default" because there's no
-        // .git in the temp dir. Both signals are unsafe-to-trust, so
-        // we fall through to Installed.
+
+        // Even with the .git ancestor, an unusable env value must
+        // fall through to Installed (NOT to Dev with a git-detected
+        // branch). The env var is the source-of-truth at step 4.
         assert_eq!(mode, RuntimeMode::Installed);
     }
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.639"
+version = "0.33.640"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.638"
+version = "0.33.639"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.639"
+version = "0.33.640"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.638"
+version = "0.33.639"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.637",
+  "version": "0.33.639",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.637",
+      "version": "0.33.639",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1022,6 +1022,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1038,6 +1039,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,6 +1056,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1070,6 +1073,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,6 +1090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1102,6 +1107,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,6 +1124,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1134,6 +1141,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,6 +1158,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1166,6 +1175,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,6 +1192,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1198,6 +1209,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1214,6 +1226,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1230,6 +1243,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1246,6 +1260,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,6 +1277,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,6 +1294,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1294,6 +1311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1310,6 +1328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1326,6 +1345,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1342,6 +1362,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,6 +1379,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,6 +1396,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1390,6 +1413,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1406,6 +1430,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1422,6 +1447,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1649,18 +1675,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1816,21 +1830,6 @@
         "langium": "^4.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1887,6 +1886,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1926,6 +1926,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1946,6 +1947,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1966,6 +1968,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1986,6 +1989,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2006,6 +2010,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2026,6 +2031,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2046,6 +2052,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2066,6 +2073,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2086,6 +2094,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2106,6 +2115,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2126,6 +2136,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,6 +2157,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,6 +2178,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2245,6 +2258,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2258,6 +2272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2271,6 +2286,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,6 +2300,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,6 +2314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2310,6 +2328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2323,6 +2342,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,6 +2356,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2349,6 +2370,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2362,6 +2384,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2375,6 +2398,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2388,6 +2412,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2401,6 +2426,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2414,6 +2440,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2427,6 +2454,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2440,6 +2468,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,6 +2482,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,6 +2496,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,6 +2510,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2492,6 +2524,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2505,6 +2538,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,6 +2552,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2531,6 +2566,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2544,6 +2580,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2557,6 +2594,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3664,7 +3702,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4494,14 +4532,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4693,7 +4723,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5545,7 +5575,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5664,7 +5694,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6029,6 +6059,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6145,6 +6176,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6190,7 +6222,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6873,7 +6905,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7025,7 +7057,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7045,7 +7077,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7236,7 +7268,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7482,7 +7514,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7515,6 +7547,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7535,6 +7568,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7555,6 +7589,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7575,6 +7610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7595,6 +7631,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7615,6 +7652,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7635,6 +7673,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7655,6 +7694,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7675,6 +7715,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7695,6 +7736,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7715,6 +7757,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7779,19 +7822,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9039,6 +9069,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9088,6 +9119,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9376,6 +9408,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9421,6 +9454,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9662,24 +9696,11 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -9994,7 +10015,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10060,6 +10081,7 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10161,7 +10183,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10370,29 +10392,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11107,34 +11106,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11225,6 +11196,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11453,7 +11425,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11473,6 +11445,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11544,7 +11517,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11775,6 +11748,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11941,6 +11915,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11957,6 +11932,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11973,6 +11949,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11989,6 +11966,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12005,6 +11983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12021,6 +12000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12037,6 +12017,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12053,6 +12034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12069,6 +12051,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,6 +12068,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12101,6 +12085,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12117,6 +12102,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12133,6 +12119,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12149,6 +12136,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12165,6 +12153,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12181,6 +12170,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12197,6 +12187,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12213,6 +12204,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12229,6 +12221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12245,6 +12238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12261,6 +12255,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12277,6 +12272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12293,6 +12289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12309,6 +12306,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12325,6 +12323,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12341,6 +12340,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,6 +12354,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12395,6 +12396,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12833,23 +12835,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.639",
+  "version": "0.33.640",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.639",
+      "version": "0.33.640",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.639",
+  "version": "0.33.640",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.638",
+  "version": "0.33.639",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -39,11 +39,10 @@ cp target/release/agentmux-launcher.exe "$PORTABLE/agentmux.exe"
 
 # Portable marker — read by agentmux-common::RuntimeMode::current to
 # distinguish portable extracts from installed builds. Both ship a
-# `runtime/` subdir, so the dir alone is not a discriminator (per
-# Claude P1 round-3 PR #695). The file's contents are advisory; the
-# detection only checks for its presence next to the launcher exe.
-# Mac .app-bundle layouts are also supported (marker can sit at the
-# bundle root).
+# `runtime/` subdir, so the dir alone is not a discriminator. The
+# file's contents are advisory; the detection only checks for its
+# presence next to the launcher exe. Mac .app-bundle layouts are
+# also supported (marker can sit at the bundle root).
 printf 'AgentMux portable build %s\n' "$VERSION" > "$PORTABLE/.agentmux-portable"
 
 # README

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -37,6 +37,15 @@ mkdir -p "$PORTABLE/data"
 # Launcher in root
 cp target/release/agentmux-launcher.exe "$PORTABLE/agentmux.exe"
 
+# Portable marker — read by agentmux-common::RuntimeMode::current to
+# distinguish portable extracts from installed builds. Both ship a
+# `runtime/` subdir, so the dir alone is not a discriminator (per
+# Claude P1 round-3 PR #695). The file's contents are advisory; the
+# detection only checks for its presence next to the launcher exe.
+# Mac .app-bundle layouts are also supported (marker can sit at the
+# bundle root).
+printf 'AgentMux portable build %s\n' "$VERSION" > "$PORTABLE/.agentmux-portable"
+
 # README
 cat > "$PORTABLE/README.txt" <<READMEEOF
 AgentMux v$VERSION - Portable Edition

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -43,7 +43,7 @@ cp target/release/agentmux-launcher.exe "$PORTABLE/agentmux.exe"
 # file's contents are advisory; the detection only checks for its
 # presence next to the launcher exe. Mac .app-bundle layouts are
 # also supported (marker can sit at the bundle root).
-printf 'AgentMux portable build %s\n' "$VERSION" > "$PORTABLE/.agentmux-portable"
+printf 'AgentMux portable build %s\n' "$VERSION" > "$PORTABLE/agentmux-portable.marker"
 
 # README
 cat > "$PORTABLE/README.txt" <<READMEEOF


### PR DESCRIPTION
Foundation PR for the data-dir unification specced in #694. Adds the \`RuntimeMode\` + \`DataPaths\` primitives in \`agentmux-common\` **without yet switching any consumer**. Launcher / host / sidecar / srv stay on legacy paths until a follow-up PR migrates them.

Why split: the spec PR (#694) is doc-only. This adds the actual primitives the spec promised. The consumer-switching PR can then be reviewed against merged primitives instead of being one giant diff.

## Adds

| File | What |
|---|---|
| \`agentmux-common/src/runtime_mode.rs\` | \`RuntimeMode { Installed, Portable, Dev { branch } }\` enum, detection priority, env round-trip, branch slug. 7 tests. |
| \`agentmux-common/src/data_paths.rs\` | \`DataPaths\` struct (8 paths + mode), \`resolve()\`, \`ensure_dirs()\`, \`to_env_vars()\`/\`from_env()\` round-trip. 6 tests. |
| \`agentmux-common/src/lib.rs\` | Re-exports. |
| \`agentmux-common/Cargo.toml\` | \`dirs = \"5\"\` runtime dep, \`tempfile\` dev-dep. |

## Detection priority (`RuntimeMode::current`)

1. \`AGENTMUX_RUNTIME_MODE\` env override (testing / CI).
2. \`<exe-dir>/runtime/\` exists → \`Portable\`.
3. \`exe_dir\` is under \`dist/cef-dev/\`, \`target/debug/\`, or \`target/release/\` → \`Dev { branch }\` (branch via \`git rev-parse --abbrev-ref HEAD\`, slugified, falls back to \`\"default\"\`).
4. \`AGENTMUX_DEV_BRANCH\` env set → \`Dev { branch: <slugified> }\`.
5. Default → \`Installed\`.

## Layout (per spec §3.1)

\`\`\`
~/.agentmux/
├── shared/                       account-wide cookies/credentials
├── versions/<v>/                 installed + portable
│   ├── data/, config/, logs/, cef-cache/, agents/
│   └── runtime/                  lock + IPC, single set per version
└── dev/<branch>/                 per-branch dev isolation
    └── (same children)
\`\`\`

## Env vars exported by the launcher (consumed via \`from_env()\` later)

\`\`\`
AGENTMUX_INSTANCE_DIR
AGENTMUX_DATA_DIR
AGENTMUX_CONFIG_DIR
AGENTMUX_LOG_DIR
AGENTMUX_CEF_CACHE_DIR
AGENTMUX_AGENTS_DIR
AGENTMUX_INSTANCE_RUNTIME_DIR
AGENTMUX_SHARED_DIR
AGENTMUX_RUNTIME_MODE
\`\`\`

\`from_env()\` returns \`None\` if any of these is absent — explicit \"no fallback\" per spec §3.2 to fail-fast instead of silently using legacy paths the way \`sidecar.rs::spawn_backend\` did.

## Test isolation note

Tests touch process-global env vars; cargo test runs in parallel. A module-scoped \`static ENV_LOCK: Mutex<()>\` serializes env-touching tests in each module. \`with_env\` (in \`runtime_mode.rs\`) does NOT take the lock so callers can nest calls without deadlocking — each test holds the lock once at the top.

## Local verification

\`\`\`
cargo test -p agentmux-common
test result: ok. 37 passed; 0 failed; 0 ignored; 0 measured
\`\`\`

## Next PR

Consumer switching: launcher's \`data_dir.rs\` becomes a thin shim, host's \`main.rs\` reads \`AGENTMUX_CEF_CACHE_DIR\`/etc directly, \`sidecar.rs::spawn_backend\` deleted (no more host-without-launcher), srv renames \`AGENTMUX_DATA_HOME\` → \`AGENTMUX_DATA_DIR\`. Will reference this PR's \`DataPaths\`/\`RuntimeMode\` types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)