### PR TITLE
fix(launcher): cap HiddenSinceOpen drift at one event per window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.686"
+version = "0.33.687"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.686"
+version = "0.33.687"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.686"
+version = "0.33.687"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.686"
+version = "0.33.687"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.685"
+version = "0.33.686"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.685"
+version = "0.33.686"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.685"
+version = "0.33.686"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.685"
+version = "0.33.686"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.685
+## Latest Version: 0.33.686
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.685 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.680 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.660 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.655 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.686
+## Latest Version: 0.33.687
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.686"
+version = "0.33.687"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.685"
+version = "0.33.686"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.685"
+version = "0.33.686"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.686"
+version = "0.33.687"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.685"
+version = "0.33.686"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.686"
+version = "0.33.687"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1668,6 +1668,85 @@ fn hidden_since_open_drift_fires_at_most_once_per_window() {
 }
 
 #[test]
+fn hidden_since_open_cap_survives_duplicate_open() {
+    // The handler overwrites the mirror wholesale on every
+    // ReportWindowOpened. Without OR-ing the prior value in, a 2nd
+    // open at the same label re-arms the cap and the next hidden
+    // visibility transition fires HiddenSinceOpen a second time.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-dup".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xDD,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-dup".into()),
+        },
+        &c,
+    );
+    let first = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: false },
+        &c,
+    );
+    assert!(
+        first.iter().any(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+        )),
+        "control: first hide emits drift"
+    );
+
+    // Duplicate open for the same label — overwrites the mirror.
+    // Cap MUST survive (OR with prior value) or the storm re-arms.
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-dup".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    assert!(
+        state
+            .windows
+            .get("window-dup")
+            .unwrap()
+            .hidden_since_open_emitted,
+        "duplicate open must preserve hidden_since_open_emitted=true"
+    );
+
+    // Subsequent hide: drift must NOT fire again.
+    let _ = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: true },
+        &c,
+    );
+    let second = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: false },
+        &c,
+    );
+    assert!(
+        !second.iter().any(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+        )),
+        "duplicate-open path: cap survives, no second drift"
+    );
+}
+
+#[test]
 fn promote_for_label_without_window_mirror_emits_event_idempotently() {
     // The handler's idempotency contract: ReportPoolWindowPromoted
     // can arrive without a paired ReportWindowOpened (e.g. the open

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1580,6 +1580,91 @@ fn cold_open_without_promote_still_initializes_foregrounded_false() {
         !state.windows.get("window-fresh").unwrap().foregrounded_since_open,
         "non-promote open must keep foregrounded_since_open=false"
     );
+    assert!(
+        !state.windows.get("window-fresh").unwrap().hidden_since_open_emitted,
+        "fresh open starts with hidden_since_open_emitted=false (cap not yet armed)"
+    );
+}
+
+#[test]
+fn hidden_since_open_drift_fires_at_most_once_per_window() {
+    // Drift-storm regression guard. The smoke crash on v0.33.685
+    // ("New Window" from hamburger after a tear-off) was 170
+    // identical HiddenSinceOpen events in 1s for the same label,
+    // exhausting the renderer's V8 stack. Cap fires once per window
+    // per session — subscribers still see the signal, no storm.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-fresh".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xCC,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-fresh".into()),
+        },
+        &c,
+    );
+    // First hide → drift fires.
+    let first = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: false },
+        &c,
+    );
+    assert_eq!(
+        first
+            .iter()
+            .filter(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+            ))
+            .count(),
+        1,
+        "first hide emits drift exactly once"
+    );
+
+    // 100 subsequent hide/show oscillations (mimics the storm
+    // observed during placement): drift must NOT re-fire.
+    let mut subsequent_drift_count = 0;
+    for _ in 0..100 {
+        let _ = update(
+            &mut state,
+            Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: true },
+            &c,
+        );
+        let evs = update(
+            &mut state,
+            Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: false },
+            &c,
+        );
+        subsequent_drift_count += evs
+            .iter()
+            .filter(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+            ))
+            .count();
+    }
+    assert_eq!(
+        subsequent_drift_count, 0,
+        "cap suppresses ALL subsequent HiddenSinceOpen emissions"
+    );
+    assert!(
+        state
+            .windows
+            .get("window-fresh")
+            .unwrap()
+            .hidden_since_open_emitted,
+        "cap flag is set after the first emission"
+    );
 }
 
 #[test]

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -117,15 +117,11 @@ pub(super) fn handle_report_window_opened(
     // corrective logic doesn't re-fire `HiddenSinceOpen` on the
     // subsequent HWND repositioning. See state.rs::just_promoted_labels.
     let was_just_promoted = state.just_promoted_labels.remove(&label);
-    // Codex P2 PR #708 round 3 — `foregrounded_since_open` is
-    // monotonic (false → true, never resets within a window's
-    // lifetime per its own contract: "has this label been
-    // foregrounded at any point since its ReportWindowOpened"). On
-    // duplicate opens (the existing handler overwrites the mirror
-    // wholesale), OR the prior value in so the flag isn't reset. The
-    // first open after a promote already consumed `just_promoted_labels`,
-    // so a 2nd open at the same label would otherwise re-arm the
-    // open-transient drift detector.
+    // Duplicate-open monotonicity (codex P2 PR #708 round 3):
+    // `foregrounded_since_open` is monotonic (false → true, never
+    // resets within a window's lifetime). On duplicate opens (the
+    // existing handler overwrites the mirror wholesale), OR the prior
+    // value in so the flag isn't reset.
     let prior_foregrounded = state
         .windows
         .get(&label)
@@ -149,6 +145,7 @@ pub(super) fn handle_report_window_opened(
             last_rect: None,
             last_foreground_at_ms: None,
             foregrounded_since_open: was_just_promoted || prior_foregrounded,
+            hidden_since_open_emitted: false,
         },
     );
     let mut out = Vec::with_capacity(2);

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -117,16 +117,26 @@ pub(super) fn handle_report_window_opened(
     // corrective logic doesn't re-fire `HiddenSinceOpen` on the
     // subsequent HWND repositioning. See state.rs::just_promoted_labels.
     let was_just_promoted = state.just_promoted_labels.remove(&label);
-    // Duplicate-open monotonicity (codex P2 PR #708 round 3):
-    // `foregrounded_since_open` is monotonic (false → true, never
-    // resets within a window's lifetime). On duplicate opens (the
-    // existing handler overwrites the mirror wholesale), OR the prior
-    // value in so the flag isn't reset.
-    let prior_foregrounded = state
+    // Duplicate-open monotonicity. The handler overwrites the mirror
+    // wholesale on every `ReportWindowOpened`; without the OR-with-
+    // prior here, a 2nd open at the same label re-arms both the
+    // open-transient drift detector and the storm cap. Both flags
+    // are monotonic for a window's lifetime: once true, never reset.
+    //
+    // - `foregrounded_since_open`: monotonic per its own contract
+    //   ("has this label been foregrounded at any point since
+    //   ReportWindowOpened"). Preserved against duplicate opens
+    //   since codex P2 PR #708 round 3.
+    // - `hidden_since_open_emitted`: monotonic for the same reason
+    //   the cap exists — fire the drift signal AT MOST ONCE per
+    //   window per session. A duplicate open that resets this to
+    //   false would re-arm the storm cap, then the next visibility
+    //   transition fires HiddenSinceOpen a second time.
+    let (prior_foregrounded, prior_hidden_emitted) = state
         .windows
         .get(&label)
-        .map(|m| m.foregrounded_since_open)
-        .unwrap_or(false);
+        .map(|m| (m.foregrounded_since_open, m.hidden_since_open_emitted))
+        .unwrap_or((false, false));
 
     state.windows.insert(
         label.clone(),
@@ -145,7 +155,7 @@ pub(super) fn handle_report_window_opened(
             last_rect: None,
             last_foreground_at_ms: None,
             foregrounded_since_open: was_just_promoted || prior_foregrounded,
-            hidden_since_open_emitted: false,
+            hidden_since_open_emitted: prior_hidden_emitted,
         },
     );
     let mut out = Vec::with_capacity(2);

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -121,6 +121,19 @@ pub struct WindowMirror {
     /// since its `ReportWindowOpened`? Used to fire `HiddenSinceOpen`
     /// drift on the first hide event when this is still false.
     pub foregrounded_since_open: bool,
+    /// Drift-storm fix (post-PR-#720 follow-up): `HiddenSinceOpen`
+    /// drift only fires ONCE per window per session. Without this
+    /// cap, a fresh top-level window that goes through several
+    /// SetWindowPos transitions during host placement re-emits the
+    /// same drift event for every intermediate `visible=false`
+    /// snapshot — observed up to 170 events in 1 second, exhausting
+    /// the renderer's V8 stack and crashing it. Cap fires once,
+    /// subscribers still see the signal, no storm.
+    /// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`
+    /// for the original storm context (this is the second instance
+    /// — pool-promote path was caught in PR #708, direct-open path
+    /// in this PR).
+    pub hidden_since_open_emitted: bool,
 }
 
 /// Top-level launcher state. Single Arc<Mutex<State>> owned by the

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -351,7 +351,17 @@ pub fn apply_hwnd_visibility_changed(
         .find(|(_, m)| m.hwnd == Some(hwnd))
         .and_then(|(label, mirror)| {
             mirror.visible = visible;
-            if !visible && !mirror.foregrounded_since_open {
+            // Drift-storm cap: HiddenSinceOpen fires AT MOST ONCE per
+            // window per session. A fresh top-level window goes
+            // through several SetWindowPos transitions during host
+            // placement; without the cap, each intermediate
+            // `visible=false` re-emits the same drift event and the
+            // renderer's V8 stack runs out (see `hidden_since_open_emitted`
+            // doc on `WindowMirror`). The flag set below is monotonic
+            // — once we've reported the drift, never report it again
+            // for the same label. Subscribers still see the signal.
+            if !visible && !mirror.foregrounded_since_open && !mirror.hidden_since_open_emitted {
+                mirror.hidden_since_open_emitted = true;
                 version_to_bump = true;
                 Some(label.clone())
             } else {

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.686"
+version = "0.33.687"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.685"
+version = "0.33.686"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.686",
+  "version": "0.33.687",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.686",
+      "version": "0.33.687",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.685",
+  "version": "0.33.686",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.685",
+      "version": "0.33.686",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.686",
+  "version": "0.33.687",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.685",
+  "version": "0.33.686",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Drift-storm regression caught during smoke testing of v0.33.685: tear off a tab, then click "New Window" from the hamburger menu, and the renderer crashes ~1 second later with `Crashpad_NotConnectedToHandler`. **170 identical `HiddenSinceOpen` events for the same label in 1 second** → V8 stack exhaustion.

PR #708 thought it had closed this class. Its fix (set `foregrounded_since_open=true` on `ReportPoolWindowPromoted` via `just_promoted_labels`) only covered the pool→user transition. The "New Window" path (`open_new_window`) emits `ReportWindowOpened` directly with no preceding promote, so it inherited the original storm.

## Root cause

```
1. open_new_window → ReportWindowOpened
2. fresh mirror has foregrounded_since_open=false
3. host repositions HWND via several SetWindowPos calls
4. each intermediate visible=false re-fires HiddenSinceOpen
5. 170 events in 1s → V8 stack out → crash
```

## Fix

Cap `HiddenSinceOpen` drift at **at most one event per window per session**.

- Add `hidden_since_open_emitted: bool` to `WindowMirror`
- Gate the emission in `apply_hwnd_visibility_changed` with `&& !mirror.hidden_since_open_emitted`
- Set the flag true on first emission (monotonic; never reset)

Subscribers still get the drift signal — just not the storm.

## Why a cap, not "default `foregrounded_since_open=true` for FullInstance"

The earlier-considered alternative (extending PR #708's "is-promoted" semantic to all FullInstance opens) would have suppressed BOTH `HiddenSinceOpen` AND `OffMonitor` corrective for fresh windows. `OffMonitor` corrective uses `foregrounded_since_open` as its "trust the user's placement" marker and IS useful for catching placement bugs that orphan a window. The cap-based fix preserves the corrective.

## Tests

- `hidden_since_open_drift_fires_at_most_once_per_window` — 100 hide/show oscillations after the first hide produce zero additional drift events; flag is set after the first emission.
- All 165 pre-existing launcher tests still pass (166 total).

## Test plan

- [x] cargo test -p agentmux-launcher — 166/166 pass
- [x] cargo check — clean
- [ ] Smoke: tear off a tab, then "New Window" from hamburger — renderer should NOT crash