### PR TITLE
fix(srv): Windows UNC path-traversal bug in writeagentconfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.643"
+version = "0.33.644"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.643"
+version = "0.33.644"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.643"
+version = "0.33.644"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.643"
+version = "0.33.644"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.644 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.643 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.624 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |
 | 0.33.614 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.643 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.624 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |
 | 0.33.614 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |
 | 0.33.592 | 2026-05-02 | 161.9 MiB | 339.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.643"
+version = "0.33.644"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.643"
+version = "0.33.644"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.643"
+version = "0.33.644"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.643"
+version = "0.33.644"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/base.rs
+++ b/agentmux-srv/src/backend/base.rs
@@ -268,6 +268,55 @@ pub fn expand_home_dir_safe(path: &str) -> PathBuf {
     expand_home_dir(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// Lexically join `relative` onto `base` while guaranteeing the result
+/// stays inside `base`. No filesystem access — does not require either
+/// path to exist, which matters on Windows where `Path::canonicalize`
+/// adds the `\\?\` UNC prefix and breaks naive `starts_with` checks
+/// against not-yet-created files.
+///
+/// The relative path:
+/// - must be non-empty
+/// - must NOT be absolute (rooted, drive-prefixed, or starting with `/`/`\`)
+/// - must NOT contain a `..` component
+/// - may contain `.` components (silently dropped)
+/// - is treated as forward- or back-slash separated; both are accepted
+///
+/// Returns `base.join(<cleaned>)` on success.
+pub fn safe_join_within_base(base: &Path, relative: &str) -> Result<PathBuf, String> {
+    if relative.is_empty() {
+        return Err("safe_join_within_base: empty relative path".into());
+    }
+    let rel_path = Path::new(relative);
+    if rel_path.is_absolute() {
+        return Err(format!("safe_join_within_base: absolute path not allowed: {relative}"));
+    }
+    // On Windows `Path::is_absolute` covers drive-letter and UNC roots,
+    // but a leading `/` or `\` (without drive) is technically "rooted but
+    // not absolute". Reject those too — they'd resolve onto the current
+    // drive's root, escaping `base`.
+    if matches!(relative.chars().next(), Some('/') | Some('\\')) {
+        return Err(format!("safe_join_within_base: rooted path not allowed: {relative}"));
+    }
+    let mut cleaned = PathBuf::new();
+    for segment in relative.split(['/', '\\']) {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                return Err(format!(
+                    "safe_join_within_base: '..' traversal not allowed: {relative}"
+                ));
+            }
+            other => cleaned.push(other),
+        }
+    }
+    if cleaned.as_os_str().is_empty() {
+        return Err(format!(
+            "safe_join_within_base: relative path resolves to empty: {relative}"
+        ));
+    }
+    Ok(base.join(cleaned))
+}
+
 /// Replace the home directory prefix with `~`.
 pub fn replace_home_dir(path: &str) -> String {
     let home = get_home_dir();
@@ -398,6 +447,68 @@ mod tests {
         // But normal dots are fine
         assert!(expand_home_dir("~/.config").is_ok());
         assert!(expand_home_dir("/tmp/.hidden").is_ok());
+    }
+
+    #[test]
+    fn test_safe_join_within_base_simple() {
+        let base = PathBuf::from("/home/user/agent");
+        let p = safe_join_within_base(&base, "CLAUDE.md").unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/agent/CLAUDE.md"));
+    }
+
+    #[test]
+    fn test_safe_join_within_base_nested() {
+        let base = PathBuf::from("/home/user/agent");
+        let p = safe_join_within_base(&base, ".claude/commands/startup.md").unwrap();
+        assert_eq!(p, PathBuf::from("/home/user/agent/.claude/commands/startup.md"));
+    }
+
+    #[test]
+    fn test_safe_join_within_base_backslash_separator() {
+        // Frontends running on Windows may send `\\` separators; accept them.
+        let base = PathBuf::from("C:\\agent");
+        let p = safe_join_within_base(&base, ".claude\\commands\\startup.md").unwrap();
+        // The cleaned components are joined as native segments — final path
+        // should contain all three trailing pieces in order.
+        let s = p.to_string_lossy();
+        assert!(s.contains(".claude"));
+        assert!(s.contains("commands"));
+        assert!(s.contains("startup.md"));
+    }
+
+    #[test]
+    fn test_safe_join_within_base_dot_segments_skipped() {
+        let base = PathBuf::from("/base");
+        let p = safe_join_within_base(&base, "./a/./b").unwrap();
+        assert_eq!(p, PathBuf::from("/base/a/b"));
+    }
+
+    #[test]
+    fn test_safe_join_within_base_rejects_dotdot() {
+        let base = PathBuf::from("/base");
+        assert!(safe_join_within_base(&base, "..").is_err());
+        assert!(safe_join_within_base(&base, "../etc").is_err());
+        assert!(safe_join_within_base(&base, "a/../b").is_err());
+        assert!(safe_join_within_base(&base, "a/b/..").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_within_base_rejects_absolute() {
+        let base = PathBuf::from("/base");
+        assert!(safe_join_within_base(&base, "/etc/passwd").is_err());
+        assert!(safe_join_within_base(&base, "\\Windows\\System32").is_err());
+        // Bare leading slash on a relative-looking path is also rooted.
+        assert!(safe_join_within_base(&base, "/foo").is_err());
+        #[cfg(windows)]
+        assert!(safe_join_within_base(&base, "C:\\Windows").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_within_base_rejects_empty() {
+        let base = PathBuf::from("/base");
+        assert!(safe_join_within_base(&base, "").is_err());
+        // After stripping `.` segments, an effectively-empty path also fails.
+        assert!(safe_join_within_base(&base, "./.").is_err());
     }
 
     #[test]

--- a/agentmux-srv/src/backend/base.rs
+++ b/agentmux-srv/src/backend/base.rs
@@ -268,6 +268,58 @@ pub fn expand_home_dir_safe(path: &str) -> PathBuf {
     expand_home_dir(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// After a lexical join, verify that no symlinked ancestor of the
+/// candidate path escapes `base_canonical`. The lexical helper alone
+/// can't catch this: if `<base>/.claude` is a symlink to `/tmp/outside`
+/// and the caller writes `<base>/.claude/commands/startup.md`, the
+/// final write follows the symlink and lands outside the working dir.
+///
+/// Walks from `final_path` upward and canonicalizes the deepest
+/// existing ancestor — that resolution dereferences any symlink in
+/// the chain. If the resolved path stays under `base_canonical`, no
+/// symlink in the existing portion escapes. Non-existent components
+/// are safe by definition (nothing to resolve, nothing to follow).
+///
+/// Returns Ok(()) if safe, Err with a human-readable message otherwise.
+///
+/// Caller invariant: the directory rooted at `base_canonical` must
+/// exist (so the upward walk is guaranteed to find it before reaching
+/// the filesystem root). `writeagentconfig` satisfies this — the
+/// working dir is created via `allocate_agent_workdir` or `mkdir_p`
+/// immediately before this is called.
+pub fn verify_no_symlink_escape(
+    final_path: &Path,
+    base_canonical: &Path,
+) -> Result<(), String> {
+    let mut p = final_path;
+    loop {
+        match p.canonicalize() {
+            Ok(canonical) => {
+                if !canonical.starts_with(base_canonical) {
+                    return Err(format!(
+                        "symlinked ancestor escapes working dir: {} → {}",
+                        p.display(),
+                        canonical.display()
+                    ));
+                }
+                return Ok(());
+            }
+            Err(_) => match p.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => p = parent,
+                _ => {
+                    // Walked past every existing ancestor without finding
+                    // one inside `base_canonical`. This violates the
+                    // caller invariant (base should exist) — fail closed.
+                    return Err(format!(
+                        "no existing ancestor found under base: {}",
+                        final_path.display()
+                    ));
+                }
+            },
+        }
+    }
+}
+
 /// True if `s` starts with `<ASCII letter>:` — a Windows drive-letter
 /// prefix. Both rooted (`C:\foo`) and drive-relative (`C:foo`) forms
 /// match. Used by `safe_join_within_base` to reject paths that would
@@ -564,6 +616,41 @@ mod tests {
         // First segment is also covered by the inner check (defense in
         // depth — both upfront + per-segment guards reject it).
         assert!(safe_join_within_base(&base, "C:foo/bar").is_err());
+    }
+
+    #[test]
+    fn test_verify_no_symlink_escape_existing_inside_base() {
+        // If the existing ancestor is the base itself, canonicalize
+        // succeeds and starts_with passes. Use the OS temp dir as a
+        // base that's guaranteed to exist on every CI/dev box.
+        let base = std::env::temp_dir();
+        let canonical_base = base.canonicalize().unwrap();
+        let target = base.join("nonexistent-subdir").join("file.md");
+        assert!(verify_no_symlink_escape(&target, &canonical_base).is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_verify_no_symlink_escape_rejects_symlinked_ancestor() {
+        // Build a temp base, create a symlink under it pointing OUTSIDE
+        // the base, and verify the helper rejects writes through it.
+        // Unix-only because std::os::unix::fs::symlink is the simplest
+        // way to set this up; the cross-platform behavior is identical.
+        use std::os::unix::fs::symlink;
+        let tmp = std::env::temp_dir();
+        let base = tmp.join("agentmux-symlink-test-base");
+        let outside = tmp.join("agentmux-symlink-test-outside");
+        let _ = std::fs::remove_dir_all(&base);
+        let _ = std::fs::remove_dir_all(&outside);
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let canonical_base = base.canonicalize().unwrap();
+        symlink(&outside, base.join(".claude")).unwrap();
+        let target = base.join(".claude").join("commands").join("startup.md");
+        assert!(verify_no_symlink_escape(&target, &canonical_base).is_err());
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&base);
+        let _ = std::fs::remove_dir_all(&outside);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/base.rs
+++ b/agentmux-srv/src/backend/base.rs
@@ -268,6 +268,18 @@ pub fn expand_home_dir_safe(path: &str) -> PathBuf {
     expand_home_dir(path).unwrap_or_else(|_| PathBuf::from(path))
 }
 
+/// True if `s` starts with `<ASCII letter>:` — a Windows drive-letter
+/// prefix. Both rooted (`C:\foo`) and drive-relative (`C:foo`) forms
+/// match. Used by `safe_join_within_base` to reject paths that would
+/// rebase off the working directory under Windows path semantics.
+fn has_drive_letter_prefix(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(c), Some(':')) if c.is_ascii_alphabetic()
+    )
+}
+
 /// Lexically join `relative` onto `base` while guaranteeing the result
 /// stays inside `base`. No filesystem access — does not require either
 /// path to exist, which matters on Windows where `Path::canonicalize`
@@ -296,6 +308,16 @@ pub fn safe_join_within_base(base: &Path, relative: &str) -> Result<PathBuf, Str
     // drive's root, escaping `base`.
     if matches!(relative.chars().next(), Some('/') | Some('\\')) {
         return Err(format!("safe_join_within_base: rooted path not allowed: {relative}"));
+    }
+    // Windows drive-letter prefix (e.g. `C:foo`, `D:\bar`). `is_absolute()`
+    // requires both prefix AND root, so a drive-relative path like
+    // `C:payload.txt` slips through unless we reject it explicitly.
+    // `Path::join` would otherwise replace the base with the drive's CWD
+    // on Windows, escaping the working directory.
+    if has_drive_letter_prefix(relative) {
+        return Err(format!(
+            "safe_join_within_base: drive-letter prefix not allowed: {relative}"
+        ));
     }
     let mut cleaned = PathBuf::new();
     for segment in relative.split(['/', '\\']) {
@@ -501,6 +523,36 @@ mod tests {
         assert!(safe_join_within_base(&base, "/foo").is_err());
         #[cfg(windows)]
         assert!(safe_join_within_base(&base, "C:\\Windows").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_within_base_rejects_drive_letter_prefix() {
+        // Drive-relative (no root) — Path::is_absolute() returns false on
+        // Windows, but Path::join would still replace base with the
+        // drive's CWD. Must be rejected on every platform so the helper
+        // behaves consistently regardless of where the validation runs.
+        let base = PathBuf::from("/base");
+        assert!(safe_join_within_base(&base, "C:foo").is_err());
+        assert!(safe_join_within_base(&base, "D:payload.txt").is_err());
+        assert!(safe_join_within_base(&base, "z:relative\\file").is_err());
+        // Rooted drive paths also rejected (already covered by is_absolute
+        // on Windows; on Unix the drive-letter check catches them).
+        assert!(safe_join_within_base(&base, "C:\\Windows\\System32").is_err());
+    }
+
+    #[test]
+    fn test_has_drive_letter_prefix() {
+        assert!(has_drive_letter_prefix("C:foo"));
+        assert!(has_drive_letter_prefix("c:bar"));
+        assert!(has_drive_letter_prefix("Z:\\baz"));
+        assert!(!has_drive_letter_prefix(":foo"));
+        assert!(!has_drive_letter_prefix("foo"));
+        assert!(!has_drive_letter_prefix("12:not-a-drive"));
+        assert!(!has_drive_letter_prefix(""));
+        // Multibyte first char: the check requires ASCII letter, so
+        // non-ASCII letters do NOT match (they wouldn't be valid drive
+        // letters on Windows anyway).
+        assert!(!has_drive_letter_prefix("Ω:foo"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/base.rs
+++ b/agentmux-srv/src/backend/base.rs
@@ -328,6 +328,16 @@ pub fn safe_join_within_base(base: &Path, relative: &str) -> Result<PathBuf, Str
                     "safe_join_within_base: '..' traversal not allowed: {relative}"
                 ));
             }
+            // A drive-letter prefix on any segment (not just the first
+            // one) is rejected — `PathBuf::push("C:foo")` on Windows
+            // discards the accumulated path and rebases on the C drive's
+            // CWD, so a nested input like `safe/C:payload.txt` would
+            // escape `base` despite the upfront whole-string guard.
+            other if has_drive_letter_prefix(other) => {
+                return Err(format!(
+                    "safe_join_within_base: drive-letter prefix in segment {other:?}: {relative}"
+                ));
+            }
             other => cleaned.push(other),
         }
     }
@@ -538,6 +548,22 @@ mod tests {
         // Rooted drive paths also rejected (already covered by is_absolute
         // on Windows; on Unix the drive-letter check catches them).
         assert!(safe_join_within_base(&base, "C:\\Windows\\System32").is_err());
+    }
+
+    #[test]
+    fn test_safe_join_within_base_rejects_drive_letter_in_inner_segment() {
+        // The whole-string drive-letter guard misses nested cases like
+        // `safe/C:payload.txt` because the prefix isn't at position 0.
+        // `PathBuf::push` on Windows would still rebase on a drive when
+        // it sees `C:payload.txt`, so the per-segment guard inside the
+        // loop must also reject these.
+        let base = PathBuf::from("/base");
+        assert!(safe_join_within_base(&base, "safe/C:payload.txt").is_err());
+        assert!(safe_join_within_base(&base, "a/b/D:malicious").is_err());
+        assert!(safe_join_within_base(&base, "subdir\\E:nested").is_err());
+        // First segment is also covered by the inner check (defense in
+        // depth — both upfront + per-segment guards reject it).
+        assert!(safe_join_within_base(&base, "C:foo/bar").is_err());
     }
 
     #[test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -919,16 +919,31 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     expanded_working_dir.to_string_lossy().to_string()
                 };
                 let base_path = std::path::Path::new(&final_working_dir);
+                // Canonicalize base ONCE (it exists — allocate_agent_workdir
+                // or the explicit-path mkdir-p created it just above). Used
+                // by the per-file symlink-escape verifier so we catch a
+                // symlinked ancestor like `<base>/.claude -> /tmp/outside`
+                // before fs::write follows it.
+                let canonical_base = base_path.canonicalize().map_err(|e| {
+                    format!("failed to canonicalize working dir {}: {e}", base_path.display())
+                })?;
 
                 for file in &cmd.files {
                     // Lexical join + traversal check — works on Windows where
                     // canonicalize() adds the `\\?\` UNC prefix and breaks
-                    // starts_with against not-yet-created files.
+                    // starts_with against not-yet-created files. Catches `..`,
+                    // absolute paths, drive-letter prefixes (root and inner).
                     let file_path = crate::backend::base::safe_join_within_base(
                         base_path,
                         &file.path,
                     )
                     .map_err(|e| format!("path traversal denied: {} ({e})", file.path))?;
+                    // Symlink-escape guard: if any EXISTING ancestor is a
+                    // symlink that resolves outside the workdir, reject.
+                    // No-op for fully-fresh agent dirs (the common case
+                    // where every component is new).
+                    crate::backend::base::verify_no_symlink_escape(&file_path, &canonical_base)
+                        .map_err(|e| format!("path traversal denied: {} ({e})", file.path))?;
                     // Create parent directories if needed
                     if let Some(parent) = file_path.parent() {
                         if !parent.exists() {

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -921,21 +921,14 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let base_path = std::path::Path::new(&final_working_dir);
 
                 for file in &cmd.files {
-                    let file_path = base_path.join(&file.path);
-                    // Prevent path traversal: resolved path must stay within base_path
-                    let canonical_base = base_path.canonicalize()
-                        .map_err(|e| format!("failed to canonicalize base path: {e}"))?;
-                    let canonical_file = file_path.canonicalize().unwrap_or_else(|_| {
-                        // File doesn't exist yet — normalize by resolving parent + filename
-                        if let (Some(parent), Some(name)) = (file_path.parent(), file_path.file_name()) {
-                            parent.canonicalize().map(|p| p.join(name)).unwrap_or_else(|_| file_path.clone())
-                        } else {
-                            file_path.clone()
-                        }
-                    });
-                    if !canonical_file.starts_with(&canonical_base) {
-                        return Err(format!("path traversal denied: {} escapes working dir", file.path));
-                    }
+                    // Lexical join + traversal check — works on Windows where
+                    // canonicalize() adds the `\\?\` UNC prefix and breaks
+                    // starts_with against not-yet-created files.
+                    let file_path = crate::backend::base::safe_join_within_base(
+                        base_path,
+                        &file.path,
+                    )
+                    .map_err(|e| format!("path traversal denied: {} ({e})", file.path))?;
                     // Create parent directories if needed
                     if let Some(parent) = file_path.parent() {
                         if !parent.exists() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.643",
+  "version": "0.33.644",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.643",
+      "version": "0.33.644",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.642",
+  "version": "0.33.643",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.642",
+      "version": "0.33.643",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.643",
+  "version": "0.33.644",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Fixes a regression that blocked every Anthropic agent launch on the merged-main build (v0.33.643 portable).

## Symptom

Click Anthropic in the agent pane → nothing happens. Host log:

```
[fe] [agent] Failed to launch forge agent {"error":"Error: path traversal denied: .claude/commands/startup.md escapes working dir"}
```

## Root cause

`agentmux-srv/src/server/websocket.rs` writeagentconfig handler validated each config-file path with `canonicalize() + starts_with(canonical_base)`. On Windows, `Path::canonicalize` adds the `\\?\` UNC prefix. For brand-new agent dirs created by `allocate_agent_workdir`, neither the target file (`<base>/.claude/commands/startup.md`) nor any of its parent directories exist yet. The fallback chain ran out of canonicalize-able ancestors and silently returned the raw non-UNC path. Comparing `C:\Users\...\base\.claude\commands\startup.md` against `\\?\C:\Users\...\base` returned false → traversal denied.

Wasn't visible before #697 (slug rename) because returning users hit existing dirs that canonicalized cleanly. New MMDDh slug means every launch creates a fresh empty dir, hitting the bug every time.

## Fix

New helper `safe_join_within_base(base, relative)` in `agentmux-srv/src/backend/base.rs`:

- empty / absolute / rooted / `..` paths → error
- accepts `/` and `\` as separators
- silently skips `.` segments
- joins cleaned components onto base, no filesystem access

writeagentconfig replaces the canonicalize check with a single `safe_join_within_base` call. No `canonicalize()` anywhere in the validator — works identically on Windows / macOS / Linux because the logic is purely lexical.

## Tests

7 new unit tests in `backend::base::tests`:
- simple + nested + backslash-separator joins
- `.` segments skipped
- `..` rejected (incl. mid-path `a/../b`, trailing `a/b/..`)
- absolute paths rejected (`/etc/passwd`, `\Windows\System32`, `/foo`, plus `C:\Windows` on Windows)
- empty + effectively-empty rejected

All 7 pass. Full `cargo test --bin agentmux-srv`: 834 pass, 3 pre-existing unrelated failures (provider count, reactive handler, session archive — same set carried over from #697).

## Out of scope

`writeeditorfile` (websocket.rs:1006) shares the canonicalize+starts_with pattern, but its fallback path returns an error instead of falling through to a non-canonical comparison, so it fails closed (request errors out) instead of failing open. Worth a follow-up to make it consistent with the new helper, but not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
