### PR TITLE
feat(browser-pane): Phase 1 diag instrumentation + host log discovery fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.716"
+version = "0.33.717"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.716"
+version = "0.33.717"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.716"
+version = "0.33.717"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.716"
+version = "0.33.717"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.716"
+version = "0.33.717"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -145,6 +145,11 @@ pub fn on_load_end_browser_pane(state: &Arc<AppState>, browser: &Browser) {
                 .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
                 .unwrap_or_default()
         };
+        let block_id_short: String = block_id.chars().take(7).collect();
+        tracing::info!(
+            "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=true",
+            block_id_short, url,
+        );
         crate::events::emit_event_from_state(
             state,
             "browser-pane-nav-state",
@@ -188,12 +193,10 @@ pub fn on_loading_state_change_browser_pane(
                 .map(|f| cef::CefString::from(&cef::ImplFrame::url(&f)).to_string())
                 .unwrap_or_default()
         };
+        let block_id_short: String = block_id.chars().take(7).collect();
         tracing::info!(
-            block_id = %block_id,
-            can_back = can_go_back,
-            can_forward = can_go_forward,
-            url = %url,
-            "[pane-nav-state] emitting",
+            "[browser-pane:diag][{}] emit-nav-state url={:?} url_only=false can_back={} can_forward={}",
+            block_id_short, url, can_go_back, can_go_forward,
         );
         crate::events::emit_event_from_state(
             state,

--- a/agentmux-cef/src/browser_pane/hwnd.rs
+++ b/agentmux-cef/src/browser_pane/hwnd.rs
@@ -228,9 +228,10 @@ pub unsafe fn install_browser_pane_focus_redirect(
             // no CEF focus callback, leaving a flag armed forever.
             if let Some(ctx) = find_context(hwnd) {
                 if let Some(state) = ctx.state.upgrade() {
+                    let block_id_short: String = ctx.block_id.chars().take(7).collect();
                     tracing::info!(
-                        block_id = %ctx.block_id,
-                        "[pane-wndproc] WM_LBUTTONDOWN — emitting browser-pane-clicked",
+                        "[browser-pane:diag][{}] emit-clicked",
+                        block_id_short,
                     );
                     crate::events::emit_event_from_state(
                         &state,

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -610,8 +610,25 @@ fn init_logging(log_dir: &std::path::Path) -> tracing_appender::non_blocking::Wo
     // Uses UTC to match tracing_appender::rolling::daily's date suffix.
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
     let current_filename = format!("{}.{}", log_prefix, today);
+    let absolute_path = log_dir.join(&current_filename);
     let pointer_name = format!("current-host-v{}.path", version);
+
+    // Pointer #1: local — inside the instance's log dir. The basename
+    // is enough here since the reader is colocated.
     let _ = std::fs::write(log_dir.join(&pointer_name), &current_filename);
+
+    // Pointer #2: global — at `<root>/logs/<pointer_name>`. Writes the
+    // ABSOLUTE PATH so legacy tooling (`muxlog host`) that lives outside
+    // the instance dir can `cat $pointer | xargs tail -f` and reach the
+    // real file. Skipped silently if the global dir can't be derived
+    // (e.g. AGENTMUX_HOME_OVERRIDE unset in some test setups).
+    if let Some(global_logs_dir) = log_dir.parent().and_then(|p| p.parent()).and_then(|p| p.parent()).map(|p| p.join("logs")) {
+        let _ = std::fs::create_dir_all(&global_logs_dir);
+        let _ = std::fs::write(
+            global_logs_dir.join(&pointer_name),
+            absolute_path.to_string_lossy().as_bytes(),
+        );
+    }
 
     // Synchronous init sentinel: append a single line directly to the
     // expected log path BEFORE the tracing subscriber is wired up. Without

--- a/agentmux-cef/src/memory_heartbeat.rs
+++ b/agentmux-cef/src/memory_heartbeat.rs
@@ -26,6 +26,13 @@ pub fn start() {
 /// Update the host log pointer file when the UTC date changes (midnight rollover).
 /// tracing_appender::rolling::daily creates a new file at UTC midnight, so the
 /// pointer must track the new date suffix.
+///
+/// Two pointers are written, matching `main::init_logging`:
+///   1. Local: `<log_dir>/<pointer_name>` with just the basename.
+///   2. Global: `<root>/logs/<pointer_name>` with the absolute path so
+///      legacy tooling (`muxlog host`) can resolve from outside the
+///      instance dir. Works for portable, installed, and dev modes —
+///      log_dir comes from `AGENTMUX_LOG_DIR`, set by data_paths.rs.
 fn refresh_log_pointer(last_date: &mut String) {
     let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
     if *last_date == today {
@@ -33,13 +40,36 @@ fn refresh_log_pointer(last_date: &mut String) {
     }
     *last_date = today.clone();
     let version = env!("CARGO_PKG_VERSION");
-    let log_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".agentmux")
-        .join("logs");
+    // Use the AGENTMUX_LOG_DIR exported by data_paths.rs. Falls back to
+    // the legacy hardcoded location only as a safety net — by the time
+    // memory_heartbeat starts, init_logging has already run with the
+    // resolved log_dir, so this env var should always be present.
+    let log_dir = std::env::var_os("AGENTMUX_LOG_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .unwrap_or_default()
+                .join(".agentmux")
+                .join("logs")
+        });
     let current_filename = format!("agentmux-host-v{}.log.{}", version, today);
+    let absolute_path = log_dir.join(&current_filename);
     let pointer_name = format!("current-host-v{}.path", version);
+
     let _ = std::fs::write(log_dir.join(&pointer_name), &current_filename);
+
+    if let Some(global_logs_dir) = log_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .map(|p| p.join("logs"))
+    {
+        let _ = std::fs::create_dir_all(&global_logs_dir);
+        let _ = std::fs::write(
+            global_logs_dir.join(&pointer_name),
+            absolute_path.to_string_lossy().as_bytes(),
+        );
+    }
 }
 
 #[cfg(target_os = "windows")]

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.716"
+version = "0.33.717"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.716"
+version = "0.33.717"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.716"
+version = "0.33.717"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/shellintegration/bash.sh
+++ b/agentmux-srv/src/backend/shellintegration/bash.sh
@@ -100,7 +100,16 @@ muxlog() {
             | sed 's|.*/current-||;s|\.path||' >&2
         return 1
     fi
-    local logfile="$AGENTMUX_LOG_DIR/$(cat "$ptr")"
+    local ptr_content="$(cat "$ptr")"
+    # Pointer content may be a basename (legacy: resolve under
+    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix:
+    # the global pointer at <root>/logs/ writes the absolute path so
+    # discovery works from outside the instance dir).
+    local logfile
+    case "$ptr_content" in
+        /* | ?:[/\\]*) logfile="$ptr_content" ;;
+        *)            logfile="$AGENTMUX_LOG_DIR/$ptr_content" ;;
+    esac
     case "$action" in
         tail) tail -f "$logfile" ;;
         cat)  cat "$logfile" ;;

--- a/agentmux-srv/src/backend/shellintegration/fish.fish
+++ b/agentmux-srv/src/backend/shellintegration/fish.fish
@@ -63,7 +63,17 @@ function muxlog
         echo "Unknown log target '$target'. Check $AGENTMUX_LOG_DIR for current-*.path files." >&2
         return 1
     end
-    set -l logfile "$AGENTMUX_LOG_DIR/"(cat "$ptr")
+    set -l ptr_content (cat "$ptr")
+    # Pointer content may be a basename (legacy: resolve under
+    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix:
+    # global pointer writes the absolute path so discovery works
+    # from outside the instance dir).
+    set -l logfile
+    if string match -q '/*' "$ptr_content"; or string match -q '?:[/\\]*' "$ptr_content"
+        set logfile "$ptr_content"
+    else
+        set logfile "$AGENTMUX_LOG_DIR/$ptr_content"
+    end
     switch $action
         case tail
             tail -f "$logfile"

--- a/agentmux-srv/src/backend/shellintegration/zsh.sh
+++ b/agentmux-srv/src/backend/shellintegration/zsh.sh
@@ -100,7 +100,14 @@ muxlog() {
             | sed 's|.*/current-||;s|\.path||' >&2
         return 1
     fi
-    local logfile="$AGENTMUX_LOG_DIR/$(cat "$ptr")"
+    local ptr_content="$(cat "$ptr")"
+    # Pointer content may be a basename (legacy: resolve under
+    # AGENTMUX_LOG_DIR) or an absolute path (post-2026-05 host fix).
+    local logfile
+    case "$ptr_content" in
+        /* | ?:[/\\]*) logfile="$ptr_content" ;;
+        *)            logfile="$AGENTMUX_LOG_DIR/$ptr_content" ;;
+    esac
     case "$action" in
         tail) tail -f "$logfile" ;;
         cat)  cat "$logfile" ;;

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -83,11 +83,20 @@ export class BrowserViewModel implements ViewModel {
     private _closed = false;
     get closed(): boolean { return this._closed; }
 
+    /** Tag every diag log with the block prefix so multi-pane sessions
+     *  are greppable per pane. See docs/specs/browser-pane-reducer-roadmap.md
+     *  Phase 1. */
+    private get _diagTag(): string { return `[browser-pane:diag][${this.blockId.slice(0, 7)}]`; }
+    private diag(msg: string): void { console.log(`${this._diagTag} ${msg}`); }
+
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
 
         this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
+
+        const ctorMetaUrl = (this.blockAtom()?.meta?.["url"] as string | undefined) ?? "";
+        console.log(`[browser-pane:diag][${blockId.slice(0, 7)}] ctor meta.url=${JSON.stringify(ctorMetaUrl)}`);
 
         this.viewName = createMemo(() => {
             const title = this.titleAtom();
@@ -109,8 +118,15 @@ export class BrowserViewModel implements ViewModel {
             can_go_forward?: boolean;
             url_only?: boolean;
         }>("browser-pane-nav-state", (payload) => {
-            if (this._closed) return;
+            if (this._closed) {
+                this.diag(`post-close-event-dropped name=browser-pane-nav-state url=${payload.url}`);
+                return;
+            }
             if (payload.block_id !== this.blockId) return;
+            this.diag(
+                `nav-state recv url=${JSON.stringify(payload.url)} url_only=${!!payload.url_only} can_back=${payload.can_go_back} can_forward=${payload.can_go_forward}`,
+            );
+            this.diag(`state-write key=url value=${JSON.stringify(payload.url)}`);
             this.setUrl(payload.url);
             // `url_only` events come from `on_load_end_pane` — they arrive
             // before the navigation controller has fully committed, so the
@@ -120,9 +136,16 @@ export class BrowserViewModel implements ViewModel {
             // which CEF invokes with direct params. Skip touching the
             // back/forward atoms on `url_only` events.
             if (!payload.url_only) {
-                if (payload.can_go_back !== undefined) this.setCanGoBack(payload.can_go_back);
-                if (payload.can_go_forward !== undefined) this.setCanGoForward(payload.can_go_forward);
+                if (payload.can_go_back !== undefined) {
+                    this.diag(`state-write key=canGoBack value=${payload.can_go_back}`);
+                    this.setCanGoBack(payload.can_go_back);
+                }
+                if (payload.can_go_forward !== undefined) {
+                    this.diag(`state-write key=canGoForward value=${payload.can_go_forward}`);
+                    this.setCanGoForward(payload.can_go_forward);
+                }
             }
+            this.diag(`state-write key=loading value=false`);
             this.setLoading(false);
             // Persist the real URL to block meta so pane restore lands
             // on the last page, not whatever was passed at create time.
@@ -131,6 +154,7 @@ export class BrowserViewModel implements ViewModel {
                 meta: { url: payload.url },
             }).catch(() => {});
         }).then((unsub) => {
+            this.diag(`sub-registered name=browser-pane-nav-state`);
             if (this._closed) unsub();
             else this._navUnsub = unsub;
         });
@@ -142,10 +166,15 @@ export class BrowserViewModel implements ViewModel {
         // at pane creation. We drive refocusNode so the layout marks this
         // block as focused (blue border + keyboard shortcut target).
         void listenEvent<{ block_id: string }>("browser-pane-clicked", (payload) => {
-            if (this._closed) return;
+            if (this._closed) {
+                this.diag(`post-close-event-dropped name=browser-pane-clicked`);
+                return;
+            }
             if (payload.block_id !== this.blockId) return;
+            this.diag(`clicked recv`);
             refocusNode(this.blockId);
         }).then((unsub) => {
+            this.diag(`sub-registered name=browser-pane-clicked`);
             if (this._closed) unsub();
             else this._clickUnsub = unsub;
         });
@@ -160,6 +189,7 @@ export class BrowserViewModel implements ViewModel {
     }
 
     navigate(url: string): void {
+        this.diag(`navigate(url=${JSON.stringify(url)}) closed=${this._closed}`);
         if (this._closed) return;
         // Normalize URL
         let normalized = url.trim();
@@ -173,8 +203,11 @@ export class BrowserViewModel implements ViewModel {
             }
         }
 
+        this.diag(`state-write key=url value=${JSON.stringify(normalized)} src=navigate`);
         this.setUrl(normalized);
+        this.diag(`state-write key=error value=null src=navigate`);
         this.setError(null);
+        this.diag(`state-write key=loading value=true src=navigate`);
         this.setLoading(true);
         // can_go_back / can_go_forward are set by the `browser-pane-nav-state`
         // event subscription; we don't touch them here. CEF is the source of
@@ -190,43 +223,56 @@ export class BrowserViewModel implements ViewModel {
     }
 
     goBack(): void {
+        this.diag(`goBack closed=${this._closed}`);
         if (this._closed) return;
         // CEF owns the history — we just fire the IPC. The button's
         // enabled/disabled state came from `can_go_back` in the nav-state
         // event, so if we got here the browser has somewhere to go.
+        this.diag(`state-write key=loading value=true src=goBack`);
         this.setLoading(true);
         invokeCommand("browser_pane_go_back", { block_id: this.blockId }).catch(() => {});
     }
 
     goForward(): void {
+        this.diag(`goForward closed=${this._closed}`);
         if (this._closed) return;
+        this.diag(`state-write key=loading value=true src=goForward`);
         this.setLoading(true);
         invokeCommand("browser_pane_go_forward", { block_id: this.blockId }).catch(() => {});
     }
 
     reload(): void {
+        this.diag(`reload closed=${this._closed}`);
         if (this._closed) return;
         const url = this.urlAtom();
         if (url) {
+            this.diag(`state-write key=url value="" src=reload-clear`);
             this.setUrl("");
             // Force iframe reload by briefly clearing then re-setting
             requestAnimationFrame(() => {
+                this.diag(`state-write key=url value=${JSON.stringify(url)} src=reload-restore`);
                 this.setUrl(url);
+                this.diag(`state-write key=loading value=true src=reload-restore`);
                 this.setLoading(true);
             });
         }
     }
 
     onLoad(): void {
+        this.diag(`onLoad state-write key=loading value=false`);
         this.setLoading(false);
     }
 
     onError(msg: string): void {
+        this.diag(`onError msg=${JSON.stringify(msg)}`);
+        this.diag(`state-write key=loading value=false src=onError`);
         this.setLoading(false);
+        this.diag(`state-write key=error value=${JSON.stringify(msg)} src=onError`);
         this.setError(msg);
     }
 
     giveFocus(): boolean {
+        this.diag(`giveFocus closed=${this._closed}`);
         if (this._closed) return false;
         // If a main-window input inside this block (e.g. the URL bar) is
         // already focused, keep it — the user is interacting with the block's
@@ -249,6 +295,7 @@ export class BrowserViewModel implements ViewModel {
     }
 
     dispose(): void {
+        this.diag(`dispose`);
         this._closed = true;
         if (this._navUnsub) {
             this._navUnsub();

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -8,6 +8,9 @@ import "./browser-view.scss";
 
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
+    const _diagTag = `[browser-pane:diag][${model.blockId.slice(0, 7)}]`;
+    const diag = (msg: string): void => { console.log(`${_diagTag} ${msg}`); };
+    diag(`view-mount initial-urlAtom=${JSON.stringify(model.urlAtom())}`);
     const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
     let addressInputRef: HTMLInputElement | undefined;
     // Reactively mirror the model's URL into the address-bar input whenever
@@ -20,7 +23,10 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     // this on PR #484 review.
     createEffect(() => {
         const modelUrl = model.urlAtom();
-        if (document.activeElement === addressInputRef) return;
+        const focused = document.activeElement === addressInputRef;
+        const willUpdate = !focused && modelUrl !== addressBar();
+        diag(`sync urlAtom=${JSON.stringify(modelUrl)} addressBar=${JSON.stringify(addressBar())} focused=${focused} willUpdate=${willUpdate}`);
+        if (focused) return;
         if (modelUrl !== addressBar()) setAddressBar(modelUrl);
     });
     let placeholderRef: HTMLDivElement | undefined;
@@ -63,6 +69,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             // for the primary window).
             const windowLabel =
                 new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+            diag(`createPane url=${JSON.stringify(url)} window_label=${windowLabel}`);
             await invokeCommand("browser_pane_create", {
                 block_id: model.blockId,
                 url: url || "about:blank",
@@ -70,6 +77,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                 ...paneRect(),
             });
             setPaneCreated(true);
+            diag(`paneCreated=true`);
             model.onLoad();
         } catch (e) {
             model.onError(`Failed to create browser pane: ${e}`);
@@ -78,6 +86,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
 
     const handleNavigate = () => {
         const url = addressBar().trim();
+        diag(`input-submit value=${JSON.stringify(url)}`);
         if (!url) return;
 
         let normalized = url;
@@ -120,6 +129,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     });
 
     onCleanup(() => {
+        diag(`view-unmount paneCreated=${paneCreated()}`);
         // Fire close IPC BEFORE disconnecting observers — the IPC flips the
         // backend pane to Closing, so any in-flight resize/focus/nav calls
         // that haven't reached the backend yet get no-op'd there instead of
@@ -162,6 +172,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
                     onFocus={(e) => {
+                        diag(`input-focus value=${JSON.stringify(addressBar())}`);
                         e.currentTarget.select();
                         // Take OS-level keyboard focus away from the pane so
                         // keystrokes reach this address-bar input. The pane
@@ -171,6 +182,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                         // the user clicks inside the pane again.
                         invokeCommand("main_window_focus", {}).catch(() => {});
                     }}
+                    onBlur={() => diag(`input-blur value=${JSON.stringify(addressBar())}`)}
                     placeholder="Enter URL or search..."
                 />
                 <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>Go</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.715",
+  "version": "0.33.716",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.715",
+      "version": "0.33.716",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.716",
+  "version": "0.33.717",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.716",
+      "version": "0.33.717",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.716",
+  "version": "0.33.717",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Phase 1 of the diagnostic-first reducer migration roadmap (`docs/specs/browser-pane-reducer-roadmap.md`).

**No behavior change.** Only logs + a log-discovery fix.

## Browser pane diag instrumentation

Every state write, IPC event in/out, public method, and focus transition emits a tagged log line:

```
[browser-pane:diag][<blockId7>] <event> <fields>
```

Greppable via `muxlog host '\[browser-pane:diag\]'`. The format is stable so Phase 2 can baseline observed sequences before Phase 3 touches state.

**Coverage:**
- `browser-model.ts`: ctor, 3× sub-registered, nav-state recv, clicked recv, state-write per atom, navigate, goBack/goForward/reload, onLoad/onError, giveFocus, dispose, post-close-event-dropped.
- `browser-view.tsx`: view-mount, **sync** (urlAtom→addressBar with focused/willUpdate flags — the suspected typing-clobber site), createPane, paneCreated, input-submit, input-focus, input-blur, view-unmount.
- Host (`browser_pane/callbacks.rs`, `hwnd.rs`): emit-nav-state (both url_only=true and on_loading_state_change paths), emit-clicked.

## Host-log discovery fix

Recent versions wrote logs to version-specific instance dirs (`<root>/versions/<v>/logs/`) but the pointer in each instance dir held only the basename, and `memory_heartbeat::refresh_log_pointer` hardcoded `~/.agentmux/logs/` instead of using `AGENTMUX_LOG_DIR`. Result: `muxlog host` from outside the instance dir couldn't resolve the log.

Fix:
- `main::init_logging` now also writes a global pointer at `<root>/logs/<pointer_name>` containing the **absolute path** of the current log. Works uniformly for portable / installed / dev modes.
- `memory_heartbeat::refresh_log_pointer` reads `AGENTMUX_LOG_DIR` (set by `data_paths.rs`) and mirrors the same dual-pointer pattern.

Without this, the Phase 1 logs above can't be collected from outside the instance dir.

## Test plan

- [x] `cargo build -p agentmux-cef` clean
- [x] `npx tsc --noEmit` clean for new files
- [ ] Smoke build → open browser pane → `muxlog host '\[browser-pane:diag\]'` shows the full nav sequence
- [ ] Phase 2 (separate PR/retro) baselines observed log sequences for the three scenarios