### PR TITLE
fix: prevent drift-storm renderer crash (tier 1 follow-up to #706)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.655"
+version = "0.33.656"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.655"
+version = "0.33.656"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.655"
+version = "0.33.656"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.655"
+version = "0.33.656"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.657"
+version = "0.33.658"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.657"
+version = "0.33.658"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.657"
+version = "0.33.658"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.657"
+version = "0.33.658"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.656"
+version = "0.33.657"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.656"
+version = "0.33.657"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.656"
+version = "0.33.657"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.656"
+version = "0.33.657"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.658"
+version = "0.33.659"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.658"
+version = "0.33.659"
 dependencies = [
  "dirs",
  "serde",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.658"
+version = "0.33.659"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.658"
+version = "0.33.659"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,8 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.655 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
+| 0.33.650 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.647 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.644 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |
 | 0.33.643 | 2026-05-05 | 162.2 MiB | 340.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.657"
+version = "0.33.658"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.658"
+version = "0.33.659"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.655"
+version = "0.33.656"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.656"
+version = "0.33.657"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.655"
+version = "0.33.656"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.656"
+version = "0.33.657"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.658"
+version = "0.33.659"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.657"
+version = "0.33.658"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.657"
+version = "0.33.658"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.655"
+version = "0.33.656"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.658"
+version = "0.33.659"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.656"
+version = "0.33.657"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/pool.rs
+++ b/agentmux-launcher/src/reducer/pool.rs
@@ -74,22 +74,30 @@ pub(super) fn handle_report_pool_window_removed(state: &mut State, label: String
 /// promote happened" — subscribers correlate with the surrounding
 /// add/remove pair if they need stronger invariants.
 ///
-/// **WRR side-effect:** flips the promoted label's
-/// `foregrounded_since_open` to `true` if the mirror exists. Promote
-/// is the user explicitly tearing off a tab into a real window, so
-/// the open-transient corrective logic in `apply_hwnd_visibility_changed`
-/// MUST stop firing for this label — otherwise the post-promote
-/// reposition (multiple SetWindowPos calls during HWND placement)
-/// re-fires `HiddenSinceOpen` indefinitely. Each fire is a launcher
-/// event broadcast to all renderers; without this reset the host
-/// fans the same drift event out across the bridge until the
-/// renderer's V8 isolate runs out of stack and crashes
-/// (`Crashpad_NotConnectedToHandler`, observed v0.33.655). See
-/// `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
+/// **WRR side-effect:** records the label in `state.just_promoted_labels`
+/// so the subsequent `ReportWindowOpened` initializes the new mirror
+/// with `foregrounded_since_open: true`. Promote is the user explicitly
+/// tearing off a tab — the open-transient corrective logic in
+/// `apply_hwnd_visibility_changed` MUST stop firing for this label,
+/// otherwise the post-promote reposition (multiple SetWindowPos calls
+/// during HWND placement) re-fires `HiddenSinceOpen` indefinitely.
+/// Each fire is a launcher event broadcast to all renderers; without
+/// this guard the host fans the same drift event out across the
+/// bridge until the renderer's V8 isolate runs out of stack and
+/// crashes (`Crashpad_NotConnectedToHandler`, observed v0.33.655).
+///
+/// The actual host emit order is
+/// `ReportPoolWindowRemoved → ReportPoolWindowPromoted →
+/// ReportWindowOpened` (`agentmux-cef/src/commands/window_pool.rs`).
+/// At promote-time the launcher has NO mirror for this label —
+/// `state.pool.contains(label)` is also false (removed by the
+/// preceding `ReportPoolWindowRemoved`), so we can't gate purely on
+/// pool membership in `handle_report_window_opened` either. The
+/// `just_promoted_labels` set bridges the microsecond gap.
+///
+/// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
 pub(super) fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
-    if let Some(mirror) = state.windows.get_mut(&label) {
-        mirror.foregrounded_since_open = true;
-    }
+    state.just_promoted_labels.insert(label.clone());
     let v = state.bump_version();
     vec![Event::PoolWindowPromoted { label, version: v }]
 }

--- a/agentmux-launcher/src/reducer/pool.rs
+++ b/agentmux-launcher/src/reducer/pool.rs
@@ -73,7 +73,23 @@ pub(super) fn handle_report_pool_window_removed(state: &mut State, label: String
 /// command, or in either order; the typed event is "host says a
 /// promote happened" — subscribers correlate with the surrounding
 /// add/remove pair if they need stronger invariants.
+///
+/// **WRR side-effect:** flips the promoted label's
+/// `foregrounded_since_open` to `true` if the mirror exists. Promote
+/// is the user explicitly tearing off a tab into a real window, so
+/// the open-transient corrective logic in `apply_hwnd_visibility_changed`
+/// MUST stop firing for this label — otherwise the post-promote
+/// reposition (multiple SetWindowPos calls during HWND placement)
+/// re-fires `HiddenSinceOpen` indefinitely. Each fire is a launcher
+/// event broadcast to all renderers; without this reset the host
+/// fans the same drift event out across the bridge until the
+/// renderer's V8 isolate runs out of stack and crashes
+/// (`Crashpad_NotConnectedToHandler`, observed v0.33.655). See
+/// `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
 pub(super) fn handle_report_pool_window_promoted(state: &mut State, label: String) -> Vec<Event> {
+    if let Some(mirror) = state.windows.get_mut(&label) {
+        mirror.foregrounded_since_open = true;
+    }
     let v = state.bump_version();
     vec![Event::PoolWindowPromoted { label, version: v }]
 }

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1609,6 +1609,65 @@ fn promote_for_label_without_window_mirror_emits_event_idempotently() {
 }
 
 #[test]
+fn duplicate_open_for_promoted_label_preserves_foregrounded_since_open() {
+    // Codex P2 PR #708 round 3: `foregrounded_since_open` is monotonic
+    // per its WindowMirror contract. The first open after a promote
+    // consumes `just_promoted_labels` and sets the flag to true. A
+    // duplicate ReportWindowOpened (existing handler overwrites the
+    // mirror wholesale) must NOT reset the flag — otherwise the next
+    // post-promote `ReportHwndVisibilityChanged` re-fires
+    // `HiddenSinceOpen` drift.
+    let (mut state, c) = registered_host_state();
+
+    // Production tear-off sequence.
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowAdded { label: "window-pool-dup".into(), saga_id: None },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowRemoved { label: "window-pool-dup".into() },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowPromoted { label: "window-pool-dup".into() },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-pool-dup".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    assert!(
+        state.windows.get("window-pool-dup").unwrap().foregrounded_since_open,
+        "first open: foregrounded_since_open=true (consumed just_promoted)"
+    );
+
+    // Duplicate open for the same label. just_promoted entry is
+    // already gone; the flag must survive via OR with the prior
+    // mirror's value.
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-pool-dup".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    assert!(
+        state.windows.get("window-pool-dup").unwrap().foregrounded_since_open,
+        "duplicate open MUST preserve foregrounded_since_open=true (regression: drift storm returns)"
+    );
+}
+
+#[test]
 fn close_drops_orphaned_just_promoted_entry() {
     // If promote was emitted but the matching open never arrived
     // (host crash mid-tear-off etc.), a subsequent close for the

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1467,19 +1467,53 @@ fn wrr_off_monitor_after_user_foregrounded_does_not_correct() {
 }
 
 #[test]
-fn promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift() {
-    // Drift-storm regression (v0.33.655 smoke): pool window opens
-    // hidden → never foregrounded → promote → host repositions HWND
-    // (multiple SetWindowPos calls) → some intermediate state has
-    // visible=false → `apply_hwnd_visibility_changed` re-fires
-    // `HiddenSinceOpen` against the now-promoted user window. The
-    // host fans each emission across the bridge to every renderer
-    // and the V8 isolate eventually crashes. Promote is the user
-    // explicitly tearing off a tab — the open-transient corrective
-    // logic must NOT apply post-promote. Promote handler flips
-    // `foregrounded_since_open=true` to suppress.
+fn tear_off_promote_emit_order_initializes_mirror_with_foregrounded_true() {
+    // Drift-storm regression (v0.33.655 smoke). PRODUCTION emit order
+    // (per agentmux-cef/src/commands/window_pool.rs):
+    //
+    //   1. ReportPoolWindowAdded   → pool spawn (some time earlier)
+    //   2. ReportPoolWindowRemoved → about to promote (no mirror yet)
+    //   3. ReportPoolWindowPromoted → records in just_promoted_labels
+    //   4. ReportWindowOpened      → mirror created NOW
+    //   5. ReportHwndOpened        → HWND linked
+    //   6. SetWindowPos churn      → ReportHwndVisibilityChanged false
+    //
+    // Pre-fix: step 4 initialized foregrounded_since_open=false, so
+    // step 6 re-fired HiddenSinceOpen drift → host fans across bridge
+    // → renderer V8 crash. Fix: step 3 records, step 4 consumes and
+    // initializes foregrounded_since_open=true.
+    //
     // See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
     let (mut state, c) = registered_host_state();
+
+    // Steps 1–2: pool spawn + remove (no mirror in state.windows).
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowAdded { label: "window-pool-abc".into(), saga_id: None },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowRemoved { label: "window-pool-abc".into() },
+        &c,
+    );
+    assert!(
+        !state.windows.contains_key("window-pool-abc"),
+        "pre-promote: no mirror yet (production invariant)"
+    );
+
+    // Step 3: promote. Records in just_promoted_labels; emits typed event.
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowPromoted { label: "window-pool-abc".into() },
+        &c,
+    );
+    assert!(
+        state.just_promoted_labels.contains("window-pool-abc"),
+        "promote must record label in just_promoted_labels"
+    );
+
+    // Step 4: window opened — mirror created with foregrounded_since_open=true.
     let _ = update(
         &mut state,
         Command::ReportWindowOpened {
@@ -1489,6 +1523,17 @@ fn promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift() 
         },
         &c,
     );
+    let mirror = state.windows.get("window-pool-abc").expect("mirror created on open");
+    assert!(
+        mirror.foregrounded_since_open,
+        "post-promote open must initialize foregrounded_since_open=true (got false → drift storm regression)"
+    );
+    assert!(
+        !state.just_promoted_labels.contains("window-pool-abc"),
+        "open consumes the just_promoted entry"
+    );
+
+    // Step 5: HWND link.
     let _ = update(
         &mut state,
         Command::ReportHwndOpened {
@@ -1499,33 +1544,8 @@ fn promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift() 
         },
         &c,
     );
-    // Pre-promote: never-foregrounded → a hide event fires drift.
-    let pre = update(
-        &mut state,
-        Command::ReportHwndVisibilityChanged { hwnd: 0xBB, visible: false },
-        &c,
-    );
-    assert!(
-        pre.iter().any(|e| matches!(
-            e,
-            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
-        )),
-        "pre-promote hide must drift (control: {:?})",
-        pre
-    );
 
-    // Promote.
-    let _ = update(
-        &mut state,
-        Command::ReportPoolWindowPromoted { label: "window-pool-abc".into() },
-        &c,
-    );
-    assert!(
-        state.windows.get("window-pool-abc").unwrap().foregrounded_since_open,
-        "promote must flip foregrounded_since_open to suppress open-transient drift"
-    );
-
-    // Post-promote: identical hide event must NOT drift.
+    // Step 6: visibility flicker during HWND repositioning. MUST NOT drift.
     let post = update(
         &mut state,
         Command::ReportHwndVisibilityChanged { hwnd: 0xBB, visible: false },
@@ -1542,13 +1562,32 @@ fn promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift() 
 }
 
 #[test]
-fn promote_for_label_without_window_mirror_is_a_no_op() {
+fn cold_open_without_promote_still_initializes_foregrounded_false() {
+    // Sanity: a regular window open (e.g. main, fresh tear-off NOT
+    // through pool) MUST keep foregrounded_since_open=false so the
+    // open-transient corrective logic still applies for those windows.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-fresh".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    assert!(
+        !state.windows.get("window-fresh").unwrap().foregrounded_since_open,
+        "non-promote open must keep foregrounded_since_open=false"
+    );
+}
+
+#[test]
+fn promote_for_label_without_window_mirror_emits_event_idempotently() {
     // The handler's idempotency contract: ReportPoolWindowPromoted
-    // can arrive before, after, or interleaved with
-    // ReportPoolWindowRemoved. If the mirror isn't present at this
-    // moment (e.g. it was removed first, or the host promote IPC
-    // outraced the open IPC), the handler must still emit the typed
-    // event without panicking.
+    // can arrive without a paired ReportWindowOpened (e.g. the open
+    // IPC was lost). The handler must emit the typed event and
+    // record in just_promoted_labels without synthesising a mirror.
     let (mut state, c) = registered_host_state();
     let evs = update(
         &mut state,
@@ -1560,8 +1599,36 @@ fn promote_for_label_without_window_mirror_is_a_no_op() {
         "promote without mirror must still emit PoolWindowPromoted"
     );
     assert!(
+        state.just_promoted_labels.contains("window-pool-xyz"),
+        "promote records in just_promoted_labels"
+    );
+    assert!(
         !state.windows.contains_key("window-pool-xyz"),
         "promote must not synthesise a mirror"
+    );
+}
+
+#[test]
+fn close_drops_orphaned_just_promoted_entry() {
+    // If promote was emitted but the matching open never arrived
+    // (host crash mid-tear-off etc.), a subsequent close for the
+    // same label must clean up the just_promoted entry to bound the
+    // leak.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowPromoted { label: "window-pool-orphan".into() },
+        &c,
+    );
+    assert!(state.just_promoted_labels.contains("window-pool-orphan"));
+    let _ = update(
+        &mut state,
+        Command::ReportWindowClosed { label: "window-pool-orphan".into() },
+        &c,
+    );
+    assert!(
+        !state.just_promoted_labels.contains("window-pool-orphan"),
+        "close must drop orphaned just_promoted entry"
     );
 }
 

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1467,6 +1467,105 @@ fn wrr_off_monitor_after_user_foregrounded_does_not_correct() {
 }
 
 #[test]
+fn promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift() {
+    // Drift-storm regression (v0.33.655 smoke): pool window opens
+    // hidden → never foregrounded → promote → host repositions HWND
+    // (multiple SetWindowPos calls) → some intermediate state has
+    // visible=false → `apply_hwnd_visibility_changed` re-fires
+    // `HiddenSinceOpen` against the now-promoted user window. The
+    // host fans each emission across the bridge to every renderer
+    // and the V8 isolate eventually crashes. Promote is the user
+    // explicitly tearing off a tab — the open-transient corrective
+    // logic must NOT apply post-promote. Promote handler flips
+    // `foregrounded_since_open=true` to suppress.
+    // See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-pool-abc".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xBB,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-pool-abc".into()),
+        },
+        &c,
+    );
+    // Pre-promote: never-foregrounded → a hide event fires drift.
+    let pre = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xBB, visible: false },
+        &c,
+    );
+    assert!(
+        pre.iter().any(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+        )),
+        "pre-promote hide must drift (control: {:?})",
+        pre
+    );
+
+    // Promote.
+    let _ = update(
+        &mut state,
+        Command::ReportPoolWindowPromoted { label: "window-pool-abc".into() },
+        &c,
+    );
+    assert!(
+        state.windows.get("window-pool-abc").unwrap().foregrounded_since_open,
+        "promote must flip foregrounded_since_open to suppress open-transient drift"
+    );
+
+    // Post-promote: identical hide event must NOT drift.
+    let post = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xBB, visible: false },
+        &c,
+    );
+    assert!(
+        !post.iter().any(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+        )),
+        "post-promote hide must not drift, got {:?}",
+        post
+    );
+}
+
+#[test]
+fn promote_for_label_without_window_mirror_is_a_no_op() {
+    // The handler's idempotency contract: ReportPoolWindowPromoted
+    // can arrive before, after, or interleaved with
+    // ReportPoolWindowRemoved. If the mirror isn't present at this
+    // moment (e.g. it was removed first, or the host promote IPC
+    // outraced the open IPC), the handler must still emit the typed
+    // event without panicking.
+    let (mut state, c) = registered_host_state();
+    let evs = update(
+        &mut state,
+        Command::ReportPoolWindowPromoted { label: "window-pool-xyz".into() },
+        &c,
+    );
+    assert!(
+        evs.iter().any(|e| matches!(e, Event::PoolWindowPromoted { .. })),
+        "promote without mirror must still emit PoolWindowPromoted"
+    );
+    assert!(
+        !state.windows.contains_key("window-pool-xyz"),
+        "promote must not synthesise a mirror"
+    );
+}
+
+#[test]
 fn wrr_duplicate_hwnd_open_for_same_label_is_idempotent() {
     // codex #600 P2: ReportHwndOpened arrives twice (once from
     // the WinEvent CREATE hook with label_hint=None, then again

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -109,6 +109,15 @@ pub(super) fn handle_report_window_opened(
         state.pending_hwnds.remove(&hwnd);
     }
 
+    // Drift-storm fix (PR #708 round 3) — if this open is the back
+    // half of a tear-off promote (host emit order is `pool_removed →
+    // pool_promoted → window_opened`), `handle_report_pool_window_promoted`
+    // recorded the label in `just_promoted_labels`. Initialize the new
+    // mirror with `foregrounded_since_open: true` so the open-transient
+    // corrective logic doesn't re-fire `HiddenSinceOpen` on the
+    // subsequent HWND repositioning. See state.rs::just_promoted_labels.
+    let was_just_promoted = state.just_promoted_labels.remove(&label);
+
     state.windows.insert(
         label.clone(),
         WindowMirror {
@@ -125,7 +134,7 @@ pub(super) fn handle_report_window_opened(
             iconic: false,
             last_rect: None,
             last_foreground_at_ms: None,
-            foregrounded_since_open: false,
+            foregrounded_since_open: was_just_promoted,
         },
     );
     let mut out = Vec::with_capacity(2);
@@ -171,6 +180,11 @@ pub(super) fn handle_report_window_opened(
 /// monotonic per-launcher-run.
 pub(super) fn handle_report_window_closed(state: &mut State, label: String) -> Vec<Event> {
     let was_present = state.windows.remove(&label).is_some();
+    // Drift-storm fix cleanup — drop any orphaned just-promoted entry.
+    // Bounded leak protection for the (rare) case where promote was
+    // emitted but the matching `ReportWindowOpened` never arrived
+    // (host crash mid-tear-off, etc.).
+    state.just_promoted_labels.remove(&label);
     if !was_present {
         // Silent: only emit when the close pairs with a known open.
         return vec![];

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -117,6 +117,20 @@ pub(super) fn handle_report_window_opened(
     // corrective logic doesn't re-fire `HiddenSinceOpen` on the
     // subsequent HWND repositioning. See state.rs::just_promoted_labels.
     let was_just_promoted = state.just_promoted_labels.remove(&label);
+    // Codex P2 PR #708 round 3 — `foregrounded_since_open` is
+    // monotonic (false → true, never resets within a window's
+    // lifetime per its own contract: "has this label been
+    // foregrounded at any point since its ReportWindowOpened"). On
+    // duplicate opens (the existing handler overwrites the mirror
+    // wholesale), OR the prior value in so the flag isn't reset. The
+    // first open after a promote already consumed `just_promoted_labels`,
+    // so a 2nd open at the same label would otherwise re-arm the
+    // open-transient drift detector.
+    let prior_foregrounded = state
+        .windows
+        .get(&label)
+        .map(|m| m.foregrounded_since_open)
+        .unwrap_or(false);
 
     state.windows.insert(
         label.clone(),
@@ -134,7 +148,7 @@ pub(super) fn handle_report_window_opened(
             iconic: false,
             last_rect: None,
             last_foreground_at_ms: None,
-            foregrounded_since_open: was_just_promoted,
+            foregrounded_since_open: was_just_promoted || prior_foregrounded,
         },
     );
     let mut out = Vec::with_capacity(2);

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -192,6 +192,23 @@ pub struct State {
     /// pending HWND by `label_hint`/timing). Anything still here
     /// after a follow-up event is classified as `HwndWithoutBrowser`.
     pub pending_hwnds: HashMap<u64, PendingHwnd>,
+    /// Drift-storm fix (PR #708 round 3) — labels for which the host
+    /// emitted `ReportPoolWindowPromoted` but the corresponding
+    /// `ReportWindowOpened` hasn't arrived yet. The actual host emit
+    /// order on tear-off is `ReportPoolWindowRemoved` →
+    /// `ReportPoolWindowPromoted` → `ReportWindowOpened`, so at
+    /// promote-time the launcher has NO `WindowMirror` for the label
+    /// — the mirror is created by `ReportWindowOpened` a few ms
+    /// later. Without this set, the post-promote mirror is initialized
+    /// with `foregrounded_since_open: false`, the open-transient drift
+    /// detector then fires `HiddenSinceOpen` on every visible→hidden
+    /// flicker during HWND repositioning, the host fans each event
+    /// out across the bridge and the renderer's V8 isolate crashes.
+    /// `ReportWindowOpened` consumes the entry to initialize the new
+    /// mirror with `foregrounded_since_open: true`. Removed on
+    /// `ReportWindowClosed` if open never arrived (bounded leak).
+    /// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
+    pub just_promoted_labels: HashSet<String>,
     // F.7 cleanup audit: removed unused `launcher_start_ms: Option<u64>`
     // field. It was set in Default but no reducer arm or consumer
     // ever read it — the WRR observability path uses the OnceLock-
@@ -232,6 +249,7 @@ impl Default for State {
             next_client_id: 1,
             monitors: Vec::new(),
             pending_hwnds: HashMap::new(),
+            just_promoted_labels: HashSet::new(),
         }
     }
 }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.655"
+version = "0.33.656"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.657"
+version = "0.33.658"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.656"
+version = "0.33.657"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.658"
+version = "0.33.659"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md
+++ b/docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md
@@ -1,0 +1,237 @@
+# Drift-storm renderer crash (post-PR #706 smoke) — architectural analysis
+
+**Date:** 2026-05-06
+**Trigger:** v0.33.655 portable smoke. After 1 tear-off, renderer crashed with
+`Crashpad_NotConnectedToHandler` ~2.5 s after the promote.
+**Symptom:** 603 `hwnd_drift_detected` log lines in <3 s, **all carrying the same
+launcher-side `version: 13`** — i.e. one launcher event re-dispatched ~600×.
+**Reads against:** [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md).
+
+---
+
+## 1. What happened (forensics)
+
+```
+12:39:24.212  workspace.TearOffTab            ┐
+12:39:24.212  [pool] promoting pool window    ├ promote of window-pool-7fa5...
+12:39:24.221  [pool] spawning pool window     │  refill: window-pool-cb01...
+12:39:24.227  complete_cross_drag (tearoff)   ┘
+12:39:24.470  …storm of 603 [fe] [launcher-event] drift entries…
+12:39:27.109  ERROR renderer process crashed  Crashpad_NotConnectedToHandler
+```
+
+Every entry in the storm:
+
+```json
+{"event":"hwnd_drift_detected",
+ "kind":"hidden_since_open",
+ "label":"window-pool-7fa5f5a3fac34c908756f640c258257a",
+ "hwnd":10945738,
+ "detail":"Window hidden without ever being foregrounded since open",
+ "severity":"warn",
+ "version":13}
+```
+
+Fixed `version: 13` ⇒ **one** launcher event, amplified somewhere in
+launcher → host → renderer.
+
+---
+
+## 2. The two real bugs
+
+### Bug A — launcher reducer correctness: WRR drift state isn't reset on promote
+
+`apply_hwnd_visibility_changed` in `agentmux-launcher/src/wrr/mod.rs:341` emits
+`HiddenSinceOpen` whenever a window goes invisible and `foregrounded_since_open`
+is still false. `foregrounded_since_open` is only flipped true by
+`Command::ReportHwndForegroundChanged`.
+
+A pool window:
+
+1. Is created hidden (off-screen, `WS_EX_TOOLWINDOW`).
+2. Sits in `pool.unpromoted` → moves to `pool.queue` after renderer-ready.
+3. **Promote**: host moves the HWND on-screen, frontend bootstraps the workspace.
+
+Between steps 2 and 3 the window has never been foregrounded, so
+`foregrounded_since_open=false`. Promote moves the HWND but doesn't
+synthesise a foreground transition into the launcher reducer. Any
+visibility flicker during repositioning (and there are several:
+`SetWindowPos`, monitor probing, taskbar reveal, focus-reclaim) re-fires
+`HiddenSinceOpen` against an already-promoted user window.
+
+**This is a Layer 1 (Launcher) reducer bug.** Fix is a state transition that
+the existing reducer lacks: on `PoolWindowPromoted`, clear the
+"open-transient" guards (`foregrounded_since_open` should arguably be
+re-armed *to true* — the user explicitly created this window by tearing
+off, so the open-transient corrective logic shouldn't apply).
+
+### Bug B — launcher → host → renderer event flood without backpressure / de-dup
+
+Same launcher event (`version: 13`) reaching the renderer ~600×. Three
+candidate amplification points; the actual one needs a small
+investigation, but each is a separate architectural gap:
+
+1. **Launcher broadcast bus subscriber leak** — every host subscription
+   that's added but not properly unsubscribed will receive the event
+   N times.
+2. **Host JS bridge has no de-dup** — `launcher_event_bridge::dispatch_to_renderers`
+   is a thin pass-through; if `apply_event_to_shadow` is invoked
+   re-entrantly for the same event, every reentry fans out again.
+3. **Pool window pipe / subscription duplication** — pool windows
+   register subscribers during their bootstrap; if pool-window
+   teardown/promote doesn't clean those up, each retained subscriber
+   re-delivers.
+
+**Whatever the amplification, the architectural bug is the same: there is
+no flow control on the launcher → host → renderer event path.** PR #706
+made promoted pool windows visible to launcher events for the first
+time, which exposed this.
+
+---
+
+## 3. How this fits the master spec
+
+| Master spec section | This bug shows |
+|---|---|
+| §3 Layer 1 Launcher — *single-writer, canonical for windows / WRR / pool* | WRR's `foregrounded_since_open` state machine is incomplete. Promote moves the HWND on-screen but no command updates the WRR mirror. **Missing arm in `apply_*` chain.** |
+| §4 Layer 2 Host — *frontend ↔ launcher via host JS bridge (decision §8.9)* | The bridge in `agentmux-cef/src/launcher_event_bridge.rs` is a thin pass-through. PR #706 corrected its filter; it still has no de-dup, no rate limit, no batching. **Architectural gap: backpressure.** |
+| §6 Frontend — *slice #6 launcher-event-reducer convergence (designed, not started)* | The renderer-side reducer exists but only owns the InstancePanel view. There's no idempotency check by `(label, version)` in the dispatcher. **A reducer with `seen_versions: Set<u64>` would absorb this flood with O(1) cost.** |
+| §5.4 Sagas — *PoolRespawnSaga ✅; WindowCleanupCascade pending; **no PoolPromote saga*** | Promote today is a sequence of side-effects, not a saga: `report_pool_window_removed` → `report_pool_window_promoted` → `report_window_opened` + host UI work + renderer bootstrap. No saga coordinates the WRR-state-update step. **Missing saga arm.** |
+| §8.4 *Versioned events + snapshot/replay; subscribers detect gaps and resync* | Versioning exists. Subscriber-side **idempotency** does not. The contract says "detect gaps", not "detect duplicates". |
+| §8.7 *WRR via Win32 hooks, no timers* | True for input. But the post-promote OS event sequence (multiple `SetWindowPos` from re-parenting) re-fires WRR detection. Not a timer; same effect. |
+| §9.1 Cross-process saga dispatch (BLOCKER for F.5/F.6) | A "host requests launcher to update WRR" call has no transport. Today the host can only emit forward-going events; no command path **back** to the launcher. **Bug A's fix needs cross-process dispatch — or the launcher must self-detect promote from the existing event stream and update its own WRR state.** |
+| §9.2 Per-event saga_id correlation (BLOCKER for E.6) | If the drift event were tagged with a saga_id, the renderer reducer could de-dup-by-saga. Today there's no correlation key; the renderer can't distinguish "same event re-broadcast" from "new event with same fields". |
+
+---
+
+## 4. Other gaps the storm reveals (beyond the master's §9 list)
+
+### 4.1 No idempotency contract on the launcher event channel
+
+The master spec §8 lists 13 architectural decisions. **None of them
+spell out idempotency.** Subscribers MUST be idempotent for resync /
+replay (§8.4) to work — but this isn't documented and isn't enforced.
+Renderer-side handlers like `tracker.deliver(evt)` deliver every
+arrival; if the host fans an event 600×, the renderer processes it
+600×.
+
+**Proposal:** add §8.14: *"Launcher event subscribers MUST be idempotent
+under (event_kind, label, version) — duplicates may legally arrive from
+re-dispatch, resync, or replay; subscribers de-dup by (kind, label,
+version) before applying."* Then bake it into `frontend/util/launcher-events.ts`
+and the host bridge.
+
+### 4.2 No "state transitions on promote" spec for WRR
+
+The pool-window state machine (`pool.unpromoted` → `pool.queue` →
+promoted) is documented in `dnd:tearoff:pool` comments and recently in
+PR #706. But the **WRR companion state** (`foregrounded_since_open`,
+`off_monitor`, `last_rect`) doesn't have a parallel transition map.
+Promote needs to be a recognised event in BOTH state machines.
+
+**Proposal:** new spec section in the host reducer master plan
+covering "WRR ↔ pool state transition matrix" — single table per
+event kind × WRR field × required transition. Today this is
+implicit and easy to miss (PR #706 didn't catch it).
+
+### 4.3 Renderer overload as an unhandled failure mode
+
+Crash kind: `Crashpad_NotConnectedToHandler` — a CEF generic crash with
+no symbol dump. Likely the V8 isolate ran out of stack/heap or the
+`fe_log_structured` IPC channel saturated and the renderer thread was
+starved.
+
+**No spec covers what the host should do when a renderer crashes
+during normal event flow.** F1.B (frontend orphan-cleanup on hard host
+failure) covers the *host* dying; the inverse (renderer dying while
+host is healthy) only triggers an auto-reload with no diagnostic
+trail beyond the Crashpad message.
+
+**Proposal:** explicit failure mode in the host reducer spec — *"on
+RendererCrashed, snapshot the recent event ring (last 100), the
+launcher-event subscribe count, and the host bridge dispatch count to
+a crash-context file."* Today we lose all that context.
+
+### 4.4 Phase F.7 missing from the master roadmap
+
+§9.1–9.7 enumerate open questions; §9.1 names cross-process dispatch
+as a F.5/F.6 blocker. **There's no F.7 "host event throttling /
+batching / de-dup".** That gap is what made this bug crashable.
+
+**Proposal:** add Phase F.7 — *"host JS bridge resilience: per-renderer
+backpressure, version-keyed de-dup, batched dispatch under load."* List
+as deferred but tracked.
+
+### 4.5 PR #706 retro: prefix-filtering masked Bug A for months
+
+Pre-PR-706, the bridge excluded all `window-pool-*` labels from
+launcher-event dispatch. That filter was *also a backpressure valve* —
+promoted pool windows were silently insulated from the WRR drift
+re-emission storm. The "InstancePanel drift" PR #706 fixed was the
+*intended* behaviour the filter blocked, but removing the filter
+exposed the drift storm at full volume.
+
+**Lesson for the master spec:** when the architecture says *"all
+top-level browsers receive launcher events"*, that's a load-bearing
+claim about volume that should be tested. Adding §8.14 (idempotency)
++ a back-pressure decision would have prevented PR #706's smoke
+crash.
+
+---
+
+## 5. Recommended fix order
+
+Prioritised by smallest-blast-radius first.
+
+1. **Frontend de-dup** *(slice #6 starter, 1 PR)*: in the renderer's
+   `tracker.deliver()`, drop events whose `(kind, label, version)` has
+   already been delivered. Caps memory at O(seen events). Prevents the
+   crash regardless of upstream amplification.
+
+2. **Launcher reducer fix for `foregrounded_since_open` on promote**
+   *(1 PR, small)*: handler arm — when `PoolWindowPromoted` is applied,
+   also set the corresponding window mirror's `foregrounded_since_open`
+   to true (or invalidate the open-transient guard). This is a Layer 1
+   correctness fix. Stops the storm at source.
+
+3. **Diagnose the actual amplification** *(investigation, 1 day)*:
+   instrument `dispatch_to_renderers` with a counter; verify whether
+   the host is fan-outing 600× or the launcher is broadcasting 600×.
+   Drives whether (4) is needed.
+
+4. **Host bridge de-dup + rate limit** *(Phase F.7 starter, 1 PR)*:
+   per-event version cache in the bridge — drop redundant
+   `Frame::ExecuteJavaScript` for a `(kind, label, version)` already
+   dispatched within window N. Defends against subscriber leaks
+   regardless of which side leaks.
+
+5. **Architecture decision §8.14 added to master**: idempotency
+   contract for launcher event subscribers. Doc-only — but it's the
+   load-bearing decision the storm proved is missing.
+
+6. **Master §9.8 added: Phase F.7 — host bridge resilience**: tracked
+   but deferred. Pairs with §9.1 (cross-process dispatch) — both are
+   about the host's role as a relay.
+
+---
+
+## 6. Why this is worth reviewing as a spec
+
+The PR #706 fix was correct in isolation but **destabilised in
+integration** because the architecture didn't have a flow-control
+decision at the launcher → renderer boundary. The master spec is
+already excellent at *layer ownership*; this analysis recommends
+extending it with **inter-layer contract** decisions — idempotency,
+backpressure, transition matrices — that are currently informal and
+easy to miss when adding new event flows.
+
+Concrete additions proposed:
+- **§8.14** idempotency contract (renderer + host subscriber requirement)
+- **§9.8** Phase F.7 host bridge resilience (open question)
+- **§4.5** WRR ↔ pool state transition matrix (host/launcher reducer joint state)
+- **§5.5** Promote saga (or document why promote isn't a saga and how WRR state stays consistent without one)
+
+Updates proposed:
+- **§9.1** note that cross-process dispatch is also needed for the
+  inverse direction (host reporting to launcher), and that without it
+  the launcher reducer has to self-detect promote-completed events.

--- a/frontend/util/launcher-events.test.ts
+++ b/frontend/util/launcher-events.test.ts
@@ -1,0 +1,82 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Drift-storm regression guard tests for the launcher-event bridge.
+// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    __resetDedupForTests,
+    launcherEventDedupStats,
+    shouldDispatchLauncherEvent,
+    type LauncherEvent,
+} from "./launcher-events";
+
+const evt = (over: Partial<LauncherEvent> & { event: string; version: number }): LauncherEvent =>
+    over as LauncherEvent;
+
+describe("launcher-event per-key dedup", () => {
+    beforeEach(() => __resetDedupForTests());
+
+    it("admits the first event for a given (kind, label, hwnd)", () => {
+        const e = evt({ event: "hwnd_drift_detected", version: 13, label: "window-pool-x", hwnd: 100 });
+        expect(shouldDispatchLauncherEvent(e)).toBe(true);
+        expect(launcherEventDedupStats()).toEqual({ tracked: 1, suppressed: 0 });
+    });
+
+    it("suppresses re-emission of the same (kind, label, hwnd) at the same version", () => {
+        const e = evt({ event: "hwnd_drift_detected", version: 13, label: "window-pool-x", hwnd: 100 });
+        expect(shouldDispatchLauncherEvent(e)).toBe(true);
+        // The drift-storm bug: same event re-arrives many times with same version.
+        for (let i = 0; i < 100; i++) {
+            expect(shouldDispatchLauncherEvent(e)).toBe(false);
+        }
+        expect(launcherEventDedupStats()).toEqual({ tracked: 1, suppressed: 100 });
+    });
+
+    it("admits a higher-versioned event for the same key", () => {
+        const a = evt({ event: "hwnd_drift_detected", version: 13, label: "x", hwnd: 1 });
+        const b = evt({ event: "hwnd_drift_detected", version: 17, label: "x", hwnd: 1 });
+        expect(shouldDispatchLauncherEvent(a)).toBe(true);
+        expect(shouldDispatchLauncherEvent(b)).toBe(true);
+    });
+
+    it("treats different event kinds at the same version as distinct keys", () => {
+        // Launcher versions are global-monotonic; same version on different
+        // event kinds is impossible upstream, but the dedup must not couple
+        // unrelated events even hypothetically.
+        expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "x" }))).toBe(true);
+        expect(shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 13, label: "x" }))).toBe(true);
+        expect(shouldDispatchLauncherEvent(evt({ event: "window_closed", version: 13, label: "x" }))).toBe(true);
+    });
+
+    it("treats different labels at the same version as distinct keys", () => {
+        expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "a" }))).toBe(true);
+        expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "b" }))).toBe(true);
+    });
+
+    it("treats missing label/hwnd as a distinct key from present ones", () => {
+        expect(shouldDispatchLauncherEvent(evt({ event: "host_should_quit", version: 5 }))).toBe(true);
+        expect(shouldDispatchLauncherEvent(evt({ event: "host_should_quit", version: 5, label: "x" }))).toBe(true);
+    });
+
+    it("bounds memory under a flood of unique keys", () => {
+        // 2000 distinct labels at v=1 — should evict oldest, keeping the cap.
+        for (let i = 0; i < 2000; i++) {
+            shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 1, label: `w-${i}` }));
+        }
+        expect(launcherEventDedupStats().tracked).toBeLessThanOrEqual(1024);
+    });
+
+    it("after eviction, an older key's re-arrival is admitted only if its version exceeds anything seen", () => {
+        // Saturate the cache to evict early entries.
+        shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "evicted" }));
+        for (let i = 0; i < 1100; i++) {
+            shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 1, label: `filler-${i}` }));
+        }
+        // "evicted" is gone. A re-arrival at v=13 looks new and admits — acceptable
+        // per the comment in launcher-events.ts: only a strictly higher version
+        // would be a real duplicate, which can't happen if the upstream is healthy.
+        expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "evicted" }))).toBe(true);
+    });
+});

--- a/frontend/util/launcher-events.test.ts
+++ b/frontend/util/launcher-events.test.ts
@@ -68,15 +68,46 @@ describe("launcher-event per-key dedup", () => {
         expect(launcherEventDedupStats().tracked).toBeLessThanOrEqual(1024);
     });
 
-    it("after eviction, an older key's re-arrival is admitted only if its version exceeds anything seen", () => {
-        // Saturate the cache to evict early entries.
+    it("after eviction, an evicted key's re-arrival is admitted regardless of version", () => {
+        // Saturate the cache to evict the early entry.
         shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "evicted" }));
         for (let i = 0; i < 1100; i++) {
             shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 1, label: `filler-${i}` }));
         }
-        // "evicted" is gone. A re-arrival at v=13 looks new and admits — acceptable
-        // per the comment in launcher-events.ts: only a strictly higher version
-        // would be a real duplicate, which can't happen if the upstream is healthy.
+        // "evicted" is gone. A re-arrival at the SAME version (13) is admitted
+        // because the per-key version is unknown post-eviction. PerSourceTracker
+        // behind this still enforces global version monotonicity, so a
+        // genuinely-duplicate same-version event is dropped one layer down.
         expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "evicted" }))).toBe(true);
+    });
+
+    it("clears the cache on launcher-restart sentinel (version=1 after prior versions)", () => {
+        // Establish prior incarnation: events at v=12, v=13.
+        shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 12, label: "main" }));
+        shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 13, label: "main", hwnd: 99 }));
+        expect(launcherEventDedupStats().tracked).toBe(2);
+
+        // Launcher restarts: event_version resets to 1. Per the codex P1 finding,
+        // without bridge-level reset the sentinel hits a cached "main" at v=12
+        // and gets suppressed → PerSourceTracker never sees v=1 → its
+        // restart-detection never fires → all post-restart events are stuck
+        // behind the dead launcher's lastVersion=13. The bridge MUST clear
+        // its cache and admit the sentinel.
+        const sentinel = evt({ event: "window_opened", version: 1, label: "main" });
+        expect(shouldDispatchLauncherEvent(sentinel)).toBe(true);
+        expect(launcherEventDedupStats().tracked).toBe(1);
+
+        // Subsequent low-version events from the new launcher should also flow.
+        expect(shouldDispatchLauncherEvent(evt({ event: "window_opened", version: 2, label: "other" }))).toBe(true);
+        expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 3, label: "main", hwnd: 99 }))).toBe(true);
+    });
+
+    it("does NOT treat the very first v=1 event as a restart (cold start)", () => {
+        // No prior versions → v=1 is just the first event of a fresh launcher,
+        // not a restart sentinel. Cache should NOT be cleared (it's already empty)
+        // and the event admits normally.
+        const e = evt({ event: "window_opened", version: 1, label: "main" });
+        expect(shouldDispatchLauncherEvent(e)).toBe(true);
+        expect(launcherEventDedupStats().tracked).toBe(1);
     });
 });

--- a/frontend/util/launcher-events.test.ts
+++ b/frontend/util/launcher-events.test.ts
@@ -102,6 +102,28 @@ describe("launcher-event per-key dedup", () => {
         expect(shouldDispatchLauncherEvent(evt({ event: "hwnd_drift_detected", version: 3, label: "main", hwnd: 99 }))).toBe(true);
     });
 
+    it("passes malformed events through without throwing or polluting the cache", () => {
+        // Codex P2 PR #708 round 2: the bridge dedup runs before
+        // PerSourceTracker, so accessing evt.version/evt.event on a
+        // null/non-object would throw out of __agentmux_launcher_event.
+        // Guard returns true (let the tracker's canonical
+        // log-and-discard handle it) and doesn't touch the cache.
+        const malformed: unknown[] = [
+            null,
+            undefined,
+            "string",
+            42,
+            {},
+            { event: "ok-but-no-version" },
+            { version: 5 }, // missing event
+            { event: "ok", version: "not-a-number" },
+        ];
+        for (const m of malformed) {
+            expect(shouldDispatchLauncherEvent(m as LauncherEvent)).toBe(true);
+        }
+        expect(launcherEventDedupStats()).toEqual({ tracked: 0, suppressed: 0 });
+    });
+
     it("does NOT treat the very first v=1 event as a restart (cold start)", () => {
         // No prior versions → v=1 is just the first event of a fresh launcher,
         // not a restart sentinel. Cache should NOT be cleared (it's already empty)

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -113,6 +113,20 @@ function dedupKey(evt: LauncherEvent): string {
  * recorded at least one prior version → clear the cache and admit.
  */
 export function shouldDispatchLauncherEvent(evt: LauncherEvent): boolean {
+    // Defensive shape check (codex P2, this PR round 3): if the event
+    // is malformed (null, non-object, missing required fields), defer
+    // to PerSourceTracker.deliver — it has the canonical
+    // log-and-discard path. Touching `evt.event` / `evt.version` here
+    // on a null/non-object would throw out of __agentmux_launcher_event,
+    // breaking the bridge for subsequent events.
+    if (
+        evt == null ||
+        typeof evt !== "object" ||
+        typeof (evt as { version?: unknown }).version !== "number" ||
+        typeof (evt as { event?: unknown }).event !== "string"
+    ) {
+        return true;
+    }
     if (evt.version === 1 && hasSeenAnyVersionAbove(0)) {
         dedupSeen.clear();
         // Don't reset suppressed counter — it's a cumulative diag.

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -98,8 +98,25 @@ function dedupKey(evt: LauncherEvent): string {
  * Per-key (event-kind, label, hwnd) version-monotonicity guard.
  * Returns true if the event should be dispatched, false if it's a
  * duplicate or stale re-emission for the same logical entity.
+ *
+ * **Launcher restart pass-through (codex P1, this PR round 2):** when
+ * the launcher process restarts, its `event_version` resets to 1
+ * (`agentmux-launcher/src/state.rs::default`). `PerSourceTracker.deliver`
+ * has explicit handling for the v=1 sentinel — it resets `lastVersion`
+ * so post-restart events aren't dropped as stale. This bridge-level
+ * dedup runs BEFORE the tracker, so without an equivalent reset the
+ * sentinel would be suppressed against a cached key from the prior
+ * incarnation (e.g. a long-lived label like `main`) and the tracker
+ * would never see v=1, leaving subsequent low-version events
+ * permanently stuck behind `lastVersion` from the dead launcher.
+ * Heuristic mirrors the tracker's: `evt.version === 1` AND we've
+ * recorded at least one prior version → clear the cache and admit.
  */
 export function shouldDispatchLauncherEvent(evt: LauncherEvent): boolean {
+    if (evt.version === 1 && hasSeenAnyVersionAbove(0)) {
+        dedupSeen.clear();
+        // Don't reset suppressed counter — it's a cumulative diag.
+    }
     const k = dedupKey(evt);
     const seenVersion = dedupSeen.get(k);
     if (seenVersion !== undefined && evt.version <= seenVersion) {
@@ -109,14 +126,24 @@ export function shouldDispatchLauncherEvent(evt: LauncherEvent): boolean {
     dedupSeen.set(k, evt.version);
     if (dedupSeen.size > MAX_DEDUP_KEYS) {
         // Bound memory. Map iteration order is insertion order → drop
-        // the oldest entry. Acceptable: a re-arrival for an evicted
-        // key can only re-fire if it carries a higher launcher
-        // version than this renderer has ever seen, which means it's
-        // not actually a duplicate.
+        // the oldest entry. Acceptable trade-off: an evicted key's
+        // next arrival is admitted unconditionally (whatever its
+        // version), but the worst case is one duplicate event slipping
+        // through after a 1024-key eviction window. The
+        // `PerSourceTracker` behind this still drops by global
+        // monotonic version, so a same-version evicted-key duplicate
+        // is still caught one layer down.
         const firstKey = dedupSeen.keys().next().value;
         if (firstKey !== undefined) dedupSeen.delete(firstKey);
     }
     return true;
+}
+
+function hasSeenAnyVersionAbove(threshold: number): boolean {
+    for (const v of dedupSeen.values()) {
+        if (v > threshold) return true;
+    }
+    return false;
 }
 
 /** Diagnostic accessor for the dedup guard — used by tests + diag tools. */
@@ -124,7 +151,13 @@ export function launcherEventDedupStats(): { tracked: number; suppressed: number
     return { tracked: dedupSeen.size, suppressed: dedupSuppressedCount };
 }
 
-/** Test-only: clear the dedup cache. Not exported in production paths. */
+/**
+ * Reset the dedup cache. Test-only by convention — the `__` prefix is
+ * the project's marker for non-production APIs (see `__snapshot` /
+ * `__resetState` in `app/store/launcher-event-reducer.ts`). Production
+ * code MUST NOT call this; the only legitimate cache reset is the
+ * launcher-restart sentinel inside `shouldDispatchLauncherEvent`.
+ */
 export function __resetDedupForTests(): void {
     dedupSeen.clear();
     dedupSuppressedCount = 0;

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -71,6 +71,65 @@ export function launcherEventStats(): PerSourceStats {
 
 let installed = false;
 
+// Drift-storm guard (v0.33.655 smoke): the host fanned a single
+// `hwnd_drift_detected` event ~600× to the renderer in 3 seconds —
+// V8 stack exhaustion → renderer crash. The launcher-side reset
+// (`handle_report_pool_window_promoted` setting
+// `foregrounded_since_open=true`) stops the storm at source; this
+// per-key cache is the renderer-side defence-in-depth so a future
+// upstream regression can't crash us. Keyed by
+// `(event, label, hwnd)`; max version observed wins. PerSourceTracker
+// already drops by global monotonic version, but a per-key check
+// catches duplicates that the global counter advances past.
+//
+// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`.
+const MAX_DEDUP_KEYS = 1024;
+const dedupSeen = new Map<string, number>();
+let dedupSuppressedCount = 0;
+
+function dedupKey(evt: LauncherEvent): string {
+    const e = evt as LauncherEvent & { label?: unknown; hwnd?: unknown };
+    const label = typeof e.label === "string" ? e.label : "";
+    const hwnd = typeof e.hwnd === "number" ? e.hwnd : "";
+    return `${evt.event}|${label}|${hwnd}`;
+}
+
+/**
+ * Per-key (event-kind, label, hwnd) version-monotonicity guard.
+ * Returns true if the event should be dispatched, false if it's a
+ * duplicate or stale re-emission for the same logical entity.
+ */
+export function shouldDispatchLauncherEvent(evt: LauncherEvent): boolean {
+    const k = dedupKey(evt);
+    const seenVersion = dedupSeen.get(k);
+    if (seenVersion !== undefined && evt.version <= seenVersion) {
+        dedupSuppressedCount++;
+        return false;
+    }
+    dedupSeen.set(k, evt.version);
+    if (dedupSeen.size > MAX_DEDUP_KEYS) {
+        // Bound memory. Map iteration order is insertion order → drop
+        // the oldest entry. Acceptable: a re-arrival for an evicted
+        // key can only re-fire if it carries a higher launcher
+        // version than this renderer has ever seen, which means it's
+        // not actually a duplicate.
+        const firstKey = dedupSeen.keys().next().value;
+        if (firstKey !== undefined) dedupSeen.delete(firstKey);
+    }
+    return true;
+}
+
+/** Diagnostic accessor for the dedup guard — used by tests + diag tools. */
+export function launcherEventDedupStats(): { tracked: number; suppressed: number } {
+    return { tracked: dedupSeen.size, suppressed: dedupSuppressedCount };
+}
+
+/** Test-only: clear the dedup cache. Not exported in production paths. */
+export function __resetDedupForTests(): void {
+    dedupSeen.clear();
+    dedupSuppressedCount = 0;
+}
+
 /**
  * Register `window.__agentmux_launcher_event` as the dispatcher.
  * Idempotent — safe to call multiple times. Called once from
@@ -80,6 +139,9 @@ let installed = false;
 export function installLauncherEventBridge(): void {
     if (installed) return;
     installed = true;
-    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => tracker.deliver(evt);
+    (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => {
+        if (!shouldDispatchLauncherEvent(evt)) return;
+        tracker.deliver(evt);
+    };
     console.log("[launcher-events] bridge installed; window.__agentmux_launcher_event ready");
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.657",
+  "version": "0.33.658",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.657",
+      "version": "0.33.658",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.656",
+  "version": "0.33.657",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.656",
+      "version": "0.33.657",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.655",
+  "version": "0.33.656",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.655",
+      "version": "0.33.656",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.658",
+  "version": "0.33.659",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.658",
+      "version": "0.33.659",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.658",
+  "version": "0.33.659",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.655",
+  "version": "0.33.656",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.656",
+  "version": "0.33.657",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.657",
+  "version": "0.33.658",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two independent fixes for the v0.33.655 smoke-test renderer crash. Tier 1 of the follow-up plan in [discussion #707](https://github.com/agentmuxai/agentmux/discussions/707) and [`docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`](https://github.com/agentmuxai/agentmux/blob/agenta/drift-storm-tier1/docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md).

**Symptom:** 1 launcher event (`HwndDriftDetected version=13`) reached the renderer ~600× in 3 seconds → V8 stack exhaustion → `Crashpad_NotConnectedToHandler`. Triggered by the very first tear-off post-PR-#706.

### 1. Launcher reducer (Bug A — stops the storm at source)

`handle_report_pool_window_promoted` now flips `foregrounded_since_open=true` on the matching `WindowMirror`.

Pool windows are spawned hidden and never foregrounded. After promote, the host repositions the HWND via several `SetWindowPos` calls; some intermediate states have `visible=false`. Without resetting the WRR mirror's flag, each flicker re-fires `HiddenSinceOpen` drift indefinitely.

Idempotent if the mirror is absent (pre-existing contract preserved).

### 2. Frontend bridge (Bug B — defence-in-depth)

Per-key `(event, label, hwnd)` dedup with max-version-seen tracking, installed at the `__agentmux_launcher_event` entry. Bounded at 1024 keys (LRU by insertion order). Diag accessor: `launcherEventDedupStats()`.

`PerSourceTracker` already drops by global monotonic version, but the global counter advances past per-key duplicates, and fresh JS contexts (pool-window bootstrap) reset `lastVersion=0`. The bridge-entry guard catches both.

## Tests

- `agentmux-launcher` — 2 new tests, all 158 pass:
  - `promote_clears_foregrounded_since_open_so_post_promote_hide_does_not_drift`
  - `promote_for_label_without_window_mirror_is_a_no_op`
- `frontend/util/launcher-events.test.ts` — 8 new tests covering admit-once, suppress-rerun, version monotonicity, key independence, memory bound.

## Test plan

- [x] cargo test -p agentmux-launcher — 158 pass
- [x] vitest frontend/util/launcher-events.test.ts — 8 pass
- [x] vitest broader (441 tests across 20 files) — green
- [ ] Smoke: portable build + tear off 5 tabs in a row, no crash, no drift-event flood in `[fe]` log
- [ ] Verify `launcherEventDedupStats().suppressed` is non-zero in normal use (proves the guard is active and the upstream is still emitting duplicates → keep tier 2 on the to-do)

## Out of scope (deferred)

- Tier 2: host bridge de-dup + rate limit (only needed if tier-1 #2 doesn't catch enough — diag will tell)
- Tier 3: idempotency property tests across all four reducers; pool state-machine fuzz; cross-layer event volume budget
- Master spec additions: §8.14 idempotency contract, §9.8 Phase F.7

These are tracked in discussion #707; will append closure comments as each lands.