### PR TITLE
feat(tabbar): replace + button with hamburger menu

### DIFF
--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.667"
+version = "0.33.668"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.666"
+version = "0.33.667"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.665"
+version = "0.33.666"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.665"
+version = "0.33.666"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.666"
+version = "0.33.667"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.667"
+version = "0.33.668"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.666"
+version = "0.33.667"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.667"
+version = "0.33.668"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.665"
+version = "0.33.666"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.666"
+version = "0.33.667"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.667"
+version = "0.33.668"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.665"
+version = "0.33.666"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -50,3 +50,18 @@
         border-radius: 2px;
     }
 }
+
+.menu-divider {
+    height: 1px;
+    background-color: rgba(255, 255, 255, 0.1);
+    margin: var(--space-0-5) var(--space-1);
+    pointer-events: none;
+}
+
+.menu-item-icon {
+    width: 14px;
+    font-size: 11px;
+    margin-right: var(--space-1);
+    opacity: 0.7;
+    flex-shrink: 0;
+}

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -163,6 +163,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
             <div
                 ref={(el) => { referenceEl = el; }}
                 class="menu-anchor"
+                data-drag-region="false"
                 onClick={() => onOpenChangeMenu(!isOpen())}
             >
                 {props.children}
@@ -186,10 +187,17 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
                                     onClick: (e: MouseEvent) => handleOnClick(e, item),
                                 };
 
+                                if (item.divider) {
+                                    return <div class="menu-divider" aria-hidden="true" />;
+                                }
+
                                 const renderedItem = props.renderMenuItem ? (
                                     props.renderMenuItem(item, menuItemProps)
                                 ) : (
                                     <div {...menuItemProps}>
+                                        <Show when={item.icon}>
+                                            <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
+                                        </Show>
                                         <span class="label">{item.label}</span>
                                         <Show when={item.subItems}>
                                             <i class="fa-sharp fa-solid fa-chevron-right" />
@@ -276,10 +284,17 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                         onClick: (e: MouseEvent) => props.handleOnClick(e, item),
                     };
 
+                    if (item.divider) {
+                        return <div class="menu-divider" aria-hidden="true" />;
+                    }
+
                     const renderedItem = props.renderMenuItem ? (
                         props.renderMenuItem(item, menuItemProps)
                     ) : (
                         <div {...menuItemProps}>
+                            <Show when={item.icon}>
+                                <i class={clsx("fa-solid fa-fw", `fa-${item.icon}`, "menu-item-icon")} />
+                            </Show>
                             <span class="label">{item.label}</span>
                             <Show when={item.subItems}>
                                 <i class="fa-sharp fa-solid fa-chevron-right" />

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -76,13 +76,13 @@
         padding: 0;
         background: transparent;
         border: none;
-        color: var(--tab-green);
+        color: var(--accent-color);
         -webkit-app-region: no-drag;
         cursor: pointer;
         align-self: center;
 
         &:hover {
-            color: color-mix(in srgb, var(--tab-green), white 25%);
+            color: color-mix(in srgb, var(--accent-color), white 25%);
         }
 
         i {

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -66,7 +66,7 @@
         }
     }
 
-    .add-tab-btn {
+    .hamburger-btn {
         flex-shrink: 0;
         display: flex;
         align-items: center;
@@ -86,7 +86,7 @@
         }
 
         i {
-            font-size: 11px;
+            font-size: 12px;
         }
     }
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -540,47 +540,6 @@ function TabBar(props: TabBarProps): JSX.Element {
             icon: "window-restore",
             onClick: () => getApi().openNewWindow().catch(console.error),
         },
-        {
-            label: "Open in New Window",
-            icon: "arrow-up-right-from-square",
-            subItems: [
-                {
-                    label: "Agent",
-                    icon: "sparkles",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "Terminal",
-                    icon: "square-terminal",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "Browser",
-                    icon: "globe",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "Editor",
-                    icon: "file-code",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "System Info",
-                    icon: "chart-line",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "Swarm",
-                    icon: "bee",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-                {
-                    label: "Help",
-                    icon: "circle-question",
-                    onClick: () => getApi().openNewWindow().catch(console.error),
-                },
-            ],
-        },
         { label: "", divider: true },
         {
             label: "Settings",

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -3,6 +3,7 @@
 
 import { atoms, createBlock, createTab, getApi, setActiveTab } from "@/store/global";
 import { FlyoutMenu } from "@/app/element/flyoutmenu";
+import { invokeCommand } from "@/app/platform/ipc";
 import { fireAndForget } from "@/util/util";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
@@ -584,7 +585,11 @@ function TabBar(props: TabBarProps): JSX.Element {
         {
             label: "Settings",
             icon: "cog",
-            onClick: () => fireAndForget(() => createBlock({ meta: { view: "settings" } })),
+            onClick: () =>
+                fireAndForget(async () => {
+                    const path = await invokeCommand<string>("ensure_settings_file");
+                    await invokeCommand("open_in_editor", { path });
+                }),
         },
         {
             label: "Help",

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -528,23 +528,6 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     const activeIndex = () => tabIds().indexOf(activeTabId());
 
-    // Widgets that can be opened in a new window, sorted by display:order.
-    // Excludes settings (non-pane, opens external editor) and devtools (toggles inspector).
-    const openInNewWindowItems = createMemo((): MenuItem[] => {
-        const wmap = atoms.fullConfigAtom()?.widgets ?? {};
-        return Object.entries(wmap)
-            .filter(([, w]) => {
-                const view = w.blockdef?.meta?.view;
-                return view !== "settings" && view !== "devtools";
-            })
-            .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
-            .map(([, widget]) => ({
-                label: widget.label ?? "",
-                icon: widget.icon,
-                onClick: () => getApi().openNewWindow().catch(console.error),
-            }));
-    });
-
     const tabBarMenuItems = createMemo((): MenuItem[] => [
         {
             label: "New Tab",
@@ -556,11 +539,6 @@ function TabBar(props: TabBarProps): JSX.Element {
             label: "New Window",
             icon: "window-restore",
             onClick: () => getApi().openNewWindow().catch(console.error),
-        },
-        {
-            label: "Open in New Window",
-            icon: "arrow-up-right-from-square",
-            subItems: openInNewWindowItems(),
         },
         { label: "", divider: true },
         {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -7,7 +7,7 @@ import { invokeCommand } from "@/app/platform/ipc";
 import { fireAndForget } from "@/util/util";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { For, onCleanup, onMount, Show } from "solid-js";
+import { createMemo, For, onCleanup, onMount, Show } from "solid-js";
 import type { JSX } from "solid-js";
 import { ObjectService, WorkspaceService } from "../store/services";
 import { makeORef, getObjectValue } from "../store/wos";
@@ -528,7 +528,24 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     const activeIndex = () => tabIds().indexOf(activeTabId());
 
-    const tabBarMenuItems: MenuItem[] = [
+    // Widgets that can be opened in a new window, sorted by display:order.
+    // Excludes settings (non-pane, opens external editor) and devtools (toggles inspector).
+    const openInNewWindowItems = createMemo((): MenuItem[] => {
+        const wmap = atoms.fullConfigAtom()?.widgets ?? {};
+        return Object.entries(wmap)
+            .filter(([, w]) => {
+                const view = w.blockdef?.meta?.view;
+                return view !== "settings" && view !== "devtools";
+            })
+            .sort(([, a], [, b]) => (a["display:order"] ?? 0) - (b["display:order"] ?? 0))
+            .map(([, widget]) => ({
+                label: widget.label ?? "",
+                icon: widget.icon,
+                onClick: () => getApi().openNewWindow().catch(console.error),
+            }));
+    });
+
+    const tabBarMenuItems = createMemo((): MenuItem[] => [
         {
             label: "New Tab",
             icon: "plus",
@@ -539,6 +556,11 @@ function TabBar(props: TabBarProps): JSX.Element {
             label: "New Window",
             icon: "window-restore",
             onClick: () => getApi().openNewWindow().catch(console.error),
+        },
+        {
+            label: "Open in New Window",
+            icon: "arrow-up-right-from-square",
+            subItems: openInNewWindowItems(),
         },
         { label: "", divider: true },
         {
@@ -555,12 +577,12 @@ function TabBar(props: TabBarProps): JSX.Element {
             icon: "circle-question",
             onClick: () => fireAndForget(() => createBlock({ meta: { view: "help" } })),
         },
-    ];
+    ]);
 
     return (
         <div class="tab-bar" {...dragProps}>
             <FlyoutMenu
-                items={tabBarMenuItems}
+                items={tabBarMenuItems()}
                 placement="bottom-start"
             >
                 <button class="hamburger-btn" title="Menu" data-drag-region="false">

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -1,7 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, createTab, getApi, setActiveTab } from "@/store/global";
+import { atoms, createBlock, createTab, getApi, setActiveTab } from "@/store/global";
+import { FlyoutMenu } from "@/app/element/flyoutmenu";
 import { fireAndForget } from "@/util/util";
 import { useWindowDrag } from "@/app/hook/useWindowDrag.platform";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
@@ -526,11 +527,82 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     const activeIndex = () => tabIds().indexOf(activeTabId());
 
+    const tabBarMenuItems: MenuItem[] = [
+        {
+            label: "New Tab",
+            icon: "plus",
+            onClick: () => createTab(),
+        },
+        { label: "", divider: true },
+        {
+            label: "New Window",
+            icon: "window-restore",
+            onClick: () => getApi().openNewWindow().catch(console.error),
+        },
+        {
+            label: "Open in New Window",
+            icon: "arrow-up-right-from-square",
+            subItems: [
+                {
+                    label: "Agent",
+                    icon: "sparkles",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "Terminal",
+                    icon: "square-terminal",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "Browser",
+                    icon: "globe",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "Editor",
+                    icon: "file-code",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "System Info",
+                    icon: "chart-line",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "Swarm",
+                    icon: "bee",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+                {
+                    label: "Help",
+                    icon: "circle-question",
+                    onClick: () => getApi().openNewWindow().catch(console.error),
+                },
+            ],
+        },
+        { label: "", divider: true },
+        {
+            label: "Settings",
+            icon: "cog",
+            onClick: () => fireAndForget(() => createBlock({ meta: { view: "settings" } })),
+        },
+        {
+            label: "Help",
+            icon: "circle-question",
+            onClick: () => fireAndForget(() => createBlock({ meta: { view: "help" } })),
+        },
+    ];
+
     return (
         <div class="tab-bar" {...dragProps}>
-            <button class="add-tab-btn" onClick={createTab} title="New Tab" data-drag-region="false">
-                <i class="fa fa-plus" />
-            </button>
+            <FlyoutMenu
+                items={tabBarMenuItems}
+                placement="bottom-start"
+            >
+                <button class="hamburger-btn" title="Menu" data-drag-region="false">
+                    <i class="fa fa-bars" />
+                </button>
+            </FlyoutMenu>
             <div ref={tabBarScrollRef!} class="tab-bar-scroll" data-drag-region="false">
                 <For each={tabIds()}>
                     {(tabId, i) => (

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -354,6 +354,7 @@ declare global {
         icon?: string | JSX.Element;
         subItems?: MenuItem[];
         onClick?: (e: MouseEvent) => void;
+        divider?: boolean;
     };
 
     type MenuButtonProps = {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.666",
+  "version": "0.33.667",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.667",
+  "version": "0.33.668",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.665",
+  "version": "0.33.666",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- Replaces the green `+` button in the tab bar with a hamburger icon (`fa-bars`), keeping the same green color and hover behavior
- Clicking opens a `FlyoutMenu` with:
  - **New Tab**
  - ────
  - **New Window**
  - **Open in New Window** ▶ (submenu with all 7 widgets: Agent, Terminal, Browser, Editor, System Info, Swarm, Help)
  - ────
  - **Settings**
  - **Help**

## Supporting changes

- `FlyoutMenu`: added `divider: true` support on `MenuItem` — renders a subtle horizontal rule
- `FlyoutMenu`: added `icon` support on `MenuItem` — renders an FA icon before the label
- `FlyoutMenu`: `.menu-anchor` now has `data-drag-region="false"` so it's never treated as a window drag region
- `custom.d.ts`: `MenuItem` type updated with `divider?: boolean` and `icon` was already present

## Notes

"Open in New Window > [Widget]" currently opens a blank new window for all variants (`openNewWindow()` has no widget-init param). The submenu correctly surfaces all widgets as options — pre-populating the widget on open is a follow-up once `open_new_window` supports an initial block definition.

## Test plan
- [ ] Hamburger icon appears in tab bar (green, same position as old `+`)
- [ ] Click opens menu below button, `bottom-start` aligned
- [ ] New Tab creates a new tab
- [ ] New Window opens a new window
- [ ] Open in New Window submenu shows on hover, lists all 7 widgets, each opens a new window
- [ ] Settings and Help open their respective blocks
- [ ] Dividers render as subtle lines between sections
- [ ] Icons appear beside each menu item label
- [ ] Click outside closes the menu
- [ ] Menu does not interfere with window dragging

🤖 Generated with [Claude Code](https://claude.com/claude-code)