### PR TITLE
docs(spec): Phase F audit — 5/7 phases migrated, master spec updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.665"
+version = "0.33.666"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.665"
+version = "0.33.666"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.665"
+version = "0.33.666"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.665"
+version = "0.33.666"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.665"
+version = "0.33.666"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.665"
+version = "0.33.666"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.665"
+version = "0.33.666"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.665"
+version = "0.33.666"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
+++ b/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
@@ -56,7 +56,7 @@ Each reducer is canonical for its domain. Cross-reducer state moves only through
 | **Launcher** | ✅ DONE — Phases B.1–B.9 + D.1–D.3 | n/a — emerged from B work | [`phase-b-roadmap.md`](../retro/phase-b-roadmap.md) |
 | **Srv (Phase E)** | ✅ MOSTLY DONE — E.1a–E.5 + F1.A/B shipped | [`SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md`](./SPEC_PHASE_E_SRV_REDUCER_2026_04_29.md) | [`phase-e-status-2026-05-01.md`](../retro/phase-e-status-2026-05-01.md) |
 | **Srv layout (E.4.B)** | 🟨 IN-FLIGHT — Phase 2/3/4 shipped, Phase 5+ pending | [`srv-phase-e4b-formal-spec-2026-05-03.md`](./srv-phase-e4b-formal-spec-2026-05-03.md) | This doc, §5 |
-| **Host (Phase F)** | 🟨 PARTIAL — mirrors built (B.5), reducer migration not started | [`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md) | [`phase-fg-status-2026-05-01.md`](../retro/phase-fg-status-2026-05-01.md) |
+| **Host (Phase F)** | 🟨 5/7 MIGRATED — H.2/H.3/H.4/H.5 + F.1 pending_window_creations complete; H.1 panes scaffolded but `BrowserPaneManager` callers not migrated; H.6 top-level dormant (no dispatchers) | [`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md) | [`PHASE_F_AUDIT_2026-05-06.md`](./PHASE_F_AUDIT_2026-05-06.md) |
 | **Frontend** | 🟨 IN-FLIGHT — slice #1 shipped (#681), #2 doc-approved, #3–#8 designed | [`frontend-reducer-architecture-2026-05-03.md`](./frontend-reducer-architecture-2026-05-03.md) | This doc, §6 |
 | **Sagas** | ✅ FOUNDATION — coordinator + 7 sagas merged | [`SPEC_SAGA_ARCHITECTURE_TARGET_2026-05-01.md`](./SPEC_SAGA_ARCHITECTURE_TARGET_2026-05-01.md) | [`saga-architecture-migration-complete-2026-05-02.md`](../retro/saga-architecture-migration-complete-2026-05-02.md) |
 | **Persistence** | ✅ Persist subscriber + event log shipped | n/a | Captured in E.2c.1–5a in phase-e-status |
@@ -93,39 +93,42 @@ Each reducer is canonical for its domain. Cross-reducer state moves only through
 
 ## 4. Layer 2 — Host reducer (Phase F)
 
-**Status: 🟨 PARTIAL.** Foundational shadow projections built (B.5); host's *own* reducer not yet started.
+**Status: 🟨 5/7 PHASES MIGRATED.** B.5 shadow mirrors built; host's own reducer (`HostState`) holds 6 of 7 planned migration domains; 5 are wired to production callers, 2 are scaffolded with reducer arms but no dispatchers. See [`PHASE_F_AUDIT_2026-05-06.md`](./PHASE_F_AUDIT_2026-05-06.md) for the per-phase status table.
 
-### 4.1 What landed (B.5 mirrors)
+### 4.1 B.5 shadow mirrors (events-only)
 
-The host now holds **read-only projections** of launcher state, updated via `apply_event_to_shadow`:
+The host holds **read-only projections** of launcher state, updated via `apply_shadow_projection` (extracted from `apply_event_to_shadow` in PR #711 for testability):
 - `shadow_instance_registry`
 - `shadow_window_meta`
 - `shadow_backend_window_ids`
-- `window_meta` (sync cache for open_subwindow + cascade-close needs)
+- `window_meta` (sync cache for `open_subwindow` parent-liveness + cascade-close child enumeration)
 
-These are already on the events-only contract — host doesn't write to them; subscribes to launcher events and projects.
+Idempotency contract enforced per §8.14 with a property test in `agentmux-cef/src/launcher_ipc.rs::shadow_projection_tests`.
 
-### 4.2 What stays scaffolding (deliberately, indefinitely)
+### 4.2 Migrated to `HostState` (5 phases, fully wired)
 
-Per [`b5-migration-architecture-2026-04-28.md`](../retro/b5-migration-architecture-2026-04-28.md), these can't migrate via the standard ratchet because of CEF FFI / UI-thread synchronization patterns:
-- `browsers: Mutex<HashMap<String, Browser>>` — CEF FFI handles, callback-driven lifecycle
-- `window_pool`, `unpromoted_pool_labels` — pool maintenance triggered by CEF callbacks
+Each followed the standard a→b→c→d→e ratchet from [`migration-pattern.md`](../retro/migration-pattern.md):
 
-**Discipline:** snapshot-and-drop. Callers snapshot `(label, HWND)` pairs, drop the lock, then do Win32 work outside the lock. Avoids cross-thread deadlock.
+| H.x | `HostState` field | Legacy field on `AppState` | Notes |
+|---|---|---|---|
+| **F.1** | `pending_window_creations: VecDeque<PendingWindowCreation>` | DELETED | Original pre-H scope; landed alongside Phase B.4 |
+| **H.2** | `browsers: HashMap<String, BrowserHandle>` | DELETED | Reversed the "scaffolding indefinitely" decision from `b5-migration-architecture-2026-04-28.md` — turned out the snapshot-and-drop discipline mapped cleanly onto reducer-arm semantics |
+| **H.3** | `active_drag: Option<DragSession>` | DELETED | |
+| **H.4** | `pool: PoolState` | DELETED (`window_pool`, `unpromoted_pool_labels`) | Drift-storm fix (PR #708) added `just_promoted_labels` to bridge the host's `PoolPromoted → WindowOpened` IPC gap |
+| **H.5** | `quit_state: QuitState` | DELETED (`is_quitting: AtomicBool`) | |
 
-### 4.3 What's in scope for Phase F (the host reducer migration)
+### 4.3 Scaffolded but NOT wired (2 phases — forward work)
 
-Per [`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md):
-- `pending_window_creations: VecDeque<PendingWindowCreation>` — clean lifecycle, ready to migrate
-- `active_drag: Option<DragSession>` — well-defined start/end
-- Tear-off hook state per window
-- `lifecycle`, `event_version` (minor)
+| H.x | `HostState` field | Legacy code still authoritative | Estimated effort |
+|---|---|---|---|
+| **H.1** panes | `browser_panes: HashMap<String, BrowserPaneEntry>` (`#[allow(dead_code)]`) | `state.browser_panes: BrowserPaneManager` (`browser_panes.rs`, 806 lines, 9+ call sites) | 5–8 days; needs its own a→e sub-PRs |
+| **H.6** top-level | `top_level_creation: TopLevelCreationState` | `ui_tasks::post_create_window` direct calls (no state to migrate; pure function-call path) | 2–3 days; lower priority — current path works |
 
-5-PR breakdown in [`SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md`](./SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md).
+H.1 is the largest remaining domain; H.6 is structural improvement, not bug-driven.
 
 ### 4.4 Why "Phase H" and "Phase F" specs both exist
 
-[`SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md`](./SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md) and [`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md) are two passes at the same scope. **PHASE_F is the canonical one** (more recent date and aligned with phase-fg-roadmap). PHASE_H exists as historical reframing — keep but treat as superseded for design decisions.
+[`SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md`](./SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md) is the granular per-domain spec; [`SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md`](./SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md) is its 5-PR operational compression. [`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md) is the original framing — the H.x naming used in code came after, when the scope expanded beyond F's "pending creations + active drag + tear-off hooks." Treat them as a series: F (initial scope) → H (full host migration) → audit (this doc) for status.
 
 ---
 
@@ -278,12 +281,11 @@ F.5's `PoolRespawnSaga` emits `IssueCmd::Host` as log-only no-op. There's no lau
 ### 9.2 Per-event saga_id correlation (BLOCKER for E.6)
 Codex flagged twice during E.5, deferred twice. Evict-and-replace policy mitigates today; proper solution is `saga_id` tags on events. ~300 LOC. Bundle with cross-process dispatch mini-phase.
 
-### 9.3 Phase F hosting strategy
-Where does the host reducer live? Options:
-- **Centralize in launcher's Tokio runtime** — easier to debug, single dispatcher, but adds another cross-process hop.
-- **Run in a host-process runtime** — lighter, harder to coordinate with launcher events.
+### 9.3 Phase F hosting strategy — RESOLVED in-process
 
-Spec defers this ([`SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`](./SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md) §0). Decision needed before F.1.
+**Resolved (de-facto):** the host reducer runs in the `agentmux-cef` process (option B), with `host_dispatch` invoked synchronously from CEF callbacks and IPC handlers. The "launcher Tokio centralisation" alternative was never built. F.1 + H.2/H.3/H.4/H.5 all shipped under this model without cross-process coordination issues.
+
+**Cross-process bridging** is still needed for sagas (§9.1), but that's about command flow between *different* reducers, not where any single reducer's runtime lives.
 
 ### 9.4 Frontend command bus scope (slice #3)
 Originally planned as single outbound dispatch chokepoint for clicks + slash commands + agent app-API calls. Descoped per conventions Q1+Q4. Open: does a single bus still make sense, or are per-slice dispatchers sufficient? **Blocker for** agent-driven UI mutation audit + policy enforcement.

--- a/docs/specs/PHASE_F_AUDIT_2026-05-06.md
+++ b/docs/specs/PHASE_F_AUDIT_2026-05-06.md
@@ -1,0 +1,74 @@
+# Phase F (host reducer) audit — 2026-05-06
+
+**Purpose.** Reconcile the master spec's "Phase F not started" status with what's actually in the code. The work has been happening in-flight via the H.x submodules (`agentmux-cef/src/reducer/{panes,browsers,drag,pool,quit,top_level}.rs`) and is far more complete than the master ledger reflects.
+
+**Authority.** The master spec ([`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md)) §2 row for Host (Phase F) flips from 🟨 *"mirrors built (B.5), reducer migration not started"* to 🟨 *"4/6 H.x phases complete; H.1 panes + H.6 top-level scaffolded but not wired"* in the companion update PR.
+
+The Phase H spec ([`SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md`](./SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md)) and 5-PR plan ([`SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md`](./SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md)) are the *operational* plan; this audit captures the actual landed state of each H.x phase.
+
+## Status by H.x phase
+
+| Phase | Field on `HostState` | Reducer arms | Production callers wired | Legacy state on `AppState` | Status |
+|---|---|---|---|---|---|
+| **H.1** panes | `browser_panes: HashMap<String, BrowserPaneEntry>` | yes (`reducer/panes.rs`) | **NO** — `state.browser_panes: BrowserPaneManager` still authoritative | `pub browser_panes: BrowserPaneManager` (`state.rs:594`) | 🟨 SCAFFOLDED |
+| **H.2** browsers | `browsers: HashMap<String, BrowserHandle>` | yes (`reducer/browsers.rs`) | **YES** — sole source of truth post-PR-#H2.e | DELETED (state.rs:483 comment) | ✅ COMPLETE |
+| **H.3** drag | `active_drag: Option<DragSession>` | yes (`reducer/drag.rs`) | **YES** — `state.active_drag` removed | DELETED | ✅ COMPLETE |
+| **H.4** pool | `pool: PoolState` | yes (`reducer/pool.rs`) | **YES** — drift-storm fix (PR #708) added `just_promoted_labels`; pool snapshot helpers in `state.rs:813-880` | DELETED (`window_pool` / `unpromoted_pool_labels`) | ✅ COMPLETE |
+| **H.5** quit | `quit_state: QuitState` | yes (`reducer/quit.rs`) | **YES** — `is_quitting: AtomicBool` replaced | DELETED (state.rs:218 comment) | ✅ COMPLETE |
+| **H.6** top-level | `top_level_creation: TopLevelCreationState` | yes (`reducer/top_level.rs`) | **NO** — `EnqueueTopLevelWindow` / `TopLevelCallbackFired` have no dispatchers | n/a (greenfield) | ⏸️ DORMANT |
+
+Plus the original Phase F field that pre-dates the H.x reframing:
+- **F.1** `pending_window_creations` — ✅ COMPLETE. State on `HostState`, single mutation path through `host_dispatch`.
+
+**Net: 5/7 fully migrated. 2/7 (H.1 panes, H.6 top-level) have reducer-side scaffolding but no production callers.**
+
+## What "scaffolded but not wired" means
+
+Each H.x phase follows the standard a→b→c→d→e ratchet from [`migration-pattern.md`](../retro/migration-pattern.md):
+
+```
+a) parallel writes — both legacy and reducer mutate
+b) reads with fallback — readers prefer reducer, fall back to legacy
+c) flip reads — reducer is authoritative; legacy is a passive shadow
+d) drop legacy writes — only the reducer mutates
+e) delete legacy field — single source of truth
+```
+
+H.2/H.3/H.4/H.5 reached step e. H.1 and H.6 are at step **a** at best — the reducer fields exist (`#[allow(dead_code)]` on `browser_panes` and `top_level_creation` annotations confirm) but no production code dispatches commands to them yet.
+
+## H.1 — pane lifecycle (largest remaining item)
+
+**Legacy:** `state.browser_panes: BrowserPaneManager` (`agentmux-cef/src/browser_panes.rs`, 806 lines). Actively written by 9+ call sites in `ipc.rs` and elsewhere.
+
+**Target:** `HostState.browser_panes: HashMap<String, BrowserPaneEntry>` keyed by `block_id`, mutated only via `host_dispatch(EnqueuePaneCreate / CompletePaneCreate / EnqueuePaneClose / CompletePaneClose / AbortPaneCreate)`.
+
+**Migration path:** the standard ratchet, but `BrowserPaneManager` has more behaviour than the other H.x fields (drain logic, navigation, focus routing, per-pane CDP wiring). A→e likely needs ~3 PRs of its own:
+1. **Parallel writes** — every `state.browser_panes.create()` / `close()` etc. also dispatches the matching `HostCommand`.
+2. **Drift compare** — on every reducer event, assert `state.browser_panes.contains(label) == HostState.browser_panes.contains_key(block_id)`.
+3. **Flip reads + delete legacy** — readers shift to `HostState.browser_panes`; `BrowserPaneManager` becomes a thin wrapper that only emits commands; eventually deleted.
+
+Estimated effort: 5-8 days wall-clock (matches the 4-5 day "high risk" budget the 5-PR plan put on PR #2 for browsers + panes combined; browsers turned out smaller than expected).
+
+## H.6 — top-level creation runner (smaller, optional)
+
+**Legacy:** `agentmux-cef/src/ui_tasks.rs::post_create_window` and friends — direct CEF Browser creation. No state to migrate — it's a function-call path.
+
+**Target:** `HostState.top_level_creation` queues `EnqueueTopLevelWindow { request }`; an event-driven runner consumes the queue, calls CEF, dispatches `TopLevelCallbackFired { label }` on `on_after_created` to advance the in-flight slot.
+
+**Why dormant:** the existing function-call path works; the reducer-driven version is a structural improvement (event log captures every top-level open + the timing per phase) but doesn't fix any current bug. Defer until H.1 lands and the host reducer is the authoritative state container — at which point H.6 becomes "the last legacy callback path."
+
+**Estimated effort:** 2-3 days wall-clock.
+
+## Recommendation
+
+1. **This PR** — doc-only update to master spec §2 + §4 reflecting actual status. Plus this audit file linking from there.
+2. **Next PR** — H.1 step (a) — parallel writes for pane lifecycle. Smallest forward step that makes meaningful progress on the largest remaining item.
+3. **After H.1 reaches step (e)** — Phase F is "essentially done" for purposes of master spec §2; reduce H.6 to a tracked-but-deferred item.
+
+## Cross-reference
+
+- Master spec authority: [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md) §4
+- Granular Phase H plan: [`SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md`](./SPEC_HOST_REDUCER_PHASE_H_2026-05-02.md)
+- 5-PR operational plan: [`SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md`](./SPEC_HOST_REDUCER_5PR_PLAN_2026-05-02.md)
+- Migration ratchet: [`migration-pattern.md`](../retro/migration-pattern.md)
+- Long-term tracking: [discussion #707](https://github.com/agentmuxai/agentmux/discussions/707)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.665",
+  "version": "0.33.666",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.665",
+      "version": "0.33.666",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.665",
+  "version": "0.33.666",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The master spec said *"Host (Phase F) — reducer migration not started"* since 2026-05-05. Reality after 4 weeks of in-flight work via the H.x submodules in `agentmux-cef/src/reducer/`: **5 of 7 planned migrations are fully wired to production callers**; 2 are scaffolded with reducer arms but no dispatchers.

You picked "Phase F.1" as the next step — F.1 (`pending_window_creations`) is already done. Rather than redo it, this PR captures the actual landed state and identifies the real next step (H.1 panes).

Tracked in [discussion #707](https://github.com/agentmuxai/agentmux/discussions/707).

## Audit (per-phase)

New doc: [`docs/specs/PHASE_F_AUDIT_2026-05-06.md`](https://github.com/agentmuxai/agentmux/blob/agenta/phase-f-audit/docs/specs/PHASE_F_AUDIT_2026-05-06.md).

| Phase | `HostState` field | Legacy field | Status |
|---|---|---|---|
| F.1 | `pending_window_creations` | DELETED | ✅ COMPLETE |
| H.2 | `browsers` | DELETED | ✅ COMPLETE — "scaffolding indefinitely" decision reversed |
| H.3 | `active_drag` | DELETED | ✅ COMPLETE |
| H.4 | `pool` | DELETED | ✅ COMPLETE — PR #708 drift-storm added `just_promoted_labels` |
| H.5 | `quit_state` | DELETED (`is_quitting: AtomicBool`) | ✅ COMPLETE |
| H.1 | `browser_panes: HashMap<…>` | `BrowserPaneManager` (806 lines) still authoritative | 🟨 SCAFFOLDED |
| H.6 | `top_level_creation` | n/a (function-call path) | ⏸️ DORMANT |

## Master spec changes

- **§2 status table** — Host row updated to "5/7 MIGRATED" with link to the audit doc
- **§4 Layer 2** — replaced the "what's in scope" speculation with a factual *Migrated* / *Scaffolded but not wired* split. Cross-references PR #711's `apply_shadow_projection` for the B.5 idempotency contract.
- **§9.3** — Phase F hosting strategy marked RESOLVED. Decision was de-facto made by every shipped H.x phase running in-process (agentmux-cef) without a launcher hop.

## What's next

H.1 panes is the biggest remaining domain (~5–8 days, needs its own a→e sub-PRs because `BrowserPaneManager` has more behaviour than the other H.x fields). H.6 is structural improvement, lower priority.

## Test plan

- [x] doc-only changes; no code touched
- [ ] master spec §2/§4/§9.3 renders correctly on GitHub