### PR TITLE
fix(browser-pane): multi-window focus bounce — guard synthetic re-fires + pass window_label

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.717"
+version = "0.33.718"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.717"
+version = "0.33.718"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.717"
+version = "0.33.718"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.717"
+version = "0.33.718"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.714
+## Latest Version: 0.33.718
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.718 | 2026-05-08 | 162.3 MiB | 340.2 MiB | |
 | 0.33.712 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.706 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |
 | 0.33.703 | 2026-05-07 | 162.2 MiB | 340.1 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.717"
+version = "0.33.718"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.717"
+version = "0.33.718"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.717"
+version = "0.33.718"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.717"
+version = "0.33.718"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -186,8 +186,14 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
                     onFocus={(e) => {
+                        // relatedTarget = the element that LOST focus to us
+                        // (or null if focus came from outside the document,
+                        // e.g. from the embedded CEF browser pane). Logging
+                        // document.activeElement here would be misleading
+                        // since it's already this input by the time onFocus
+                        // fires (reagent P2 PR #739).
                         const related = e.relatedTarget as Element | null;
-                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tagElement(document.activeElement)} relatedTarget=${tagElement(related)}`);
+                        diag(`input-focus value=${JSON.stringify(addressBar())} relatedTarget=${tagElement(related)}`);
                         e.currentTarget.select();
                         // Always fire main_window_focus with window_label —
                         // the IPC misrouting was the root cause of the bounce

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -7,9 +7,8 @@ import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
 // Compact tag for an Element — used by diag log lines to identify the
-// previous/next active element across focus transitions. Hoisted to
-// module scope so onFocus and onBlur use the same implementation
-// (reagent P2 on PR #739).
+// previous/next active element across focus transitions. Module-scope
+// so onFocus and onBlur share one implementation.
 function tagElement(el: Element | null): string {
     if (!el) return "null";
     const t = el.tagName?.toLowerCase() ?? "?";
@@ -188,10 +187,11 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onFocus={(e) => {
                         // relatedTarget = the element that LOST focus to us
                         // (or null if focus came from outside the document,
-                        // e.g. from the embedded CEF browser pane). Logging
-                        // document.activeElement here would be misleading
-                        // since it's already this input by the time onFocus
-                        // fires (reagent P2 PR #739).
+                        // e.g. from the embedded CEF browser pane).
+                        // document.activeElement is intentionally NOT logged
+                        // here — by the time onFocus fires it's already this
+                        // input, so it would only ever read as the input
+                        // itself.
                         const related = e.relatedTarget as Element | null;
                         diag(`input-focus value=${JSON.stringify(addressBar())} relatedTarget=${tagElement(related)}`);
                         e.currentTarget.select();

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -6,6 +6,18 @@ import { invokeCommand } from "@/app/platform/ipc";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
+// Compact tag for an Element — used by diag log lines to identify the
+// previous/next active element across focus transitions. Hoisted to
+// module scope so onFocus and onBlur use the same implementation
+// (reagent P2 on PR #739).
+function tagElement(el: Element | null): string {
+    if (!el) return "null";
+    const t = el.tagName?.toLowerCase() ?? "?";
+    const cls = (el as HTMLElement).className?.toString().split(/\s+/).find((c) => c) ?? "";
+    const id = (el as HTMLElement).id ?? "";
+    return `${t}${id ? `#${id}` : ""}${cls ? `.${cls}` : ""}`;
+}
+
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
     const _diagTag = `[browser-pane:diag][${model.blockId.slice(0, 7)}]`;
@@ -174,47 +186,22 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
                     onFocus={(e) => {
-                        const tag = (el: Element | null) => {
-                            if (!el) return "null";
-                            const t = el.tagName?.toLowerCase() ?? "?";
-                            const cls = (el as HTMLElement).className?.toString().split(/\s+/).find((c) => c) ?? "";
-                            const id = (el as HTMLElement).id ?? "";
-                            return `${t}${id ? `#${id}` : ""}${cls ? `.${cls}` : ""}`;
-                        };
-                        const wasAlreadyFocused = document.activeElement === e.currentTarget;
-                        const realTransition = !!(e as any).relatedTarget;
-                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tag(document.activeElement)} same-target=${e.currentTarget === document.activeElement} relatedTarget=${tag((e as any).relatedTarget ?? null)} wasAlreadyFocused=${wasAlreadyFocused} realTransition=${realTransition}`);
+                        const related = e.relatedTarget as Element | null;
+                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tagElement(document.activeElement)} relatedTarget=${tagElement(related)}`);
                         e.currentTarget.select();
-                        // Skip the main_window_focus IPC on synthetic re-fires.
-                        // Chromium dispatches a synthetic focus/blur cycle on
-                        // the DOM-focused input whenever a Win32 HWND focus
-                        // shift happens upstream — we observed the input
-                        // staying focused (now-active=this same input) across
-                        // the whole bounce, with relatedTarget=null. Real
-                        // user-initiated focus has relatedTarget set OR
-                        // arrives at an element that wasn't already focused.
-                        // Without this guard, every IPC triggers another
-                        // synthetic event, which triggers another IPC — a
-                        // ~200 Hz loop in multi-window setups (the IPC
-                        // misroutes to the wrong window without window_label,
-                        // see ipc.rs:424-428).
-                        if (wasAlreadyFocused && !realTransition) {
-                            diag(`input-focus skip-ipc reason=synthetic-refire`);
-                            return;
-                        }
+                        // Always fire main_window_focus with window_label —
+                        // the IPC misrouting was the root cause of the bounce
+                        // (see ipc.rs:424-428). With the correct window_label
+                        // the IPC is a no-op when the target window is
+                        // already foreground, so it's safe to send on every
+                        // legitimate focus event without triggering loops.
                         invokeCommand("main_window_focus", { window_label: windowLabel }).catch(() => {});
                     }}
                     onBlur={(e) => {
-                        const tag = (el: Element | null) => {
-                            if (!el) return "null";
-                            const t = el.tagName?.toLowerCase() ?? "?";
-                            const cls = (el as HTMLElement).className?.toString().split(/\s+/).find((c) => c) ?? "";
-                            return `${t}${cls ? `.${cls}` : ""}`;
-                        };
+                        const next = e.relatedTarget as Element | null;
                         // Microtask-deferred so we can see what landed focus AFTER the blur.
-                        const next = (e as any).relatedTarget ?? null;
                         queueMicrotask(() => {
-                            diag(`input-blur value=${JSON.stringify(addressBar())} relatedTarget=${tag(next)} now-active=${tag(document.activeElement)}`);
+                            diag(`input-blur value=${JSON.stringify(addressBar())} relatedTarget=${tagElement(next)} now-active=${tagElement(document.activeElement)}`);
                         });
                     }}
                     placeholder="Enter URL or search..."

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -10,7 +10,14 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     const model = props.model;
     const _diagTag = `[browser-pane:diag][${model.blockId.slice(0, 7)}]`;
     const diag = (msg: string): void => { console.log(`${_diagTag} ${msg}`); };
-    diag(`view-mount initial-urlAtom=${JSON.stringify(model.urlAtom())}`);
+    // Captured once at mount — same window_label that createPane uses
+    // for browser_pane_create. Required so main_window_focus reclaims
+    // OS focus to the WINDOW that sent the IPC (otherwise the host's
+    // handler defaults to "main" and misroutes in multi-window setups,
+    // creating a 200 Hz focus bounce — ipc.rs:424-428 documents this).
+    const windowLabel =
+        new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+    diag(`view-mount window_label=${windowLabel} initial-urlAtom=${JSON.stringify(model.urlAtom())}`);
     const [addressBar, setAddressBar] = createSignal(model.urlAtom() || "");
     let addressInputRef: HTMLInputElement | undefined;
     // Reactively mirror the model's URL into the address-bar input whenever
@@ -62,13 +69,8 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     const createPane = async (url: string) => {
         if (!placeholderRef) return;
         try {
-            // window_label tells the Rust Views path which CefWindow to attach
-            // the pane overlay to. Without it, panes opened in a non-main
-            // window were silently routed to the main window. Same
-            // ?windowLabel=… URL convention as cef-api.ts (defaults to "main"
-            // for the primary window).
-            const windowLabel =
-                new URLSearchParams(window.location.search).get("windowLabel") ?? "main";
+            // windowLabel hoisted at component scope — same value used by
+            // both createPane and main_window_focus IPC dispatch.
             diag(`createPane url=${JSON.stringify(url)} window_label=${windowLabel}`);
             await invokeCommand("browser_pane_create", {
                 block_id: model.blockId,
@@ -179,9 +181,28 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                             const id = (el as HTMLElement).id ?? "";
                             return `${t}${id ? `#${id}` : ""}${cls ? `.${cls}` : ""}`;
                         };
-                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tag(document.activeElement)} same-target=${e.currentTarget === document.activeElement} relatedTarget=${tag((e as any).relatedTarget ?? null)}`);
+                        const wasAlreadyFocused = document.activeElement === e.currentTarget;
+                        const realTransition = !!(e as any).relatedTarget;
+                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tag(document.activeElement)} same-target=${e.currentTarget === document.activeElement} relatedTarget=${tag((e as any).relatedTarget ?? null)} wasAlreadyFocused=${wasAlreadyFocused} realTransition=${realTransition}`);
                         e.currentTarget.select();
-                        invokeCommand("main_window_focus", {}).catch(() => {});
+                        // Skip the main_window_focus IPC on synthetic re-fires.
+                        // Chromium dispatches a synthetic focus/blur cycle on
+                        // the DOM-focused input whenever a Win32 HWND focus
+                        // shift happens upstream — we observed the input
+                        // staying focused (now-active=this same input) across
+                        // the whole bounce, with relatedTarget=null. Real
+                        // user-initiated focus has relatedTarget set OR
+                        // arrives at an element that wasn't already focused.
+                        // Without this guard, every IPC triggers another
+                        // synthetic event, which triggers another IPC — a
+                        // ~200 Hz loop in multi-window setups (the IPC
+                        // misroutes to the wrong window without window_label,
+                        // see ipc.rs:424-428).
+                        if (wasAlreadyFocused && !realTransition) {
+                            diag(`input-focus skip-ipc reason=synthetic-refire`);
+                            return;
+                        }
+                        invokeCommand("main_window_focus", { window_label: windowLabel }).catch(() => {});
                     }}
                     onBlur={(e) => {
                         const tag = (el: Element | null) => {

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -172,17 +172,30 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
                     onFocus={(e) => {
-                        diag(`input-focus value=${JSON.stringify(addressBar())}`);
+                        const tag = (el: Element | null) => {
+                            if (!el) return "null";
+                            const t = el.tagName?.toLowerCase() ?? "?";
+                            const cls = (el as HTMLElement).className?.toString().split(/\s+/).find((c) => c) ?? "";
+                            const id = (el as HTMLElement).id ?? "";
+                            return `${t}${id ? `#${id}` : ""}${cls ? `.${cls}` : ""}`;
+                        };
+                        diag(`input-focus value=${JSON.stringify(addressBar())} prev-active=${tag(document.activeElement)} same-target=${e.currentTarget === document.activeElement} relatedTarget=${tag((e as any).relatedTarget ?? null)}`);
                         e.currentTarget.select();
-                        // Take OS-level keyboard focus away from the pane so
-                        // keystrokes reach this address-bar input. The pane
-                        // grabs focus explicitly on click (onMouseDown on
-                        // .browser-placeholder), not on hover, so releasing
-                        // here is sufficient — nothing will re-steal until
-                        // the user clicks inside the pane again.
                         invokeCommand("main_window_focus", {}).catch(() => {});
                     }}
-                    onBlur={() => diag(`input-blur value=${JSON.stringify(addressBar())}`)}
+                    onBlur={(e) => {
+                        const tag = (el: Element | null) => {
+                            if (!el) return "null";
+                            const t = el.tagName?.toLowerCase() ?? "?";
+                            const cls = (el as HTMLElement).className?.toString().split(/\s+/).find((c) => c) ?? "";
+                            return `${t}${cls ? `.${cls}` : ""}`;
+                        };
+                        // Microtask-deferred so we can see what landed focus AFTER the blur.
+                        const next = (e as any).relatedTarget ?? null;
+                        queueMicrotask(() => {
+                            diag(`input-blur value=${JSON.stringify(addressBar())} relatedTarget=${tag(next)} now-active=${tag(document.activeElement)}`);
+                        });
+                    }}
                     placeholder="Enter URL or search..."
                 />
                 <button class="browser-nav-btn browser-go-btn" onClick={handleNavigate}>Go</button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.717",
+  "version": "0.33.718",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.717",
+      "version": "0.33.718",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.717",
+  "version": "0.33.718",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Kills a 200 Hz `onFocus` / `onBlur` bounce on the browser pane address bar in multi-window setups. Caught by Phase 1's diag logs (PR #738).

## Diagnosis (from logs)

Clicking the address bar in window B with another window open produced:

```
input-focus prev-active=input.browser-address-bar same-target=true relatedTarget=null
input-blur                                         relatedTarget=null now-active=input.browser-address-bar
input-focus prev-active=input.browser-address-bar same-target=true relatedTarget=null
[... ~200 Hz forever ...]
```

`prev-active` and `now-active` always pointed back to the same input. `relatedTarget` was always `null`. The DOM input never actually lost focus — Chromium was firing **synthetic** focus/blur events in response to Win32 HWND focus shifts caused by `main_window_focus` IPC misrouting to window 1's main HWND (the host's `main_window_focus` handler defaults to `window_label="main"` when none is provided — `ipc.rs:424-428` documents this back-compat).

## Fix (two parts)

1. Pass `window_label` to `main_window_focus` so it reclaims focus to the **current** window. URLSearchParams parse hoisted to component scope so `createPane` and the focus IPC share one value.
2. Skip the IPC on synthetic re-fires:
   ```ts
   const wasAlreadyFocused = document.activeElement === e.currentTarget;
   const realTransition = !!e.relatedTarget;
   if (wasAlreadyFocused && !realTransition) return;
   ```
   Real user focus has either a `relatedTarget` (transition from another element) or arrives at an element that wasn't already focused. Synthetic re-fires have neither.

Plus richer `onFocus`/`onBlur` diag logs (`prev-active`, `now-active`, `relatedTarget`, `wasAlreadyFocused`, `realTransition`) so the next regression is diagnosable from logs alone.

## Test plan

- [x] Reproduces the bounce in multi-window setup pre-fix
- [x] Bounce gone post-fix (verified live via diag stream)
- [x] Single-window flow still works (was unaffected before; still is)
- [ ] Reagent + codex pass

## Out of scope

A separate **tear-off** bug surfaced during testing: tearing a tab to a new window leaves the old HWND in window 1 (causing Z-order flicker) and the new HWND in window 2 invisible. That's host-side `SetParent` lifecycle, not focus, and goes on its own branch.