### PR TITLE
ci: add Kimi community PR reviewer

### DIFF
--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -1,0 +1,21 @@
+name: Kimi Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: howardpen9/kimi-code-reviewer@main
+        with:
+          kimi_api_key: ${{ secrets.MOONSHOT_API_KEY }}
+          language: en
+          fail_on: critical

--- a/.github/workflows/kimi-review.yml
+++ b/.github/workflows/kimi-review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: howardpen9/kimi-code-reviewer@main
+      - uses: howardpen9/kimi-code-reviewer@183bb281ce03338ef8ddfb6ed6d5ff4aaa866bcb
         with:
           kimi_api_key: ${{ secrets.MOONSHOT_API_KEY }}
           language: en


### PR DESCRIPTION
Adds [howardpen9/kimi-code-reviewer](https://github.com/howardpen9/kimi-code-reviewer) as a GitHub Action.

- Triggers on PR open/push
- Posts inline diff annotations via GitHub Checks API
- Uses `MOONSHOT_API_KEY` secret (already set on this repo)
- Model: kimi-k2.5 (262K context), language: en, fail_on: critical

Complementary to ReAgent — this posts annotations directly in the diff while ReAgent posts a full review comment.