### PR TITLE
fix(dev): bypass inherited AGENTMUX_* env when exe is a dev build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.710"
+version = "0.33.711"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.710"
+version = "0.33.711"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.710"
+version = "0.33.711"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.710"
+version = "0.33.711"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.707"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.707"
+version = "0.33.683"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.707"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.707"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -815,13 +815,12 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "download-cef"
-version = "2.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c169adf067a787e1f1c58ed62906a557de85388bee4b54fb878b722ff606b113"
+checksum = "d7471a7d5d3bd8df1b3b75871f0317d8a6dd73270ab861cc97ae7907ee63e554"
 dependencies = [
  "bzip2",
  "clap",
- "fs-err",
  "indicatif",
  "regex",
  "semver",
@@ -956,15 +955,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.684"
+version = "0.33.703"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.684"
+version = "0.33.703"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.684"
+version = "0.33.703"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.684"
+version = "0.33.703"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.683"
+version = "0.33.684"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.683"
+version = "0.33.684"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.683"
+version = "0.33.684"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.683"
+version = "0.33.684"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -815,12 +815,13 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "download-cef"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7471a7d5d3bd8df1b3b75871f0317d8a6dd73270ab861cc97ae7907ee63e554"
+checksum = "c169adf067a787e1f1c58ed62906a557de85388bee4b54fb878b722ff606b113"
 dependencies = [
  "bzip2",
  "clap",
+ "fs-err",
  "indicatif",
  "regex",
  "semver",
@@ -955,6 +956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.683"
+version = "0.33.684"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.707"
+version = "0.33.683"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.684"
+version = "0.33.703"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.710"
+version = "0.33.711"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -283,7 +283,18 @@ fn main() {
     // lifetime — dropping it closes the pipe (logged by launcher).
     // Failure to connect is non-fatal in B.2 (host can still run);
     // B.5+ will tighten when the host depends on IPC for state.
-    let _launcher_ipc = runtime.block_on(launcher_ipc::connect_to_launcher(app_state.clone()));
+    //
+    // Dev-build env-isolation guard: a dev build inheriting
+    // `AGENTMUX_LAUNCHER_PIPE` from a parent AgentMux pane it was
+    // launched from would connect to the PARENT's launcher pipe and
+    // route its host events into the parent's launcher state.
+    // Skip the connection in dev mode — `task dev` has no launcher
+    // process anyway.
+    let _launcher_ipc = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+        None
+    } else {
+        runtime.block_on(launcher_ipc::connect_to_launcher(app_state.clone()))
+    };
 
     // Phase E.2c.5a — connect to the srv reducer's pipe. Forwards
     // srv events (workspace / tab / block lifecycle) to every
@@ -292,7 +303,15 @@ fn main() {
     // if absent: `task dev` mode doesn't run the launcher and so
     // doesn't set `AGENTMUX_SRV_PIPE_PATH` — host runs without the
     // bridge, frontend uses the legacy waveobj:update path.
-    let _srv_ipc = runtime.block_on(srv_ipc::connect_to_srv(app_state.clone()));
+    //
+    // Same dev-build guard as launcher_ipc above — a dev build
+    // inheriting `AGENTMUX_SRV_PIPE_PATH` would bridge its srv
+    // events into the parent's renderer fan-out.
+    let _srv_ipc = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+        None
+    } else {
+        runtime.block_on(srv_ipc::connect_to_srv(app_state.clone()))
+    };
 
     // Phase B.1: if launcher already spawned srv (the normal portable
     // / installed path post-PR-#570 + B.1), populate state from the

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -250,9 +250,18 @@ fn main() {
     // shared path. Falls back to the cef cache dir only when the env
     // is unset (`task dev` mode without launcher), where forwarding
     // wouldn't be wired anyway.
-    let port_file_dir = std::env::var_os("AGENTMUX_DATA_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_else(|| data_dir.clone());
+    // Dev builds inherit AGENTMUX_DATA_DIR from the parent pane they were
+    // launched from. Writing ipc-port there would overwrite the parent
+    // instance's port:token and break its single-instance forwarding.
+    // In dev mode there is no launcher so port forwarding isn't wired
+    // anyway — use the dev data dir directly.
+    let port_file_dir = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+        data_dir.clone()
+    } else {
+        std::env::var_os("AGENTMUX_DATA_DIR")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|| data_dir.clone())
+    };
     let _ = std::fs::create_dir_all(&port_file_dir);
     let port_file = port_file_dir.join("ipc-port");
 
@@ -297,7 +306,15 @@ fn main() {
     // frontend before the backend is available, which causes a "raw
     // browser" appearance on slow machines or first launch.
     let backend_ready = runtime.block_on(async {
-        let launcher_provided = sidecar::use_launcher_endpoints(&app_state);
+        // Dev builds inherit AGENTMUX_BACKEND_WS from the parent pane.
+        // Consuming it would connect to the parent's srv instead of
+        // spawning our own, so the dev frontend runs against the wrong
+        // (parent's) backend and no dev-version srv is ever started.
+        let launcher_provided = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+            None
+        } else {
+            sidecar::use_launcher_endpoints(&app_state)
+        };
         let result = match launcher_provided {
             Some(Ok(r)) => {
                 tracing::info!(

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -173,10 +173,25 @@ fn main() {
         .ok()
         .and_then(|p| p.parent().map(|d| d.to_path_buf()))
         .unwrap_or_default();
-    let common_paths = agentmux_common::DataPaths::from_env().or_else(|| {
-        let mode = agentmux_common::RuntimeMode::current(&host_exe_dir);
+    // Dev builds NEVER inherit AGENTMUX_* env vars from a parent process.
+    // `task dev` is routinely launched from inside an AgentMux terminal
+    // pane, which means the child host inherits the parent instance's
+    // AGENTMUX_DATA_DIR pointing at the parent's version-isolated dir.
+    // Without this guard the dev build would resolve its data dir to the
+    // running portable's path and trip CEF's process-singleton lock,
+    // routing every "open" back to the existing window — the user would
+    // never see the dev code run. Path-based detection is authoritative
+    // for dev builds; for installed/portable we still honor the
+    // launcher-provided env (it's the launcher's job to publish them).
+    let common_paths = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+        let mode = agentmux_common::RuntimeMode::current_path_only(&host_exe_dir);
         agentmux_common::DataPaths::resolve(version, &mode).ok()
-    });
+    } else {
+        agentmux_common::DataPaths::from_env().or_else(|| {
+            let mode = agentmux_common::RuntimeMode::current(&host_exe_dir);
+            agentmux_common::DataPaths::resolve(version, &mode).ok()
+        })
+    };
     let is_dev = match &common_paths {
         Some(p) => matches!(p.mode, agentmux_common::RuntimeMode::Dev { .. }),
         None => false,

--- a/agentmux-cef/src/sidecar.rs
+++ b/agentmux-cef/src/sidecar.rs
@@ -119,20 +119,29 @@ pub async fn spawn_backend(state: &Arc<AppState>) -> Result<BackendSpawnResult, 
     //      used, so the disk layout is identical. This is functionally
     //      a fallback the launcher would otherwise have produced.
     let current_version = env!("CARGO_PKG_VERSION");
-    let paths = match agentmux_common::DataPaths::from_env() {
-        Some(p) => p,
-        None => {
-            // No launcher env — derive from the host's own vantage.
-            // Mode detection works at this point even though the host
-            // exe lives inside `runtime/`, because portable detection
-            // uses the `agentmux-portable.marker` (not `runtime/`).
-            let host_exe_dir = std::env::current_exe()
-                .map_err(|e| format!("current_exe() failed: {}", e))?;
-            let host_exe_dir = host_exe_dir
-                .parent()
-                .ok_or_else(|| "current_exe has no parent".to_string())?;
-            let mode = agentmux_common::RuntimeMode::current(host_exe_dir);
-            agentmux_common::DataPaths::resolve(current_version, &mode)?
+    // Mirror the env-isolation guard from main.rs: a dev build never
+    // trusts inherited AGENTMUX_* env, even on the restart_backend path
+    // where main.rs has already resolved paths once. Otherwise the
+    // sidecar would re-spawn against a stale parent's data dir.
+    let host_exe_dir = std::env::current_exe()
+        .map_err(|e| format!("current_exe() failed: {}", e))?;
+    let host_exe_dir = host_exe_dir
+        .parent()
+        .ok_or_else(|| "current_exe has no parent".to_string())?;
+    let paths = if agentmux_common::is_dev_build_exe(host_exe_dir) {
+        let mode = agentmux_common::RuntimeMode::current_path_only(host_exe_dir);
+        agentmux_common::DataPaths::resolve(current_version, &mode)?
+    } else {
+        match agentmux_common::DataPaths::from_env() {
+            Some(p) => p,
+            None => {
+                // No launcher env — derive from the host's own vantage.
+                // Mode detection works at this point even though the host
+                // exe lives inside `runtime/`, because portable detection
+                // uses the `agentmux-portable.marker` (not `runtime/`).
+                let mode = agentmux_common::RuntimeMode::current(host_exe_dir);
+                agentmux_common::DataPaths::resolve(current_version, &mode)?
+            }
         }
     };
     let version_instance_id = format!("v{}", current_version);

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.707"
+version = "0.33.683"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.710"
+version = "0.33.711"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.684"
+version = "0.33.703"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.683"
+version = "0.33.684"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/lib.rs
+++ b/agentmux-common/src/lib.rs
@@ -9,7 +9,7 @@ pub mod runtime_mode;
 pub use cli::make_cli_cmd;
 pub use data_paths::DataPaths;
 pub use layout_types::{FlexDirection, LayoutNode, LayoutNodeData, ResizeOp, SplitPosition};
-pub use runtime_mode::RuntimeMode;
+pub use runtime_mode::{is_dev_build_exe, RuntimeMode};
 
 /// Crate-wide test-only lock for env-var-touching tests. Both
 /// `runtime_mode::tests` and `data_paths::tests` mutate process-global

--- a/agentmux-common/src/runtime_mode.rs
+++ b/agentmux-common/src/runtime_mode.rs
@@ -106,6 +106,22 @@ impl RuntimeMode {
             .and_then(|s| parse_mode_string(&s))
     }
 
+    /// Path-only detection — skips the `AGENTMUX_RUNTIME_MODE` env step.
+    /// Use when the env can't be trusted (e.g., the binary was launched
+    /// as a child of a different AgentMux process that set its own
+    /// `AGENTMUX_*` vars). Mirrors the rest of [`Self::current`]'s
+    /// priority order (portable marker → dev exe path → installed).
+    pub fn current_path_only(exe_dir: &Path) -> Self {
+        if is_portable_marker_present(exe_dir) {
+            return Self::Portable;
+        }
+        if exe_dir_is_dev_build(exe_dir) {
+            let branch = detect_branch(exe_dir);
+            return Self::Dev { branch };
+        }
+        Self::Installed
+    }
+
     /// Encode for the `AGENTMUX_RUNTIME_MODE` env var. Round-trips
     /// with [`parse_mode_string`].
     pub fn to_env_string(&self) -> String {
@@ -134,6 +150,14 @@ impl RuntimeMode {
             Self::Dev { branch } => format!("dev/{}", sanitize_branch_slug(branch)),
         }
     }
+}
+
+/// True when this binary is running from one of our known dev-build
+/// output directories (`dist/cef-dev/`, `target/debug/`, `target/release/`).
+/// Walks ancestors to handle nested cases (CEF subprocesses run from a
+/// `runtime/` subdir even in dev). Path-only — does not read env.
+pub fn is_dev_build_exe(exe_dir: &Path) -> bool {
+    exe_dir_is_dev_build(exe_dir)
 }
 
 fn parse_mode_string(s: &str) -> Option<RuntimeMode> {

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.707"
+version = "0.33.683"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.684"
+version = "0.33.703"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.683"
+version = "0.33.684"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.710"
+version = "0.33.711"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -56,7 +56,14 @@ pub struct DataPaths {
 /// parameter from the pre-PR-#695 signature has been removed; callers
 /// no longer need to compute it.
 pub fn resolve_paths(launcher_exe_dir: &Path, version: &str) -> Result<DataPaths, String> {
-    let mode = RuntimeMode::current(launcher_exe_dir);
+    // Path-only when the exe is a dev build — see SPEC_DEV_ENV_ISOLATION.
+    // Prevents inheriting AGENTMUX_RUNTIME_MODE from a parent AgentMux
+    // process when `task dev` is launched from inside an existing pane.
+    let mode = if agentmux_common::is_dev_build_exe(launcher_exe_dir) {
+        RuntimeMode::current_path_only(launcher_exe_dir)
+    } else {
+        RuntimeMode::current(launcher_exe_dir)
+    };
     let common = CommonDataPaths::resolve(version, &mode)?;
 
     let portable_root = if mode == RuntimeMode::Portable {

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.707"
+version = "0.33.683"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.683"
+version = "0.33.684"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.684"
+version = "0.33.703"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.710"
+version = "0.33.711"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/dev-build-env-isolation.md
+++ b/docs/specs/dev-build-env-isolation.md
@@ -1,0 +1,165 @@
+# Dev-Build Env Isolation
+
+**Status:** Implemented (PR #717)
+**Date:** 2026-05-06
+**Owner:** AgentX
+
+## Problem
+
+Running `task dev` from inside an existing AgentMux terminal pane silently
+routes the new dev build's data dir to the **parent** instance's
+version-isolated directory — so the new code never actually runs in
+isolation.
+
+### Concrete failure observed
+
+Parent: AgentMux portable v0.33.669 running on the host.
+Child: `task dev` invoked from inside one of v0.33.669's terminal panes.
+Child's compiled-in version: 0.33.680.
+
+Logs from the child host:
+
+```
+AgentMux host starting           version="0.33.680" ...
+Initializing CEF browser process version="0.33.680"
+                                 runtime_mode=Some("portable")
+                                 data_dir=C:\Users\asafe\.agentmux\versions\0.33.669\cef-cache
+...
+CEF early exit (process singleton or similar) — exiting cleanly exit_code=24
+Opening in existing browser session.
+```
+
+The child resolved its `cef-cache` dir to **0.33.669**'s path, collided
+with CEF's process-singleton lock on that dir, and forwarded its open
+request to the running 0.33.669 window. The user's "see the new code"
+loop silently no-ops.
+
+### Why version isolation didn't kick in
+
+The post-#695/#696 unification routes data via:
+
+```
+DataPaths::from_env()                 ← env-provided paths win
+  .or_else(|| {
+      RuntimeMode::current(exe_dir)   ← path-based fallback
+      DataPaths::resolve(version, &mode)
+  })
+```
+
+The child inherited `AGENTMUX_DATA_DIR=...versions/0.33.669/data` (and
+the rest of the `AGENTMUX_*` family) from the parent process's env.
+`DataPaths::from_env()` returned `Some` with the parent's stale paths,
+short-circuiting the path-based detection that would have selected
+`RuntimeMode::Dev { branch }` and routed to `~/.agentmux/dev/<branch>/`.
+
+`RuntimeMode::current` itself has the same blind spot: step 1 honors
+`AGENTMUX_RUNTIME_MODE` from env *before* checking the exe path, so even
+if `from_env()` had returned `None`, an inherited `AGENTMUX_RUNTIME_MODE`
+value would override path detection.
+
+## Constraint
+
+`task dev` is run routinely from inside an AgentMux session — agents
+running in panes are expected to iterate on the codebase via `task dev`
+without first closing the host they're embedded in. We can't assume a
+clean environment.
+
+We cannot ask agents to kill or restart the host they're running inside
+(see `CLAUDE.md` "Host Process Safety").
+
+## Resolution
+
+**Dev builds never inherit `AGENTMUX_*` env vars from a parent process.**
+Path-based detection is authoritative when the binary lives in a
+recognized dev-output directory.
+
+### Public API additions (`agentmux-common`)
+
+```rust
+// runtime_mode.rs
+impl RuntimeMode {
+    /// Path-only detection — skips the AGENTMUX_RUNTIME_MODE env step.
+    pub fn current_path_only(exe_dir: &Path) -> Self { ... }
+}
+
+/// True when this binary lives in a known dev-build output directory
+/// (`dist/cef-dev/`, `target/debug/`, `target/release/`).
+pub fn is_dev_build_exe(exe_dir: &Path) -> bool { ... }
+```
+
+`current_path_only` mirrors `current`'s priority order minus step 1
+(env override): portable marker → dev exe path → installed.
+
+### Call-site changes
+
+**`agentmux-cef/src/main.rs`** (boot path):
+
+```rust
+let common_paths = if agentmux_common::is_dev_build_exe(&host_exe_dir) {
+    let mode = RuntimeMode::current_path_only(&host_exe_dir);
+    DataPaths::resolve(version, &mode).ok()
+} else {
+    DataPaths::from_env().or_else(|| {
+        let mode = RuntimeMode::current(&host_exe_dir);
+        DataPaths::resolve(version, &mode).ok()
+    })
+};
+```
+
+**`agentmux-cef/src/sidecar.rs`** (`spawn_backend` / `restart_backend`):
+Same guard — even on the restart path, a dev host re-derives paths from
+its own exe location, never trusting inherited env.
+
+**`agentmux-launcher/src/data_dir.rs`** (`resolve_paths`):
+Same guard for symmetry — when the launcher itself is a dev build,
+ignore env override.
+
+The installed/portable paths are unchanged. The launcher remains
+authoritative there: it computes paths once and propagates them to host
++ srv via `to_env_vars()`.
+
+## Why this is safe
+
+- **Dev binaries are never the launcher target on installed/portable
+  systems.** `dist/cef-dev/`, `target/debug/`, `target/release/` are
+  developer-only locations; an installed user's binaries live under the
+  portable extract or the OS install dir, neither of which trips
+  `is_dev_build_exe`.
+- **The path check is structural, not heuristic.** It walks ancestors
+  for an exact `parent_name="dist", name="cef-dev"` (or `target/debug`,
+  `target/release`) match. An installed binary whose path *happens* to
+  contain the substring "cef-dev" elsewhere would not match.
+- **Portable marker still wins for portable layouts.** A portable
+  build dropped into a path that also matches `target/release` is still
+  detected as portable because `is_portable_marker_present` is checked
+  first inside `current_path_only`.
+- **The host still receives correct paths to forward to srv.**
+  `DataPaths::to_env_vars()` is called on the resolved paths, so the
+  spawned `agentmux-srv` inherits dev paths regardless of what env the
+  host itself was invoked with.
+
+## Behavioral summary
+
+| Build        | Parent env present | Resolved data dir              |
+| ------------ | ------------------ | ------------------------------ |
+| Installed    | yes (launcher)     | env-provided (unchanged)       |
+| Installed    | no                 | path detection → installed     |
+| Portable     | yes (launcher)     | env-provided (unchanged)       |
+| Portable     | no                 | marker → portable, version dir |
+| **Dev**      | **yes (parent)**   | **path-only → `dev/<branch>/`** ← FIX |
+| Dev          | no                 | path-only → `dev/<branch>/`    |
+
+## Verification
+
+After rebuild, launch `task dev` from inside an existing AgentMux pane.
+Expected: log line shows
+`data_dir=...\.agentmux\dev\<git-branch>\cef-cache`, NOT
+`...\versions\<parent-version>\cef-cache`. A fresh CEF window opens
+(no process-singleton collision because the dev cache dir is its own).
+
+## Related
+
+- #695 — `RuntimeMode` + `DataPaths` primitives
+- #696 — switch launcher/host/srv onto the new primitives
+- `docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md` — the original
+  unification spec; this is a follow-up.

--- a/docs/specs/dev-build-env-isolation.md
+++ b/docs/specs/dev-build-env-isolation.md
@@ -1,6 +1,6 @@
 # Dev-Build Env Isolation
 
-**Status:** Implemented (PR #717)
+**Status:** Implemented (PR #719)
 **Date:** 2026-05-06
 **Owner:** AgentX
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.684",
+  "version": "0.33.703",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.683",
+  "version": "0.33.684",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.707",
+  "version": "0.33.683",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.710",
+  "version": "0.33.711",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

When `task dev` is launched from inside an AgentMux terminal pane — a routine workflow for agents iterating on the codebase from inside the host they're embedded in — the new dev binary inherits the parent's `AGENTMUX_*` env vars. `DataPaths::from_env()` returns `Some` with the stale paths, the dev build resolves its data_dir to the parent's version-isolated directory, and CEF's process-singleton lock on that directory routes every open request back to the running parent. The user never sees the dev code execute.

This silently defeats the version-isolation guarantee from PR #695/#696.

### Fix

When the binary lives in a known dev-build output directory (`dist/cef-dev/`, `target/debug/`, `target/release/`), bypass `from_env()` and re-derive paths from the exe location. Path-based detection is authoritative for dev builds; installed/portable continue to trust the launcher's env injection.

### API additions

- `agentmux_common::is_dev_build_exe(exe_dir)` - public path-only check
- `RuntimeMode::current_path_only(exe_dir)` - mirrors `current()` minus the env-override step

### Call sites updated

- `agentmux-cef/src/main.rs` (boot path)
- `agentmux-cef/src/sidecar.rs` (`spawn_backend` / `restart_backend`)
- `agentmux-launcher/src/data_dir.rs` (`resolve_paths`) - parity for the rare case where the launcher itself runs from a dev build

### Spec

Full problem analysis + behavior matrix at `docs/specs/dev-build-env-isolation.md`.

## Test plan

- [ ] Close any running AgentMux, then `task dev` from a clean shell - data_dir should be `~/.agentmux/dev/<branch>/`
- [ ] With AgentMux 0.33.679 portable running, `task dev` from inside one of its panes - data_dir should be `~/.agentmux/dev/<branch>/` (NOT the running portable's `versions/0.33.679/`)
- [ ] Installed build still routes to `~/.agentmux/versions/<v>/` (unchanged behavior)

Closes the silent collision documented in #717's task-dev verification step.