### PR TITLE
feat(drag): try warm pool first on tear-off via shared helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.647"
+version = "0.33.648"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.647"
+version = "0.33.648"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.647"
+version = "0.33.648"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.647"
+version = "0.33.648"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.647"
+version = "0.33.648"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.647"
+version = "0.33.648"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.647"
+version = "0.33.648"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.647"
+version = "0.33.648"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md
+++ b/docs/specs/SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md
@@ -1,0 +1,89 @@
+# Pool window HWND-null at promote time
+
+**Date:** 2026-05-06
+**Owner:** AgentA
+**Status:** spec
+**Related:** [`SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md`](./SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md) (PR #704), [`SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md`](./SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md)
+
+---
+
+## 1. Problem
+
+Pool windows are spawned correctly, mark `renderer ready`, get enqueued — but their underlying Win32 HWND is null when `promote_pool_window` tries to use them. Every cross-window tear-off observed during PR #704 smoke testing fell back to the cold path because the host's pool reported `host window handle is null (state inconsistency)`.
+
+Trace from v0.33.648 / `agenta/tear-off-pool-path` smoke (3 tear-offs in a row, all reproduced):
+
+```
+06:38:56.718  [pool] promoting pool window   label=window-pool-813cdce63a...
+06:38:56.718  ERROR  host window handle is null (state inconsistency)
+06:38:56.718  [pool] orphan close_browser issued — on_before_close will run cleanup + refill
+06:38:56.718  WARN   [pool] pool exhausted on tear-off — frontend will cold-path
+06:38:56.724  WARN   [pool] pool window destroyed before promote — releasing semaphore + refilling
+```
+
+The pool slot was created at `06:27:32` and consumed at `06:38:56` — 11 minutes idle. Subsequent attempts at 06:39:03 and 06:39:26 all hit the same error against fresher pool slots (sub-second to ~1-min idle).
+
+## 2. Why it matters
+
+- The frontend correctly tries the pool first (PR #704); the pool's failure mode is what breaks the user-visible behavior. Result: every tear-off shows the cold-path's 150–300ms first-paint flash that the pool was specifically designed to eliminate.
+- The cold-path code path is also where the source-side renderer crash occasionally fires (per `SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md` §1 finding (B)). Fixing this spec eliminates both the flash AND the destabilization risk in one go.
+- Pool refill machinery wastes work spawning replacements that will themselves go HWND-null and be discarded.
+
+## 3. Investigation surface
+
+The host's `promote_pool_window` is the place that detects the failure:
+
+- `agentmux-cef/src/commands/window_pool.rs::promote_pool_window` — pops a label from `state.pool.queue`, looks up the Browser, fetches its `BrowserHost::window_handle()`. If null → emits `ERROR host window handle is null (state inconsistency)`, dispatches `close_browser`, releases the semaphore, returns `None`.
+- `agentmux-cef/src/commands/window_pool.rs::mark_pool_window_renderer_ready` — fires the `pool window renderer ready, enqueued` log. Called from a frontend signal that the renderer has fully initialized.
+
+The mismatch: a pool window is "renderer ready" but has no HWND. Possible causes (none yet confirmed):
+
+1. **Pool windows are CEF-views browsers, not Win32 HWNDs.** When `cef::window_create_top_level` returns, the wrapper has a CefViews handle but the underlying HWND may not be assigned until later (or possibly never for hidden windows). `BrowserHost::window_handle()` returns the platform handle, which for a hidden CefViews window may be null until the window is shown.
+2. **HWND was destroyed by the OS while the window was off-screen.** Pool windows are positioned off-screen at `(-32000, -32000)` per `[ipc] WRR-POS hwnd=... rect=(-32000,-32000)-(...)` log lines. Windows occasionally cleans up off-screen windows that never receive input. Unlikely but possible.
+3. **Race with a CEF lifecycle callback.** The renderer-ready signal may fire from a worker thread before the UI thread has fully attached the HWND. If frontend dispatches a tear-off in the gap, the host sees `Some(browser)` from the queue but its HWND lookup races with the UI thread's HWND assignment.
+
+The 11-minute-idle case argues against (3) (way too long for a thread race) but supports (1) or (2).
+
+## 4. Proposed approach
+
+### 4.1 Diagnose first
+
+Before patching, instrument:
+
+- In `mark_pool_window_renderer_ready`, log the HWND from `Browser::host().window_handle()` at enqueue time.
+- In `promote_pool_window`, log the HWND value (null vs non-null vs stale-pointer) and the time-since-enqueue.
+- If HWND is null at enqueue time → cause (1): the renderer-ready signal precedes HWND assignment.
+- If HWND is non-null at enqueue but null at promote → cause (2): OS cleaned it up.
+- If HWND is non-null at enqueue, non-null at promote, but `IsWindow(hwnd)` returns false → stale handle.
+
+### 4.2 If cause (1) — defer enqueue
+
+Don't enqueue a pool window until BOTH renderer-ready AND `host().window_handle()` is non-null. Add a second gate. If the renderer is ready but no HWND yet, schedule a deferred check (e.g. on the next `WM_WINDOWPOSCHANGED`).
+
+### 4.3 If cause (2) — show + hide cycle
+
+Periodically nudge pool windows: `ShowWindow(SW_HIDE)` → `ShowWindow(SW_SHOW)` to keep them registered with the OS without making them visible. Hacky but proven workaround for similar Windows behavior.
+
+### 4.4 If cause (3) — synchronize
+
+Move the renderer-ready signal onto the UI thread, ensuring it can only fire after `on_after_created` has registered the HWND. Single-threaded happens-before relationship.
+
+## 5. Out of scope
+
+- Refactoring the pool to not rely on Win32 handles at all. The whole point of the warm pool is to preserve the underlying CEF browser; promote-time HWND access is necessary for SC_MOVE handshake (Phase 4 of `SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md`).
+- Cross-platform behavior. macOS / Linux pool implementations have their own HWND-equivalent (NSWindow / X11 Window); same diagnosis-first approach should apply, but the actual cause may differ.
+- Reducing pool size. The pool is fine sized at 2; the bug is independent of how many slots are in flight.
+
+## 6. Tests
+
+Hard to unit-test because the bug lives at the CEF/Win32 boundary. Options:
+
+1. **Manual smoke.** Open AgentMux → wait 30s → tear off a tab. Confirm pool was used (BrowserRegistered with `is_pool: true`). Repeat for 5min idle, 30min idle.
+2. **Property-style instrumentation.** Add a metric `pool.promote_hwnd_null_count` and emit it in launcher logs. After this fix lands, expect zero increments under normal operation. Regression would be obvious.
+
+## 7. References
+
+- `agentmux-cef/src/commands/window_pool.rs` — pool spawn / enqueue / promote
+- `agentmux-cef/src/commands/drag.rs:308` — `tear_off_pool_promote` host handler
+- `frontend/app/drag/tear-off-pool-helper.ts` — frontend's try-pool-first wiring (PR #704)
+- v0.33.648 task dev smoke trace — `~/.agentmux/dev/agenta-tear-off-pool-path/logs/`

--- a/docs/specs/SPEC_TASK_DEV_LAUNCHER_GAPS_2026_05_06.md
+++ b/docs/specs/SPEC_TASK_DEV_LAUNCHER_GAPS_2026_05_06.md
@@ -1,0 +1,170 @@
+# task dev — launcher-driven shutdown gaps
+
+**Date:** 2026-05-06
+**Owner:** AgentA
+**Status:** spec
+**Layer:** crosses Layer 1 (launcher) ↔ Layer 2 (host) — see [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md) §1.
+
+---
+
+## 1. Problem
+
+`task dev` does not run the `agentmux-launcher` process. The Taskfile's `dev:serve` recipe launches `agentmux-cef` directly:
+
+```bash
+cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-cef --url=http://localhost:5173
+```
+
+Portable and installed builds invoke the host indirectly via the launcher. Many cross-process behaviors depend on a launcher being present; in `task dev` they're inert.
+
+**Observed symptom (smoke test 2026-05-06):** closing every visible window of a `task dev` session leaves zombie processes — `agentmux-cef.exe` × 6 + `agentmux-srv-*` × 2 — for the lifetime of the user's login. Identical to the v0.33.643 portable bug PR #702 just fixed, but PR #702's fix can't trigger here because it hooks `Event::HostShouldQuit`, which only the launcher emits.
+
+## 2. What's missing in dev mode
+
+Per master spec §3 / §4 / §6, the launcher owns:
+
+| Subsystem | Owned by | Effect of launcher absence in dev |
+|---|---|---|
+| `state.windows` mirror | Launcher reducer | Host has no canonical "user-visible windows count" view from outside |
+| WRR (Window Reality Reconciliation) | Launcher (`SetWinEventHook` + reducer) | No drift detection (`OrphanInstance`, `OrphanDestroy`, `HwndWithoutBrowser`, etc.) |
+| `Event::HostShouldQuit` emission | Launcher reducer's `handle_report_window_closed` + `wrr::apply_hwnd_destroyed` | Reconciler in `agentmux-cef/src/commands/orphan_reconcile.rs` never invoked |
+| `window_cleanup_cascade` saga | Launcher saga coordinator | No cleanup cascade fires |
+| Cross-process saga dispatch | Launcher → host pipe | Host's saga-action hooks see no commands |
+| Launcher event log + ring buffer (Phase D) | Launcher | No persistent event audit trail in dev |
+| Window placement / monitor topology (Phase B.9) | Launcher reducer | No off-monitor correction |
+| Single-instance enforcement (Phase B.6) | Launcher pipe lock | Multiple `task dev` sessions can collide |
+
+The host-side `on_before_close` cascade (`agentmux-cef/src/client/mod.rs:680`) is the ONLY shutdown path in dev mode. Its Stage-1 close-pool-windows + Stage-2 `quit_message_loop` logic was designed assuming launcher presence in many subtle ways:
+
+- Stage-1 gate `if user_browser_count == 0 && !self.is_browser_pane` reads `state.list_browser_labels()` for the count. The closing browser's `UnregisterBrowser` dispatch happens earlier in the same `on_before_close` body, so by the time the gate evaluates, `keys` should exclude the closing window. In dev mode this should work — but the smoke trace shows it didn't fire (Stage-1 PostMessage(WM_CLOSE) to `window-pool-*` browsers never logged), so something is keeping `user_browser_count > 0`. Hypotheses:
+  - The pool labels were promoted (out of `unpromoted_pool`) and now count as user windows.
+  - A `browser-pane-*` or other unaccounted browser is still in the registry.
+  - Timing: `UnregisterBrowser` is async-dispatched but the snapshot reads pre-dispatch.
+- Even if Stage-1 fires, Stage-2 (`if self.browser_list.is_empty()`) gates on the CefClient's internal `browser_list`, which is populated by CEF callbacks, not the reducer's `state.browsers`. PR #702's whole point was to drive `quit_message_loop` directly when the reducer says we're done; without launcher → no `HostShouldQuit` → no direct drive → Stage 2 has to converge on its own.
+
+## 3. Why it matters
+
+Three flavors of pain:
+
+1. **Developer ergonomics.** Every `task dev` session leaves zombies that have to be killed manually before the next one starts (port 5173, srv pipe, AppData lock files). Easy to forget; easy to test against stale state.
+2. **Smoke parity.** Anything you smoke-test in `task dev` won't exercise the launcher-driven shutdown path. PR #702's fix can't be smoke-tested in dev — only in portable builds. That's a known good practice (build a portable for shutdown testing) but it shouldn't be the ONLY way to validate.
+3. **Phase F follow-ons.** Master spec §9.1 has cross-process saga dispatch as a BLOCKER for `IssueCmd::Host` actions. Until that lands, the launcher's saga coordinator is the only place these dispatches go. Dev mode skips it entirely. As more of the architecture moves to launcher-coordinated flows, dev mode's coverage shrinks.
+
+## 4. Options
+
+### Option A — Run the launcher in `task dev` too
+
+Modify `dev:serve` so it launches `agentmux-launcher` (which spawns `agentmux-cef` for us) instead of `agentmux-cef` directly. Mirror the portable startup contract.
+
+**Pros:**
+- True parity. Every shutdown test, drift test, and saga test exercises the same code path as portable.
+- No new code paths to maintain — just glue.
+- PR #702's reconciler activates naturally in dev.
+
+**Cons:**
+- The launcher needs to know to point at Vite (`http://localhost:5173`) rather than the bundled `index.html`. Today the launcher accepts `--url=` only because the dev path goes around it.
+- Single-instance pipe lock: launcher's `first_pipe_instance(true)` would block a second `task dev` from running (existing portable instances already grab their own per-version pipe; dev would need its own pipe name).
+- Launcher logging path: dev should log to `~/.agentmux/dev/<branch>/logs/` rather than the global `~/.agentmux/logs/`. Already addressed by the data-dir unification work — verify before merging.
+- Trap-and-clean: the existing `dev:serve` traps `EXIT` to kill `VITE_PID`. Adding the launcher means we need to kill the launcher (and its child host + srv) on dev-server exit. Cleaner if launcher's normal shutdown path handles it — but if the dev shutdown is unclean (Ctrl+C the task), we need a fallback.
+
+### Option B — Stub launcher events into the host directly
+
+Keep the dev startup as-is (no launcher). Add a `--dev-stub-launcher` flag to `agentmux-cef` that wires up a minimal in-process emulator: emits `HostShouldQuit` when the host's own window count drops to zero, fakes `WindowOpened`/`WindowClosed` mirrors, etc.
+
+**Pros:**
+- No process management changes.
+- Dev mode stays "single binary, run from anywhere".
+
+**Cons:**
+- Two implementations of the launcher's reducer to keep in sync. Every change to launcher logic now needs a stub-equivalent.
+- Stub is fundamentally different from the real launcher (no separate process, no WRR via Win32 hooks, no event ring). Smoke parity is illusory.
+- This was effectively the v0.33.491–v0.33.494 strategy of trying to drive launcher work from inside the host. Three failed attempts. Not the way.
+
+### Option C — Make `on_before_close` self-sufficient
+
+Refactor the host-side cascade so it doesn't depend on launcher signals. Specifically: when `user_browser_count == 0` post-close, invoke `commands::orphan_reconcile::reconcile_and_drain` directly on the UI thread (bypass `Event::HostShouldQuit`).
+
+**Pros:**
+- Single shutdown code path that works in all modes.
+- Frees the host from depending on launcher availability for clean shutdown.
+- Fully testable via existing 21 planner integration tests.
+
+**Cons:**
+- Doesn't address WRR / saga / drift detection — those still need the launcher.
+- Risks duplicating shutdown logic if the launcher ALSO emits `HostShouldQuit` — both paths fire.
+- The orphan reconciler is currently designed for the post-launcher-emit case (assumes `HostShouldQuit` → reconcile). Repurposing it as the canonical close-cascade entry would inflate its scope.
+
+### Option D — Status quo
+
+Leave dev mode without launcher. Document the gap. Use portable for shutdown testing.
+
+**Pros:** Zero work.
+
+**Cons:** Continued zombie processes. Continued smoke parity gap. Pain compounds as more Phase F lands.
+
+## 5. Recommendation
+
+**Pursue Option A** with a small Option C hedge.
+
+Option A is the principled fix. The launcher already exists, already works in production, and is the source of truth for the shutdown path PR #702 just exercised. Wiring `task dev` through it gives us:
+- Real `HostShouldQuit` emission → real orphan reconciliation testing in dev
+- Real WRR → drift detection during development (catches a class of bugs we currently can only reproduce in portable)
+- Real saga coordinator → cross-process dispatch testing as that work lands
+
+The Option C hedge: while wiring up Option A, also verify that the host's `on_before_close` cascade Stage 2 fires correctly in the simple case (last user window closes, no zombies, no warm pool open). The smoke trace shows it didn't fire in dev — fixing that is independent of launcher presence and should land regardless.
+
+## 6. Implementation sketch (Option A)
+
+### 6.1 Taskfile change
+
+`dev:serve` swaps the final command:
+
+```diff
+-                cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-cef{{exeExt}} --url=http://localhost:5173
++                cd "$DEV_DIR" && LD_LIBRARY_PATH=. AGENTMUX_DEV=1 ./agentmux-launcher{{exeExt}} --dev --url=http://localhost:5173
+```
+
+Need to verify `agentmux-launcher` already builds into `$DEV_DIR/`. The `build:host` task currently builds host + launcher per `Taskfile.yml:380`; check the bundle copies both.
+
+### 6.2 Launcher: `--dev` flag
+
+Add `--dev` to the launcher arg parser. Its job:
+- Pass `--url=...` through to the spawned host (today the launcher already spawns the host with bundled assets; dev mode swaps to the URL).
+- Use a per-branch pipe name (e.g. `\\.\pipe\agentmux-dev-<branch-hash>`) so concurrent `task dev` runs on different branches don't collide.
+- Use `~/.agentmux/dev/<branch>/` as the data root (already wired by the recent data-dir unification — verify).
+
+### 6.3 Single-instance handling
+
+The launcher's `first_pipe_instance(true)` lock is per-pipe-name. In dev, the pipe name is per-branch. If the user kicks off a second `task dev` on the same branch, the second launcher fails fast with `ERROR_ACCESS_DENIED` — acceptable.
+
+### 6.4 EXIT trap
+
+`dev:serve` traps `EXIT` and currently kills `VITE_PID`. Extend to also `taskkill /T /F /PID $LAUNCHER_PID`. The `/T` flag kills the whole tree — host + srv go with it. If the launcher exits cleanly on its own (the user hit Ctrl+C, all windows closed), the trap is a no-op.
+
+### 6.5 Smoke test parity
+
+After this lands, the v0.33.643-style zombie scenario (last window closed, warm pool kept alive) should be reproducible in `task dev` and addressable by the same orphan reconciler PR #702 introduced. Add a smoke test note to `docs/specs/SPEC_HOST_ORPHAN_RECONCILIATION_2026_05_05.md` confirming dev-mode applicability.
+
+## 7. Out of scope
+
+- Refactoring `on_before_close` to cover the launcher-absent case (covered by Option C if we choose to land it as a hedge — separate PR).
+- Cross-process saga dispatch (master spec §9.1, separate spec).
+- Reverse: making the launcher optional for portable too. Master spec §6 keeps the launcher as a hard requirement, by design.
+
+## 8. Tests
+
+Mostly smoke. The existing planner unit tests already cover the reconciler logic. New tests:
+
+1. **Smoke: task dev clean exit.** Start `task dev`, open and close the main window, observe all `agentmux-*` processes exit within ~5s of the last window close. Document this in BUILD.md alongside `task package` smoke instructions.
+2. **Manual: task dev orphan reconciliation.** Force a renderer crash (DevTools → "Inspect" → the inspect window crashes the renderer). Confirm `[wrr] HostShouldQuit received — running orphan reconciler` log line appears. (Today this is impossible in dev.)
+3. **Manual: per-branch pipe isolation.** Run `task dev` on two different branches concurrently. Both should run; their data dirs / logs / pipes should not collide. The data-dir unification work largely covers this — verify.
+
+## 9. References
+
+- [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md) §3 (3-level stack), §4 (host scaffolding), §6 (Phase B), §9.1 (cross-process dispatch BLOCKER).
+- [`SPEC_HOST_ORPHAN_RECONCILIATION_2026_05_05.md`](./SPEC_HOST_ORPHAN_RECONCILIATION_2026_05_05.md) — the reconciler that this spec wires into dev mode.
+- `Taskfile.yml:469-529` — current `dev:serve` recipe.
+- `agentmux-cef/src/client/mod.rs:680-880` — `on_before_close` cascade (Stage 1 + Stage 2).
+- `agentmux-cef/src/launcher_ipc.rs:416` — `Event::HostShouldQuit` handler (calls `reconcile_and_drain`).
+- `agentmux-launcher/src/reducer/window.rs:200-213` — clean-close path's `HostShouldQuit` emission.
+- `agentmux-launcher/src/wrr/mod.rs:284-322` — crash-detected close path's `HostShouldQuit` emission (added by PR #702).

--- a/docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md
+++ b/docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md
@@ -1,0 +1,128 @@
+# Tab Tear-Off — Always Use Warm Pool + Source-Side Renderer Crash
+
+**Date:** 2026-05-06
+**Owner:** AgentA
+**Status:** spec
+**Related:** [`SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md`](./SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md), [`SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md`](./SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md)
+
+---
+
+## 1. Problem
+
+Two bugs surface together when the user tears a tab off into a new window:
+
+**(A) Tear-off bypasses the warm pool.** The host has a Phase-6 pre-warmed pool (`tear_off_pool_promote` in `agentmux-cef/src/commands/drag.rs:308`) that holds 2 ready-to-go CEF windows so tear-off can promote one with no first-paint flash. The HTML5 drag path (`CrossWindowDragMonitor.{win32,darwin,linux}.tsx`) never calls `tearOffPoolPromote`; it goes straight to `openWindowAtPosition` (cold path, ~150–300ms flash). Only `tabbar.tsx`'s SC_MOVE handshake path tries the pool first.
+
+**(B) Source window's renderer crashes ~3s after a cold-path tear-off.** Repro from v0.33.647 portable smoke test:
+
+```
+06:13:07.295  start_cross_drag        source_window=main
+06:13:07.311  workspace.TearOffTab    OK
+06:13:07.311  open_window_at_position label=window-dca56f9d... (COLD PATH)
+06:13:07.321  BrowserRegistered       is_pool=false
+06:13:08.87   destination booting
+06:13:09.50   destination DragOverlay listening (alive)
+06:13:10.428  ERROR renderer process crashed   ← source's renderer
+              error_code=-36861 detail="Crashpad_NotConnectedToHandler"
+```
+
+The destination window is alive and well. The source's renderer dies. The host's `on_render_process_terminated` handler (per [`SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md`](./SPEC_GRACEFUL_CRASH_HANDLING_2026_04_13.md)) catches it and shows the recovery dialog — that part works.
+
+(A) is the proximate cause of (B): if the warm pool is used, the cold-path codepath that destabilizes the source isn't exercised. Fixing (A) likely papers over (B) for the common case, but (B) is its own bug worth tracking.
+
+## 2. Why this matters
+
+- **First-paint flash.** Cold path is 150–300ms of blank window before content paints. Pool promote is ~0ms.
+- **Crash exposure.** Cold-path window creation is the same path that has the long-standing Phase-1 freeze investigation in `commands/mod.rs:create_isolated_request_context`. Fewer trips through that code = fewer crash opportunities.
+- **Pool waste.** Pool windows are spawned eagerly on app start and refilled after use. If tear-off never consumes them, they sit idle and the refill machinery does nothing useful.
+- **Drift signal.** v0.33.647 launcher log: `DriftDetected { kind: Pool, host_count: 0, mirror_count: 2 }` — the mirror tracks pool slots that the host's reducer claims aren't there. Aggravated by the cold-path code creating `window-{uuid}` labels that share the pool spawning machinery without going through the promote flow.
+
+## 3. Root cause for (A)
+
+`CrossWindowDragMonitor.{win32,darwin,linux}.tsx` predates the warm-pool work. Its `handleCrossDragEnd` function:
+
+```ts
+} else if (dragType === "tab" && payload.tabId) {
+    const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
+    if (newWsId) {
+        await api.openWindowAtPosition(screenX, screenY, newWsId);
+    }
+}
+```
+
+Direct cold-path call. No pool attempt. Same shape for the `pane` branch and on macOS / Linux variants.
+
+`tabbar.tsx::performTabTearOff` (lines 600–710) does the right thing: tries `tearOffPoolPromote` first, falls back to `openWindowAtPosition` only if that throws. But that path is only reached when the drag goes through the SC_MOVE handshake, not the legacy HTML5 dragend path.
+
+## 4. Decision
+
+### 4.1 (A) Wire tear-off pool promote into `CrossWindowDragMonitor`
+
+Replace the direct `openWindowAtPosition` calls with the same try-pool-first pattern `tabbar.tsx` uses:
+
+```ts
+} else if (dragType === "tab" && payload.tabId) {
+    const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
+    if (newWsId) {
+        try {
+            await api.tearOffPoolPromote(newWsId, screenX, screenY);
+        } catch (poolErr) {
+            // Pool exhausted or unavailable — fall back to cold path.
+            await api.openWindowAtPosition(screenX, screenY, newWsId);
+        }
+    }
+}
+```
+
+Same change for the `pane` branch. Same change in `.darwin.tsx` and `.linux.tsx`.
+
+The pool fallback is conservative — if `tearOffPoolPromote` throws (e.g., pool exhausted, host rejects for any reason), we cold-path the same way `tabbar.tsx` does. No regression risk.
+
+### 4.2 (B) Source-side renderer crash investigation (separate scope)
+
+Out of scope for this PR. To track:
+
+- After cold-path tear-off, the SOURCE window's renderer crashes ~3s later.
+- The destination window finishes initializing fine.
+- After (A) lands, this should rarely fire (cold path becomes the exception). If it still reproduces with the pool path, it's a deeper tear-off-induced source-side bug.
+
+Suspected causes worth investigating in a follow-up:
+
+1. The frontend's tab-removal rerender in the source window triggers a state mutation that crashes the renderer (e.g., a race on `documentAtom` or layout tree).
+2. The cross-window drag cleanup (`setCurrentDragPayload(null)`) racing with another listener.
+3. The launcher's `HwndDriftDetected` event flooding the source window's launcher-event-bridge after the new window registers.
+
+## 5. Out of scope
+
+- Refactoring CrossWindowDragMonitor entirely (e.g., merging into `tabbar.tsx`'s SC_MOVE flow). The current design has both paths for OS-specific reasons; consolidation is a separate effort.
+- The Phase-1 cold-path freeze investigation in `commands/mod.rs::create_isolated_request_context`.
+- Pool sizing / refill policy.
+
+## 6. Tests
+
+`CrossWindowDragMonitor` doesn't currently have its own tests (the harness mocks `getApi()` at integration time). Adding focused tests requires either:
+
+- A unit test that mocks `getApi()` and verifies `tearOffPoolPromote` is called before `openWindowAtPosition` for both tab and pane dragtypes.
+- A manual smoke step in BUILD.md: tear off a tab, verify the new window's `BrowserRegistered` event has `is_pool: true` (confirming pool was used).
+
+For this PR, the manual smoke is the validating signal. Add it to `docs/specs/SPEC_TAB_TEAR_OFF_SIZE_PRESERVATION_2026_04_26.md`'s smoke section.
+
+## 7. Implementation order
+
+1. Update all three `CrossWindowDragMonitor.*.tsx` files (~10 lines each, identical change).
+2. Bump patch version.
+3. Build portable, smoke-test:
+   - Open new tab → tear off → confirm log shows pool promote, not cold-path
+   - Look for the BrowserRegistered event with `is_pool: true`
+   - Confirm the source renderer doesn't crash (validates (B) is largely papered over by (A))
+4. If source renderer still crashes occasionally, file a separate issue against (B).
+
+## 8. References
+
+- `agentmux-cef/src/commands/drag.rs:304-340` — `tear_off_pool_promote` host handler
+- `agentmux-cef/src/commands/drag.rs:342-426` — `open_window_at_position` (cold path)
+- `frontend/app/tab/tabbar.tsx:600-710` — reference implementation (try-pool-first)
+- `frontend/app/drag/CrossWindowDragMonitor.win32.tsx:237,242` — current cold-path-only call sites
+- `frontend/util/cef-api.ts:589-594` — `openWindowAtPosition` + `tearOffPoolPromote` IPC bindings
+- `agentmux-cef/src/client/mod.rs:1089` — `on_render_process_terminated` recovery handler
+- v0.33.647 portable smoke trace — `~/.agentmux/versions/0.33.647/logs/agentmux-host-v0.33.647.log.2026-05-06`

--- a/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.darwin.tsx
@@ -12,6 +12,7 @@ import { atoms, getApi } from "@/store/global";
 import { invokeCommand } from "@/app/platform/ipc";
 import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
+import { openTearOffWindow } from "./tear-off-pool-helper";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import type { LayoutNode } from "@/layout/lib/types";
@@ -132,10 +133,10 @@ async function performTearOff(
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
         const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
-        if (newWsId) await api.openWindowAtPosition(screenX, screenY, newWsId);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
-        if (newWsId) await api.openWindowAtPosition(screenX, screenY, newWsId);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
     }
 }
 

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -11,6 +11,7 @@
 import { atoms, getApi } from "@/store/global";
 import { WorkspaceService } from "@/app/store/services";
 import { Logger } from "@/util/logger";
+import { openTearOffWindow } from "./tear-off-pool-helper";
 import { invokeCommand } from "@/app/platform/ipc";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
@@ -132,10 +133,10 @@ async function performTearOff(
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
         const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
-        if (newWsId) await api.openWindowAtPosition(screenX, screenY, newWsId);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
-        if (newWsId) await api.openWindowAtPosition(screenX, screenY, newWsId);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
     }
 }
 

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -25,6 +25,7 @@ import { WorkspaceService } from "@/app/store/services";
 import { getLayoutModelForStaticTab, LayoutTreeActionType, LayoutTreeDeleteNodeAction } from "@/layout/index";
 import { invokeCommand } from "@/app/platform/ipc";
 import { Logger } from "@/util/logger";
+import { openTearOffWindow } from "./tear-off-pool-helper";
 import { onCleanup, onMount } from "solid-js";
 import type { JSX } from "solid-js";
 import type { LayoutNode } from "@/layout/lib/types";
@@ -234,12 +235,12 @@ async function performTearOff(
                     } as LayoutTreeDeleteNodeAction);
                 }
             }
-            await api.openWindowAtPosition(screenX, screenY, newWsId);
+            await openTearOffWindow(api, newWsId, screenX, screenY);
         }
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
         if (newWsId) {
-            await api.openWindowAtPosition(screenX, screenY, newWsId);
+            await openTearOffWindow(api, newWsId, screenX, screenY);
         }
     }
 }

--- a/frontend/app/drag/tear-off-pool-helper.ts
+++ b/frontend/app/drag/tear-off-pool-helper.ts
@@ -1,0 +1,46 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared tear-off helper: try the warm pool first, fall back to the
+ * cold-path `openWindowAtPosition` only on rejection. Used by every
+ * platform-specific `CrossWindowDragMonitor` variant
+ * (win32 / darwin / linux).
+ *
+ * `tabbar.tsx::performTabTearOff` does NOT use this helper — its
+ * tear-off pipeline tracks `coldPathFailed` for F1.B orphan-workspace
+ * cleanup safety (codex P1 round-3 #624) and pairs the open with an
+ * SC_MOVE handshake. Both flows still try-pool-first, just with
+ * different surrounding logic.
+ *
+ * Pool path is ~0ms first paint; cold path is 150–300ms and goes
+ * through `create_isolated_request_context` whose stability issues
+ * have been observed to destabilize the source window's renderer
+ * post-tearoff. Spec: `docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md`.
+ */
+
+import { getApi } from "@/store/global";
+import { Logger } from "@/util/logger";
+
+type Api = ReturnType<typeof getApi>;
+
+/**
+ * Open a tear-off destination window at `(screenX, screenY)`,
+ * preferring the pre-warmed pool. Falls back to cold-path only when
+ * `tearOffPoolPromote` rejects (e.g. pool exhausted, host refuses).
+ */
+export async function openTearOffWindow(
+    api: Api,
+    newWsId: string,
+    screenX: number,
+    screenY: number,
+): Promise<void> {
+    try {
+        await api.tearOffPoolPromote(newWsId, screenX, screenY);
+    } catch (poolErr) {
+        Logger.warn("dnd:cross", "pool promote failed, cold-pathing", {
+            error: String(poolErr),
+        });
+        await api.openWindowAtPosition(screenX, screenY, newWsId);
+    }
+}

--- a/frontend/app/drag/tear-off-pool-helper.ts
+++ b/frontend/app/drag/tear-off-pool-helper.ts
@@ -19,7 +19,7 @@
  * post-tearoff. Spec: `docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md`.
  */
 
-import { getApi } from "@/store/global";
+import type { getApi } from "@/store/global";
 import { Logger } from "@/util/logger";
 
 type Api = ReturnType<typeof getApi>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.647",
+  "version": "0.33.648",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.647",
+      "version": "0.33.648",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.646",
+  "version": "0.33.647",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.646",
+      "version": "0.33.647",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.647",
+  "version": "0.33.648",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## What

`CrossWindowDragMonitor.{win32,darwin,linux}.tsx` all called `api.openWindowAtPosition` directly when handling cross-window drag tear-off. The host has a pre-warmed pool (`tear_off_pool_promote`) designed for ~0ms first-paint flash, but it was only used by `tabbar.tsx::performTabTearOff` (the SC_MOVE handshake path). The HTML5-dragend path bypassed it entirely.

## Fix

Extract a shared `openTearOffWindow(api, newWsId, screenX, screenY)` helper to `frontend/app/drag/tear-off-pool-helper.ts`. It tries `tearOffPoolPromote` first and falls back to `openWindowAtPosition` on rejection. All three platform variants of `CrossWindowDragMonitor` now call it.

Same try-pool-first pattern `tabbar.tsx` uses inline. Kept inline there because it tracks `coldPathFailed` for F1.B orphan-cleanup safety (codex P1 round-3 #624).

## DRY

Before: three duplicate inline blocks (one per platform monitor).
After: one helper, three callers.

`tabbar.tsx` deliberately not migrated — its tear-off pipeline has additional state-tracking that doesn't fit the shared helper.

## Smoke

Tested on `task dev` with `agenta/tear-off-pool-path`:

- Pool spawned and enqueued (`pool_size=2`)
- Tab tear-off fired the new helper (`[fe] [dnd:cross] pool promote failed, cold-pathing` proves the pool was tried)
- Fallback to `openWindowAtPosition` happened gracefully
- No source-side renderer crash (was intermittent in the prior cold-path-only build)
- Cold-path's 150–300ms first-paint flash is still visible (because the fallback fires)

## What this PR doesn't fix

The pool itself is broken at the host level — pool windows enqueue with `renderer ready` but their HWND is null at promote time:

```
[pool] promoting pool window   label=window-pool-...
[pool] host window handle is null (state inconsistency)
[pool] pool window destroyed before promote — releasing semaphore + refilling
```

That's a separate host-side bug. This PR is the correct frontend wiring regardless — once the pool is fixed, both the flash AND the source-side crash risk go away with no further frontend changes.

## Spec

`docs/specs/SPEC_TEAR_OFF_POOL_PATH_2026_05_06.md` — full design + observed behavior + recommended follow-ups.

Related: `docs/specs/SPEC_TASK_DEV_LAUNCHER_GAPS_2026_05_06.md` — `task dev` doesn't run the launcher, so PR #702's reconciler is dead code in dev mode. Independent issue, also documented in this PR for traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
