### PR TITLE
feat(agent): drop activity log auto-open + shell label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.644"
+version = "0.33.645"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.644"
+version = "0.33.645"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.644"
+version = "0.33.645"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.644"
+version = "0.33.645"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1442,16 +1442,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3012,9 +3002,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -3025,7 +3015,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -3035,7 +3024,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
+ "url",
 ]
 
 [[package]]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.644"
+version = "0.33.645"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.644"
+version = "0.33.645"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.644"
+version = "0.33.645"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.644"
+version = "0.33.645"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/ActivityLogPanel.tsx
+++ b/frontend/app/view/agent/components/ActivityLogPanel.tsx
@@ -6,15 +6,14 @@
  * Shows the per-pane activity log (launch flow, subprocess lifecycle,
  * slash command outcomes, errors). Collapsed by default; a one-line
  * summary (most recent entry + total count) is shown in the header.
- * Clicking the header toggles expansion. Auto-opens when a new entry
- * arrives with `level: "error"` so the user can't miss genuine failures.
+ * Expansion is purely user-driven — clicking the header toggles it.
  *
  * Replaces the old `.agent-status-log` block that lived at the top of
  * the conversation scroll area and grew unbounded over the session —
  * see `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { For, Show, createEffect, createMemo, createSignal, type Accessor, type JSX } from "solid-js";
+import { For, Show, createMemo, createSignal, type Accessor, type JSX } from "solid-js";
 import type { LogLine } from "../types";
 import { NodeHoverStrip } from "./NodeHoverStrip";
 
@@ -25,34 +24,6 @@ interface ActivityLogPanelProps {
 export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
     const [isOpen, setIsOpen] = createSignal(false);
     const [expandedIds, setExpandedIds] = createSignal<Set<string>>(new Set());
-
-    // Track the highest-index entry we've seen, so we can only react to
-    // NEW entries arriving — not to every re-render. Without this, the
-    // error auto-open effect would fire on every parent render whose
-    // entries() array ends in an error (e.g. collapsed + re-expanded).
-    //
-    // Resets to 0 when the parent list drops to empty (e.g. clear() via
-    // /clear slash command), so auto-open works again after reset
-    // instead of requiring the new entry count to exceed the stale
-    // watermark before firing.
-    let lastSeenLength = 0;
-    createEffect(() => {
-        const list = props.entries();
-        if (list.length === 0) {
-            lastSeenLength = 0;
-            return;
-        }
-        if (list.length > lastSeenLength) {
-            // Scan the newly-arrived slice for any error-level entry.
-            for (let i = lastSeenLength; i < list.length; i++) {
-                if (list[i].level === "error") {
-                    setIsOpen(true);
-                    break;
-                }
-            }
-            lastSeenLength = list.length;
-        }
-    });
 
     const mostRecent = createMemo(() => {
         const list = props.entries();
@@ -86,7 +57,6 @@ export const ActivityLogPanel = (props: ActivityLogPanelProps): JSX.Element => {
                     aria-expanded={isOpen()}
                 >
                     <span class="agent-activity-log-chevron">{isOpen() ? "⌄" : "›"}</span>
-                    <span class="agent-activity-log-label">shell</span>
                     <Show when={!isOpen() && mostRecent()}>
                         {(entry) => (
                             <span class="agent-activity-log-preview">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.644",
+  "version": "0.33.645",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.644",
+      "version": "0.33.645",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.644",
+  "version": "0.33.645",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Why

ESC-to-cancel emits an `error`-level entry into the activity log as part of the normal cancel flow. The `ActivityLogPanel` was wired to auto-open whenever a new error-level entry arrived, so cancelling popped the whole shell log open every time. Annoying — user has to keep collapsing it.

Also dropping the redundant `shell` text label next to the chevron. The chevron alone reads fine; surrounding agent-pane chrome already gives enough context.

## What changed

`frontend/app/view/agent/components/ActivityLogPanel.tsx`:

1. Removed the `createEffect` that watched for new error entries and called `setIsOpen(true)`. Also removed the `lastSeenLength` watermark that paired with it. `createEffect` import dropped (unused after removal).
2. Removed the `<span class="agent-activity-log-label">shell</span>`. Chevron + preview + count remain.
3. Updated module JSDoc — removed the "Auto-opens when a new entry arrives with `level: 'error'`" sentence so docs match code.

The `agent-activity-log--has-error` / `agent-activity-log--has-warn` modifier classes still toggle on `mostRecent()?.level`, so the color cue stays. Just the auto-open behavior + the label text are gone.

## Verification

Tested live in dev mode (Vite HMR) before opening this PR:
- ESC-cancel emits the error entry; preview line updates with the new entry text; panel stays collapsed.
- Click chevron → expands and shows full history as before.
- Header row no longer contains the word "shell".

## Spec

`docs/specs/SPEC_AGENT_ACTIVITY_LOG_NO_AUTO_OPEN_2026_05_05.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
