### PR TITLE
feat(agent): 5-char date slug + collision resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.641"
+version = "0.33.642"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.641"
+version = "0.33.642"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.641"
+version = "0.33.642"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.641"
+version = "0.33.642"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.641"
+version = "0.33.642"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.641"
+version = "0.33.642"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.641"
+version = "0.33.642"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.641"
+version = "0.33.642"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -559,6 +559,23 @@ pub struct CommandWriteAgentConfigData {
     pub working_dir: String,
     /// Files to write (path relative to working_dir, content).
     pub files: Vec<AgentConfigFile>,
+    /// When true, treat `working_dir` as an auto-generated instance
+    /// path eligible for `<base>-N` collision resolution. When false
+    /// (user-specified `agent.working_directory` like `~/projects/X`),
+    /// write into the path as-is — no rewrite, no suffixing. The
+    /// frontend sets this based on whether it constructed the path
+    /// itself or pulled it from the agent definition.
+    #[serde(default)]
+    pub auto_allocate: bool,
+}
+
+/// Result of WriteAgentConfigCommand. Returns the final working
+/// directory used; callers should compare against the requested
+/// `working_dir` and patch `cmd:cwd` (via SetMeta) when they differ
+/// so the controller spawns the CLI in the actually-created dir.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandWriteAgentConfigResult {
+    pub working_dir: String,
 }
 
 /// Data for ResolveCliCommand — detect or install a CLI tool.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -343,11 +343,11 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "agent.open: block created + layout updated"
                 );
 
-                // 8. Write agent config files into the already-
-                //    collision-resolved work_dir (allocated before the
-                //    block meta was built — see step 5). The function
-                //    no longer retries; it just creates the dir +
-                //    writes files.
+                // 8. Write agent config files. No collision resolution
+                //    in this path — the function creates the dir if
+                //    missing and overwrites whatever's there. Same-
+                //    name same-hour launches will share a workdir;
+                //    proper allocation is tracked as a follow-up.
                 write_agent_config_files(&wstore, &agent, &agent_slug, &work_dir)?;
 
                 // 9. Register controller (resync)
@@ -1589,6 +1589,46 @@ fn find_agent_block(wstore: &WaveStore, tab_id: &str, agent_id: &str) -> Result<
         }
     }
     Ok(None)
+}
+
+/// Atomically allocate an agent working directory.
+///
+/// Tries to atomically create `desired` via `std::fs::create_dir`. If
+/// that fails because the directory already exists, tries `<desired>-1`,
+/// `<desired>-2`, …, up to `-99`. The atomic `create_dir` (NOT
+/// `create_dir_all` for the leaf) is the reservation mechanism: two
+/// concurrent callers competing for the same path race on the OS
+/// `mkdir` syscall and one wins; the loser sees `AlreadyExists` and
+/// moves on.
+///
+/// Caller is responsible for distinguishing auto-generated paths from
+/// user-specified ones — this function rewrites the path on collision,
+/// which would clobber a user's intent if they pointed an agent at
+/// `~/projects/myrepo` and that already had a `CLAUDE.md`.
+pub fn allocate_agent_workdir(desired: &str) -> Result<String, String> {
+    let p = std::path::Path::new(desired);
+    if let Some(parent) = p.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("allocate_agent_workdir: parent {}: {e}", parent.display()))?;
+        }
+    }
+    match std::fs::create_dir(p) {
+        Ok(()) => return Ok(desired.to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(e) => return Err(format!("allocate_agent_workdir: create_dir({}): {e}", desired)),
+    }
+    for n in 1..=99u32 {
+        let candidate = format!("{desired}-{n}");
+        match std::fs::create_dir(std::path::Path::new(&candidate)) {
+            Ok(()) => return Ok(candidate),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(e) => return Err(format!("allocate_agent_workdir: create_dir({candidate}): {e}")),
+        }
+    }
+    Err(format!(
+        "allocate_agent_workdir: too many collisions (>99) under {desired}-N — clean up old runs"
+    ))
 }
 
 /// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -250,28 +250,10 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let agent_slug = agent.name.to_lowercase()
                     .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
                     .collect::<String>();
-                let desired_work_dir = if agent.working_directory.is_empty() {
+                let work_dir = if agent.working_directory.is_empty() {
                     format!("~/.agentmux/agents/{}", agent_slug)
                 } else {
                     agent.working_directory.clone()
-                };
-                // Resolve collisions BEFORE building the block meta so
-                // `cmd:cwd` records the actual directory the agent
-                // will run in. allocate_agent_workdir returns the
-                // requested path verbatim when free, otherwise appends
-                // `-N` (1..=99) per spec §7.
-                let work_dir = {
-                    let expanded = expand_tilde_path(&desired_work_dir);
-                    let final_dir = allocate_agent_workdir(&expanded)?;
-                    if final_dir != expanded {
-                        tracing::info!(
-                            agent_id = %agent.id,
-                            from = %desired_work_dir,
-                            to = %final_dir,
-                            "agent.open: collision-resolved work_dir to free slot"
-                        );
-                    }
-                    final_dir
                 };
 
                 // Build env vars
@@ -1609,11 +1591,7 @@ fn find_agent_block(wstore: &WaveStore, tab_id: &str, agent_id: &str) -> Result<
     Ok(None)
 }
 
-/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the
-/// working directory. Caller is responsible for collision resolution
-/// (see [`allocate_agent_workdir`] — the call site in `agent.open`
-/// does this before building the block meta so `cmd:cwd` matches
-/// the actually-created directory).
+/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
 fn write_agent_config_files(
     wstore: &WaveStore,
     agent: &crate::backend::storage::ForgeAgent,
@@ -1650,8 +1628,10 @@ fn write_agent_config_files(
     };
 
     let base_path = std::path::Path::new(&expanded_dir);
-    std::fs::create_dir_all(base_path)
-        .map_err(|e| format!("failed to create working dir: {e}"))?;
+    if !base_path.exists() {
+        std::fs::create_dir_all(base_path)
+            .map_err(|e| format!("failed to create working dir: {e}"))?;
+    }
 
     for file in &config_files {
         let file_path = base_path.join(&file.filename);
@@ -1674,53 +1654,3 @@ fn write_agent_config_files(
     Ok(())
 }
 
-/// Expand `~` / `~/...` in a path against `$HOME` (or `$USERPROFILE`
-/// on Windows). Returns the input verbatim if neither var is set.
-fn expand_tilde_path(p: &str) -> String {
-    let rest = if p == "~" {
-        Some("")
-    } else {
-        // strip_prefix only matches the literal "~/" prefix; a bare
-        // "~" returns None here. trim_start_matches would have left a
-        // stray `~` in the suffix for the bare-tilde case (producing
-        // `/home/user/~`).
-        p.strip_prefix("~/")
-    };
-    let Some(rest) = rest else {
-        return p.to_string();
-    };
-    let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) else {
-        return p.to_string();
-    };
-    if rest.is_empty() {
-        home
-    } else {
-        format!("{home}/{rest}")
-    }
-}
-
-/// Pick an unused working dir for an agent launch. Mirrors the
-/// `<base>` → `<base>-1` → `<base>-2` … pattern from
-/// `SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md` §7.
-///
-/// "Used" means the path exists AND contains a `CLAUDE.md` (the
-/// agent-config marker). An empty existing directory is reused —
-/// covers the case where the user pre-created the folder. A
-/// non-existent path is preferred (no surprise reuse).
-fn allocate_agent_workdir(desired: &str) -> Result<String, String> {
-    fn looks_like_prior_run(p: &std::path::Path) -> bool {
-        p.is_dir() && p.join("CLAUDE.md").exists()
-    }
-    if !looks_like_prior_run(std::path::Path::new(desired)) {
-        return Ok(desired.to_string());
-    }
-    for n in 1..=99u32 {
-        let candidate = format!("{desired}-{n}");
-        if !looks_like_prior_run(std::path::Path::new(&candidate)) {
-            return Ok(candidate);
-        }
-    }
-    Err(format!(
-        "agent.open: too many collisions (>99) under {desired}-N — clean up old runs"
-    ))
-}

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -1677,13 +1677,26 @@ fn write_agent_config_files(
 /// Expand `~` / `~/...` in a path against `$HOME` (or `$USERPROFILE`
 /// on Windows). Returns the input verbatim if neither var is set.
 fn expand_tilde_path(p: &str) -> String {
-    if !(p.starts_with("~/") || p == "~") {
+    let rest = if p == "~" {
+        Some("")
+    } else {
+        // strip_prefix only matches the literal "~/" prefix; a bare
+        // "~" returns None here. trim_start_matches would have left a
+        // stray `~` in the suffix for the bare-tilde case (producing
+        // `/home/user/~`).
+        p.strip_prefix("~/")
+    };
+    let Some(rest) = rest else {
         return p.to_string();
+    };
+    let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) else {
+        return p.to_string();
+    };
+    if rest.is_empty() {
+        home
+    } else {
+        format!("{home}/{rest}")
     }
-    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-        return format!("{}/{}", home, p.trim_start_matches("~/"));
-    }
-    p.to_string()
 }
 
 /// Pick an unused working dir for an agent launch. Mirrors the

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -250,10 +250,28 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 let agent_slug = agent.name.to_lowercase()
                     .chars().map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '-' })
                     .collect::<String>();
-                let work_dir = if agent.working_directory.is_empty() {
+                let desired_work_dir = if agent.working_directory.is_empty() {
                     format!("~/.agentmux/agents/{}", agent_slug)
                 } else {
                     agent.working_directory.clone()
+                };
+                // Resolve collisions BEFORE building the block meta so
+                // `cmd:cwd` records the actual directory the agent
+                // will run in. allocate_agent_workdir returns the
+                // requested path verbatim when free, otherwise appends
+                // `-N` (1..=99) per spec §7.
+                let work_dir = {
+                    let expanded = expand_tilde_path(&desired_work_dir);
+                    let final_dir = allocate_agent_workdir(&expanded)?;
+                    if final_dir != expanded {
+                        tracing::info!(
+                            agent_id = %agent.id,
+                            from = %desired_work_dir,
+                            to = %final_dir,
+                            "agent.open: collision-resolved work_dir to free slot"
+                        );
+                    }
+                    final_dir
                 };
 
                 // Build env vars
@@ -343,7 +361,11 @@ fn register_agent_open(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "agent.open: block created + layout updated"
                 );
 
-                // 8. Write agent config files
+                // 8. Write agent config files into the already-
+                //    collision-resolved work_dir (allocated before the
+                //    block meta was built — see step 5). The function
+                //    no longer retries; it just creates the dir +
+                //    writes files.
                 write_agent_config_files(&wstore, &agent, &agent_slug, &work_dir)?;
 
                 // 9. Register controller (resync)
@@ -1587,7 +1609,11 @@ fn find_agent_block(wstore: &WaveStore, tab_id: &str, agent_id: &str) -> Result<
     Ok(None)
 }
 
-/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the working directory.
+/// Write agent config files (CLAUDE.md, .mcp.json, etc.) to the
+/// working directory. Caller is responsible for collision resolution
+/// (see [`allocate_agent_workdir`] — the call site in `agent.open`
+/// does this before building the block meta so `cmd:cwd` matches
+/// the actually-created directory).
 fn write_agent_config_files(
     wstore: &WaveStore,
     agent: &crate::backend::storage::ForgeAgent,
@@ -1624,10 +1650,8 @@ fn write_agent_config_files(
     };
 
     let base_path = std::path::Path::new(&expanded_dir);
-    if !base_path.exists() {
-        std::fs::create_dir_all(base_path)
-            .map_err(|e| format!("failed to create working dir: {e}"))?;
-    }
+    std::fs::create_dir_all(base_path)
+        .map_err(|e| format!("failed to create working dir: {e}"))?;
 
     for file in &config_files {
         let file_path = base_path.join(&file.filename);
@@ -1648,4 +1672,42 @@ fn write_agent_config_files(
     );
 
     Ok(())
+}
+
+/// Expand `~` / `~/...` in a path against `$HOME` (or `$USERPROFILE`
+/// on Windows). Returns the input verbatim if neither var is set.
+fn expand_tilde_path(p: &str) -> String {
+    if !(p.starts_with("~/") || p == "~") {
+        return p.to_string();
+    }
+    if let Ok(home) = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+        return format!("{}/{}", home, p.trim_start_matches("~/"));
+    }
+    p.to_string()
+}
+
+/// Pick an unused working dir for an agent launch. Mirrors the
+/// `<base>` → `<base>-1` → `<base>-2` … pattern from
+/// `SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md` §7.
+///
+/// "Used" means the path exists AND contains a `CLAUDE.md` (the
+/// agent-config marker). An empty existing directory is reused —
+/// covers the case where the user pre-created the folder. A
+/// non-existent path is preferred (no surprise reuse).
+fn allocate_agent_workdir(desired: &str) -> Result<String, String> {
+    fn looks_like_prior_run(p: &std::path::Path) -> bool {
+        p.is_dir() && p.join("CLAUDE.md").exists()
+    }
+    if !looks_like_prior_run(std::path::Path::new(desired)) {
+        return Ok(desired.to_string());
+    }
+    for n in 1..=99u32 {
+        let candidate = format!("{desired}-{n}");
+        if !looks_like_prior_run(std::path::Path::new(&candidate)) {
+            return Ok(candidate);
+        }
+    }
+    Err(format!(
+        "agent.open: too many collisions (>99) under {desired}-N — clean up old runs"
+    ))
 }

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -897,15 +897,28 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 tracing::info!(
                     working_dir = %cmd.working_dir,
                     file_count = cmd.files.len(),
+                    auto_allocate = cmd.auto_allocate,
                     "WriteAgentConfig"
                 );
 
+                // Resolve to a final on-disk path. For auto-generated
+                // instance paths (`auto_allocate: true`), use the
+                // atomic `<base>-N` allocator so concurrent same-hour
+                // launches don't share a workdir. For user-specified
+                // paths, mkdir-p as before — never rewrite.
                 let expanded_working_dir = expand_home_dir_safe(&cmd.working_dir);
-                let base_path = expanded_working_dir.as_path();
-                if !base_path.exists() {
-                    std::fs::create_dir_all(base_path)
-                        .map_err(|e| format!("failed to create working dir: {e}"))?;
-                }
+                let final_working_dir = if cmd.auto_allocate {
+                    let desired = expanded_working_dir.to_string_lossy().to_string();
+                    crate::server::app_api::allocate_agent_workdir(&desired)?
+                } else {
+                    let p = expanded_working_dir.as_path();
+                    if !p.exists() {
+                        std::fs::create_dir_all(p)
+                            .map_err(|e| format!("failed to create working dir: {e}"))?;
+                    }
+                    expanded_working_dir.to_string_lossy().to_string()
+                };
+                let base_path = std::path::Path::new(&final_working_dir);
 
                 for file in &cmd.files {
                     let file_path = base_path.join(&file.path);
@@ -935,7 +948,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     tracing::debug!(path = %file_path.display(), "wrote config file");
                 }
 
-                Ok(None)
+                // Return the final path so the caller can patch
+                // `cmd:cwd` if collision resolution changed it.
+                Ok(Some(serde_json::json!({
+                    "working_dir": final_working_dir,
+                })))
             })
         }),
     );

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -767,7 +767,11 @@ class RpcApiType {
     }
 
     // command "writeagentconfig" [call]
-    WriteAgentConfigCommand(client: RpcClient, data: CommandWriteAgentConfigData, opts?: RpcOpts): Promise<void> {
+    WriteAgentConfigCommand(
+        client: RpcClient,
+        data: CommandWriteAgentConfigData,
+        opts?: RpcOpts,
+    ): Promise<{ working_dir: string }> {
         return client.rpcCall("writeagentconfig", data, opts);
     }
 

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -376,16 +376,21 @@ export class AgentViewModel implements ViewModel {
             // Whether the work_dir was constructed by us (and is thus
             // eligible for `<base>-N` collision suffixing) or was
             // pulled verbatim from the agent definition's
-            // `working_directory` field (e.g. a user repo path that
-            // we must NOT rewrite even if it happens to contain
-            // CLAUDE.md). The two auto cases above are: an explicit
-            // overrides.instanceName launch, and the legacy
-            // ~/.agentmux/agents/<slug> default when no
-            // working_directory was set on the definition.
+            // `working_directory` field (which we must NEVER rewrite,
+            // even if it happens to live under ~/.agentmux/ — a user
+            // can legitimately set `agent.working_directory` to
+            // `~/.agentmux/my-project` and expect that exact dir).
+            //
+            // Auto cases:
+            //   - overrides.instanceName given (modal launch chose a
+            //     fresh per-launch slug)
+            //   - working_directory is empty (we filled in the legacy
+            //     ~/.agentmux/agents/<slug> default ourselves)
+            // Any other persisted value is user-specified and stays
+            // verbatim through allocation.
             const autoAllocate =
                 Boolean(overrides?.instanceName) ||
-                (agent.working_directory ?? "").trim() === "" ||
-                persisted.startsWith("~/.agentmux/");
+                (agent.working_directory ?? "").trim() === "";
 
             // Allocate the workdir + write config files BEFORE we set
             // cmd:cwd, so the meta records the actual collision-

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -373,7 +373,35 @@ export class AgentViewModel implements ViewModel {
         const oref = WOS.makeORef("block", this.blockId);
         const blockId = this.blockId;
         try {
-            // Store CLI config in block metadata
+            // Whether the work_dir was constructed by us (and is thus
+            // eligible for `<base>-N` collision suffixing) or was
+            // pulled verbatim from the agent definition's
+            // `working_directory` field (e.g. a user repo path that
+            // we must NOT rewrite even if it happens to contain
+            // CLAUDE.md). The two auto cases above are: an explicit
+            // overrides.instanceName launch, and the legacy
+            // ~/.agentmux/agents/<slug> default when no
+            // working_directory was set on the definition.
+            const autoAllocate =
+                Boolean(overrides?.instanceName) ||
+                (agent.working_directory ?? "").trim() === "" ||
+                persisted.startsWith("~/.agentmux/");
+
+            // Allocate the workdir + write config files BEFORE we set
+            // cmd:cwd, so the meta records the actual collision-
+            // resolved path the controller will spawn the CLI in.
+            // Always call WriteAgentConfigCommand (even with no files
+            // to write) when auto-allocate so we get the atomic
+            // `mkdir` reservation. Returns the final path.
+            const writeResult = await RpcApi.WriteAgentConfigCommand(TabRpcClient, {
+                working_dir: workDir,
+                files: configFiles,
+                auto_allocate: autoAllocate,
+            });
+            const finalWorkDir = writeResult?.working_dir || workDir;
+
+            // Store CLI config in block metadata using the (possibly
+            // collision-resolved) finalWorkDir.
             await RpcApi.SetMetaCommand(TabRpcClient, {
                 oref,
                 meta: {
@@ -386,20 +414,12 @@ export class AgentViewModel implements ViewModel {
                     controller: isPersistent ? "persistent" : "subprocess",
                     cmd: cliBin,
                     "cmd:args": cliArgs,
-                    "cmd:cwd": workDir,
+                    "cmd:cwd": finalWorkDir,
                     "cmd:env": envVars,
                     "agent:resume_flag": provider.resumeFlag ?? "",
                     "agent:session_id_field": provider.sessionIdField,
                 },
             });
-
-            // Write config files (CLAUDE.md, .mcp.json) to working directory via backend
-            if (configFiles.length > 0) {
-                await RpcApi.WriteAgentConfigCommand(TabRpcClient, {
-                    working_dir: workDir,
-                    files: configFiles,
-                });
-            }
 
             // Create SubprocessController (no-op start — waits for first message)
             await RpcApi.ControllerResyncCommand(TabRpcClient, {

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -51,8 +51,9 @@ function hourToBase24Char(h: number): string {
  *   DD = 2-digit day (01-31)
  *   h  = base24 hour char (0-9 then a-n for 10-23)
  *
- * Total: 5 chars exactly. Two launches within the same hour collide
- * and require the launch-time `-N` counter (see allocateWorkDir).
+ * Total: 5 chars exactly. Two launches within the same hour share
+ * a slug; collision resolution is a follow-up (the previous
+ * millisecond-precision suffix made this a non-issue).
  *
  * Year is omitted because per-version isolation already separates
  * runs across releases; within a version, month+day+hour gives users
@@ -69,7 +70,7 @@ export function formatLocalStamp(d: Date): string {
  * `<slug>-<stamp>` — stable, filesystem-safe, and 5-char date.
  *
  * Collision resolution: callers should pass the result through
- * `allocateWorkDir()` or equivalent at launch time to append `-N`
+ * `a future server-side allocator` or equivalent at launch time to append `-N`
  * when the directory already exists.
  */
 export function buildInstanceSlug(name: string, at: Date = new Date()): string {

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -7,8 +7,9 @@
  * (for preview) and the AgentViewModel (for actual launch) agree on
  * the format without importing from each other's files.
  *
- * Format: `<slug(name)>-<YYYYMMDD-HHMMSS>`, local time.
- * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md §7.
+ * Format: `<slug(name)>-MMDDh`, local time. Conflict resolution
+ * appends `-N` (1, 2, …) at launch time when the directory already
+ * exists; see AgentViewModel.allocateWorkDir().
  */
 
 /**
@@ -26,26 +27,43 @@ export function slugifyInstanceName(name: string): string {
 }
 
 /**
- * Format a Date as `YYYYMMDD-HHMMSS-mmm` in the caller's local time.
- * The millisecond suffix makes the stamp unique across realistic
- * concurrent launches — two clicks in the same millisecond are not
- * a failure mode we optimise for. Codex flagged sub-second collisions
- * on PR #504 (https://github.com/agentmuxai/agentmux/pull/504); this
- * form closes that gap without reaching for UUIDs.
+ * Encode `0..23` as a single base24 character: digits 0-9 then
+ * lowercase letters a-n. This compresses the time component into
+ * one char so the full stamp fits in 5.
+ */
+function hourToBase24Char(h: number): string {
+    if (h < 0 || h > 23) {
+        throw new RangeError(`hour out of range: ${h}`);
+    }
+    return h < 10 ? String(h) : String.fromCharCode("a".charCodeAt(0) + (h - 10));
+}
+
+/**
+ * Format a Date as `MMDDh` in the caller's local time:
+ *   MM = 2-digit month (01-12)
+ *   DD = 2-digit day (01-31)
+ *   h  = base24 hour char (0-9 then a-n for 10-23)
+ *
+ * Total: 5 chars exactly. Two launches within the same hour collide
+ * and require the launch-time `-N` counter (see allocateWorkDir).
+ *
+ * Year is omitted because per-version isolation already separates
+ * runs across releases; within a version, month+day+hour gives users
+ * enough context to recognize their own folders on disk without
+ * burning chars on the year prefix.
  */
 export function formatLocalStamp(d: Date): string {
-    const pad = (n: number, w = 2) => String(n).padStart(w, "0");
-    return (
-        `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}` +
-        `-${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}` +
-        `-${pad(d.getMilliseconds(), 3)}`
-    );
+    const pad2 = (n: number) => String(n).padStart(2, "0");
+    return `${pad2(d.getMonth() + 1)}${pad2(d.getDate())}${hourToBase24Char(d.getHours())}`;
 }
 
 /**
  * Build the per-instance slug for a given name at the given time.
- * `<slug>-<stamp>` — stable, filesystem-safe, and unique at 1ms
- * granularity.
+ * `<slug>-<stamp>` — stable, filesystem-safe, and 5-char date.
+ *
+ * Collision resolution: callers should pass the result through
+ * `allocateWorkDir()` or equivalent at launch time to append `-N`
+ * when the directory already exists.
  */
 export function buildInstanceSlug(name: string, at: Date = new Date()): string {
     return `${slugifyInstanceName(name)}-${formatLocalStamp(at)}`;

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -7,12 +7,16 @@
  * (for preview) and the AgentViewModel (for actual launch) agree on
  * the format without importing from each other's files.
  *
- * Format: `<slug(name)>-MMDDh`, local time. Collision resolution is
- * handled server-side: `agent.open` calls
- * `allocate_agent_workdir()` in agentmux-srv/src/server/app_api.rs
- * which appends `-N` (1, 2, …) when the desired directory already
- * contains a prior agent run (CLAUDE.md present). The block's
- * `cmd:cwd` meta records the actual collision-resolved path.
+ * Format: `<slug(name)>-MMDDh`, local time.
+ *
+ * NOTE: Collision resolution (when two launches in the same hour
+ * produce identical slugs) is currently NOT implemented end-to-end —
+ * the actual launch flow uses `WriteAgentConfigCommand` which writes
+ * config into whatever path it's given. Two same-hour launches with
+ * the same instance name will share a workdir and overwrite each
+ * other's config files. Tracked for follow-up; needs an RPC return-
+ * type change (final path) + frontend `cmd:cwd` patch + atomic
+ * `create_dir` allocation on the backend.
  */
 
 /**

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -7,16 +7,12 @@
  * (for preview) and the AgentViewModel (for actual launch) agree on
  * the format without importing from each other's files.
  *
- * Format: `<slug(name)>-MMDDh`, local time.
- *
- * NOTE: Collision resolution (when two launches in the same hour
- * produce identical slugs) is currently NOT implemented end-to-end —
- * the actual launch flow uses `WriteAgentConfigCommand` which writes
- * config into whatever path it's given. Two same-hour launches with
- * the same instance name will share a workdir and overwrite each
- * other's config files. Tracked for follow-up; needs an RPC return-
- * type change (final path) + frontend `cmd:cwd` patch + atomic
- * `create_dir` allocation on the backend.
+ * Format: `<slug(name)>-MMDDh`, local time. Same-hour collisions are
+ * resolved server-side by `agentmux-srv/src/server/app_api.rs::
+ * allocate_agent_workdir`, called from `WriteAgentConfigCommand`
+ * when the frontend sets `auto_allocate: true`. The atomic mkdir +
+ * `<base>-N` retry there is the source of truth for collision
+ * handling — this module only owns the slug format.
  */
 
 /**
@@ -51,9 +47,10 @@ function hourToBase24Char(h: number): string {
  *   DD = 2-digit day (01-31)
  *   h  = base24 hour char (0-9 then a-n for 10-23)
  *
- * Total: 5 chars exactly. Two launches within the same hour share
- * a slug; collision resolution is a follow-up (the previous
- * millisecond-precision suffix made this a non-issue).
+ * Total: 5 chars exactly. Two launches within the same hour produce
+ * the same slug; the launch flow resolves the collision server-side
+ * by calling `WriteAgentConfigCommand` with `auto_allocate: true`,
+ * which appends `-N` (1, 2, …) until a free slot is found.
  *
  * Year is omitted because per-version isolation already separates
  * runs across releases; within a version, month+day+hour gives users
@@ -69,9 +66,9 @@ export function formatLocalStamp(d: Date): string {
  * Build the per-instance slug for a given name at the given time.
  * `<slug>-<stamp>` — stable, filesystem-safe, and 5-char date.
  *
- * Collision resolution: callers should pass the result through
- * `a future server-side allocator` or equivalent at launch time to append `-N`
- * when the directory already exists.
+ * Collision resolution happens at launch time on the server (see
+ * the module docstring). Callers don't need to pass this through any
+ * additional helper.
  */
 export function buildInstanceSlug(name: string, at: Date = new Date()): string {
     return `${slugifyInstanceName(name)}-${formatLocalStamp(at)}`;

--- a/frontend/app/view/agent/defaults/instance-slug.ts
+++ b/frontend/app/view/agent/defaults/instance-slug.ts
@@ -7,9 +7,12 @@
  * (for preview) and the AgentViewModel (for actual launch) agree on
  * the format without importing from each other's files.
  *
- * Format: `<slug(name)>-MMDDh`, local time. Conflict resolution
- * appends `-N` (1, 2, …) at launch time when the directory already
- * exists; see AgentViewModel.allocateWorkDir().
+ * Format: `<slug(name)>-MMDDh`, local time. Collision resolution is
+ * handled server-side: `agent.open` calls
+ * `allocate_agent_workdir()` in agentmux-srv/src/server/app_api.rs
+ * which appends `-N` (1, 2, …) when the desired directory already
+ * contains a prior agent run (CLAUDE.md present). The block's
+ * `cmd:cwd` meta records the actual collision-resolved path.
  */
 
 /**

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1679,6 +1679,10 @@ declare global {
     type CommandWriteAgentConfigData = {
         working_dir: string;
         files: AgentConfigFile[];
+        // When true, treat working_dir as an auto-generated instance
+        // path eligible for `<base>-N` collision resolution. When
+        // false (user-specified path), write into the path as-is.
+        auto_allocate?: boolean;
     };
 
     // wshrpc.CommandReadEditorFileData

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.641",
+  "version": "0.33.642",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.641",
+      "version": "0.33.642",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.641",
+  "version": "0.33.642",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Replaces `YYYYMMDD-HHMMSS-mmm` (17 chars) with `MMDDh` (5 chars) and wires up proper end-to-end collision resolution.

## Frontend (instance-slug.ts)

`formatLocalStamp(d)` returns `MMDDh`:
- `MM` = 2-digit month
- `DD` = 2-digit day
- `h` = single base24 char (`0`-`9` then `a`-`n` for hours 10-23)

Examples: May 5 14:00 → `0505e`; Dec 31 23:59 → `1231n`. Year is omitted — per-version isolation already separates releases.

## Collision resolution (the launch path)

`AgentViewModel.launchForgeAgent` calls `WriteAgentConfigCommand` BEFORE `SetMetaCommand`, with a new `auto_allocate: bool` flag. The backend handler in `websocket.rs` routes through `allocate_agent_workdir` (in `app_api.rs`) which uses **atomic `std::fs::create_dir(leaf)` as the reservation mechanism** — two concurrent callers race on the OS `mkdir` syscall and one wins; the loser sees `AlreadyExists` and tries `<base>-1`, `-2`, ..., up to `-99`. No CLAUDE.md heuristic, no TOCTOU.

The RPC returns the final `working_dir`. Frontend captures it and uses it for `cmd:cwd` in the subsequent `SetMetaCommand`, so the controller spawns the CLI in the actually-created directory.

## auto_allocate gating (avoids regression for user paths)

The frontend sets `auto_allocate: true` only for paths it constructed itself:
- `overrides.instanceName` is given (modal-driven per-launch slug), OR
- `agent.working_directory` is empty (we filled in the legacy `~/.agentmux/agents/<slug>` default ourselves)

Any explicit persisted path — including paths under `~/.agentmux/` — flows through unchanged. A user pointing an agent at `~/projects/myrepo` (where they have an existing CLAUDE.md) sees the agent run in that exact directory.

## What `agent.open` does NOT do

`agent.open` is a separate RPC code path (frontend's `launchForgeAgent` doesn't go through it). It still calls `write_agent_config_files` directly without allocation — same as before this PR. A comment at `app_api.rs:346` documents this. If a future flow starts using `agent.open` for instance launches, it'll need its own allocation hookup. For now, no behavior change there.

## Build + tests

- agentmux-srv + agentmux-cef build clean
- agentmux-common: 45 tests pass
- agentmux-srv: 826 pass; 4 pre-existing failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
