### PR TITLE
fix(launcher-bridge): forward events to PROMOTED pool windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.653"
+version = "0.33.654"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.653"
+version = "0.33.654"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.653"
+version = "0.33.654"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.653"
+version = "0.33.654"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.650"
+version = "0.33.651"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.650"
+version = "0.33.651"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.650"
+version = "0.33.651"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.650"
+version = "0.33.651"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.651"
+version = "0.33.652"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.651"
+version = "0.33.652"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.651"
+version = "0.33.652"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.651"
+version = "0.33.652"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.652"
+version = "0.33.653"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.652"
+version = "0.33.653"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.652"
+version = "0.33.653"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.652"
+version = "0.33.653"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.650"
+version = "0.33.651"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.653"
+version = "0.33.654"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.651"
+version = "0.33.652"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.652"
+version = "0.33.653"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -670,27 +670,33 @@ impl AgentMuxHandler {
         // (`browser-pane-*`) are sub-views of a parent window, not
         // standalone instances, so they don't count either.
         //
-        // Use `pool_inventory_labels_snapshot()` — union of
-        // `unpromoted` (spawn-time) and `pool.queue` (renderer-ready,
-        // pre-promote). Both states are hidden off-screen with no
-        // user UI; counting them as user-visible inflates this
-        // gate and prevents the cascade from firing when the user
-        // really did close their last visible window.
+        // Use `user_visibility_snapshot()` — atomic read of pool
+        // inventory (`unpromoted` ∪ `pool.queue`) AND the browser
+        // registry under ONE host_state lock. Both pool states are
+        // hidden off-screen with no user UI; counting them as
+        // user-visible inflates this gate and prevents the cascade
+        // from firing when the user really did close their last
+        // visible window.
+        //
+        // The single-lock read is required because a two-lock
+        // variant races against `promote_pool_window`: a label can
+        // move from `pool.queue` to promoted between the two reads,
+        // leaving the stale inventory excluding a now-real user
+        // window — making `was_last` true and triggering a cascade
+        // that closes the freshly torn-off window.
         //
         // Promoted pool windows ARE counted: they're removed from
         // BOTH pool sets at promote time.
         let (user_browser_count, browsers_keys, pool_keys) = {
-            // Phase H.2.b — reducer-aware label snapshot. Single helper call
-            // replaces an interleaved pool_labels.lock + browsers.lock pair.
-            let pool_labels = self.state.pool_inventory_labels_snapshot();
-            let keys = self.state.list_browser_labels();
+            let (pool_labels, browsers) = self.state.user_visibility_snapshot();
+            let keys: Vec<String> = browsers.into_iter().map(|(l, _)| l).collect();
             let count = keys
                 .iter()
                 .filter(|label| {
                     !pool_labels.contains(label.as_str()) && !label.starts_with("browser-pane-")
                 })
                 .count();
-            let pool: Vec<String> = pool_labels.iter().cloned().collect();
+            let pool: Vec<String> = pool_labels.into_iter().collect();
             (count, keys, pool)
         };
 

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -670,17 +670,19 @@ impl AgentMuxHandler {
         // (`browser-pane-*`) are sub-views of a parent window, not
         // standalone instances, so they don't count either.
         //
-        // Use `unpromoted_pool_labels` (populated at spawn time)
-        // rather than `window_pool` (populated only after the
-        // renderer-ready handshake) so this filter is correct
-        // even during the spawn → ready gap.
+        // Use `pool_inventory_labels_snapshot()` — union of
+        // `unpromoted` (spawn-time) and `pool.queue` (renderer-ready,
+        // pre-promote). Both states are hidden off-screen with no
+        // user UI; counting them as user-visible inflates this
+        // gate and prevents the cascade from firing when the user
+        // really did close their last visible window.
         //
         // Promoted pool windows ARE counted: they're removed from
-        // `unpromoted_pool_labels` at promote time.
+        // BOTH pool sets at promote time.
         let (user_browser_count, browsers_keys, pool_keys) = {
             // Phase H.2.b — reducer-aware label snapshot. Single helper call
             // replaces an interleaved pool_labels.lock + browsers.lock pair.
-            let pool_labels = self.state.unpromoted_pool_labels_snapshot();
+            let pool_labels = self.state.pool_inventory_labels_snapshot();
             let keys = self.state.list_browser_labels();
             let count = keys
                 .iter()

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -409,15 +409,14 @@ pub fn get_double_click_time() -> serde_json::Value {
 /// window before its frontend has finished init. Callers should
 /// fall back to label/index-based naming in that case.
 pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
-    // Use the full pool inventory (unpromoted + ready-queued), not
-    // just unpromoted, so renderer-ready-but-not-yet-promoted pool
-    // windows don't appear in the user-facing listing as phantom
-    // entries. Same reasoning applies to `dispatch_to_renderers`.
-    let pool_labels = state.pool_inventory_labels_snapshot();
-    // Phase H.2.b — reducer-aware label snapshot.
-    let labels: Vec<String> = state
-        .list_browser_labels()
+    // Atomic snapshot — pool inventory + browsers under ONE lock.
+    // Two-lock variants race against `promote_pool_window` between
+    // the reads and would let a just-promoted user window be
+    // excluded (or admit a still-hidden pool window).
+    let (pool_labels, browsers) = state.user_visibility_snapshot();
+    let labels: Vec<String> = browsers
         .into_iter()
+        .map(|(l, _)| l)
         .filter(|l| !pool_labels.contains(l.as_str()) && !l.starts_with("browser-pane-"))
         .collect();
     // Read backend window IDs via `state.backend_window_id()`,
@@ -442,18 +441,18 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
 /// in `list_windows` inflates the frontend's InstancePanel row count
 /// with phantom entries the user can't see or focus.
 ///
-/// Uses `state.pool_inventory_labels_snapshot()` — the union of
-/// `unpromoted` (synchronous, populated at spawn time) and `pool.queue`
-/// (populated after the renderer-ready handshake but before promote).
-/// Both states are host-internal: the window is hidden off-screen and
-/// has no UI a user could see or focus, so neither belongs in this
-/// listing.
+/// Uses `state.user_visibility_snapshot()` — atomic read of pool
+/// inventory (`unpromoted` ∪ `pool.queue`) and the browser registry
+/// under one host_state lock. Both `unpromoted` (populated at spawn
+/// time) and `pool.queue` (populated after renderer-ready, before
+/// promote) are host-internal: the window is hidden off-screen and
+/// has no UI a user could see or focus. The atomic read is required
+/// because a two-lock variant races against `promote_pool_window`.
 pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
-    let pool_labels = state.pool_inventory_labels_snapshot();
-    // Phase H.2.b — reducer-aware label snapshot.
-    let labels: Vec<String> = state
-        .list_browser_labels()
+    let (pool_labels, browsers) = state.user_visibility_snapshot();
+    let labels: Vec<String> = browsers
         .into_iter()
+        .map(|(l, _)| l)
         .filter(|l| !pool_labels.contains(l.as_str()))
         .collect();
     serde_json::json!(labels)

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -409,7 +409,11 @@ pub fn get_double_click_time() -> serde_json::Value {
 /// window before its frontend has finished init. Callers should
 /// fall back to label/index-based naming in that case.
 pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
-    let pool_labels = state.unpromoted_pool_labels_snapshot();
+    // Use the full pool inventory (unpromoted + ready-queued), not
+    // just unpromoted, so renderer-ready-but-not-yet-promoted pool
+    // windows don't appear in the user-facing listing as phantom
+    // entries. Same reasoning applies to `dispatch_to_renderers`.
+    let pool_labels = state.pool_inventory_labels_snapshot();
     // Phase H.2.b — reducer-aware label snapshot.
     let labels: Vec<String> = state
         .list_browser_labels()
@@ -438,15 +442,14 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
 /// in `list_windows` inflates the frontend's InstancePanel row count
 /// with phantom entries the user can't see or focus.
 ///
-/// Use `state.unpromoted_pool_labels_snapshot()` (NOT `state.pool.queue`) as the
-/// "is unpromoted pool" oracle — the pool queue is only populated
-/// after the renderer-ready handshake (~100 ms after spawn), so it
-/// would miss freshly-spawned pool windows during the gap.
-/// `unpromoted_pool_labels` is populated synchronously in
-/// `spawn_pool_window` and removed in `promote_pool_window` /
-/// `on_pool_window_destroyed`.
+/// Uses `state.pool_inventory_labels_snapshot()` — the union of
+/// `unpromoted` (synchronous, populated at spawn time) and `pool.queue`
+/// (populated after the renderer-ready handshake but before promote).
+/// Both states are host-internal: the window is hidden off-screen and
+/// has no UI a user could see or focus, so neither belongs in this
+/// listing.
 pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
-    let pool_labels = state.unpromoted_pool_labels_snapshot();
+    let pool_labels = state.pool_inventory_labels_snapshot();
     // Phase H.2.b — reducer-aware label snapshot.
     let labels: Vec<String> = state
         .list_browser_labels()

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -168,7 +168,18 @@ pub fn spawn_pool_window(state: &Arc<AppState>) {
     // P2 PR #578 rounds 2 + 3.)
     crate::launcher_ipc::report_pool_window_added(label.clone());
     {
-        let pool_count = state.unpromoted_pool_labels_snapshot().len() as u32;
+        // Pool inventory (unpromoted ∪ queue), not unpromoted-only:
+        // the launcher's `state.pool` mirror is built from
+        // ReportPoolWindowAdded/Removed/Promoted events; the host's
+        // unpromoted→queue transition emits NO event, so the
+        // launcher retains queued labels in its pool set. Reporting
+        // unpromoted.len() under-counts and triggers spurious pool
+        // drift while a warm slot is queued. Atomic snapshot —
+        // single host_state lock.
+        let pool_count = {
+            let st = state.host_state.lock();
+            (st.pool.unpromoted.len() + st.pool.queue.len()) as u32
+        };
         crate::launcher_ipc::report_host_pool_count(pool_count);
     }
 

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -29,17 +29,24 @@ use cef::{CefString, ImplBrowser, ImplFrame};
 /// Forward a launcher event to every top-level renderer.
 ///
 /// Excluded:
-///   - **Unpromoted** pool labels (`window-pool-*` still in
-///     `state.unpromoted_pool_labels`): no UI yet; renderer is
-///     waiting for `pool:promote`. Sending launcher events here
-///     would be wasted work.
+///   - Pool **inventory** labels (`window-pool-*` in
+///     `pool.unpromoted` OR `pool.queue`): no user UI yet. Two
+///     sub-states:
+///       * `pool.unpromoted` — spawning, renderer not ready.
+///       * `pool.queue` — renderer ready, waiting for promote.
+///     Both are hidden off-screen and would build stale InstancePanel
+///     state from launcher events the user never sees. The bridge
+///     uses `state.pool_inventory_labels_snapshot()` (unpromoted ∪
+///     queue) so a renderer-ready-but-pre-promote pool window
+///     doesn't slip through (`unpromoted_pool_labels_snapshot()`
+///     alone misses that case).
 ///   - Browser-pane labels (`browser-pane-*`): not top-level
 ///     windows; have no InstancePanel.
 ///
 /// Promoted pool windows (label still has the `window-pool-*`
-/// prefix but the entry is no longer in `unpromoted_pool_labels`)
-/// ARE included — they're the user-visible torn-off windows. Pre-fix,
-/// a label-prefix-only check excluded them too, so torn-off windows
+/// prefix but the entry is in NEITHER pool set) ARE included —
+/// they're the user-visible torn-off windows. Pre-fix, a
+/// label-prefix-only check excluded them too, so torn-off windows
 /// stopped receiving launcher events post-promotion (InstancePanel
 /// drift, plus anything else listening to launcher events).
 ///
@@ -66,18 +73,19 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
-    // Snapshot unpromoted pool labels once. Iterating `list_browsers()`
-    // calls into the reducer per-iteration; the prefix+set check is
-    // a hot path on every event so we precompute the set.
-    let unpromoted = state.unpromoted_pool_labels_snapshot();
+    // Snapshot pool inventory once (unpromoted + ready-queue). Hot
+    // path — every launcher event runs this loop, and we want to
+    // avoid re-locking host_state per browser.
+    let pool_inventory = state.pool_inventory_labels_snapshot();
 
     // Phase H.2.b — reducer-aware iteration with fallback.
     for (label, browser) in state.list_browsers() {
         if label.starts_with("browser-pane-") {
             continue;
         }
-        if unpromoted.contains(label.as_str()) {
-            // Unpromoted pool window — has no UI, skip.
+        if pool_inventory.contains(label.as_str()) {
+            // Pool inventory (unpromoted or ready-queued) — no user
+            // UI yet, skip.
             continue;
         }
         if let Some(frame) = browser.main_frame() {

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -28,10 +28,24 @@ use cef::{CefString, ImplBrowser, ImplFrame};
 
 /// Forward a launcher event to every top-level renderer.
 ///
-/// Pool + browser-pane labels are excluded — they have no UI.
-/// The JSON payload uses `serde_json::to_string`, so any string
-/// content from the Event is escaped against quote / backtick
-/// injection at the JS-string boundary.
+/// Excluded:
+///   - **Unpromoted** pool labels (`window-pool-*` still in
+///     `state.unpromoted_pool_labels`): no UI yet; renderer is
+///     waiting for `pool:promote`. Sending launcher events here
+///     would be wasted work.
+///   - Browser-pane labels (`browser-pane-*`): not top-level
+///     windows; have no InstancePanel.
+///
+/// Promoted pool windows (label still has the `window-pool-*`
+/// prefix but the entry is no longer in `unpromoted_pool_labels`)
+/// ARE included — they're the user-visible torn-off windows. Pre-fix,
+/// a label-prefix-only check excluded them too, so torn-off windows
+/// stopped receiving launcher events post-promotion (InstancePanel
+/// drift, plus anything else listening to launcher events).
+///
+/// JSON payload uses `serde_json::to_string`, so any string content
+/// from the Event is escaped against quote / backtick injection at
+/// the JS-string boundary.
 pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event) {
     let json = match serde_json::to_string(event) {
         Ok(s) => s,
@@ -52,9 +66,18 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
+    // Snapshot unpromoted pool labels once. Iterating `list_browsers()`
+    // calls into the reducer per-iteration; the prefix+set check is
+    // a hot path on every event so we precompute the set.
+    let unpromoted = state.unpromoted_pool_labels_snapshot();
+
     // Phase H.2.b — reducer-aware iteration with fallback.
     for (label, browser) in state.list_browsers() {
-        if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
+        if label.starts_with("browser-pane-") {
+            continue;
+        }
+        if unpromoted.contains(label.as_str()) {
+            // Unpromoted pool window — has no UI, skip.
             continue;
         }
         if let Some(frame) = browser.main_frame() {

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -36,10 +36,12 @@ use cef::{CefString, ImplBrowser, ImplFrame};
 ///       * `pool.queue` — renderer ready, waiting for promote.
 ///     Both are hidden off-screen and would build stale InstancePanel
 ///     state from launcher events the user never sees. The bridge
-///     uses `state.pool_inventory_labels_snapshot()` (unpromoted ∪
-///     queue) so a renderer-ready-but-pre-promote pool window
-///     doesn't slip through (`unpromoted_pool_labels_snapshot()`
-///     alone misses that case).
+///     uses `state.user_visibility_snapshot()` which atomically
+///     reads the pool inventory (unpromoted ∪ queue) and the
+///     browser registry under one host_state lock — a two-lock
+///     variant would race against `promote_pool_window` and let a
+///     just-promoted window slip through (or, worse, count a
+///     real user window in the close-cascade gate's exclusion).
 ///   - Browser-pane labels (`browser-pane-*`): not top-level
 ///     windows; have no InstancePanel.
 ///
@@ -73,13 +75,13 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     let code = CefString::from(script.as_str());
     let url = CefString::from("");
 
-    // Snapshot pool inventory once (unpromoted + ready-queue). Hot
-    // path — every launcher event runs this loop, and we want to
-    // avoid re-locking host_state per browser.
-    let pool_inventory = state.pool_inventory_labels_snapshot();
+    // Atomic snapshot — pool inventory + browsers under ONE lock.
+    // Two-lock variants race against `promote_pool_window` between
+    // the reads.
+    let (pool_inventory, browsers) = state.user_visibility_snapshot();
 
     // Phase H.2.b — reducer-aware iteration with fallback.
-    for (label, browser) in state.list_browsers() {
+    for (label, browser) in browsers {
         if label.starts_with("browser-pane-") {
             continue;
         }

--- a/agentmux-cef/src/launcher_ipc.rs
+++ b/agentmux-cef/src/launcher_ipc.rs
@@ -792,13 +792,11 @@ pub fn report_monitor_topology_changed(rects: Vec<agentmux_common::ipc::Rect>) {
 /// `docs/retro/multi-reducer-proposal-2026-04-28.md`), this becomes
 /// "report host's authoritative reducer-state to the launcher."
 pub fn compute_and_report_host_counts(state: &std::sync::Arc<crate::state::AppState>) {
-    // Phase H.2.b — reducer-aware label snapshot.
-    let unpromoted = state.unpromoted_pool_labels_snapshot();
-    let pool = unpromoted.len() as u32;
-    let windows = state
-        .list_browser_labels()
-        .into_iter()
-        .filter(|k| !k.starts_with("browser-pane-") && !unpromoted.contains(k.as_str()))
-        .count() as u32;
+    // Atomic snapshot — pool inventory + browsers under ONE
+    // `host_state` lock. Two-lock variants race against
+    // `promote_pool_window` between reads and let queued pool
+    // windows leak into the user-window count, triggering spurious
+    // launcher drift-detection.
+    let (windows, pool) = state.host_counts_snapshot();
     report_host_counts(windows, pool);
 }

--- a/agentmux-cef/src/saga_dispatch.rs
+++ b/agentmux-cef/src/saga_dispatch.rs
@@ -353,13 +353,17 @@ impl SagaActionRunner for LiveActionRunner {
 
     fn drain_pool_if_last(&self, label: &str) -> bool {
         // Compute the same condition `on_before_close` uses to
-        // decide drain. Read-only snapshot of host state.
-        // Phase H.2.b — reducer-aware label snapshot.
-        let unpromoted = self.state.unpromoted_pool_labels_snapshot();
-        let labels = self.state.list_browser_labels();
+        // decide drain. MUST mirror that gate exactly: same pool
+        // inventory (unpromoted ∪ queue), same atomic-snapshot
+        // discipline. A two-lock variant or unpromoted-only check
+        // here lets a queued pool window inflate `user_count` and
+        // suppress the drain when the user actually did close
+        // their last visible window.
+        let (pool_inventory, browsers) = self.state.user_visibility_snapshot();
+        let labels: Vec<String> = browsers.into_iter().map(|(l, _)| l).collect();
         let user_count = labels
             .iter()
-            .filter(|k| !unpromoted.contains(k.as_str()) && !k.starts_with("browser-pane-"))
+            .filter(|k| !pool_inventory.contains(k.as_str()) && !k.starts_with("browser-pane-"))
             .count();
         // `was_last` semantics: closing window is the last user-
         // visible window. Caller's `label` should be subtracted —

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -836,6 +836,25 @@ impl AppState {
         self.host_state.lock().pool.queue.len()
     }
 
+    /// Union of `pool.unpromoted` and `pool.queue` — every pool label
+    /// that's still HOST-INTERNAL (no user UI yet). Used by
+    /// `launcher_event_bridge::dispatch_to_renderers` to skip both
+    /// pre-ready and ready-but-not-yet-promoted pool windows.
+    /// `unpromoted_pool_labels_snapshot()` alone misses the
+    /// renderer-ready window-but-not-yet-promoted state where
+    /// `handle_pool_ready` has moved the label to `pool.queue`.
+    pub fn pool_inventory_labels_snapshot(&self) -> std::collections::HashSet<String> {
+        let st = self.host_state.lock();
+        let mut set: std::collections::HashSet<String> = st
+            .pool
+            .unpromoted
+            .iter()
+            .cloned()
+            .collect();
+        set.extend(st.pool.queue.iter().cloned());
+        set
+    }
+
     /// PR #5 H.5 — read-side helper for the legacy `is_quitting` check.
     /// Returns true iff the host has begun draining (BeginDrain
     /// dispatched) OR has fully quit. Replaces the AtomicBool.

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -819,10 +819,14 @@ impl AppState {
     /// - exclude pool inventory (`pool.unpromoted` ∪ `pool.queue`)
     /// - exclude `browser-pane-*` child HWNDs
     ///
-    /// `unpromoted_pool_count` is the count the launcher's
-    /// `state.pool` mirror tracks (added/removed events emit at
-    /// the unpromoted boundary; `pool.queue` is host-internal and
-    /// has no launcher event).
+    /// `pool_count` is the size of the pool **inventory** (unpromoted
+    /// ∪ queue) — NOT just unpromoted. The launcher's `state.pool`
+    /// mirror is built from `ReportPoolWindowAdded` / `Removed` /
+    /// `Promoted` events. On the host's unpromoted→queue transition
+    /// (when `pool_ready` fires) NO event is emitted, so the
+    /// launcher mirror retains the queued label. Reporting just
+    /// `unpromoted.len()` would under-count and trigger spurious
+    /// pool drift while the warm pool is idle and ready.
     pub fn host_counts_snapshot(&self) -> (u32, u32) {
         let st = self.host_state.lock();
         let pool_inventory: std::collections::HashSet<&str> = st
@@ -832,13 +836,13 @@ impl AppState {
             .map(String::as_str)
             .chain(st.pool.queue.iter().map(String::as_str))
             .collect();
-        let unpromoted = st.pool.unpromoted.len() as u32;
+        let pool = pool_inventory.len() as u32;
         let windows = st
             .browsers
             .keys()
             .filter(|k| !k.starts_with("browser-pane-") && !pool_inventory.contains(k.as_str()))
             .count() as u32;
-        (windows, unpromoted)
+        (windows, pool)
     }
 
     /// Snapshot of unpromoted pool labels. Used by orphan

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -836,23 +836,40 @@ impl AppState {
         self.host_state.lock().pool.queue.len()
     }
 
-    /// Union of `pool.unpromoted` and `pool.queue` — every pool label
-    /// that's still HOST-INTERNAL (no user UI yet). Used by
-    /// `launcher_event_bridge::dispatch_to_renderers` to skip both
-    /// pre-ready and ready-but-not-yet-promoted pool windows.
-    /// `unpromoted_pool_labels_snapshot()` alone misses the
-    /// renderer-ready window-but-not-yet-promoted state where
-    /// `handle_pool_ready` has moved the label to `pool.queue`.
-    pub fn pool_inventory_labels_snapshot(&self) -> std::collections::HashSet<String> {
+    /// Atomic snapshot for user-visibility filtering: pool inventory
+    /// (`pool.unpromoted` ∪ `pool.queue`) AND the browser registry,
+    /// taken under ONE `host_state` lock acquisition.
+    ///
+    /// Two-lock variants (one snapshot for the pool, one for
+    /// `list_browsers()`) race against `promote_pool_window`:
+    /// between the reads, a label can move from pool.queue to
+    /// promoted, leaving the stale inventory excluding a now-real
+    /// user window. Atomic snapshot eliminates the gap.
+    ///
+    /// Returns:
+    /// - `pool_inventory`: labels in `pool.unpromoted` ∪ `pool.queue`
+    ///   (host-internal, no user UI yet — exclude from user-visible
+    ///   filters and from launcher-event dispatch).
+    /// - `browsers`: every label → Browser pair currently registered
+    ///   (cheap clone — `Browser` is a CEF refcounted wrapper).
+    pub fn user_visibility_snapshot(&self) -> (
+        std::collections::HashSet<String>,
+        Vec<(String, Browser)>,
+    ) {
         let st = self.host_state.lock();
-        let mut set: std::collections::HashSet<String> = st
+        let pool_inventory: std::collections::HashSet<String> = st
             .pool
             .unpromoted
             .iter()
             .cloned()
+            .chain(st.pool.queue.iter().cloned())
             .collect();
-        set.extend(st.pool.queue.iter().cloned());
-        set
+        let browsers: Vec<(String, Browser)> = st
+            .browsers
+            .iter()
+            .map(|(k, h)| (k.clone(), h.browser.clone()))
+            .collect();
+        (pool_inventory, browsers)
     }
 
     /// PR #5 H.5 — read-side helper for the legacy `is_quitting` check.

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -809,10 +809,42 @@ impl AppState {
     // `state.window_pool: Mutex<VecDeque>` reads. All under one
     // `host_state` lock, snapshot-and-drop discipline.
 
-    /// Snapshot of unpromoted pool labels. Used by `list_windows`,
-    /// `compute_and_report_host_counts`, and saga-dispatch's
-    /// `drain_pool_if_last`. Caller can `.contains()` against the set
-    /// or iterate.
+    /// Atomic snapshot of (user_window_count, unpromoted_pool_count)
+    /// for the launcher drift-detection report. Both reads taken
+    /// under ONE `host_state` lock; a two-lock variant races
+    /// against `promote_pool_window` and would let queued pool
+    /// windows leak into the user-window count.
+    ///
+    /// Filter rules (mirror `list_windows` / `dispatch_to_renderers`):
+    /// - exclude pool inventory (`pool.unpromoted` ∪ `pool.queue`)
+    /// - exclude `browser-pane-*` child HWNDs
+    ///
+    /// `unpromoted_pool_count` is the count the launcher's
+    /// `state.pool` mirror tracks (added/removed events emit at
+    /// the unpromoted boundary; `pool.queue` is host-internal and
+    /// has no launcher event).
+    pub fn host_counts_snapshot(&self) -> (u32, u32) {
+        let st = self.host_state.lock();
+        let pool_inventory: std::collections::HashSet<&str> = st
+            .pool
+            .unpromoted
+            .iter()
+            .map(String::as_str)
+            .chain(st.pool.queue.iter().map(String::as_str))
+            .collect();
+        let unpromoted = st.pool.unpromoted.len() as u32;
+        let windows = st
+            .browsers
+            .keys()
+            .filter(|k| !k.starts_with("browser-pane-") && !pool_inventory.contains(k.as_str()))
+            .count() as u32;
+        (windows, unpromoted)
+    }
+
+    /// Snapshot of unpromoted pool labels. Used by orphan
+    /// reconciliation and the pool-count report after spawning a
+    /// new pool slot. Caller can `.contains()` against the set or
+    /// iterate.
     pub fn unpromoted_pool_labels_snapshot(&self) -> std::collections::HashSet<String> {
         self.host_state
             .lock()

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.651"
+version = "0.33.652"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.652"
+version = "0.33.653"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.653"
+version = "0.33.654"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.650"
+version = "0.33.651"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.653"
+version = "0.33.654"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.652"
+version = "0.33.653"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.650"
+version = "0.33.651"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.651"
+version = "0.33.652"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.653"
+version = "0.33.654"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.650"
+version = "0.33.651"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.652"
+version = "0.33.653"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.651"
+version = "0.33.652"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/launcher-event/reducer.test.ts
+++ b/frontend/app/store/launcher-event/reducer.test.ts
@@ -12,13 +12,17 @@ const win = (label: string, windowId: string | null = null): WindowEntry => ({ l
 
 describe("launcher-event reducer", () => {
     describe("isInstanceLabel filter", () => {
-        it("ignores window_opened for pool labels", () => {
+        it("accepts window_opened for promoted pool labels", () => {
+            // Promoted pool windows retain their `window-pool-*` prefix.
+            // The host-side gates (list_window_instances + launcher_event_bridge)
+            // exclude unpromoted pool labels upstream, so by the time
+            // a `window-pool-*` label reaches the reducer, it has been
+            // promoted to a user window and must be tracked.
             const r = update(initialState(), {
                 type: "ApplyEvent",
                 event: evt({ event: "window_opened", label: "window-pool-abc" }),
             });
-            expect(r.state.knownEntries.size).toBe(0);
-            expect(r.events[0]).toMatchObject({ type: "filtered-out", reason: "non-instance-label" });
+            expect(r.state.knownEntries.size).toBe(1);
         });
 
         it("ignores window_opened for browser-pane labels", () => {

--- a/frontend/app/store/launcher-event/types.ts
+++ b/frontend/app/store/launcher-event/types.ts
@@ -117,12 +117,18 @@ export interface ReducerResult {
  *
  * Exported via the store layer for callers that need the same filter
  * outside the reducer (notably `app-init.ts::initInstanceTracking`).
- * The two filters MUST stay in sync — past divergence on `window-pool-*`
- * was caught by reagent P2 #603.
+ *
+ * `window-pool-*` labels are accepted: the host-side gates
+ * (`list_window_instances` and `launcher_event_bridge::dispatch_to_renderers`)
+ * already exclude UNPROMOTED pool labels via
+ * `unpromoted_pool_labels_snapshot`. By the time a `window-pool-*` label
+ * reaches this filter, the host has promoted it to a real user window,
+ * and InstancePanel must include it. Filtering on prefix here
+ * incorrectly drops torn-off windows (which keep their `window-pool-*`
+ * prefix forever).
  */
 export function isInstanceLabel(label: string): boolean {
     if (label === "main") return true;
-    if (label.startsWith("window-pool-")) return false;
     if (label.startsWith("browser-pane-")) return false;
     return label.startsWith("window-");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.649",
+  "version": "0.33.650",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.649",
+      "version": "0.33.650",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.653",
+  "version": "0.33.654",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.653",
+      "version": "0.33.654",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.652",
+  "version": "0.33.653",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.652",
+      "version": "0.33.653",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.651",
+  "version": "0.33.652",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.651",
+      "version": "0.33.652",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.650",
+  "version": "0.33.651",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.650",
+      "version": "0.33.651",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.652",
+  "version": "0.33.653",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.653",
+  "version": "0.33.654",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.650",
+  "version": "0.33.651",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.651",
+  "version": "0.33.652",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## What

`agentmux-cef/src/launcher_event_bridge.rs::dispatch_to_renderers` filtered renderer destinations on label PREFIX:

```rust
if label.starts_with("window-pool-") || label.starts_with("browser-pane-") {
    continue;  // skip
}
```

But promoted pool windows (= the destination of a tab tear-off) **keep their `window-pool-*` prefix indefinitely** — only their entry in `state.unpromoted_pool_labels` is removed at promotion time. The prefix-only filter therefore excluded torn-off user windows from receiving launcher events.

## Symptom

Reproduced in v0.33.650 portable smoke (see linked logs):

1. Open AgentMux (main window).
2. Tear off 3 tabs (3 pool promotes).
3. Close 2 of those tear-off windows + main.
4. Open another new window.
5. Look at the InstancePanel in any torn-off window: it shows **1 window** when there are actually **2** alive.

Launcher log confirms the mirror is correct (5 `WindowOpened` / 3 `WindowClosed` = 2 alive). The drift lives in the renderer's per-window `launcher-event-reducer.ts` state, because no events reached it.

## Fix

Right discriminator is `state.unpromoted_pool_labels` (the canonical "is this a pre-promote pool slot or a real user window?" set). Snapshot it once per dispatch, skip only labels currently in the unpromoted set. Promoted labels — still prefixed `window-pool-*` but no longer in `unpromoted_pool_labels` — now receive events.

Browser-pane labels still skipped (they have no InstancePanel / launcher-event-reducer; the prefix check stays).

## Smoke

`cargo build -p agentmux-cef` clean. Will validate end-to-end with a fresh portable on the merged main.

## Wider impact

InstancePanel drift was the visible symptom because the user noticed the count mismatch. **Every launcher-event-reducer subscriber in a torn-off window was silently stale** — same root cause. Fixing this also fixes any other launcher-event-driven UI in those windows that nobody had noticed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
