### PR TITLE
fix(InstancePanel): use Reconcile (replace) instead of Seed (additive) on refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.706"
+version = "0.33.707"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.706"
+version = "0.33.707"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.706"
+version = "0.33.707"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.706"
+version = "0.33.707"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.692
+## Latest Version: 0.33.707
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.706"
+version = "0.33.707"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.706"
+version = "0.33.707"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.706"
+version = "0.33.707"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.706"
+version = "0.33.707"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -17,6 +17,7 @@
 
 import { getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
 import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
+import { launcherEventsActive } from "@/util/launcher-events";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
@@ -56,20 +57,26 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
 
-    // Refresh window-instance state each time the panel mounts. In
+    // Refresh window-instance state ONLY when the launcher is silent
+    // (`task dev` mode — no launcher process, no typed events). In
     // production the launcher pushes WindowOpened/Closed events and
-    // `openWindowEntriesAtom` stays in sync; in `task dev` there's no
-    // launcher and each window stays stuck on its boot snapshot.
+    // `openWindowEntriesAtom` stays in sync; reconciling against a
+    // stale `listWindowInstances()` snapshot would clobber a newer
+    // launcher event the renderer just applied — same race protection
+    // that motivates ApplySeed at boot (codex P2 PR #733).
     //
-    // Uses the RECONCILE path (replaces wholesale) rather than the
-    // additive seed: closed-but-still-tracked windows must actually
-    // disappear from the panel (codex P3 PR #732).
-    getApi()
-        .listWindowInstances()
-        .then((snapshot) => {
-            reconcileKnownEntriesFromSnapshot(snapshot);
-        })
-        .catch(() => {});
+    // `launcherEventsActive` flips true on the first typed event the
+    // renderer receives; if false here, we're in dev mode and the
+    // reconcile is the only way windows opened/closed since boot will
+    // appear/disappear in the panel.
+    if (!launcherEventsActive()) {
+        getApi()
+            .listWindowInstances()
+            .then((snapshot) => {
+                reconcileKnownEntriesFromSnapshot(snapshot);
+            })
+            .catch(() => {});
+    }
 
     // Rename mode state — keyed by host label so the row's identity
     // survives entries() reordering. Single rename at a time.

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -16,7 +16,7 @@
  */
 
 import { getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
-import { seedKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
+import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
@@ -56,19 +56,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
     getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
 
-    // Refresh window-instance seed each time the panel mounts. In
-    // production the launcher pushes WindowOpened/Closed events to all
-    // renderers and `openWindowEntriesAtom` stays in sync. In `task dev`
-    // mode there's no launcher, so each window only knows the snapshot
-    // it was seeded with at boot — windows opened later don't appear,
-    // closed ones aren't removed. Re-querying `listWindowInstances`
-    // every time the user opens the panel papers over this for dev
-    // mode without changing prod behavior (events also arriving will
-    // overwrite the seed shortly after).
+    // Refresh window-instance state each time the panel mounts. In
+    // production the launcher pushes WindowOpened/Closed events and
+    // `openWindowEntriesAtom` stays in sync; in `task dev` there's no
+    // launcher and each window stays stuck on its boot snapshot.
+    //
+    // Uses the RECONCILE path (replaces wholesale) rather than the
+    // additive seed: closed-but-still-tracked windows must actually
+    // disappear from the panel (codex P3 PR #732).
     getApi()
         .listWindowInstances()
         .then((snapshot) => {
-            seedKnownEntriesFromSnapshot(snapshot);
+            reconcileKnownEntriesFromSnapshot(snapshot);
         })
         .catch(() => {});
 

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -73,6 +73,12 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         getApi()
             .listWindowInstances()
             .then((snapshot) => {
+                // Re-check at resolution time. Between the sync gate
+                // above and the snapshot arriving (~ms RPC round-trip),
+                // a launcher event may have flipped launcherEventsActive
+                // true — applying the now-stale snapshot would clobber
+                // that newer state (codex P1 PR #733 round 2).
+                if (launcherEventsActive()) return;
                 reconcileKnownEntriesFromSnapshot(snapshot);
             })
             .catch(() => {});

--- a/frontend/app/store/launcher-event-reducer.ts
+++ b/frontend/app/store/launcher-event-reducer.ts
@@ -131,6 +131,24 @@ export function seedKnownEntriesFromSnapshot(
     dispatch({ type: "ApplySeed", entries });
 }
 
+/**
+ * Reconcile knownEntries against a fresh `listWindowInstances` snapshot.
+ * Differs from `seedKnownEntriesFromSnapshot` (`ApplySeed`) in that it
+ * REPLACES the known set wholesale — labels absent from the snapshot
+ * are removed from the panel.
+ *
+ * Use for periodic refresh paths (e.g. InstancePanel reopens in
+ * `task dev` mode where the launcher doesn't push WindowClosed
+ * events). Don't use at boot — `ApplySeed` is the right boot path
+ * because it's additive against typed events that may have raced
+ * the snapshot fetch (codex P1 #603).
+ */
+export function reconcileKnownEntriesFromSnapshot(
+    entries: ReadonlyArray<WindowEntry>,
+): void {
+    dispatch({ type: "ReconcileFromSnapshot", entries });
+}
+
 let started = false;
 
 /**

--- a/frontend/app/store/launcher-event/reducer.test.ts
+++ b/frontend/app/store/launcher-event/reducer.test.ts
@@ -286,6 +286,83 @@ describe("launcher-event reducer", () => {
         });
     });
 
+    describe("ReconcileFromSnapshot", () => {
+        it("removes labels absent from snapshot (closed windows actually disappear)", () => {
+            // Codex P3 PR #732: ApplySeed is additive (doesn't remove
+            // labels missing from the snapshot) so the previous
+            // InstancePanel-on-open-refresh path left closed windows
+            // visible in dev mode. Reconcile REPLACES wholesale.
+            const seeded = update(initialState(), {
+                type: "ApplySeed",
+                entries: [
+                    { label: "window-a", windowId: null },
+                    { label: "window-b", windowId: null },
+                    { label: "window-c", windowId: null },
+                ],
+            }).state;
+            expect(seeded.knownEntries.size).toBe(3);
+
+            // window-c was closed in the host; snapshot only has a, b.
+            const r = update(seeded, {
+                type: "ReconcileFromSnapshot",
+                entries: [
+                    { label: "window-a", windowId: null },
+                    { label: "window-b", windowId: null },
+                ],
+            });
+            expect(r.state.knownEntries.has("window-c")).toBe(false);
+            expect(r.state.knownEntries.size).toBe(2);
+            expect(r.events[0]).toMatchObject({
+                type: "reconciled",
+                addedCount: 0,
+                removedCount: 1,
+                totalAfter: 2,
+            });
+        });
+
+        it("adds new labels and removes missing ones in one pass", () => {
+            const seeded = update(initialState(), {
+                type: "ApplySeed",
+                entries: [{ label: "window-a", windowId: null }],
+            }).state;
+            const r = update(seeded, {
+                type: "ReconcileFromSnapshot",
+                entries: [
+                    { label: "window-b", windowId: null },
+                    { label: "window-c", windowId: null },
+                ],
+            });
+            expect(r.state.knownEntries.has("window-a")).toBe(false);
+            expect(r.state.knownEntries.has("window-b")).toBe(true);
+            expect(r.state.knownEntries.has("window-c")).toBe(true);
+            expect(r.events[0]).toMatchObject({
+                type: "reconciled",
+                addedCount: 2,
+                removedCount: 1,
+                totalAfter: 2,
+            });
+        });
+
+        it("filters non-instance labels (parity with ApplySeed)", () => {
+            // `window-pool-*` IS an instance label at this layer
+            // (promoted pool windows keep the prefix and ARE user-
+            // visible; unpromoted ones are filtered host-side in
+            // list_window_instances). Only browser-pane-* is rejected.
+            const r = update(initialState(), {
+                type: "ReconcileFromSnapshot",
+                entries: [
+                    { label: "window-a", windowId: null },
+                    { label: "window-pool-promoted", windowId: null },
+                    { label: "browser-pane-x", windowId: null },
+                ],
+            });
+            expect(r.state.knownEntries.size).toBe(2);
+            expect(r.state.knownEntries.has("window-a")).toBe(true);
+            expect(r.state.knownEntries.has("window-pool-promoted")).toBe(true);
+            expect(r.state.knownEntries.has("browser-pane-x")).toBe(false);
+        });
+    });
+
     describe("saga + drift + unknown variants", () => {
         it("hwnd_drift_detected emits drift-detected audit event", () => {
             const start = initialState();

--- a/frontend/app/store/launcher-event/reducer.ts
+++ b/frontend/app/store/launcher-event/reducer.ts
@@ -31,6 +31,8 @@ export function update(
             return applyEvent(state, command.event);
         case "ApplySeed":
             return applySeed(state, command.entries);
+        case "ReconcileFromSnapshot":
+            return reconcileFromSnapshot(state, command.entries);
     }
 }
 
@@ -262,6 +264,53 @@ function applySeed(
             instances: deriveInstances(next),
         },
         events: [{ type: "seeded", addedCount: added, tombstonesSkipped }],
+    };
+}
+
+// ── ReconcileFromSnapshot ──────────────────────────────────────────────
+
+function reconcileFromSnapshot(
+    state: LauncherEventState,
+    entries: ReadonlyArray<WindowEntry>,
+): ReducerResult {
+    // Wholesale REPLACE knownEntries with the fresh snapshot. Adds new
+    // labels (like ApplySeed) AND removes labels absent from the
+    // snapshot (unlike ApplySeed). Used for steady-state refresh in
+    // dev mode where the launcher doesn't push close events. Only
+    // accepts instance labels — non-instance labels in the snapshot
+    // are filtered the same as in ApplySeed.
+    //
+    // No tombstone handling: by the time reconcile runs, the seed
+    // phase is over (`seedHasHappened: true`); pre-seed tombstones
+    // are no longer relevant.
+    const next = new Map<string, WindowEntry>();
+    for (const e of entries) {
+        if (!isInstanceLabel(e.label)) continue;
+        next.set(e.label, { label: e.label, windowId: e.windowId });
+    }
+    let added = 0;
+    for (const label of next.keys()) {
+        if (!state.knownEntries.has(label)) added++;
+    }
+    let removed = 0;
+    for (const label of state.knownEntries.keys()) {
+        if (!next.has(label)) removed++;
+    }
+    return {
+        state: {
+            knownEntries: next,
+            seedHasHappened: state.seedHasHappened,
+            closedBeforeSeed: state.closedBeforeSeed,
+            instances: deriveInstances(next),
+        },
+        events: [
+            {
+                type: "reconciled",
+                addedCount: added,
+                removedCount: removed,
+                totalAfter: next.size,
+            },
+        ],
     };
 }
 

--- a/frontend/app/store/launcher-event/types.ts
+++ b/frontend/app/store/launcher-event/types.ts
@@ -62,13 +62,21 @@ export const initialState = (): LauncherEventState => ({
 });
 
 /**
- * Two command shapes feed the reducer:
+ * Three command shapes feed the reducer:
  *   1. `ApplyEvent` — typed event from the launcher channel
- *   2. `ApplySeed` — RPC-snapshot seed at app init
+ *   2. `ApplySeed` — RPC-snapshot seed at app init (additive merge)
+ *   3. `ReconcileFromSnapshot` — periodic refresh that REPLACES the
+ *      known set wholesale. Removes labels absent from the snapshot
+ *      — needed for the `task dev` no-launcher path where close
+ *      events never arrive. Distinct from `ApplySeed` because seed
+ *      is intentionally additive to protect against typed events
+ *      racing with the snapshot fetch (codex P1 #603); reconcile is
+ *      for steady-state refresh after seed.
  */
 export type LauncherEventCommand =
     | { type: "ApplyEvent"; event: LauncherEvent }
-    | { type: "ApplySeed"; entries: ReadonlyArray<WindowEntry> };
+    | { type: "ApplySeed"; entries: ReadonlyArray<WindowEntry> }
+    | { type: "ReconcileFromSnapshot"; entries: ReadonlyArray<WindowEntry> };
 
 /**
  * Audit events emitted by the reducer. Useful for tests + future
@@ -101,7 +109,13 @@ export type LauncherEventReducerEvent =
     | { type: "saga-event-observed"; eventName: string; raw: LauncherEvent }
     | { type: "unknown-variant-ignored"; eventName: string }
     | { type: "filtered-out"; label: string; reason: string }
-    | { type: "seeded"; addedCount: number; tombstonesSkipped: number };
+    | { type: "seeded"; addedCount: number; tombstonesSkipped: number }
+    | {
+          type: "reconciled";
+          addedCount: number;
+          removedCount: number;
+          totalAfter: number;
+      };
 
 export interface ReducerResult {
     state: LauncherEventState;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.706",
+  "version": "0.33.707",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.706",
+      "version": "0.33.707",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.706",
+  "version": "0.33.707",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Codex P3 follow-up to PR #732. The InstancePanel-on-open refresh added in #732 used `ApplySeed`, which is **intentionally additive** (codex P1 #603: protects against typed events racing the boot snapshot fetch). That meant in dev mode where the launcher never pushes WindowClosed events, closed windows persisted as ghost rows in the panel even after re-opening.

## Fix

Add a new reducer command `ReconcileFromSnapshot` that **replaces** `knownEntries` wholesale:
- Adds labels in the snapshot but not in `knownEntries`
- **Removes** labels in `knownEntries` but not in the snapshot
- Filters non-instance labels (same `isInstanceLabel` rule as `ApplySeed`)
- No tombstone handling (post-seed; pre-seed tombstones are no longer relevant)

Distinct from `ApplySeed`:
- `ApplySeed` — boot-time, additive, race-protected
- `ReconcileFromSnapshot` — steady-state, replace, used for periodic refresh

`InstancePanel.tsx::onMount` now calls `reconcileKnownEntriesFromSnapshot` instead of `seedKnownEntriesFromSnapshot`.

## Test plan

- [x] 3 new regression tests in `reducer.test.ts`:
  - `removes labels absent from snapshot (closed windows actually disappear)`
  - `adds new labels and removes missing ones in one pass`
  - `filters non-instance labels (parity with ApplySeed)`
- [x] All 29 reducer tests pass
- [ ] Smoke in dev: open InstancePanel → close a window → re-open InstancePanel; the closed window's row should be gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)