### PR TITLE
fix(cef): host-bridge dedup — Phase F.7 cap on launcher event fan-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.691"
+version = "0.33.692"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.691"
+version = "0.33.692"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.691"
+version = "0.33.692"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.691"
+version = "0.33.692"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.688"
+version = "0.33.689"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.688"
+version = "0.33.689"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.688"
+version = "0.33.689"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.688"
+version = "0.33.689"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.689"
+version = "0.33.690"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.689"
+version = "0.33.690"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.689"
+version = "0.33.690"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.689"
+version = "0.33.690"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.690"
+version = "0.33.691"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.690"
+version = "0.33.691"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.690"
+version = "0.33.691"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.690"
+version = "0.33.691"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.690
+## Latest Version: 0.33.691
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.691
+## Latest Version: 0.33.692
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.689
+## Latest Version: 0.33.690
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.688
+## Latest Version: 0.33.689
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.688 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.685 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.680 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |
 | 0.33.660 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.690"
+version = "0.33.691"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.689"
+version = "0.33.690"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.691"
+version = "0.33.692"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.688"
+version = "0.33.689"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -56,6 +56,17 @@ use cef::{CefString, ImplBrowser, ImplFrame};
 /// from the Event is escaped against quote / backtick injection at
 /// the JS-string boundary.
 pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event) {
+    // Phase F.7 host-bridge dedup. Mirror of the renderer-side guard
+    // (`shouldDispatchLauncherEvent` in launcher-events.ts), but at
+    // the host so a fresh V8 context post-crash, multi-context fan-
+    // out, or any renderer-side guard failure mode can't amplify the
+    // launcher's single emit. Skip the entire dispatch if the event's
+    // version is not strictly higher than the per-key max we've
+    // already sent.
+    if !should_dispatch(state, event) {
+        return;
+    }
+
     let json = match serde_json::to_string(event) {
         Ok(s) => s,
         Err(e) => {
@@ -80,7 +91,6 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     // the reads.
     let (pool_inventory, browsers) = state.user_visibility_snapshot();
 
-    // Phase H.2.b — reducer-aware iteration with fallback.
     for (label, browser) in browsers {
         if label.starts_with("browser-pane-") {
             continue;
@@ -93,5 +103,200 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
         if let Some(frame) = browser.main_frame() {
             frame.execute_java_script(Some(&code), Some(&url), 0);
         }
+    }
+}
+
+/// Phase F.7 dedup gate. Returns `true` if the event is strictly
+/// newer for its `(event_kind, label, hwnd)` key and should be
+/// dispatched; `false` if a higher-or-equal version was already
+/// sent.
+///
+/// Mirrors the renderer-side `shouldDispatchLauncherEvent`. Bounded
+/// at 4096 keys with FIFO eviction so a long-running host can't
+/// leak unbounded state. Re-arrival of an evicted key bypasses the
+/// host gate but the renderer guard still catches it.
+fn should_dispatch(state: &Arc<crate::state::AppState>, event: &Event) -> bool {
+    const MAX_DEDUP_KEYS: usize = 4096;
+    let (key, version) = dedup_key(event);
+    let mut cache = state.launcher_bridge_dedup.lock();
+    if let Some(&seen) = cache.get(&key) {
+        if version <= seen {
+            return false;
+        }
+    }
+    cache.insert(key, version);
+    if cache.len() > MAX_DEDUP_KEYS {
+        // FIFO eviction — drop the first key by iteration order. Map
+        // iteration order isn't strictly insertion in std HashMap, but
+        // for this bounded-leak guard any victim is fine.
+        if let Some(victim) = cache.keys().next().cloned() {
+            cache.remove(&victim);
+        }
+    }
+    true
+}
+
+/// Build the dedup cache key + extract the version for an event.
+/// Returns `("{kind}|{label}|{hwnd}", version)`. Missing label/hwnd
+/// fields contribute empty strings — kinds without those fields
+/// dedup by kind+version alone.
+fn dedup_key(event: &Event) -> (String, u64) {
+    use Event::*;
+    let (kind, label, hwnd, version) = match event {
+        WindowOpened { label, version, .. } => ("window_opened", label.as_str(), 0u64, *version),
+        WindowClosed { label, version, .. } => ("window_closed", label.as_str(), 0, *version),
+        WindowInstanceAssigned { label, version, .. } => ("window_instance_assigned", label.as_str(), 0, *version),
+        WindowInstanceReleased { label, version, .. } => ("window_instance_released", label.as_str(), 0, *version),
+        BackendWindowIdRegistered { label, version, .. } => ("backend_window_id_registered", label.as_str(), 0, *version),
+        BackendWindowIdUnregistered { label, version, .. } => ("backend_window_id_unregistered", label.as_str(), 0, *version),
+        PoolWindowAdded { label, version, .. } => ("pool_window_added", label.as_str(), 0, *version),
+        PoolWindowRemoved { label, version, .. } => ("pool_window_removed", label.as_str(), 0, *version),
+        PoolWindowPromoted { label, version, .. } => ("pool_window_promoted", label.as_str(), 0, *version),
+        HwndDriftDetected { kind: _, label, hwnd, version, .. } => (
+            "hwnd_drift_detected",
+            label.as_deref().unwrap_or(""),
+            hwnd.unwrap_or(0),
+            *version,
+        ),
+        DriftDetected { version, .. } => ("drift_detected", "", 0, *version),
+        CorrectiveWindowMove { hwnd, version, .. } => ("corrective_window_move", "", *hwnd, *version),
+        HostShouldQuit { version, .. } => ("host_should_quit", "", 0, *version),
+        // Conservative: events without obvious dedup keys still
+        // benefit from the cap. Use the variant name + version with
+        // empty label/hwnd; same-version duplicates drop.
+        other => {
+            let v = match serde_json::to_value(other).ok().and_then(|v| {
+                v.get("version").and_then(|x| x.as_u64())
+            }) {
+                Some(v) => v,
+                None => 0,
+            };
+            ("__catchall__", "", 0, v)
+        }
+    };
+    (format!("{}|{}|{}", kind, label, hwnd), version)
+}
+
+#[cfg(test)]
+mod bridge_dedup_tests {
+    //! Phase F.7 host-bridge dedup. The bridge's job is to amplify-zero —
+    //! one launcher event per `(kind, label, hwnd)` key, monotonic by
+    //! version. v0.33.688 smoke surfaced a 164× amplification (single
+    //! launcher emit at v=78, 164 lines logged by the renderer);
+    //! these tests pin the cap.
+    use super::*;
+    use agentmux_common::ipc::{HwndDriftKind, Severity};
+    use std::sync::Arc;
+
+    fn fresh_state() -> Arc<crate::state::AppState> {
+        Arc::new(crate::state::AppState::default())
+    }
+
+    fn drift_event(version: u64, label: &str, hwnd: u64) -> Event {
+        Event::HwndDriftDetected {
+            kind: HwndDriftKind::HiddenSinceOpen,
+            label: Some(label.to_string()),
+            hwnd: Some(hwnd),
+            detail: "test".to_string(),
+            severity: Severity::Warn,
+            version,
+        }
+    }
+
+    #[test]
+    fn first_dispatch_passes_gate() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(1, "window-x", 100)));
+    }
+
+    #[test]
+    fn duplicate_same_version_drops() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(78, "window-x", 100)));
+        for _ in 0..200 {
+            assert!(
+                !should_dispatch(&state, &drift_event(78, "window-x", 100)),
+                "same (kind,label,hwnd,version) must drop"
+            );
+        }
+    }
+
+    #[test]
+    fn higher_version_for_same_key_passes() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(5, "window-x", 100)));
+        assert!(should_dispatch(&state, &drift_event(6, "window-x", 100)));
+    }
+
+    #[test]
+    fn lower_version_for_same_key_drops() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(10, "window-x", 100)));
+        assert!(!should_dispatch(&state, &drift_event(9, "window-x", 100)));
+    }
+
+    #[test]
+    fn different_labels_dont_collide() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(78, "window-a", 100)));
+        assert!(should_dispatch(&state, &drift_event(78, "window-b", 200)));
+        assert!(should_dispatch(&state, &drift_event(78, "window-c", 300)));
+    }
+
+    #[test]
+    fn different_hwnds_dont_collide() {
+        let state = fresh_state();
+        assert!(should_dispatch(&state, &drift_event(78, "window-x", 100)));
+        // Same label, different hwnd (e.g. mid-promote re-link).
+        assert!(should_dispatch(&state, &drift_event(78, "window-x", 200)));
+    }
+
+    #[test]
+    fn drift_storm_replay_collapses_to_one() {
+        // Reproduce the v0.33.688 smoke pattern: 164 dispatches of
+        // an identical HiddenSinceOpen event. The bridge must emit
+        // at most ONE through `should_dispatch`.
+        let state = fresh_state();
+        let evt = drift_event(78, "window-ee4504a143984a4db9a1559f5b66ac21", 6162460);
+        let mut admitted = 0;
+        for _ in 0..164 {
+            if should_dispatch(&state, &evt) {
+                admitted += 1;
+            }
+        }
+        assert_eq!(admitted, 1, "bridge must amplify-zero same-version drift");
+    }
+
+    #[test]
+    fn dedup_cache_bounded() {
+        let state = fresh_state();
+        // 5000 unique labels — cache must not exceed MAX_DEDUP_KEYS (4096).
+        for i in 0..5000 {
+            let label = format!("window-{}", i);
+            let _ = should_dispatch(&state, &drift_event(1, &label, i as u64));
+        }
+        let len = state.launcher_bridge_dedup.lock().len();
+        assert!(
+            len <= 4096,
+            "cache size {} exceeds bound 4096 — eviction broken",
+            len
+        );
+    }
+
+    #[test]
+    fn distinct_event_kinds_dont_collide() {
+        let state = fresh_state();
+        let label = "window-x";
+        // Both at v=10, different kinds, same label — must both pass.
+        assert!(should_dispatch(
+            &state,
+            &Event::WindowOpened {
+                label: label.to_string(),
+                kind: agentmux_common::ipc::WindowKind::FullInstance,
+                parent_label: None,
+                version: 10,
+            }
+        ));
+        assert!(should_dispatch(&state, &drift_event(10, label, 100)));
     }
 }

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -479,19 +479,21 @@ mod bridge_dedup_tests {
         // not insertion order, so the previous implementation could
         // evict the just-inserted key. Now: VecDeque tracks insert
         // order; pop_front drops the oldest.
+        //
+        // Use version=2 (NOT 1) for every event so the v=1 restart
+        // sentinel doesn't fire each iteration and clear the cache
+        // (reagent P2 PR #722 round 3 anti-vacuity guard).
         let state = fresh_state();
-        // Fill cache with 5000 unique keys.
         for i in 0..5000 {
             let label = format!("window-{}", i);
-            assert!(should_dispatch(&state, &drift_event(1, &label, i as u64)));
+            assert!(should_dispatch(&state, &drift_event(2, &label, i as u64)));
         }
         let cache = state.launcher_bridge_dedup.lock();
         assert!(cache.len() <= 4096, "cache bounded at 4096");
         // First 904 keys (5000 - 4096) should have been evicted.
-        // Verify a few from the start are gone:
         assert!(!cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-0|0"));
         assert!(!cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-100|100"));
-        // Verify recent keys are retained:
+        // Recent keys retained.
         assert!(cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-4999|4999"));
     }
 }

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -21,10 +21,80 @@
 //
 // See `docs/specs/SPEC_B_7_3_LAUNCHER_EVENTS_TO_RENDERER_2026_04_29.md`.
 
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use agentmux_common::ipc::Event;
 use cef::{CefString, ImplBrowser, ImplFrame};
+
+/// Phase F.7 host-bridge dedup cache. Bounded FIFO map keyed by
+/// `"{event_kind}|{label}|{hwnd}"` → max version dispatched.
+///
+/// FIFO insertion order is tracked explicitly via `insertion_order`
+/// because std `HashMap::keys().next()` iteration order is undefined
+/// per-rebuild — the previous implementation could evict the
+/// just-inserted key (reagent P1 PR #722 round 1).
+///
+/// Reset on launcher restart sentinel (codex P1 PR #722 round 1):
+/// when the launcher's `event_version` resets to 1, any cached key
+/// holding a higher version blocks the v=1 event. Mirror the
+/// renderer-side guard's heuristic — clear the cache when we see a
+/// v=1 event AND any cached entry has a version > 0.
+#[derive(Default)]
+pub struct DedupCache {
+    seen: HashMap<String, u64>,
+    insertion_order: VecDeque<String>,
+}
+
+impl DedupCache {
+    pub fn new() -> Self {
+        Self {
+            seen: HashMap::new(),
+            insertion_order: VecDeque::new(),
+        }
+    }
+
+    /// Returns true if the event should be dispatched (strictly newer
+    /// for its key). Updates the cache as a side-effect when admitted.
+    /// Bounded at `cap`; on overflow, evicts the oldest insertion in
+    /// FIFO order.
+    pub fn check_and_record(&mut self, key: String, version: u64, cap: usize) -> bool {
+        if let Some(&seen) = self.seen.get(&key) {
+            if version <= seen {
+                return false;
+            }
+            // Update existing entry — don't reorder for this case;
+            // FIFO ordering is "first inserted, first evicted" not
+            // "least recently used".
+            self.seen.insert(key, version);
+            return true;
+        }
+        self.seen.insert(key.clone(), version);
+        self.insertion_order.push_back(key);
+        if self.seen.len() > cap {
+            if let Some(victim) = self.insertion_order.pop_front() {
+                self.seen.remove(&victim);
+            }
+        }
+        true
+    }
+
+    /// Clear the cache. Called on launcher-restart sentinel.
+    pub fn clear(&mut self) {
+        self.seen.clear();
+        self.insertion_order.clear();
+    }
+
+    /// True if any cached entry has a version above 0 — used as the
+    /// guard for the v=1 restart sentinel.
+    pub fn has_any_versioned_entry(&self) -> bool {
+        self.seen.values().any(|&v| v > 0)
+    }
+
+    pub fn len(&self) -> usize {
+        self.seen.len()
+    }
+}
 
 /// Forward a launcher event to every top-level renderer.
 ///
@@ -107,71 +177,81 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
 }
 
 /// Phase F.7 dedup gate. Returns `true` if the event is strictly
-/// newer for its `(event_kind, label, hwnd)` key and should be
-/// dispatched; `false` if a higher-or-equal version was already
-/// sent.
+/// newer for its key and should be dispatched; `false` if a
+/// higher-or-equal version was already sent.
 ///
 /// Mirrors the renderer-side `shouldDispatchLauncherEvent`. Bounded
 /// at 4096 keys with FIFO eviction so a long-running host can't
 /// leak unbounded state. Re-arrival of an evicted key bypasses the
 /// host gate but the renderer guard still catches it.
+///
+/// Restart sentinel (codex P1 PR #722 round 1): clear the cache
+/// when the launcher's event_version resets to 1 and any cached
+/// entry holds a higher version. Mirrors the renderer guard.
 fn should_dispatch(state: &Arc<crate::state::AppState>, event: &Event) -> bool {
     const MAX_DEDUP_KEYS: usize = 4096;
     let (key, version) = dedup_key(event);
     let mut cache = state.launcher_bridge_dedup.lock();
-    if let Some(&seen) = cache.get(&key) {
-        if version <= seen {
-            return false;
-        }
+    if version == 1 && cache.has_any_versioned_entry() {
+        cache.clear();
     }
-    cache.insert(key, version);
-    if cache.len() > MAX_DEDUP_KEYS {
-        // FIFO eviction — drop the first key by iteration order. Map
-        // iteration order isn't strictly insertion in std HashMap, but
-        // for this bounded-leak guard any victim is fine.
-        if let Some(victim) = cache.keys().next().cloned() {
-            cache.remove(&victim);
-        }
-    }
-    true
+    cache.check_and_record(key, version, MAX_DEDUP_KEYS)
 }
 
 /// Build the dedup cache key + extract the version for an event.
-/// Returns `("{kind}|{label}|{hwnd}", version)`. Missing label/hwnd
-/// fields contribute empty strings — kinds without those fields
-/// dedup by kind+version alone.
+/// Returns `("{kind}|{label}|{hwnd}", version)`.
+///
+/// `kind` for `HwndDriftDetected` is `"hwnd_drift_detected:{drift_kind}"`
+/// so HiddenSinceOpen and OffMonitor for the same `(label, hwnd)`
+/// don't collide (reagent P2 PR #722 round 2).
+///
+/// Unhandled variants are tagged with their serde discriminant
+/// (the `event` field of the JSON tagged-union) so different
+/// variants don't share the same `__catchall__` key (reagent P1
+/// PR #722 round 1).
 fn dedup_key(event: &Event) -> (String, u64) {
     use Event::*;
     let (kind, label, hwnd, version) = match event {
-        WindowOpened { label, version, .. } => ("window_opened", label.as_str(), 0u64, *version),
-        WindowClosed { label, version, .. } => ("window_closed", label.as_str(), 0, *version),
-        WindowInstanceAssigned { label, version, .. } => ("window_instance_assigned", label.as_str(), 0, *version),
-        WindowInstanceReleased { label, version, .. } => ("window_instance_released", label.as_str(), 0, *version),
-        BackendWindowIdRegistered { label, version, .. } => ("backend_window_id_registered", label.as_str(), 0, *version),
-        BackendWindowIdUnregistered { label, version, .. } => ("backend_window_id_unregistered", label.as_str(), 0, *version),
-        PoolWindowAdded { label, version, .. } => ("pool_window_added", label.as_str(), 0, *version),
-        PoolWindowRemoved { label, version, .. } => ("pool_window_removed", label.as_str(), 0, *version),
-        PoolWindowPromoted { label, version, .. } => ("pool_window_promoted", label.as_str(), 0, *version),
-        HwndDriftDetected { kind: _, label, hwnd, version, .. } => (
-            "hwnd_drift_detected",
+        WindowOpened { label, version, .. } => ("window_opened".to_string(), label.as_str(), 0u64, *version),
+        WindowClosed { label, version, .. } => ("window_closed".to_string(), label.as_str(), 0, *version),
+        WindowInstanceAssigned { label, version, .. } => ("window_instance_assigned".to_string(), label.as_str(), 0, *version),
+        WindowInstanceReleased { label, version, .. } => ("window_instance_released".to_string(), label.as_str(), 0, *version),
+        BackendWindowIdRegistered { label, version, .. } => ("backend_window_id_registered".to_string(), label.as_str(), 0, *version),
+        BackendWindowIdUnregistered { label, version, .. } => ("backend_window_id_unregistered".to_string(), label.as_str(), 0, *version),
+        PoolWindowAdded { label, version, .. } => ("pool_window_added".to_string(), label.as_str(), 0, *version),
+        PoolWindowRemoved { label, version, .. } => ("pool_window_removed".to_string(), label.as_str(), 0, *version),
+        PoolWindowPromoted { label, version, .. } => ("pool_window_promoted".to_string(), label.as_str(), 0, *version),
+        HwndDriftDetected { kind: drift_kind, label, hwnd, version, .. } => (
+            format!("hwnd_drift_detected:{:?}", drift_kind),
             label.as_deref().unwrap_or(""),
             hwnd.unwrap_or(0),
             *version,
         ),
-        DriftDetected { version, .. } => ("drift_detected", "", 0, *version),
-        CorrectiveWindowMove { hwnd, version, .. } => ("corrective_window_move", "", *hwnd, *version),
-        HostShouldQuit { version, .. } => ("host_should_quit", "", 0, *version),
-        // Conservative: events without obvious dedup keys still
-        // benefit from the cap. Use the variant name + version with
-        // empty label/hwnd; same-version duplicates drop.
+        DriftDetected { kind: drift_kind, version, .. } => (
+            format!("drift_detected:{:?}", drift_kind),
+            "",
+            0,
+            *version,
+        ),
+        CorrectiveWindowMove { hwnd, version, .. } => ("corrective_window_move".to_string(), "", *hwnd, *version),
+        HostShouldQuit { version, .. } => ("host_should_quit".to_string(), "", 0, *version),
+        // Catchall: extract the serde discriminant ("event" tag in
+        // the JSON tagged-union) so different unhandled variants
+        // don't collide on the same `__catchall__` key.
         other => {
-            let v = match serde_json::to_value(other).ok().and_then(|v| {
-                v.get("version").and_then(|x| x.as_u64())
-            }) {
-                Some(v) => v,
-                None => 0,
-            };
-            ("__catchall__", "", 0, v)
+            let value = serde_json::to_value(other).ok();
+            let event_tag = value
+                .as_ref()
+                .and_then(|v| v.get("event"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("__unknown__")
+                .to_string();
+            let v = value
+                .as_ref()
+                .and_then(|v| v.get("version"))
+                .and_then(|x| x.as_u64())
+                .unwrap_or(0);
+            (event_tag, "", 0, v)
         }
     };
     (format!("{}|{}|{}", kind, label, hwnd), version)
@@ -298,5 +378,120 @@ mod bridge_dedup_tests {
             }
         ));
         assert!(should_dispatch(&state, &drift_event(10, label, 100)));
+    }
+
+    #[test]
+    fn distinct_drift_kinds_dont_collide() {
+        // Reagent P2 PR #722 round 2: HwndDriftDetected key must
+        // include the drift kind, otherwise HiddenSinceOpen and
+        // OffMonitor for the same (label, hwnd) collide.
+        let state = fresh_state();
+        let label = "window-x";
+        let hwnd = 100u64;
+        let hidden = Event::HwndDriftDetected {
+            kind: HwndDriftKind::HiddenSinceOpen,
+            label: Some(label.to_string()),
+            hwnd: Some(hwnd),
+            detail: "h".into(),
+            severity: Severity::Warn,
+            version: 10,
+        };
+        let off = Event::HwndDriftDetected {
+            kind: HwndDriftKind::OffMonitor,
+            label: Some(label.to_string()),
+            hwnd: Some(hwnd),
+            detail: "o".into(),
+            severity: Severity::Warn,
+            version: 10,
+        };
+        assert!(should_dispatch(&state, &hidden));
+        assert!(
+            should_dispatch(&state, &off),
+            "different drift kinds at same (label, hwnd, version) must NOT collide"
+        );
+    }
+
+    #[test]
+    fn launcher_restart_sentinel_clears_cache() {
+        // Codex P1 PR #722 round 1: when launcher restarts and
+        // event_version resets to 1, prior cached entries with
+        // higher versions block the v=1 sentinel and subsequent
+        // low-version events. Cache must clear on the sentinel.
+        let state = fresh_state();
+        // Establish some prior-incarnation cache entries.
+        assert!(should_dispatch(&state, &drift_event(10, "window-a", 100)));
+        assert!(should_dispatch(&state, &drift_event(15, "window-b", 200)));
+        assert!(state.launcher_bridge_dedup.lock().has_any_versioned_entry());
+
+        // Launcher restarts: emits v=1 for some new window. Without
+        // the cache reset, the v=1 wouldn't necessarily collide
+        // (different label) but SUBSEQUENT low-version events for
+        // pre-existing labels would block. The reset is keyed off
+        // "v=1 with prior versions cached" — fires once, clears all.
+        let sentinel = Event::WindowOpened {
+            label: "main".into(),
+            kind: agentmux_common::ipc::WindowKind::FullInstance,
+            parent_label: None,
+            version: 1,
+        };
+        assert!(should_dispatch(&state, &sentinel));
+        // Cache should now contain only the sentinel + nothing else.
+        assert_eq!(
+            state.launcher_bridge_dedup.lock().len(),
+            1,
+            "restart sentinel clears cache before recording new entry"
+        );
+
+        // Subsequent low-version events for the same key must admit
+        // (cache no longer holds the stale higher version).
+        assert!(should_dispatch(
+            &state,
+            &Event::WindowOpened {
+                label: "window-a".into(),
+                kind: agentmux_common::ipc::WindowKind::FullInstance,
+                parent_label: None,
+                version: 2,
+            }
+        ));
+    }
+
+    #[test]
+    fn cold_v1_event_into_empty_cache_admits() {
+        // Anti-vacuity guard: a cold v=1 event with no prior cache
+        // is the first event of a fresh launcher and admits cleanly.
+        // The sentinel logic only fires when v=1 arrives WITH a
+        // pre-existing cache entry (renderer-side mirror), so a
+        // truly-empty-cache v=1 just admits without ceremony.
+        let state = fresh_state();
+        let evt = Event::WindowOpened {
+            label: "main".into(),
+            kind: agentmux_common::ipc::WindowKind::FullInstance,
+            parent_label: None,
+            version: 1,
+        };
+        assert!(should_dispatch(&state, &evt));
+        assert_eq!(state.launcher_bridge_dedup.lock().len(), 1);
+    }
+
+    #[test]
+    fn fifo_eviction_drops_oldest_not_newest() {
+        // Reagent P1 PR #722 round 1: HashMap iteration order is
+        // not insertion order, so the previous implementation could
+        // evict the just-inserted key. Now: VecDeque tracks insert
+        // order; pop_front drops the oldest.
+        let state = fresh_state();
+        // Fill cache with 5000 unique keys.
+        for i in 0..5000 {
+            let label = format!("window-{}", i);
+            assert!(should_dispatch(&state, &drift_event(1, &label, i as u64)));
+        }
+        let cache = state.launcher_bridge_dedup.lock();
+        assert!(cache.len() <= 4096, "cache bounded at 4096");
+        // First 904 keys (5000 - 4096) should have been evicted.
+        // Verify a few from the start are gone:
+        assert!(!cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-0|0"));
+        assert!(!cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-100|100"));
+        // Verify recent keys are retained:
+        assert!(cache.seen.contains_key("hwnd_drift_detected:HiddenSinceOpen|window-4999|4999"));
     }
 }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -512,6 +512,26 @@ pub struct AppState {
     /// `docs/specs/SPEC_PHASE_F_HOST_REDUCER_2026-05-01.md`.
     pub host_state: Mutex<crate::reducer::HostState>,
 
+    /// Phase F.7 host-bridge dedup. Keyed by `"{event_kind}|{label}|{hwnd}"`,
+    /// value is the highest launcher-event version dispatched to renderers
+    /// for that key. The bridge skips dispatch if the incoming event's
+    /// version is `<=` the cached version — preserving subscriber
+    /// idempotency under §8.14 even if the renderer-side guard fails
+    /// (multiple V8 contexts, fresh-renderer post-crash, race during
+    /// init, etc.).
+    ///
+    /// Originally proposed in `ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`
+    /// §4.4 / master spec §9.8 as Phase F.7. Implementation forced when
+    /// v0.33.688 smoke surfaced a 164× amplification of a single
+    /// `HiddenSinceOpen` drift event v=78 — launcher cap (PR #721)
+    /// prevented multi-emit but the bridge fanned the one event into
+    /// many V8 contexts, exhausting the renderer.
+    ///
+    /// Bounded at 4096 keys with FIFO eviction (insertion order). A
+    /// re-arrival for an evicted key bypasses dedup once but the
+    /// renderer guard still catches it.
+    pub launcher_bridge_dedup: Mutex<std::collections::HashMap<String, u64>>,
+
     /// Linux/macOS only — registry of live top-level `CefWindow` handles,
     /// keyed by window label ("main" for the primary, otherwise the label
     /// CreateWindowTask assigns to a sub-window). Populated by
@@ -640,6 +660,7 @@ impl Default for AppState {
             // browsers field removed in H.2.e — see comment near struct decl.
             window_meta: Mutex::new(HashMap::new()),
             host_state: Mutex::new(crate::reducer::HostState::default()),
+            launcher_bridge_dedup: Mutex::new(std::collections::HashMap::new()),
             #[cfg(not(target_os = "windows"))]
             windows: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -530,7 +530,7 @@ pub struct AppState {
     /// Bounded at 4096 keys with FIFO eviction (insertion order). A
     /// re-arrival for an evicted key bypasses dedup once but the
     /// renderer guard still catches it.
-    pub launcher_bridge_dedup: Mutex<std::collections::HashMap<String, u64>>,
+    pub launcher_bridge_dedup: Mutex<crate::launcher_event_bridge::DedupCache>,
 
     /// Linux/macOS only — registry of live top-level `CefWindow` handles,
     /// keyed by window label ("main" for the primary, otherwise the label
@@ -660,7 +660,7 @@ impl Default for AppState {
             // browsers field removed in H.2.e — see comment near struct decl.
             window_meta: Mutex::new(HashMap::new()),
             host_state: Mutex::new(crate::reducer::HostState::default()),
-            launcher_bridge_dedup: Mutex::new(std::collections::HashMap::new()),
+            launcher_bridge_dedup: Mutex::new(crate::launcher_event_bridge::DedupCache::new()),
             #[cfg(not(target_os = "windows"))]
             windows: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.689"
+version = "0.33.690"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.690"
+version = "0.33.691"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.691"
+version = "0.33.692"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.688"
+version = "0.33.689"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.688"
+version = "0.33.689"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.690"
+version = "0.33.691"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.691"
+version = "0.33.692"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.689"
+version = "0.33.690"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1747,6 +1747,221 @@ fn hidden_since_open_cap_survives_duplicate_open() {
 }
 
 #[test]
+fn off_monitor_drift_fires_at_most_once_per_window() {
+    // Companion cap to HiddenSinceOpen. apply_hwnd_position_changed
+    // fires per WM_MOVE; without the cap, dragging an off-monitor
+    // window storms the renderer.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportMonitorTopologyChanged {
+            rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w-off".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xEE,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("w-off".into()),
+        },
+        &c,
+    );
+    // Foreground first so corrective is suppressed (we test
+    // OffMonitor drift independently).
+    let _ = update(
+        &mut state,
+        Command::ReportHwndForegroundChanged { hwnd: 0xEE },
+        &c,
+    );
+    // First off-monitor position → drift fires.
+    let first = update(
+        &mut state,
+        Command::ReportHwndPositionChanged {
+            hwnd: 0xEE,
+            rect: Rect { left: 5000, top: 5000, right: 5500, bottom: 5400 },
+        },
+        &c,
+    );
+    assert_eq!(
+        first.iter().filter(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. }
+        )).count(),
+        1,
+        "first off-monitor position emits drift exactly once"
+    );
+
+    // 100 more off-monitor moves: drift must NOT re-fire.
+    let mut subsequent = 0;
+    for i in 0..100 {
+        let dx = i * 10;
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xEE,
+                rect: Rect {
+                    left: 5000 + dx,
+                    top: 5000,
+                    right: 5500 + dx,
+                    bottom: 5400,
+                },
+            },
+            &c,
+        );
+        subsequent += evs.iter().filter(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. }
+        )).count();
+    }
+    assert_eq!(subsequent, 0, "cap suppresses subsequent OffMonitor drift");
+}
+
+#[test]
+fn corrective_window_move_fires_at_most_once_per_window() {
+    // Same cap shape for the self-heal corrective. Without it, a
+    // never-foregrounded window dragged through off-monitor regions
+    // emits CorrectiveWindowMove every move.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportMonitorTopologyChanged {
+            rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w-corr".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xFF,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("w-corr".into()),
+        },
+        &c,
+    );
+    // Note: NOT foregrounded — that's the corrective trigger.
+    let first = update(
+        &mut state,
+        Command::ReportHwndPositionChanged {
+            hwnd: 0xFF,
+            rect: Rect { left: 5000, top: 5000, right: 5500, bottom: 5400 },
+        },
+        &c,
+    );
+    assert_eq!(
+        first.iter().filter(|e| matches!(e, Event::CorrectiveWindowMove { .. })).count(),
+        1,
+        "first off-monitor + never-foregrounded emits corrective"
+    );
+    // Subsequent off-monitor moves: no more corrective.
+    let mut subsequent = 0;
+    for i in 0..100 {
+        let evs = update(
+            &mut state,
+            Command::ReportHwndPositionChanged {
+                hwnd: 0xFF,
+                rect: Rect {
+                    left: 5000 + i * 10,
+                    top: 5000,
+                    right: 5500 + i * 10,
+                    bottom: 5400,
+                },
+            },
+            &c,
+        );
+        subsequent += evs.iter().filter(|e| matches!(
+            e,
+            Event::CorrectiveWindowMove { .. }
+        )).count();
+    }
+    assert_eq!(subsequent, 0, "cap suppresses subsequent corrective emissions");
+}
+
+#[test]
+fn off_monitor_drift_cap_survives_duplicate_open() {
+    // Same monotonicity discipline as hidden_since_open_emitted.
+    // After cap fires, a duplicate ReportWindowOpened must preserve
+    // the cap or the storm re-arms.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportMonitorTopologyChanged {
+            rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w-dup-off".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xAB,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("w-dup-off".into()),
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndForegroundChanged { hwnd: 0xAB },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndPositionChanged {
+            hwnd: 0xAB,
+            rect: Rect { left: 5000, top: 5000, right: 5500, bottom: 5400 },
+        },
+        &c,
+    );
+    assert!(state.windows.get("w-dup-off").unwrap().off_monitor_drift_emitted);
+
+    // Duplicate open — cap must survive.
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w-dup-off".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    assert!(
+        state.windows.get("w-dup-off").unwrap().off_monitor_drift_emitted,
+        "cap survives duplicate open"
+    );
+}
+
+#[test]
 fn promote_for_label_without_window_mirror_emits_event_idempotently() {
     // The handler's idempotency contract: ReportPoolWindowPromoted
     // can arrive without a paired ReportWindowOpened (e.g. the open

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1899,6 +1899,90 @@ fn corrective_window_move_fires_at_most_once_per_window() {
 }
 
 #[test]
+fn off_monitor_cap_blocks_repeated_topology_change_emissions() {
+    // Codex P2 PR #722 round 3: display hot-plug emits
+    // ReportMonitorTopologyChanged repeatedly. If a window stays
+    // stranded across multiple topology events, drift was being
+    // re-emitted every event because apply_monitor_topology_changed
+    // didn't consult the off_monitor_drift_emitted cap.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportMonitorTopologyChanged {
+            rects: vec![Rect { left: 0, top: 0, right: 1920, bottom: 1080 }],
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "w-strand".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xCD,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("w-strand".into()),
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndForegroundChanged { hwnd: 0xCD },
+        &c,
+    );
+    // Park the window where it WILL be stranded by topology change.
+    let _ = update(
+        &mut state,
+        Command::ReportHwndPositionChanged {
+            hwnd: 0xCD,
+            rect: Rect { left: 1000, top: 100, right: 1500, bottom: 600 },
+        },
+        &c,
+    );
+    // Topology change strands the window.
+    let first = update(
+        &mut state,
+        Command::ReportMonitorTopologyChanged {
+            rects: vec![Rect { left: 0, top: 0, right: 800, bottom: 600 }],
+        },
+        &c,
+    );
+    assert_eq!(
+        first.iter().filter(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. }
+        )).count(),
+        1,
+        "first stranding emits drift once"
+    );
+
+    // Repeated topology changes (e.g. user toggles displays multiple
+    // times). Window stays stranded but cap should suppress.
+    let mut subsequent = 0;
+    for _ in 0..50 {
+        let evs = update(
+            &mut state,
+            Command::ReportMonitorTopologyChanged {
+                rects: vec![Rect { left: 0, top: 0, right: 800, bottom: 600 }],
+            },
+            &c,
+        );
+        subsequent += evs.iter().filter(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::OffMonitor, .. }
+        )).count();
+    }
+    assert_eq!(subsequent, 0, "cap suppresses repeated topology-change OffMonitor");
+}
+
+#[test]
 fn off_monitor_drift_cap_survives_duplicate_open() {
     // Same monotonicity discipline as hidden_since_open_emitted.
     // After cap fires, a duplicate ReportWindowOpened must preserve

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -132,11 +132,16 @@ pub(super) fn handle_report_window_opened(
     //   window per session. A duplicate open that resets this to
     //   false would re-arm the storm cap, then the next visibility
     //   transition fires HiddenSinceOpen a second time.
-    let (prior_foregrounded, prior_hidden_emitted) = state
+    let (prior_foregrounded, prior_hidden_emitted, prior_off_monitor_emitted, prior_corrective_emitted) = state
         .windows
         .get(&label)
-        .map(|m| (m.foregrounded_since_open, m.hidden_since_open_emitted))
-        .unwrap_or((false, false));
+        .map(|m| (
+            m.foregrounded_since_open,
+            m.hidden_since_open_emitted,
+            m.off_monitor_drift_emitted,
+            m.corrective_window_move_emitted,
+        ))
+        .unwrap_or((false, false, false, false));
 
     state.windows.insert(
         label.clone(),
@@ -156,6 +161,8 @@ pub(super) fn handle_report_window_opened(
             last_foreground_at_ms: None,
             foregrounded_since_open: was_just_promoted || prior_foregrounded,
             hidden_since_open_emitted: prior_hidden_emitted,
+            off_monitor_drift_emitted: prior_off_monitor_emitted,
+            corrective_window_move_emitted: prior_corrective_emitted,
         },
     );
     let mut out = Vec::with_capacity(2);

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -121,19 +121,32 @@ pub struct WindowMirror {
     /// since its `ReportWindowOpened`? Used to fire `HiddenSinceOpen`
     /// drift on the first hide event when this is still false.
     pub foregrounded_since_open: bool,
-    /// Drift-storm fix (post-PR-#720 follow-up): `HiddenSinceOpen`
-    /// drift only fires ONCE per window per session. Without this
-    /// cap, a fresh top-level window that goes through several
-    /// SetWindowPos transitions during host placement re-emits the
-    /// same drift event for every intermediate `visible=false`
+    /// Drift-storm fix: `HiddenSinceOpen` / `OffMonitor` /
+    /// `CorrectiveWindowMove` each fire AT MOST ONCE per window per
+    /// session. Without these caps, a fresh top-level window that
+    /// goes through several SetWindowPos transitions during host
+    /// placement re-emits the same event for every intermediate
     /// snapshot — observed up to 170 events in 1 second, exhausting
-    /// the renderer's V8 stack and crashing it. Cap fires once,
+    /// the renderer's V8 stack and crashing it. The cap fires once;
     /// subscribers still see the signal, no storm.
+    ///
+    /// `OffMonitor` shares the same risk as `HiddenSinceOpen` because
+    /// `apply_hwnd_position_changed` fires per WM_MOVE — dragging an
+    /// already-off-monitor window emits drift on every pixel.
+    /// `CorrectiveWindowMove` rides with it (fires per position
+    /// change while `!foregrounded_since_open`).
+    ///
+    /// All three flags are monotonic for a window's lifetime: once
+    /// true, never reset (preserve via OR-with-prior on duplicate
+    /// `ReportWindowOpened`, codex P2 PR #708 round 3).
+    ///
     /// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`
-    /// for the original storm context (this is the second instance
-    /// — pool-promote path was caught in PR #708, direct-open path
-    /// in this PR).
+    /// for storm context.
     pub hidden_since_open_emitted: bool,
+    /// See `hidden_since_open_emitted` doc above.
+    pub off_monitor_drift_emitted: bool,
+    /// See `hidden_since_open_emitted` doc above.
+    pub corrective_window_move_emitted: bool,
 }
 
 /// Top-level launcher state. Single Arc<Mutex<State>> owned by the

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -499,10 +499,17 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
     // the corrective trigger (we always want to move a window off
     // the sentinel before the user notices), even though it's
     // suppressed for drift to avoid log noise.
-    if !r.foregrounded_since_open && !r.corrective_window_move_emitted {
-        if pick_primary_centered(&monitors).is_some() {
-            fire_corrective = true;
-        }
+    //
+    // Compute the corrective target ONCE (reagent P2 PR #722 round 2)
+    // — used both as the gate for `fire_corrective` and as the
+    // event payload below.
+    let corrective_target = if !r.foregrounded_since_open && !r.corrective_window_move_emitted {
+        pick_primary_centered(&monitors)
+    } else {
+        None
+    };
+    if corrective_target.is_some() {
+        fire_corrective = true;
     }
 
     if fire_drift {
@@ -530,23 +537,21 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
         });
     }
 
-    if fire_corrective {
-        if let Some(target) = pick_primary_centered(&monitors) {
-            if let Some((_, mirror)) = state
-                .windows
-                .iter_mut()
-                .find(|(_, m)| m.hwnd == Some(hwnd))
-            {
-                mirror.corrective_window_move_emitted = true;
-            }
-            let v = state.bump_version();
-            events.push(Event::CorrectiveWindowMove {
-                hwnd,
-                target_rect: target,
-                reason: HwndDriftKind::OffMonitor,
-                version: v,
-            });
+    if let Some(target) = corrective_target.filter(|_| fire_corrective) {
+        if let Some((_, mirror)) = state
+            .windows
+            .iter_mut()
+            .find(|(_, m)| m.hwnd == Some(hwnd))
+        {
+            mirror.corrective_window_move_emitted = true;
         }
+        let v = state.bump_version();
+        events.push(Event::CorrectiveWindowMove {
+            hwnd,
+            target_rect: target,
+            reason: HwndDriftKind::OffMonitor,
+            version: v,
+        });
     }
 
     events

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -443,10 +443,19 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
     // Resolve the mirror: collect everything we need from a scoped
     // borrow, then release it before calling `state.bump_version()`
     // (rustc E0499 — same trick as `apply_hwnd_opened`).
+    //
+    // Storm-cap snapshot: capture the prior emit-flags so the gate
+    // logic below knows whether each side-effect has fired before.
+    // `apply_hwnd_position_changed` fires per WM_MOVE during a
+    // drag — without the caps, a window dragged across an off-
+    // monitor region storms the renderer with drift + corrective
+    // events.
     struct Resolved {
         label: String,
         off_monitor: bool,
         foregrounded_since_open: bool,
+        off_monitor_drift_emitted: bool,
+        corrective_window_move_emitted: bool,
     }
     let resolved: Option<Resolved> = state
         .windows
@@ -460,6 +469,8 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
                 label: label.clone(),
                 off_monitor,
                 foregrounded_since_open: mirror.foregrounded_since_open,
+                off_monitor_drift_emitted: mirror.off_monitor_drift_emitted,
+                corrective_window_move_emitted: mirror.corrective_window_move_emitted,
             }
         });
 
@@ -472,8 +483,38 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
     }
 
     // Window is off all monitors. Fire drift unless we're in the
-    // open-transient sentinel state (per above).
-    if !is_sentinel {
+    // open-transient sentinel state (per above) OR the cap has
+    // already fired for this window.
+    let mut fire_drift = false;
+    let mut fire_corrective = false;
+    if !is_sentinel && !r.off_monitor_drift_emitted {
+        fire_drift = true;
+    }
+
+    // Phase B.9.2 — pure-reducer self-heal. If the window has
+    // never been foregrounded, this off-monitor state is from the
+    // open transition (NOT user action), so we emit a corrective
+    // move. The host's WRR subscriber applies it via SetWindowPos
+    // on the UI thread. The Win32 hidden sentinel is INCLUDED in
+    // the corrective trigger (we always want to move a window off
+    // the sentinel before the user notices), even though it's
+    // suppressed for drift to avoid log noise.
+    if !r.foregrounded_since_open && !r.corrective_window_move_emitted {
+        if pick_primary_centered(&monitors).is_some() {
+            fire_corrective = true;
+        }
+    }
+
+    if fire_drift {
+        // Mark the cap before bumping the version so re-entrant
+        // event handlers see consistent state.
+        if let Some((_, mirror)) = state
+            .windows
+            .iter_mut()
+            .find(|(_, m)| m.hwnd == Some(hwnd))
+        {
+            mirror.off_monitor_drift_emitted = true;
+        }
         let v = state.bump_version();
         events.push(Event::HwndDriftDetected {
             kind: HwndDriftKind::OffMonitor,
@@ -489,16 +530,15 @@ pub fn apply_hwnd_position_changed(state: &mut State, hwnd: u64, new_rect: Rect)
         });
     }
 
-    // Phase B.9.2 — pure-reducer self-heal. If the window has
-    // never been foregrounded, this off-monitor state is from the
-    // open transition (NOT user action), so we emit a corrective
-    // move. The host's WRR subscriber applies it via SetWindowPos
-    // on the UI thread. The Win32 hidden sentinel is INCLUDED in
-    // the corrective trigger (we always want to move a window off
-    // the sentinel before the user notices), even though it's
-    // suppressed for drift to avoid log noise.
-    if !r.foregrounded_since_open {
+    if fire_corrective {
         if let Some(target) = pick_primary_centered(&monitors) {
+            if let Some((_, mirror)) = state
+                .windows
+                .iter_mut()
+                .find(|(_, m)| m.hwnd == Some(hwnd))
+            {
+                mirror.corrective_window_move_emitted = true;
+            }
             let v = state.bump_version();
             events.push(Event::CorrectiveWindowMove {
                 hwnd,

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -608,10 +608,17 @@ pub fn apply_monitor_topology_changed(state: &mut State, rects: Vec<Rect>) -> Ve
         return vec![];
     }
     let mut events: Vec<Event> = Vec::new();
+    // Gate emission on `off_monitor_drift_emitted` (codex P2 PR
+    // #722 round 3): without this, repeated topology changes
+    // (display hot-plug or rapid resolution change) re-emit drift
+    // for the same stranded window every event.
     let stranded: Vec<(String, u64, Rect)> = state
         .windows
         .iter()
         .filter_map(|(label, mirror)| {
+            if mirror.off_monitor_drift_emitted {
+                return None;
+            }
             let r = mirror.last_rect?;
             let h = mirror.hwnd?;
             if rect::intersects_any(&r, &monitors) {
@@ -622,6 +629,13 @@ pub fn apply_monitor_topology_changed(state: &mut State, rects: Vec<Rect>) -> Ve
         })
         .collect();
     for (label, hwnd, rect) in stranded {
+        if let Some((_, mirror)) = state
+            .windows
+            .iter_mut()
+            .find(|(l, _)| **l == label)
+        {
+            mirror.off_monitor_drift_emitted = true;
+        }
         let v = state.bump_version();
         events.push(Event::HwndDriftDetected {
             kind: HwndDriftKind::OffMonitor,

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.691"
+version = "0.33.692"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.688"
+version = "0.33.689"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.690"
+version = "0.33.691"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.689"
+version = "0.33.690"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.689",
+  "version": "0.33.690",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.689",
+      "version": "0.33.690",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.688",
+  "version": "0.33.689",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.688",
+      "version": "0.33.689",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.691",
+  "version": "0.33.692",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.691",
+      "version": "0.33.692",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.690",
+  "version": "0.33.691",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.690",
+      "version": "0.33.691",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.689",
+  "version": "0.33.690",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.690",
+  "version": "0.33.691",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.688",
+  "version": "0.33.689",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.691",
+  "version": "0.33.692",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third-layer cap on the drift-storm renderer crash class. Smoke testing of v0.33.688 surfaced a **164× amplification of a single launcher event**:

```
launcher: HiddenSinceOpen v=78 (emitted once — PR #721 cap works)
  ↓
host bridge: dispatch_to_renderers(v=78) (called once)
  ↓
renderer: logs [fe] [launcher-event] drift v=78 × 164
  ↓
V8 stack exhausted → renderer crash
```

Renderer-side guards (PR #708 dedup + `PerSourceTracker` version-stale drop) are installed but miss this case — suspect multi-V8-context fan-out (each browser has its own context; tracker state isn't shared) or a fresh renderer post-crash hitting an empty cache.

[`ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md) §4.4 / master spec §9.8 flagged this as **Phase F.7 — host bridge resilience**. Implementing now since the launcher cap alone isn't sufficient.

## Defense-in-depth, three layers

| Layer | Where | What | Shipped |
|---|---|---|---|
| 1 | launcher reducer | At-most-one `HiddenSinceOpen` per window via `hidden_since_open_emitted` | PR #721 |
| 2 | renderer guard + tracker | `shouldDispatchLauncherEvent` per-key cache + `PerSourceTracker.deliver` version-stale drop | PR #708 / #709 |
| 3 | **this PR** | host bridge per-`(kind,label,hwnd,version)` cap | new |

## Implementation

- New `AppState.launcher_bridge_dedup: Mutex<HashMap<String, u64>>` — key `"{event_kind}|{label}|{hwnd}"`, value max version dispatched.
- `dispatch_to_renderers` calls `should_dispatch(state, event)` before serializing or iterating browsers. Skip entirely if version `<=` cached.
- `dedup_key(event)` extracts key + version per Event variant. Window-tracking variants use label+hwnd; conservative catchall for the rest.
- Cache bounded at 4096 keys with FIFO eviction. Re-arrival of an evicted key bypasses the host gate but the renderer guard still catches it.

## Tests

9 new tests in `launcher_event_bridge::bridge_dedup_tests`:
- `first_dispatch_passes_gate`
- `duplicate_same_version_drops` — 200 identical events admitted=1
- `higher_version_for_same_key_passes`
- `lower_version_for_same_key_drops`
- `different_labels_dont_collide`
- `different_hwnds_dont_collide`
- `drift_storm_replay_collapses_to_one` — replays the exact v0.33.688 pattern (164 identical events) and asserts only 1 passes
- `dedup_cache_bounded` — 5000 unique keys → cache stays ≤ 4096
- `distinct_event_kinds_dont_collide` — different kinds at same version pass

96 host tests pass.

## Test plan

- [x] cargo test -p agentmux-cef — 96/96 pass
- [x] cargo check — clean
- [ ] Smoke: tear off + status-bar new window → no renderer crash