### PR TITLE
feat: agent pane state machine refinements (#728)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.719"
+version = "0.33.720"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.719"
+version = "0.33.720"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.719"
+version = "0.33.720"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.719"
+version = "0.33.720"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -2936,9 +2936,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.719"
+version = "0.33.720"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.719"
+version = "0.33.720"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.719"
+version = "0.33.720"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.719"
+version = "0.33.720"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -21,6 +21,7 @@ import {
     AgentDocumentCommand,
     AgentDocumentEvent,
     AgentDocumentState,
+    type ReducerOptions,
     initialState,
 } from "./agent-document/types";
 import { type CommandSource, recordDispatch } from "./command-source";
@@ -99,6 +100,7 @@ export function dispatch(
     blockId: string,
     command: AgentDocumentCommand,
     source: CommandSource = "system",
+    opts?: ReducerOptions,
 ): AgentDocumentEvent[] {
     const slot = slots.get(blockId);
     if (!slot) {
@@ -106,7 +108,7 @@ export function dispatch(
             `[agent-document-store] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously in the component body.`,
         );
     }
-    const result = update(slot.state, command);
+    const result = update(slot.state, command, Date.now(), opts);
     const prevNodes = slot.state.nodes;
     slot.state = result.state;
     // Push to atom only if nodes changed (referential equality).
@@ -129,6 +131,15 @@ export function dispatch(
 /** Snapshot a pane's reducer state. Diagnostics + tests only. */
 export function snapshot(blockId: string): AgentDocumentState | null {
     return slots.get(blockId)?.state ?? null;
+}
+
+/**
+ * Read the reducer-maintained dedup index for a pane. Returns an empty
+ * set if the pane isn't registered (e.g. very early during mount).
+ * Issue #728 gap 4 — replaces the per-mount rebuild in useAgentStream.
+ */
+export function getNodeIdSet(blockId: string): Set<string> {
+    return slots.get(blockId)?.state.nodeIdSet ?? new Set<string>();
 }
 
 /** Test/dev helper — wipe all slots. Never call in production. */

--- a/frontend/app/store/agent-document/reducer.test.ts
+++ b/frontend/app/store/agent-document/reducer.test.ts
@@ -13,6 +13,18 @@ const md = (id: string, content = id): DocumentNode => ({
     timestamp: 0,
 });
 
+/**
+ * Build a state with `nodes` AND a matching `nodeIdSet`. Required since
+ * issue #728 gap 4 made `nodeIdSet` part of `AgentDocumentState` — bare
+ * `{ ...initialState(), nodes: [...] }` would leave the index empty
+ * and break dedup invariants.
+ */
+const seed = (nodes: DocumentNode[]) => ({
+    ...initialState(),
+    nodes,
+    nodeIdSet: new Set(nodes.map((n) => n.id)),
+});
+
 describe("agent document reducer", () => {
     describe("HistoryLoaded", () => {
         it("prepends nodes onto an empty document", () => {
@@ -24,14 +36,14 @@ describe("agent document reducer", () => {
         });
 
         it("dedups against existing IDs", () => {
-            const start = { ...initialState(), nodes: [md("a"), md("b")] };
+            const start = seed([md("a"), md("b")]);
             const r = update(start, { type: "HistoryLoaded", nodes: [md("a"), md("h1")] });
             expect(r.state.nodes.map((n) => n.id)).toEqual(["h1", "a", "b"]);
             expect(r.events[0]).toMatchObject({ addedCount: 1, duplicatesDropped: 1 });
         });
 
         it("is a no-op when all incoming nodes are duplicates", () => {
-            const start = { ...initialState(), nodes: [md("a")] };
+            const start = seed([md("a")]);
             const r = update(start, { type: "HistoryLoaded", nodes: [md("a")] });
             expect(r.state).toBe(start); // referentially unchanged
         });
@@ -118,7 +130,7 @@ describe("agent document reducer", () => {
 
     describe("StreamTruncate suppression", () => {
         it("honors truncate when not yet started (loading-history phase)", () => {
-            const start = { ...initialState(), nodes: [md("h1")] };
+            const start = seed([md("h1")]);
             const r = update(start, { type: "StreamTruncate", reason: "fileop" }, 1000);
             expect(r.state.nodes).toEqual([]);
             expect(r.events[0]).toMatchObject({ type: "truncate-applied", clearedCount: 1 });
@@ -216,16 +228,129 @@ describe("agent document reducer", () => {
         });
     });
 
+    describe("nodeIdSet invariant (gap 4)", () => {
+        it("StreamFlush adds new node ids to nodeIdSet", () => {
+            const r = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a"), md("b")],
+                updatedNodes: [],
+            });
+            expect([...r.state.nodeIdSet].sort()).toEqual(["a", "b"]);
+        });
+
+        it("HistoryLoaded adds prepended node ids to nodeIdSet", () => {
+            const r = update(initialState(), {
+                type: "HistoryLoaded",
+                nodes: [md("h1"), md("h2")],
+            });
+            expect([...r.state.nodeIdSet].sort()).toEqual(["h1", "h2"]);
+        });
+
+        it("UserClear resets nodeIdSet", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a"), md("b")],
+                updatedNodes: [],
+            }).state;
+            expect(s0.nodeIdSet.size).toBe(2);
+            const r = update(s0, { type: "UserClear" });
+            expect(r.state.nodeIdSet.size).toBe(0);
+        });
+
+        it("StreamTruncate (when honored) resets nodeIdSet", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            // Truncate before any session-active grace would kick in →
+            // honored unconditionally (sessionPhase still loading-history).
+            const r = update(s0, { type: "StreamTruncate", reason: "fileop" });
+            expect(r.state.nodeIdSet.size).toBe(0);
+        });
+
+        it("StreamFlush updates do not double-add to nodeIdSet on collision", () => {
+            const s0 = update(initialState(), {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            const r = update(s0, {
+                type: "StreamFlush",
+                newNodes: [md("a", "v2")], // collides → in-place update
+                updatedNodes: [],
+            });
+            expect(r.state.nodeIdSet.size).toBe(1);
+        });
+    });
+
+    describe("Injectable truncate grace (gap 6)", () => {
+        it("respects opts.truncateGraceMs override", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 0 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            // With a 100ms grace override, a truncate at t=200 should
+            // suppress (200 > 100).
+            const r = update(
+                withNodes,
+                { type: "StreamTruncate", reason: "fileop" },
+                200,
+                { truncateGraceMs: 100 },
+            );
+            expect(r.events[0].type).toBe("truncate-suppressed");
+            expect(r.state.nodes).toHaveLength(1);
+        });
+
+        it("0ms grace makes any active truncate suppress immediately", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 0 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            const r = update(
+                withNodes,
+                { type: "StreamTruncate", reason: "fileop" },
+                1,
+                { truncateGraceMs: 0 },
+            );
+            expect(r.events[0].type).toBe("truncate-suppressed");
+        });
+
+        it("falls back to default grace when opts omitted", () => {
+            const start = update(initialState(), { type: "SessionStart", at: 1000 }).state;
+            const withNodes = update(start, {
+                type: "StreamFlush",
+                newNodes: [md("a")],
+                updatedNodes: [],
+            }).state;
+            // No opts → uses TRUNCATE_GRACE_MS default. Within window → honored.
+            const r = update(
+                withNodes,
+                { type: "StreamTruncate", reason: "fileop" },
+                1000 + TRUNCATE_GRACE_MS - 100,
+            );
+            expect(r.events[0].type).toBe("truncate-applied");
+        });
+    });
+
     describe("Purity", () => {
         it("does not mutate the input state", () => {
-            const start = { ...initialState(), nodes: [md("a")] };
-            const snapshot = JSON.parse(JSON.stringify(start));
+            const start = seed([md("a")]);
+            const snapshot = {
+                nodes: start.nodes.slice(),
+                ids: [...start.nodeIdSet],
+            };
             update(start, { type: "StreamFlush", newNodes: [md("b")], updatedNodes: [] });
-            expect(start).toEqual(snapshot);
+            expect(start.nodes).toEqual(snapshot.nodes);
+            expect([...start.nodeIdSet]).toEqual(snapshot.ids);
         });
 
         it("returns referentially same state when no work to do", () => {
-            const start = { ...initialState(), nodes: [md("a")] };
+            const start = seed([md("a")]);
             const r = update(start, { type: "StreamFlush", newNodes: [], updatedNodes: [] });
             expect(r.state).toBe(start);
         });

--- a/frontend/app/store/agent-document/reducer.ts
+++ b/frontend/app/store/agent-document/reducer.ts
@@ -8,15 +8,16 @@
  * function, no I/O, snapshot input, return new state + audit events.
  * See docs/specs/agent-pane-document-reducer-2026-05-03.md.
  *
- * Indices (id → position) are derived per-command, not stored.
- * Doc sizes are bounded (~50–500 nodes typical, ~5k worst case) so
- * the rebuild cost is negligible vs. the simplicity of immutable state.
+ * `nodeIdSet` is maintained as a sibling to `nodes[]` so consumers
+ * (useAgentStream) can dedup new events without rebuilding the index
+ * on every mount. Issue #728 gap 4.
  */
 
 import type { DocumentNode } from "../../view/agent/types";
 import {
     AgentDocumentCommand,
     AgentDocumentState,
+    ReducerOptions,
     ReducerResult,
     TRUNCATE_GRACE_MS,
 } from "./types";
@@ -26,6 +27,8 @@ export function update(
     command: AgentDocumentCommand,
     /** Time injection for testability; defaults to Date.now(). */
     nowMs: number = Date.now(),
+    /** Optional reducer knobs (gap 6 — injectable truncate grace). */
+    opts?: ReducerOptions,
 ): ReducerResult {
     switch (command.type) {
         case "SessionStart":
@@ -48,15 +51,15 @@ export function update(
             if (command.nodes.length === 0) {
                 return { state, events: [] };
             }
-            const existingIds = idSet(state.nodes);
+            const nextIdSet = new Set(state.nodeIdSet);
             const fresh: DocumentNode[] = [];
             let duplicates = 0;
             for (const n of command.nodes) {
-                if (existingIds.has(n.id)) {
+                if (nextIdSet.has(n.id)) {
                     duplicates++;
                     continue;
                 }
-                existingIds.add(n.id);
+                nextIdSet.add(n.id);
                 fresh.push(n);
             }
             if (fresh.length === 0) {
@@ -68,7 +71,11 @@ export function update(
                 };
             }
             return {
-                state: { ...state, nodes: [...fresh, ...state.nodes] },
+                state: {
+                    ...state,
+                    nodes: [...fresh, ...state.nodes],
+                    nodeIdSet: nextIdSet,
+                },
                 events: [
                     {
                         type: "history-loaded",
@@ -118,6 +125,7 @@ export function update(
             // against the rebuild-while-pending race).
             let appendedNew = 0;
             let collidedAndUpdated = 0;
+            let nextIdSet: Set<string> | null = null;
             for (const n of command.newNodes) {
                 const idx = indexById.get(n.id);
                 if (idx != null) {
@@ -129,6 +137,8 @@ export function update(
                 const arr = ensureClone();
                 arr.push(n);
                 indexById.set(n.id, arr.length - 1);
+                if (!nextIdSet) nextIdSet = new Set(state.nodeIdSet);
+                nextIdSet.add(n.id);
                 appendedNew++;
             }
 
@@ -136,7 +146,11 @@ export function update(
                 return { state, events: [] };
             }
             return {
-                state: { ...state, nodes: next },
+                state: {
+                    ...state,
+                    nodes: next,
+                    nodeIdSet: nextIdSet ?? state.nodeIdSet,
+                },
                 events: [
                     {
                         type: "stream-flushed",
@@ -150,7 +164,8 @@ export function update(
         }
 
         case "StreamTruncate": {
-            if (shouldSuppressTruncate(state, nowMs)) {
+            const graceMs = opts?.truncateGraceMs ?? TRUNCATE_GRACE_MS;
+            if (shouldSuppressTruncate(state, nowMs, graceMs)) {
                 return {
                     state,
                     events: [
@@ -170,7 +185,7 @@ export function update(
                 return { state, events: [] };
             }
             return {
-                state: { ...state, nodes: [] },
+                state: { ...state, nodes: [], nodeIdSet: new Set<string>() },
                 events: [
                     { type: "truncate-applied", reason: command.reason, clearedCount: cleared },
                 ],
@@ -180,17 +195,14 @@ export function update(
         case "UserClear": {
             const cleared = state.nodes.length;
             return {
-                state: cleared === 0 ? state : { ...state, nodes: [] },
+                state:
+                    cleared === 0
+                        ? state
+                        : { ...state, nodes: [], nodeIdSet: new Set<string>() },
                 events: [{ type: "user-cleared", clearedCount: cleared }],
             };
         }
     }
-}
-
-function idSet(nodes: DocumentNode[]): Set<string> {
-    const s = new Set<string>();
-    for (const n of nodes) s.add(n.id);
-    return s;
 }
 
 /**
@@ -205,9 +217,13 @@ function idSet(nodes: DocumentNode[]): Set<string> {
  * default is to ignore it and keep the conversation visible. /clear is
  * the explicit way to wipe.
  */
-function shouldSuppressTruncate(state: AgentDocumentState, now: number): boolean {
+function shouldSuppressTruncate(
+    state: AgentDocumentState,
+    now: number,
+    graceMs: number,
+): boolean {
     if (state.sessionPhase !== "active") return false;
     if (state.nodes.length === 0) return false;
     if (state.sessionStartedAt == null) return false;
-    return now - state.sessionStartedAt > TRUNCATE_GRACE_MS;
+    return now - state.sessionStartedAt > graceMs;
 }

--- a/frontend/app/store/agent-document/types.ts
+++ b/frontend/app/store/agent-document/types.ts
@@ -19,13 +19,32 @@ export interface AgentDocumentState {
     sessionPhase: SessionPhase;
     /** ms epoch of the most recent SessionStart, or null if never started. */
     sessionStartedAt: number | null;
+    /**
+     * Authoritative dedup index, kept in lockstep with `nodes`. Replaces
+     * the per-mount rebuild in useAgentStream that scanned `nodes[]` and
+     * could miss in-flight events arriving between mount and scan. The
+     * stream-side cache still exists for in-batch dedup but is now seeded
+     * from this set rather than rebuilt. Issue #728 gap 4.
+     */
+    nodeIdSet: Set<string>;
 }
 
 export const initialState = (): AgentDocumentState => ({
     nodes: [],
     sessionPhase: "loading-history",
     sessionStartedAt: null,
+    nodeIdSet: new Set<string>(),
 });
+
+/** Optional knobs the dispatcher can pass through to the reducer. */
+export interface ReducerOptions {
+    /**
+     * Override for `TRUNCATE_GRACE_MS`. Issue #728 gap 6 — makes the grace
+     * window injectable for unit tests + lets the diagnostics panel tune
+     * it under load without rebuilding.
+     */
+    truncateGraceMs?: number;
+}
 
 /**
  * Hooks emit these. The reducer decides what to do based on current

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -21,6 +21,7 @@ import {
     AgentPaneCommand,
     AgentPaneEvent,
     AgentPaneState,
+    type InitPhase,
     initialState,
 } from "./agent-pane-state/types";
 import { type CommandSource, recordDispatch } from "./command-source";
@@ -39,6 +40,8 @@ export interface AgentPaneProjections {
     turnActive: (next: boolean) => void;
     stopping: (next: boolean) => void;
     pending: (next: PendingMessage[]) => void;
+    /** Init phase — drives the "Loading history…" overlay (issue #728 gap 1). */
+    initPhase?: (next: InitPhase) => void;
 }
 
 interface Slot {
@@ -106,6 +109,7 @@ export function dispatch(
     if (slot.state.turnActive !== prev.turnActive) slot.proj.turnActive(slot.state.turnActive);
     if (slot.state.stopping !== prev.stopping) slot.proj.stopping(slot.state.stopping);
     if (slot.state.pending !== prev.pending) slot.proj.pending(slot.state.pending);
+    if (slot.state.initPhase !== prev.initPhase) slot.proj.initPhase?.(slot.state.initPhase);
 
     for (const ev of result.events) eventSink(blockId, ev);
     recordDispatch({

--- a/frontend/app/store/agent-pane-state/reducer.test.ts
+++ b/frontend/app/store/agent-pane-state/reducer.test.ts
@@ -3,9 +3,18 @@
 
 import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
-import { initialState } from "./types";
+import { initialState, STUCK_THRESHOLD_MS } from "./types";
 
 const mk = () => initialState("test-agent");
+/**
+ * Convenience: bring a fresh state up to the "ready + subscribed" baseline
+ * that most turn-related tests assume. Issue #728 introduced an init-phase
+ * gate, so subscribing alone no longer permits `TurnStart`.
+ */
+const ready = (atMs = 100) => {
+    const s0 = update(mk(), { type: "InitReady" }).state;
+    return update(s0, { type: "StreamSubscribe", at: atMs }).state;
+};
 
 describe("agent-pane-state reducer", () => {
     describe("Stream lifecycle", () => {
@@ -17,7 +26,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("StreamUnsubscribe clears active and force-clears turnActive", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             expect(s1.turnActive).toBe(true);
             const r = update(s1, { type: "StreamUnsubscribe", at: 200 });
@@ -51,7 +60,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TurnStart while active sets turnActive + clears stale stats", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const sWithStats = { ...s0, sessionStats: { input_tokens: 50, output_tokens: 100 } };
             const r = update(sWithStats, { type: "TurnStart", at: 110 });
             expect(r.state.turnActive).toBe(true);
@@ -59,7 +68,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TurnEnd clears tool/tokens/turnActive AND stopping in one shot", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "ToolStart", name: "Read" }).state;
             const s3 = update(s2, { type: "TokensIn", input: 50 }).state;
@@ -83,7 +92,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TurnEnd with explicit stats merges live token totals", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "TokensIn", input: 80 }).state;
             const r = update(s2, {
@@ -98,7 +107,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TurnReset clears turn-scoped state but keeps streaming + pending", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const s1 = update(s0, {
                 type: "PendingMessageQueued",
                 id: "p1",
@@ -155,7 +164,7 @@ describe("agent-pane-state reducer", () => {
         });
 
         it("TurnEnd clears stopping (the normal path — no explicit StopApplied needed)", () => {
-            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const s0 = ready(100);
             const s1 = update(s0, { type: "TurnStart", at: 110 }).state;
             const s2 = update(s1, { type: "RequestStop", at: 120 }).state;
             const r = update(s2, { type: "TurnEnd", stats: null });
@@ -217,6 +226,148 @@ describe("agent-pane-state reducer", () => {
             expect(s2.pending.map((m) => m.id)).toEqual(["a", "b", "c"]);
             const r = update(s2, { type: "PendingMessageAccepted", id: "b" });
             expect(r.state.pending.map((m) => m.id)).toEqual(["a", "c"]);
+        });
+    });
+
+    describe("Init phase (gap 1)", () => {
+        it("starts in 'loading'", () => {
+            expect(mk().initPhase).toBe("loading");
+            expect(mk().initError).toBe(null);
+        });
+
+        it("InitReady advances to ready and clears error", () => {
+            const s0 = update(mk(), { type: "InitFailed", reason: "boom" }).state;
+            expect(s0.initPhase).toBe("error");
+            expect(s0.initError).toBe("boom");
+            const r = update(s0, { type: "InitReady" });
+            expect(r.state.initPhase).toBe("ready");
+            expect(r.state.initError).toBe(null);
+            expect(r.events[0]).toMatchObject({ type: "init-ready" });
+        });
+
+        it("InitFailed captures reason", () => {
+            const r = update(mk(), { type: "InitFailed", reason: "RPC timeout" });
+            expect(r.state.initPhase).toBe("error");
+            expect(r.state.initError).toBe("RPC timeout");
+            expect(r.events[0]).toMatchObject({ type: "init-failed", reason: "RPC timeout" });
+        });
+
+        it("InitStart while already loading is a no-op (same ref)", () => {
+            const start = mk();
+            const r = update(start, { type: "InitStart" });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("TurnStart suppressed while initPhase === 'loading'", () => {
+            // Subscribed but not InitReady — gap 1 invariant.
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const r = update(s0, { type: "TurnStart", at: 110 });
+            expect(r.state.turnActive).toBe(false);
+            expect(r.events[0]).toMatchObject({
+                type: "turn-start-suppressed",
+                reason: "init still loading",
+            });
+        });
+
+        it("TurnStart permitted on init error (fail-open)", () => {
+            const s0 = update(mk(), { type: "InitFailed", reason: "load failed" }).state;
+            const s1 = update(s0, { type: "StreamSubscribe", at: 100 }).state;
+            const r = update(s1, { type: "TurnStart", at: 110 });
+            expect(r.state.turnActive).toBe(true);
+        });
+    });
+
+    describe("Stream watchdog (gap 3)", () => {
+        it("StreamWatchdogTick is no-op when stream inactive", () => {
+            const start = mk();
+            const r = update(start, { type: "StreamWatchdogTick", nowMs: 100_000 });
+            expect(r.state).toBe(start);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamWatchdogTick is no-op when no event seen yet", () => {
+            // StreamSubscribe sets lastEventMs, so manually clear it to
+            // exercise the "stream active but no events" branch.
+            const s0 = update(mk(), { type: "StreamSubscribe", at: 100 }).state;
+            const cleared = { ...s0, lastEventMs: null };
+            const r = update(cleared, { type: "StreamWatchdogTick", nowMs: 200_000 });
+            expect(r.state).toBe(cleared);
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamWatchdogTick below threshold is silent", () => {
+            const s0 = ready(1_000); // lastEventMs = 1000 from StreamSubscribe
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: 10_000 });
+            expect(r.events).toEqual([]);
+        });
+
+        it("StreamWatchdogTick at threshold emits stream-stuck", () => {
+            const s0 = ready(0);
+            const tick = STUCK_THRESHOLD_MS + 1_000;
+            const r = update(s0, { type: "StreamWatchdogTick", nowMs: tick });
+            expect(r.events).toHaveLength(1);
+            expect(r.events[0]).toMatchObject({
+                type: "stream-stuck",
+                idleSinceMs: tick,
+                thresholdMs: STUCK_THRESHOLD_MS,
+            });
+            // Watchdog never mutates state.
+            expect(r.state).toBe(s0);
+        });
+
+        it("ToolStart bumps lastEventMs (resets watchdog clock)", () => {
+            const s0 = ready(1_000);
+            const r = update(s0, { type: "ToolStart", name: "Read" }, 5_000);
+            expect(r.state.lastEventMs).toBe(5_000);
+        });
+    });
+
+    describe("Pending message expiry (gap 2)", () => {
+        it("PendingMessageExpired removes the entry by id", () => {
+            const s0 = update(mk(), {
+                type: "PendingMessageQueued",
+                id: "x",
+                text: "hi",
+                at: 1_000,
+            }).state;
+            const r = update(s0, { type: "PendingMessageExpired", id: "x" }, 31_000);
+            expect(r.state.pending).toHaveLength(0);
+            expect(r.events[0]).toMatchObject({
+                type: "pending-expired",
+                id: "x",
+                queuedAt: 1_000,
+                ageMs: 30_000,
+                wasPresent: true,
+            });
+        });
+
+        it("PendingMessageExpired for unknown id is idempotent no-op", () => {
+            const start = mk();
+            const r = update(start, { type: "PendingMessageExpired", id: "ghost" });
+            expect(r.state).toBe(start);
+            expect(r.events[0]).toMatchObject({
+                type: "pending-expired",
+                id: "ghost",
+                wasPresent: false,
+            });
+        });
+
+        it("PendingMessageExpired after Accepted is harmless (already removed)", () => {
+            const s0 = update(mk(), {
+                type: "PendingMessageQueued",
+                id: "y",
+                text: "hi",
+                at: 100,
+            }).state;
+            const s1 = update(s0, { type: "PendingMessageAccepted", id: "y" }).state;
+            // Race: timeout fires after acceptance.
+            const r = update(s1, { type: "PendingMessageExpired", id: "y" });
+            expect(r.state.pending).toHaveLength(0);
+            expect(r.events[0]).toMatchObject({
+                type: "pending-expired",
+                wasPresent: false,
+            });
         });
     });
 

--- a/frontend/app/store/agent-pane-state/reducer.ts
+++ b/frontend/app/store/agent-pane-state/reducer.ts
@@ -8,23 +8,59 @@
  *
  * Invariants enforced:
  *   1. turnActive cannot be set while streaming inactive (suppressed).
- *   2. stopping clears automatically on TurnEnd / TurnReset.
- *   3. currentTool and turnTokens clear on TurnEnd / TurnReset.
- *   4. pending FIFO; accepting/rejecting unknown ids is idempotent no-op.
- *   5. StreamFlushObserved is a no-op when streaming inactive.
+ *   2. turnActive cannot be set while initPhase !== "ready" (suppressed).
+ *   3. stopping clears automatically on TurnEnd / TurnReset.
+ *   4. currentTool and turnTokens clear on TurnEnd / TurnReset.
+ *   5. pending FIFO; accepting/rejecting/expiring unknown ids is no-op.
+ *   6. StreamFlushObserved is a no-op when streaming inactive.
+ *   7. StreamWatchdogTick is a no-op when streaming inactive or
+ *      lastEventMs is null (no events seen yet).
  */
 
 import {
     AgentPaneCommand,
     AgentPaneState,
     ReducerResult,
+    STUCK_THRESHOLD_MS,
 } from "./types";
 
 export function update(
     state: AgentPaneState,
     command: AgentPaneCommand,
+    /**
+     * Time injection for testability + watchdog determinism. Used by
+     * tool/token transitions to bump `lastEventMs` (the stuck-stream
+     * watchdog clock). Defaults to `Date.now()` so existing callers
+     * don't need to thread a timestamp.
+     */
+    nowMs: number = Date.now(),
 ): ReducerResult {
     switch (command.type) {
+        // ── Init lifecycle (gap 1) ─────────────────────────────────
+        case "InitStart": {
+            if (state.initPhase === "loading") return { state, events: [] };
+            return {
+                state: { ...state, initPhase: "loading", initError: null },
+                events: [{ type: "init-started" }],
+            };
+        }
+
+        case "InitReady": {
+            if (state.initPhase === "ready") return { state, events: [] };
+            return {
+                state: { ...state, initPhase: "ready", initError: null },
+                events: [{ type: "init-ready" }],
+            };
+        }
+
+        case "InitFailed": {
+            return {
+                state: { ...state, initPhase: "error", initError: command.reason },
+                events: [{ type: "init-failed", reason: command.reason }],
+            };
+        }
+
+        // ── Stream lifecycle ───────────────────────────────────────
         case "StreamSubscribe":
             return {
                 state: {
@@ -34,6 +70,7 @@ export function update(
                         active: true,
                         lastEventTime: command.at,
                     },
+                    lastEventMs: command.at,
                 },
                 events: [{ type: "stream-subscribed", at: command.at }],
             };
@@ -45,6 +82,7 @@ export function update(
                     streaming: { ...state.streaming, active: false },
                     // Defensive: subscription gone → no turn can be active.
                     turnActive: false,
+                    lastEventMs: null,
                 },
                 events: [{ type: "stream-unsubscribed", at: command.at }],
             };
@@ -61,9 +99,31 @@ export function update(
                         bufferSize: state.streaming.bufferSize + command.addedCount,
                         lastEventTime: command.at,
                     },
+                    lastEventMs: command.at,
                 },
                 events: [
                     { type: "stream-flush-observed", addedCount: command.addedCount },
+                ],
+            };
+        }
+
+        case "StreamWatchdogTick": {
+            // No-op when stream inactive or no event has ever been seen.
+            if (!state.streaming.active || state.lastEventMs == null) {
+                return { state, events: [] };
+            }
+            const idleSinceMs = command.nowMs - state.lastEventMs;
+            if (idleSinceMs < STUCK_THRESHOLD_MS) {
+                return { state, events: [] };
+            }
+            return {
+                state,
+                events: [
+                    {
+                        type: "stream-stuck",
+                        idleSinceMs,
+                        thresholdMs: STUCK_THRESHOLD_MS,
+                    },
                 ],
             };
         }
@@ -81,11 +141,27 @@ export function update(
                     ],
                 };
             }
+            // Invariant 2: can't start a turn while still loading history.
+            // After init failure we fail open — the live stream may still
+            // work even if history fetch hung, and blocking the user
+            // would be worse than silently dropping a stale send.
+            if (state.initPhase === "loading") {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "turn-start-suppressed",
+                            reason: "init still loading",
+                        },
+                    ],
+                };
+            }
             return {
                 state: {
                     ...state,
                     turnActive: true,
                     sessionStats: null, // clear stale stats from prior turn
+                    lastEventMs: command.at,
                 },
                 events: [{ type: "turn-started", at: command.at }],
             };
@@ -131,13 +207,13 @@ export function update(
 
         case "ToolStart":
             return {
-                state: { ...state, currentTool: command.name },
+                state: bumpEvent({ ...state, currentTool: command.name }, nowMs),
                 events: [{ type: "tool-started", name: command.name }],
             };
 
         case "ToolEnd":
             return {
-                state: { ...state, currentTool: null },
+                state: bumpEvent({ ...state, currentTool: null }, nowMs),
                 events: [{ type: "tool-ended" }],
             };
 
@@ -147,7 +223,7 @@ export function update(
                 output: state.turnTokens?.output ?? 0,
             };
             return {
-                state: { ...state, turnTokens: next },
+                state: bumpEvent({ ...state, turnTokens: next }, nowMs),
                 events: [{ type: "tokens-updated", input: command.input, output: null }],
             };
         }
@@ -158,7 +234,7 @@ export function update(
                 output: command.output,
             };
             return {
-                state: { ...state, turnTokens: next },
+                state: bumpEvent({ ...state, turnTokens: next }, nowMs),
                 events: [{ type: "tokens-updated", input: null, output: command.output }],
             };
         }
@@ -220,7 +296,51 @@ export function update(
                 events: [{ type: "pending-rejected", id: command.id, wasPresent: true }],
             };
         }
+
+        case "PendingMessageExpired": {
+            const entry = state.pending.find((m) => m.id === command.id);
+            if (!entry) {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "pending-expired",
+                            id: command.id,
+                            queuedAt: 0,
+                            ageMs: 0,
+                            wasPresent: false,
+                        },
+                    ],
+                };
+            }
+            return {
+                state: {
+                    ...state,
+                    pending: state.pending.filter((m) => m.id !== command.id),
+                },
+                events: [
+                    {
+                        type: "pending-expired",
+                        id: command.id,
+                        queuedAt: entry.createdAt,
+                        ageMs: nowMs - entry.createdAt,
+                        wasPresent: true,
+                    },
+                ],
+            };
+        }
     }
+}
+
+/**
+ * Bump `lastEventMs` to "now" only while the stream is subscribed. Used
+ * by tool/token transitions which are observable stream activity. Skip
+ * the bump when streaming is inactive — those would correspond to stale
+ * commands and shouldn't reset the watchdog clock.
+ */
+function bumpEvent(state: AgentPaneState, nowMs: number): AgentPaneState {
+    if (!state.streaming.active) return state;
+    return { ...state, lastEventMs: nowMs };
 }
 
 /**

--- a/frontend/app/store/agent-pane-state/types.ts
+++ b/frontend/app/store/agent-pane-state/types.ts
@@ -7,7 +7,8 @@
  *
  * Bundles the per-pane atoms that have cohesive cross-atom invariants:
  *   streaming, sessionStats, currentTool, turnTokens, turnActive,
- *   stopping, pendingMessages.
+ *   stopping, pendingMessages, plus init phase and stream-watchdog fields
+ *   added in issue #728.
  *
  * The agent document (message list) lives in its own slice
  * (`agent-document/`); reducer scope is intentionally separate per the
@@ -20,6 +21,9 @@ import type {
     StreamingState,
     TurnTokens,
 } from "../../view/agent/types";
+
+/** Init lifecycle — covers the "history still loading" gap. */
+export type InitPhase = "loading" | "ready" | "error";
 
 /**
  * The reducer's state. Each field maps 1:1 to a Solid signal that the
@@ -34,6 +38,16 @@ export interface AgentPaneState {
     turnActive: boolean;
     stopping: boolean;
     pending: PendingMessage[];
+    /** Init phase — `loading` until history fetch completes (or fails). */
+    initPhase: InitPhase;
+    /** Reason captured on InitFailed; null otherwise. */
+    initError: string | null;
+    /**
+     * Wall-clock ms of the last observable stream activity (subscribe,
+     * flush, tool, tokens). Drives the stuck-stream watchdog. null
+     * when no stream is active.
+     */
+    lastEventMs: number | null;
 }
 
 export const initialState = (agentId: string): AgentPaneState => ({
@@ -44,9 +58,20 @@ export const initialState = (agentId: string): AgentPaneState => ({
     turnActive: false,
     stopping: false,
     pending: [],
+    initPhase: "loading",
+    initError: null,
+    lastEventMs: null,
 });
 
 export type AgentPaneCommand =
+    // ── Init lifecycle (gap 1) ─────────────────────────────────────
+    /** Caller signal: history fetch began. */
+    | { type: "InitStart" }
+    /** Caller signal: history fetch resolved successfully. */
+    | { type: "InitReady" }
+    /** Caller signal: history fetch failed; reason surfaced for diagnostics. */
+    | { type: "InitFailed"; reason: string }
+
     // ── Stream lifecycle ───────────────────────────────────────────
     /** Hook signal: subscription is up. */
     | { type: "StreamSubscribe"; at: number }
@@ -57,6 +82,12 @@ export type AgentPaneCommand =
      * lastEventTime. No state change beyond those counters.
      */
     | { type: "StreamFlushObserved"; addedCount: number; at: number }
+    /**
+     * Periodic tick from useAgentStream's watchdog interval. Emits a
+     * `stream-stuck` event when the active stream has been silent for
+     * more than `STUCK_THRESHOLD_MS`. No state mutation.
+     */
+    | { type: "StreamWatchdogTick"; nowMs: number }
 
     // ── Turn lifecycle ─────────────────────────────────────────────
     /**
@@ -97,17 +128,39 @@ export type AgentPaneCommand =
     /** Backend acknowledged the message — remove from pending. */
     | { type: "PendingMessageAccepted"; id: string }
     /** RPC failed — remove the entry so user doesn't see a ghost row. */
-    | { type: "PendingMessageRejected"; id: string };
+    | { type: "PendingMessageRejected"; id: string }
+    /**
+     * Pending entry ageing watchdog fired (caller-scheduled setTimeout).
+     * Removes the entry by id; idempotent no-op if already accepted/rejected.
+     * Issue #728 gap 2 — prevents zombie pending rows when the backend
+     * never acknowledges a queued message (e.g. RPC hang post-send).
+     */
+    | { type: "PendingMessageExpired"; id: string };
 
 export type AgentPaneEvent =
+    | { type: "init-started" }
+    | { type: "init-ready" }
+    | { type: "init-failed"; reason: string }
     | { type: "stream-subscribed"; at: number }
     | { type: "stream-unsubscribed"; at: number }
     | { type: "stream-flush-observed"; addedCount: number }
+    | {
+          /**
+           * Stream has been silent for `idleSinceMs` while subscribed —
+           * exceeds `thresholdMs`. Surfaced for diagnostics / UI badge.
+           */
+          type: "stream-stuck";
+          idleSinceMs: number;
+          thresholdMs: number;
+      }
     | { type: "turn-started"; at: number }
     | { type: "turn-ended"; statsMerged: boolean; stoppingCleared: boolean }
     | { type: "turn-reset" }
     | {
-          /** Invariant fire: TurnStart while streaming inactive — dropped. */
+          /**
+           * Invariant fire: TurnStart while streaming inactive OR
+           * initPhase !== "ready" — dropped.
+           */
           type: "turn-start-suppressed";
           reason: string;
       }
@@ -118,9 +171,26 @@ export type AgentPaneEvent =
     | { type: "stop-failed" }
     | { type: "pending-queued"; id: string }
     | { type: "pending-accepted"; id: string; wasPresent: boolean }
-    | { type: "pending-rejected"; id: string; wasPresent: boolean };
+    | { type: "pending-rejected"; id: string; wasPresent: boolean }
+    | {
+          /** Pending entry expired and was removed; queuedAt for log/audit. */
+          type: "pending-expired";
+          id: string;
+          queuedAt: number;
+          ageMs: number;
+          wasPresent: boolean;
+      };
 
 export interface ReducerResult {
     state: AgentPaneState;
     events: AgentPaneEvent[];
 }
+
+/**
+ * Stuck-stream threshold. A subscribed stream that hasn't received any
+ * observable event (subscribe, flush, tool, tokens) for this many ms is
+ * flagged. 45s covers the typical Claude/Codex idle window between
+ * thinking and tool calls during long reasoning runs without false
+ * positives. Issue #728 gap 3.
+ */
+export const STUCK_THRESHOLD_MS = 45_000;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -124,6 +124,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
             turnActive: a.turnActiveAtom[1],
             stopping: a.stoppingAtom[1],
             pending: a.pendingMessagesAtom[1],
+            initPhase: a.initPhaseAtom[1],
         });
         onCleanup(() => unregisterAgentPaneStatePane(model.blockId));
     }

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -23,7 +23,7 @@
  * flags (permission mode, model, effort) take effect on this turn.
  */
 
-import { type Accessor, createMemo, createSignal } from "solid-js";
+import { type Accessor, createMemo, createSignal, onCleanup } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
@@ -146,6 +146,15 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
     // registered first and can't be shadowed (see registry.register).
     const registry = createMemo(() => buildRegistry(opts.provider()));
 
+    // Pending-message expiry timers — cleared on pane unmount so the
+    // delayed dispatch doesn't hit an unregistered slot and throw.
+    // Issue #728 gap 2 / PR #742 ReAgent P1.
+    const pendingExpiryTimers = new Set<ReturnType<typeof setTimeout>>();
+    onCleanup(() => {
+        for (const id of pendingExpiryTimers) clearTimeout(id);
+        pendingExpiryTimers.clear();
+    });
+
     // ── Inline picker state ───────────────────────────────────────────
     // The dispatcher calls `ctx.openPicker(spec)` for required enum/
     // dynamic args; this hook hands back a Promise that resolves when
@@ -252,12 +261,16 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // PENDING_TIMEOUT_MS, the reducer removes the ghost entry. Idempotent
         // when the message lands first — the entry is already gone and
         // PendingMessageExpired is a no-op.
-        setTimeout(() => {
+        // Tracked + cleared on pane unmount to avoid dispatching against
+        // an unregistered slot (which throws). PR #742 ReAgent P1.
+        const expiryId = setTimeout(() => {
+            pendingExpiryTimers.delete(expiryId);
             dispatchPane(opts.blockId, {
                 type: "PendingMessageExpired",
                 id: messageId,
             });
         }, PENDING_TIMEOUT_MS);
+        pendingExpiryTimers.add(expiryId);
 
         // Defer the scroll-to-bottom by one animation frame so the
         // pending row has a chance to mount before the scroll math runs.

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -37,6 +37,14 @@ import type { SignalPair } from "../state";
 import type { DocumentNode } from "../types";
 import type { LogFn } from "./useAgentControllerStatus";
 
+/**
+ * How long a pending message can sit unacknowledged before the reducer
+ * gives up and removes it. 30s covers normal backend turnaround
+ * (typically <2s on local sockets) with margin for transient hiccups.
+ * Issue #728 gap 2.
+ */
+const PENDING_TIMEOUT_MS = 30_000;
+
 export interface UseAgentCommandsOptions {
     blockId: string;
     block: Accessor<{ meta?: Record<string, any> } | undefined>;
@@ -238,6 +246,18 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             },
             "user",
         );
+
+        // Pending acceptance timeout (issue #728 gap 2). If the backend
+        // never echoes `agent-message-accepted` for this id within
+        // PENDING_TIMEOUT_MS, the reducer removes the ghost entry. Idempotent
+        // when the message lands first — the entry is already gone and
+        // PendingMessageExpired is a no-op.
+        setTimeout(() => {
+            dispatchPane(opts.blockId, {
+                type: "PendingMessageExpired",
+                id: messageId,
+            });
+        }, PENDING_TIMEOUT_MS);
 
         // Defer the scroll-to-bottom by one animation frame so the
         // pending row has a chance to mount before the scroll math runs.

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -35,6 +35,7 @@ import { createSignal, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
+import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
 import { parseHistoryLines } from "../parseHistoryLines";
 
 import type { LogFn } from "../types";
@@ -109,6 +110,11 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
     // during a reconnect (where in-flight turns can briefly appear in
     // both the persisted ring buffer and the live stream).
     onMount(() => {
+        // Init lifecycle (issue #728 gap 1): dispatch InitStart before the
+        // fetch, InitReady on success, InitFailed on error. The reducer
+        // gates TurnStart on initPhase === "ready" so we don't accept
+        // sends while history is still loading.
+        dispatchPane(opts.blockId, { type: "InitStart" });
         (async () => {
             try {
                 const countResp = await RpcApi.BlockfileLineCountCommand(TabRpcClient, {
@@ -117,7 +123,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 }, { timeout: 5000 });
 
                 const total = countResp?.count ?? 0;
-                if (total === 0) return;
+                if (total === 0) {
+                    dispatchPane(opts.blockId, { type: "InitReady" });
+                    return;
+                }
 
                 const offset = Math.max(0, total - PAGE_SIZE);
                 const limit = total - offset;
@@ -144,9 +153,18 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 setHistoryTotal(available);
 
                 opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);
+                dispatchPane(opts.blockId, { type: "InitReady" });
             } catch (err: any) {
-                // Non-fatal — fresh session or backend not ready yet
-                opts.log("history", `could not load history: ${err?.message ?? String(err)}`, "warn");
+                // Non-fatal — fresh session or backend not ready yet.
+                // Surface the failure to the reducer so it can gate
+                // turn-start and the UI can render an error state, then
+                // flip to ready so the user can still send (best-effort).
+                const reason = err?.message ?? String(err);
+                opts.log("history", `could not load history: ${reason}`, "warn");
+                // Reducer fails open on `error` — TurnStart is only
+                // suppressed while `loading`. Surfacing the failure
+                // captures it for diagnostics without blocking sends.
+                dispatchPane(opts.blockId, { type: "InitFailed", reason });
             }
         })();
     });

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -161,9 +161,10 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 // flip to ready so the user can still send (best-effort).
                 const reason = err?.message ?? String(err);
                 opts.log("history", `could not load history: ${reason}`, "warn");
-                // Reducer fails open on `error` — TurnStart is only
-                // suppressed while `loading`. Surfacing the failure
-                // captures it for diagnostics without blocking sends.
+                // Surface the failure for diagnostics. The reducer's
+                // TurnStart guard treats `error` as fail-open (only
+                // `loading` blocks sends), so no follow-up InitReady
+                // is needed — the user can still send.
                 dispatchPane(opts.blockId, { type: "InitFailed", reason });
             }
         })();

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -16,6 +16,7 @@ import {
     StreamingState,
     TurnTokens,
 } from "./types";
+import type { InitPhase } from "@/app/store/agent-pane-state/types";
 
 /**
  * A signal pair: [getter, setter]
@@ -51,6 +52,12 @@ export interface AgentAtoms {
      * "accepted" signal. FIFO, matches the backend's `VecDeque` queue.
      */
     pendingMessagesAtom: SignalPair<PendingMessage[]>;
+    /**
+     * Init lifecycle — `loading` until the initial history fetch resolves
+     * (or fails). Drives a "Loading history…" hint and gates `TurnStart`.
+     * Issue #728 gap 1.
+     */
+    initPhaseAtom: SignalPair<InitPhase>;
 }
 
 /**
@@ -95,5 +102,6 @@ export function createAgentAtoms(agentId: string): AgentAtoms {
         turnActiveAtom: createSignal<boolean>(false),
         stoppingAtom: createSignal<boolean>(false),
         pendingMessagesAtom: createSignal<PendingMessage[]>([]),
+        initPhaseAtom: createSignal<InitPhase>("loading"),
     };
 }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -10,16 +10,27 @@
 import { getFileSubject, waveEventSubscribe } from "@/app/store/wps";
 import * as WOS from "@/app/store/wos";
 import { base64ToArray } from "@/util/util";
-import { createEffect, onCleanup, onMount, untrack } from "solid-js";
+import { createEffect, onCleanup, onMount } from "solid-js";
 import { createTranslator } from "./providers/translator-factory";
 import type { PendingMessage, SignalPair } from "./state";
 import { ClaudeCodeStreamParser } from "./stream-parser";
 import type { DocumentNode, SessionStats, StreamingState, TurnTokens, UserMessageNode } from "./types";
 import { recordTurn } from "@/store/token-usage";
-import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
+import {
+    dispatch as dispatchDoc,
+    getNodeIdSet,
+} from "@/app/store/agent-document-store";
 import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
 
 const OutputFileName = "output";
+
+/**
+ * Watchdog tick rate. Every 5s the hook dispatches a StreamWatchdogTick
+ * to the pane-state reducer; the reducer compares against
+ * `STUCK_THRESHOLD_MS` (45s) and emits a `stream-stuck` event when the
+ * subscribed stream has been silent that long. Issue #728 gap 3.
+ */
+const WATCHDOG_INTERVAL_MS = 5_000;
 
 interface UseAgentStreamOpts {
     blockId: string;
@@ -131,8 +142,6 @@ export function useAgentStream({
         nodeIdSet = new Set();
         pendingNew = [];
         pendingUpdates = [];
-
-        const [doc] = documentAtom;
 
         /**
          * Shared finalization for "the turn is over." Called by both the
@@ -265,12 +274,12 @@ export function useAgentStream({
             onCleanup(() => acceptedUnsub());
         }
 
-        // Seed the local in-batch dedup set from any history that was
-        // already loaded into the document before the hook mounted. The
-        // reducer owns authoritative dedup; this set just avoids enqueuing
-        // already-known nodes into pendingNew, saving a redundant flush.
-        nodeIdSet = new Set();
-        for (const n of untrack(() => doc())) nodeIdSet.add(n.id);
+        // Seed the in-batch dedup cache from the reducer-maintained
+        // index. Issue #728 gap 4 — replaces the per-mount scan of
+        // `doc()` that could miss in-flight events arriving between
+        // mount and scan. The reducer keeps `nodeIdSet` in lockstep
+        // with `nodes[]` so this read is always current.
+        nodeIdSet = new Set(getNodeIdSet(blockId));
 
         // Two reducers signaled in lockstep: pane-state owns the streaming
         // metadata (active flag), agent-document owns the session phase
@@ -278,6 +287,18 @@ export function useAgentStream({
         const subscribedAt = Date.now();
         dispatchPane(blockId, { type: "StreamSubscribe", at: subscribedAt });
         dispatchDoc(blockId, { type: "SessionStart", at: subscribedAt });
+
+        // Stuck-stream watchdog (issue #728 gap 3). The reducer evaluates
+        // each tick against `lastEventMs` and emits a `stream-stuck`
+        // event when the gap exceeds `STUCK_THRESHOLD_MS`. The interval
+        // cleans up via the same effect cleanup as the subscription.
+        const watchdogId = setInterval(() => {
+            dispatchPane(blockId, {
+                type: "StreamWatchdogTick",
+                nowMs: Date.now(),
+            });
+        }, WATCHDOG_INTERVAL_MS);
+        onCleanup(() => clearInterval(watchdogId));
 
         const fileSubject = getFileSubject(blockId, OutputFileName);
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.718",
+  "version": "0.33.719",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.719",
+  "version": "0.33.720",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_07.md
+++ b/specs/SPEC_AGENT_PANE_STATE_MACHINE_2026_05_07.md
@@ -1,0 +1,321 @@
+# Spec: Agent Pane State Machine Refinement
+
+**Date:** 2026-05-07  
+**Status:** Draft  
+**Area:** `frontend/app/store/`, `frontend/app/view/agent/`
+
+---
+
+## Background
+
+The agent pane is already reducer-based — two pure slices handle all state mutations:
+
+- **`agent-document/`** — message list (nodes, sessionPhase, history)
+- **`agent-pane-state/`** — lifecycle (streaming, turn, tokens, stopping, pending)
+
+Each slice follows the `update(state, command) → {state, events}` contract: no I/O, immutable updates, typed audit events. This foundation is sound and should be preserved.
+
+However, several gaps were found during analysis:
+
+1. **Pending message durability** — `pending[]` is in-memory; pane unmount loses all queued entries.
+2. **No acceptance timeout** — a pending entry can linger indefinitely if the backend never emits `agent-message-accepted`.
+3. **Init phase not covered** — `InitState`/`InitQuestion` types exist in `types.ts` but neither reducer handles the init lifecycle.
+4. **Stuck-stream recovery** — the only guard is a 1500 ms stop fallback timer; there is no watchdog for streams that stay active with no events for an extended period.
+5. **`nodeIdSet` rebuilt on remount** — the dedup index is reconstructed from `nodes[]` on each mount; in-flight duplicates can slip through the gap.
+6. **`DocumentState` lives outside reducers** — `collapsedNodes`, `pinnedNodes`, `filter`, and `scrollPosition` are managed via separate local signals; they are invisible to the audit trail and cannot be restored after navigation.
+7. **Grace window hardcoded** — `TRUNCATE_GRACE_MS = 5000` is a compile-time constant with no way to extend it under load.
+
+---
+
+## Goals
+
+1. **Close the init-phase gap** — model the init lifecycle as explicit reducer commands so the pane can render correctly from first paint.
+2. **Bound pending messages** — add an acceptance timeout with a `PendingMessageExpired` command so stale entries are evicted.
+3. **Add a stuck-stream watchdog** — `StreamWatchdogTick` command that transitions a stuck active stream to an error state.
+4. **Persist DocumentState in the reducer** — migrate `collapsedNodes`, `pinnedNodes`, `filter`, `scrollPosition` into `agent-document` so they participate in the audit trail and survive navigation.
+5. **Expose `nodeIdSet` from the reducer** — store the dedup index in `AgentDocumentState` so remounts skip the rebuild scan.
+6. **Make grace window injectable** — accept `nowMs` already; extend to accept `gracePeriodMs` for tests and future tunability.
+
+---
+
+## Current Architecture (What Works — Keep It)
+
+### Two-slice reducer contract
+
+```
+update(state, command) → { state: S, events: E[] }
+```
+
+- Pure functions: no side effects, no I/O, no async.
+- Immutable updates via lazy clone (only clone when a field actually changes).
+- Typed discriminated unions for `Command` and `Event`.
+- Time injected as `nowMs?: number` for deterministic tests.
+
+**Do not break this contract.** All additions below extend it, not replace it.
+
+### Stream subscription and dispatch loop
+
+`useAgentStream.ts` owns the imperative I/O:
+
+```
+subscribe → RAF batch → dispatch to both reducers → emit side-effect events
+```
+
+RAF batching coalesces high-frequency stream events before triggering reactive re-renders. Keep this; it is the primary performance guard.
+
+### Stop fallback timer
+
+After `RequestStop`, a 1500 ms `setTimeout` calls `finalizeTurn(null)` if the stream is still active. This guards against a `session_end` that never arrives.
+
+### Pending → accepted visual transition
+
+`agent-message-accepted` WPS event → `PendingMessageAccepted` + `TurnStart` + append `UserMessageNode`. The amber→blue color shift relies on `pending[]` containing the matching entry. This flow is correct; the gap is the missing timeout.
+
+---
+
+## Proposed Additions
+
+### 1. Init phase commands (`agent-pane-state`)
+
+Add to `AgentPaneCommand`:
+
+```ts
+| { type: "InitStart" }                             // pane mounted, loading history
+| { type: "InitReady" }                             // history loaded, ready for input
+| { type: "InitFailed"; reason: string }            // init error (session not found, etc.)
+```
+
+Add to `AgentPaneState`:
+
+```ts
+initPhase: "loading" | "ready" | "error";
+initError?: string;
+```
+
+Initial value: `initPhase: "loading"`.
+
+Reducer behavior:
+- `InitStart` → reset `initPhase` to `"loading"`, clear `initError`.
+- `InitReady` → set `initPhase: "ready"`.
+- `InitFailed` → set `initPhase: "error"`, set `initError`.
+- Guard: `TurnStart` is suppressed when `initPhase !== "ready"` (same guard as streaming check).
+
+### 2. Pending message acceptance timeout (`agent-pane-state`)
+
+Add to `AgentPaneCommand`:
+
+```ts
+| { type: "PendingMessageExpired"; localId: string }
+```
+
+Add to `AgentPaneEvent`:
+
+```ts
+| { type: "pending-message-expired"; localId: string; queuedAt: number; ageMs: number }
+```
+
+Reducer behavior for `PendingMessageExpired`:
+- Find entry in `pending[]` by `localId`; if not found, emit nothing (idempotent).
+- Remove entry; emit `pending-message-expired` event.
+
+**Caller responsibility** (`useAgentCommands.ts`):
+- On `PendingMessageQueued`, schedule a `setTimeout(PENDING_TIMEOUT_MS)` that dispatches `PendingMessageExpired(localId)` if the entry is still in `state.pending`.
+- `PENDING_TIMEOUT_MS = 30_000` (30 s; configurable via `AgentRuntimeConfig`).
+
+### 3. Stuck-stream watchdog (`agent-pane-state`)
+
+Add to `AgentPaneCommand`:
+
+```ts
+| { type: "StreamWatchdogTick"; nowMs: number }
+```
+
+Add to `AgentPaneState`:
+
+```ts
+lastEventMs: number | null;   // updated on every stream event dispatch
+streamStuckMs: number | null; // ms since last event; set by watchdog
+```
+
+Add to `AgentPaneEvent`:
+
+```ts
+| { type: "stream-stuck"; idleSinceMs: number; thresholdMs: number }
+```
+
+Reducer behavior for `StreamWatchdogTick`:
+- If `!state.streaming.active` or `lastEventMs == null`, no-op.
+- Compute `idleMs = nowMs - lastEventMs`.
+- If `idleMs >= STUCK_THRESHOLD_MS` (default 45 000 ms), set `streamStuckMs = idleMs`, emit `stream-stuck` event.
+
+**Caller responsibility** (`useAgentStream.ts`):
+- On `StreamSubscribe`, start a `setInterval(WATCHDOG_INTERVAL_MS = 5_000)` that dispatches `StreamWatchdogTick(Date.now())`.
+- On `StreamUnsubscribe`, clear the interval.
+- React to `stream-stuck` event: log a warning, optionally surface an error node.
+
+Every stream event dispatch should also dispatch a lightweight `StreamEventReceived` (or extend existing commands) to update `lastEventMs`. The simplest approach: add `lastEventMs` update as a side effect in the existing `update()` calls that handle stream events (TurnStart, ToolStart, TokensIn, etc.) by adding it to the returned state unconditionally.
+
+### 4. Persist DocumentState in reducer (`agent-document`)
+
+Move the following from local signals into `AgentDocumentState`:
+
+```ts
+collapsedNodes: Set<string>;   // node IDs that are collapsed
+pinnedNodes: Set<string>;      // node IDs that are pinned
+filter: string;                // active search/filter string
+scrollPosition: number;        // px from top, snapshotted on blur
+```
+
+Add to `AgentDocumentCommand`:
+
+```ts
+| { type: "NodeToggleCollapsed"; nodeId: string }
+| { type: "NodeTogglePinned"; nodeId: string }
+| { type: "FilterChanged"; filter: string }
+| { type: "ScrollPositionSaved"; position: number }
+```
+
+No events needed for these (they are purely view state; no audit value).
+
+Reducer behavior: straightforward toggling / assignment; lazy clone.
+
+**Why this matters:** Navigating away and back to the agent pane currently resets all collapsed/pinned state. With this in the reducer, the store persists across pane mount/unmount (the store is owned by the parent, not the view).
+
+### 5. Expose `nodeIdSet` from `AgentDocumentState`
+
+Currently `useAgentStream.ts` rebuilds a local `nodeIdSet` on each remount by scanning `nodes[]`. If a duplicate arrives in the gap before the set is populated, it is inserted twice.
+
+Add to `AgentDocumentState`:
+
+```ts
+nodeIdSet: Set<string>;   // maintained by reducer; always in sync with nodes[]
+```
+
+Reducer responsibility:
+- On every `StreamFlush` that adds a node: `nodeIdSet.add(nodeId)`.
+- On `UserClear`: `nodeIdSet = new Set()`.
+- On `SessionStart`/`HistoryLoaded`: populate from the incoming nodes.
+
+**Caller change:** Remove the local `nodeIdSet` rebuild in `useAgentStream.ts`; read `state.nodeIdSet` instead.
+
+### 6. Injectable grace period (`agent-document`)
+
+Current signature:
+
+```ts
+update(state, command, nowMs?: number)
+```
+
+Extended signature:
+
+```ts
+update(state, command, nowMs?: number, opts?: { truncateGraceMs?: number })
+```
+
+`shouldSuppressTruncate` reads `opts?.truncateGraceMs ?? TRUNCATE_GRACE_MS`.
+
+Callers in tests can pass `{ truncateGraceMs: 0 }` to disable suppression. The production caller passes nothing (defaults to 5000 ms). If future load testing shows 5 s is too short, the value can be passed in from `AgentRuntimeConfig` without a code change.
+
+---
+
+## Command / Event Type Additions Summary
+
+### `agent-pane-state/types.ts`
+
+**State additions:**
+```ts
+initPhase: "loading" | "ready" | "error";
+initError?: string;
+lastEventMs: number | null;
+streamStuckMs: number | null;
+```
+
+**New commands:**
+```ts
+| { type: "InitStart" }
+| { type: "InitReady" }
+| { type: "InitFailed"; reason: string }
+| { type: "PendingMessageExpired"; localId: string }
+| { type: "StreamWatchdogTick"; nowMs: number }
+```
+
+**New events:**
+```ts
+| { type: "pending-message-expired"; localId: string; queuedAt: number; ageMs: number }
+| { type: "stream-stuck"; idleSinceMs: number; thresholdMs: number }
+```
+
+### `agent-document/types.ts`
+
+**State additions:**
+```ts
+nodeIdSet: Set<string>;
+collapsedNodes: Set<string>;
+pinnedNodes: Set<string>;
+filter: string;
+scrollPosition: number;
+```
+
+**New commands:**
+```ts
+| { type: "NodeToggleCollapsed"; nodeId: string }
+| { type: "NodeTogglePinned"; nodeId: string }
+| { type: "FilterChanged"; filter: string }
+| { type: "ScrollPositionSaved"; position: number }
+```
+
+**Signature change:**
+```ts
+update(state, command, nowMs?: number, opts?: { truncateGraceMs?: number })
+```
+
+---
+
+## Non-Goals
+
+- **Sorting / filtering the document list** — `FilterChanged` stores the string; actual filtering is a `createMemo` in the view, not a reducer concern.
+- **Undo / redo** — not requested; no command history stack.
+- **Cross-pane state sharing** — each pane owns its own store instance; sharing is out of scope.
+- **Persistence to disk** — pending queue and document state live in memory. Disk persistence would require a separate serialization layer; defer.
+- **Changing the RAF batching strategy** — the current approach works; leave it alone.
+
+---
+
+## Implementation Order
+
+1. **Add `nodeIdSet` to `AgentDocumentState`** — pure reducer change, no caller changes needed except removing the local rebuild in `useAgentStream.ts`. Lowest risk.
+
+2. **Injectable grace period** — one-line signature change + update `shouldSuppressTruncate`. Update existing tests.
+
+3. **Init phase commands** — add `initPhase` to state, add three commands, add guard in `TurnStart`. Wire `InitStart`/`InitReady`/`InitFailed` dispatch in `useAgentStream.ts` around history load.
+
+4. **Pending message timeout** — add `PendingMessageExpired` command + event. Wire `setTimeout` in `useAgentCommands.ts` on `PendingMessageQueued`.
+
+5. **DocumentState migration** — add four commands, migrate callers from local signals. Most impactful for UX (collapse/pin persistence); medium risk.
+
+6. **Stuck-stream watchdog** — add `StreamWatchdogTick`, `lastEventMs`, watchdog interval in `useAgentStream.ts`. Add `lastEventMs` update to all stream-event commands.
+
+---
+
+## Testing Guidance
+
+All reducer additions are pure functions and should have unit tests:
+
+```ts
+// agent-pane-state reducer
+it("suppresses TurnStart when initPhase is loading")
+it("PendingMessageExpired removes entry and emits event")
+it("PendingMessageExpired is a no-op when localId not found")
+it("StreamWatchdogTick emits stream-stuck when idle >= threshold")
+it("StreamWatchdogTick is a no-op when stream not active")
+
+// agent-document reducer
+it("StreamFlush updates nodeIdSet")
+it("UserClear resets nodeIdSet")
+it("NodeToggleCollapsed toggles membership in collapsedNodes")
+it("StreamTruncate respects injected gracePeriodMs")
+```
+
+Integration tests (`app.e2e.test.ts`) should cover:
+- Send message → pending entry appears → accepted → disappears within 30 s
+- Stop agent → finalizeTurn fires within 1500 ms fallback


### PR DESCRIPTION
Closes 5 of the 6 gaps from #728. Pure additive changes — no redesign of the existing two-slice reducer architecture.

## Summary

| Gap | What | Files |
|-----|------|-------|
| 1 | Init phase — `InitStart`/`InitReady`/`InitFailed` gate `TurnStart` while history loads | `agent-pane-state/*`, `useHistoryPagination.ts`, `state.ts`, `agent-view.tsx` |
| 2 | Pending message expiry — 30 s timeout removes ghost rows | `agent-pane-state/*`, `useAgentCommands.ts` |
| 3 | Stuck-stream watchdog — 5 s tick emits `stream-stuck` after 45 s of silence | `agent-pane-state/*`, `useAgentStream.ts` |
| 4 | `nodeIdSet` in reducer — replaces per-mount scan in `useAgentStream` | `agent-document/*`, `agent-document-store.ts`, `useAgentStream.ts` |
| 6 | Injectable `truncateGraceMs` — reducer opts param | `agent-document/*`, `agent-document-store.ts` |
| 5 | **Deferred** — DocumentState migration | follow-up (see below) |

## Why deferred gap 5

`collapsedNodes` / `pinnedNodes` / `filter` / `scrollPosition` migration into the reducer requires refactoring `AgentDocumentView.tsx` (537 LoC) plus restructuring `documentStateAtom` in `state.ts`. The per-blockId atoms already persist for the block lifetime via `createAgentAtoms`, so the visible \"reset on pane navigation\" symptom doesn't actually occur today. The audit-trail benefit alone doesn't justify the surface area in this PR — tracking as a follow-up issue.

## Architecture fit

Every change is additive within the existing pattern:
- New variants on the discriminated `Command`/`Event` union types
- New `case` arms in the `update(state, command, nowMs?, opts?)` switch
- New `AgentPaneProjections.initPhase?` setter — optional so non-agent panes keep working
- One new optional reducer param (`opts.truncateGraceMs`) — defaults preserve existing behavior

The reducers stay pure: `nowMs` is now the second arg in `agent-pane-state/reducer` too, used by `bumpEvent` for tool/token transitions and by `PendingMessageExpired` for `ageMs`. No `Date.now()` inside the reducer body.

## Invariant changes

- `TurnStart` now suppressed when `initPhase === \"loading\"` (fail-open on `error`)
- `bumpEvent` updates `lastEventMs` on `ToolStart`/`ToolEnd`/`TokensIn`/`TokensOut` so the watchdog clock resets during long reasoning runs that produce tools but no nodes
- `StreamUnsubscribe` clears `lastEventMs` to null

## Test plan

- [x] Reducer unit tests: 22 new (404 vs 382 on main, all passing)
- [x] Type check passes for all touched files
- [ ] Manual: open agent pane, verify no \"Loading…\" race when sending a message immediately after open
- [ ] Manual: kill `agentmux-srv` mid-conversation; verify pending row disappears within 30 s
- [ ] Manual: long reasoning run with no node output for >45 s — confirm `stream-stuck` audit event in console / dispatch records

🤖 Generated with [Claude Code](https://claude.com/claude-code)