### PR TITLE
fix(launcher): placement grace for HiddenSinceOpen drift detector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.698"
+version = "0.33.699"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.698"
+version = "0.33.699"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.698"
+version = "0.33.699"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.698"
+version = "0.33.699"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,8 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.697 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
+| 0.33.696 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.695 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.694 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.693 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.697"
+version = "0.33.698"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.698"
+version = "0.33.699"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.697"
+version = "0.33.698"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.698"
+version = "0.33.699"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.697"
+version = "0.33.698"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.698"
+version = "0.33.699"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -83,7 +83,15 @@ mod connection;
 /// (panics are reserved for internal invariant violations).
 pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
     let _ = ctx.conn_id; // reserved for B.4 routing
-    match cmd {
+
+    // Heartbeat-via-traffic: drain any deferred hidden-since-open
+    // drifts whose grace window has now expired. Catches windows
+    // that hid during placement and produced no further visibility
+    // events; any subsequent reducer call past the grace promotes
+    // the deferred state to a fired drift.
+    let mut deferred = crate::wrr::drain_deferred_hidden_since_open(state, ctx.now_ms);
+
+    let mut cmd_events = match cmd {
         Command::Register {
             kind,
             pid,
@@ -535,7 +543,9 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
                 version: v,
             }]
         }
-    }
+    };
+    deferred.append(&mut cmd_events);
+    deferred
 }
 
 

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -258,7 +258,7 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             if let Some(err) = connection::enforce_host_only(state, ctx, "ReportHwndVisibilityChanged") {
                 return vec![err];
             }
-            crate::wrr::apply_hwnd_visibility_changed(state, hwnd, visible)
+            crate::wrr::apply_hwnd_visibility_changed(state, hwnd, visible, ctx.now_ms)
         }
         Command::ReportHwndForegroundChanged { hwnd } => {
             if let Some(err) = connection::enforce_host_only(state, ctx, "ReportHwndForegroundChanged") {

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -84,13 +84,6 @@ mod connection;
 pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
     let _ = ctx.conn_id; // reserved for B.4 routing
 
-    // Heartbeat-via-traffic: drain any deferred hidden-since-open
-    // drifts whose grace window has now expired. Catches windows
-    // that hid during placement and produced no further visibility
-    // events; any subsequent reducer call past the grace promotes
-    // the deferred state to a fired drift.
-    let mut deferred = crate::wrr::drain_deferred_hidden_since_open(state, ctx.now_ms);
-
     let mut cmd_events = match cmd {
         Command::Register {
             kind,
@@ -544,8 +537,20 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             }]
         }
     };
-    deferred.append(&mut cmd_events);
-    deferred
+
+    // Heartbeat-via-traffic: drain any deferred hidden-since-open
+    // drifts AFTER the command processes. Running this AFTER (not
+    // before) is critical — the command itself may legitimately clear
+    // the deferred state (visible=true / foreground / window closed),
+    // and a pre-command drain would fire spurious drift on an event
+    // whose own purpose is the recovery (codex P2 PR #725 round 2).
+    //
+    // Catches windows that hid during placement and produced no
+    // further visibility events: any subsequent unrelated command
+    // past the grace promotes the deferred state to a fired drift.
+    let mut deferred = crate::wrr::drain_deferred_hidden_since_open(state, ctx.now_ms);
+    cmd_events.append(&mut deferred);
+    cmd_events
 }
 
 

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -13,6 +13,18 @@ fn ctx(conn_id: u64) -> Ctx {
     }
 }
 
+/// Clone a Ctx with `now_ms` advanced. Used by tests that need to
+/// fire commands past the `HIDDEN_SINCE_OPEN_GRACE_MS` placement
+/// window without re-deriving the rest of the Ctx.
+fn ctx_advance(base: &Ctx, ms: u64) -> Ctx {
+    Ctx {
+        now_rfc3339: base.now_rfc3339.clone(),
+        conn_id: base.conn_id,
+        registered_pid: base.registered_pid,
+        now_ms: base.now_ms + ms,
+    }
+}
+
 fn ctx_with_pid(conn_id: u64, pid: u32) -> Ctx {
     Ctx {
         now_rfc3339: "2026-04-28T00:00:00Z".to_string(),
@@ -1587,6 +1599,80 @@ fn cold_open_without_promote_still_initializes_foregrounded_false() {
 }
 
 #[test]
+fn hidden_since_open_grace_suppresses_placement_hides() {
+    // CEF creates top-level windows hidden, places them, then shows.
+    // Hides arriving within HIDDEN_SINCE_OPEN_GRACE_MS of open are
+    // placement transitions and must NOT fire drift. Without this
+    // grace, every fresh top-level window emits one false-positive
+    // drift on creation. (PR #?, smoke regression on v0.33.696 showed
+    // 8 such hides for 8 fresh windows in a clean session.)
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-placing".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xEE,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-placing".into()),
+        },
+        &c,
+    );
+
+    // Hide within grace window (now_ms still 0, opened_at_ms=0,
+    // delta=0, < 500ms). Drift suppressed.
+    let placement_hide = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xEE, visible: false },
+        &c,
+    );
+    assert_eq!(
+        placement_hide
+            .iter()
+            .filter(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+            ))
+            .count(),
+        0,
+        "hide within placement grace must NOT fire drift"
+    );
+    assert!(
+        !state.windows.get("window-placing").unwrap().hidden_since_open_emitted,
+        "cap flag must NOT be armed by placement-grace hides — \
+         a hide PAST the grace can still fire its drift"
+    );
+
+    // Hide PAST grace → drift fires (the cap should not have been
+    // armed by the placement-grace hide).
+    let post_grace = ctx_advance(&c, 600);
+    let real_hide = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xEE, visible: false },
+        &post_grace,
+    );
+    assert_eq!(
+        real_hide
+            .iter()
+            .filter(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+            ))
+            .count(),
+        1,
+        "hide past grace fires drift (cap was not pre-armed by placement)"
+    );
+}
+
+#[test]
 fn hidden_since_open_drift_fires_at_most_once_per_window() {
     // Drift-storm regression guard. The smoke crash on v0.33.685
     // ("New Window" from hamburger after a tear-off) was 170
@@ -1613,11 +1699,14 @@ fn hidden_since_open_drift_fires_at_most_once_per_window() {
         },
         &c,
     );
-    // First hide → drift fires.
+    // First hide past the placement grace → drift fires. Hides
+    // within HIDDEN_SINCE_OPEN_GRACE_MS of open are placement
+    // transitions and don't fire (separate test below).
+    let post_grace = ctx_advance(&c, 600);
     let first = update(
         &mut state,
         Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: false },
-        &c,
+        &post_grace,
     );
     assert_eq!(
         first
@@ -1638,12 +1727,12 @@ fn hidden_since_open_drift_fires_at_most_once_per_window() {
         let _ = update(
             &mut state,
             Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: true },
-            &c,
+            &post_grace,
         );
         let evs = update(
             &mut state,
             Command::ReportHwndVisibilityChanged { hwnd: 0xCC, visible: false },
-            &c,
+            &post_grace,
         );
         subsequent_drift_count += evs
             .iter()
@@ -1693,10 +1782,11 @@ fn hidden_since_open_cap_survives_duplicate_open() {
         },
         &c,
     );
+    let post_grace = ctx_advance(&c, 600);
     let first = update(
         &mut state,
         Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: false },
-        &c,
+        &post_grace,
     );
     assert!(
         first.iter().any(|e| matches!(
@@ -1730,12 +1820,12 @@ fn hidden_since_open_cap_survives_duplicate_open() {
     let _ = update(
         &mut state,
         Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: true },
-        &c,
+        &post_grace,
     );
     let second = update(
         &mut state,
         Command::ReportHwndVisibilityChanged { hwnd: 0xDD, visible: false },
-        &c,
+        &post_grace,
     );
     assert!(
         !second.iter().any(|e| matches!(

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1673,6 +1673,174 @@ fn hidden_since_open_grace_suppresses_placement_hides() {
 }
 
 #[test]
+fn hidden_since_open_deferred_fires_when_window_stays_hidden_past_grace() {
+    // Codex P2 PR #725 round 1: if the ONLY visible=false event arrives
+    // within the placement grace and no further visibility events fire,
+    // we MUST still emit the drift. The deferred flag + drain pass on
+    // every reducer call (heartbeat-via-traffic) catches this.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-stuck".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xFE,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-stuck".into()),
+        },
+        &c,
+    );
+
+    // The ONLY visibility event arrives within grace. Drift suppressed
+    // but mirror is marked deferred.
+    let placement_hide = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xFE, visible: false },
+        &c,
+    );
+    assert_eq!(
+        placement_hide
+            .iter()
+            .filter(|e| matches!(e, Event::HwndDriftDetected { .. }))
+            .count(),
+        0,
+        "hide within grace must NOT fire drift (deferred)"
+    );
+    assert!(
+        state.windows.get("window-stuck").unwrap().hidden_since_open_deferred,
+        "deferred flag must be set"
+    );
+
+    // No further visibility events. ANY subsequent reducer call past
+    // the grace promotes the deferred state to a fired drift via the
+    // drain pass. Use a Ping (cheapest unrelated command) past grace.
+    let post_grace = ctx_advance(&c, 600);
+    let drained = update(&mut state, Command::Ping { nonce: 1 }, &post_grace);
+    assert_eq!(
+        drained
+            .iter()
+            .filter(|e| matches!(
+                e,
+                Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+            ))
+            .count(),
+        1,
+        "deferred drift fires on next post-grace reducer call regardless \
+         of command kind"
+    );
+    assert!(
+        state.windows.get("window-stuck").unwrap().hidden_since_open_emitted,
+        "cap is now armed (drift was emitted)"
+    );
+    assert!(
+        !state.windows.get("window-stuck").unwrap().hidden_since_open_deferred,
+        "deferred flag cleared after drift fires"
+    );
+}
+
+#[test]
+fn hidden_since_open_deferred_cleared_by_visible_or_foreground() {
+    // The deferred flag must clear when the window completes its
+    // placement transition (becomes visible OR foregrounded). Without
+    // this, a window that hid during placement, became visible, and
+    // was never seen again would fire spurious deferred drift.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-recovers".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xFD,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-recovers".into()),
+        },
+        &c,
+    );
+
+    // Hide during grace → deferred set.
+    let _ = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xFD, visible: false },
+        &c,
+    );
+    assert!(state.windows.get("window-recovers").unwrap().hidden_since_open_deferred);
+
+    // Become visible → deferred cleared.
+    let _ = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xFD, visible: true },
+        &c,
+    );
+    assert!(
+        !state.windows.get("window-recovers").unwrap().hidden_since_open_deferred,
+        "visible=true clears deferred flag"
+    );
+
+    // Past-grace heartbeat must NOT fire drift since deferred was cleared.
+    let post_grace = ctx_advance(&c, 600);
+    let drained = update(&mut state, Command::Ping { nonce: 1 }, &post_grace);
+    assert!(
+        !drained
+            .iter()
+            .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. })),
+        "no spurious drift after window recovers visibility"
+    );
+}
+
+#[test]
+fn opened_at_ms_preserved_on_duplicate_open() {
+    // Codex P2 PR #725 round 1: duplicate ReportWindowOpened must NOT
+    // reset opened_at_ms. Otherwise a duplicate that arrives after
+    // the original 500ms grace and before the first hide would
+    // re-anchor the grace window, suppressing real hides for another
+    // 500ms.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-dup-open".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let original_opened_at_ms = state.windows.get("window-dup-open").unwrap().opened_at_ms;
+
+    // Duplicate open arrives MUCH later (1000ms past grace).
+    let later = ctx_advance(&c, 1000);
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-dup-open".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &later,
+    );
+    assert_eq!(
+        state.windows.get("window-dup-open").unwrap().opened_at_ms,
+        original_opened_at_ms,
+        "duplicate open must preserve original opened_at_ms (grace anchor)"
+    );
+}
+
+#[test]
 fn hidden_since_open_drift_fires_at_most_once_per_window() {
     // Drift-storm regression guard. The smoke crash on v0.33.685
     // ("New Window" from hamburger after a tear-off) was 170

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -1604,7 +1604,7 @@ fn hidden_since_open_grace_suppresses_placement_hides() {
     // Hides arriving within HIDDEN_SINCE_OPEN_GRACE_MS of open are
     // placement transitions and must NOT fire drift. Without this
     // grace, every fresh top-level window emits one false-positive
-    // drift on creation. (PR #?, smoke regression on v0.33.696 showed
+    // drift on creation. (PR #725, smoke regression on v0.33.696 showed
     // 8 such hides for 8 fresh windows in a clean session.)
     let (mut state, c) = registered_host_state();
     let _ = update(
@@ -1800,6 +1800,66 @@ fn hidden_since_open_deferred_cleared_by_visible_or_foreground() {
             .iter()
             .any(|e| matches!(e, Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. })),
         "no spurious drift after window recovers visibility"
+    );
+}
+
+#[test]
+fn deferred_drain_runs_after_command_so_recovery_events_clear_first() {
+    // Codex P2 PR #725 round 2: if the FIRST command past grace is
+    // the recovery event itself (visible=true or foreground change),
+    // the drain MUST run AFTER the command — otherwise it sees the
+    // still-deferred mirror and fires premature HiddenSinceOpen
+    // drift on a slow-but-successful placement.
+    let (mut state, c) = registered_host_state();
+    let _ = update(
+        &mut state,
+        Command::ReportWindowOpened {
+            label: "window-slow-show".into(),
+            kind: WindowKind::FullInstance,
+            parent_label: None,
+        },
+        &c,
+    );
+    let _ = update(
+        &mut state,
+        Command::ReportHwndOpened {
+            hwnd: 0xFC,
+            class_name: "Chrome_WidgetWin_1".into(),
+            title: "".into(),
+            label_hint: Some("window-slow-show".into()),
+        },
+        &c,
+    );
+
+    // Hide during grace → deferred set.
+    let _ = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xFC, visible: false },
+        &c,
+    );
+    assert!(state.windows.get("window-slow-show").unwrap().hidden_since_open_deferred);
+
+    // Slow placement: visible=true is the FIRST event past grace.
+    let post_grace = ctx_advance(&c, 600);
+    let evs = update(
+        &mut state,
+        Command::ReportHwndVisibilityChanged { hwnd: 0xFC, visible: true },
+        &post_grace,
+    );
+    assert!(
+        !evs.iter().any(|e| matches!(
+            e,
+            Event::HwndDriftDetected { kind: HwndDriftKind::HiddenSinceOpen, .. }
+        )),
+        "recovery event must clear deferred before drain runs, no drift fires"
+    );
+    assert!(
+        !state.windows.get("window-slow-show").unwrap().hidden_since_open_emitted,
+        "cap must NOT be armed by a recovery event"
+    );
+    assert!(
+        !state.windows.get("window-slow-show").unwrap().hidden_since_open_deferred,
+        "deferred cleared by visible=true"
     );
 }
 

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -132,16 +132,20 @@ pub(super) fn handle_report_window_opened(
     //   window per session. A duplicate open that resets this to
     //   false would re-arm the storm cap, then the next visibility
     //   transition fires HiddenSinceOpen a second time.
-    let (prior_foregrounded, prior_hidden_emitted, prior_off_monitor_emitted, prior_corrective_emitted) = state
-        .windows
-        .get(&label)
-        .map(|m| (
-            m.foregrounded_since_open,
-            m.hidden_since_open_emitted,
-            m.off_monitor_drift_emitted,
-            m.corrective_window_move_emitted,
-        ))
-        .unwrap_or((false, false, false, false));
+    // Lifetime-state preservation. All these fields are monotonic for
+    // a given (label, lifetime) and must survive a duplicate
+    // `ReportWindowOpened` (which overwrites the mirror wholesale).
+    // `opened_at_ms` is the grace-window anchor — preserving the
+    // ORIGINAL value avoids resetting the placement grace every time
+    // a duplicate open arrives, which would let real hides past the
+    // first grace window be re-suppressed (codex P2 PR #725 round 1).
+    let prior = state.windows.get(&label);
+    let prior_foregrounded = prior.map(|m| m.foregrounded_since_open).unwrap_or(false);
+    let prior_hidden_emitted = prior.map(|m| m.hidden_since_open_emitted).unwrap_or(false);
+    let prior_hidden_deferred = prior.map(|m| m.hidden_since_open_deferred).unwrap_or(false);
+    let prior_off_monitor_emitted = prior.map(|m| m.off_monitor_drift_emitted).unwrap_or(false);
+    let prior_corrective_emitted = prior.map(|m| m.corrective_window_move_emitted).unwrap_or(false);
+    let prior_opened_at_ms = prior.map(|m| m.opened_at_ms);
 
     state.windows.insert(
         label.clone(),
@@ -150,7 +154,9 @@ pub(super) fn handle_report_window_opened(
             kind,
             parent_label: parent_label.clone(),
             opened_at: ctx.now_rfc3339.clone(),
-            opened_at_ms: ctx.now_ms,
+            // Preserve original open time on duplicate so the grace
+            // anchor never moves forward.
+            opened_at_ms: prior_opened_at_ms.unwrap_or(ctx.now_ms),
             // Best-effort drain above; authoritative explicit
             // ReportHwndOpened from on_after_created arrives a few
             // ms later via `apply_hwnd_opened` and REPAIRS any wrong
@@ -162,6 +168,7 @@ pub(super) fn handle_report_window_opened(
             last_foreground_at_ms: None,
             foregrounded_since_open: was_just_promoted || prior_foregrounded,
             hidden_since_open_emitted: prior_hidden_emitted,
+            hidden_since_open_deferred: prior_hidden_deferred,
             off_monitor_drift_emitted: prior_off_monitor_emitted,
             corrective_window_move_emitted: prior_corrective_emitted,
         },

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -117,28 +117,28 @@ pub(super) fn handle_report_window_opened(
     // corrective logic doesn't re-fire `HiddenSinceOpen` on the
     // subsequent HWND repositioning. See state.rs::just_promoted_labels.
     let was_just_promoted = state.just_promoted_labels.remove(&label);
-    // Duplicate-open monotonicity. The handler overwrites the mirror
-    // wholesale on every `ReportWindowOpened`; without the OR-with-
-    // prior here, a 2nd open at the same label re-arms both the
-    // open-transient drift detector and the storm cap. Both flags
-    // are monotonic for a window's lifetime: once true, never reset.
+    // Lifetime-state preservation. The handler overwrites the mirror
+    // wholesale on every `ReportWindowOpened`; without OR-with-prior
+    // here, a 2nd open at the same label would reset every monotonic
+    // flag/anchor below.
     //
     // - `foregrounded_since_open`: monotonic per its own contract
     //   ("has this label been foregrounded at any point since
     //   ReportWindowOpened"). Preserved against duplicate opens
     //   since codex P2 PR #708 round 3.
-    // - `hidden_since_open_emitted`: monotonic for the same reason
-    //   the cap exists — fire the drift signal AT MOST ONCE per
-    //   window per session. A duplicate open that resets this to
-    //   false would re-arm the storm cap, then the next visibility
-    //   transition fires HiddenSinceOpen a second time.
-    // Lifetime-state preservation. All these fields are monotonic for
-    // a given (label, lifetime) and must survive a duplicate
-    // `ReportWindowOpened` (which overwrites the mirror wholesale).
-    // `opened_at_ms` is the grace-window anchor — preserving the
-    // ORIGINAL value avoids resetting the placement grace every time
-    // a duplicate open arrives, which would let real hides past the
-    // first grace window be re-suppressed (codex P2 PR #725 round 1).
+    // - `hidden_since_open_emitted` / `off_monitor_drift_emitted` /
+    //   `corrective_window_move_emitted`: storm-cap flags. Each fires
+    //   AT MOST ONCE per window per session. A duplicate open that
+    //   reset these to false would re-arm the cap and the next
+    //   transition would fire the drift again.
+    // - `hidden_since_open_deferred`: pending-drift flag set when
+    //   `apply_hwnd_visibility_changed` suppresses a hide during the
+    //   placement grace. A duplicate open that cleared it would lose
+    //   the deferred signal (codex P2 PR #725 round 1).
+    // - `opened_at_ms`: grace-window anchor. Preserving the ORIGINAL
+    //   value avoids resetting the placement grace every time a
+    //   duplicate open arrives, which would let real hides past the
+    //   first grace window be re-suppressed (codex P2 PR #725 round 1).
     let prior = state.windows.get(&label);
     let prior_foregrounded = prior.map(|m| m.foregrounded_since_open).unwrap_or(false);
     let prior_hidden_emitted = prior.map(|m| m.hidden_since_open_emitted).unwrap_or(false);

--- a/agentmux-launcher/src/reducer/window.rs
+++ b/agentmux-launcher/src/reducer/window.rs
@@ -150,6 +150,7 @@ pub(super) fn handle_report_window_opened(
             kind,
             parent_label: parent_label.clone(),
             opened_at: ctx.now_rfc3339.clone(),
+            opened_at_ms: ctx.now_ms,
             // Best-effort drain above; authoritative explicit
             // ReportHwndOpened from on_after_created arrives a few
             // ms later via `apply_hwnd_opened` and REPAIRS any wrong

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -150,6 +150,15 @@ pub struct WindowMirror {
     /// See `docs/specs/ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`
     /// for storm context.
     pub hidden_since_open_emitted: bool,
+    /// Set when `apply_hwnd_visibility_changed` sees `visible=false`
+    /// during the placement grace window. Marks "we suppressed a
+    /// hide; if it persists past the grace, drift fires on the next
+    /// reducer call via `drain_deferred_hidden_since_open`". Cleared
+    /// when the window subsequently becomes visible or is foregrounded.
+    /// Without this, a window that goes hidden during grace and
+    /// receives no further visibility events would permanently lose
+    /// its `HiddenSinceOpen` drift signal (codex P2 PR #725 round 1).
+    pub hidden_since_open_deferred: bool,
     /// See `hidden_since_open_emitted` doc above.
     pub off_monitor_drift_emitted: bool,
     /// See `hidden_since_open_emitted` doc above.

--- a/agentmux-launcher/src/state.rs
+++ b/agentmux-launcher/src/state.rs
@@ -99,6 +99,13 @@ pub struct WindowMirror {
     /// has the parent linkage.
     pub parent_label: Option<String>,
     pub opened_at: String,
+    /// Milliseconds-since-launcher-start at which the host's
+    /// `ReportWindowOpened` arrived. Used by `apply_hwnd_visibility_changed`
+    /// to suppress `HiddenSinceOpen` drift during the post-create
+    /// placement grace window — CEF creates windows hidden, places
+    /// them, then shows them, and the intermediate `WM_HIDE` events
+    /// would otherwise fire spurious drift on every fresh window.
+    pub opened_at_ms: u64,
     /// Phase B.9.1 — Win32 HWND linked to this label by the WRR
     /// reducer arm (via `ReportHwndOpened` with matching
     /// `label_hint` or via the post-hoc reconciliation against

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -334,14 +334,24 @@ pub fn apply_hwnd_destroyed(state: &mut State, hwnd: u64, host_running: bool) ->
     vec![]
 }
 
+/// Placement grace window. CEF creates top-level windows hidden,
+/// runs `SetWindowPos` to place them, then shows them. The
+/// intermediate `WM_HIDE` events arrive before `WM_FOREGROUND`,
+/// which would otherwise look like `HiddenSinceOpen` drift on
+/// every fresh window. Hides occurring within this window of the
+/// host's `ReportWindowOpened` are part of normal placement and
+/// don't count.
+const HIDDEN_SINCE_OPEN_GRACE_MS: u64 = 500;
+
 /// Phase B.9.1 — handle `Command::ReportHwndVisibilityChanged`.
 /// Drift fires only on `visible=false` for a known label that has
-/// not been foregrounded since open: the user can't see this
-/// window and never has.
+/// not been foregrounded since open AND is past the post-open
+/// placement grace window.
 pub fn apply_hwnd_visibility_changed(
     state: &mut State,
     hwnd: u64,
     visible: bool,
+    now_ms: u64,
 ) -> Vec<Event> {
     let mut drift: Option<Event> = None;
     let mut version_to_bump = false;
@@ -352,15 +362,22 @@ pub fn apply_hwnd_visibility_changed(
         .and_then(|(label, mirror)| {
             mirror.visible = visible;
             // Drift-storm cap: HiddenSinceOpen fires AT MOST ONCE per
-            // window per session. A fresh top-level window goes
-            // through several SetWindowPos transitions during host
-            // placement; without the cap, each intermediate
-            // `visible=false` re-emits the same drift event and the
-            // renderer's V8 stack runs out (see `hidden_since_open_emitted`
-            // doc on `WindowMirror`). The flag set below is monotonic
-            // — once we've reported the drift, never report it again
-            // for the same label. Subscribers still see the signal.
-            if !visible && !mirror.foregrounded_since_open && !mirror.hidden_since_open_emitted {
+            // window per session. The cap flag is monotonic for the
+            // window's lifetime. The placement grace check below is
+            // additive: hides during placement don't fire AND don't
+            // set the cap, so a hide that persists past the grace
+            // window can still fire (one) drift.
+            //
+            // See `hidden_since_open_emitted` doc on `WindowMirror`
+            // for storm context (PR #708 added the cap; this PR adds
+            // the grace to suppress placement-only false positives).
+            let past_grace =
+                now_ms.saturating_sub(mirror.opened_at_ms) > HIDDEN_SINCE_OPEN_GRACE_MS;
+            if !visible
+                && past_grace
+                && !mirror.foregrounded_since_open
+                && !mirror.hidden_since_open_emitted
+            {
                 mirror.hidden_since_open_emitted = true;
                 version_to_bump = true;
                 Some(label.clone())

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -361,26 +361,41 @@ pub fn apply_hwnd_visibility_changed(
         .find(|(_, m)| m.hwnd == Some(hwnd))
         .and_then(|(label, mirror)| {
             mirror.visible = visible;
+            // Visibility=true at any time clears any deferred hide
+            // — the placement transition completed, no drift needed.
+            if visible {
+                mirror.hidden_since_open_deferred = false;
+                return None;
+            }
             // Drift-storm cap: HiddenSinceOpen fires AT MOST ONCE per
             // window per session. The cap flag is monotonic for the
             // window's lifetime. The placement grace check below is
-            // additive: hides during placement don't fire AND don't
-            // set the cap, so a hide that persists past the grace
-            // window can still fire (one) drift.
-            //
-            // See `hidden_since_open_emitted` doc on `WindowMirror`
-            // for storm context (PR #708 added the cap; this PR adds
-            // the grace to suppress placement-only false positives).
+            // additive: hides during placement set `hidden_since_open_deferred`
+            // (without arming the cap) so the next reducer call past
+            // the grace via `drain_deferred_hidden_since_open` can
+            // fire the drift. Hides past the grace fire immediately.
             let past_grace =
                 now_ms.saturating_sub(mirror.opened_at_ms) > HIDDEN_SINCE_OPEN_GRACE_MS;
-            if !visible
-                && past_grace
+            if past_grace
                 && !mirror.foregrounded_since_open
                 && !mirror.hidden_since_open_emitted
             {
                 mirror.hidden_since_open_emitted = true;
+                mirror.hidden_since_open_deferred = false;
                 version_to_bump = true;
                 Some(label.clone())
+            } else if !past_grace
+                && !mirror.foregrounded_since_open
+                && !mirror.hidden_since_open_emitted
+            {
+                // Suppressed during placement grace. Mark as deferred
+                // so a later reducer call past the grace window can
+                // promote this to a drift if the window is still
+                // hidden (codex P2 PR #725 round 1 — without this,
+                // a stuck-hidden window that gets no further
+                // visibility events permanently loses the signal).
+                mirror.hidden_since_open_deferred = true;
+                None
             } else {
                 None
             }
@@ -399,6 +414,48 @@ pub fn apply_hwnd_visibility_changed(
     drift.into_iter().collect()
 }
 
+/// Sweep `hidden_since_open_deferred` mirrors and emit drift for any
+/// that have crossed the placement grace boundary while still hidden
+/// and never foregrounded. Called from `reducer::update` BEFORE every
+/// command processes so events from any subsequent command serve as
+/// the heartbeat that catches stuck-hidden windows whose own
+/// `ReportHwndVisibilityChanged` was suppressed during grace.
+///
+/// (codex P2 PR #725 round 1 — addresses the "no recheck after grace"
+/// concern. Stuck-hidden windows that produce ZERO further commands
+/// are still a hole — we'd need a periodic timer for that — but
+/// realistic launcher traffic generates events constantly, so this
+/// catches the practical cases.)
+pub fn drain_deferred_hidden_since_open(state: &mut State, now_ms: u64) -> Vec<Event> {
+    let stuck: Vec<(String, Option<u64>)> = state
+        .windows
+        .iter()
+        .filter(|(_, m)| m.hidden_since_open_deferred)
+        .filter(|(_, m)| !m.visible)
+        .filter(|(_, m)| !m.foregrounded_since_open)
+        .filter(|(_, m)| !m.hidden_since_open_emitted)
+        .filter(|(_, m)| now_ms.saturating_sub(m.opened_at_ms) > HIDDEN_SINCE_OPEN_GRACE_MS)
+        .map(|(label, m)| (label.clone(), m.hwnd))
+        .collect();
+    let mut events = Vec::with_capacity(stuck.len());
+    for (label, hwnd) in stuck {
+        if let Some(mirror) = state.windows.get_mut(&label) {
+            mirror.hidden_since_open_emitted = true;
+            mirror.hidden_since_open_deferred = false;
+        }
+        let v = state.bump_version();
+        events.push(Event::HwndDriftDetected {
+            kind: HwndDriftKind::HiddenSinceOpen,
+            label: Some(label),
+            hwnd,
+            detail: "Window hidden without ever being foregrounded since open (deferred from placement grace)".to_string(),
+            severity: severity_for(HwndDriftKind::HiddenSinceOpen),
+            version: v,
+        });
+    }
+    events
+}
+
 /// Phase B.9.1 — handle `Command::ReportHwndForegroundChanged`.
 /// Updates the "has been seen" flag. Never emits drift directly
 /// — its role is to suppress future `HiddenSinceOpen` emissions.
@@ -406,6 +463,10 @@ pub fn apply_hwnd_foreground_changed(state: &mut State, hwnd: u64, now_ms: u64) 
     if let Some((_, mirror)) = state.windows.iter_mut().find(|(_, m)| m.hwnd == Some(hwnd)) {
         mirror.foregrounded_since_open = true;
         mirror.last_foreground_at_ms = Some(now_ms);
+        // Foreground = window made it to the user. Clear any deferred
+        // hide so the drain pass doesn't fire spurious drift past the
+        // grace for a window the user actually saw.
+        mirror.hidden_since_open_deferred = false;
     }
     vec![]
 }

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -426,10 +426,18 @@ pub fn apply_hwnd_visibility_changed(
 
 /// Sweep `hidden_since_open_deferred` mirrors and emit drift for any
 /// that have crossed the placement grace boundary while still hidden
-/// and never foregrounded. Called from `reducer::update` BEFORE every
-/// command processes so events from any subsequent command serve as
-/// the heartbeat that catches stuck-hidden windows whose own
-/// `ReportHwndVisibilityChanged` was suppressed during grace.
+/// and never foregrounded. Called from `reducer::update` AFTER every
+/// command processes so any recovery event the command itself
+/// dispatched (visible=true / foreground change / window closed) has
+/// a chance to clear the deferred state first. Without the AFTER
+/// ordering, a slow placement whose first post-grace event is the
+/// recovery itself would fire a spurious drift before the recovery
+/// runs (codex P2 PR #725 round 2).
+///
+/// Even with the AFTER ordering, this pass is the heartbeat that
+/// catches stuck-hidden windows whose own `ReportHwndVisibilityChanged`
+/// was suppressed during grace: any subsequent unrelated command
+/// past the grace promotes the deferred state to a fired drift.
 ///
 /// (codex P2 PR #725 round 1 — addresses the "no recheck after grace"
 /// concern. Stuck-hidden windows that produce ZERO further commands

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.698"
+version = "0.33.699"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.697"
+version = "0.33.698"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.698",
+  "version": "0.33.699",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.698",
+      "version": "0.33.699",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.697",
+  "version": "0.33.698",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.697",
+      "version": "0.33.698",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.696",
+  "version": "0.33.697",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.696",
+      "version": "0.33.697",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.698",
+  "version": "0.33.699",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.697",
+  "version": "0.33.698",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Stop the launcher from firing `HiddenSinceOpen` drift on every fresh top-level window during CEF's placement transition.

CEF creates top-level windows hidden, runs `SetWindowPos` to place them, then shows them. The intermediate `WM_HIDE` events arrive before the first `WM_FOREGROUND`, so the drift detector at `apply_hwnd_visibility_changed` was firing every time. Observed in v0.33.696 smoke: 8 false-positive `HiddenSinceOpen` drifts for 8 fresh windows in a clean session.

The PR #708 storm cap (`hidden_since_open_emitted`) made these fire AT MOST once per window so they didn't cause crashes — but they're still noise that masks real drift cases.

## Approach

- Add `HIDDEN_SINCE_OPEN_GRACE_MS = 500`
- `WindowMirror` records `opened_at_ms` from `ctx.now_ms` at `ReportWindowOpened`
- `apply_hwnd_visibility_changed` now takes `now_ms` and ignores hides within the grace window
- The cap flag (`hidden_since_open_emitted`) is **not** set by placement-grace hides, so a hide that persists past the grace can still fire its drift exactly once

## Test plan

- [x] New regression test `hidden_since_open_grace_suppresses_placement_hides` — drives a hide within grace (must NOT fire), then a hide past grace (must fire once)
- [x] Existing `hidden_since_open_drift_fires_at_most_once_per_window` + `hidden_since_open_cap_survives_duplicate_open` updated to advance `now_ms` past the grace before their hides
- [x] 172 launcher tests pass
- [ ] Smoke: count `kind:hidden_since_open` drifts in host log over a fresh session — should be 0 for normal lifecycle

## Notes

Pairs with a follow-up PR for `hwnd_without_browser` repaired-suppression (the other drift class observed in the same smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)