### PR TITLE
fix(launcher): suppress drift event on routine Repaired hwnd-link

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.697"
+version = "0.33.698"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.697"
+version = "0.33.698"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.697"
+version = "0.33.698"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.697"
+version = "0.33.698"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -2245,10 +2245,21 @@ fn wrr_duplicate_hwnd_open_for_same_label_is_idempotent() {
 }
 
 #[test]
-fn wrr_double_link_with_different_hwnd_for_same_label_emits_drift() {
-    // The non-duplicate path: a second ReportHwndOpened for
-    // the same label but a DIFFERENT HWND is genuine drift —
-    // host is reporting a related popup or there's a real bug.
+fn wrr_double_link_with_different_hwnd_for_same_label_repairs_silently() {
+    // A second ReportHwndOpened for the same label but a DIFFERENT
+    // HWND is the Repaired path: the launcher's drain wrong-picked
+    // earlier and the explicit on_after_created is correcting it.
+    // This is normal self-healing — mirror.hwnd is overwritten,
+    // no drift event is emitted (logged via crate::log for visibility).
+    //
+    // Rationale: in v0.33.696 smoke this fired 6 false-positive
+    // HwndWithoutBrowser drifts in a clean session because the drain-
+    // wrong-pick happens routinely under burst create. Drift firing
+    // on every routine repair masked genuine drifts.
+    //
+    // Drift IS still fired for Linked+stole (different HWND that had
+    // to be taken from another label's mirror) — see the
+    // wrr_repair_steals_hwnd_from_other_mirror test for that case.
     let (mut state, c) = registered_host_state();
     let _ = update(
         &mut state,
@@ -2279,12 +2290,13 @@ fn wrr_double_link_with_different_hwnd_for_same_label_emits_drift() {
         },
         &c,
     );
+    assert_eq!(state.windows["w1"].hwnd, Some(0xBB), "mirror.hwnd repaired to new value");
     assert!(
-        evs.iter().any(|e| matches!(
+        !evs.iter().any(|e| matches!(
             e,
             Event::HwndDriftDetected { kind: HwndDriftKind::HwndWithoutBrowser, .. }
         )),
-        "different HWND for same label must fire drift, got {:?}", evs
+        "plain Repair must NOT emit drift event, got {:?}", evs
     );
 }
 
@@ -2545,11 +2557,15 @@ fn wrr_burst_creates_with_drain_then_repair() {
         title: "".into(), label_hint: Some("w1".into()),
     }, &c5);
     assert_eq!(state.windows["w1"].hwnd, Some(0xAA), "repair to authoritative");
+    // Repaired path (plain repair, no cross-label steal here) is a
+    // normal self-healing flow — log only, no drift event. Drift
+    // would still fire if this were a Linked+stole case (different
+    // HWND that took the slot from another label).
     assert!(
-        evs1.iter().any(|e| matches!(e, Event::HwndDriftDetected {
+        !evs1.iter().any(|e| matches!(e, Event::HwndDriftDetected {
             kind: HwndDriftKind::HwndWithoutBrowser, ..
         })),
-        "repair emits drift for diagnostic visibility, got {:?}", evs1
+        "plain Repair must NOT emit drift event (logged via crate::log instead), got {:?}", evs1
     );
 
     // on_after_created for w2 arrives with 0xBB. CRUCIAL: w1's
@@ -2710,11 +2726,15 @@ fn wrr_apply_hwnd_opened_repairs_stale_link() {
         state.windows["w1"].hwnd, Some(0xAA),
         "stale link must be REPAIRED to the authoritative HWND"
     );
+    // Repair logged via crate::log; no drift event (would otherwise
+    // fire on every routine drain wrong-pick correction). See the
+    // wrr_double_link_with_different_hwnd_for_same_label_repairs_silently
+    // test for the contract.
     assert!(
-        evs.iter().any(|e| matches!(e, Event::HwndDriftDetected {
+        !evs.iter().any(|e| matches!(e, Event::HwndDriftDetected {
             kind: HwndDriftKind::HwndWithoutBrowser, ..
         })),
-        "drift event must be emitted so the repair is visible in logs, got {:?}", evs
+        "plain Repair must NOT emit drift event, got {:?}", evs
     );
 }
 

--- a/agentmux-launcher/src/wrr/mod.rs
+++ b/agentmux-launcher/src/wrr/mod.rs
@@ -189,22 +189,32 @@ pub fn apply_hwnd_opened(
                 }];
             }
             HwndOpenedOutcome::Repaired(existing) => {
-                let v = state.bump_version();
+                // Repair is a normal self-healing path: the launcher's
+                // best-effort drain in `handle_report_window_opened`
+                // wrong-picked an HWND under burst-create concurrency,
+                // and the explicit `apply_hwnd_opened` from
+                // `client.rs::on_after_created` is now correcting it.
+                // Logging this at Error severity as a `HwndDriftDetected`
+                // event flooded the renderer with one drift per fresh
+                // top-level (6 in a clean v0.33.696 session) and made
+                // genuine drifts harder to spot.
+                //
+                // Now: log via tracing only, no event. The pure-state
+                // mutation (mirror.hwnd overwrite + drain_pending +
+                // optional steal-clear on the prior holder) still
+                // happens above. Linked + stole still emits drift —
+                // that's a different shape (clean link that had to
+                // claim a wrongly-held HWND, which the prior holder's
+                // own `apply_hwnd_opened` may not yet have repaired).
                 let stolen_suffix = stolen_from
                     .as_deref()
                     .map(|s| format!(" (stole from label={})", s))
                     .unwrap_or_default();
-                return vec![Event::HwndDriftDetected {
-                    kind: HwndDriftKind::HwndWithoutBrowser,
-                    label: Some(label.to_string()),
-                    hwnd: Some(hwnd),
-                    detail: format!(
-                        "ReportHwndOpened label_hint={} repaired stale link from hwnd={} to hwnd={}{}",
-                        label, existing, hwnd, stolen_suffix
-                    ),
-                    severity: severity_for(HwndDriftKind::HwndWithoutBrowser),
-                    version: v,
-                }];
+                crate::log(&format!(
+                    "[wrr] hwnd_repaired label={} prior_hwnd={} new_hwnd={}{}",
+                    label, existing, hwnd, stolen_suffix
+                ));
+                return vec![];
             }
             HwndOpenedOutcome::NoMatchingLabel => { /* fall through to pending */ }
         }

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.697"
+version = "0.33.698"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.696",
+  "version": "0.33.698",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.696",
+      "version": "0.33.698",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.697",
+  "version": "0.33.698",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Stop the launcher from firing `HwndWithoutBrowser` drift on every routine drain wrong-pick correction. Drain wrong-picks happen routinely under burst-create concurrency (the launcher's `handle_report_window_opened` picks the most-recent unattributed pending HWND, which can belong to another concurrent window) and the explicit `on_after_created` with `label_hint` then repairs the link. This was firing 6 false-positive Error-severity drifts in a clean v0.33.696 smoke session — one per fresh top-level — and masking the class as a signal for genuine drift.

## Approach

`apply_hwnd_opened`'s `Repaired` outcome:
- **Before:** emit `HwndDriftDetected` with `kind: HwndWithoutBrowser, severity: Error`
- **After:** log via `crate::log` only, no event

The pure-state mutation (mirror.hwnd overwrite + drain_pending + steal-clear) still happens. `Linked + stole` still emits drift — that's a different shape (a clean new link that had to claim a wrongly-held HWND from another label that hasn't yet self-corrected).

## Test plan

- [x] `wrr_double_link_with_different_hwnd_for_same_label_repairs_silently` (renamed from `_emits_drift`, inverted assertion + added state-mutation assertion)
- [x] `wrr_apply_hwnd_opened_repairs_stale_link` (inverted assertion to match new contract)
- [x] `wrr_burst_creates_with_drain_then_repair` (inverted assertion)
- [x] `wrr_repair_steals_hwnd_from_other_mirror` (unchanged — Linked+stole still emits drift)
- [x] 171 launcher tests pass
- [ ] Smoke: count `kind:hwnd_without_browser` drifts in host log over a fresh session — should be 0 for normal lifecycle

## Notes

Pairs with #725 (placement grace for `HiddenSinceOpen`). Independent — both can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)