### PR TITLE
chore(ipc): refresh F.5/F.6 saga doc-comments + close §9.1/§9.2 (RESOLVED)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.670"
+version = "0.33.671"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.670"
+version = "0.33.671"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.670"
+version = "0.33.671"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.670"
+version = "0.33.671"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.670"
+version = "0.33.671"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.670"
+version = "0.33.671"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -619,26 +619,21 @@ pub enum Command {
     /// Phase F.5 — launcher-side saga coordinator asks the host to
     /// spawn a fresh pool window (refill after promote).
     ///
-    /// **F.5 status: framework-only.** Today the launcher's saga
-    /// coordinator does not yet have a launcher→host command pipe
-    /// (host's `launcher_ipc.rs` is wired to send Commands up but
-    /// not receive them down on the same connection). The
-    /// pool-respawn saga issues this command via `SagaAction::IssueCmd`
-    /// for state-machine completeness, but the dispatch is currently a
-    /// no-op LOG and the saga relies on the host's existing implicit
-    /// `spawn_pool_window` call inside `promote_pool_window` to
-    /// produce the `Event::PoolWindowAdded` it waits for. F.6 (or
-    /// the cross-process command dispatch follow-up) replaces the
-    /// log with a real wire-level send.
+    /// **Status: live.** Cross-process dispatch (CPD-1 through CPD-5)
+    /// shipped; the saga coordinator's `apply_action` for
+    /// `PipeTarget::Host` writes this command through `host_pipe`
+    /// (`agentmux-launcher/src/host_pipe/`) and waits on the
+    /// `Event::PoolWindowAdded { saga_id: Some(N) }` echo. Host's
+    /// implicit `spawn_pool_window` call inside `promote_pool_window`
+    /// remains the organic refill path for non-saga-driven
+    /// promotions (with `saga_id: None`).
     ///
-    /// Phase CPD-1 (cross-process dispatch) — `saga_id` is mandatory
-    /// on the wire (every host-bound command carries the originating
+    /// `saga_id`: every host-bound command carries the originating
     /// saga's id so the host can echo it on the corresponding
-    /// `Report*` reply). Defaults to `0` via `#[serde(default)]` for
-    /// forward-compat with launchers running pre-CPD-1 builds; the
-    /// soak default is removed in a later PR (CPD-3) once the wire
-    /// has shipped a release cycle. `0` is reserved as "no saga"
-    /// and is treated by the host as a non-saga-driven dispatch.
+    /// `Report*` reply. `0` is reserved as "no saga" and treated as a
+    /// non-saga dispatch. `#[serde(default)]` retained for
+    /// forward-compat with any pre-CPD-1 deserializers (no real-world
+    /// consumer today; portable runtime is bundled per release).
     SpawnPoolWindow {
         #[serde(default)]
         saga_id: u64,
@@ -699,18 +694,17 @@ pub enum Command {
     /// Phase F.6 — launcher-side saga coordinator asks the host to
     /// reap all browser-pane HWNDs for a window that just closed.
     ///
-    /// **F.6 status: framework-only.** Same as `SpawnPoolWindow` in
-    /// F.5: no launcher→host command pipe exists yet. The saga
-    /// issues this with `target = PipeTarget::Host` for forward
-    /// compatibility; the coordinator's IssueCmd handler logs the
-    /// dispatch without transmitting. The host's existing implicit
-    /// pane drain inside `on_before_close` produces the
-    /// `Event::PanesReaped` the saga waits for. F.7 / cross-process
-    /// dispatch follow-up replaces the log with a real wire send.
+    /// **Status: live.** Wired through `host_pipe` post-CPD-3. The
+    /// saga issues this with `target = PipeTarget::Host`; the
+    /// coordinator's `apply_action` writes it through the host pipe
+    /// and waits for the `Event::PanesReaped { saga_id: Some(N) }`
+    /// echo. Host's organic pane drain inside `on_before_close` still
+    /// emits the same Report with `saga_id: None` for non-saga-driven
+    /// closes.
     ///
-    /// Phase CPD-1 — `saga_id` is mandatory on the wire (host echoes
-    /// back on `ReportPanesReaped`). `#[serde(default)]` returning `0`
-    /// for forward-compat soak; removed in CPD-3.
+    /// `saga_id`: mandatory on the wire (host echoes back on
+    /// `ReportPanesReaped`). `#[serde(default)]` retained for
+    /// forward-compat (see `SpawnPoolWindow` for rationale).
     ReapPanes {
         label: String,
         #[serde(default)]
@@ -721,14 +715,15 @@ pub enum Command {
     /// user-visible window (i.e. trigger Stage 1 of the close
     /// cascade).
     ///
-    /// **F.6 status: framework-only** (same caveat as `ReapPanes`).
-    /// Today the host's `on_before_close` already runs the equivalent
-    /// inline check; the saga relies on the resulting
-    /// `Event::PoolDrained` / `Event::PoolNotLast` to close its
-    /// bracket.
+    /// **Status: live** (same shipping path as `ReapPanes`). Wired
+    /// through `host_pipe` post-CPD-3; saga waits on
+    /// `Event::PoolDrained { saga_id: Some(N) }` /
+    /// `Event::PoolNotLast { saga_id: Some(N) }` echo. Host's
+    /// `on_before_close` still runs the equivalent inline check
+    /// organically (with `saga_id: None`).
     ///
-    /// Phase CPD-1 — `saga_id` is mandatory on the wire.
-    /// `#[serde(default)]` for forward-compat soak; removed in CPD-3.
+    /// `saga_id`: mandatory on the wire. `#[serde(default)]` retained
+    /// for forward-compat.
     DrainPoolIfLast {
         label: String,
         #[serde(default)]

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.670"
+version = "0.33.671"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.670"
+version = "0.33.671"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
+++ b/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
@@ -275,11 +275,25 @@ These came out of the multi-reducer proposal sessions and have been reaffirmed a
 
 These are real design decisions still pending. Listed in priority order.
 
-### 9.1 Cross-process saga dispatch (BLOCKER for F.5/F.6)
-F.5's `PoolRespawnSaga` emits `IssueCmd::Host` as log-only no-op. There's no launcher→host pipe yet. **Spec needed.** Sketch in [`SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md`](./SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md); needs formal write per phase-fg-roadmap §3. Until this lands, sagas can't coordinate atomic operations across the launcher / host boundary.
+### 9.1 Cross-process saga dispatch — RESOLVED (CPD-1 through CPD-5 shipped)
 
-### 9.2 Per-event saga_id correlation (BLOCKER for E.6)
-Codex flagged twice during E.5, deferred twice. Evict-and-replace policy mitigates today; proper solution is `saga_id` tags on events. ~300 LOC. Bundle with cross-process dispatch mini-phase.
+**Status: ✅ DONE.** All five sub-PRs from [`SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md`](./SPEC_CROSS_PROCESS_DISPATCH_2026-05-01.md) §4 landed:
+
+| CPD-N | Scope | Lands as |
+|---|---|---|
+| **CPD-1** | Schema additions: `saga_id` mandatory on `SpawnPoolWindow`/`ReapPanes`/`DrainPoolIfLast`; `Option<u64>` on `Report*` Commands and Events; `HostFrame` envelope; `ReportSagaActionFailed` event | `agentmux-common/src/ipc.rs` |
+| **CPD-2** | `HostPipe` wrapper + framing + connection loop + bounded `pending_buffer` | `agentmux-launcher/src/host_pipe/` |
+| **CPD-3** | `apply_action` dispatches via `host_pipe.send_command()` instead of log-only; `inject_saga_id` helper; per-saga `timeout()` override | `agentmux-launcher/src/saga/mod.rs` |
+| **CPD-4** | Per-saga `on_event()` correlation by `saga_id`; evict-and-replace policy retired | `pool_respawn.rs`, `window_cleanup.rs` |
+| **CPD-5** | Host-side `(saga_id, kind)` LRU for idempotency on duplicate launcher dispatches | `agentmux-cef/src/saga_dispatch.rs` |
+
+F.5 (`pool_respawn_on_promote`) and F.6 (`window_cleanup_cascade`) sagas drive host-side actions through the wire instead of just narrating organic events. Saga timeouts and retries are meaningful for `IssueCmd::Host`. Concurrent same-kind sagas correlate cleanly.
+
+**Open follow-up (deferred):** `PipeTarget::LauncherSelf` and `PipeTarget::Srv` arms are still log-only stubs (no consumer); spec §3.6 recommended preemptive wire-up; deferred until a class-D/E saga needs them. The companion durability spec ([`SPEC_LAUNCHER_SAGA_DURABILITY`](./SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md), Phase LSD) builds on top of CPD and is its own thread.
+
+### 9.2 Per-event saga_id correlation — RESOLVED (folded into CPD-4)
+
+**Status: ✅ DONE.** Closed with §9.1 above. CPD-4 wires `saga.on_event()` to filter by `event.saga_id == self.expected_saga_id`; evict-and-replace policy retired. The "~300 LOC, deferred twice" estimate was the work that landed inside CPD-4.
 
 ### 9.3 Phase F hosting strategy — RESOLVED in-process
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.670",
+  "version": "0.33.671",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.670",
+      "version": "0.33.671",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.670",
+  "version": "0.33.671",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

You asked to do §9.1 cross-process saga dispatch — turns out **all of it has already shipped** (CPD-1 through CPD-5, just like Phase F was already 6/7 done). This PR captures the actual state.

Companion to PR #713 (Phase F status fix). Same pattern: the master spec was wrong about §9.1 + §9.2 being "BLOCKER" / "needs spec write."

Tracked in [discussion #707](https://github.com/agentmuxai/agentmux/discussions/707).

## Code change

Refreshed the doc-comments on `Command::SpawnPoolWindow`, `Command::ReapPanes`, and `Command::DrainPoolIfLast` in `agentmux-common/src/ipc.rs`. All three still said "framework-only" / "no launcher→host command pipe exists yet" / "removed in CPD-3" — all stale since CPD-1 through CPD-5 shipped weeks ago.

New text describes the live behaviour:
- Saga coordinator's `apply_action` dispatches through `host_pipe` (CPD-3); host echoes `saga_id` on the corresponding `Report*`.
- Organic non-saga drains (host's `on_before_close` running inline) still emit the same Report with `saga_id: None`.
- `#[serde(default)]` retained for forward-compat (rationale documented).

## Master spec changes (riding with the code, per `feedback_no_doc_only_prs`)

**§9.1** Cross-process saga dispatch → **RESOLVED**. Per-CPD-N table documenting which sub-PR shipped what:

| CPD-N | Scope | Lands as |
|---|---|---|
| CPD-1 | Schema (`saga_id` on Commands, `Option<u64>` on Events, `HostFrame` envelope, `ReportSagaActionFailed`) | `agentmux-common/src/ipc.rs` |
| CPD-2 | `HostPipe` wrapper + framing + reconnect + bounded `pending_buffer` | `agentmux-launcher/src/host_pipe/` |
| CPD-3 | `apply_action` dispatches via `host_pipe.send_command()`; `inject_saga_id`; per-saga `timeout()` | `agentmux-launcher/src/saga/mod.rs` |
| CPD-4 | Per-saga `on_event()` correlation by `saga_id`; evict-and-replace retired | `pool_respawn.rs`, `window_cleanup.rs` |
| CPD-5 | Host-side `(saga_id, kind)` LRU for idempotency | `agentmux-cef/src/saga_dispatch.rs` |

**§9.2** Per-event saga_id correlation → **RESOLVED** (folded into CPD-4).

**Open follow-up** noted: `PipeTarget::LauncherSelf` / `PipeTarget::Srv` log-only stubs (no consumer); spec §3.6 recommended preemptive wire-up; deferred until a class-D/E saga needs them.

## Test plan

- [x] cargo check — clean
- [x] cargo test -p agentmux-launcher saga — 60 pass (verified pre-PR)
- [x] no behaviour change — only doc-comment refresh + master spec status update