### PR TITLE
fix(pool): cache HWND at register, use as fallback when CEF returns null

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.648"
+version = "0.33.649"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.648"
+version = "0.33.649"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.648"
+version = "0.33.649"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.648"
+version = "0.33.649"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.647 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.644 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.643 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.624 | 2026-05-03 | 161.9 MiB | 339.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.648"
+version = "0.33.649"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -30,8 +30,31 @@
 //   the process.
 
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::collections::HashMap;
 
 use crate::state::{AppState, WindowKind, WindowMeta};
+
+/// HWND cache for pool windows. Populated at `on_after_created`
+/// (register_pool_window) and consulted at `promote_pool_window` as
+/// the source of truth — `BrowserHost::window_handle()` returns null
+/// once the page loads even though the underlying Win32 window is
+/// alive (verified by `IsWindow` — see
+/// `SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md` §4.1 diagnostic run).
+///
+/// Entries are removed on pool-window destruction
+/// (`on_pool_window_destroyed`) so the map can't leak across the
+/// process lifetime. The HWND is stored as `usize` so this state is
+/// `Send + Sync` without `unsafe`; callers cast back to `HWND` /
+/// `*mut c_void` at use site.
+#[cfg(target_os = "windows")]
+static POOL_HWND_CACHE: std::sync::OnceLock<Mutex<HashMap<String, usize>>> =
+    std::sync::OnceLock::new();
+
+#[cfg(target_os = "windows")]
+fn pool_hwnd_cache() -> &'static Mutex<HashMap<String, usize>> {
+    POOL_HWND_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 /// Target pool size. See module-level comment for rationale.
 pub const POOL_TARGET_SIZE: usize = 2;
@@ -238,12 +261,21 @@ pub fn register_pool_window(state: &Arc<AppState>, label: &str) {
                 })
             });
         if let Some(hwnd) = raw_hwnd {
+            // Cache the HWND for promote-time use. CEF's
+            // `BrowserHost::window_handle()` returns null after the
+            // page loads (verified diagnostic run 2026-05-06), but
+            // the underlying Win32 window is still alive. The cache
+            // is the only reliable source for the HWND at promote.
+            pool_hwnd_cache()
+                .lock()
+                .unwrap()
+                .insert(label.to_string(), hwnd as usize);
             set_taskbar_hidden(hwnd, true);
         } else {
             tracing::warn!(
                 target: "dnd:tearoff:pool",
                 label = %label,
-                "[pool] HWND not yet available at register time — taskbar hide skipped"
+                "[pool] HWND null at register time — taskbar hide skipped, cache not populated"
             );
         }
     }
@@ -306,6 +338,14 @@ pub fn on_pool_window_destroyed(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;
     }
+    // Drop the cached HWND so the map can't grow unbounded across the
+    // process lifetime. Idempotent — fine if the entry isn't present
+    // (e.g. a window destroyed before register_pool_window populated
+    // the cache).
+    #[cfg(target_os = "windows")]
+    {
+        pool_hwnd_cache().lock().unwrap().remove(label);
+    }
     // PR #5 H.4 — atomic remove-from-{unpromoted,queue} + clear
     // respawn semaphore via reducer. The dispatch returns:
     //   - `pool_destroyed_was_unpromoted`: distinguishes pre-promote
@@ -351,6 +391,7 @@ pub fn mark_pool_window_renderer_ready(state: &Arc<AppState>, label: &str) {
     if !label.starts_with("window-pool-") {
         return;
     }
+
     // PR #5 H.4 — atomic move-from-unpromoted-to-queue + clear respawn
     // semaphore via reducer. Idempotent against duplicate frontend
     // signals (re-mount, hot reload). `pool_size_after` is the queue
@@ -452,7 +493,15 @@ pub fn promote_pool_window(
     // expected failure — log per-step at ERROR so an operator can
     // tell which invariant broke.
     use cef::{ImplBrowser, ImplBrowserHost};
-    // Phase H.2.b — reducer-aware lookup with fallback.
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::WindowsAndMessaging::IsWindow;
+    // Resolve the HWND. CEF's `BrowserHost::window_handle()` returns
+    // null after the page loads on Views-based browsers, even though
+    // the underlying Win32 window is alive (verified 2026-05-06,
+    // SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md). Use the cache we
+    // populated at `register_pool_window`; the CEF path is kept as a
+    // first-try in case some future CEF version starts returning the
+    // HWND consistently again.
     let raw_hwnd: Option<*mut std::ffi::c_void> = match state.get_browser(&label) {
         None => {
             tracing::error!(
@@ -472,16 +521,46 @@ pub fn promote_pool_window(
                 None
             }
             Some(host) => {
-                let h = host.window_handle();
-                if h.0.is_null() {
-                    tracing::error!(
-                        target: "dnd:tearoff:pool",
-                        label = %label,
-                        "[pool] host window handle is null (state inconsistency)"
-                    );
-                    None
+                let cef_hwnd = host.window_handle().0;
+                if !cef_hwnd.is_null() {
+                    Some(cef_hwnd as *mut std::ffi::c_void)
                 } else {
-                    Some(h.0 as *mut std::ffi::c_void)
+                    // CEF lost the reference — fall back to cache.
+                    let cached = pool_hwnd_cache().lock().unwrap().get(&label).copied();
+                    match cached {
+                        None => {
+                            tracing::error!(
+                                target: "dnd:tearoff:pool",
+                                label = %label,
+                                "[pool] CEF HWND null AND no cache entry (state inconsistency)"
+                            );
+                            None
+                        }
+                        Some(h) => {
+                            // Verify the cached HWND is still a live
+                            // OS window. If the OS has reclaimed it,
+                            // the slot is genuinely dead; refuse the
+                            // promote and fall back to cold-path.
+                            let alive = unsafe { IsWindow(h as HWND) } != 0;
+                            if alive {
+                                tracing::debug!(
+                                    target: "dnd:tearoff:pool",
+                                    label = %label,
+                                    hwnd = format!("0x{:x}", h),
+                                    "[pool] using cached HWND (CEF returned null)"
+                                );
+                                Some(h as *mut std::ffi::c_void)
+                            } else {
+                                tracing::error!(
+                                    target: "dnd:tearoff:pool",
+                                    label = %label,
+                                    hwnd = format!("0x{:x}", h),
+                                    "[pool] cached HWND no longer a live window"
+                                );
+                                None
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.648"
+version = "0.33.649"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.648"
+version = "0.33.649"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.648"
+version = "0.33.649"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md
+++ b/docs/specs/SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md
@@ -44,29 +44,31 @@ The mismatch: a pool window is "renderer ready" but has no HWND. Possible causes
 
 The 11-minute-idle case argues against (3) (way too long for a thread race) but supports (1) or (2).
 
-## 4. Proposed approach
+## 4. Diagnosis (2026-05-06)
 
-### 4.1 Diagnose first
+Instrumented diagnostic build (PR #704 follow-up) captured this:
 
-Before patching, instrument:
+```
+07:14:17  HWND probe at register time: valid  hwnd=0x130892
+07:15:39  HWND probe at renderer-ready time   cef_status=null  cached_status=cached=0x130892 alive=true
+```
 
-- In `mark_pool_window_renderer_ready`, log the HWND from `Browser::host().window_handle()` at enqueue time.
-- In `promote_pool_window`, log the HWND value (null vs non-null vs stale-pointer) and the time-since-enqueue.
-- If HWND is null at enqueue time → cause (1): the renderer-ready signal precedes HWND assignment.
-- If HWND is non-null at enqueue but null at promote → cause (2): OS cleaned it up.
-- If HWND is non-null at enqueue, non-null at promote, but `IsWindow(hwnd)` returns false → stale handle.
+The HWND is **alive** per Win32 `IsWindow`, but `BrowserHost::window_handle()` returns null. Pattern:
 
-### 4.2 If cause (1) — defer enqueue
+- **Register time:** CEF's `BrowserHost::window_handle()` returns the valid HWND.
+- **Renderer-ready time** (~80s later in dev mode, ~1-2s in production): CEF returns null. The cached HWND is still a live OS window.
 
-Don't enqueue a pool window until BOTH renderer-ready AND `host().window_handle()` is non-null. Add a second gate. If the renderer is ready but no HWND yet, schedule a deferred check (e.g. on the next `WM_WINDOWPOSCHANGED`).
+So this is **none of (1), (2), or (3)** as previously hypothesized. CEF Views' `BrowserHost::window_handle()` is unreliable after the page loads — the underlying Win32 window is intact, CEF just stops reporting its handle. Root cause likely lives inside CEF's view-attachment lifecycle (the parent HWND association on the view changes once content is fully loaded).
 
-### 4.3 If cause (2) — show + hide cycle
+### 4.1 Fix: cache the HWND at register time
 
-Periodically nudge pool windows: `ShowWindow(SW_HIDE)` → `ShowWindow(SW_SHOW)` to keep them registered with the OS without making them visible. Hacky but proven workaround for similar Windows behavior.
+Pool windows have one moment when CEF reliably reports their HWND: `on_after_created`, where `register_pool_window` already runs. Cache the HWND there in a module-level `Mutex<HashMap<String, usize>>`. At promote time, fall back to the cache if `host.window_handle()` returns null. Verify cache is still a live OS window via `IsWindow` before using; if not (genuine OS-level destruction), refuse the promote and let the frontend cold-path.
 
-### 4.4 If cause (3) — synchronize
+Cache cleanup happens in `on_pool_window_destroyed`, which fires for any `window-pool-*` close (including post-promote user-window closes that retain the prefix).
 
-Move the renderer-ready signal onto the UI thread, ensuring it can only fire after `on_after_created` has registered the HWND. Single-threaded happens-before relationship.
+### 4.2 Why not just always use the cached HWND
+
+`BrowserHost::window_handle()` is preferred when it returns non-null — that's the path CEF intends, and a future CEF version may stop returning null after page-load. Keeping the CEF call as the first try means the moment CEF stabilizes, no further code change is needed.
 
 ## 5. Out of scope
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.648",
+  "version": "0.33.649",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.648",
+      "version": "0.33.649",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.648",
+  "version": "0.33.649",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## What

CEF's `BrowserHost::window_handle()` returns null on Views-based browsers once the page loads, even though the underlying Win32 window is alive. Every pool promote fails with `host window handle is null (state inconsistency)` and the frontend cold-paths every tear-off — exactly the waste the warm pool exists to prevent.

## Diagnosis (2026-05-06)

Instrumented `register_pool_window` and `mark_pool_window_renderer_ready` to log the HWND at each lifecycle stage. Captured:

```
07:14:17  HWND probe at register time:        valid hwnd=0x130892
07:15:39  HWND probe at renderer-ready time:  cef_status=null  cached_status=cached=0x130892 alive=true
```

The HWND **is alive** per Win32 `IsWindow`. CEF Views' `BrowserHost::window_handle()` is what's broken — it returns null after the page has loaded, but the underlying Win32 window is intact.

## Fix

Cache the HWND at `register_pool_window` time (when CEF reliably reports it) in a module-level `Mutex<HashMap<String, usize>>`. At `promote_pool_window`, fall back to the cache if `host.window_handle()` returns null. Verify the cached value is still a live OS window via `IsWindow` before using; if not (genuine OS-level destruction), refuse the promote so the frontend cold-paths cleanly.

Cache cleanup runs in `on_pool_window_destroyed` (which fires for any `window-pool-*` close, including post-promote user-window closes that retain the prefix).

The CEF call is still tried first. The moment a future CEF version returns the HWND consistently after page-load, the fallback stops being exercised — no further code change.

## Smoke (task dev, `agenta/pool-hwnd-cache`)

- 2 sequential tab tear-offs both **promoted from the pool**
- Zero `host window handle is null` errors
- Zero `pool exhausted` warnings
- Pool refilled after each promote
- No first-paint flash

This is the host-side companion to PR #704 — the frontend wiring (PR #704) tries the pool first; this PR makes the pool actually work.

## Spec

`docs/specs/SPEC_POOL_WINDOW_HWND_NULL_2026_05_06.md` — full diagnosis + design (§4 updated with diagnostic results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
