### PR TITLE
feat: voice input via Web Speech API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -2936,9 +2936,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -1,0 +1,118 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createSignalAtom, type SignalAtom } from "@/util/util";
+
+export interface PaneVoiceHandle {
+    appendFinal: (text: string) => void;
+    setInterim: (text: string) => void;
+}
+
+export interface VoiceSession {
+    isListening: SignalAtom<boolean>;
+    isAvailable: () => boolean;
+    toggleListening: () => void;
+    registerPane: (handle: PaneVoiceHandle) => void;
+}
+
+const RESTART_DELAY_MS = 100;
+
+function createVoiceSession(): VoiceSession {
+    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+    const isListening = createSignalAtom(false);
+
+    if (!SR) {
+        return {
+            isListening,
+            isAvailable: () => false,
+            toggleListening: () => {},
+            registerPane: () => {},
+        };
+    }
+
+    const recognition: SpeechRecognition = new SR();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language;
+
+    let activeHandle: PaneVoiceHandle | null = null;
+    let interimActive = false;
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+        let interim = "";
+        let finals = "";
+
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+            const result = event.results[i];
+            if (result.isFinal) {
+                finals += result[0].transcript;
+            } else {
+                interim += result[0].transcript;
+            }
+        }
+
+        if (finals) {
+            activeHandle?.setInterim("");
+            interimActive = false;
+            activeHandle?.appendFinal(finals);
+        }
+
+        if (interim) {
+            activeHandle?.setInterim(interim);
+            interimActive = true;
+        } else if (!finals) {
+            activeHandle?.setInterim("");
+            interimActive = false;
+        }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+            isListening._set(false);
+            window.dispatchEvent(new CustomEvent("voice-input-error", { detail: event.error }));
+        }
+        // "no-speech" and "aborted" are non-fatal; onend auto-restarts.
+    };
+
+    recognition.onend = () => {
+        if (isListening()) {
+            setTimeout(() => {
+                if (isListening()) {
+                    try { recognition.start(); } catch { /* already started */ }
+                }
+            }, RESTART_DELAY_MS);
+        }
+    };
+
+    const toggleListening = () => {
+        if (isListening()) {
+            recognition.stop();
+            if (interimActive) {
+                activeHandle?.setInterim("");
+                interimActive = false;
+            }
+            isListening._set(false);
+        } else {
+            try {
+                recognition.start();
+                isListening._set(true);
+            } catch {
+                // Race with onend auto-restart — ignore.
+            }
+        }
+    };
+
+    return {
+        isListening,
+        isAvailable: () => true,
+        toggleListening,
+        registerPane: (handle) => { activeHandle = handle; },
+    };
+}
+
+let _session: VoiceSession | null = null;
+
+export function getVoiceSession(): VoiceSession {
+    if (!_session) _session = createVoiceSession();
+    return _session;
+}

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -28,6 +28,7 @@ import { deleteLayoutModelForTab, getLayoutModelForStaticTab, NavigateDirection 
 import * as keyutil from "@/util/keyutil";
 import { CHORD_TIMEOUT } from "@/util/sharedconst";
 import { fireAndForget } from "@/util/util";
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
 import { createSignal } from "solid-js";
 import { modalsModel } from "./modalmodel";
 
@@ -556,6 +557,10 @@ function registerGlobalKeys() {
             return true;
         }
         setIsTermMultiInput(!curMI);
+        return true;
+    });
+    globalKeyMap.set("Ctrl:Shift:v", () => {
+        getVoiceSession().toggleListening();
         return true;
     });
     for (let idx = 1; idx <= 9; idx++) {

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -9,6 +9,8 @@ import { Show, createEffect, createMemo, createSignal, onCleanup, type JSX } fro
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
+import { MicButton } from "./MicButton";
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
 
 // ── AgentStatusLine ───────────────────────────────────────────────────────────
 // Displayed above the control bar. Shows a cycling thinking phrase while the
@@ -208,6 +210,8 @@ interface AgentFooterProps {
      * If absent, autocomplete is disabled.
      */
     getCompletions?: (prefix: string) => SlashCommand[];
+    /** Called when this footer becomes the active voice input target. */
+    onFocused?: () => void;
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -232,6 +236,36 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     // per-keystroke cost: <2ms. See
     // specs/SPEC_TOOL_OVERLAY_AND_SCROLL_ON_TYPE_2026_04_13.md §3.4.
     let textareaRef: HTMLTextAreaElement | undefined;
+
+    // ── Voice input ───────────────────────────────────────────────────
+    const voice = getVoiceSession();
+
+    // Tracks committed text length so interim transcript appends after it
+    // without overwriting text the user typed manually.
+    let voiceBaseLength = 0;
+
+    const voiceHandle = {
+        appendFinal: (text: string) => {
+            if (!textareaRef) return;
+            const current = textareaRef.value;
+            const separator = current.length > 0 && !current.endsWith(" ") ? " " : "";
+            textareaRef.value = current + separator + text.trimStart();
+            voiceBaseLength = textareaRef.value.length;
+            props.onTyping?.();
+        },
+        setInterim: (text: string) => {
+            if (!textareaRef) return;
+            const base = textareaRef.value.slice(0, voiceBaseLength);
+            textareaRef.value = text ? base + " " + text : base;
+            props.onTyping?.();
+        },
+    };
+
+    const handleFocusIn = () => {
+        voice.registerPane(voiceHandle);
+        voiceBaseLength = textareaRef?.value.length ?? 0;
+        props.onFocused?.();
+    };
 
     // ── Slash autocomplete state ──────────────────────────────────────
     // Tracks the current `/prefix` (without the leading slash) when the
@@ -295,6 +329,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
         if (props.onSendMessage) {
             props.onSendMessage(message);
             textareaRef.value = "";
+            voiceBaseLength = 0;
             setAutocompletePrefix(null);
             // Scroll the new user message into view. SolidJS flushes the
             // document signal synchronously before this point, so jumpToBottom
@@ -355,6 +390,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             if (textareaRef.value.trim().length > 0) {
                 e.preventDefault();
                 textareaRef.value = "";
+                voiceBaseLength = 0;
                 // Kick the RAF-debounced typing scroll so the footer's
                 // auto-grow collapses and the document stays anchored.
                 props.onTyping?.();
@@ -370,7 +406,7 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             {/* "Send now" now renders inside PendingMessagesPanel (right
                 of the queue header) so it sits next to the messages it
                 accelerates, not above the composer. */}
-            <div class="agent-input-container">
+            <div class="agent-input-container" onFocusIn={handleFocusIn}>
                 <Show when={autocompletePrefix() !== null && completions().length > 0}>
                     <SlashAutocomplete
                         completions={completions()}
@@ -379,14 +415,22 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
                         onSelect={acceptCompletion}
                     />
                 </Show>
-                <textarea
-                    ref={textareaRef}
-                    class="agent-input"
-                    placeholder={`Send message to ${props.agentId}...`}
-                    onKeyDown={handleKeyDown}
-                    onInput={handleInput}
-                    rows={1}
-                />
+                <div class="agent-input-row">
+                    <MicButton />
+                    <textarea
+                        ref={textareaRef}
+                        class="agent-input"
+                        classList={{ "voice-active": voice.isListening() }}
+                        placeholder={`Send message to ${props.agentId}...`}
+                        onKeyDown={handleKeyDown}
+                        onInput={(e) => {
+                            // User typed: update voiceBaseLength so interim appends correctly.
+                            voiceBaseLength = (e.target as HTMLTextAreaElement).value.length;
+                            handleInput();
+                        }}
+                        rows={1}
+                    />
+                </div>
                 <div class="agent-input-hint">
                     <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
                 </div>

--- a/frontend/app/view/agent/components/MicButton.scss
+++ b/frontend/app/view/agent/components/MicButton.scss
@@ -1,0 +1,24 @@
+.mic-button-wrap {
+    display: flex;
+    align-items: center;
+
+    &.mic-active .wave-iconbutton {
+        color: var(--color-primary, var(--accent-color));
+        position: relative;
+
+        &::after {
+            content: "";
+            position: absolute;
+            inset: -3px;
+            border-radius: 50%;
+            border: 1.5px solid var(--color-primary, var(--accent-color));
+            opacity: 0.6;
+            animation: mic-pulse 1.4s ease-in-out infinite;
+        }
+    }
+}
+
+@keyframes mic-pulse {
+    0%, 100% { transform: scale(1);   opacity: 0.6; }
+    50%       { transform: scale(1.3); opacity: 0;   }
+}

--- a/frontend/app/view/agent/components/MicButton.tsx
+++ b/frontend/app/view/agent/components/MicButton.tsx
@@ -1,0 +1,32 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ToggleIconButton } from "@/app/element/iconbutton";
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
+import { Show, type JSX } from "solid-js";
+import "./MicButton.scss";
+
+export function MicButton(): JSX.Element {
+    const voice = getVoiceSession();
+
+    // Wrap toggleListening into the SignalAtom._set slot so ToggleIconButton
+    // can call _set(!active()) to trigger the toggle.
+    const activeAtom = Object.assign(() => voice.isListening(), {
+        _set: (_v: boolean) => voice.toggleListening(),
+    });
+
+    return (
+        <Show when={voice.isAvailable()}>
+            <div class="mic-button-wrap" classList={{ "mic-active": voice.isListening() }}>
+                <ToggleIconButton
+                    decl={{
+                        elemtype: "toggleiconbutton",
+                        icon: "regular@microphone",
+                        title: "Voice input (Ctrl+Shift+V)",
+                        active: activeAtom,
+                    }}
+                />
+            </div>
+        </Show>
+    );
+}

--- a/frontend/app/view/agent/styles/_pending-footer.scss
+++ b/frontend/app/view/agent/styles/_pending-footer.scss
@@ -108,8 +108,15 @@
             gap: 1px;
             position: relative;
 
+            .agent-input-row {
+                display: flex;
+                align-items: flex-start;
+                gap: var(--space-0-5);
+            }
+
             .agent-input {
-                width: 100%;
+                flex: 1;
+                min-width: 0;
                 padding: 3px var(--space-1);
                 background: var(--main-bg-color);
                 border: 1px solid var(--border-color);
@@ -133,6 +140,12 @@
                 &:focus {
                     outline: none;
                     border-color: var(--accent-color);
+                }
+
+                &.voice-active {
+                    border-color: var(--color-primary, var(--accent-color));
+                    box-shadow: 0 0 0 1px var(--color-primary, var(--accent-color));
+                    transition: border-color 0.2s, box-shadow 0.2s;
                 }
             }
 

--- a/frontend/types/speech.d.ts
+++ b/frontend/types/speech.d.ts
@@ -1,0 +1,50 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Web Speech API type declarations (not fully covered by lib.dom.d.ts in all
+// TypeScript versions, and webkitSpeechRecognition is always vendor-prefixed).
+
+interface SpeechRecognitionResultList {
+    readonly length: number;
+    item(index: number): SpeechRecognitionResult;
+    [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+    readonly isFinal: boolean;
+    readonly length: number;
+    item(index: number): SpeechRecognitionAlternative;
+    [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+    readonly transcript: string;
+    readonly confidence: number;
+}
+
+interface SpeechRecognitionEvent extends Event {
+    readonly resultIndex: number;
+    readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: string;
+    readonly message: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    maxAlternatives: number;
+    start(): void;
+    stop(): void;
+    abort(): void;
+    onresult: ((event: SpeechRecognitionEvent) => void) | null;
+    onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+    onend: (() => void) | null;
+    onstart: (() => void) | null;
+}
+
+declare var SpeechRecognition: { new (): SpeechRecognition } | undefined;
+declare var webkitSpeechRecognition: { new (): SpeechRecognition } | undefined;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.718",
+  "version": "0.33.719",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_VOICE_INPUT_2026_05_08.md
+++ b/specs/SPEC_VOICE_INPUT_2026_05_08.md
@@ -1,0 +1,357 @@
+# Spec: Voice Input for Agent Pane
+
+**Date:** 2026-05-08  
+**Status:** Draft  
+**Area:** `frontend/app/view/agent/`, `frontend/app/hook/`
+
+---
+
+## Problem
+
+Users want to dictate messages across multiple agent panes rapidly — click a pane, speak, the transcript appears in that pane's input, move to the next pane, speak again. Typing between separate AI conversations is a bottleneck; voice removes it.
+
+---
+
+## UX Model
+
+```
+┌─────────────────────┐   ┌─────────────────────┐
+│  Agent Pane A       │   │  Agent Pane B       │
+│  ─────────────────  │   │  ─────────────────  │
+│  [conversation...]  │   │  [conversation...]  │
+│                     │   │                     │
+│  ┌───────────────┐  │   │  ┌───────────────┐  │
+│  │ "fix the bug" │  │   │  │ |             │  │
+│  └───────────────┘  │   │  └───────────────┘  │
+│  [🎤 listening]     │   │                     │
+└─────────────────────┘   └─────────────────────┘
+   user is here                not active
+```
+
+**Core behaviours:**
+
+1. **Global mic toggle** — one Ctrl+Shift+M hotkey (or a mic button in the title bar) starts/stops the voice session. The session is global, not per-pane.
+2. **Pane-following** — transcript is injected into whichever pane the user last clicked (focused). Switching panes while the mic is on immediately redirects future transcript to the new pane.
+3. **Interim display** — partial results appear in the textarea in italic or a distinct style, replaced by the final result when the sentence ends.
+4. **No auto-send** — transcript accumulates in the textarea; the user presses Enter to send, exactly as if they had typed it. Voice is an input method, not an autonomous actor.
+5. **Coexistence** — the user can type additional text while the mic is on; voice appends after the current cursor position.
+
+---
+
+## Option Analysis
+
+### Option 1 — Web Speech API (Chromium-native)
+
+**What it is:** `webkitSpeechRecognition` / `SpeechRecognition`, built into every Chromium build. No install, no API key.
+
+**How it works:**
+- Browser captures mic audio, streams to Google's Speech Recognition servers, returns interim + final results via events (`onresult`, `onspeechend`).
+- Continuous mode keeps the session alive between pauses.
+
+**Integration point:** Pure frontend hook (`useVoiceInput.ts`). No backend or sidecar changes. Hooks into `AgentFooter.tsx` textarea ref.
+
+**CEF compatibility:** Fully supported. CEF inherits all Chromium Web APIs. Permission prompt appears once; CEF persists it. On Windows CEF uses the standard browser permission flow.
+
+**Latency:** ~200–500 ms for interim results. Final results within ~1 s of a pause.
+
+**Cost:** Free. Google's infrastructure, silently.
+
+**Privacy:** Audio is sent to Google's speech servers. Acceptable for most users; not for air-gapped or privacy-sensitive deployments.
+
+**Language support:** 100+ locales via `lang` property.
+
+**Limitations:**
+- Requires internet (no offline fallback).
+- Google controls the recognition quality and rate limits.
+- No custom vocabulary / domain-specific terms.
+
+**Verdict:** Best choice for Phase 1. Zero friction, streaming partial results, no API key, already works in CEF.
+
+---
+
+### Option 2 — OpenAI Whisper API
+
+**What it is:** OpenAI's `/v1/audio/transcriptions` REST endpoint. Accepts an audio file, returns a text transcript.
+
+**How it works:**
+- Frontend records audio via `MediaRecorder` (WebM/Opus).
+- On each pause (voice activity detection), sends the chunk to agentmux-srv via existing RPC.
+- agentmux-srv POSTs to `api.openai.com/v1/audio/transcriptions` using the stored OpenAI API key.
+- Result is returned via WPS event or RPC response and injected into the focused pane.
+
+**Latency:** 1–3 s per chunk (non-streaming, per-file API). Noticeably laggier than Web Speech API for real-time use.
+
+**Cost:** $0.006/minute (~$0.36/hour of voice input).
+
+**Privacy:** Audio goes to OpenAI. No worse than using OpenAI's chat API.
+
+**Accuracy:** Excellent — Whisper large-v3 is state-of-the-art for most languages.
+
+**Requirements:** OpenAI API key; agentmux-srv HTTP client to proxy the request.
+
+**Verdict:** Good for Phase 2 as a high-accuracy option for users who already have OpenAI credentials. Not ideal for real-time use due to per-chunk latency.
+
+---
+
+### Option 3 — Deepgram Streaming API
+
+**What it is:** Deepgram's `wss://api.deepgram.com/v1/listen` WebSocket. Accepts raw PCM audio chunks, emits word-level transcripts in real time.
+
+**How it works:**
+- Frontend opens a WebSocket to agentmux-srv's local WS endpoint.
+- agentmux-srv opens a WebSocket to Deepgram's API (proxies audio chunks from the frontend, relays transcript events back).
+- Transcripts arrive as JSON events with `is_final` flag for interim vs. committed words.
+
+**Latency:** < 300 ms for interim results — closest to the Web Speech API experience.
+
+**Cost:** $0.0043/minute for the Nova-2 model.
+
+**Accuracy:** Excellent; comparable to Whisper for English. Strong multi-language support.
+
+**Privacy:** Audio goes to Deepgram's servers.
+
+**Requirements:** Deepgram API key; new WS proxy in agentmux-srv; MediaRecorder in frontend.
+
+**Verdict:** Best cloud streaming option. Viable for Phase 2 alongside Whisper, especially for non-English languages.
+
+---
+
+### Option 4 — Local Whisper (whisper.cpp sidecar)
+
+**What it is:** Run [whisper.cpp](https://github.com/ggerganov/whisper.cpp) as a local subprocess inside agentmux-srv. No network, no API key, offline-capable.
+
+**How it works:**
+- Frontend records audio via `MediaRecorder` (WebM/Opus → WAV decode).
+- Sends audio chunks to agentmux-srv via RPC.
+- agentmux-srv pipes chunks to the `whisper-cli` subprocess.
+- whisper.cpp emits word-level timestamps and text as JSON to stdout.
+- Results relayed back via WPS event to the focused pane.
+
+**Model sizes:**
+
+| Model | Size | WER (en) | Speed (RTF) |
+|-------|------|-----------|-------------|
+| tiny | 39 MB | ~5% | ~10x real-time |
+| base | 74 MB | ~4% | ~7x real-time |
+| small | 244 MB | ~3% | ~3x real-time |
+| medium | 769 MB | ~2.5% | ~1.5x real-time |
+| large-v3 | 1.5 GB | ~2% | ~0.7x real-time |
+
+**Latency:** With the `small` model, ~300–600 ms per utterance on a modern CPU. GPU acceleration (CUDA/Metal) reduces to ~100 ms.
+
+**Cost:** One-time model download. No per-use cost.
+
+**Privacy:** Fully local. No audio leaves the machine.
+
+**Requirements:** whisper.cpp binary distributed or downloaded on demand; model file (~74–244 MB for practical sizes); agentmux-srv subprocess management.
+
+**Verdict:** Best for Phase 3 / privacy-focused users. Meaningful download UX required. whisper.cpp already supports Windows (MSVC), macOS, and Linux.
+
+---
+
+### Option 5 — Claude Multimodal (Audio → Text via Claude API)
+
+**What it is:** Send audio to Claude as a file and ask it to transcribe.
+
+**Verdict:** Not suitable. Claude's API is not designed for real-time STT. Round-trip latency would be 3–10 s. Wastes input tokens. No interim results. Ruled out.
+
+---
+
+## Recommendation: Phased Rollout
+
+| Phase | Approach | Effort | Latency | Cost | Privacy |
+|-------|----------|--------|---------|------|---------|
+| 1 | Web Speech API | Low — frontend only | ~300 ms | Free | Google |
+| 2 | Whisper API / Deepgram | Medium — sidecar proxy | ~1–3 s / ~300 ms | $0.006/min | OpenAI/DG |
+| 3 | Local whisper.cpp | High — binary + model | ~300–600 ms | Free | Fully local |
+
+**Phase 1 is what ships first.** It requires zero infrastructure changes and covers the vast majority of users. Phases 2 and 3 are provider-select additions in the settings pane.
+
+---
+
+## Phase 1 Architecture (Web Speech API)
+
+### New files
+
+```
+frontend/app/hook/useVoiceInput.ts          — global voice session singleton
+frontend/app/view/agent/components/MicButton.tsx  — icon button for the footer
+```
+
+### Modified files
+
+```
+frontend/app/view/agent/components/AgentFooter.tsx  — wire MicButton + transcript injection
+frontend/app/view/agent/agent-view.tsx              — propagate focused pane to voice hook
+frontend/app/app-init.ts                            — install global Ctrl+Shift+M handler
+```
+
+---
+
+### `useVoiceInput.ts` — Global singleton hook
+
+```ts
+// Singleton: one SpeechRecognition instance shared across all panes.
+// The "active pane" is tracked via a signal updated on pane focus.
+
+interface VoiceInputHandle {
+    isListening: () => boolean;
+    interimText: () => string;
+    toggleListening: () => void;
+    setActivePaneRef: (ref: { append: (text: string) => void } | null) => void;
+}
+```
+
+**State machine:**
+
+```
+idle
+  │ toggleListening()
+  ▼
+listening
+  │ onresult (interim) → inject interimText into focused pane textarea
+  │ onresult (final)   → commit final text, clear interim
+  │ onend              → auto-restart (continuous mode)
+  │ toggleListening()
+  ▼
+idle
+```
+
+**Key implementation details:**
+
+```ts
+const recognition = new (window.SpeechRecognition ?? window.webkitSpeechRecognition)();
+recognition.continuous = true;
+recognition.interimResults = true;
+recognition.lang = navigator.language;  // user's OS locale
+
+recognition.onresult = (event) => {
+    let interim = "";
+    let final = "";
+    for (const result of Array.from(event.results).slice(event.resultIndex)) {
+        if (result.isFinal) final += result[0].transcript;
+        else interim += result[0].transcript;
+    }
+    if (final) activePaneRef?.appendFinal(final);
+    setInterimText(interim);
+};
+
+recognition.onend = () => {
+    // Auto-restart: Web Speech API stops after a pause on some browsers.
+    if (isListening()) recognition.start();
+};
+```
+
+**Pane focus tracking:**
+- Each `AgentFooter` calls `setActivePaneRef` with a `{ appendFinal, setInterim }` handle on mount and on every focus event.
+- The handle writes into the textarea's current value via the `textareaRef`.
+- On pane blur, the handle is not cleared (voice continues mid-sentence); it is replaced when another pane gains focus.
+
+---
+
+### `MicButton.tsx` — Mic indicator in footer
+
+Small icon button placed left of the textarea. Uses existing `IconButton` pattern.
+
+```
+┌────────────────────────────────────────────────────────┐
+│  🎤  │ [transcript appears here as you speak...]       │
+└────────────────────────────────────────────────────────┘
+```
+
+States:
+- **Idle:** Mic icon, muted color. Click to start.
+- **Listening:** Animated pulse ring around the mic icon (CSS keyframe), primary color.
+- **Interim text present:** Mic icon + subtle italic text overlay in textarea.
+
+The mic button is always visible in the footer (does not appear/disappear) so users know voice input is available.
+
+---
+
+### Textarea interim text display
+
+Interim results are appended to the textarea's value in a way that is clearly distinguishable and replaceable:
+
+```ts
+// When interim arrives:
+textareaRef.value = committedText + " " + interimTranscript;
+// Style the interim portion: not trivial in a plain textarea.
+// Simpler: suffix with a cursor-like marker and rely on italics via
+// a sibling ghost element overlaid on the textarea (same approach as
+// autocomplete overlays in modern IDEs).
+```
+
+Simplest workable approach: a `<div>` overlay (same font, same size, transparent background) renders `committedText` as invisible and `interimText` as dimmed/italic. When the final result arrives, `committedText` is updated and the overlay is cleared.
+
+---
+
+### Keyboard shortcut
+
+**Ctrl+Shift+M** — global, installed at app-init level. Toggles the voice session regardless of which element has focus.
+
+Works even when the user's cursor is in a terminal pane (voice output still targets the last focused agent pane, not the terminal).
+
+---
+
+### Permission flow
+
+On first toggle, the browser shows the standard "Allow microphone" prompt (CEF inherits Chromium's permission UI). The permission is persisted by CEF's user-data profile (per version, as with all CEF state).
+
+If the user denies permission, `recognition.onerror` fires with `{ error: "not-allowed" }`. Show a toast: "Microphone access denied — allow it in your OS sound settings."
+
+---
+
+## Phase 2 Architecture (Provider-based STT)
+
+Add a `speechProvider` field to the settings schema:
+
+```ts
+type SpeechProvider = 
+    | { type: "web-speech" }                         // Phase 1 (default)
+    | { type: "openai-whisper"; apiKey?: string }     // uses stored OpenAI key
+    | { type: "deepgram"; apiKey: string }
+    | { type: "local-whisper"; model: "tiny" | "base" | "small" | "medium" }
+```
+
+The `useVoiceInput` hook reads `speechProvider` from settings and routes audio accordingly.
+
+For Whisper/Deepgram: `MediaRecorder` captures audio → sends chunks to agentmux-srv → srv proxies to API → WPS event delivers transcript.
+
+For local Whisper: same IPC path but agentmux-srv calls whisper.cpp subprocess.
+
+---
+
+## Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| User switches pane mid-sentence | Final result goes to the pane active when the sentence ends |
+| Agent is running (streaming response) | Transcript still injected into textarea; send is blocked until stream ends (existing behaviour) |
+| Two agent panes in the same window | Last focused wins |
+| User opens a terminal pane | Terminal pane is not an agent pane; does not register a voice handle; previous agent pane keeps the target |
+| Mic permission denied | Toast + mic button shows error state; toggle does nothing until page reload |
+| No SpeechRecognition API in browser | Mic button is hidden; falls through to Phase 2 provider if configured |
+| Multiple AgentMux windows | Each window's voice session is independent; Ctrl+Shift+M affects the focused window |
+
+---
+
+## Non-Goals
+
+- **Voice commands** (e.g., "stop agent", "scroll to top") — voice is input method only, not a command interface.
+- **Text-to-speech / agent speaking back** — out of scope for this spec.
+- **Wake word** ("hey mux") — not planned; hotkey is sufficient and less invasive.
+- **Multi-speaker diarization** — not relevant for single-user desktop.
+- **Recording history** — voice input is ephemeral; nothing is stored.
+
+---
+
+## Implementation Order
+
+1. `useVoiceInput.ts` — Web Speech API session, pane handle registry, `isListening` signal.
+2. `MicButton.tsx` — icon button with pulse animation.
+3. `AgentFooter.tsx` — mount/focus events to register pane handle; wire interim text overlay.
+4. `agent-view.tsx` — pass `onFocus` callback to footer.
+5. `app-init.ts` — global Ctrl+Shift+M keybinding.
+6. Manual test: open two panes, toggle mic, alternate speaking into each.
+
+**Estimated effort:** Phase 1 is ~2–3 days frontend-only work. No Rust changes required.

--- a/specs/SPEC_VOICE_INPUT_IMPL_WEB_SPEECH_2026_05_08.md
+++ b/specs/SPEC_VOICE_INPUT_IMPL_WEB_SPEECH_2026_05_08.md
@@ -1,0 +1,545 @@
+# Implementation Spec: Voice Input — Web Speech API (Phase 1)
+
+**Date:** 2026-05-08  
+**Status:** Draft  
+**Parent:** `SPEC_VOICE_INPUT_2026_05_08.md`  
+**Effort:** ~2–3 days, frontend-only, no Rust changes
+
+---
+
+## Scope
+
+Implement Ctrl+Shift+M voice input using the browser-native `webkitSpeechRecognition` API. Transcript is injected into whichever agent pane was last focused. No auto-send; the user presses Enter as usual.
+
+---
+
+## Files
+
+| Action | Path |
+|--------|------|
+| **Create** | `frontend/app/hook/useVoiceInput.ts` |
+| **Create** | `frontend/app/view/agent/components/MicButton.tsx` |
+| **Create** | `frontend/app/view/agent/components/MicButton.scss` |
+| **Modify** | `frontend/app/view/agent/components/AgentFooter.tsx` |
+| **Modify** | `frontend/app/view/agent/agent-view.tsx` |
+| **Modify** | `frontend/app/app-init.ts` |
+
+---
+
+## 1. `frontend/app/hook/useVoiceInput.ts`
+
+Module-level singleton. One `SpeechRecognition` instance exists for the entire app lifetime. Multiple `AgentFooter` instances register/deregister a handle; the last-focused one receives transcript.
+
+### Type definitions
+
+```ts
+/** Provided by each AgentFooter on focus. Tells the voice session where to write. */
+export interface PaneVoiceHandle {
+    /** Append committed (final) transcript at current cursor position in the textarea. */
+    appendFinal: (text: string) => void;
+    /** Replace the in-progress interim suffix in the textarea. Pass "" to clear. */
+    setInterim: (text: string) => void;
+}
+
+export interface VoiceSession {
+    isListening: () => boolean;
+    isAvailable: () => boolean;         // false when SpeechRecognition absent in this runtime
+    toggleListening: () => void;
+    /** Called by AgentFooter on focus to become the transcript target. */
+    registerPane: (handle: PaneVoiceHandle) => void;
+}
+```
+
+### Singleton implementation
+
+```ts
+import { createSignal } from "solid-js";
+
+const RESTART_DELAY_MS = 100;   // pause before auto-restarting after onend
+
+function createVoiceSession(): VoiceSession {
+    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+    const [isListening, setIsListening] = createSignal(false);
+
+    if (!SR) {
+        return {
+            isListening: () => false,
+            isAvailable: () => false,
+            toggleListening: () => {},
+            registerPane: () => {},
+        };
+    }
+
+    const recognition: SpeechRecognition = new SR();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = navigator.language;  // honour OS locale
+
+    let activeHandle: PaneVoiceHandle | null = null;
+    let interimActive = false;      // whether we've written interim text to the textarea
+
+    recognition.onresult = (event: SpeechRecognitionEvent) => {
+        let interim = "";
+        let finals = "";
+
+        // Only process results from this event batch (resultIndex onward).
+        for (let i = event.resultIndex; i < event.results.length; i++) {
+            const result = event.results[i];
+            if (result.isFinal) {
+                finals += result[0].transcript;
+            } else {
+                interim += result[0].transcript;
+            }
+        }
+
+        if (finals) {
+            // Clear any interim suffix first, then append final text with a
+            // leading space (unless the textarea is empty).
+            activeHandle?.setInterim("");
+            interimActive = false;
+            activeHandle?.appendFinal(finals);
+        }
+
+        if (interim) {
+            activeHandle?.setInterim(interim);
+            interimActive = true;
+        } else if (!finals) {
+            // No new content in this event — clear stale interim.
+            activeHandle?.setInterim("");
+            interimActive = false;
+        }
+    };
+
+    recognition.onerror = (event: SpeechRecognitionErrorEvent) => {
+        if (event.error === "not-allowed" || event.error === "service-not-allowed") {
+            // Permission denied — surface to user via a toast (see §5).
+            setIsListening(false);
+            window.dispatchEvent(new CustomEvent("voice-input-error", { detail: event.error }));
+        }
+        // "no-speech" and "aborted" are non-fatal; onend will restart if still listening.
+    };
+
+    recognition.onend = () => {
+        // Web Speech API stops automatically after a long pause or on some
+        // browser builds after every utterance. Auto-restart if the user hasn't
+        // toggled off.
+        if (isListening()) {
+            setTimeout(() => {
+                if (isListening()) {
+                    try { recognition.start(); } catch { /* already started race */ }
+                }
+            }, RESTART_DELAY_MS);
+        }
+    };
+
+    const toggleListening = () => {
+        if (isListening()) {
+            recognition.stop();
+            if (interimActive) {
+                activeHandle?.setInterim("");
+                interimActive = false;
+            }
+            setIsListening(false);
+        } else {
+            try {
+                recognition.start();
+                setIsListening(true);
+            } catch {
+                // Already started (race with onend auto-restart) — ignore.
+            }
+        }
+    };
+
+    return {
+        isListening,
+        isAvailable: () => true,
+        toggleListening,
+        registerPane: (handle) => { activeHandle = handle; },
+    };
+}
+
+// Module-level singleton — created once on first import.
+let _session: VoiceSession | null = null;
+
+export function getVoiceSession(): VoiceSession {
+    if (!_session) _session = createVoiceSession();
+    return _session;
+}
+```
+
+**Key decisions:**
+
+- `continuous: true` — keeps the session alive across pauses without requiring the user to click again.
+- `interimResults: true` — partial words appear as the user speaks.
+- `registerPane` does not deregister on blur. If the user clicks the title bar or a scrollbar, the voice target stays on the last agent pane. It is only replaced when another agent pane gains focus.
+- Auto-restart on `onend` with a 100 ms delay avoids an infinite restart loop when the user calls `recognition.stop()`.
+
+---
+
+## 2. `frontend/app/view/agent/components/MicButton.tsx`
+
+Uses the existing `ToggleIconButton` from `frontend/app/element/iconbutton.tsx`, which already supports an `active()` signal.
+
+```tsx
+import { ToggleIconButton } from "@/app/element/iconbutton";
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
+import { Show, JSX } from "solid-js";
+import "./MicButton.scss";
+
+export function MicButton(): JSX.Element {
+    const voice = getVoiceSession();
+
+    return (
+        <Show when={voice.isAvailable()}>
+            <div class="mic-button-wrap" classList={{ "mic-active": voice.isListening() }}>
+                <ToggleIconButton
+                    decl={{
+                        elemtype: "toggleiconbutton",
+                        icon: "regular@microphone",
+                        title: "Voice input (Ctrl+Shift+M)",
+                        active: voice.isListening,
+                        click: voice.toggleListening,
+                    }}
+                />
+            </div>
+        </Show>
+    );
+}
+```
+
+---
+
+## 3. `frontend/app/view/agent/components/MicButton.scss`
+
+```scss
+.mic-button-wrap {
+    display: flex;
+    align-items: center;
+
+    &.mic-active .wave-iconbutton {
+        color: var(--color-primary);
+        position: relative;
+
+        &::after {
+            content: "";
+            position: absolute;
+            inset: -3px;
+            border-radius: 50%;
+            border: 1.5px solid var(--color-primary);
+            opacity: 0.6;
+            animation: mic-pulse 1.4s ease-in-out infinite;
+        }
+    }
+}
+
+@keyframes mic-pulse {
+    0%, 100% { transform: scale(1);   opacity: 0.6; }
+    50%       { transform: scale(1.3); opacity: 0;   }
+}
+```
+
+---
+
+## 4. `frontend/app/view/agent/components/AgentFooter.tsx`
+
+### 4a. New prop
+
+Add one optional prop to `AgentFooterProps` (line 187):
+
+```ts
+interface AgentFooterProps {
+    agentId: string;
+    onSendMessage?: (message: string) => void | Promise<void>;
+    onTyping?: () => void;
+    onStopAgent?: () => void;
+    getCompletions?: (prefix: string) => SlashCommand[];
+    // NEW:
+    onFocused?: () => void;   // called when this pane becomes the voice target
+}
+```
+
+### 4b. Voice handle registration
+
+Inside `AgentFooter` component body, after `let textareaRef`:
+
+```ts
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
+import { MicButton } from "./MicButton";
+
+// ── Voice input ───────────────────────────────────────────────────────────
+const voice = getVoiceSession();
+
+// Track committed text length so interim can be appended/replaced without
+// disturbing text the user typed manually.
+let voiceBaseLength = 0;  // length of textareaRef.value when this utterance started
+
+const voiceHandle = {
+    appendFinal: (text: string) => {
+        if (!textareaRef) return;
+        // Ensure there is a space separator unless the textarea is empty.
+        const current = textareaRef.value;
+        const separator = current.length > 0 && !current.endsWith(" ") ? " " : "";
+        textareaRef.value = current + separator + text.trimStart();
+        voiceBaseLength = textareaRef.value.length;
+        props.onTyping?.();
+    },
+    setInterim: (text: string) => {
+        if (!textareaRef) return;
+        // Replace everything after voiceBaseLength with the interim text.
+        const base = textareaRef.value.slice(0, voiceBaseLength);
+        textareaRef.value = text ? base + " " + text : base;
+        props.onTyping?.();
+    },
+};
+
+const handleFocus = () => {
+    voice.registerPane(voiceHandle);
+    // Reset base to current length so interim appends after existing text.
+    voiceBaseLength = textareaRef?.value.length ?? 0;
+    props.onFocused?.();
+};
+```
+
+### 4c. Wire focus and MicButton into the JSX
+
+The current JSX (lines 373–393):
+
+```tsx
+<div class="agent-input-container">
+    <Show when={autocompletePrefix() !== null && completions().length > 0}>
+        <SlashAutocomplete ... />
+    </Show>
+    <textarea
+        ref={textareaRef}
+        class="agent-input"
+        placeholder={`Send message to ${props.agentId}...`}
+        onKeyDown={handleKeyDown}
+        onInput={handleInput}
+        rows={1}
+    />
+    <div class="agent-input-hint">
+        <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
+    </div>
+</div>
+```
+
+Replace with:
+
+```tsx
+<div class="agent-input-container" onFocusIn={handleFocus}>
+    <Show when={autocompletePrefix() !== null && completions().length > 0}>
+        <SlashAutocomplete ... />
+    </Show>
+    <div class="agent-input-row">
+        <MicButton />
+        <textarea
+            ref={textareaRef}
+            class="agent-input"
+            classList={{ "voice-active": voice.isListening() }}
+            placeholder={`Send message to ${props.agentId}...`}
+            onKeyDown={handleKeyDown}
+            onInput={(e) => {
+                // User typed: update voiceBaseLength so interim appends correctly.
+                voiceBaseLength = (e.target as HTMLTextAreaElement).value.length;
+                handleInput(e);
+            }}
+            rows={1}
+        />
+    </div>
+    <div class="agent-input-hint">
+        <span>Enter to send • Shift+Enter for newline • Esc to clear / stop</span>
+    </div>
+</div>
+```
+
+**`onFocusIn`** bubbles from any child click (including the textarea and the mic button), so a single handler covers the whole footer area.
+
+**`classList={{ "voice-active": voice.isListening() }}`** on the textarea lets CSS add a subtle pulse border while the mic is active:
+
+```scss
+.agent-input.voice-active {
+    border-color: var(--color-primary);
+    box-shadow: 0 0 0 1px var(--color-primary);
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+```
+
+Add this to the existing agent SCSS file.
+
+### 4d. `voiceBaseLength` reset on send
+
+In `handleSend` (line 291), after clearing the textarea, reset the base:
+
+```ts
+const handleSend = () => {
+    if (!textareaRef) return;
+    const message = textareaRef.value;
+    if (!message.trim()) return;
+    if (props.onSendMessage) {
+        props.onSendMessage(message);
+        textareaRef.value = "";
+        voiceBaseLength = 0;    // ← add this
+        // ... rest unchanged
+    }
+};
+```
+
+---
+
+## 5. `frontend/app/view/agent/agent-view.tsx`
+
+No structural changes needed. The `onFocusIn` handler inside `AgentFooter` handles pane registration automatically.
+
+However, wire the `onFocused` prop if any parent-level behaviour is needed (currently none required). Leave the `AgentFooter` call at line 719 as-is for now — `onFocused` is optional.
+
+---
+
+## 6. `frontend/app/app-init.ts`
+
+Install the global Ctrl+Shift+M keybinding once at startup:
+
+```ts
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
+
+// Inside initApp() or at module level after imports:
+document.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.ctrlKey && e.shiftKey && e.key === "M") {
+        e.preventDefault();
+        getVoiceSession().toggleListening();
+    }
+});
+```
+
+Also listen for the `voice-input-error` event dispatched from the session on permission denial:
+
+```ts
+window.addEventListener("voice-input-error", (e: Event) => {
+    const error = (e as CustomEvent<string>).detail;
+    if (error === "not-allowed" || error === "service-not-allowed") {
+        // Replace with whatever toast/notification system the app uses.
+        console.warn("[voice] Microphone permission denied");
+        // TODO: surface toast: "Microphone access denied — allow it in your OS sound settings"
+    }
+});
+```
+
+---
+
+## 7. Interim text display strategy
+
+**Decision: write-through to textarea value, no overlay.**
+
+Rationale: a sibling overlay `<div>` must match the textarea's exact font, line-height, padding, scrollTop, and wrapping — fragile and requires synchronous layout reads (which the existing footer deliberately avoids; see comment at `AgentFooter.tsx:219–233`). The write-through approach writes directly to `textareaRef.value`:
+
+```
+"fix the bug in " ← voiceBaseLength = 17 (user typed)
+"fix the bug in main.rs" ← interim (main.rs = in-progress word)
+"fix the bug in main.rs" ← final — voiceBaseLength advances to 23
+```
+
+If the user types while interim is showing, `onInput` updates `voiceBaseLength` to the new `.value.length`, effectively committing any interim text as-is (it becomes part of the base). This is correct — the user's editing intent takes precedence.
+
+**Visual cue:** The `voice-active` class on the textarea and the pulse ring on the MicButton are sufficient for the user to know voice is active. Dimming the interim text is deferred to a future iteration.
+
+---
+
+## 8. CEF microphone permission
+
+CEF prompts the user for microphone access via the standard Chromium permission UI on first use. The permission is stored in the CEF user-data profile per version directory (`~/.agentmux/versions/<v>/`).
+
+No additional CEF configuration is required. `navigator.mediaDevices` and `webkitSpeechRecognition` are available in CEF by default.
+
+If access is denied, `recognition.onerror` fires with `error: "not-allowed"`. The session catches this, emits `voice-input-error`, and the keybinding stops responding until the app restarts (CEF caches the denial; the user must clear it in OS sound settings).
+
+---
+
+## 9. State machine
+
+```
+IDLE
+ │  Ctrl+Shift+M  /  MicButton click
+ ▼
+LISTENING
+ │  onresult (interim)  →  setInterim(text) on active pane
+ │  onresult (final)    →  appendFinal(text), setInterim("")
+ │  onend               →  auto-restart after 100 ms (recognition.onend handler)
+ │  Ctrl+Shift+M  /  MicButton click
+ ▼
+IDLE (recognition.stop(); setInterim("") to clear any dangling interim)
+```
+
+Error transitions:
+
+```
+LISTENING
+ │  onerror "not-allowed"   →  IDLE + emit voice-input-error
+ │  onerror "no-speech"     →  (stay LISTENING; onend will auto-restart)
+ │  onerror "aborted"       →  (stay LISTENING; onend will auto-restart)
+```
+
+---
+
+## 10. Edge cases
+
+| Scenario | Handling |
+|----------|----------|
+| User switches to terminal pane | Terminal has no `onFocusIn` → `registerPane` not called → `activeHandle` stays on last agent pane → transcript still goes there |
+| User clicks title bar / scrollbar | `onFocusIn` not triggered → handle unchanged → correct |
+| Two agent panes side-by-side | Whichever was clicked last holds `activeHandle`; the other pane is unaffected |
+| User types mid-utterance | `onInput` updates `voiceBaseLength` to current length; interim is appended after what the user typed |
+| User presses Esc to clear | `handleKeyDown` sets `textareaRef.value = ""`, then `voiceBaseLength = 0` (add this reset in the Esc branch alongside the existing clear) |
+| Send while listening | `handleSend` clears textarea and resets `voiceBaseLength = 0`; voice session keeps running; next words go into the now-empty textarea |
+| No `SpeechRecognition` API | `isAvailable()` returns `false`; `MicButton` is hidden; Ctrl+Shift+M is a no-op |
+| Rapid pane switches during an utterance | The final `onresult` fires on whichever pane is registered at that moment (the newest focused one) |
+
+---
+
+## 11. TypeScript — `SpeechRecognition` types
+
+The Web Speech API types are not in `lib.dom.d.ts` by default in all TypeScript versions. Add a declaration file:
+
+**`frontend/types/speech.d.ts`** (new file):
+
+```ts
+interface SpeechRecognitionEvent extends Event {
+    readonly resultIndex: number;
+    readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: string;
+    readonly message: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+    continuous: boolean;
+    interimResults: boolean;
+    lang: string;
+    start(): void;
+    stop(): void;
+    abort(): void;
+    onresult: ((event: SpeechRecognitionEvent) => void) | null;
+    onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+    onend: (() => void) | null;
+}
+
+declare var SpeechRecognition: { new(): SpeechRecognition };
+declare var webkitSpeechRecognition: { new(): SpeechRecognition };
+```
+
+---
+
+## 12. Implementation order
+
+1. **`speech.d.ts`** — types first so the rest compiles.
+2. **`useVoiceInput.ts`** — singleton with stub `registerPane` (no real handle wired yet). Verify Ctrl+Shift+M toggles `isListening` in devtools console.
+3. **`MicButton.tsx` + `MicButton.scss`** — render in footer, verify pulse animation.
+4. **`AgentFooter.tsx`** — `onFocusIn`, `voiceHandle`, `voiceBaseLength` tracking, `voice-active` class on textarea.
+5. **`app-init.ts`** — global keybinding + error listener.
+6. **Manual test:**
+   - Open two agent panes.
+   - Ctrl+Shift+M → mic button pulses.
+   - Speak → words appear in the focused pane.
+   - Click the other pane → speak → words appear there.
+   - Press Enter → sends, textarea clears, mic stays on.
+   - Ctrl+Shift+M → stops.


### PR DESCRIPTION
## Summary

- Adds a mic button (`MicButton`) to each agent pane footer
- `Ctrl+Shift+V` global hotkey toggles listening from anywhere in the app
- Transcript (interim + final) is injected into the last-focused agent textarea — no auto-send, user presses Enter as usual
- Switching between agent panes redirects voice output to whichever pane was clicked last
- Mic button shows a pulse ring animation while active; textarea gets a highlighted border

## Files

| Action | Path |
|--------|------|
| New | `frontend/types/speech.d.ts` — Web Speech API type declarations |
| New | `frontend/app/hook/useVoiceInput.ts` — module-level singleton session |
| New | `frontend/app/view/agent/components/MicButton.tsx` |
| New | `frontend/app/view/agent/components/MicButton.scss` |
| Modified | `frontend/app/view/agent/components/AgentFooter.tsx` — voice handle registration, `onFocusIn`, `voiceBaseLength` |
| Modified | `frontend/app/view/agent/styles/_pending-footer.scss` — `agent-input-row` layout, `voice-active` border |
| Modified | `frontend/app/store/keymodel.ts` — `Ctrl:Shift:v` binding |
| New | `specs/SPEC_VOICE_INPUT_2026_05_08.md` — high-level options spec |
| New | `specs/SPEC_VOICE_INPUT_IMPL_WEB_SPEECH_2026_05_08.md` — detailed implementation spec |

## Key decisions

- **`Ctrl+Shift+V`** (not M — M is taken by terminal multi-input toggle at keymodel.ts:552)
- **Module-level singleton** — one `webkitSpeechRecognition` instance for the whole app; `registerPane` swaps the target on focus
- **Write-through to textarea value** — no overlay div; `voiceBaseLength` tracks the committed boundary so user edits and interim transcript coexist cleanly
- **Auto-restart on `onend`** with 100 ms delay — CEF's Web Speech implementation sometimes stops after long pauses

## Test plan

- [ ] Open an agent pane, click its textarea, press Ctrl+Shift+V → mic button pulses
- [ ] Speak → words appear in the textarea as interim, committed on pause
- [ ] Open two agent panes side-by-side, click between them → voice goes to whichever was last focused
- [ ] Press Enter to send while mic is on → textarea clears, mic keeps listening
- [ ] Press Ctrl+Shift+V again → mic stops
- [ ] Deny microphone permission → no crash, Ctrl+Shift+V becomes a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)