### PR TITLE
fix(srv): reject explicit insert targets on empty tree (codex P2 #715 follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.680"
+version = "0.33.681"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.680"
+version = "0.33.681"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.680"
+version = "0.33.681"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.680"
+version = "0.33.681"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.681"
+version = "0.33.682"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.681"
+version = "0.33.682"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.681"
+version = "0.33.682"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.681"
+version = "0.33.682"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.679"
+version = "0.33.680"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.679"
+version = "0.33.680"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.679"
+version = "0.33.680"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.679"
+version = "0.33.680"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.678"
+version = "0.33.679"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.678"
+version = "0.33.679"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.678"
+version = "0.33.679"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.678"
+version = "0.33.679"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.680
+## Latest Version: 0.33.682
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.679
+## Latest Version: 0.33.680
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.680 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.660 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.655 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.650 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.32.89
+## Latest Version: 0.33.679
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.680"
+version = "0.33.681"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.679"
+version = "0.33.680"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.678"
+version = "0.33.679"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.681"
+version = "0.33.682"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.680"
+version = "0.33.681"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.678"
+version = "0.33.679"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.679"
+version = "0.33.680"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.681"
+version = "0.33.682"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.678"
+version = "0.33.679"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.681"
+version = "0.33.682"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.680"
+version = "0.33.681"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.679"
+version = "0.33.680"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.679"
+version = "0.33.680"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.678"
+version = "0.33.679"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.680"
+version = "0.33.681"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.681"
+version = "0.33.682"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -793,7 +793,7 @@ fn handle_layout_set_tree(
         }];
     };
     tab.rootnode = new_tree.clone();
-    // Reagent P1 PR #715 round 1: when the tree is wiped, focused/
+    // when the tree is wiped, focused/
     // magnified ids would point at non-existent nodes. Match
     // `handle_layout_clear`'s contract for the empty-tree case.
     if new_tree.is_none() {
@@ -833,10 +833,10 @@ fn handle_layout_insert_node(
     //   2. parent_id given → insert under that specific parent at
     //      `index` (or append if None). If parent_id is given but
     //      doesn't resolve to a group node, REJECT with
-    //      Event::Error rather than fall back to the heuristic —
-    //      Codex P2 PR #715 round 5 flagged the silent-fallback
-    //      path as a consistency hole: the emitted event would
-    //      echo the requested parent_id while the actual mutation
+    //      Event::Error rather than fall back to the heuristic.
+    //      A silent-fallback path is a consistency hole: the
+    //      emitted event would echo the requested parent_id while
+    //      the actual mutation
     //      went elsewhere, diverging the persist subscriber and
     //      replay consumers from the reducer.
     //   3. parent_id None → `findNextInsertLocation` heuristic.
@@ -900,12 +900,12 @@ fn handle_layout_insert_node(
         let root = tab.rootnode.as_mut().expect("non-empty checked above");
         crate::backend::layout::insert_node(root, node.clone());
     }
-    // Codex P2 PR #715 round 1: honour focus_after / magnify_after.
+    // honour focus_after / magnify_after.
     // The schema documents these as the side effects callers rely on
     // for "insert + activate" flows; ignoring them desyncs the snapshot
     // from the event the caller's handler observed.
     //
-    // Codex P2 PR #715 round 4: a magnified node must also be the
+    // a magnified node must also be the
     // focused one. Without this, a `magnify_after=true,
     // focus_after=false` insert leaves `focused_node_id` pointing at
     // the prior pane while `magnified_node_id` points at the new one
@@ -921,7 +921,7 @@ fn handle_layout_insert_node(
     vec![Event::LayoutNodeInserted {
         tab_id,
         node,
-        // Reagent P2 (kimi) PR #715 round 3: pass the command's
+        // pass the command's
         // parent_id / index through to the event so subscribers see
         // what the caller asked for, not a hardcoded `None, None`.
         // The pure helper currently uses the `findNextInsertLocation`
@@ -958,7 +958,7 @@ fn handle_layout_delete_node(
         // Empty tree — nothing to delete; idempotent no-op (no event).
         return Vec::new();
     };
-    // Codex P2 PR #715 round 1: `backend::layout::delete_node` leaves
+    // `backend::layout::delete_node` leaves
     // root deletion to the caller (returns Ok(()) with the root
     // unmodified). Detect the root case here and clear the tree
     // wholesale so the reducer state matches the
@@ -975,15 +975,14 @@ fn handle_layout_delete_node(
         }];
     }
 
-    // Reagent P2 PR #715 round 3 (finding B) and Codex P2 round 3
-    // (finding C): both involve focus/magnify ids referencing nodes
-    // that no longer exist in the tree post-delete:
-    //   - B: `delete_recursive` collapse-sole-child rewrites a
+    // Two ways focus/magnify ids can reference nodes that no longer
+    // exist in the tree post-delete; both must be cleared:
+    //   - `delete_recursive` collapse-sole-child rewrites a
     //        parent's id to the promoted child's id. If
     //        focused/magnified was the parent's original id, that
     //        id is gone from the tree even though the same physical
     //        node remains.
-    //   - C: deleting a container removes all descendants. If
+    //   - Deleting a container removes all descendants. If
     //        focused/magnified was a descendant, it's gone too.
     // Direct-target match (`pre_focused == node_id`) doesn't catch
     // either case. Reconcile by walking the post-delete tree and
@@ -3868,7 +3867,7 @@ mod tests {
 
     #[test]
     fn layout_set_tree_to_none_also_clears_focused_and_magnified() {
-        // Reagent P1 PR #715 round 1: empty-tree set must match
+        // empty-tree set must match
         // `LayoutClear`'s contract — focused/magnified ids would
         // otherwise dangle past the wipe.
         let (mut state, tab_id) = fresh_tab();
@@ -3913,7 +3912,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_honours_focus_after() {
-        // Codex P2 PR #715 round 1: focus_after=true must update
+        // focus_after=true must update
         // focused_node_id so the snapshot matches the event.
         let (mut state, tab_id) = fresh_tab();
         let node = leaf_node("new", "b1");
@@ -3936,7 +3935,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_magnify_after_implies_focus() {
-        // Codex P2 PR #715 round 4: magnify-implies-focus. Even when
+        // magnify-implies-focus. Even when
         // focus_after=false, setting magnify_after=true must also
         // update focused_node_id so it doesn't dangle on the prior
         // pane (UI invariant: a magnified pane is the focused pane).
@@ -3965,7 +3964,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_honours_explicit_parent_id_and_index() {
-        // Codex P2 PR #715 round 4: with parent_id given, insert at
+        // with parent_id given, insert at
         // that node at the requested index instead of running the
         // heuristic helper.
         let (mut state, tab_id) = fresh_tab();
@@ -4023,7 +4022,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_into_empty_tree_with_explicit_parent_id_emits_error() {
-        // Codex P2 PR #715 round 6 (post-merge follow-up): empty-tree
+        // empty-tree
         // promotion must reject explicit parent_id — otherwise the
         // event echoes a target that subscribers can't resolve.
         let (mut state, tab_id) = fresh_tab();
@@ -4077,7 +4076,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_with_unknown_parent_id_emits_error() {
-        // Codex P2 PR #715 round 5: silent fallback to heuristic
+        // silent fallback to heuristic
         // diverges the event from the actual mutation. Reject
         // explicit-but-invalid parent_id with Event::Error so
         // subscribers (especially the persist subscriber, future)
@@ -4162,7 +4161,7 @@ mod tests {
 
     #[test]
     fn layout_delete_node_on_root_clears_the_tree() {
-        // Codex P2 PR #715 round 1: backend::layout::delete_node leaves
+        // backend::layout::delete_node leaves
         // root deletion to the caller. Without the root-detection
         // branch, we'd emit LayoutNodeDeleted while rootnode still
         // contains the supposedly-deleted tree.
@@ -4187,7 +4186,7 @@ mod tests {
 
     #[test]
     fn layout_delete_node_clears_magnified_when_target_was_magnified() {
-        // Reagent P1 PR #715 round 1: magnified must be cleared
+        // magnified must be cleared
         // alongside focused; same staleness concern.
         let (mut state, tab_id) = fresh_tab();
         let mut root = leaf_node("group", "");
@@ -4209,7 +4208,7 @@ mod tests {
 
     #[test]
     fn layout_node_deleted_event_carries_was_magnified() {
-        // Reagent P1 (kimi+sonnet) PR #715 round 3: subscribers need
+        // subscribers need
         // the was_magnified field to refresh their UI when the
         // magnified node is deleted.
         let (mut state, tab_id) = fresh_tab();
@@ -4239,7 +4238,6 @@ mod tests {
 
     #[test]
     fn layout_delete_node_clears_focused_when_collapse_replaces_parent_id() {
-        // Reagent P2 (kimi+sonnet) PR #715 round 3 (finding B):
         // `backend::layout::delete_node`'s collapse-sole-child path
         // promotes the surviving child and rewrites the parent's id
         // to the child's id. If focused/magnified pointed at the
@@ -4282,7 +4280,7 @@ mod tests {
 
     #[test]
     fn layout_delete_node_clears_focused_when_target_subtree_contains_focus() {
-        // Codex P2 PR #715 round 3 (finding C): deleting a container
+        // deleting a container
         // wipes its descendants, but a direct-id-match check on
         // focused/magnified misses descendants — they stay dangling.
         let (mut state, tab_id) = fresh_tab();
@@ -4327,7 +4325,7 @@ mod tests {
 
     #[test]
     fn layout_insert_node_event_echoes_parent_id_and_index() {
-        // Reagent P2 (kimi only) PR #715 round 3 (finding D): event
+        // event
         // hardcoded `parent_id: None, index: None`; subscribers had
         // no record of what the caller asked for. Tree pre-populated
         // with a group so the explicit-parent path doesn't take the

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -842,13 +842,12 @@ fn handle_layout_insert_node(
     //   3. parent_id None → `findNextInsertLocation` heuristic.
     let empty_tree = tab.rootnode.is_none();
     if empty_tree {
-        // Codex P2 PR #715 round 6 (post-merge follow-up): empty-tree
-        // promotion must reject any explicit `parent_id`/`index` for
-        // the same divergence reason path #2 rejects them — the
-        // event would echo a target that no caller can possibly
-        // resolve to (the tree is empty), and a replay consumer or
-        // the persist subscriber would diverge from the reducer.
-        // Per `srv-phase-e4b-formal-spec-2026-05-03.md` §7.1, both
+        // Empty-tree promotion must reject any explicit `parent_id`/
+        // `index` for the same divergence reason as the explicit-
+        // parent path below — the event would echo a target the
+        // tree cannot resolve, and a replay consumer or the persist
+        // subscriber would diverge from the reducer. Per
+        // `srv-phase-e4b-formal-spec-2026-05-03.md` §7.1, both
         // fields must be `None` for empty-tree promote.
         if parent_id.is_some() || index.is_some() {
             let v = state.bump_version();

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -4325,11 +4325,10 @@ mod tests {
 
     #[test]
     fn layout_insert_node_event_echoes_parent_id_and_index() {
-        // event
-        // hardcoded `parent_id: None, index: None`; subscribers had
-        // no record of what the caller asked for. Tree pre-populated
-        // with a group so the explicit-parent path doesn't take the
-        // empty-tree rejection branch (codex round 6).
+        // The emitted event must echo the command's parent_id /
+        // index so subscribers see what was requested. Tree pre-
+        // populated with a group so the explicit-parent path
+        // doesn't take the empty-tree rejection branch.
         let (mut state, tab_id) = fresh_tab();
         let mut group = leaf_node("group", "");
         group.data = None;

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -842,6 +842,26 @@ fn handle_layout_insert_node(
     //   3. parent_id None → `findNextInsertLocation` heuristic.
     let empty_tree = tab.rootnode.is_none();
     if empty_tree {
+        // Codex P2 PR #715 round 6 (post-merge follow-up): empty-tree
+        // promotion must reject any explicit `parent_id`/`index` for
+        // the same divergence reason path #2 rejects them — the
+        // event would echo a target that no caller can possibly
+        // resolve to (the tree is empty), and a replay consumer or
+        // the persist subscriber would diverge from the reducer.
+        // Per `srv-phase-e4b-formal-spec-2026-05-03.md` §7.1, both
+        // fields must be `None` for empty-tree promote.
+        if parent_id.is_some() || index.is_some() {
+            let v = state.bump_version();
+            return vec![Event::Error {
+                code: ErrorCode::InvalidCommand,
+                message: format!(
+                    "LayoutInsertNode: empty tree cannot honour explicit parent_id={:?} / index={:?} (tab {})",
+                    parent_id, index, tab_id
+                ),
+                fatal: false,
+                version: v,
+            }];
+        }
         tab.rootnode = Some(node.clone());
     } else if let Some(pid) = parent_id.as_deref() {
         let root = tab.rootnode.as_mut().expect("non-empty checked above");
@@ -4003,6 +4023,60 @@ mod tests {
     }
 
     #[test]
+    fn layout_insert_node_into_empty_tree_with_explicit_parent_id_emits_error() {
+        // Codex P2 PR #715 round 6 (post-merge follow-up): empty-tree
+        // promotion must reject explicit parent_id — otherwise the
+        // event echoes a target that subscribers can't resolve.
+        let (mut state, tab_id) = fresh_tab();
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("first", "b1"),
+                parent_id: Some("does-not-exist".into()),
+                index: None,
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::InvalidCommand, .. }
+        ));
+        assert!(
+            state.tabs[&tab_id].rootnode.is_none(),
+            "tree must stay empty on rejection"
+        );
+    }
+
+    #[test]
+    fn layout_insert_node_into_empty_tree_with_explicit_index_emits_error() {
+        // Same rationale but with `index` only — the spec §7.1
+        // requires both fields be `None` for empty-tree promote.
+        let (mut state, tab_id) = fresh_tab();
+        let events = update(
+            &mut state,
+            Command::LayoutInsertNode {
+                tab_id: tab_id.clone(),
+                node: leaf_node("first", "b1"),
+                parent_id: None,
+                index: Some(0),
+                focus_after: false,
+                magnify_after: false,
+                correlation_id: "corr".into(),
+            },
+            &ctx(1),
+        );
+        assert!(matches!(
+            &events[0],
+            Event::Error { code: ErrorCode::InvalidCommand, .. }
+        ));
+        assert!(state.tabs[&tab_id].rootnode.is_none());
+    }
+
+    #[test]
     fn layout_insert_node_with_unknown_parent_id_emits_error() {
         // Codex P2 PR #715 round 5: silent fallback to heuristic
         // diverges the event from the actual mutation. Reject
@@ -4256,15 +4330,22 @@ mod tests {
     fn layout_insert_node_event_echoes_parent_id_and_index() {
         // Reagent P2 (kimi only) PR #715 round 3 (finding D): event
         // hardcoded `parent_id: None, index: None`; subscribers had
-        // no record of what the caller asked for.
+        // no record of what the caller asked for. Tree pre-populated
+        // with a group so the explicit-parent path doesn't take the
+        // empty-tree rejection branch (codex round 6).
         let (mut state, tab_id) = fresh_tab();
+        let mut group = leaf_node("group", "");
+        group.data = None;
+        group.children = vec![leaf_node("a", "ba")];
+        state.tabs.get_mut(&tab_id).unwrap().rootnode = Some(group);
+
         let events = update(
             &mut state,
             Command::LayoutInsertNode {
                 tab_id: tab_id.clone(),
                 node: leaf_node("new", "b1"),
-                parent_id: Some("explicit-parent".into()),
-                index: Some(3),
+                parent_id: Some("group".into()),
+                index: Some(0),
                 focus_after: false,
                 magnify_after: false,
                 correlation_id: "corr".into(),
@@ -4273,8 +4354,8 @@ mod tests {
         );
         match &events[0] {
             Event::LayoutNodeInserted { parent_id, index, .. } => {
-                assert_eq!(parent_id.as_deref(), Some("explicit-parent"));
-                assert_eq!(*index, Some(3));
+                assert_eq!(parent_id.as_deref(), Some("group"));
+                assert_eq!(*index, Some(0));
             }
             other => panic!("expected LayoutNodeInserted, got {:?}", other),
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.681",
+  "version": "0.33.682",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.681",
+      "version": "0.33.682",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.679",
+  "version": "0.33.680",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.679",
+      "version": "0.33.680",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.678",
+  "version": "0.33.679",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.678",
+      "version": "0.33.679",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.680",
+  "version": "0.33.681",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.680",
+      "version": "0.33.681",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.681",
+  "version": "0.33.682",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.680",
+  "version": "0.33.681",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.678",
+  "version": "0.33.679",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.679",
+  "version": "0.33.680",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to merged PR #715. Codex flagged a P2 in its post-merge review (commit `403a2ac6`, 2026-05-07T00:07:15Z) — the empty-tree branch of `LayoutInsertNode` silently promoted the new node to root even when the caller supplied a `parent_id` or `index`, then emitted a `LayoutNodeInserted` event echoing the requested target.

Subscribers and replay consumers would see "successful insert under parent X / index N" while the reducer placed it at root, diverging.

## Fix

Per `srv-phase-e4b-formal-spec-2026-05-03.md` §7.1, both `parent_id` and `index` must be `None` for empty-tree promotion. Symmetric with the round-5 reject paths for the non-empty branch:

| Empty tree | parent_id | index | Result |
|---|---|---|---|
| ✓ | None | None | Promote to root |
| ✓ | Some(_) | * | `Event::Error` |
| ✓ | * | Some(_) | `Event::Error` |

## Tests

- `layout_insert_node_into_empty_tree_with_explicit_parent_id_emits_error`
- `layout_insert_node_into_empty_tree_with_explicit_index_emits_error`

Existing `layout_insert_node_event_echoes_parent_id_and_index` updated: pre-populates a group so it exercises the non-empty explicit-parent path it was always meant to.

33 layout tests pass.

## Test plan

- [x] cargo test -p agentmux-srv layout_ — 33/33 pass
- [x] cargo check — clean