### PR TITLE
fix(frontend): wrap recordDispatch in untrack() — root cause of renderer storm crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.695"
+version = "0.33.696"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.695"
+version = "0.33.696"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.695"
+version = "0.33.696"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.695"
+version = "0.33.696"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.695 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.694 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.693 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.688 | 2026-05-06 | 162.2 MiB | 340.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.695"
+version = "0.33.696"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/launcher_event_bridge.rs
+++ b/agentmux-cef/src/launcher_event_bridge.rs
@@ -133,20 +133,9 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     // launcher's single emit. Skip the entire dispatch if the event's
     // version is not strictly higher than the per-key max we've
     // already sent.
-    let (dedup_key_str, dedup_version) = dedup_key(event);
     if !should_dispatch(state, event) {
-        tracing::warn!(
-            target: "launcher-event-bridge",
-            "[launcher-event-bridge] dedup BLOCKED: key={} v={}",
-            dedup_key_str, dedup_version
-        );
         return;
     }
-    tracing::warn!(
-        target: "launcher-event-bridge",
-        "[launcher-event-bridge] dedup PASSED: key={} v={}",
-        dedup_key_str, dedup_version
-    );
 
     let json = match serde_json::to_string(event) {
         Ok(s) => s,
@@ -171,35 +160,20 @@ pub fn dispatch_to_renderers(state: &Arc<crate::state::AppState>, event: &Event)
     // Two-lock variants race against `promote_pool_window` between
     // the reads.
     let (pool_inventory, browsers) = state.user_visibility_snapshot();
-    let total_browsers = browsers.len();
-    let mut fanout_count = 0usize;
-    let mut skipped_pane = 0usize;
-    let mut skipped_pool = 0usize;
 
     for (label, browser) in browsers {
         if label.starts_with("browser-pane-") {
-            skipped_pane += 1;
             continue;
         }
         if pool_inventory.contains(label.as_str()) {
-            skipped_pool += 1;
+            // Pool inventory (unpromoted or ready-queued) — no user
+            // UI yet, skip.
             continue;
         }
         if let Some(frame) = browser.main_frame() {
             frame.execute_java_script(Some(&code), Some(&url), 0);
-            fanout_count += 1;
-            tracing::warn!(
-                target: "launcher-event-bridge",
-                "[launcher-event-bridge] FANOUT label={} key={} v={}",
-                label, dedup_key_str, dedup_version
-            );
         }
     }
-    tracing::warn!(
-        target: "launcher-event-bridge",
-        "[launcher-event-bridge] dispatch_summary key={} v={} total_browsers={} fanout={} skipped_pane={} skipped_pool={}",
-        dedup_key_str, dedup_version, total_browsers, fanout_count, skipped_pane, skipped_pool
-    );
 }
 
 /// Phase F.7 dedup gate. Returns `true` if the event is strictly

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.695"
+version = "0.33.696"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.695"
+version = "0.33.696"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.695"
+version = "0.33.696"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/command-source.test.ts
+++ b/frontend/app/store/command-source.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { beforeEach, describe, expect, it } from "vitest";
+import { createEffect, createRoot, createSignal } from "solid-js";
 import {
     __resetDispatchLog,
     describeSource,
@@ -82,6 +83,45 @@ describe("command-source / dispatch log", () => {
             at: 1,
         });
         expect(dispatchRecordsAtom()).toHaveLength(1);
+    });
+
+    // Regression: storm-crash root cause — `recordDispatch` called from
+    // inside a SolidJS reactive context (e.g. the launcher-event reducer's
+    // createEffect) must NOT establish a dependency on `recordsAtom`.
+    // Without `untrack`, the read+write pair on recordsAtom caused the
+    // outer effect to re-run on every dispatch, observed as ~3000×
+    // runaway and renderer V8-stack crash on the storm path.
+    it("does not register reactive deps when called from inside createEffect", async () => {
+        let outerEffectRunCount = 0;
+        const dispose = createRoot((d) => {
+            const [trigger, setTrigger] = createSignal(0);
+            createEffect(() => {
+                trigger();
+                outerEffectRunCount++;
+                recordDispatch({
+                    slice: "test",
+                    key: null,
+                    command: { type: "X" },
+                    events: [],
+                    source: "system",
+                    at: outerEffectRunCount,
+                });
+            });
+            // SolidJS schedules effects on microtask; flush synchronously
+            // by triggering the signal a 2nd time after the first commit.
+            queueMicrotask(() => setTrigger((n) => n + 1));
+            return d;
+        });
+        // Wait for both microtask + any subsequent ones (if there's a
+        // leak the count would balloon; bound the wait by yielding twice).
+        await Promise.resolve();
+        await Promise.resolve();
+        await new Promise((r) => setTimeout(r, 0));
+        dispose();
+        // Initial run + one explicit trigger = 2 runs total. Anything
+        // more means recordDispatch leaked a reactive dep on recordsAtom
+        // (the storm-crash root cause).
+        expect(outerEffectRunCount).toBe(2);
     });
 
     it("describeSource handles all variants", () => {

--- a/frontend/app/store/command-source.ts
+++ b/frontend/app/store/command-source.ts
@@ -20,7 +20,7 @@
  * concrete debugging need surfaces (per the plan's lean default).
  */
 
-import { createSignal, type Accessor } from "solid-js";
+import { createSignal, untrack, type Accessor } from "solid-js";
 
 /**
  * Who initiated a command. Defaults to `"system"` when not specified
@@ -71,11 +71,19 @@ export const dispatchRecordsAtom: Accessor<ReadonlyArray<DispatchRecord>> = reco
  * function. Trims to RING_CAPACITY by dropping oldest first.
  */
 export function recordDispatch(record: DispatchRecord): void {
-    const prev = recordsAtom();
-    const next = prev.length >= RING_CAPACITY
-        ? [...prev.slice(prev.length - RING_CAPACITY + 1), record]
-        : [...prev, record];
-    setRecordsAtom(next);
+    // Read inside `untrack` so this call doesn't establish reactive
+    // deps when invoked from a SolidJS reactive context (e.g. the
+    // launcher-event reducer's createEffect dispatches through here).
+    // Without this, the read+write pair on `recordsAtom` causes the
+    // outer effect to re-run on every dispatch — observed as a
+    // ~3000× runaway and renderer V8-stack crash on the storm path.
+    untrack(() => {
+        const prev = recordsAtom();
+        const next = prev.length >= RING_CAPACITY
+            ? [...prev.slice(prev.length - RING_CAPACITY + 1), record]
+            : [...prev, record];
+        setRecordsAtom(next);
+    });
 }
 
 /**

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -109,13 +109,11 @@ function project(): void {
  * pre-refactor behavior); the rest are silent. The diagnostics-panel
  * surface will hook this once PR-C ships.
  */
-let onAuditCount = 0;
 function onAuditEvent(event: LauncherEventReducerEvent): void {
-    onAuditCount++;
     if (event.type === "drift-detected") {
-        console.warn(`[launcher-event] drift #${onAuditCount}`, event.raw);
+        console.warn("[launcher-event] drift", event.raw);
     } else if (event.type === "saga-event-observed") {
-        console.info(`[launcher-event] #${onAuditCount}`, event.eventName, event.raw);
+        console.info("[launcher-event]", event.eventName, event.raw);
     }
 }
 
@@ -144,13 +142,8 @@ export function startLauncherEventReducer(): void {
     if (started) return;
     started = true;
 
-    let effectRunCount = 0;
     createEffect(() => {
-        effectRunCount++;
         const evt = launcherEvent();
-        const v = (evt as any)?.version ?? "??";
-        const ev = (evt as any)?.event ?? "??";
-        (window as any).console.error(`[diag] EFFECT run #${effectRunCount} evt=${ev} v=${v}`);
         // Read version too so SolidJS tracks the version signal as a
         // dependency — guarantees the effect re-runs even when two
         // consecutive events have referentially-equal payloads (e.g.

--- a/frontend/util/launcher-events.ts
+++ b/frontend/util/launcher-events.ts
@@ -186,21 +186,8 @@ export function __resetDedupForTests(): void {
 export function installLauncherEventBridge(): void {
     if (installed) return;
     installed = true;
-    let bridgeCallCount = 0;
-    let dedupBlockCount = 0;
     (window as any).__agentmux_launcher_event = (evt: LauncherEvent) => {
-        bridgeCallCount++;
-        const before = dedupSuppressedCount;
-        if (!shouldDispatchLauncherEvent(evt)) {
-            dedupBlockCount++;
-            const k = (evt as any)?.event ?? "??";
-            const v = (evt as any)?.version ?? "??";
-            (window as any).console.error(`[diag] BRIDGE BLOCKED #${bridgeCallCount} (blocks=${dedupBlockCount} suppressed=${dedupSuppressedCount}) key=${k} v=${v}`);
-            return;
-        }
-        const k = (evt as any)?.event ?? "??";
-        const v = (evt as any)?.version ?? "??";
-        (window as any).console.error(`[diag] BRIDGE PASSED #${bridgeCallCount} key=${k} v=${v} (suppressed_before=${before})`);
+        if (!shouldDispatchLauncherEvent(evt)) return;
         tracker.deliver(evt);
     };
     console.log("[launcher-events] bridge installed; window.__agentmux_launcher_event ready");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.694",
+  "version": "0.33.695",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.694",
+      "version": "0.33.695",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.695",
+  "version": "0.33.696",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Found the actual root cause of the renderer storm crashes that PRs #708 / #721 / #722 were trying to address. Those PRs added host-side dedup/fan-out caps (treating symptoms — per-event flood reaching the renderer); the disease is a **per-effect SolidJS feedback loop** that turns one event into thousands of console.warn calls.

## Diagnosis

Built a diagnostic build (v0.33.695) with counters at:
- host bridge `should_dispatch` and `dispatch_to_renderers` fan-out
- frontend `__agentmux_launcher_event` bridge call counter
- frontend `createEffect` re-run counter

Repro on v0.33.695, opening a browser widget pane:
- **Launcher**: emitted `pool_window_added v=7` once (cap held)
- **Host bridge**: dispatched once, `fanout=2` (correct: 2 user-visible browsers)
- **Frontend bridge**: 1 call per V8 context (dedup correct)
- **SolidJS effect**: re-ran **3230+ times in 1.2 sec** for that one event
- Each re-run -> drift-detected audit -> `console.warn` -> `fe_log_structured` RPC -> renderer V8 stack exhaustion -> Crashpad

## Root cause

`recordDispatch` (`command-source.ts:74`) reads `recordsAtom()` and writes `setRecordsAtom(next)` in the same call. The launcher-event reducer's `createEffect` calls `dispatch -> recordDispatch`. The bare `recordsAtom()` getter, called inside the effect's reactive context, registers `recordsAtom` as a tracked dep of the effect. The subsequent `setRecordsAtom` write re-fires the effect -> dispatch again -> recordDispatch again -> infinite loop.

## Fix

Wrap the read+write pair in `untrack()`. `recordDispatch` is a passive ring-buffer log and should never establish reactive deps.

## Test plan

- [x] New regression test in `command-source.test.ts` — drives a `createEffect` that calls `recordDispatch`, asserts effect runs exactly once per explicit trigger
- [x] Test fails on the un-fixed code (confirmed locally)
- [x] All 6 command-source tests pass with the fix
- [ ] Smoke test the post-merge portable: open browser widget pane, tear off tab + open new window from hamburger — neither should crash the renderer

## Notes for review

The host-side caps from #708/#721/#722 are still useful defense-in-depth. This PR doesn't remove them; it eliminates the actual amplifier downstream of where they sit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)