### PR TITLE
docs: simplify Contact Us section

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,9 +239,7 @@ curl -sf https://agentmux.ai/release.json | jq .version  # landing shows new ver
 
 ## Contact Us
 
-For enterprises interested in adopting or deploying AgentMux at scale, including technical consulting, sponsorship opportunities, or partnership inquiries, please contact us at [enterprise@agentmux.ai](mailto:enterprise@agentmux.ai) or [partner@agentmux.ai](mailto:partner@agentmux.ai).
-
-Long-term active AgentMux contributors are eligible for coding agent sponsorship, including tools such as Cursor, Claude Code, or OpenAI Codex. Email [partner@agentmux.ai](mailto:partner@agentmux.ai) with your most important commits or pull requests.
+For enterprises interested in adopting or deploying AgentMux at scale, including technical consulting, sponsorship opportunities, or partnership inquiries, please contact us at [enterprise@agentmux.ai](mailto:enterprise@agentmux.ai).
 
 ## License
 


### PR DESCRIPTION
## Summary

- Removes the second paragraph (contributor/sponsorship copy)
- Removes `partner@agentmux.ai`, leaving only `enterprise@agentmux.ai`

## Result

> For enterprises interested in adopting or deploying AgentMux at scale, including technical consulting, sponsorship opportunities, or partnership inquiries, please contact us at enterprise@agentmux.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)