### PR TITLE
feat(tearoff): match tear-off window size to source window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.700"
+version = "0.33.701"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.700"
+version = "0.33.701"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.700"
+version = "0.33.701"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.700"
+version = "0.33.701"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.700 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.697 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.696 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |
 | 0.33.695 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.701 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.700 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.697 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.696 | 2026-05-06 | 162.2 MiB | 340.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.700"
+version = "0.33.701"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -321,8 +321,28 @@ pub fn tear_off_pool_promote(
         .get("screenY")
         .and_then(|v| v.as_f64())
         .ok_or_else(|| "missing screenY".to_string())? as i32;
+    // Optional source-window dimensions for size-matching tear-off.
+    // Sanity-clamp before passing through so a malformed arg can't
+    // size the promoted pool window absurdly.
+    const MIN_DIM: i32 = 200;
+    const MAX_DIM: i32 = 8192;
+    let width = args
+        .get("width")
+        .and_then(|v| v.as_f64())
+        .map(|w| (w as i32).clamp(MIN_DIM, MAX_DIM));
+    let height = args
+        .get("height")
+        .and_then(|v| v.as_f64())
+        .map(|h| (h as i32).clamp(MIN_DIM, MAX_DIM));
 
-    match super::window_pool::promote_pool_window(state, workspace_id, screen_x, screen_y) {
+    match super::window_pool::promote_pool_window(
+        state,
+        workspace_id,
+        screen_x,
+        screen_y,
+        width,
+        height,
+    ) {
         Some(label) => Ok(serde_json::json!(label)),
         None => {
             // Per spec §0 the cold path is defence-in-depth, not an
@@ -359,8 +379,24 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
     let window_id = uuid::Uuid::new_v4();
     let label = format!("window-{}", window_id.simple());
 
-    let win_w = 1200i32;
-    let win_h = 800i32;
+    // Source-window-matching tear-off size. Frontend captures
+    // window.outerWidth/Height of the dragged-from window and passes
+    // them through; cold path falls back to the historical default if
+    // the args are absent (manual host RPC, etc.). Sanity-clamp to
+    // reasonable bounds so a malformed arg can't create a zero-sized
+    // or absurdly large window.
+    const MIN_DIM: i32 = 200;
+    const MAX_DIM: i32 = 8192;
+    let win_w = args
+        .get("width")
+        .and_then(|v| v.as_f64())
+        .map(|w| (w as i32).clamp(MIN_DIM, MAX_DIM))
+        .unwrap_or(1200);
+    let win_h = args
+        .get("height")
+        .and_then(|v| v.as_f64())
+        .map(|h| (h as i32).clamp(MIN_DIM, MAX_DIM))
+        .unwrap_or(800);
 
     // Position so cursor lands near top-center of title bar
     let pos_x = ((screen_x - win_w as f64 / 2.0).max(0.0)) as i32;

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -16,6 +16,12 @@ use cef::{ImplBrowser, ImplBrowserHost};
 use crate::events;
 use crate::state::{AppState, DragPayload, DragSession, DragType};
 
+/// Sanity bounds for tear-off window dimensions. Frontend caps via
+/// `window.outerWidth/Height` (CSS/DIP) but a malformed or hostile
+/// arg should not be able to size the new window absurdly.
+const TEAROFF_MIN_DIM: i32 = 200;
+const TEAROFF_MAX_DIM: i32 = 8192;
+
 /// Start a cross-window drag session.
 pub fn start_cross_drag(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let drag_type: DragType = serde_json::from_value(
@@ -322,18 +328,14 @@ pub fn tear_off_pool_promote(
         .and_then(|v| v.as_f64())
         .ok_or_else(|| "missing screenY".to_string())? as i32;
     // Optional source-window dimensions for size-matching tear-off.
-    // Sanity-clamp before passing through so a malformed arg can't
-    // size the promoted pool window absurdly.
-    const MIN_DIM: i32 = 200;
-    const MAX_DIM: i32 = 8192;
     let width = args
         .get("width")
         .and_then(|v| v.as_f64())
-        .map(|w| (w as i32).clamp(MIN_DIM, MAX_DIM));
+        .map(|w| (w as i32).clamp(TEAROFF_MIN_DIM, TEAROFF_MAX_DIM));
     let height = args
         .get("height")
         .and_then(|v| v.as_f64())
-        .map(|h| (h as i32).clamp(MIN_DIM, MAX_DIM));
+        .map(|h| (h as i32).clamp(TEAROFF_MIN_DIM, TEAROFF_MAX_DIM));
 
     match super::window_pool::promote_pool_window(
         state,
@@ -382,20 +384,16 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
     // Source-window-matching tear-off size. Frontend captures
     // window.outerWidth/Height of the dragged-from window and passes
     // them through; cold path falls back to the historical default if
-    // the args are absent (manual host RPC, etc.). Sanity-clamp to
-    // reasonable bounds so a malformed arg can't create a zero-sized
-    // or absurdly large window.
-    const MIN_DIM: i32 = 200;
-    const MAX_DIM: i32 = 8192;
+    // the args are absent (manual host RPC, etc.).
     let win_w = args
         .get("width")
         .and_then(|v| v.as_f64())
-        .map(|w| (w as i32).clamp(MIN_DIM, MAX_DIM))
+        .map(|w| (w as i32).clamp(TEAROFF_MIN_DIM, TEAROFF_MAX_DIM))
         .unwrap_or(1200);
     let win_h = args
         .get("height")
         .and_then(|v| v.as_f64())
-        .map(|h| (h as i32).clamp(MIN_DIM, MAX_DIM))
+        .map(|h| (h as i32).clamp(TEAROFF_MIN_DIM, TEAROFF_MAX_DIM))
         .unwrap_or(800);
 
     // Position so cursor lands near top-center of title bar

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -662,8 +662,25 @@ pub fn promote_pool_window(
     // Use the source window's dimensions when provided (tear-off
     // UX: new window matches the frame the user dragged from). Fall
     // back to the pool default otherwise.
-    let win_w = width.unwrap_or(POOL_WIDTH);
-    let win_h = height.unwrap_or(POOL_HEIGHT);
+    //
+    // DPI conversion (codex P2 PR #727 round 1): the frontend sends
+    // `window.outerWidth/Height`, which are CSS/DIP pixels. Win32
+    // `SetWindowPos` expects PHYSICAL pixels for a DPI-aware process,
+    // so on a scaled display (DPR > 1) the window would shrink by the
+    // monitor scale (e.g. 1200 DIP → 960 physical px at 125%). Convert
+    // using the destination HWND's DPI before SetWindowPos. The
+    // cold-path uses CEF's `set_bounds` which is DIP-aware natively,
+    // so only this Win32 path needs the conversion.
+    let dpi_scale: f32 = unsafe {
+        use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
+        let dpi = GetDpiForWindow(raw_hwnd);
+        if dpi == 0 { 1.0 } else { dpi as f32 / 96.0 }
+    };
+    let to_physical = |dip: i32| -> i32 { (dip as f32 * dpi_scale).round() as i32 };
+    let win_w_dip = width.unwrap_or(POOL_WIDTH);
+    let win_h_dip = height.unwrap_or(POOL_HEIGHT);
+    let win_w = if width.is_some() { to_physical(win_w_dip) } else { win_w_dip };
+    let win_h = if height.is_some() { to_physical(win_h_dip) } else { win_h_dip };
     let pos_x = screen_x - win_w / 2;
     let pos_y = screen_y - TITLE_BAR_OFFSET_PX;
 

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -663,18 +663,26 @@ pub fn promote_pool_window(
     // UX: new window matches the frame the user dragged from). Fall
     // back to the pool default otherwise.
     //
-    // DPI conversion (codex P2 PR #727 round 1): the frontend sends
-    // `window.outerWidth/Height`, which are CSS/DIP pixels. Win32
-    // `SetWindowPos` expects PHYSICAL pixels for a DPI-aware process,
-    // so on a scaled display (DPR > 1) the window would shrink by the
-    // monitor scale (e.g. 1200 DIP → 960 physical px at 125%). Convert
-    // using the destination HWND's DPI before SetWindowPos. The
-    // cold-path uses CEF's `set_bounds` which is DIP-aware natively,
-    // so only this Win32 path needs the conversion.
+    // DPI conversion (codex P2 / reagent P1 PR #727): the frontend
+    // sends `window.outerWidth/Height` in CSS/DIP pixels but Win32
+    // `SetWindowPos` expects PHYSICAL pixels. Use the DESTINATION
+    // monitor's DPI (the one under cursor at the drop point), NOT
+    // the pool HWND's current monitor — pool windows live at
+    // POOL_OFFSCREEN_X/Y which is typically the primary monitor, so
+    // on mixed-DPI multi-monitor the pool HWND's DPI doesn't match
+    // the user's actual drop target.
     let dpi_scale: f32 = unsafe {
-        use windows_sys::Win32::UI::HiDpi::GetDpiForWindow;
-        let dpi = GetDpiForWindow(raw_hwnd);
-        if dpi == 0 { 1.0 } else { dpi as f32 / 96.0 }
+        use windows_sys::Win32::Foundation::POINT;
+        use windows_sys::Win32::Graphics::Gdi::{
+            MonitorFromPoint, MONITOR_DEFAULTTONEAREST,
+        };
+        use windows_sys::Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI};
+        let pt = POINT { x: screen_x, y: screen_y };
+        let monitor = MonitorFromPoint(pt, MONITOR_DEFAULTTONEAREST);
+        let mut dpi_x: u32 = 0;
+        let mut dpi_y: u32 = 0;
+        let hr = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+        if hr != 0 || dpi_x == 0 { 1.0 } else { dpi_x as f32 / 96.0 }
     };
     let to_physical = |dip: i32| -> i32 { (dip as f32 * dpi_scale).round() as i32 };
     let win_w_dip = width.unwrap_or(POOL_WIDTH);

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -467,6 +467,8 @@ pub fn promote_pool_window(
     workspace_id: &str,
     screen_x: i32,
     screen_y: i32,
+    width: Option<i32>,
+    height: Option<i32>,
 ) -> Option<String> {
     // PR #5 H.4 — atomic pop+remove via reducer. The dispatch pops
     // the front of the pool queue, removes the label from
@@ -657,7 +659,12 @@ pub fn promote_pool_window(
     // of or above the primary have negative coords), and clamping
     // would push tear-offs onto the primary monitor when the user
     // grabbed from a secondary.
-    let pos_x = screen_x - POOL_WIDTH / 2;
+    // Use the source window's dimensions when provided (tear-off
+    // UX: new window matches the frame the user dragged from). Fall
+    // back to the pool default otherwise.
+    let win_w = width.unwrap_or(POOL_WIDTH);
+    let win_h = height.unwrap_or(POOL_HEIGHT);
+    let pos_x = screen_x - win_w / 2;
     let pos_y = screen_y - TITLE_BAR_OFFSET_PX;
 
     // Take the window out of WS_EX_TOOLWINDOW so the promoted window
@@ -680,8 +687,8 @@ pub fn promote_pool_window(
             HWND_TOP,
             pos_x,
             pos_y,
-            POOL_WIDTH,
-            POOL_HEIGHT,
+            win_w,
+            win_h,
             0, // no flags — apply move + size + Z-order all
         );
         if pos_ok == 0 {
@@ -796,6 +803,8 @@ pub fn promote_pool_window(
     _workspace_id: &str,
     _screen_x: i32,
     _screen_y: i32,
+    _width: Option<i32>,
+    _height: Option<i32>,
 ) -> Option<String> {
     // Non-Windows: pool isn't built yet (Phase 7). Caller falls
     // back to the cold path.

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.700"
+version = "0.33.701"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.700"
+version = "0.33.701"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.700"
+version = "0.33.701"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.linux.tsx
@@ -133,10 +133,10 @@ async function performTearOff(
     const api = getApi();
     if (dragType === "pane" && payload.blockId) {
         const newWsId = await WorkspaceService.TearOffBlock(payload.blockId, sourceTabId, sourceWsId, true);
-        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
-        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY);
+        if (newWsId) await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
     }
 }
 

--- a/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
+++ b/frontend/app/drag/CrossWindowDragMonitor.win32.tsx
@@ -235,12 +235,12 @@ async function performTearOff(
                     } as LayoutTreeDeleteNodeAction);
                 }
             }
-            await openTearOffWindow(api, newWsId, screenX, screenY);
+            await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
         }
     } else if (dragType === "tab" && payload.tabId) {
         const newWsId = await WorkspaceService.TearOffTab(payload.tabId, sourceWsId);
         if (newWsId) {
-            await openTearOffWindow(api, newWsId, screenX, screenY);
+            await openTearOffWindow(api, newWsId, screenX, screenY, window.outerWidth, window.outerHeight);
         }
     }
 }

--- a/frontend/app/drag/tear-off-pool-helper.ts
+++ b/frontend/app/drag/tear-off-pool-helper.ts
@@ -34,13 +34,15 @@ export async function openTearOffWindow(
     newWsId: string,
     screenX: number,
     screenY: number,
+    width?: number,
+    height?: number,
 ): Promise<void> {
     try {
-        await api.tearOffPoolPromote(newWsId, screenX, screenY);
+        await api.tearOffPoolPromote(newWsId, screenX, screenY, width, height);
     } catch (poolErr) {
         Logger.warn("dnd:cross", "pool promote failed, cold-pathing", {
             error: String(poolErr),
         });
-        await api.openWindowAtPosition(screenX, screenY, newWsId);
+        await api.openWindowAtPosition(screenX, screenY, newWsId, width, height);
     }
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -661,6 +661,12 @@ async function requestTearOff(
     // to register against. (codex P1 round-3 #624.)
     let newWsId: string | undefined;
     let coldPathFailed = false;
+    // Capture source window's outer dimensions so the tear-off result
+    // matches the user's current frame instead of the hardcoded pool
+    // default (1200×800). UX expectation: dragging a tab out gives you
+    // a window the same size as the one you dragged from.
+    const sourceWidth = window.outerWidth;
+    const sourceHeight = window.outerHeight;
     try {
         const sourceWindowLabel = await getApi().getWindowLabel();
         // Step 1 — sidecar transfers the tab into a new workspace.
@@ -674,7 +680,13 @@ async function requestTearOff(
         // exhausted increments and can investigate the underlying race.
         let destWindowLabel: string;
         try {
-            destWindowLabel = await getApi().tearOffPoolPromote(newWsId, cursorX, cursorY);
+            destWindowLabel = await getApi().tearOffPoolPromote(
+                newWsId,
+                cursorX,
+                cursorY,
+                sourceWidth,
+                sourceHeight,
+            );
             Logger.info("dnd", "tear-off used warm pool", { destWindowLabel });
         } catch (poolErr) {
             Logger.warn("dnd", "tear-off pool exhausted, falling back to cold path", {
@@ -685,6 +697,8 @@ async function requestTearOff(
                     cursorX,
                     cursorY,
                     newWsId,
+                    sourceWidth,
+                    sourceHeight,
                 );
             } catch (coldErr) {
                 // F1.B safe-restore signal: cold-path API itself

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -186,12 +186,29 @@ declare global {
             screenY: number
         ) => Promise<void>;
         cancelCrossDrag: (dragId: string) => Promise<void>;
-        openWindowAtPosition: (screenX: number, screenY: number, workspaceId?: string) => Promise<string>;
+        /** Cold-path tear-off / new top-level. `width`/`height` set the
+         *  outer window dimensions when matching the source window's
+         *  size on tab tear-off; omit for the historical default. */
+        openWindowAtPosition: (
+            screenX: number,
+            screenY: number,
+            workspaceId?: string,
+            width?: number,
+            height?: number,
+        ) => Promise<string>;
         /** Phase 6 — promote a pre-warmed pool window for tear-off.
          *  Returns the destination window label on success. Throws if
          *  the pool is empty (caller should fall back to
-         *  openWindowAtPosition for the cold path). */
-        tearOffPoolPromote: (workspaceId: string, screenX: number, screenY: number) => Promise<string>;
+         *  openWindowAtPosition for the cold path). `width`/`height`
+         *  resize the promoted window to match the source frame on
+         *  tab tear-off; omit to keep the pool default. */
+        tearOffPoolPromote: (
+            workspaceId: string,
+            screenX: number,
+            screenY: number,
+            width?: number,
+            height?: number,
+        ) => Promise<string>;
         /** Tear-off Phase 2 Win32 SC_MOVE handshake. Call AFTER
          *  TearOffTab + openWindowAtPosition; this hands cursor capture
          *  to the new window so it follows the mouse like a Chrome

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -586,11 +586,35 @@ export function buildCefApi(): AppApi {
         cancelCrossDrag: async (dragId: string) => {
             await invokeCommand("cancel_cross_drag", { dragId });
         },
-        openWindowAtPosition: async (screenX: number, screenY: number, workspaceId?: string) => {
-            return await invokeCommand<string>("open_window_at_position", { screenX, screenY, workspaceId: workspaceId ?? "" });
+        openWindowAtPosition: async (
+            screenX: number,
+            screenY: number,
+            workspaceId?: string,
+            width?: number,
+            height?: number,
+        ) => {
+            return await invokeCommand<string>("open_window_at_position", {
+                screenX,
+                screenY,
+                workspaceId: workspaceId ?? "",
+                width,
+                height,
+            });
         },
-        tearOffPoolPromote: async (workspaceId: string, screenX: number, screenY: number) => {
-            return await invokeCommand<string>("tear_off_pool_promote", { workspaceId, screenX, screenY });
+        tearOffPoolPromote: async (
+            workspaceId: string,
+            screenX: number,
+            screenY: number,
+            width?: number,
+            height?: number,
+        ) => {
+            return await invokeCommand<string>("tear_off_pool_promote", {
+                workspaceId,
+                screenX,
+                screenY,
+                width,
+                height,
+            });
         },
         tearOffSCMoveHandshake: async (args) => {
             return await invokeCommand<{ handshakeMs: number; totalMs: number }>(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.699",
+  "version": "0.33.700",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.699",
+      "version": "0.33.700",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.700",
+  "version": "0.33.701",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.700",
+      "version": "0.33.701",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.700",
+  "version": "0.33.701",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

When a tab is torn off (dragged out of the tabbar) or a pane is torn off via cross-window drag, the resulting top-level window now matches the dimensions of the source window the user was dragging from. Before this PR, all tear-off windows were a hardcoded 1200×800 regardless of where they came from.

## Wiring

- **Frontend capture**: `window.outerWidth` / `window.outerHeight` taken at the start of `tabbar.tsx::performTabTearOff` and in both `CrossWindowDragMonitor.{win32,linux}.tsx` callers.
- **API** (`cef-api.ts`, `custom.d.ts`, `tear-off-pool-helper.ts`): `tearOffPoolPromote` and `openWindowAtPosition` accept optional `width` / `height`.
- **Backend** (`drag.rs` / `window_pool.rs`):
  - `open_window_at_position` (cold path) — uses provided dims, falls back to 1200×800 if absent
  - `tear_off_pool_promote` → `promote_pool_window` — passes dims to the `SetWindowPos` for the pool window's relocate-and-show step
  - Both clamp to [200, 8192] so a malformed arg can't create a zero-sized or absurd window
- Default behavior preserved when args absent (manual host RPC, non-tear-off callers).

## Test plan

- [x] `cargo build -p agentmux-cef` clean
- [x] `cargo test -p agentmux-cef` (100 passed)
- [x] `npx tsc --noEmit` clean for the changed files
- [ ] Smoke: tear off a tab from a 1600×1000 window — new window should be 1600×1000, not 1200×800
- [ ] Smoke: tear off from a small 800×600 window — new window should be 800×600
- [ ] Smoke: regular new-window-from-hamburger still uses default (no regression)
- [ ] Smoke: drift counts stay near zero (no new regressions in WRR signal)

## Notes

Builds on the v0.33.700 baseline (drift fixes from #725 + #726 already landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)