### PR TITLE
fix: cmd-flash + tear-off alignment + hamburger SVG (multiple polish)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.705"
+version = "0.33.706"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.705"
+version = "0.33.706"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.705"
+version = "0.33.706"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.705"
+version = "0.33.706"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.704"
+version = "0.33.705"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.704"
+version = "0.33.705"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.704"
+version = "0.33.705"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.704"
+version = "0.33.705"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.703"
+version = "0.33.704"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.703"
+version = "0.33.704"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.703"
+version = "0.33.704"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.703"
+version = "0.33.704"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -815,12 +815,13 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "download-cef"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7471a7d5d3bd8df1b3b75871f0317d8a6dd73270ab861cc97ae7907ee63e554"
+checksum = "c169adf067a787e1f1c58ed62906a557de85388bee4b54fb878b722ff606b113"
 dependencies = [
  "bzip2",
  "clap",
+ "fs-err",
  "indicatif",
  "regex",
  "semver",
@@ -955,6 +956,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.706 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.703 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.702 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.701 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.703"
+version = "0.33.704"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.705"
+version = "0.33.706"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.704"
+version = "0.33.705"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/drag.rs
+++ b/agentmux-cef/src/commands/drag.rs
@@ -408,18 +408,11 @@ pub fn open_window_at_position(state: &Arc<AppState>, args: &serde_json::Value) 
     let tab_anchor_x = args.get("tabAnchorX").and_then(|v| v.as_f64()).map(|n| n as i32);
     let tab_anchor_y = args.get("tabAnchorY").and_then(|v| v.as_f64()).map(|n| n as i32);
 
-    // Position the new window. With tab anchor: place so the first
-    // tab's top-left lands at the anchor (cursor stays on the grabbed
-    // pixel). Without: cursor-centered title bar (legacy behavior).
-    //
-    // No `.max(0)` clamp on the anchor branch (codex P2 PR #730
-    // round 2): negative coords are valid on multi-monitor setups
-    // where a secondary display is left/above primary.
+    // Anchor is the new window's outer top-left (frontend pre-computed,
+    // chrome inset already subtracted). See window_pool.rs for full
+    // rationale. Negative coords valid on multi-monitor.
     let (pos_x, pos_y) = match (tab_anchor_x, tab_anchor_y) {
-        (Some(ax), Some(ay)) => (
-            ax - super::window_pool::FIRST_TAB_INSET_X,
-            ay - super::window_pool::TAB_STRIP_TOP_OFFSET_PX,
-        ),
+        (Some(ax), Some(ay)) => (ax, ay),
         _ => (
             ((screen_x - win_w as f64 / 2.0).max(0.0)) as i32,
             ((screen_y - 16.0).max(0.0)) as i32,

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -419,6 +419,17 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
         .map(|(l, _)| l)
         .filter(|l| !pool_labels.contains(l.as_str()) && !l.starts_with("browser-pane-"))
         .collect();
+    // Diagnostic for the v0.33.704 InstancePanel-shows-ghost-window
+    // bug. If labels.len() differs from the user's actual window
+    // count, this log identifies the ghost. Remove after RCA.
+    tracing::info!(
+        target: "window_instances",
+        count = labels.len(),
+        labels = ?labels,
+        pool_labels = ?pool_labels,
+        "[list_window_instances] returning {} labels: {:?}",
+        labels.len(), labels
+    );
     // Read backend window IDs via `state.backend_window_id()`,
     // which queries the launcher-fed `shadow_backend_window_ids`
     // (sole source of truth post-B.5e). Resolve labels OUTSIDE
@@ -459,29 +470,17 @@ pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
 }
 
 /// Focus a specific window by label.
+///
+/// Uses the CEF Views `Window::activate()` API on all platforms (via
+/// `post_focus_window` → `FocusWindowTask`). On Windows in Views mode,
+/// `browser.host().window_handle()` returns NULL — the legacy direct
+/// SetForegroundWindow path silently failed. Views' `activate()` calls
+/// SetForegroundWindow internally on the actual top-level HWND
+/// resolved through `browser_view_get_for_browser → window()`, which
+/// is the only correct way to get the HWND in Views mode.
 pub fn focus_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-
-    #[cfg(target_os = "windows")]
-    {
-        // Phase H.2.b — reducer-aware lookup with fallback.
-        if let Some(browser) = state.get_browser(label) {
-            if let Some(host) = browser.host() {
-                let hwnd = host.window_handle();
-                if !hwnd.0.is_null() {
-                    unsafe {
-                        windows_sys::Win32::UI::WindowsAndMessaging::SetForegroundWindow(
-                            hwnd.0 as *mut std::ffi::c_void,
-                        );
-                    }
-                    return Ok(serde_json::Value::Null);
-                }
-            }
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
     crate::ui_tasks::post_focus_window(state, label);
-    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -419,17 +419,6 @@ pub fn list_window_instances(state: &Arc<AppState>) -> serde_json::Value {
         .map(|(l, _)| l)
         .filter(|l| !pool_labels.contains(l.as_str()) && !l.starts_with("browser-pane-"))
         .collect();
-    // Diagnostic for the v0.33.704 InstancePanel-shows-ghost-window
-    // bug. If labels.len() differs from the user's actual window
-    // count, this log identifies the ghost. Remove after RCA.
-    tracing::info!(
-        target: "window_instances",
-        count = labels.len(),
-        labels = ?labels,
-        pool_labels = ?pool_labels,
-        "[list_window_instances] returning {} labels: {:?}",
-        labels.len(), labels
-    );
     // Read backend window IDs via `state.backend_window_id()`,
     // which queries the launcher-fed `shadow_backend_window_ids`
     // (sole source of truth post-B.5e). Resolve labels OUTSIDE

--- a/agentmux-cef/src/commands/window_pool.rs
+++ b/agentmux-cef/src/commands/window_pool.rs
@@ -71,19 +71,13 @@ const POOL_HEIGHT: i32 = 800;
 /// of the title bar after promotion.
 const TITLE_BAR_OFFSET_PX: i32 = 16;
 
-/// Tab-anchor placement constants. When the frontend supplies
-/// `tabAnchorX/Y` (the screen point where the user grabbed the tab),
-/// the new window is positioned so its FIRST TAB's top-left lands at
-/// that anchor — cursor stays on the same visual element across the
-/// handoff. Spec: SPEC_TAB_TEAROFF_POSITION_AND_PAINT_2026-05-07.md §4.4.
-///
-/// `FIRST_TAB_INSET_X` is the left-edge gap from the window's outer
-/// frame to where the first tab actually starts (tab strip leading
-/// padding). `TAB_STRIP_TOP_OFFSET_PX` is the vertical distance from
-/// the window's outer top to the top of the tab strip — title bar
-/// sits above it.
-pub(super) const FIRST_TAB_INSET_X: i32 = 8;
-pub(super) const TAB_STRIP_TOP_OFFSET_PX: i32 = TITLE_BAR_OFFSET_PX;
+// Tab-anchor placement: PR #730 hardcoded FIRST_TAB_INSET_X /
+// TAB_STRIP_TOP_OFFSET_PX as best-effort window-chrome offsets.
+// Smoke on v0.33.704 showed they were inaccurate (new window's
+// first tab not landing where the dragged tab was). The frontend
+// now measures the source window's chrome dynamically and computes
+// the new window's outer top-left position itself; backend just
+// uses the supplied anchor verbatim. The constants are gone.
 
 /// Spawn a single pool window. Called at startup (N times) and
 /// after each promote (1 refill). Idempotent against the
@@ -728,11 +722,17 @@ pub fn promote_pool_window(
     // left of or above the primary, screen coords can legitimately be
     // negative, and clamping to 0 would yank the window back onto the
     // primary monitor. The legacy fallback also doesn't clamp.
+    //
+    // Anchor semantics (refined post-PR #730 smoke): tab_anchor_{x,y}
+    // is now the OUTER TOP-LEFT of the new window, not the screen
+    // position of the grabbed tab. Frontend computes
+    //   anchor = cursor_screen - grab_offset - source_chrome_inset
+    // so its hardcoded chrome inset (was FIRST_TAB_INSET_X /
+    // TAB_STRIP_TOP_OFFSET_PX) is gone — frontend measures the source
+    // window's actual chrome dynamically. Backend just places the
+    // window at anchor with no further offset.
     let (pos_x, pos_y) = match (tab_anchor_x, tab_anchor_y) {
-        (Some(ax), Some(ay)) => (
-            ax - FIRST_TAB_INSET_X,
-            ay - TAB_STRIP_TOP_OFFSET_PX,
-        ),
+        (Some(ax), Some(ay)) => (ax, ay),
         _ => (
             screen_x - win_w / 2,
             screen_y - TITLE_BAR_OFFSET_PX,

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.705"
+version = "0.33.706"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.704"
+version = "0.33.705"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.703"
+version = "0.33.704"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.703"
+version = "0.33.704"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.704"
+version = "0.33.705"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.705"
+version = "0.33.706"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.705"
+version = "0.33.706"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.704"
+version = "0.33.705"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.703"
+version = "0.33.704"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -51,13 +51,27 @@ const SHELL_INPUT_CH_SIZE: usize = 32;
 ///   3. Fall back to `cmd.exe`
 #[cfg(windows)]
 fn detect_local_shell_path_windows() -> String {
+    use std::os::windows::process::CommandExt;
     use std::process::Command;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
     // Try pwsh (PowerShell 7)
-    if Command::new("where").arg("pwsh").output().map(|o| o.status.success()).unwrap_or(false) {
+    if Command::new("where")
+        .arg("pwsh")
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
         return "pwsh".to_string();
     }
     // Try powershell (Windows PowerShell 5.x)
-    if Command::new("where").arg("powershell").output().map(|o| o.status.success()).unwrap_or(false) {
+    if Command::new("where")
+        .arg("powershell")
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
         return "powershell".to_string();
     }
     "cmd.exe".to_string()

--- a/agentmux-srv/src/backend/tool_store.rs
+++ b/agentmux-srv/src/backend/tool_store.rs
@@ -140,8 +140,10 @@ pub fn current_platform() -> Result<&'static str, String> {
 fn probe_system_path(name: &str) -> bool {
     #[cfg(windows)]
     {
+        use std::os::windows::process::CommandExt;
         std::process::Command::new("where")
             .arg(name)
+            .creation_flags(0x08000000)
             .output()
             .map(|o| o.status.success())
             .unwrap_or(false)
@@ -159,7 +161,14 @@ fn probe_system_path(name: &str) -> bool {
 /// Returns the system PATH location of `name`, or None.
 fn system_path_of(name: &str) -> Option<String> {
     #[cfg(windows)]
-    let output = std::process::Command::new("where").arg(name).output().ok()?;
+    let output = {
+        use std::os::windows::process::CommandExt;
+        std::process::Command::new("where")
+            .arg(name)
+            .creation_flags(0x08000000)
+            .output()
+            .ok()?
+    };
     #[cfg(not(windows))]
     let output = std::process::Command::new("which").arg(name).output().ok()?;
 
@@ -182,10 +191,14 @@ fn system_path_of(name: &str) -> Option<String> {
 /// the output contains no recognisable version token.
 fn probe_version(cmd: &str, version_arg: &Option<String>) -> Option<String> {
     let arg = version_arg.as_deref()?;
-    let output = std::process::Command::new(cmd)
-        .arg(arg)
-        .output()
-        .ok()?;
+    let mut command = std::process::Command::new(cmd);
+    command.arg(arg);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(0x08000000);
+    }
+    let output = command.output().ok()?;
     // Some tools write version to stderr (e.g. older jq), try both.
     let text = if !output.stdout.is_empty() {
         String::from_utf8_lossy(&output.stdout).into_owned()

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -141,6 +141,16 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 //   cmd /C npm install ... --prefix "C:\path with spaces\..." pkg
                                 // and tokenizes "..." as a quoted path correctly.
                                 use std::os::windows::process::CommandExt;
+                                // CREATE_NO_WINDOW (0x08000000): suppress the
+                                // brief cmd.exe console flash that Windows
+                                // shows by default when CreateProcess is
+                                // called from a GUI process. Without this
+                                // flag the user sees a black console
+                                // window pop and disappear during npm
+                                // install — observed during workspace
+                                // setup paths (e.g. tear-off triggering
+                                // CLI install on first agent block).
+                                const CREATE_NO_WINDOW: u32 = 0x08000000;
                                 let npm_cmd_str = format!(
                                     "npm install --loglevel=http --no-audit --no-fund --no-progress --prefix \"{}\" {}",
                                     prefix_dir, package_arg
@@ -148,6 +158,7 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 std::process::Command::new("cmd")
                                     .arg("/C")
                                     .raw_arg(&npm_cmd_str)
+                                    .creation_flags(CREATE_NO_WINDOW)
                                     .env("CI", "true")
                                     .env("FORCE_COLOR", "0")
                                     .output()

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -94,8 +94,16 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 {
                     // Verify npm is available before attempting install.
                     let npm_available = if cfg!(windows) {
-                        tokio::process::Command::new("where").arg("npm").output().await
-                            .map(|o| o.status.success()).unwrap_or(false)
+                        // CREATE_NO_WINDOW (0x08000000) suppresses cmd flash —
+                        // see broader fix in this file's other spawns.
+                        let mut probe = tokio::process::Command::new("where");
+                        probe.arg("npm");
+                        #[cfg(windows)]
+                        {
+                            use std::os::windows::process::CommandExt;
+                            probe.creation_flags(0x08000000);
+                        }
+                        probe.output().await.map(|o| o.status.success()).unwrap_or(false)
                     } else {
                         tokio::process::Command::new("which").arg("npm").output().await
                             .map(|o| o.status.success()).unwrap_or(false)
@@ -398,7 +406,14 @@ pub(crate) async fn resolve_cli_on_path(cli_command: &str) -> Option<String> {
         cli_command.to_string()
     };
     let which_result = if cfg!(windows) {
-        tokio::process::Command::new("where").arg(&path_cmd).output().await
+        let mut probe = tokio::process::Command::new("where");
+        probe.arg(&path_cmd);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            probe.creation_flags(0x08000000);
+        }
+        probe.output().await
     } else {
         tokio::process::Command::new("which").arg(&path_cmd).output().await
     };

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -16,6 +16,7 @@
  */
 
 import { getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
+import { seedKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
@@ -54,6 +55,22 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const entries = openWindowEntriesAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
+
+    // Refresh window-instance seed each time the panel mounts. In
+    // production the launcher pushes WindowOpened/Closed events to all
+    // renderers and `openWindowEntriesAtom` stays in sync. In `task dev`
+    // mode there's no launcher, so each window only knows the snapshot
+    // it was seeded with at boot — windows opened later don't appear,
+    // closed ones aren't removed. Re-querying `listWindowInstances`
+    // every time the user opens the panel papers over this for dev
+    // mode without changing prod behavior (events also arriving will
+    // overwrite the seed shortly after).
+    getApi()
+        .listWindowInstances()
+        .then((snapshot) => {
+            seedKnownEntriesFromSnapshot(snapshot);
+        })
+        .catch(() => {});
 
     // Rename mode state — keyed by host label so the row's identity
     // survives entries() reordering. Single rename at a time.
@@ -257,25 +274,20 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         e.stopPropagation();
                                         return;
                                     }
-                                    // If a focus was pending on THIS row, this is
-                                    // the second click of a dblclick — let dblClick
-                                    // handle it; cancel the pending focus.
-                                    if (pendingFocus && pendingFocus.label === entry.label) {
-                                        cancelPendingFocus();
-                                        return;
-                                    }
-                                    // Otherwise schedule a fresh focus past the
-                                    // dblclick threshold so a follow-up click can
-                                    // promote it to rename instead.
-                                    cancelPendingFocus();
-                                    const label = entry.label;
-                                    pendingFocus = {
-                                        label,
-                                        timer: window.setTimeout(() => {
-                                            pendingFocus = null;
-                                            handleFocusWindow(label);
-                                        }, dblclickDelayMs()),
-                                    };
+                                    // Focus immediately — the previous design
+                                    // deferred via setTimeout(dblclickDelayMs)
+                                    // to disambiguate from dblclick-rename, but
+                                    // the StatusBar's outside-click dismiss
+                                    // unmounts InstancePanel before the timer
+                                    // fires, and onCleanup cancels the timer.
+                                    // Result: clicks did nothing.
+                                    //
+                                    // Firing focus immediately means a
+                                    // double-click still triggers focus first
+                                    // (harmless — rename input then takes
+                                    // over). dblClick handler still runs and
+                                    // enters rename mode.
+                                    handleFocusWindow(entry.label);
                                 }}
                                 onDblClick={(e) => {
                                     e.preventDefault();

--- a/frontend/app/tab/tabbar.scss
+++ b/frontend/app/tab/tabbar.scss
@@ -85,8 +85,14 @@
             color: color-mix(in srgb, var(--accent-color), white 25%);
         }
 
-        i {
-            font-size: 12px;
+        // Inline SVG (replaces fa-bars icon font). Icon fonts rasterize
+        // each glyph independently at the zoomed size; tiny sub-pixel
+        // boundary differences caused one of the three hamburger bars
+        // to render thinner than the other two, with a different bar
+        // affected at each zoom level. SVG rectangles fill uniformly
+        // and scale predictably with parent zoom.
+        svg {
+            display: block;
         }
     }
 

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -164,19 +164,47 @@ function TabBar(props: TabBarProps): JSX.Element {
                         // (works across multi-monitor setups).
                         const screenX = window.screenX + input.clientX;
                         const screenY = window.screenY + input.clientY;
-                        // Tab anchor: where the user grabbed the tab,
-                        // expressed as a screen point. Backend places the
-                        // new window's first tab at that point so the
-                        // cursor stays on the same pixel of the same
-                        // visual element across the handoff (no teleport).
-                        // Spec: SPEC_TAB_TEAROFF_POSITION_AND_PAINT_2026-05-07.md §4.3.
+                        // Tab anchor: position of the NEW window's outer
+                        // top-left such that its first tab lands at the
+                        // same screen pixel as the source tab the user
+                        // grabbed. The new window has identical chrome
+                        // + CSS, so its first-tab-rect equals the source's.
+                        //
+                        // Computation:
+                        //   sourceFirstTabScreenX = (cursor screen X)
+                        //                           - (cursor offset within grabbed tab)
+                        //                           - (first-tab-left in inner viewport)
+                        //   newOuterLeft = sourceFirstTabScreenX
+                        //                  - (chrome border-left, outer→inner)
+                        //
+                        // Total: newOuterLeft = screenX - grabOffset.x
+                        //                       - firstTabRect.left - chromeBorderX
+                        //
+                        // (window.outerWidth - innerWidth) on Windows is
+                        // left+right border; assume symmetric.
+                        // (window.outerHeight - innerHeight) - chromeBorderX
+                        // isolates title bar height.
                         const grabOffset = getTabGrabOffset();
-                        const tabAnchorX = grabOffset
-                            ? screenX - grabOffset.x
-                            : undefined;
-                        const tabAnchorY = grabOffset
-                            ? screenY - grabOffset.y
-                            : undefined;
+                        const chromeBorderX =
+                            Math.max(0, window.outerWidth - window.innerWidth) / 2;
+                        const chromeBorderY = Math.max(
+                            0,
+                            window.outerHeight - window.innerHeight - chromeBorderX,
+                        );
+                        const firstTabEl = tabBarScrollRef?.firstElementChild as HTMLElement | null;
+                        const firstTabRect = firstTabEl?.getBoundingClientRect();
+                        const tabAnchorX =
+                            grabOffset && firstTabRect
+                                ? Math.round(
+                                      screenX - grabOffset.x - firstTabRect.left - chromeBorderX,
+                                  )
+                                : undefined;
+                        const tabAnchorY =
+                            grabOffset && firstTabRect
+                                ? Math.round(
+                                      screenY - grabOffset.y - firstTabRect.top - chromeBorderY,
+                                  )
+                                : undefined;
                         // Phase 2: real tear-off (sidecar TearOffTab +
                         // host openWindowAtPosition + Win32 SC_MOVE).
                         // Fire-and-forget — the user is mid-drag and the
@@ -592,7 +620,25 @@ function TabBar(props: TabBarProps): JSX.Element {
                 placement="bottom-start"
             >
                 <button class="hamburger-btn" title="Menu" data-drag-region="false">
-                    <i class="fa fa-bars" />
+                    {/*
+                     * Inline SVG with three filled rects instead of
+                     * `fa fa-bars`. Icon-font glyphs rasterized one of
+                     * the three lines on a fractional pixel boundary at
+                     * different chrome zoom levels, making it noticeably
+                     * thinner — and the affected line shifted as zoom
+                     * changed. Filled rects scale uniformly with the
+                     * parent's CSS zoom, no rasterization unevenness.
+                     */}
+                    <svg
+                        width="14"
+                        height="12"
+                        viewBox="0 0 14 12"
+                        fill="currentColor"
+                    >
+                        <rect x="1" y="1" width="12" height="2" rx="1" />
+                        <rect x="1" y="5" width="12" height="2" rx="1" />
+                        <rect x="1" y="9" width="12" height="2" rx="1" />
+                    </svg>
                 </button>
             </FlyoutMenu>
             <div ref={tabBarScrollRef!} class="tab-bar-scroll" data-drag-region="false">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.703",
+  "version": "0.33.704",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.703",
+      "version": "0.33.704",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.705",
+  "version": "0.33.706",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.705",
+      "version": "0.33.706",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.704",
+  "version": "0.33.705",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.704",
+      "version": "0.33.705",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.705",
+  "version": "0.33.706",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.703",
+  "version": "0.33.704",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.704",
+  "version": "0.33.705",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Three coupled UX/polish fixes following PR #730 (size match + position match + threshold).

### 1. cmd.exe console flash on tear-off (root cause + broader fix)

User report: a cmd window briefly flashed just before the new window appeared on tear-off. Round 1 patched `cli_handlers.rs::npm install`. Round 2 found that wasn't the actual culprit — bisecting back to PR #724 confirmed the flash predates ALL recent tear-off work.

Real source: latent spawn sites in old code that never had `CREATE_NO_WINDOW`:
- `agentmux-srv/server/cli_handlers.rs` — `where npm` probe + `resolve_cli_on_path` `where <cmd>` lookup
- `agentmux-srv/backend/blockcontroller/shell.rs::detect_local_shell_path_windows` — `where pwsh` / `where powershell` probes (fires during terminal block init in the new workspace — the actual culprit)
- `agentmux-srv/backend/tool_store.rs` — `probe_system_path`, `system_path_of`, `probe_version` `where`/`which` calls

All now use `CREATE_NO_WINDOW (0x08000000)` so the `cmd.exe` / `where.exe` children run windowless.

### 2. Dynamic tear-off alignment

PR #730 hardcoded `FIRST_TAB_INSET_X = 8` and `TAB_STRIP_TOP_OFFSET_PX = 16` as best-effort offsets. Smoke confirmed inaccurate — new window's tab didn't land where the source tab was.

Frontend now measures the source window's actual chrome:
```ts
chromeBorderX = (outerWidth - innerWidth) / 2;
chromeBorderY = (outerHeight - innerHeight) - chromeBorderX;
newOuterX = cursor_screen.x - grab.x - firstTabRect.left - chromeBorderX;
newOuterY = cursor_screen.y - grab.y - firstTabRect.top  - chromeBorderY;
```
Backend uses `tabAnchorX/Y` verbatim. Constants removed. Lands the new window's first tab at exactly the same screen pixel the source tab was — Chrome-style no-teleport.

### 3. Hamburger menu SVG (icon-font rasterization fix)

User report: at different chrome zoom levels, one of three horizontal hamburger bars was visibly thinner than the others — and the affected bar shifted as zoom changed. `fa-bars` glyph rasterizer rounding differed across zoom levels.

Replaced with inline SVG using three filled `<rect>` elements that scale uniformly with the parent's `zoom: var(--zoomfactor)`.

## Test plan

- [x] task dev smoke: cmd flash gone
- [x] task dev smoke: new window's first tab lands exactly at source tab's drag-start position (verified left-edge + right-edge)
- [x] task dev smoke: hamburger uniform across zoom levels
- [x] Cargo build clean
- [ ] Smoke on portable build

## Bisect provenance

Bisected to `6b84df2a` (PR #724 — earliest commit where tear-off doesn't crash the renderer); cmd flash present there too. Patches address latent issues, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)