### PR TITLE
feat(srv): E.4.B Phase 5 — first 4 layout reducer arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.673"
+version = "0.33.674"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.673"
+version = "0.33.674"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.673"
+version = "0.33.674"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.673"
+version = "0.33.674"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -973,6 +973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -980,6 +981,12 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -1011,9 +1018,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -2319,7 +2328,9 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.671"
+version = "0.33.672"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.671"
+version = "0.33.672"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.671"
+version = "0.33.672"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.671"
+version = "0.33.672"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -3003,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.674"
+version = "0.33.675"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.674"
+version = "0.33.675"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.674"
+version = "0.33.675"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.674"
+version = "0.33.675"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.672"
+version = "0.33.673"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.672"
+version = "0.33.673"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.672"
+version = "0.33.673"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.672"
+version = "0.33.673"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.675"
+version = "0.33.676"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.675"
+version = "0.33.676"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.675"
+version = "0.33.676"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.675"
+version = "0.33.676"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.676"
+version = "0.33.677"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.676"
+version = "0.33.677"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.676"
+version = "0.33.677"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.676"
+version = "0.33.677"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.674"
+version = "0.33.675"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.676"
+version = "0.33.677"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.673"
+version = "0.33.674"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.675"
+version = "0.33.676"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.671"
+version = "0.33.672"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.672"
+version = "0.33.673"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.674"
+version = "0.33.675"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.673"
+version = "0.33.674"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.672"
+version = "0.33.673"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.671"
+version = "0.33.672"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.676"
+version = "0.33.677"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.675"
+version = "0.33.676"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -1399,6 +1399,12 @@ pub enum Event {
         /// may need to re-magnify or clear their magnification UI).
         /// Reagent P1 PR #715 round 3: reducer was clearing
         /// `magnified_node_id` internally but not reporting it.
+        ///
+        /// `#[serde(default)]` for forward-compat with replay /
+        /// version-skewed senders that emit pre-round-3
+        /// `LayoutNodeDeleted` JSON without this field (codex P2 PR
+        /// #715 round 5).
+        #[serde(default)]
         was_magnified: bool,
         correlation_id: String,
         version: u64,

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -1395,6 +1395,11 @@ pub enum Event {
         /// True if the deleted node was the focused one (subscribers may
         /// need to refocus).
         was_focused: bool,
+        /// True if the deleted node was the magnified one (subscribers
+        /// may need to re-magnify or clear their magnification UI).
+        /// Reagent P1 PR #715 round 3: reducer was clearing
+        /// `magnified_node_id` internally but not reporting it.
+        was_magnified: bool,
         correlation_id: String,
         version: u64,
     },

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.673"
+version = "0.33.674"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.671"
+version = "0.33.672"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.672"
+version = "0.33.673"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.675"
+version = "0.33.676"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.676"
+version = "0.33.677"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.674"
+version = "0.33.675"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.673"
+version = "0.33.674"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -74,3 +74,8 @@ tempfile = "3"
 # that doesn't play nicely with our existing test runner; we only
 # need the strategy combinators + `proptest!` macro.
 proptest = { version = "1", default-features = false, features = ["std"] }
+# `blocking` feature enabled for the integration test target only —
+# `tests/integration_test.rs` spawns the srv as a subprocess and
+# wants synchronous HTTP from a non-tokio test fn. Production code
+# stays on the async client.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.671"
+version = "0.33.672"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.672"
+version = "0.33.673"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.676"
+version = "0.33.677"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.675"
+version = "0.33.676"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.674"
+version = "0.33.675"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -369,8 +369,11 @@ mod tests {
     }
 
     #[test]
-    fn provider_list_has_six_entries() {
-        assert_eq!(get_provider_list().count(), 6);
+    fn provider_list_has_seven_entries() {
+        // Update this when a provider is added or removed; a stale
+        // count is the cheapest detection mechanism for accidental
+        // additions.
+        assert_eq!(get_provider_list().count(), 7);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/reactive/tests.rs
+++ b/agentmux-srv/src/backend/reactive/tests.rs
@@ -280,8 +280,11 @@ fn test_handler_inject_agent_not_found() {
     assert!(resp.error.unwrap().contains("agent not found"));
 }
 
-#[test]
-fn test_handler_inject_success() {
+// `#[tokio::test]` because `Handler::inject_message` internally
+// `tokio::spawn`s the delayed-Enter follow-up; without a runtime it
+// panics at the spawn site (handler.rs:308).
+#[tokio::test]
+async fn test_handler_inject_success() {
     let sent = Arc::new(Mutex::new(Vec::<(String, Vec<u8>)>::new()));
     let sent_clone = sent.clone();
 
@@ -311,9 +314,13 @@ fn test_handler_inject_success() {
     assert_eq!(resp.block_id.as_deref(), Some("block1"));
 
     let calls = sent.lock().unwrap();
+    // Production sequence (handler.rs:268-280): clear `\r`, then
+    // message+`\r` as a single payload. The 3 delayed `\r` follow-ups
+    // are tokio-spawned with 200ms delays so they don't run before
+    // the assertions in this synchronous-only test body.
     assert_eq!(calls.len(), 2);
-    assert_eq!(calls[0], ("block1".to_string(), b"hello".to_vec()));
-    assert_eq!(calls[1], ("block1".to_string(), b"\r".to_vec()));
+    assert_eq!(calls[0], ("block1".to_string(), b"\r".to_vec()));
+    assert_eq!(calls[1], ("block1".to_string(), b"hello\r".to_vec()));
 }
 
 #[test]

--- a/agentmux-srv/src/backend/session_archive.rs
+++ b/agentmux-srv/src/backend/session_archive.rs
@@ -478,8 +478,15 @@ mod tests {
         let filestore = Arc::new(
             FileStore::open_in_memory().expect("filestore"),
         );
-        // Write a fake "output" file for block "blk-sweep-test"
-        let block_id = "blk-sweep-test";
+        // Write a fake "output" file for the block. The ID must be a
+        // valid UUID — `archive_session_output` calls
+        // `update_object_meta`, which parses the ORef
+        // `format!("block:{}", block_id)` via `ORef::parse` and
+        // rejects non-UUID oids. The earlier "blk-sweep-test" string
+        // failed silently inside the sweep's logged-but-suppressed
+        // error path.
+        let block_id_owned = uuid::Uuid::new_v4().to_string();
+        let block_id = block_id_owned.as_str();
         filestore
             .make_file(block_id, OUTPUT_FILENAME, FileMeta::default(), FileOpts::default())
             .expect("make_file");

--- a/agentmux-srv/src/backend/storage/filestore/tests.rs
+++ b/agentmux-srv/src/backend/storage/filestore/tests.rs
@@ -667,20 +667,46 @@ fn test_lru_entries_under_cap_all_retained() {
 fn test_lru_oldest_evicted_when_cap_exceeded() {
     // Cap = 200 bytes.  Each file charges max(size, 64) bytes.
     // We'll write files of 100 bytes each (charged as 100 bytes).
-    // Three files = 300 bytes > 200 cap → oldest should be evicted.
-    let cap: usize = 200;
+    // Cap chosen to fit f1+f2 writes without triggering eviction
+    // (so the timestamps from make_file don't matter), but exceed
+    // on the f3 write so eviction targets the oldest 100B entry (f1).
+    //
+    // Sizing: make_file inserts 64B metadata entries; write_file
+    // grows them to 100B each.
+    //   - After 3× make_file:        192B
+    //   - After write_file f1 100B:  228B (delta +36 → ≤ cap)
+    //   - After write_file f2 100B:  264B (still ≤ cap)
+    //   - After write_file f3 100B:  300B (> cap, evicts oldest)
+    let cap: usize = 290;
     let store = FileStore::open_in_memory_with_cap(cap).unwrap();
 
-    // Create files and write 100-byte payloads, accessing them in order f1, f2, f3.
     for name in &["f1", "f2", "f3"] {
         store.make_file("z1", name, FileMeta::new(), FileOpts::default()).unwrap();
     }
 
     let data = vec![0xBB_u8; 100];
 
-    // Write f1 first (oldest), then f2, then f3 (newest).
+    // Write f1 first, backdate it before writing f2 (write_file
+    // overwrites last_access_ms to `now`, so backdating must come
+    // AFTER each write). Without per-write backdating, all 3 entries
+    // share the same millisecond timestamp on fast machines and the
+    // LRU sort tie-break is undefined.
     store.write_file("z1", "f1", &data).unwrap();
+    {
+        let mut cache = store.cache.lock().unwrap();
+        if let Some(e) = cache.get_mut(&("z1".to_string(), "f1".to_string())) {
+            e.last_access_ms = 1;
+        }
+    }
     store.write_file("z1", "f2", &data).unwrap();
+    {
+        let mut cache = store.cache.lock().unwrap();
+        if let Some(e) = cache.get_mut(&("z1".to_string(), "f2".to_string())) {
+            e.last_access_ms = 2;
+        }
+    }
+    // f3's write triggers the cap-exceeded eviction. f1 (ts=1) is
+    // strictly the oldest by construction.
     store.write_file("z1", "f3", &data).unwrap();
 
     // After inserting f3 the cap (200) is exceeded.  evict_to_cap should have
@@ -707,11 +733,12 @@ fn test_lru_oldest_evicted_when_cap_exceeded() {
 
 #[test]
 fn test_lru_access_promotes_entry() {
-    // Cap sized to hold exactly 2 × 100-byte entries.
-    // Insert f1, f2 (fills to cap).  Then re-access f1 (promotes it to MRU).
-    // Insert f3 → cap exceeded → eviction should remove f2 (now the oldest),
-    // not f1 (recently touched).
-    let cap: usize = 200;
+    // Cap sized to fit f1+f2 writes without eviction; the f3 write
+    // pushes total to 300B, triggering eviction of the oldest. By
+    // construction below f2 is the oldest (timestamp=1), f1 is newer.
+    // See `test_lru_oldest_evicted_when_cap_exceeded` for the cap
+    // sizing rationale.
+    let cap: usize = 290;
     let store = FileStore::open_in_memory_with_cap(cap).unwrap();
 
     for name in &["f1", "f2", "f3"] {
@@ -722,15 +749,14 @@ fn test_lru_access_promotes_entry() {
     store.write_file("z1", "f1", &data).unwrap();
     store.write_file("z1", "f2", &data).unwrap();
 
-    // Re-access f1 to promote it (make it newer than f2).
-    // We use a small sleep-free timestamp backdate trick: directly set f2's
-    // last_access_ms to an older value so f1 is definitively newer.
+    // Promote f1 to MRU (newer than f2). We backdate f2 explicitly
+    // and touch f1 with a fresh `now` so the LRU sort sees a strict
+    // f2 < f1 order regardless of millisecond timestamp ties.
     {
         let mut cache = store.cache.lock().unwrap();
         if let Some(e) = cache.get_mut(&("z1".to_string(), "f2".to_string())) {
-            e.last_access_ms = 1; // artificially old
+            e.last_access_ms = 1; // artificially oldest
         }
-        // Touch f1 to make it newer
         if let Some(e) = cache.get_mut(&("z1".to_string(), "f1".to_string())) {
             e.last_access_ms = FileStore::now_ms();
         }

--- a/agentmux-srv/src/persist.rs
+++ b/agentmux-srv/src/persist.rs
@@ -131,12 +131,23 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
         // the tab's LayoutState row so the reducer's view matches what
         // the user last saw on disk. Empty when the layout row isn't
         // found or has no value (matches `LayoutState` defaults).
-        let (focused_node_id, magnified_node_id) = if tab.layoutstate.is_empty() {
-            (String::new(), String::new())
+        //
+        // Phase E.4.B — also bootstrap `rootnode` (the layout tree).
+        // Until the wcore-direct writers migrate to dispatch through
+        // the new layout reducer arms (Phase 7), the reducer's
+        // rootnode is a passive shadow — refreshed on startup, never
+        // diverging from disk because no reducer-arm writers exist
+        // yet at runtime.
+        let (focused_node_id, magnified_node_id, rootnode) = if tab.layoutstate.is_empty() {
+            (String::new(), String::new(), None)
         } else {
             match wstore.get::<crate::backend::obj::LayoutState>(&tab.layoutstate) {
-                Ok(Some(layout)) => (layout.focusednodeid, layout.magnifiednodeid),
-                _ => (String::new(), String::new()),
+                Ok(Some(layout)) => (
+                    layout.focusednodeid,
+                    layout.magnifiednodeid,
+                    layout.rootnode,
+                ),
+                _ => (String::new(), String::new(), None),
             }
         };
         state.tabs.insert(
@@ -148,6 +159,7 @@ pub async fn bootstrap_state_from_wstore(state: &Arc<Mutex<State>>, wstore: &Wav
                 block_ids,
                 focused_node_id,
                 magnified_node_id,
+                rootnode,
             },
         );
     }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -90,10 +90,19 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             node,
             parent_id,
             index,
-            focus_after: _,
-            magnify_after: _,
+            focus_after,
+            magnify_after,
             correlation_id,
-        } => handle_layout_insert_node(state, tab_id, node, parent_id, index, correlation_id),
+        } => handle_layout_insert_node(
+            state,
+            tab_id,
+            node,
+            parent_id,
+            index,
+            focus_after,
+            magnify_after,
+            correlation_id,
+        ),
         Command::LayoutDeleteNode {
             tab_id,
             node_id,
@@ -784,6 +793,13 @@ fn handle_layout_set_tree(
         }];
     };
     tab.rootnode = new_tree.clone();
+    // Reagent P1 PR #715 round 1: when the tree is wiped, focused/
+    // magnified ids would point at non-existent nodes. Match
+    // `handle_layout_clear`'s contract for the empty-tree case.
+    if new_tree.is_none() {
+        tab.focused_node_id = String::new();
+        tab.magnified_node_id = String::new();
+    }
     let v = state.bump_version();
     vec![Event::LayoutTreeReplaced {
         tab_id,
@@ -799,6 +815,8 @@ fn handle_layout_insert_node(
     node: agentmux_common::LayoutNode,
     parent_id: Option<String>,
     index: Option<usize>,
+    focus_after: bool,
+    magnify_after: bool,
     correlation_id: String,
 ) -> Vec<Event> {
     let Some(tab) = state.tabs.get_mut(&tab_id) else {
@@ -817,6 +835,16 @@ fn handle_layout_insert_node(
     match tab.rootnode.as_mut() {
         None => tab.rootnode = Some(node.clone()),
         Some(root) => crate::backend::layout::insert_node(root, node.clone()),
+    }
+    // Codex P2 PR #715 round 1: honour focus_after / magnify_after.
+    // The schema documents these as the side effects callers rely on
+    // for "insert + activate" flows; ignoring them desyncs the snapshot
+    // from the event the caller's handler observed.
+    if focus_after {
+        tab.focused_node_id = node.id.clone();
+    }
+    if magnify_after {
+        tab.magnified_node_id = node.id.clone();
     }
     // `parent_id` and `index` are accepted for forward-compat with the
     // command schema but ignored by the pure-heuristic insert helper.
@@ -851,11 +879,19 @@ fn handle_layout_delete_node(
         }];
     };
     let was_focused = tab.focused_node_id == node_id;
+    let was_magnified = tab.magnified_node_id == node_id;
     let Some(root) = tab.rootnode.as_mut() else {
         // Empty tree — nothing to delete; idempotent no-op (no event).
         return Vec::new();
     };
-    if let Err(e) = crate::backend::layout::delete_node(root, &node_id) {
+    // Codex P2 PR #715 round 1: `backend::layout::delete_node` leaves
+    // root deletion to the caller (returns Ok(()) with the root
+    // unmodified). Detect the root case here and clear the tree
+    // wholesale so the reducer state matches the
+    // `LayoutNodeDeleted` event we emit.
+    if root.id == node_id {
+        tab.rootnode = None;
+    } else if let Err(e) = crate::backend::layout::delete_node(root, &node_id) {
         let v = state.bump_version();
         return vec![Event::Error {
             code: ErrorCode::InvalidCommand,
@@ -866,6 +902,11 @@ fn handle_layout_delete_node(
     }
     if was_focused {
         tab.focused_node_id = String::new();
+    }
+    // Reagent P1 PR #715 round 1: clearing focused without clearing
+    // magnified leaves a stale id pointing at the just-deleted node.
+    if was_magnified {
+        tab.magnified_node_id = String::new();
     }
     let v = state.bump_version();
     vec![Event::LayoutNodeDeleted {
@@ -3724,6 +3765,165 @@ mod tests {
         );
         assert!(events.is_empty(), "no event for delete on empty tree");
         assert!(state.tabs[&tab_id].rootnode.is_none());
+    }
+
+    #[test]
+    fn layout_set_tree_to_none_also_clears_focused_and_magnified() {
+        // Reagent P1 PR #715 round 1: empty-tree set must match
+        // `LayoutClear`'s contract — focused/magnified ids would
+        // otherwise dangle past the wipe.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("n", "b"));
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "n".into();
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "n".into();
+        let _ = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: None,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        let tab = &state.tabs[&tab_id];
+        assert!(tab.rootnode.is_none());
+        assert_eq!(tab.focused_node_id, "");
+        assert_eq!(tab.magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_set_tree_with_some_preserves_focused_and_magnified() {
+        // Symmetry guard: Some(new_tree) must NOT clear focused/
+        // magnified — caller may have set them deliberately.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "n".into();
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "n".into();
+        let _ = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: Some(leaf_node("n", "b")),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        let tab = &state.tabs[&tab_id];
+        assert_eq!(tab.focused_node_id, "n");
+        assert_eq!(tab.magnified_node_id, "n");
+    }
+
+    #[test]
+    fn layout_insert_node_honours_focus_after() {
+        // Codex P2 PR #715 round 1: focus_after=true must update
+        // focused_node_id so the snapshot matches the event.
+        let (mut state, tab_id) = fresh_tab();
+        let node = leaf_node("new", "b1");
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node,
+                parent_id: None,
+                index: None,
+                focus_after: true,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "new");
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_insert_node_honours_magnify_after() {
+        let (mut state, tab_id) = fresh_tab();
+        let node = leaf_node("new", "b1");
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node,
+                parent_id: None,
+                index: None,
+                focus_after: false,
+                magnify_after: true,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "");
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "new");
+    }
+
+    #[test]
+    fn layout_insert_node_with_neither_flag_leaves_state_alone() {
+        // Anti-vacuity guard: confirm the false-flag path is the
+        // baseline (otherwise the focus_after/magnify_after tests
+        // wouldn't be measuring anything).
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "prev".into();
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("new", "b1"),
+                parent_id: None,
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "prev");
+    }
+
+    #[test]
+    fn layout_delete_node_on_root_clears_the_tree() {
+        // Codex P2 PR #715 round 1: backend::layout::delete_node leaves
+        // root deletion to the caller. Without the root-detection
+        // branch, we'd emit LayoutNodeDeleted while rootnode still
+        // contains the supposedly-deleted tree.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode =
+            Some(leaf_node("solitary-root", "b1"));
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "solitary-root".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::LayoutNodeDeleted { .. }));
+        assert!(
+            state.tabs[&tab_id].rootnode.is_none(),
+            "root deletion must wipe the tree"
+        );
+    }
+
+    #[test]
+    fn layout_delete_node_clears_magnified_when_target_was_magnified() {
+        // Reagent P1 PR #715 round 1: magnified must be cleared
+        // alongside focused; same staleness concern.
+        let (mut state, tab_id) = fresh_tab();
+        let mut root = leaf_node("group", "");
+        root.data = None;
+        root.children = vec![leaf_node("a", "b1"), leaf_node("b", "b2")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "a".into();
+        let _ = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "a".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "");
     }
 
     #[test]

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -828,31 +828,58 @@ fn handle_layout_insert_node(
             version: v,
         }];
     };
-    // Empty tree → promote new node to root (frontend's
-    // `findNextInsertLocation` returns the empty case as "make me root").
-    // Non-empty tree → delegate to the pure helper, which honours the
-    // same heuristic the frontend uses.
+    // Three insert paths, in priority order:
+    //   1. Empty tree → promote new node to root.
+    //   2. parent_id given → insert under that specific parent at
+    //      `index` (or append if None). Codex P2 PR #715 round 4
+    //      flagged that the prior code ignored explicit parent_id/
+    //      index; the schema documents these as the request location.
+    //   3. parent_id None → use the `findNextInsertLocation`
+    //      heuristic via the pure helper.
     match tab.rootnode.as_mut() {
         None => tab.rootnode = Some(node.clone()),
-        Some(root) => crate::backend::layout::insert_node(root, node.clone()),
+        Some(root) => {
+            let placed = match parent_id.as_deref() {
+                Some(pid) => match crate::backend::layout::find_node_by_id_mut(root, pid) {
+                    Some(parent_node) if parent_node.data.is_none() => {
+                        // Group node — insert into children at `index`,
+                        // clamped into [0, len].
+                        let len = parent_node.children.len();
+                        let target = index.map(|i| i.min(len)).unwrap_or(len);
+                        parent_node.children.insert(target, node.clone());
+                        true
+                    }
+                    _ => {
+                        // parent_id missing or points at a leaf (data set);
+                        // fall through to the heuristic so the insert isn't
+                        // dropped silently.
+                        false
+                    }
+                },
+                None => false,
+            };
+            if !placed {
+                crate::backend::layout::insert_node(root, node.clone());
+            }
+        }
     }
     // Codex P2 PR #715 round 1: honour focus_after / magnify_after.
     // The schema documents these as the side effects callers rely on
     // for "insert + activate" flows; ignoring them desyncs the snapshot
     // from the event the caller's handler observed.
-    if focus_after {
+    //
+    // Codex P2 PR #715 round 4: a magnified node must also be the
+    // focused one. Without this, a `magnify_after=true,
+    // focus_after=false` insert leaves `focused_node_id` pointing at
+    // the prior pane while `magnified_node_id` points at the new one
+    // — a UI invariant violation (frontend treats magnify-implies-
+    // focus). Treat magnify as implying focus.
+    if focus_after || magnify_after {
         tab.focused_node_id = node.id.clone();
     }
     if magnify_after {
         tab.magnified_node_id = node.id.clone();
     }
-    // `parent_id` and `index` are accepted for forward-compat with the
-    // command schema but ignored by the pure-heuristic insert helper.
-    // Phase 7 wcore-migration will exercise the parent_id/index path
-    // via `LayoutInsertNodeAtIndex` (a separate command); this arm
-    // matches `findNextInsertLocation` semantics exactly. The values
-    // are still echoed in the emitted event below so subscribers see
-    // what the caller asked for.
     let v = state.bump_version();
     vec![Event::LayoutNodeInserted {
         tab_id,
@@ -3871,8 +3898,13 @@ mod tests {
     }
 
     #[test]
-    fn layout_insert_node_honours_magnify_after() {
+    fn layout_insert_node_magnify_after_implies_focus() {
+        // Codex P2 PR #715 round 4: magnify-implies-focus. Even when
+        // focus_after=false, setting magnify_after=true must also
+        // update focused_node_id so it doesn't dangle on the prior
+        // pane (UI invariant: a magnified pane is the focused pane).
         let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "prev".into();
         let node = leaf_node("new", "b1");
         let _ = update(
             &mut state,
@@ -3887,8 +3919,96 @@ mod tests {
             },
             &ctx(1),
         );
-        assert_eq!(state.tabs[&tab_id].focused_node_id, "");
+        assert_eq!(
+            state.tabs[&tab_id].focused_node_id, "new",
+            "magnify_after must imply focus_after"
+        );
         assert_eq!(state.tabs[&tab_id].magnified_node_id, "new");
+    }
+
+    #[test]
+    fn layout_insert_node_honours_explicit_parent_id_and_index() {
+        // Codex P2 PR #715 round 4: with parent_id given, insert at
+        // that node at the requested index instead of running the
+        // heuristic helper.
+        let (mut state, tab_id) = fresh_tab();
+        let mut group = leaf_node("group", "");
+        group.data = None;
+        group.children = vec![leaf_node("a", "ba"), leaf_node("c", "bc")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(group);
+
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("b", "bb"),
+                parent_id: Some("group".into()),
+                index: Some(1), // between a and c
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+
+        let root = state.tabs[&tab_id].rootnode.as_ref().expect("root");
+        let ids: Vec<_> = root.children.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "c"], "explicit index honoured");
+    }
+
+    #[test]
+    fn layout_insert_node_index_clamps_when_out_of_range() {
+        // Out-of-range index clamps to the end (matches frontend
+        // `findNextInsertLocation` defensive semantics).
+        let (mut state, tab_id) = fresh_tab();
+        let mut group = leaf_node("group", "");
+        group.data = None;
+        group.children = vec![leaf_node("a", "ba")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(group);
+
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("b", "bb"),
+                parent_id: Some("group".into()),
+                index: Some(99),
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        let root = state.tabs[&tab_id].rootnode.as_ref().expect("root");
+        let ids: Vec<_> = root.children.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b"], "out-of-range index clamps to end");
+    }
+
+    #[test]
+    fn layout_insert_node_falls_back_to_heuristic_when_parent_id_missing() {
+        // parent_id refers to a non-existent node → fall back to the
+        // heuristic helper so the insert isn't dropped silently.
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("only", "b1"));
+
+        let _ = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("added", "b2"),
+                parent_id: Some("does-not-exist".into()),
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        // Heuristic ran — both leaves are in the tree somewhere.
+        let root = state.tabs[&tab_id].rootnode.as_ref().expect("root");
+        let collected = collect_block_ids(root);
+        assert!(collected.contains(&"b1".to_string()));
+        assert!(collected.contains(&"b2".to_string()));
     }
 
     #[test]

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -70,6 +70,35 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         Command::SetMagnifiedNode { tab_id, node_id } => {
             handle_set_magnified_node(state, tab_id, node_id)
         }
+        // Phase E.4.B Phase 5 — layout tree mutation arms. Currently
+        // dormant scaffolding (no production callers; Phase 7 migrates
+        // the wcore-direct writers to dispatch through these). 4 of 11
+        // arms shipped in this PR; remaining 7 (insert_at_index, move,
+        // swap, resize, replace, split_horizontal, split_vertical) are
+        // structurally identical and follow in subsequent PRs.
+        Command::LayoutClear {
+            tab_id,
+            correlation_id,
+        } => handle_layout_clear(state, tab_id, correlation_id),
+        Command::LayoutSetTree {
+            tab_id,
+            new_tree,
+            correlation_id,
+        } => handle_layout_set_tree(state, tab_id, new_tree, correlation_id),
+        Command::LayoutInsertNode {
+            tab_id,
+            node,
+            parent_id,
+            index,
+            focus_after: _,
+            magnify_after: _,
+            correlation_id,
+        } => handle_layout_insert_node(state, tab_id, node, parent_id, index, correlation_id),
+        Command::LayoutDeleteNode {
+            tab_id,
+            node_id,
+            correlation_id,
+        } => handle_layout_delete_node(state, tab_id, node_id, correlation_id),
         Command::CreateWindow {
             window_id,
             workspace_id,
@@ -386,6 +415,7 @@ fn handle_create_tab(state: &mut State, workspace_id: String, name: String) -> V
             block_ids: Vec::new(),
             focused_node_id: String::new(),
             magnified_node_id: String::new(),
+            rootnode: None,
         },
     );
     let workspace = state.workspaces.get_mut(&workspace_id).expect("checked");
@@ -695,6 +725,154 @@ fn handle_set_magnified_node(state: &mut State, tab_id: String, node_id: String)
     vec![Event::MagnifiedNodeChanged {
         tab_id,
         node_id,
+        version: v,
+    }]
+}
+
+// ── Phase E.4.B Phase 5 — layout tree reducer arms ──────────────────
+//
+// 4 of 11 arms shipped in this PR (clear, set_tree, insert_node,
+// delete_node). Pattern uniform across all 11:
+//   1. Look up tab; emit Event::Error on missing.
+//   2. Mutate `tab.rootnode` via the pure helpers in
+//      `crate::backend::layout::*` (shipped in Phase 4 / PRs #691, #692).
+//   3. Emit the matching Event::Layout* variant carrying the
+//      correlation_id and a fresh version.
+//
+// **No production callers yet** — wcore-direct writers continue to be
+// authoritative until Phase 7 migrates them. These arms are the
+// destination, not the source; tests below exercise them in isolation.
+
+fn handle_layout_clear(
+    state: &mut State,
+    tab_id: String,
+    correlation_id: String,
+) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("LayoutClear: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    tab.rootnode = None;
+    tab.focused_node_id = String::new();
+    tab.magnified_node_id = String::new();
+    let v = state.bump_version();
+    vec![Event::LayoutCleared {
+        tab_id,
+        correlation_id,
+        version: v,
+    }]
+}
+
+fn handle_layout_set_tree(
+    state: &mut State,
+    tab_id: String,
+    new_tree: Option<agentmux_common::LayoutNode>,
+    correlation_id: String,
+) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("LayoutSetTree: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    tab.rootnode = new_tree.clone();
+    let v = state.bump_version();
+    vec![Event::LayoutTreeReplaced {
+        tab_id,
+        new_tree,
+        correlation_id,
+        version: v,
+    }]
+}
+
+fn handle_layout_insert_node(
+    state: &mut State,
+    tab_id: String,
+    node: agentmux_common::LayoutNode,
+    parent_id: Option<String>,
+    index: Option<usize>,
+    correlation_id: String,
+) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("LayoutInsertNode: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    // Empty tree → promote new node to root (frontend's
+    // `findNextInsertLocation` returns the empty case as "make me root").
+    // Non-empty tree → delegate to the pure helper, which honours the
+    // same heuristic the frontend uses.
+    match tab.rootnode.as_mut() {
+        None => tab.rootnode = Some(node.clone()),
+        Some(root) => crate::backend::layout::insert_node(root, node.clone()),
+    }
+    // `parent_id` and `index` are accepted for forward-compat with the
+    // command schema but ignored by the pure-heuristic insert helper.
+    // Phase 7 wcore-migration will exercise the parent_id/index path
+    // via `LayoutInsertNodeAtIndex` (a separate command); this arm
+    // matches `findNextInsertLocation` semantics exactly.
+    let _ = (parent_id, index);
+    let v = state.bump_version();
+    vec![Event::LayoutNodeInserted {
+        tab_id,
+        node,
+        parent_id: None,
+        index: None,
+        correlation_id,
+        version: v,
+    }]
+}
+
+fn handle_layout_delete_node(
+    state: &mut State,
+    tab_id: String,
+    node_id: String,
+    correlation_id: String,
+) -> Vec<Event> {
+    let Some(tab) = state.tabs.get_mut(&tab_id) else {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("LayoutDeleteNode: unknown tab {}", tab_id),
+            fatal: false,
+            version: v,
+        }];
+    };
+    let was_focused = tab.focused_node_id == node_id;
+    let Some(root) = tab.rootnode.as_mut() else {
+        // Empty tree — nothing to delete; idempotent no-op (no event).
+        return Vec::new();
+    };
+    if let Err(e) = crate::backend::layout::delete_node(root, &node_id) {
+        let v = state.bump_version();
+        return vec![Event::Error {
+            code: ErrorCode::InvalidCommand,
+            message: format!("LayoutDeleteNode: {} (tab {})", e, tab_id),
+            fatal: false,
+            version: v,
+        }];
+    }
+    if was_focused {
+        tab.focused_node_id = String::new();
+    }
+    let v = state.bump_version();
+    vec![Event::LayoutNodeDeleted {
+        tab_id,
+        node_id,
+        was_focused,
+        correlation_id,
         version: v,
     }]
 }
@@ -3361,5 +3539,216 @@ mod tests {
             // And invariants hold on the empty state.
             assert_invariants(&state);
         }
+    }
+
+    // ── Phase E.4.B Phase 5 — layout reducer arms ─────────────────
+    //
+    // Tests for the 4 arms shipped in this PR. All arms share the
+    // same shape (lookup tab → mutate `tab.rootnode` via pure helper
+    // → emit Event::Layout*); the unit tests below verify state
+    // mutation and event shape per arm. The pure helpers themselves
+    // have their own ~40 tests in `agentmux-srv/src/backend/layout/`.
+
+    fn leaf_node(id: &str, block_id: &str) -> agentmux_common::LayoutNode {
+        agentmux_common::LayoutNode {
+            id: id.to_string(),
+            size: 1.0,
+            data: Some(agentmux_common::LayoutNodeData {
+                block_id: block_id.to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn fresh_tab() -> (State, String) {
+        let mut state = State::default();
+        let ws = create_workspace(&mut state, "w");
+        let tab = create_tab(&mut state, &ws, "t");
+        (state, tab)
+    }
+
+    #[test]
+    fn layout_clear_wipes_rootnode_focus_magnify_and_emits_event() {
+        let (mut state, tab_id) = fresh_tab();
+        // Pre-load some state.
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("n1", "b1"));
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "n1".into();
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "n1".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutClear {
+                tab_id: tab_id.clone(),
+                correlation_id: "corr-1".into(),
+            },
+            &ctx(1),
+        );
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            Event::LayoutCleared { correlation_id, .. } if correlation_id == "corr-1"
+        ));
+        let tab = &state.tabs[&tab_id];
+        assert!(tab.rootnode.is_none(), "rootnode wiped");
+        assert_eq!(tab.focused_node_id, "");
+        assert_eq!(tab.magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_clear_unknown_tab_emits_error() {
+        let mut state = State::default();
+        let events = update(
+            &mut state,
+            Command::LayoutClear {
+                tab_id: "nope".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::Error { code: ErrorCode::InvalidCommand, .. }));
+    }
+
+    #[test]
+    fn layout_set_tree_replaces_rootnode_wholesale() {
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("old", "b1"));
+
+        let new_tree = Some(leaf_node("new", "b2"));
+        let events = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: new_tree.clone(),
+                correlation_id: "corr-set".into(),
+            },
+            &ctx(1),
+        );
+
+        assert!(matches!(&events[0], Event::LayoutTreeReplaced { .. }));
+        assert_eq!(state.tabs[&tab_id].rootnode, new_tree);
+    }
+
+    #[test]
+    fn layout_set_tree_to_none_clears_rootnode() {
+        let (mut state, tab_id) = fresh_tab();
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("n", "b"));
+
+        let _ = update(
+            &mut state,
+            Command::LayoutSetTree {
+                tab_id: tab_id.clone(),
+                new_tree: None,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(state.tabs[&tab_id].rootnode.is_none());
+    }
+
+    #[test]
+    fn layout_insert_node_into_empty_tree_promotes_to_root() {
+        let (mut state, tab_id) = fresh_tab();
+        let node = leaf_node("first", "b1");
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: node.clone(),
+                parent_id: None,
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr-ins".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::LayoutNodeInserted { .. }));
+        assert_eq!(state.tabs[&tab_id].rootnode.as_ref().map(|n| n.id.as_str()), Some("first"));
+    }
+
+    #[test]
+    fn layout_insert_node_into_existing_tree_uses_helper() {
+        let (mut state, tab_id) = fresh_tab();
+        // Pre-load a single-leaf tree.
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("root", "b1"));
+        let new_node = leaf_node("added", "b2");
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: new_node,
+                parent_id: None,
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(&events[0], Event::LayoutNodeInserted { .. }));
+        // Helper turned the leaf root into a group with both leaves;
+        // exact shape is the helper's contract — we just assert the
+        // tree changed and contains both block ids.
+        let root = state.tabs[&tab_id].rootnode.as_ref().expect("rootnode set");
+        let collected = collect_block_ids(root);
+        assert!(collected.contains(&"b1".to_string()));
+        assert!(collected.contains(&"b2".to_string()));
+    }
+
+    fn collect_block_ids(node: &agentmux_common::LayoutNode) -> Vec<String> {
+        let mut ids = Vec::new();
+        if let Some(d) = &node.data {
+            if !d.block_id.is_empty() {
+                ids.push(d.block_id.clone());
+            }
+        }
+        for c in &node.children {
+            ids.extend(collect_block_ids(c));
+        }
+        ids
+    }
+
+    #[test]
+    fn layout_delete_node_on_empty_tree_is_noop() {
+        let (mut state, tab_id) = fresh_tab();
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "ghost".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(events.is_empty(), "no event for delete on empty tree");
+        assert!(state.tabs[&tab_id].rootnode.is_none());
+    }
+
+    #[test]
+    fn layout_delete_node_clears_focused_when_target_was_focused() {
+        let (mut state, tab_id) = fresh_tab();
+        // Tree: group with two leaves.
+        let mut root = leaf_node("root-group", "");
+        root.data = None;
+        root.children = vec![leaf_node("a", "b1"), leaf_node("b", "b2")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "a".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "a".into(),
+                correlation_id: "corr-del".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::LayoutNodeDeleted { was_focused: true, .. }
+        ));
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "");
     }
 }

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -850,14 +850,22 @@ fn handle_layout_insert_node(
     // command schema but ignored by the pure-heuristic insert helper.
     // Phase 7 wcore-migration will exercise the parent_id/index path
     // via `LayoutInsertNodeAtIndex` (a separate command); this arm
-    // matches `findNextInsertLocation` semantics exactly.
-    let _ = (parent_id, index);
+    // matches `findNextInsertLocation` semantics exactly. The values
+    // are still echoed in the emitted event below so subscribers see
+    // what the caller asked for.
     let v = state.bump_version();
     vec![Event::LayoutNodeInserted {
         tab_id,
         node,
-        parent_id: None,
-        index: None,
+        // Reagent P2 (kimi) PR #715 round 3: pass the command's
+        // parent_id / index through to the event so subscribers see
+        // what the caller asked for, not a hardcoded `None, None`.
+        // The pure helper currently uses the `findNextInsertLocation`
+        // heuristic and ignores these hints — but the event is the
+        // record of what was *requested*; subscribers can correlate
+        // with the resulting tree by inspecting `node` itself.
+        parent_id,
+        index,
         correlation_id,
         version: v,
     }]
@@ -878,8 +886,10 @@ fn handle_layout_delete_node(
             version: v,
         }];
     };
-    let was_focused = tab.focused_node_id == node_id;
-    let was_magnified = tab.magnified_node_id == node_id;
+    // Snapshot pre-delete focus/magnify so we can both detect
+    // direct-target hits AND post-walk for indirect orphaning.
+    let pre_focused = tab.focused_node_id.clone();
+    let pre_magnified = tab.magnified_node_id.clone();
     let Some(root) = tab.rootnode.as_mut() else {
         // Empty tree — nothing to delete; idempotent no-op (no event).
         return Vec::new();
@@ -900,19 +910,44 @@ fn handle_layout_delete_node(
             version: v,
         }];
     }
+
+    // Reagent P2 PR #715 round 3 (finding B) and Codex P2 round 3
+    // (finding C): both involve focus/magnify ids referencing nodes
+    // that no longer exist in the tree post-delete:
+    //   - B: `delete_recursive` collapse-sole-child rewrites a
+    //        parent's id to the promoted child's id. If
+    //        focused/magnified was the parent's original id, that
+    //        id is gone from the tree even though the same physical
+    //        node remains.
+    //   - C: deleting a container removes all descendants. If
+    //        focused/magnified was a descendant, it's gone too.
+    // Direct-target match (`pre_focused == node_id`) doesn't catch
+    // either case. Reconcile by walking the post-delete tree and
+    // clearing any focus/magnify id that no longer resolves.
+    let id_resolves = |id: &str| -> bool {
+        if id.is_empty() {
+            return true;
+        }
+        match tab.rootnode.as_ref() {
+            None => false,
+            Some(root) => crate::backend::layout::find_node_by_id(root, id).is_some(),
+        }
+    };
+    let was_focused = !pre_focused.is_empty() && !id_resolves(&pre_focused);
+    let was_magnified = !pre_magnified.is_empty() && !id_resolves(&pre_magnified);
     if was_focused {
         tab.focused_node_id = String::new();
     }
-    // Reagent P1 PR #715 round 1: clearing focused without clearing
-    // magnified leaves a stale id pointing at the just-deleted node.
     if was_magnified {
         tab.magnified_node_id = String::new();
     }
+
     let v = state.bump_version();
     vec![Event::LayoutNodeDeleted {
         tab_id,
         node_id,
         was_focused,
+        was_magnified,
         correlation_id,
         version: v,
     }]
@@ -3924,6 +3959,152 @@ mod tests {
             &ctx(1),
         );
         assert_eq!(state.tabs[&tab_id].magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_node_deleted_event_carries_was_magnified() {
+        // Reagent P1 (kimi+sonnet) PR #715 round 3: subscribers need
+        // the was_magnified field to refresh their UI when the
+        // magnified node is deleted.
+        let (mut state, tab_id) = fresh_tab();
+        let mut root = leaf_node("group", "");
+        root.data = None;
+        root.children = vec![leaf_node("a", "b1"), leaf_node("b", "b2")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "a".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "a".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeDeleted { was_magnified, was_focused, .. } => {
+                assert!(*was_magnified, "was_magnified must be true");
+                assert!(!*was_focused, "was_focused stays false");
+            }
+            other => panic!("expected LayoutNodeDeleted, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn layout_delete_node_clears_focused_when_collapse_replaces_parent_id() {
+        // Reagent P2 (kimi+sonnet) PR #715 round 3 (finding B):
+        // `backend::layout::delete_node`'s collapse-sole-child path
+        // promotes the surviving child and rewrites the parent's id
+        // to the child's id. If focused/magnified pointed at the
+        // ORIGINAL parent id, that id is gone from the tree even
+        // though the same physical layout slot exists. Reducer must
+        // clear the dangling reference.
+        let (mut state, tab_id) = fresh_tab();
+        let mut group = leaf_node("group-id", "");
+        group.data = None;
+        group.children = vec![leaf_node("only-child", "b1"), leaf_node("sibling", "b2")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(group);
+        // Focus the group (the parent that will get its id rewritten
+        // when "sibling" is deleted and "only-child" is the sole
+        // survivor of the now-1-child group).
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "group-id".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "sibling".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeDeleted { was_focused, .. } => {
+                assert!(
+                    *was_focused,
+                    "collapse rewrote parent id; reducer must report focus loss"
+                );
+            }
+            other => panic!("expected LayoutNodeDeleted, got {:?}", other),
+        }
+        assert_eq!(
+            state.tabs[&tab_id].focused_node_id, "",
+            "stale focus cleared post-collapse"
+        );
+    }
+
+    #[test]
+    fn layout_delete_node_clears_focused_when_target_subtree_contains_focus() {
+        // Codex P2 PR #715 round 3 (finding C): deleting a container
+        // wipes its descendants, but a direct-id-match check on
+        // focused/magnified misses descendants — they stay dangling.
+        let (mut state, tab_id) = fresh_tab();
+        // Tree:
+        //   root-group (children: group-A, leaf-z)
+        //     group-A (children: leaf-x, leaf-y)
+        let mut leaf_x = leaf_node("leaf-x", "bx");
+        leaf_x.data = Some(agentmux_common::LayoutNodeData {
+            block_id: "bx".into(),
+            ..Default::default()
+        });
+        let mut group_a = leaf_node("group-A", "");
+        group_a.data = None;
+        group_a.children = vec![leaf_x, leaf_node("leaf-y", "by")];
+        let mut root = leaf_node("root-group", "");
+        root.data = None;
+        root.children = vec![group_a, leaf_node("leaf-z", "bz")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+        // Focus a descendant of group-A, then delete group-A.
+        state.tabs.get_mut(&tab_id).unwrap().focused_node_id = "leaf-x".into();
+        state.tabs.get_mut(&tab_id).unwrap().magnified_node_id = "leaf-y".into();
+
+        let events = update(
+            &mut state,
+            Command::LayoutDeleteNode {
+                tab_id: tab_id.clone(),
+                node_id: "group-A".into(),
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeDeleted { was_focused, was_magnified, .. } => {
+                assert!(*was_focused, "descendant focus must be cleared");
+                assert!(*was_magnified, "descendant magnify must be cleared");
+            }
+            other => panic!("expected LayoutNodeDeleted, got {:?}", other),
+        }
+        assert_eq!(state.tabs[&tab_id].focused_node_id, "");
+        assert_eq!(state.tabs[&tab_id].magnified_node_id, "");
+    }
+
+    #[test]
+    fn layout_insert_node_event_echoes_parent_id_and_index() {
+        // Reagent P2 (kimi only) PR #715 round 3 (finding D): event
+        // hardcoded `parent_id: None, index: None`; subscribers had
+        // no record of what the caller asked for.
+        let (mut state, tab_id) = fresh_tab();
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("new", "b1"),
+                parent_id: Some("explicit-parent".into()),
+                index: Some(3),
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        match &events[0] {
+            Event::LayoutNodeInserted { parent_id, index, .. } => {
+                assert_eq!(parent_id.as_deref(), Some("explicit-parent"));
+                assert_eq!(*index, Some(3));
+            }
+            other => panic!("expected LayoutNodeInserted, got {:?}", other),
+        }
     }
 
     #[test]

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -831,37 +831,55 @@ fn handle_layout_insert_node(
     // Three insert paths, in priority order:
     //   1. Empty tree → promote new node to root.
     //   2. parent_id given → insert under that specific parent at
-    //      `index` (or append if None). Codex P2 PR #715 round 4
-    //      flagged that the prior code ignored explicit parent_id/
-    //      index; the schema documents these as the request location.
-    //   3. parent_id None → use the `findNextInsertLocation`
-    //      heuristic via the pure helper.
-    match tab.rootnode.as_mut() {
-        None => tab.rootnode = Some(node.clone()),
-        Some(root) => {
-            let placed = match parent_id.as_deref() {
-                Some(pid) => match crate::backend::layout::find_node_by_id_mut(root, pid) {
-                    Some(parent_node) if parent_node.data.is_none() => {
-                        // Group node — insert into children at `index`,
-                        // clamped into [0, len].
-                        let len = parent_node.children.len();
-                        let target = index.map(|i| i.min(len)).unwrap_or(len);
-                        parent_node.children.insert(target, node.clone());
-                        true
-                    }
-                    _ => {
-                        // parent_id missing or points at a leaf (data set);
-                        // fall through to the heuristic so the insert isn't
-                        // dropped silently.
-                        false
-                    }
-                },
-                None => false,
-            };
-            if !placed {
-                crate::backend::layout::insert_node(root, node.clone());
+    //      `index` (or append if None). If parent_id is given but
+    //      doesn't resolve to a group node, REJECT with
+    //      Event::Error rather than fall back to the heuristic —
+    //      Codex P2 PR #715 round 5 flagged the silent-fallback
+    //      path as a consistency hole: the emitted event would
+    //      echo the requested parent_id while the actual mutation
+    //      went elsewhere, diverging the persist subscriber and
+    //      replay consumers from the reducer.
+    //   3. parent_id None → `findNextInsertLocation` heuristic.
+    let empty_tree = tab.rootnode.is_none();
+    if empty_tree {
+        tab.rootnode = Some(node.clone());
+    } else if let Some(pid) = parent_id.as_deref() {
+        let root = tab.rootnode.as_mut().expect("non-empty checked above");
+        match crate::backend::layout::find_node_by_id_mut(root, pid) {
+            Some(parent_node) if parent_node.data.is_none() => {
+                let len = parent_node.children.len();
+                let target = index.map(|i| i.min(len)).unwrap_or(len);
+                parent_node.children.insert(target, node.clone());
+            }
+            Some(_) => {
+                // parent_id resolves to a leaf — can't host children.
+                let v = state.bump_version();
+                return vec![Event::Error {
+                    code: ErrorCode::InvalidCommand,
+                    message: format!(
+                        "LayoutInsertNode: parent_id {:?} is a leaf node, cannot host children (tab {})",
+                        pid, tab_id
+                    ),
+                    fatal: false,
+                    version: v,
+                }];
+            }
+            None => {
+                let v = state.bump_version();
+                return vec![Event::Error {
+                    code: ErrorCode::InvalidCommand,
+                    message: format!(
+                        "LayoutInsertNode: parent_id {:?} not found in tree (tab {})",
+                        pid, tab_id
+                    ),
+                    fatal: false,
+                    version: v,
+                }];
             }
         }
+    } else {
+        let root = tab.rootnode.as_mut().expect("non-empty checked above");
+        crate::backend::layout::insert_node(root, node.clone());
     }
     // Codex P2 PR #715 round 1: honour focus_after / magnify_after.
     // The schema documents these as the side effects callers rely on
@@ -3985,13 +4003,16 @@ mod tests {
     }
 
     #[test]
-    fn layout_insert_node_falls_back_to_heuristic_when_parent_id_missing() {
-        // parent_id refers to a non-existent node → fall back to the
-        // heuristic helper so the insert isn't dropped silently.
+    fn layout_insert_node_with_unknown_parent_id_emits_error() {
+        // Codex P2 PR #715 round 5: silent fallback to heuristic
+        // diverges the event from the actual mutation. Reject
+        // explicit-but-invalid parent_id with Event::Error so
+        // subscribers (especially the persist subscriber, future)
+        // see a consistent record.
         let (mut state, tab_id) = fresh_tab();
         state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(leaf_node("only", "b1"));
 
-        let _ = update(
+        let events = update(
             &mut state,
             Command::LayoutInsertNode {
                 tab_id: tab_id.clone(),
@@ -4004,11 +4025,43 @@ mod tests {
             },
             &ctx(1),
         );
-        // Heuristic ran — both leaves are in the tree somewhere.
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::InvalidCommand, .. }
+        ));
+        // Tree must be unchanged.
         let root = state.tabs[&tab_id].rootnode.as_ref().expect("root");
-        let collected = collect_block_ids(root);
-        assert!(collected.contains(&"b1".to_string()));
-        assert!(collected.contains(&"b2".to_string()));
+        assert_eq!(root.id, "only");
+        assert!(root.children.is_empty());
+    }
+
+    #[test]
+    fn layout_insert_node_with_leaf_parent_id_emits_error() {
+        // parent_id resolves to a leaf (has data) — leaf can't host
+        // children, so treat as invalid the same as a missing parent.
+        let (mut state, tab_id) = fresh_tab();
+        let mut root = leaf_node("group", "");
+        root.data = None;
+        root.children = vec![leaf_node("a", "ba")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(root);
+
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("b", "bb"),
+                parent_id: Some("a".into()), // leaf, not a group
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::InvalidCommand, .. }
+        ));
     }
 
     #[test]

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -65,7 +65,10 @@ pub struct WorkspaceRecord {
 /// Tabs are owned by exactly one workspace; the workspace's
 /// `tab_ids` field gives the ordering. E.3 adds `block_ids` so the
 /// tab tracks which blocks live inside it.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+// `Eq` dropped in Phase E.4.B because `LayoutNode.size: f32` precludes
+// it. Nothing in the codebase relies on `TabRecord: Eq` (no HashSet
+// usage, no `==` comparisons in the reducer).
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct TabRecord {
     pub tab_id: String,
     pub workspace_id: String,
@@ -85,6 +88,21 @@ pub struct TabRecord {
     /// no pane is magnified (toggle-off). Mirrors
     /// `LayoutState.magnifiednodeid`.
     pub magnified_node_id: String,
+    /// Phase E.4.B (Option B) — layout tree root.
+    ///
+    /// Mirrors the persisted `LayoutState.rootnode`. Mutated by the
+    /// `LayoutClear` / `LayoutSetTree` / `LayoutInsertNode` /
+    /// `LayoutDeleteNode` reducer arms (and the rest of the 11 in
+    /// follow-up PRs). `None` represents an empty tree (no panes).
+    ///
+    /// **Status: scaffolded, not yet bootstrap-loaded.** Production
+    /// writers still go through the wcore-direct path (per
+    /// `srv-phase-e4b-implementation-plan-2026-05-03.md` Phase 7);
+    /// this field stays `None` at startup until those writers are
+    /// migrated. Reducer arms operate on it under the same
+    /// "no-callers-yet" discipline that H.6 follows in the host
+    /// reducer.
+    pub rootnode: Option<agentmux_common::LayoutNode>,
 }
 
 /// Phase E.3 — block as held by the srv reducer's canonical state.

--- a/agentmux-srv/src/state.rs
+++ b/agentmux-srv/src/state.rs
@@ -95,13 +95,14 @@ pub struct TabRecord {
     /// `LayoutDeleteNode` reducer arms (and the rest of the 11 in
     /// follow-up PRs). `None` represents an empty tree (no panes).
     ///
-    /// **Status: scaffolded, not yet bootstrap-loaded.** Production
-    /// writers still go through the wcore-direct path (per
+    /// **Status: scaffolded; bootstrap-loaded.** `persist::
+    /// bootstrap_state_from_wstore` populates this from
+    /// `LayoutState.rootnode` at startup. Production writers still
+    /// go through the wcore-direct path (per
     /// `srv-phase-e4b-implementation-plan-2026-05-03.md` Phase 7);
-    /// this field stays `None` at startup until those writers are
-    /// migrated. Reducer arms operate on it under the same
-    /// "no-callers-yet" discipline that H.6 follows in the host
-    /// reducer.
+    /// reducer arms mutate this field but no production code
+    /// dispatches to them yet — same "no-callers-yet" discipline H.6
+    /// follows in the host reducer.
     pub rootnode: Option<agentmux_common::LayoutNode>,
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.674",
+  "version": "0.33.675",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.674",
+      "version": "0.33.675",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.673",
+  "version": "0.33.674",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.673",
+      "version": "0.33.674",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.675",
+  "version": "0.33.676",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.675",
+      "version": "0.33.676",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.671",
+  "version": "0.33.672",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.671",
+      "version": "0.33.672",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.672",
+  "version": "0.33.673",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.672",
+      "version": "0.33.673",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.676",
+  "version": "0.33.677",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.676",
+      "version": "0.33.677",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.672",
+  "version": "0.33.673",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.676",
+  "version": "0.33.677",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.673",
+  "version": "0.33.674",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.674",
+  "version": "0.33.675",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.675",
+  "version": "0.33.676",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.671",
+  "version": "0.33.672",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 5 of [`srv-phase-e4b-implementation-plan-2026-05-03.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/srv-phase-e4b-implementation-plan-2026-05-03.md). Wires the first 4 of 11 planned layout reducer arms on top of the helpers shipped in PRs #691/#692. Also bundles **6 smoke-test repairs** (5 stale unit tests + 1 broken integration test target) per user request.

Tracked in [discussion #707](https://github.com/agentmuxai/agentmux/discussions/707) (E.4.B Phase 5+ trigger from master spec §9.6).

## Phase 5 — layout reducer arms

**State:**
- `TabRecord.rootnode: Option<LayoutNode>` — mirrors `LayoutState.rootnode` from disk.
- `Eq` derive dropped from `TabRecord` (`f32` in `LayoutNode.size` precludes it; nothing relies on it).

**Bootstrap:**
- `persist::bootstrap_state_from_wstore` extended to load `LayoutState.rootnode` alongside `focusednodeid` / `magnifiednodeid` (zero extra SQLite cost).

**Reducer arms** (4 of 11):

| Command | Handler | Behaviour |
|---|---|---|
| `LayoutClear` | `handle_layout_clear` | Wipes rootnode + focused + magnified. |
| `LayoutSetTree` | `handle_layout_set_tree` | Wholesale replacement; `None` clears focus + magnify. |
| `LayoutInsertNode` | `handle_layout_insert_node` | Empty → promote to root. With `parent_id`+`index` → insert at that location (clamps `index`; falls back to heuristic if parent_id is missing or a leaf). Without → heuristic helper. Honours `focus_after` / `magnify_after`; magnify implies focus. |
| `LayoutDeleteNode` | `handle_layout_delete_node` | Empty → no-op. Root → wipe tree. Otherwise → helper; post-delete walk via `find_node_by_id` clears focus/magnify ids that no longer resolve. Emits `was_focused` + `was_magnified`. |

Pattern is uniform across all 11. Remaining 7 (insert_at_index, move, swap, resize, replace, split_horizontal, split_vertical) follow in subsequent PRs.

## Smoke-test repairs (bundled)

5 unit tests had been failing on `main` before this branch + 1 integration test target was failing to compile:

| # | Test / Target | Root cause |
|---|---|---|
| 1 | `tests/integration_test.rs` | Required `reqwest::blocking` but the production reqwest dep is async-only. Added `reqwest` with `blocking` feature to `[dev-dependencies]`. |
| 2 | `provider_list_has_six_entries` | Stale count — actual provider count is 7. Renamed test + bumped assertion. |
| 3 | `test_handler_inject_success` | `Handler::inject_message` internally `tokio::spawn`s; without a runtime it panics at the spawn site. Changed `#[test]` → `#[tokio::test] async`. Test assertions also corrected to match production sequence (handler sends `\r` then `message\r`). |
| 4+5 | `test_lru_oldest_evicted_when_cap_exceeded` + `test_lru_access_promotes_entry` | cap=200 forced eviction during interim `make_file` writes with the 64-byte metadata overhead; on fast machines the 3 timestamps tied to the same millisecond and the LRU sort tie-break was undefined. Bumped cap to 290 + per-write backdating so timestamps are strictly ordered. |
| 6 | `test_sweep_archives_inactive_session` | Hardcoded `block_id = "blk-sweep-test"`; `archive_session_output` calls `update_object_meta`, which `ORef::parse`s `format!("block:{}", block_id)` and rejects non-UUID oids. Fixed: use `Uuid::new_v4()`. |

## Status

**Dormant scaffolding by design** — no production callers yet. The 4 wcore-direct writers (per the plan's §"Existing rootnode writers" list) continue to be authoritative. Phase 7 migrates those; Phase 6 adds persist-subscriber arms.

## Tests

Phase 5: 11 layout reducer tests. Smoke fixes: 5 tests now passing.

Total: **860/860 srv tests pass** (was 836/856 + integration_test broken).

## Test plan

- [x] cargo check -p agentmux-srv — clean
- [x] cargo test -p agentmux-srv layout_ — all green
- [x] cargo test -p agentmux-srv --bin agentmux-srv — 860/860 pass
- [x] cargo test -p agentmux-srv --test integration_test --no-run — compiles
