### PR TITLE
fix(window): switch title-bar drag to absolute positioning (extracted from #729)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.708"
+version = "0.33.709"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.708"
+version = "0.33.709"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.708"
+version = "0.33.709"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.708"
+version = "0.33.709"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.707"
+version = "0.33.708"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.707"
+version = "0.33.708"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.707"
+version = "0.33.708"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.707"
+version = "0.33.708"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.708"
+version = "0.33.709"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.707"
+version = "0.33.708"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -208,6 +208,41 @@ pub fn move_window_by(state: &Arc<AppState>, args: &serde_json::Value) -> Result
     Ok(serde_json::Value::Null)
 }
 
+/// Move the window to an absolute screen position (x, y).
+/// Each call is self-contained — no read-modify-write — so concurrent in-flight
+/// calls are idempotent: the last write wins, which is exactly correct for drag.
+pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::*;
+        use windows_sys::Win32::Foundation::RECT;
+        let hwnd = find_own_top_level_window();
+        if !hwnd.is_null() {
+            let mut rect: RECT = std::mem::zeroed();
+            GetWindowRect(hwnd, &mut rect);
+            let width = rect.right - rect.left;
+            let height = rect.bottom - rect.top;
+            SetWindowPos(
+                hwnd,
+                std::ptr::null_mut(),
+                x,
+                y,
+                width,
+                height,
+                0x0014, // SWP_NOZORDER | SWP_NOSIZE
+            );
+            return Ok(serde_json::Value::Null);
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_set_window_position(state, "main", x, y);
+    let _ = state;
+    Ok(serde_json::Value::Null)
+}
+
 /// Initiate window drag (for frameless windows).
 /// Windows: sends WM_NCLBUTTONDOWN/HTCAPTION via Win32 — find_own_top_level_window
 /// resolves the per-process HWND so multi-window works without a label.
@@ -459,17 +494,29 @@ pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
 }
 
 /// Focus a specific window by label.
-///
-/// Uses the CEF Views `Window::activate()` API on all platforms (via
-/// `post_focus_window` → `FocusWindowTask`). On Windows in Views mode,
-/// `browser.host().window_handle()` returns NULL — the legacy direct
-/// SetForegroundWindow path silently failed. Views' `activate()` calls
-/// SetForegroundWindow internally on the actual top-level HWND
-/// resolved through `browser_view_get_for_browser → window()`, which
-/// is the only correct way to get the HWND in Views mode.
 pub fn focus_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
+
+    #[cfg(target_os = "windows")]
+    {
+        // Phase H.2.b — reducer-aware lookup with fallback.
+        if let Some(browser) = state.get_browser(label) {
+            if let Some(host) = browser.host() {
+                let hwnd = host.window_handle();
+                if !hwnd.0.is_null() {
+                    unsafe {
+                        windows_sys::Win32::UI::WindowsAndMessaging::SetForegroundWindow(
+                            hwnd.0 as *mut std::ffi::c_void,
+                        );
+                    }
+                    return Ok(serde_json::Value::Null);
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
     crate::ui_tasks::post_focus_window(state, label);
+    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -517,7 +517,6 @@ pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
 pub fn focus_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
     crate::ui_tasks::post_focus_window(state, label);
-    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -176,9 +176,17 @@ pub fn get_window_position(state: &Arc<AppState>) -> Result<serde_json::Value, S
 }
 
 /// Move the window by a delta (dx, dy) from its current position.
+///
+/// **Prefer `set_window_position` for drag flows.** This function reads
+/// the current rect via `GetWindowRect` then SetWindowPos with the new
+/// origin — under rapid concurrent calls (mousemove drag), in-flight
+/// IPCs all read the same stale rect and only one delta gets applied.
+/// `set_window_position` is self-contained (no read-modify-write) and
+/// idempotent under concurrency.
 pub fn move_window_by(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let dx = args.get("dx").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let dy = args.get("dy").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
 
     #[cfg(target_os = "windows")]
     unsafe {
@@ -197,14 +205,15 @@ pub fn move_window_by(state: &Arc<AppState>, args: &serde_json::Value) -> Result
                 rect.top + dy,
                 width,
                 height,
-                0x0014, // SWP_NOZORDER | SWP_NOSIZE
+                // 0x0014 = SWP_NOZORDER (0x0004) | SWP_NOACTIVATE (0x0010).
+                0x0014,
             );
             return Ok(serde_json::Value::Null);
         }
     }
     #[cfg(not(target_os = "windows"))]
-    crate::ui_tasks::post_move_window(state, "main", dx, dy);
-    let _ = state;
+    crate::ui_tasks::post_move_window(state, label, dx, dy);
+    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 
@@ -214,6 +223,7 @@ pub fn move_window_by(state: &Arc<AppState>, args: &serde_json::Value) -> Result
 pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
     let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
 
     #[cfg(target_os = "windows")]
     unsafe {
@@ -232,14 +242,17 @@ pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> R
                 y,
                 width,
                 height,
-                0x0014, // SWP_NOZORDER | SWP_NOSIZE
+                // 0x0014 = SWP_NOZORDER (0x0004) | SWP_NOACTIVATE (0x0010).
+                // (Width/height are still passed explicitly above so size
+                // is preserved without needing SWP_NOSIZE.)
+                0x0014,
             );
             return Ok(serde_json::Value::Null);
         }
     }
     #[cfg(not(target_os = "windows"))]
-    crate::ui_tasks::post_set_window_position(state, "main", x, y);
-    let _ = state;
+    crate::ui_tasks::post_set_window_position(state, label, x, y);
+    let _ = (state, label);
     Ok(serde_json::Value::Null)
 }
 
@@ -494,27 +507,15 @@ pub fn list_windows(state: &Arc<AppState>) -> serde_json::Value {
 }
 
 /// Focus a specific window by label.
+///
+/// Uses the CEF Views `Window::activate()` API on all platforms (via
+/// `post_focus_window` → `FocusWindowTask`). On Windows in Views mode,
+/// `browser.host().window_handle()` returns NULL — the previous direct
+/// SetForegroundWindow path silently failed there. Views' `activate()`
+/// resolves the actual top-level HWND through `browser_view_get_for_browser
+/// → window()` which is the only correct way to reach it in Views mode.
 pub fn focus_window(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
     let label = args.get("label").and_then(|v| v.as_str()).unwrap_or("main");
-
-    #[cfg(target_os = "windows")]
-    {
-        // Phase H.2.b — reducer-aware lookup with fallback.
-        if let Some(browser) = state.get_browser(label) {
-            if let Some(host) = browser.host() {
-                let hwnd = host.window_handle();
-                if !hwnd.0.is_null() {
-                    unsafe {
-                        windows_sys::Win32::UI::WindowsAndMessaging::SetForegroundWindow(
-                            hwnd.0 as *mut std::ffi::c_void,
-                        );
-                    }
-                    return Ok(serde_json::Value::Null);
-                }
-            }
-        }
-    }
-    #[cfg(not(target_os = "windows"))]
     crate::ui_tasks::post_focus_window(state, label);
     let _ = (state, label);
     Ok(serde_json::Value::Null)

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -240,6 +240,7 @@ async fn route_command(
         "start_window_drag" => commands::window::start_window_drag(state, args),
         "get_window_position" => commands::window::get_window_position(state),
         "move_window_by" => commands::window::move_window_by(state, args),
+        "set_window_position" => commands::window::set_window_position(state, args),
         "toggle_devtools" => commands::window::toggle_devtools(state, args),
         "show_context_menu" => {
             tracing::debug!("show_context_menu: handled in JS overlay");

--- a/agentmux-cef/src/ui_tasks.rs
+++ b/agentmux-cef/src/ui_tasks.rs
@@ -249,6 +249,36 @@ pub fn post_move_window(state: &Arc<AppState>, label: &str, dx: i32, dy: i32) {
     post_task(ThreadId::UI, Some(&mut task));
 }
 
+// ── Set window to absolute position ──────────────────────────────────────
+
+wrap_task! {
+    pub struct SetWindowPositionTask {
+        state: Arc<AppState>,
+        label: String,
+        x: i32,
+        y: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            if let Some(window) = get_window_on_ui(&self.state, &self.label) {
+                let bounds = window.bounds();
+                window.set_bounds(Some(&Rect {
+                    x: self.x,
+                    y: self.y,
+                    width: bounds.width,
+                    height: bounds.height,
+                }));
+            }
+        }
+    }
+}
+
+pub fn post_set_window_position(state: &Arc<AppState>, label: &str, x: i32, y: i32) {
+    let mut task = SetWindowPositionTask::new(state.clone(), label.to_string(), x, y);
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
 // ── Phase B.9.2 (WRR) — corrective absolute-position move ─────────────────
 //
 // Reducer-driven self-heal. Triggered by `Event::CorrectiveWindowMove` when

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.707"
+version = "0.33.708"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.708"
+version = "0.33.709"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.707"
+version = "0.33.708"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.708"
+version = "0.33.709"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.708"
+version = "0.33.709"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.707"
+version = "0.33.708"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md
+++ b/docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md
@@ -1,0 +1,197 @@
+# Bug Report: Window Drag Cursor Drift
+
+**Date:** 2026-05-07  
+**Symptom:** When dragging the title bar to move the window, the cursor's position on the bar drifts — it does not stay at the point where the user originally clicked.  
+**Severity:** P2 — noticeable UX regression, not a crash  
+**Area:** `frontend/app/hook/useWindowDrag.win32.ts`, `agentmux-cef/src/commands/window.rs`
+
+---
+
+## Observed Behaviour
+
+User clicks 100 px from the left edge of the title bar and drags right. As the drag continues the cursor gradually slides toward the right edge of the bar; by the time the window has moved ~200 px the cursor is visibly offset from the original click point.
+
+---
+
+## Code Path
+
+### 1. Frontend — `useWindowDrag.win32.ts`
+
+Because CEF does not expose `WM_NCLBUTTONDOWN`-style OS-native drag (comment at line 7), AgentMux implements dragging entirely in JS: track mouse deltas and forward them to the Rust host via IPC.
+
+```
+mousedown  → capture click position in startScreenX/Y (lines 37-38)
+           → fire get_window_position IPC (line 42) — NOT awaited, result discarded
+mousemove  → dx = e.screenX − startScreenX           (line 49)
+           → dy = e.screenY − startScreenY           (line 50)
+           → startScreenX = e.screenX                (line 52)  ← rolling baseline
+           → startScreenY = e.screenY                (line 53)  ← rolling baseline
+           → invokeCommand("move_window_by", {dx,dy}) (line 54) ← fire-and-forget
+mouseup    → dragging = false
+```
+
+### 2. Rust host — `agentmux-cef/src/commands/window.rs`
+
+`move_window_by` (lines 179–209):
+
+```rust
+GetWindowRect(hwnd, &mut rect);          // read current position
+SetWindowPos(hwnd, ..., rect.left + dx, rect.top + dy, ...);
+```
+
+No `set_window_position` (absolute) command exists. The only positioning API is relative (`move_window_by`).
+
+---
+
+## Root Cause
+
+The bug is a **stale-read race** between concurrent in-flight IPC calls, amplified by the fire-and-forget dispatch pattern.
+
+### Why the delta approach is fragile under load
+
+At normal mouse speeds mousemove fires 60–200+ events per second. Each event:
+1. Computes a delta from the rolling baseline (`startScreenX`)
+2. **Immediately advances** `startScreenX` to the current position
+3. Sends `move_window_by({dx, dy})` as a fire-and-forget IPC — no await, no back-pressure
+
+This means at any moment there are N in-flight IPC calls queued in the CEF IPC channel, each carrying a partial delta.
+
+### The stale-rect scenario
+
+`move_window_by` calls `GetWindowRect` then `SetWindowPos` in the Rust handler. In CEF the IPC handler runs on a non-UI (IO/render) thread. `SetWindowPos` called from a non-owning thread is relayed to the UI thread via the Windows message queue — it does **not** apply synchronously to the internal `RECT` that `GetWindowRect` reads.
+
+Timeline with 4 rapid mousemoves (+10 px each, target: +40 px total):
+
+| IPC call | GetWindowRect returns | SetWindowPos target | Window actually at |
+|----------|-----------------------|---------------------|--------------------|
+| IPC 1    | left = 100 (initial)  | 110                 | 100 (not yet applied) |
+| IPC 2    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| IPC 3    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| IPC 4    | left = 100 (stale!)   | 110                 | 100 (still stale)  |
+| DWM flush | —                    | —                   | 110 (last wins)    |
+
+All four calls see the same old rect. The window moves +10 instead of +40. The cursor has moved +40 on screen. The cursor is now 30 px further right on the title bar than when the drag started — exactly the reported drift.
+
+The severity of the drift scales with:
+- Mouse speed (more events per SetWindowPos cycle → larger stale-read window)
+- IPC round-trip latency (slower machines / heavier load → more staleness)
+- DWM composition interval (higher refresh rate = faster flush = less visible; lower rate = worse)
+
+### Why `get_window_position` on mousedown doesn't help
+
+Line 42 calls `get_window_position()` but:
+- The returned value is never stored (`invokeCommand<{x,y}>(...).catch(...)` — result is dropped)
+- It is not awaited, so dragging begins before the initial position is known
+
+This call was presumably added in anticipation of absolute positioning but was never wired up.
+
+---
+
+## Fix: Absolute Positioning
+
+Switch from incremental deltas to absolute target coordinates. This eliminates the stale-read race entirely — each IPC call is independent and does not depend on the outcome of previous calls.
+
+### Frontend changes (`useWindowDrag.win32.ts`)
+
+```ts
+let dragging = false;
+let clickScreenX = 0;
+let clickScreenY = 0;
+let initWinX = 0;
+let initWinY = 0;
+let initFetched = false;
+
+document.addEventListener("mousedown", async (e: MouseEvent) => {
+    if (e.button !== 0 || !isInDragRegion(e.target as HTMLElement)) return;
+    e.preventDefault();
+    try {
+        const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+        clickScreenX = e.screenX;
+        clickScreenY = e.screenY;
+        initWinX = pos.x;
+        initWinY = pos.y;
+        initFetched = true;
+        dragging = true;
+    } catch {
+        // host unavailable — abort
+    }
+}, true);
+
+document.addEventListener("mousemove", (e: MouseEvent) => {
+    if (!dragging || !initFetched) return;
+    const tx = initWinX + (e.screenX - clickScreenX);
+    const ty = initWinY + (e.screenY - clickScreenY);
+    invokeCommand("set_window_position", { x: tx, y: ty }).catch(() => {});
+});
+```
+
+Key differences:
+- `get_window_position` is now **awaited** — drag does not start until the initial position is known
+- `clickScreenX/Y` is captured after the await (avoids the gap between click and IPC response)
+- Deltas are computed from the **fixed** click origin, not a rolling baseline
+- Each mousemove sends an absolute target, not a relative delta
+
+### Rust host: add `set_window_position` (`commands/window.rs`)
+
+```rust
+pub fn set_window_position(state: &Arc<AppState>, args: &serde_json::Value) -> Result<serde_json::Value, String> {
+    let x = args.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+    let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows_sys::Win32::UI::WindowsAndMessaging::*;
+        use windows_sys::Win32::Foundation::RECT;
+        let hwnd = find_own_top_level_window();
+        if !hwnd.is_null() {
+            let mut rect: RECT = std::mem::zeroed();
+            GetWindowRect(hwnd, &mut rect);
+            let width = rect.right - rect.left;
+            let height = rect.bottom - rect.top;
+            SetWindowPos(hwnd, std::ptr::null_mut(), x, y, width, height, 0x0014);
+            return Ok(serde_json::Value::Null);
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    crate::ui_tasks::post_set_window_position(state, "main", x, y);
+    let _ = state;
+    Ok(serde_json::Value::Null)
+}
+```
+
+Register in `ipc.rs` alongside the existing commands:
+
+```rust
+"set_window_position" => commands::window::set_window_position(state, args),
+```
+
+### Why absolute positioning is superior to fixing the delta approach
+
+| Property | Delta + rolling baseline | Absolute (proposed) |
+|----------|--------------------------|---------------------|
+| Stale-read race | Yes — N in-flight IPCs all apply from same old rect | No — each call is self-contained |
+| Cursor drift under fast mouse | Yes | No |
+| Correctness under IPC backpressure | Degrades | Idempotent — last-write-wins is correct |
+| Dropped events | Accumulate error | No effect on final position |
+| `get_window_position` round-trip on mousedown | Already exists, just not used | Uses the existing call |
+
+---
+
+## Secondary Issue: `mousedown` Async Gap
+
+With the await on `mousedown`, there is a brief window (~1–2 ms IPC round-trip) between the user's click and `dragging = true`. This is acceptable — the cursor is stationary at click time and the first `mousemove` events fire after the click handler completes. No perceptible delay.
+
+If latency is a concern, the initial position can be pre-fetched on title-bar `mouseenter` and cached; the mousedown handler then uses the cached value synchronously.
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `frontend/app/hook/useWindowDrag.win32.ts` | Switch to absolute positioning (await initial pos, fixed click origin) |
+| `agentmux-cef/src/commands/window.rs` | Add `set_window_position(x, y)` |
+| `agentmux-cef/src/ipc.rs` | Register `set_window_position` in the command router |
+| `agentmux-cef/src/ui_tasks.rs` (if it exists) | Add `post_set_window_position` for non-Windows paths |
+
+`move_window_by` and `get_window_position` can remain — they may be used elsewhere.

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -40,6 +40,14 @@ function installCefDragListener() {
     let clickScreenY = 0;
     let initWinX = 0;
     let initWinY = 0;
+    // Track the latest cursor position seen during a press, even
+    // before `dragging` is armed. When the get_window_position IPC
+    // resolves we can immediately catch up with one set_window_position
+    // call against the latest cursor — otherwise mousemoves during
+    // the initial round-trip are silently dropped (codex P2 PR #734
+    // round 4).
+    let latestScreenX = 0;
+    let latestScreenY = 0;
 
     document.addEventListener("mousedown", async (e: MouseEvent) => {
         if (e.button !== 0) return;
@@ -47,16 +55,28 @@ function installCefDragListener() {
         e.preventDefault();
         currentMouseDownId += 1;
         const myId = currentMouseDownId;
+        // Capture press coords synchronously — used as the baseline
+        // for both the live drag math and the catch-up move below.
+        clickScreenX = e.screenX;
+        clickScreenY = e.screenY;
+        latestScreenX = e.screenX;
+        latestScreenY = e.screenY;
         try {
             const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
             // Race guard: bail if a mouseup or a newer mousedown has
             // happened during the IPC round-trip.
             if (myId !== currentMouseDownId) return;
-            clickScreenX = e.screenX;
-            clickScreenY = e.screenY;
             initWinX = pos.x;
             initWinY = pos.y;
             dragging = true;
+            // Catch-up: if the cursor moved during the IPC, fire one
+            // set_window_position immediately against the latest known
+            // position so we don't lose the first few pixels of motion.
+            if (latestScreenX !== clickScreenX || latestScreenY !== clickScreenY) {
+                const tx = initWinX + (latestScreenX - clickScreenX);
+                const ty = initWinY + (latestScreenY - clickScreenY);
+                sendPos(tx, ty);
+            }
         } catch {
             // host unavailable — abort drag
         }
@@ -93,6 +113,12 @@ function installCefDragListener() {
             });
     };
     document.addEventListener("mousemove", (e: MouseEvent) => {
+        // Track latest cursor position even before `dragging` is armed
+        // so the catch-up at IPC resolution can use the most recent
+        // value (otherwise initial mousemoves during the round-trip
+        // are dropped).
+        latestScreenX = e.screenX;
+        latestScreenY = e.screenY;
         if (!dragging) return;
         const tx = initWinX + (e.screenX - clickScreenX);
         const ty = initWinY + (e.screenY - clickScreenY);
@@ -105,9 +131,12 @@ function installCefDragListener() {
         // fires when they resolve.
         currentMouseDownId += 1;
         dragging = false;
-        // Drop any queued post-drag position so a stray pendingPos
-        // doesn't fire after release.
-        pendingPos = null;
+        // Do NOT clear pendingPos — that would discard the FINAL
+        // queued position (the cursor's location at release time)
+        // and leave the window stranded at the previous in-flight
+        // position. Let the in-flight set_window_position complete
+        // naturally; its `.finally` will drain pendingPos to its
+        // correct end state. (codex P2 PR #734 round 4.)
     });
 
     document.addEventListener("dblclick", (e: MouseEvent) => {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -62,11 +62,41 @@ function installCefDragListener() {
         }
     }, true);
 
+    // One-in-flight + coalesce. Native mousemove fires at ~120Hz; the
+    // IPC round-trip can be slower under load. If two requests overlap
+    // and the older one resolves AFTER the newer (e.g. transient host
+    // jitter), the window snaps backward to the older absolute position.
+    // Codex P2 PR #734 round 3.
+    //
+    // Strategy: at most one set_window_position in flight. If more
+    // mousemoves arrive while in flight, stash the latest pending
+    // position; on completion, fire that. Older positions are dropped
+    // — they're stale by definition. Keeps the window tracking the
+    // most recent cursor without ordering hazards.
+    let setPosInFlight = false;
+    let pendingPos: { x: number; y: number } | null = null;
+    const sendPos = (x: number, y: number): void => {
+        if (setPosInFlight) {
+            pendingPos = { x, y };
+            return;
+        }
+        setPosInFlight = true;
+        invokeCommand("set_window_position", { x, y })
+            .catch(() => {})
+            .finally(() => {
+                setPosInFlight = false;
+                if (pendingPos) {
+                    const { x: nx, y: ny } = pendingPos;
+                    pendingPos = null;
+                    sendPos(nx, ny);
+                }
+            });
+    };
     document.addEventListener("mousemove", (e: MouseEvent) => {
         if (!dragging) return;
         const tx = initWinX + (e.screenX - clickScreenX);
         const ty = initWinY + (e.screenY - clickScreenY);
-        invokeCommand("set_window_position", { x: tx, y: ty }).catch(() => {});
+        sendPos(tx, ty);
     });
 
     document.addEventListener("mouseup", () => {
@@ -75,6 +105,9 @@ function installCefDragListener() {
         // fires when they resolve.
         currentMouseDownId += 1;
         dragging = false;
+        // Drop any queued post-drag position so a stray pendingPos
+        // doesn't fire after release.
+        pendingPos = null;
     });
 
     document.addEventListener("dblclick", (e: MouseEvent) => {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -26,32 +26,32 @@ function installCefDragListener() {
     cefDragListenerInstalled = true;
 
     let dragging = false;
-    let startScreenX = 0;
-    let startScreenY = 0;
+    let clickScreenX = 0;
+    let clickScreenY = 0;
+    let initWinX = 0;
+    let initWinY = 0;
 
-    document.addEventListener("mousedown", (e: MouseEvent) => {
+    document.addEventListener("mousedown", async (e: MouseEvent) => {
         if (e.button !== 0) return;
         if (!isInDragRegion(e.target as HTMLElement)) return;
-
-        dragging = true;
-        startScreenX = e.screenX;
-        startScreenY = e.screenY;
         e.preventDefault();
-
-        // Get initial window position
-        invokeCommand<{ x: number; y: number }>("get_window_position").catch(() => {
-            dragging = false;
-        });
+        try {
+            const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+            clickScreenX = e.screenX;
+            clickScreenY = e.screenY;
+            initWinX = pos.x;
+            initWinY = pos.y;
+            dragging = true;
+        } catch {
+            // host unavailable — abort drag
+        }
     }, true);
 
     document.addEventListener("mousemove", (e: MouseEvent) => {
         if (!dragging) return;
-        const dx = e.screenX - startScreenX;
-        const dy = e.screenY - startScreenY;
-        if (dx === 0 && dy === 0) return;
-        startScreenX = e.screenX;
-        startScreenY = e.screenY;
-        invokeCommand("move_window_by", { dx, dy }).catch(() => {});
+        const tx = initWinX + (e.screenX - clickScreenX);
+        const ty = initWinY + (e.screenY - clickScreenY);
+        invokeCommand("set_window_position", { x: tx, y: ty }).catch(() => {});
     });
 
     document.addEventListener("mouseup", () => {

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -25,6 +25,15 @@ function installCefDragListener() {
     if (cefDragListenerInstalled || detectHost() !== "cef") return;
     cefDragListenerInstalled = true;
 
+    // `mouseDownActive` is set synchronously in mousedown and cleared
+    // in mouseup. `dragging` is set after the async `get_window_position`
+    // resolves. The mousedown→mouseup race (codex P2 PR #734): if the
+    // user clicks and releases quickly (or the IPC round-trip is slow),
+    // `mouseup` fires while `get_window_position` is still in flight;
+    // when the promise resolves we'd otherwise arm drag AFTER release
+    // and the next mousemove (a stray pointer move) would teleport
+    // the window. Guard by checking `mouseDownActive` at resolution.
+    let mouseDownActive = false;
     let dragging = false;
     let clickScreenX = 0;
     let clickScreenY = 0;
@@ -35,8 +44,12 @@ function installCefDragListener() {
         if (e.button !== 0) return;
         if (!isInDragRegion(e.target as HTMLElement)) return;
         e.preventDefault();
+        mouseDownActive = true;
         try {
             const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
+            // Race guard: bail if the user has already released the
+            // mouse during the IPC round-trip.
+            if (!mouseDownActive) return;
             clickScreenX = e.screenX;
             clickScreenY = e.screenY;
             initWinX = pos.x;
@@ -55,6 +68,7 @@ function installCefDragListener() {
     });
 
     document.addEventListener("mouseup", () => {
+        mouseDownActive = false;
         dragging = false;
     });
 

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -25,15 +25,16 @@ function installCefDragListener() {
     if (cefDragListenerInstalled || detectHost() !== "cef") return;
     cefDragListenerInstalled = true;
 
-    // `mouseDownActive` is set synchronously in mousedown and cleared
-    // in mouseup. `dragging` is set after the async `get_window_position`
-    // resolves. The mousedown→mouseup race (codex P2 PR #734): if the
-    // user clicks and releases quickly (or the IPC round-trip is slow),
-    // `mouseup` fires while `get_window_position` is still in flight;
-    // when the promise resolves we'd otherwise arm drag AFTER release
-    // and the next mousemove (a stray pointer move) would teleport
-    // the window. Guard by checking `mouseDownActive` at resolution.
-    let mouseDownActive = false;
+    // Per-mousedown sequence token. Each press increments
+    // `currentMouseDownId`; the async `get_window_position` handler
+    // captures the value at press time and bails if it doesn't still
+    // match when the promise resolves.
+    //
+    // Without the sequence token, a rapid press → release → press
+    // sequence with a slow IPC could let the OLDER request arm drag
+    // using the older click coords (a shared boolean would already
+    // be true again from the newer press). Codex P2 PR #734 round 2.
+    let currentMouseDownId = 0;
     let dragging = false;
     let clickScreenX = 0;
     let clickScreenY = 0;
@@ -44,12 +45,13 @@ function installCefDragListener() {
         if (e.button !== 0) return;
         if (!isInDragRegion(e.target as HTMLElement)) return;
         e.preventDefault();
-        mouseDownActive = true;
+        currentMouseDownId += 1;
+        const myId = currentMouseDownId;
         try {
             const pos = await invokeCommand<{ x: number; y: number }>("get_window_position");
-            // Race guard: bail if the user has already released the
-            // mouse during the IPC round-trip.
-            if (!mouseDownActive) return;
+            // Race guard: bail if a mouseup or a newer mousedown has
+            // happened during the IPC round-trip.
+            if (myId !== currentMouseDownId) return;
             clickScreenX = e.screenX;
             clickScreenY = e.screenY;
             initWinX = pos.x;
@@ -68,7 +70,10 @@ function installCefDragListener() {
     });
 
     document.addEventListener("mouseup", () => {
-        mouseDownActive = false;
+        // Invalidate any in-flight mousedown handler — incrementing
+        // the id ensures their `myId !== currentMouseDownId` check
+        // fires when they resolve.
+        currentMouseDownId += 1;
         dragging = false;
     });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.707",
+  "version": "0.33.708",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.708",
+  "version": "0.33.709",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Extract from PR #729 (`fix/window-drag-cursor-drift`), keeping ONLY the drag-drift fix. PR #729 had scope bleed — its branch picked up PR #718's table-formatter content. The drag-drift fix itself is well-motivated; this PR carries it on a fresh branch from main.

## Root cause

`move_window_by` calls `GetWindowRect` then `SetWindowPos` from the IPC thread. Under rapid `mousemove`, multiple in-flight IPC calls all read the same stale rect (SetWindowPos is relayed to the UI thread async via the Windows message queue), so the window accumulates only one delta-worth of movement instead of N — the cursor visibly shifts from its original click point on the title bar.

## Fix

Switch to **absolute positioning**:
- `mousedown` snapshots the initial window origin via `get_window_position`
- Each `mousemove` sends `set_window_position(initWin + totalCursorDelta)`
- Each call is self-contained, so concurrent calls are idempotent — no stale-read race possible

New IPC command `set_window_position(x, y)`:
- Rust handler in `agentmux-cef/src/commands/window.rs`
- Registered in `agentmux-cef/src/ipc.rs`
- Non-Windows CEF Views path via `SetWindowPositionTask` in `agentmux-cef/src/ui_tasks.rs`

## Files

| File | Change |
|---|---|
| `frontend/app/hook/useWindowDrag.win32.ts` | Switch from delta + rolling baseline to absolute target coords |
| `agentmux-cef/src/commands/window.rs` | Add `set_window_position(x, y)` |
| `agentmux-cef/src/ui_tasks.rs` | Add `SetWindowPositionTask` + `post_set_window_position` |
| `agentmux-cef/src/ipc.rs` | Register `set_window_position` command |
| `docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md` | Bug report + analysis (moved into `docs/retro/` per repo convention) |

## Test plan

- [ ] Drag title bar slowly — cursor stays fixed at click point throughout
- [ ] Drag title bar fast — cursor stays fixed at click point (the stale-race scenario)
- [ ] Double-click title bar — maximizes/restores correctly
- [ ] Minimize / close buttons still work
- [ ] Second window title bar also drags correctly (find_own_top_level_window is per-process)

## Provenance

Original credit: a5af / @asaf via PR #729. This PR separates the drag-drift fix from #729's accidentally-included #718 content. **Recommend closing #729** in favor of this clean-scope replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)