### PR TITLE
fix: window drag cursor drift — switch to absolute positioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.682"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.682"
+version = "0.33.683"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.682"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.682"
+version = "0.33.683"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1467,9 +1467,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3378,9 +3378,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3391,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3401,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3424,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3467,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.682"
+version = "0.33.683"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -208,6 +208,41 @@ pub fn move_window_by(state: &Arc<AppState>, args: &serde_json::Value) -> Result
     Ok(serde_json::Value::Null)
 }
 
+/// Move the window to an absolute screen position (x, y).
+/// Each call is self-contained — no read-modify-write — so concurrent in-flight
+/// calls are idempotent: the last write wins, which is exactly correct for drag.
+pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::*;
+        use windows_sys::Win32::Foundation::RECT;
+        let hwnd = find_own_top_level_window();
+        if !hwnd.is_null() {
+            let mut rect: RECT = std::mem::zeroed();
+            GetWindowRect(hwnd, &mut rect);
+            let width = rect.right - rect.left;
+            let height = rect.bottom - rect.top;
+            SetWindowPos(
+                hwnd,
+                std::ptr::null_mut(),
+                x,
+                y,
+                width,
+                height,
+                0x0014, // SWP_NOZORDER | SWP_NOSIZE
+            );
+            return Ok(serde_json::Value::Null);
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_set_window_position(state, "main", x, y);
+    let _ = state;
+    Ok(serde_json::Value::Null)
+}
+
 /// Initiate window drag (for frameless windows).
 /// Windows: sends WM_NCLBUTTONDOWN/HTCAPTION via Win32 — find_own_top_level_window
 /// resolves the per-process HWND so multi-window works without a label.

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -240,6 +240,7 @@ async fn route_command(
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_position" => commands::window::get_window_position(state),
         "move_window_by" => commands::window::move_window_by(state, args),
+        "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),
         "show_context_menu" => {
             tracing::debug!("show_context_menu: handled in JS overlay");

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -249,6 +249,36 @@ pub fn post_move_window(state: &Arc<AppState>, label: &str, dx: i32, dy: i32) {
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Set window to absolute position ──────────────────────────────────────
+
+wrap_task! {
+    pub struct SetWindowPositionTask {
+        state: Arc<AppState>,
+        label: String,
+        x: i32,
+        y: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            if let Some(window) = get_window_on_ui(&self.state, &self.label) {
+                let bounds = window.bounds();
+                window.set_bounds(Some(&Rect {
+                    x: self.x,
+                    y: self.y,
+                    width: bounds.width,
+                    height: bounds.height,
+                }));
+            }
+        }
+    }
+}
+
+pub fn post_set_window_position(state: &Arc<AppState>, label: &str, x: i32, y: i32) {
+    let mut task = SetWindowPositionTask::new(state.clone(), label.to_string(), x, y);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Phase B.9.2 (WRR) — corrective absolute-position move ─────────────────
 //
 // Reducer-driven self-heal. Triggered by `Event::CorrectiveWindowMove` when

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.682"
+version = "0.33.683"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.682"
+version = "0.33.683"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.682"
+version = "0.33.683"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/markdown.scss
+++ b/frontend/app/element/markdown.scss
@@ -3,6 +3,17 @@
 
 @import "../../../node_modules/highlight.js/scss/github-dark-dimmed.scss";
 
+// Global — applies to TableBlock wherever it renders (markdown.tsx and streamdown.tsx)
+.table-block {
+    tbody tr:nth-child(odd) {
+        background: color-mix(in srgb, var(--hover-bg-color) 40%, transparent);
+    }
+
+    tbody tr:hover {
+        background: var(--hover-bg-color);
+    }
+}
+
 .markdown {
     display: flex;
     flex-direction: row;

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -457,6 +457,14 @@ const Markdown = ({
                                   ["media"],
                                   ["type"],
                               ],
+                              th: [
+                                  ...(defaultSchema.attributes?.th || []),
+                                  ["className", /^text-(?:left|center|right)$/],
+                              ],
+                              td: [
+                                  ...(defaultSchema.attributes?.td || []),
+                                  ["className", /^text-(?:left|center|right)$/],
+                              ],
                               waveblock: [["blockkey"]],
                           },
                           tagNames: [

--- a/frontend/app/element/markdown.tsx
+++ b/frontend/app/element/markdown.tsx
@@ -11,7 +11,9 @@ import {
     resolveSrcSet,
     transformBlocks,
 } from "@/app/element/markdown-util";
+import { rehypeAlignToClass } from "@/app/element/rehype-align-to-class";
 import remarkMermaidToTag from "@/app/element/remark-mermaid-to-tag";
+import { TableBlock } from "@/app/element/table-block";
 import { boundNumber, useAtomValueSafe, cn } from "@/util/util";
 import clsx from "clsx";
 import { toJsxRuntime } from "hast-util-to-jsx-runtime";
@@ -401,6 +403,20 @@ const Markdown = ({
         source: (props: any) => <MarkdownSource props={props} resolveOpts={resolveOpts} />,
         code: Code,
         pre: (props: any) => <CodeBlock children={props.children} onClickExecute={onClickExecute} />,
+        table: (props: any) => <TableBlock>{props.children}</TableBlock>,
+        thead: (props: any) => <thead class="border-b border-border bg-white/[0.03]">{props.children}</thead>,
+        tbody: (props: any) => <tbody>{props.children}</tbody>,
+        tr: (props: any) => <tr class="border-b border-border/40 last:border-0">{props.children}</tr>,
+        th: (props: any) => (
+            <th class={cn("px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-primary", props.class)}>
+                {props.children}
+            </th>
+        ),
+        td: (props: any) => (
+            <td class={cn("px-3 py-2 text-sm text-secondary", props.class)}>
+                {props.children}
+            </td>
+        ),
         waveblock: (props: any) => <WaveBlock {...props} blockmap={contentBlocksMap()} />,
         mermaidblock: (props: any) => {
             const getTextContent = (children: any): string => {
@@ -428,6 +444,7 @@ const Markdown = ({
             ? [
                   rehypeRaw,
                   rehypeHighlight,
+                  rehypeAlignToClass,
                   () =>
                       rehypeSanitize({
                           ...defaultSchema,

--- a/frontend/app/element/rehype-align-to-class.ts
+++ b/frontend/app/element/rehype-align-to-class.ts
@@ -1,0 +1,33 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { visit } from "unist-util-visit";
+import type { Root, Element } from "hast";
+
+const ALIGN_CLASS: Record<string, string> = {
+    left: "text-left",
+    center: "text-center",
+    right: "text-right",
+};
+
+// Rehype plugin: converts remark-gfm's deprecated `align` attribute on <th>/<td>
+// into a Tailwind class before rehype-sanitize strips it. Must run before sanitize.
+export function rehypeAlignToClass() {
+    return (tree: Root) => {
+        visit(tree, "element", (node: Element) => {
+            if (node.tagName !== "th" && node.tagName !== "td") return;
+            const align = node.properties?.align as string | undefined;
+            if (!align) return;
+            const cls = ALIGN_CLASS[align];
+            if (!cls) return;
+            const existing = node.properties.className;
+            const existingArr: (string | number)[] = Array.isArray(existing)
+                ? (existing as (string | number)[])
+                : existing && typeof existing !== "boolean"
+                ? [existing as string | number]
+                : [];
+            node.properties.className = [...existingArr, cls];
+            delete node.properties.align;
+        });
+    };
+}

--- a/frontend/app/element/streamdown.tsx
+++ b/frontend/app/element/streamdown.tsx
@@ -262,17 +262,12 @@ export const WaveStreamdown = (props: WaveStreamdownProps): JSX.Element => {
         tbody: (tbProps: any) => <tbody {...tbProps} />,
         tr: (trProps: any) => <tr {...trProps} class="border-b border-border/40 last:border-0" />,
         th: (thProps: any) => (
-            <th
-                class={cn(
-                    "px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-primary",
-                    thProps.className
-                )}
-            >
+            <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-primary">
                 {thProps.children}
             </th>
         ),
         td: (tdProps: any) => (
-            <td class={cn("px-3 py-2 text-sm text-secondary", tdProps.className)}>
+            <td class="px-3 py-2 text-sm text-secondary">
                 {tdProps.children}
             </td>
         ),

--- a/frontend/app/element/streamdown.tsx
+++ b/frontend/app/element/streamdown.tsx
@@ -5,6 +5,7 @@ import { CopyButton } from "@/app/element/copybutton";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ErrorBoundary } from "@/app/element/errorboundary";
 import { IconButton } from "@/app/element/iconbutton";
+import { TableBlock } from "@/app/element/table-block";
 import { cn, useAtomValueSafe } from "@/util/util";
 import { createEffect, createMemo, createSignal, JSX, onCleanup, Show } from "solid-js";
 import { Streamdown as StreamdownReact } from "streamdown";
@@ -256,12 +257,25 @@ export const WaveStreamdown = (props: WaveStreamdownProps): JSX.Element => {
         h4: (hProps: any) => <h4 {...hProps} class="text-base font-semibold text-primary mt-3 mb-1" />,
         h5: (hProps: any) => <h5 {...hProps} class="text-sm font-semibold text-primary mt-2 mb-1" />,
         h6: (hProps: any) => <h6 {...hProps} class="text-sm text-primary mt-2 mb-1" />,
-        table: (tProps: any) => <table {...tProps} class="w-full border-collapse my-4" />,
-        thead: (thProps: any) => <thead {...thProps} class="border-b border-border" />,
+        table: (tProps: any) => <TableBlock>{tProps.children}</TableBlock>,
+        thead: (thProps: any) => <thead {...thProps} class="border-b border-border bg-white/[0.03]" />,
         tbody: (tbProps: any) => <tbody {...tbProps} />,
-        tr: (trProps: any) => <tr {...trProps} class="border-b border-border/50 last:border-0" />,
-        th: (thProps: any) => <th {...thProps} class="text-left font-semibold px-2 py-1.5 text-sm text-primary" />,
-        td: (tdProps: any) => <td {...tdProps} class="px-2 py-1.5 text-sm text-secondary" />,
+        tr: (trProps: any) => <tr {...trProps} class="border-b border-border/40 last:border-0" />,
+        th: (thProps: any) => (
+            <th
+                class={cn(
+                    "px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-primary",
+                    thProps.className
+                )}
+            >
+                {thProps.children}
+            </th>
+        ),
+        td: (tdProps: any) => (
+            <td class={cn("px-3 py-2 text-sm text-secondary", tdProps.className)}>
+                {tdProps.children}
+            </td>
+        ),
         ul: (ulProps: any) => (
             <ul
                 {...ulProps}

--- a/frontend/app/element/table-block.tsx
+++ b/frontend/app/element/table-block.tsx
@@ -28,10 +28,14 @@ export function TableBlock(props: TableBlockProps): JSX.Element {
 
     const handleCopy = async () => {
         if (!tableRef) return;
-        const csv = extractCsv(tableRef);
-        await clipboardWriteText(csv);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        try {
+            const csv = extractCsv(tableRef);
+            await clipboardWriteText(csv);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch (e) {
+            console.warn("TableBlock: clipboard write failed", e);
+        }
     };
 
     return (

--- a/frontend/app/element/table-block.tsx
+++ b/frontend/app/element/table-block.tsx
@@ -1,0 +1,58 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { writeText as clipboardWriteText } from "@/util/clipboard";
+import { cn } from "@/util/util";
+import { createSignal, JSX, Show } from "solid-js";
+
+function extractCsv(table: HTMLTableElement): string {
+    const rows: string[] = [];
+    for (const row of Array.from(table.rows)) {
+        const cells = Array.from(row.cells).map((cell) => {
+            const text = (cell.innerText ?? "").replace(/\r?\n/g, " ").trim();
+            return /[,"\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+        });
+        rows.push(cells.join(","));
+    }
+    return rows.join("\n");
+}
+
+interface TableBlockProps {
+    children?: JSX.Element;
+    class?: string;
+}
+
+export function TableBlock(props: TableBlockProps): JSX.Element {
+    let tableRef: HTMLTableElement | undefined;
+    const [copied, setCopied] = createSignal(false);
+
+    const handleCopy = async () => {
+        if (!tableRef) return;
+        const csv = extractCsv(tableRef);
+        await clipboardWriteText(csv);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+    };
+
+    return (
+        <div class="table-block group relative my-4 overflow-x-auto rounded-lg border border-border">
+            <button
+                class={cn(
+                    "absolute right-2 top-2 z-10 rounded border border-border px-2 py-0.5",
+                    "text-xs text-muted opacity-0 transition-opacity group-hover:opacity-100",
+                    "bg-panel hover:bg-hover",
+                    copied() && "text-success opacity-100"
+                )}
+                onClick={handleCopy}
+                title="Copy as CSV"
+            >
+                <Show when={copied()} fallback="CSV">
+                    ✓ copied
+                </Show>
+            </button>
+            <table ref={tableRef} class={cn("w-full border-collapse", props.class)}>
+                {props.children}
+            </table>
+        </div>
+    );
+}

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -26,32 +26,32 @@ function installCefDragListener() {
     cefDragListenerInstalled = true;
 
     let dragging = false;
-    let startScreenX = 0;
-    let startScreenY = 0;
+    let clickScreenX = 0;
+    let clickScreenY = 0;
+    let initWinX = 0;
+    let initWinY = 0;
 
-    document.addEventListener("mousedown", (e: MouseEvent) => {
+    document.addEventListener("mousedown", async (e: MouseEvent) => {
         if (e.button !== 0) return;
         if (!isInDragRegion(e.target as HTMLElement)) return;
-
-        dragging = true;
-        startScreenX = e.screenX;
-        startScreenY = e.screenY;
         e.preventDefault();
-
-        // Get initial window position
-        invokeCommand<{ x: number; y: number }>("get_window_position").catch(() => {
-            dragging = false;
-        });
+        try {
+            const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+            clickScreenX = e.screenX;
+            clickScreenY = e.screenY;
+            initWinX = pos.x;
+            initWinY = pos.y;
+            dragging = true;
+        } catch {
+            // host unavailable — abort drag
+        }
     }, true);
 
     document.addEventListener("mousemove", (e: MouseEvent) => {
         if (!dragging) return;
-        const dx = e.screenX - startScreenX;
-        const dy = e.screenY - startScreenY;
-        if (dx === 0 && dy === 0) return;
-        startScreenX = e.screenX;
-        startScreenY = e.screenY;
-        invokeCommand("move_window_by", { dx, dy }).catch(() => {});
+        const tx = initWinX + (e.screenX - clickScreenX);
+        const ty = initWinY + (e.screenY - clickScreenY);
+        invokeCommand("set_window_position", { x: tx, y: ty }).catch(() => {});
     });
 
     document.addEventListener("mouseup", () => {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.682",
+  "version": "0.33.683",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026_05_07.md
+++ b/specs/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026_05_07.md
@@ -1,0 +1,197 @@
+# Bug Report: Window Drag Cursor Drift
+
+**Date:** 2026-05-07  
+**Symptom:** When dragging the title bar to move the window, the cursor's position on the bar drifts — it does not stay at the point where the user originally clicked.  
+**Severity:** P2 — noticeable UX regression, not a crash  
+**Area:** `frontend/app/hook/useWindowDrag.win32.ts`, `agentmux-cef/src/commands/window.rs`
+
+---
+
+## Observed Behaviour
+
+User clicks 100 px from the left edge of the title bar and drags right. As the drag continues the cursor gradually slides toward the right edge of the bar; by the time the window has moved ~200 px the cursor is visibly offset from the original click point.
+
+---
+
+## Code Path
+
+### 1. Frontend — `useWindowDrag.win32.ts`
+
+Because CEF does not expose `WM_NCLBUTTONDOWN`-style OS-native drag (comment at line 7), AgentMux implements dragging entirely in JS: track mouse deltas and forward them to the Rust host via IPC.
+
+```
+mousedown  → capture click position in startScreenX/Y (lines 37-38)
+           → fire get_window_position IPC (line 42) — NOT awaited, result discarded
+mousemove  → dx = e.screenX − startScreenX           (line 49)
+           → dy = e.screenY − startScreenY           (line 50)
+           → startScreenX = e.screenX                (line 52)  ← rolling baseline
+           → startScreenY = e.screenY                (line 53)  ← rolling baseline
+           → invokeCommand("move_window_by", {dx,dy}) (line 54) ← fire-and-forget
+mouseup    → dragging = false
+```
+
+### 2. Rust host — `agentmux-cef/src/commands/window.rs`
+
+`move_window_by` (lines 179–209):
+
+```rust
+GetWindowRect(hwnd, &mut rect);          // read current position
+SetWindowPos(hwnd, ..., rect.left + dx, rect.top + dy, ...);
+```
+
+No `set_window_position` (absolute) command exists. The only positioning API is relative (`move_window_by`).
+
+---
+
+## Root Cause
+
+The bug is a **stale-read race** between concurrent in-flight IPC calls, amplified by the fire-and-forget dispatch pattern.
+
+### Why the delta approach is fragile under load
+
+At normal mouse speeds mousemove fires 60–200+ events per second. Each event:
+1. Computes a delta from the rolling baseline (`startScreenX`)
+2. **Immediately advances** `startScreenX` to the current position
+3. Sends `move_window_by({dx, dy})` as a fire-and-forget IPC — no await, no back-pressure
+
+This means at any moment there are N in-flight IPC calls queued in the CEF IPC channel, each carrying a partial delta.
+
+### The stale-rect scenario
+
+`move_window_by` calls `GetWindowRect` then `SetWindowPos` in the Rust handler. In CEF the IPC handler runs on a non-UI (IO/render) thread. `SetWindowPos` called from a non-owning thread is relayed to the UI thread via the Windows message queue — it does **not** apply synchronously to the internal `RECT` that `GetWindowRect` reads.
+
+Timeline with 4 rapid mousemoves (+10 px each, target: +40 px total):
+
+| IPC call | GetWindowRect returns | SetWindowPos target | Window actually at |
+|----------|-----------------------|---------------------|--------------------|
+| IPC 1    | left = 100 (initial)  | 110                 | 100 (not yet applied) |
+| IPC 2    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| IPC 3    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| IPC 4    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| DWM flush | —                    | —                   | 110 (last wins)    |
+
+All four calls see the same old rect. The window moves +10 instead of +40. The cursor has moved +40 on screen. The cursor is now 30 px further right on the title bar than when the drag started — exactly the reported drift.
+
+The severity of the drift scales with:
+- Mouse speed (more events per SetWindowPos cycle → larger stale-read window)
+- IPC round-trip latency (slower machines / heavier load → more staleness)
+- DWM composition interval (higher refresh rate = faster flush = less visible; lower rate = worse)
+
+### Why `get_window_position` on mousedown doesn't help
+
+Line 42 calls `get_window_position()` but:
+- The returned value is never stored (`invokeCommand<{x,y}>(...).catch(...)` — result is dropped)
+- It is not awaited, so dragging begins before the initial position is known
+
+This call was presumably added in anticipation of absolute positioning but was never wired up.
+
+---
+
+## Fix: Absolute Positioning
+
+Switch from incremental deltas to absolute target coordinates. This eliminates the stale-read race entirely — each IPC call is independent and does not depend on the outcome of previous calls.
+
+### Frontend changes (`useWindowDrag.win32.ts`)
+
+```ts
+let dragging = false;
+let clickScreenX = 0;
+let clickScreenY = 0;
+let initWinX = 0;
+let initWinY = 0;
+let initFetched = false;
+
+document.addEventListener("mousedown", async (e: MouseEvent) => {
+    if (e.button !== 0 || !isInDragRegion(e.target as HTMLElement)) return;
+    e.preventDefault();
+    try {
+        const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+        clickScreenX = e.screenX;
+        clickScreenY = e.screenY;
+        initWinX = pos.x;
+        initWinY = pos.y;
+        initFetched = true;
+        dragging = true;
+    } catch {
+        // host unavailable — abort
+    }
+}, true);
+
+document.addEventListener("mousemove", (e: MouseEvent) => {
+    if (!dragging || !initFetched) return;
+    const tx = initWinX + (e.screenX - clickScreenX);
+    const ty = initWinY + (e.screenY - clickScreenY);
+    invokeCommand("set_window_position", { x: tx, y: ty }).catch(() => {});
+});
+```
+
+Key differences:
+- `get_window_position` is now **awaited** — drag does not start until the initial position is known
+- `clickScreenX/Y` is captured after the await (avoids the gap between click and IPC response)
+- Deltas are computed from the **fixed** click origin, not a rolling baseline
+- Each mousemove sends an absolute target, not a relative delta
+
+### Rust host: add `set_window_position` (`commands/window.rs`)
+
+```rust
+pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::*;
+        use windows_sys::Win32::Foundation::RECT;
+        let hwnd = find_own_top_level_window();
+        if !hwnd.is_null() {
+            let mut rect: RECT = std::mem::zeroed();
+            GetWindowRect(hwnd, &mut rect);
+            let width = rect.right - rect.left;
+            let height = rect.bottom - rect.top;
+            SetWindowPos(hwnd, std::ptr::null_mut(), x, y, width, height, 0x0014);
+            return Ok(serde_json::Value::Null);
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_set_window_position(state, "main", x, y);
+    let _ = state;
+    Ok(serde_json::Value::Null)
+}
+```
+
+Register in `ipc.rs` alongside the existing commands:
+
+```rust
+"set_window_position" => commands::window::set_window_position(state, args),
+```
+
+### Why absolute positioning is superior to fixing the delta approach
+
+| Property | Delta + rolling baseline | Absolute (proposed) |
+|----------|--------------------------|---------------------|
+| Stale-read race | Yes — N in-flight IPCs all apply from same old rect | No — each call is self-contained |
+| Cursor drift under fast mouse | Yes | No |
+| Correctness under IPC backpressure | Degrades | Idempotent — last-write-wins is correct |
+| Dropped events | Accumulate error | No effect on final position |
+| `get_window_position` round-trip on mousedown | Already exists, just not used | Uses the existing call |
+
+---
+
+## Secondary Issue: `mousedown` Async Gap
+
+With the await on `mousedown`, there is a brief window (~1–2 ms IPC round-trip) between the user's click and `dragging = true`. This is acceptable — the cursor is stationary at click time and the first `mousemove` events fire after the click handler completes. No perceptible delay.
+
+If latency is a concern, the initial position can be pre-fetched on title-bar `mouseenter` and cached; the mousedown handler then uses the cached value synchronously.
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `frontend/app/hook/useWindowDrag.win32.ts` | Switch to absolute positioning (await initial pos, fixed click origin) |
+| `agentmux-cef/src/commands/window.rs` | Add `set_window_position(x, y)` |
+| `agentmux-cef/src/ipc.rs` | Register `set_window_position` in the command router |
+| `agentmux-cef/src/ui_tasks.rs` (if it exists) | Add `post_set_window_position` for non-Windows paths |
+
+`move_window_by` and `get_window_position` can remain — they may be used elsewhere.

--- a/specs/SPEC_TABLE_FORMATTER_2026_05_07.md
+++ b/specs/SPEC_TABLE_FORMATTER_2026_05_07.md
@@ -1,0 +1,273 @@
+# Spec: Refined Table Formatter for Presentation Layer
+
+**Date:** 2026-05-07  
+**Status:** Draft  
+**Area:** `frontend/app/element/`
+
+---
+
+## Background
+
+Tables are currently rendered in two places with minimal inline Tailwind classes and no
+dedicated component:
+
+- **`streamdown.tsx:259-264`** — inline component map passed to `<WaveStreamdown>`:
+  ```tsx
+  table: (tProps: any) => <table {...tProps} class="w-full border-collapse my-4" />,
+  thead: (thProps: any) => <thead {...thProps} class="border-b border-border" />,
+  tbody: (tbProps: any) => <tbody {...tbProps} />,
+  tr: (trProps: any) => <tr {...trProps} class="border-b border-border/50 last:border-0" />,
+  th: (thProps: any) => <th {...thProps} class="text-left font-semibold px-2 py-1.5 text-sm text-primary" />,
+  td: (tdProps: any) => <td {...tdProps} class="px-2 py-1.5 text-sm text-secondary" />,
+  ```
+- **`markdown.tsx`** — no custom table overrides; falls through to default rehype HTML output
+  with no styling.
+
+Problems:
+1. Wide tables overflow their container and break layout (no horizontal scroll).
+2. Rows are hard to scan — no zebra striping or hover highlight.
+3. GFM column alignment (`:---`, `:---:`, `---:`) is ignored.
+4. No way to copy table data.
+5. `markdown.tsx` tables are completely unstyled.
+
+---
+
+## Goals
+
+1. **Visual polish** — consistent, readable table style across both rendering paths.
+2. **Overflow handling** — wide tables scroll horizontally inside a contained wrapper.
+3. **Column alignment** — respect GFM alignment markers from the parsed AST.
+4. **Dedicated `TableBlock` component** — encapsulates all table logic, adds copy-as-CSV action.
+
+---
+
+## New File: `frontend/app/element/table-block.tsx`
+
+A self-contained SolidJS component that renders the full `<table>` subtree.
+
+### Props
+
+```tsx
+interface TableBlockProps {
+    children: JSX.Element;   // thead + tbody passed through from markdown/streamdown
+    class?: string;
+}
+```
+
+### Behaviour
+
+#### Overflow wrapper
+Wrap the `<table>` in a `<div class="overflow-x-auto ...">` so wide tables scroll
+horizontally. The wrapper should have a thin border and rounded corners matching the app
+design language, acting as a visible container boundary.
+
+```
+┌─────────────────────────────────────────────────┐
+│ Name        │ Status  │ Date         │ Score     │◄── horizontal scroll if needed
+│─────────────┼─────────┼──────────────┼───────────│
+│ foo         │ OK      │ 2026-05-01   │ 98        │
+│ bar         │ FAIL    │ 2026-05-03   │ 12        │   ← zebra stripe on odd rows
+└─────────────────────────────────────────────────┘
+                                        [copy CSV]  ◄── top-right button
+```
+
+#### Copy-as-CSV
+A small icon button (use existing `<IconButton>`) appears in the top-right corner of the
+wrapper on hover. On click, it extracts all cell text via DOM traversal and writes a CSV
+string to the clipboard via `clipboardWriteText` from `@/util/clipboard`.
+
+CSV rules:
+- Comma-separated; values containing `,` or `"` or newlines are quoted and escaped.
+- First row = header row.
+- No trailing newline.
+
+The button should use the existing `<CopyButton>` pattern from `copybutton.tsx` — show a
+checkmark for 1.5 s after a successful copy.
+
+#### Zebra striping
+Odd `<tbody>` rows get a subtle background tint: `bg-white/[0.02]` (works on dark themes;
+adjust if light theme is added).
+
+#### Row hover highlight
+`<tbody> tr:hover` gets `bg-white/[0.04]`. Implemented via Tailwind group or direct class.
+
+#### Header distinction
+`<thead>` background: `bg-white/[0.04]` (slightly raised vs body). Bold font already in
+place. Add `text-xs uppercase tracking-wide` to `<th>` for a stronger header feel.
+
+---
+
+## Column Alignment
+
+### Streamdown path (`streamdown.tsx`)
+
+Streamdown's component map receives the processed HTML props, which **do** include a `style`
+attribute when the markdown source has alignment markers (markdown-it sets `text-align` via
+inline style). Pass through the `style` prop on `<th>` and `<td>` without overriding it.
+
+Current code strips alignment by spreading `{...thProps}` but then setting `class` which
+does not interfere — however, if markdown-it emits `style="text-align: center"`, that will
+already work. Verify this is preserved; if not, explicitly forward `tProps.style`.
+
+### Markdown.tsx path (remark-gfm / rehype)
+
+`remark-gfm` adds `align` attribute to `<th>`/`<td>` elements. `rehypeSanitize` strips
+non-whitelisted attributes. Solution: add `"align"` (or `"style"`) to the allowed attributes
+for `th` and `td` in the sanitize schema used in `markdown.tsx`.
+
+Alternatively, add a custom rehype plugin that converts `align` attribute to inline
+`style="text-align: ..."` before sanitization.
+
+---
+
+## Changes Required
+
+### 1. New file: `frontend/app/element/table-block.tsx`
+
+Full `TableBlock` component as described above.
+
+### 2. `frontend/app/element/streamdown.tsx`
+
+Replace the inline table component map entries (lines 259-264) with `TableBlock`:
+
+```tsx
+import { TableBlock } from "@/app/element/table-block";
+
+// inside createMemo components:
+table: (tProps: any) => <TableBlock {...tProps} />,
+thead: (thProps: any) => <thead {...thProps} class="bg-white/[0.04]" />,
+tbody: (tbProps: any) => <tbody {...tbProps} />,
+tr: (trProps: any) => (
+    <tr {...trProps} class="border-b border-border/40 last:border-0 hover:bg-white/[0.04] odd:bg-white/[0.02]" />
+),
+th: (thProps: any) => (
+    <th
+        {...thProps}
+        class="text-left font-semibold px-3 py-2 text-xs uppercase tracking-wide text-primary"
+    />
+),
+td: (tdProps: any) => <td {...tdProps} class="px-3 py-2 text-sm text-secondary" />,
+```
+
+### 3. `frontend/app/element/markdown.tsx`
+
+Add custom component overrides for `table`, `thead`, `tbody`, `tr`, `th`, `td` inside
+`markdownComponents` (around line 391), mirroring the streamdown treatment. Use `TableBlock`
+for the outer wrapper.
+
+Add custom component overrides for `table`, `thead`, `tbody`, `tr`, `th`, `td` inside
+`markdownComponents` (around line 391). Wire in `TableBlock` for the outer `table` element.
+The alignment-to-class rehype plugin (see Column Alignment section) handles `th`/`td`
+alignment without touching the sanitize schema.
+
+### 4. New rehype plugin: alignment-to-class (inline, ~20 lines)
+
+```ts
+// runs BEFORE rehypeSanitize in both paths
+function rehypeAlignToClass() {
+    return (tree: Root) => {
+        visit(tree, "element", (node) => {
+            if (node.tagName !== "th" && node.tagName !== "td") return;
+            const align = node.properties?.align as string | undefined;
+            if (!align) return;
+            const cls = align === "center" ? "text-center"
+                      : align === "right"  ? "text-right"
+                      : "text-left";
+            node.properties.className = [
+                ...(Array.isArray(node.properties.className) ? node.properties.className : []),
+                cls,
+            ];
+            delete node.properties.align;
+        });
+    };
+}
+```
+
+Insert this before `rehypeSanitize` in `markdown.tsx`'s `rehypePlugins` array. For `streamdown.tsx`,
+pass it as a custom `rehypePlugin` to `<Streamdown>` prepended before the default plugins.
+
+### 5. `frontend/app/element/markdown.scss`
+
+Add a `.table-block` rule for zebra striping and hover. Tailwind's `odd:` variant cannot be
+applied from a parent component — SCSS is cleaner here (see Theming section).
+
+---
+
+## Non-Goals
+
+- **Sortable columns** — out of scope for this iteration. Would require extracting cell data
+  into a signal-driven store; defer to a follow-up spec.
+- **Vertical scroll / max-height** — most tables in agent output are short; adding a fixed
+  max-height would clip useful content. Revisit if user feedback calls for it.
+- **Editable cells** — out of scope.
+- **Pagination** — out of scope.
+
+---
+
+## Implementation Order
+
+1. Create `table-block.tsx` with wrapper, copy-as-CSV, zebra/hover styling.
+2. Wire into `streamdown.tsx` component map.
+3. Wire into `markdown.tsx` component map + fix sanitize schema for alignment.
+4. Manual smoke test: paste a GFM table with mixed alignment columns into an agent pane,
+   verify horizontal scroll on a narrow pane, verify CSV copy output.
+
+---
+
+## Resolved: Open Questions
+
+### Light theme — use `var(--hover-bg-color)` via `color-mix()`
+
+**Finding**: All 8 themes (catppuccin, dracula, gruvbox, high-contrast, midnight, monokai,
+nord, tokyo-night) are dark-only. No light theme exists. Every theme defines
+`--hover-bg-color` as an accent-tinted semi-transparent color (e.g. `rgba(203,166,247,0.07)`
+for catppuccin, `rgba(100,160,255,0.08)` for tokyo-night). The default theme uses
+`rgba(255,255,255,0.1)`. Tailwind maps this to `--color-hover` in `@theme`.
+
+**Solution**: Use CSS variables instead of `bg-white/[...]` hardcodes:
+
+```scss
+// In markdown.scss or a new table-block.scss
+.table-block {
+    tbody tr:nth-child(odd) {
+        background: color-mix(in srgb, var(--hover-bg-color) 40%, transparent);
+    }
+    tbody tr:hover {
+        background: var(--hover-bg-color);
+    }
+}
+```
+
+`color-mix()` is supported in Chrome 111+ — CEF bundles Chromium 120+ so this is safe.
+If a light theme ships, it only needs to define `--hover-bg-color` with a dark-tinted value
+and both zebra striping and hover adapt automatically. No `dark:` prefix required.
+
+---
+
+### Column alignment — `align` attribute, stripped by sanitize; fix via pre-sanitize plugin
+
+**Finding** (confirmed via runtime test against the actual remark-gfm version in node_modules):
+
+```bash
+remark-gfm → remark-rehype → toHtml produces:
+<th align="left">Left</th>
+<th align="center">Center</th>
+<th align="right">Right</th>
+```
+
+remark-gfm outputs the **deprecated HTML `align` attribute**, not `style="text-align: ..."`.
+
+**Both paths strip it**:
+- `markdown.tsx`: `rehypeSanitize({ ...defaultSchema })` — `align` is not in `defaultSchema`'s
+  allowed attributes for `th`/`td`, so it is silently dropped.
+- `streamdown.tsx`: Streamdown runs its own internal `rehype-sanitize` with `defaultSchema`
+  before props reach our custom `th`/`td` component functions — same result.
+
+**Solution**: A small rehype plugin (`rehypeAlignToClass`, ~20 lines) that runs **before**
+`rehypeSanitize` in both paths. It visits `th`/`td` HAST nodes, reads `node.properties.align`,
+maps it to a Tailwind class (`text-left` / `text-center` / `text-right`), appends it to
+`node.properties.className`, and deletes `align`. Since `className` IS in `defaultSchema`'s
+allowed attributes, it survives sanitization.
+
+This avoids whitelisting `style` on table cells (which would open a CSS injection vector)
+and avoids whitelisting the deprecated `align` attribute. See Changes Required §4 above.


### PR DESCRIPTION
## Summary

- **Root cause:** `move_window_by` calls `GetWindowRect` then `SetWindowPos` from the IPC thread. Under rapid mousemove, multiple in-flight IPC calls all read the same stale rect (SetWindowPos is relayed to the UI thread async via the Windows message queue), so the window accumulates only one delta-worth of movement instead of N — the cursor visibly shifts from its original click point on the title bar.
- **Fix:** await `get_window_position` on mousedown to snapshot the initial window origin; each mousemove sends `set_window_position(initWin + totalCursorDelta)`. Each call is self-contained, so concurrent calls are idempotent — no stale-read race possible.
- **New IPC command:** `set_window_position(x, y)` — Rust handler in `commands/window.rs`, registered in `ipc.rs`, non-Windows CEF Views path via `SetWindowPositionTask` in `ui_tasks.rs`.

## Changes

| File | Change |
|------|--------|
| `frontend/app/hook/useWindowDrag.win32.ts` | Switch from delta + rolling baseline to absolute target coords |
| `agentmux-cef/src/commands/window.rs` | Add `set_window_position(x, y)` |
| `agentmux-cef/src/ui_tasks.rs` | Add `SetWindowPositionTask` + `post_set_window_position` |
| `agentmux-cef/src/ipc.rs` | Register `set_window_position` command |
| `specs/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026_05_07.md` | Bug report with full analysis |

## Test plan

- [ ] Drag title bar slowly — cursor stays fixed at click point throughout
- [ ] Drag title bar fast — cursor stays fixed at click point (the stale-race scenario)
- [ ] Double-click title bar — maximizes/restores correctly
- [ ] Minimize / close buttons still work
- [ ] Second window title bar also drags correctly (find_own_top_level_window is per-process)

🤖 Generated with [Claude Code](https://claude.com/claude-code)