### PR TITLE
build(linux): patched-libcef.so resolver for bundle:linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -2936,9 +2936,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -449,18 +449,21 @@ tasks:
         platforms: [linux]
         cmds:
             - |
-                CEF_DIR=$(find target -name "libcef.so" -path "*/cef-dll-sys*/out/*" -printf '%h' -quit 2>/dev/null)
-                if [ -z "$CEF_DIR" ]; then
-                  echo "❌ libcef.so not found in target/ — run build:host first"
-                  exit 1
-                fi
-                echo "Found runtime binaries in: $CEF_DIR"
+                # Resolve CEF runtime via shell helper. Three-tier order:
+                #   1. $AGENTMUX_CEF_RUNTIME_DIR (explicit override)
+                #   2. ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64 (default)
+                #   3. cef-dll-sys cargo cache (fallback — upstream, drag broken)
+                # See docs/specs/patched-libcef-bundling-2026-05-08.md.
+                CEF_DIR="$(bash scripts/resolve-cef-runtime.sh)"
+                echo "Using CEF runtime from: $CEF_DIR"
                 mkdir -p dist/cef/locales
                 cp -f "$CEF_DIR/libcef.so" dist/cef/
                 cp -f "$CEF_DIR/libEGL.so" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR/libGLESv2.so" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR/chrome-sandbox" dist/cef/ 2>/dev/null || true
+                cp -f "$CEF_DIR/chrome_crashpad_handler" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR/icudtl.dat" dist/cef/
+                cp -f "$CEF_DIR/snapshot_blob.bin" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
                 cp -f "$CEF_DIR"/*.pak dist/cef/
                 cp -f "$CEF_DIR/locales/en-US.pak" dist/cef/locales/ 2>/dev/null || true

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/cef-build/build-patched-libcef.md
+++ b/docs/cef-build/build-patched-libcef.md
@@ -1,0 +1,210 @@
+# Building the Patched libcef.so for AgentMux
+
+**Audience:** AgentMux maintainers building a Linux release binary that needs left-click window drag (and, eventually, transparency).
+**Time:** First build ~3-6 hours wall-clock on a 32-core box (CPU-bound chromium compile).
+**Disk:** ~99 GB chromium working tree + ~8 GB build output.
+**Output:** A `libcef.so` (~613 MB stripped) with two AgentMux-specific patches that aren't in upstream CEF or its prebuilt binary distribution.
+
+---
+
+## What this libcef contains that upstream's doesn't
+
+1. **`CefWindow::BeginWindowDrag()`** — appended to the `_cef_window_t` C struct, called via raw FFI by `agentmux-cef/src/ui_tasks.rs::StartWindowDragTask` to dispatch `xdg_toplevel.move` (Wayland) / `_NET_WM_MOVERESIZE` (X11) on the user's left-click drag of the title-bar area. Without this, AgentMux PR #663's drag IPC is a no-op.
+2. **Transparency broadening** — Chad Nelson's `SetBackgroundOpaque(false)` IPC support extended to views-hosted browsers. Foundation for future Wayland window transparency. Not yet user-visible.
+
+Both patches live in the AgentMux fork of CEF:
+- **Repo:** https://github.com/a5af/cef
+- **Branch:** `agentmux/7680-drag-rightclick-and-transparency`
+- **Base:** Chromium 146.0.7680.179
+- **HEAD:** `5ab41b6` at last build (2026-05-01)
+
+---
+
+## Prerequisites
+
+- Linux x86-64 host (Ubuntu 22.04+ tested).
+- ≥ 32 GB RAM. Build peak hits ~25 GB at `-j 12 -l 16`. Lower job counts work but slower.
+- ≥ 120 GB free disk.
+- `python3`, `git`, `clang`, GCC. The chromium `build/install-build-deps.sh` will list anything missing.
+- `systemd-run` available (default on systemd distros).
+
+---
+
+## Build steps
+
+### 1. Initial setup
+
+```bash
+mkdir -p ~/cef-build
+cd ~/cef-build
+
+# Get the chromium depot_tools
+git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+export PATH="$PWD/depot_tools:$PATH"
+
+# Get the CEF automate-git script
+mkdir -p chromium_git
+cd chromium_git
+wget https://bitbucket.org/chromiumembedded/cef/raw/master/tools/automate/automate-git.py
+
+# First sync (downloads chromium ~99 GB, takes hours)
+python3 automate-git.py \
+  --download-dir=$(pwd) \
+  --branch=7680 \
+  --no-distrib \
+  --no-build
+```
+
+### 2. Switch to the AgentMux fork
+
+```bash
+cd ~/cef-build/chromium_git/cef
+git remote add a5af https://github.com/a5af/cef.git
+git fetch a5af agentmux/7680-drag-rightclick-and-transparency
+git checkout a5af/agentmux/7680-drag-rightclick-and-transparency
+
+# Mirror to the chromium-side cef checkout
+rsync -a --delete --exclude=.git ~/cef-build/chromium_git/cef/ ~/cef-build/chromium_git/chromium/src/cef/
+```
+
+### 3. Apply CEF patches to chromium
+
+```bash
+cd ~/cef-build/chromium_git/chromium/src
+# Reset to clean state — patcher is NOT idempotent; double-apply produces .rej files
+git reset --hard HEAD
+find . -name '*.rej' -delete
+# Now apply
+python3 cef/tools/patcher.py --root-dir=cef
+```
+
+If you see "class member cannot be redeclared" compile errors later, the patcher likely double-applied — repeat the reset and re-run.
+
+### 4. Configure the build
+
+```bash
+cd ~/cef-build/chromium_git/chromium/src
+gn gen out/Release_GN_x64 --args='
+  is_debug=false
+  symbol_level=1
+  is_component_build=false
+  proprietary_codecs=true
+  ffmpeg_branding="Chrome"
+  use_sysroot=false
+  enable_nacl=false
+  cc_wrapper="ccache"
+'
+```
+
+### 5. Build (use the OOM-resistant wrapper)
+
+The default `ninja -j$(nproc)` peak-allocates 40+ GiB → OOM-kills the terminal cgroup → can cascade into a system reboot. Use `-j 12 -l 16` AND launch under `systemd-run --user --scope` to isolate the build from your shell:
+
+```bash
+# First, set up the wrapper script (one-time)
+cat > ~/cef-build/ninja-with-retry.sh <<'EOF'
+#!/bin/bash
+set -uo pipefail
+cd ~/cef-build/chromium_git/chromium/src
+for attempt in 1 2 3; do
+    if ninja -j 12 -l 16 -C out/Release_GN_x64 cef; then
+        echo "==================== NINJA SUCCESS on attempt $attempt at $(date) ===================="
+        exit 0
+    fi
+    echo "==================== NINJA FAILED attempt $attempt — retrying in 60s ===================="
+    sleep 60
+done
+exit 1
+EOF
+chmod +x ~/cef-build/ninja-with-retry.sh
+
+# Build under an isolated cgroup
+systemd-run --user --scope --collect --unit=cef-build.scope \
+  ~/cef-build/ninja-with-retry.sh
+```
+
+Expect ~3-6 hours on first build with cold ccache. Subsequent rebuilds (modifying just the patches) are 5-30 minutes depending on what touched.
+
+### 6. Strip the output
+
+The default build produces a `libcef.so` ~1.3 GB with full debug info. Strip it for distribution:
+
+```bash
+cd ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64
+strip --strip-debug libcef.so   # → ~613 MB
+```
+
+(The AgentMux AppImage build script does this strip step automatically when assembling the package, but doing it once after the source build keeps the bundling step cheap.)
+
+### 7. Verify it boots
+
+```bash
+cd ~/cef-build/chromium_git/cef/tests
+out/Release_GN_x64/cefsimple --no-sandbox --url=https://example.com
+```
+
+A window with example.com proves the libcef is functional. (The `BeginWindowDrag` patch isn't exercised by cefsimple — verification of THAT happens via `task package:linux` + the AgentMux app.)
+
+---
+
+## Using the built libcef in AgentMux
+
+The AgentMux build pipeline finds your patched libcef automatically if it's in the standard location. Two options:
+
+### Option A: Default location
+
+If you built at `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/`, you're done — `task bundle:linux` and `task package:linux` will pick it up via the resolver in `scripts/resolve-cef-runtime.sh`.
+
+### Option B: Explicit override
+
+If your build is somewhere else, set the env var:
+
+```bash
+export AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64
+task bundle:linux
+```
+
+The resolver prints which path it picked at the start of the bundle step:
+
+```
+Using CEF runtime from: /home/you/cef-build/chromium_git/chromium/src/out/Release_GN_x64
+```
+
+If you see a `WARNING: libcef.so at ... is 1272 MB (>1 GB) — likely unpatched upstream debug build`, the resolver fell through to the cef-dll-sys cargo cache because no patched build was found at either of the higher-priority locations. The bundle will still produce a runnable AgentMux, but left-click window drag will silently no-op (the runtime ABI guard logs a warning).
+
+---
+
+## Re-building after patch changes
+
+You don't need to re-run `patcher.py` if you're modifying within the already-patched tree. Just edit, mirror, ninja:
+
+```bash
+# Edit in the cef checkout (where you actually develop)
+cd ~/cef-build/chromium_git/cef
+# ... edit ...
+
+# Mirror to the chromium-side
+rsync -a --delete --exclude=.git ~/cef-build/chromium_git/cef/ ~/cef-build/chromium_git/chromium/src/cef/
+
+# Re-build (incremental; usually 5-30 min)
+systemd-run --user --scope --collect --unit=cef-build.scope \
+  ~/cef-build/ninja-with-retry.sh
+
+# Re-strip
+strip --strip-debug ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so
+```
+
+---
+
+## Known gotchas
+
+- **`automate-git.py --fast-update` does not always trigger `gclient sync`** if the top-level checkout already matches. Run `gclient sync --nohooks --with_branch_heads` directly to force.
+- **Don't pass `--reset --delete_unversioned_trees`** to `gclient sync` — it reverts all 114 applied CEF patches.
+- **`tools/patcher.py` is NOT idempotent.** Always precede with `git reset --hard HEAD && find . -name '*.rej' -delete`.
+- **`.gclient` has `'managed': False`** — gclient is lazy. Dirs in broken half-clone state get silently skipped. Symptom: a missing dep at compile time. Fix: `rm -rf` the broken dep dir and re-sync.
+
+---
+
+## Future: upstreaming `BeginWindowDrag`
+
+The whole `~/cef-build/...` machinery exists to host one (eventually two) patches not in upstream CEF. The long-term cure is to upstream `BeginWindowDrag` to chromiumembedded/cef and bump cef-dll-sys past it; then this whole document becomes obsolete. There's no open upstream PR yet — tracked separately.

--- a/docs/specs/patched-libcef-bundling-2026-05-08.md
+++ b/docs/specs/patched-libcef-bundling-2026-05-08.md
@@ -88,37 +88,42 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-candidates=()
-if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
-    candidates+=("$AGENTMUX_CEF_RUNTIME_DIR")
-fi
-candidates+=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
-# cef-dll-sys cache — find first match (debug or release).
-while IFS= read -r d; do
-    candidates+=("$d")
-done < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
-
-for dir in "${candidates[@]}"; do
-    if [ -f "$dir/libcef.so" ] && [ -f "$dir/icudtl.dat" ]; then
-        # Sanity: warn if libcef.so is suspiciously large (>1GB suggests
-        # unstripped upstream debug build, almost certainly unpatched).
-        size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so")
-        size_mb=$((size_bytes / 1024 / 1024))
-        if [ "$size_bytes" -gt 1073741824 ]; then
-            echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — this is likely the unpatched upstream debug build." >&2
-            echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
-            echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then set" >&2
-            echo "         AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64 to override." >&2
-            # Don't exit — let the caller decide. (CI can re-check by passing --strict.)
-        fi
-        echo "$dir"
-        exit 0
+# Validate: print path + exit 0 if libcef.so + icudtl.dat are present;
+# also warn on suspiciously large libcef (likely unpatched upstream debug).
+validate_dir() {
+    local dir="$1"
+    [ -f "$dir/libcef.so" ] && [ -f "$dir/icudtl.dat" ] || return 1
+    local size_bytes
+    size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
+    local size_mb=$((size_bytes / 1024 / 1024))
+    if [ "$size_bytes" -gt 1073741824 ]; then
+        echo "WARNING: libcef.so at $dir is ${size_mb} MB — likely unpatched upstream debug build." >&2
+        # ... + drag-broken-warning + build doc + env var hint ...
     fi
+    echo "$dir"
+    return 0
+}
+
+# 1. Explicit override — STRICT (see D1). Set-but-invalid env var is a hard
+#    error, not a silent fallthrough, because in CI / release packaging the
+#    env var is the only way to inject the patched libcef and a typo would
+#    silently regress to upstream.
+if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
+    if validate_dir "$AGENTMUX_CEF_RUNTIME_DIR"; then exit 0; fi
+    echo "ERROR: AGENTMUX_CEF_RUNTIME_DIR=$AGENTMUX_CEF_RUNTIME_DIR is set but invalid." >&2
+    exit 1
+fi
+
+# 2 + 3. Auto-detect. Default path first; cef-dll-sys cache as floor.
+candidates=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
+while IFS= read -r d; do candidates+=("$d"); done \
+    < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
+for dir in "${candidates[@]}"; do
+    if validate_dir "$dir"; then exit 0; fi
 done
 
-echo "ERROR: could not find libcef.so in any of these locations:" >&2
+echo "ERROR: could not find libcef.so + icudtl.dat in any of these locations:" >&2
 for c in "${candidates[@]}"; do echo "  - $c" >&2; done
-echo "Build the patched libcef (docs/cef-build/build-patched-libcef.md) or run \`cargo build\` to populate cef-dll-sys cache." >&2
 exit 1
 ```
 

--- a/docs/specs/patched-libcef-bundling-2026-05-08.md
+++ b/docs/specs/patched-libcef-bundling-2026-05-08.md
@@ -168,9 +168,11 @@ For non-maintainers contributing without local libcef builds, the resolver's fal
 
 ## Design decisions
 
-### D1. Three-tier resolution order, env var first
+### D1. Three-tier resolution order, env var first, env var is STRICT
 
-Env var wins so a maintainer with multiple cef builds can switch between them without moving directories. Default path (`~/cef-build/...`) wins when env var is unset because that's the canonical layout the build doc produces. cef-dll-sys cache is the floor — anyone who runs `cargo build` gets *something* that boots, even if drag is broken.
+Env var wins so a maintainer with multiple cef builds can switch between them without moving directories. **A set-but-invalid env var is a hard error, not a soft signal.** The original draft of this spec treated `AGENTMUX_CEF_RUNTIME_DIR=/typo/path` as falling through to the next candidate — that was wrong: in CI / release packaging the env var is the only signal that the patched libcef should be used, and a silent fallback would produce a successful but drag-broken bundle. Codex P2 on PR #743 caught the regression risk; the implementation now exits 1 on a set-but-unusable env var.
+
+Default path (`~/cef-build/...`) wins when env var is unset because that's the canonical layout the build doc produces. cef-dll-sys cache is the floor — anyone who runs `cargo build` gets *something* that boots, even if drag is broken.
 
 ### D2. Warn, don't fail, on size heuristic
 
@@ -222,7 +224,7 @@ Today the patched libcef has no version of its own — it's whatever `5ab41b6` o
 
 ## Test plan
 
-- [ ] `bash scripts/resolve-cef-runtime.sh` with `AGENTMUX_CEF_RUNTIME_DIR=/tmp/no-such-dir` falls through to next candidate (silently — env var pointing at a nonexistent dir is a soft signal, treat as unset).
+- [ ] `bash scripts/resolve-cef-runtime.sh` with `AGENTMUX_CEF_RUNTIME_DIR=/tmp/no-such-dir` exits 1 with a clear error pointing at the typo. **Does not silently fall through** — Codex P2 on #743 (a set-but-invalid env var would otherwise produce a drag-broken bundle in CI).
 - [ ] With env var set to a valid patched build dir, resolver prints that path and exits 0.
 - [ ] Without env var, resolver finds `~/cef-build/.../Release_GN_x64` and prints it.
 - [ ] After `cargo clean -p agentmux-cef && cargo build --release -p agentmux-cef && task bundle`, dist/cef/libcef.so is the patched 613 MB version, not cef-dll-sys's 1.3 GB upstream.

--- a/docs/specs/patched-libcef-bundling-2026-05-08.md
+++ b/docs/specs/patched-libcef-bundling-2026-05-08.md
@@ -1,0 +1,258 @@
+# Patched libcef.so Bundling for Linux
+
+**Date:** 2026-05-08
+**Status:** Spec / Proposal
+**Repo state:** main @ `d7dc58c1`, AgentMux v0.33.703
+**Author:** AgentC
+
+---
+
+## Problem
+
+AgentMux's Linux build needs **two patches to `libcef.so`** that are not in upstream CEF:
+
+1. **`CefWindow::BeginWindowDrag()`** — added by [a5af/cef PR #1](https://github.com/a5af/cef/pull/1) (merged into the `agentmux/7680-drag-rightclick-and-transparency` branch). Needed by AgentMux PR #663 for left-click window drag on Linux/Wayland (`agentmux-cef/src/ui_tasks.rs::StartWindowDragTask` calls `cef::sys::_cef_window_t::begin_window_drag` via raw FFI; the slot doesn't exist in the upstream `_cef_window_t` struct).
+2. **Transparency broadening** for views-hosted browsers (cherry-pick of Chad Nelson's `SetBackgroundOpaque(false)` change) — needed for the eventual transparency feature.
+
+The patches live in a built `libcef.so` at `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so` (642 MB stripped, head `5ab41b6` on the `agentmux/7680-...` branch — see `~/.claude/projects/-home-snowbark/memory/cef_build_in_progress.md`).
+
+**The pain:** `task bundle:linux` and `scripts/build-appimage-linux.sh` both source `libcef.so` from cef-dll-sys's cargo cache (`target/debug/build/cef-dll-sys-*/out/cef_linux_x86_64/`), which is the **upstream unpatched** prebuilt downloaded by cef-dll-sys's build script. Every clean build silently regresses to upstream libcef, breaking left-click drag (and, in the future, transparency).
+
+Workaround today: manually overlay the patched libcef + matching V8 paks after every `task bundle` run. Easy to forget, time-consuming, and the only diagnostic when forgotten is "left-click drag silently does nothing" (the runtime ABI guard logs a warning but the user-visible failure mode looks like an unrelated bug).
+
+**Until the BeginWindowDrag patch is upstreamed to chromiumembedded/cef and cef-dll-sys is bumped past it**, we need a sticky way to inject our patched runtime into the build pipeline.
+
+---
+
+## TL;DR
+
+- Add a `CEF_RUNTIME_DIR` resolver to `bundle:linux` and `scripts/build-appimage-linux.sh` with three sources, in priority order:
+  1. `$AGENTMUX_CEF_RUNTIME_DIR` env var (explicit override).
+  2. `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/` (the cef-build standard layout for anyone following `docs/cef-build/...`).
+  3. The cef-dll-sys cargo cache (`target/.../cef_linux_x86_64/`) — current behavior.
+- Add a sanity-check at copy time: warn (and exit non-zero in CI mode) if the chosen `libcef.so` is the unpatched upstream — detected by the same `_cef_window_t.size` field the runtime ABI guard reads, or by a simpler heuristic (file size: patched is ~613 MB stripped, unpatched debug is ~1.3 GB).
+- Factor the resolver into one shell helper (`scripts/resolve-cef-runtime.sh`) so the Taskfile bundle command and the AppImage build script share one source of truth.
+- Document the build-from-source path for libcef in `docs/cef-build/build-patched-libcef.md` (existing build notes from `cef_build_in_progress.md` memory) and link from this spec.
+- Estimated change: 1 new ~50-line shell helper, 1 new docs page, ~10 line edits to `Taskfile.yml` (`bundle:linux`) and `scripts/build-appimage-linux.sh`. No Rust changes. No new versions to bump.
+
+---
+
+## Why a script-level resolver, not a cef-dll-sys vendor
+
+Three architectural alternatives were considered and rejected:
+
+### A. Vendor the patched libcef in-tree
+
+A `vendored/cef/linux-x64/libcef.so` (~600 MB) committed to the repo. Pros: dead-simple bundle path. Cons: 600 MB binary in git history, infeasible. Even with git-lfs, fetch cost on every clone is unacceptable. Rejected.
+
+### B. Patch cef-dll-sys's build.rs to swap in our libcef
+
+Override the cef-dll-sys build script to fetch our patched binary instead of upstream. Pros: single source of truth, all downstream consumers get the right libcef automatically. Cons: requires forking cef-dll-sys (or vendoring + patching), version-pinning becomes painful, every `cargo update` could blow it away (we already see this with the `_cef_window_t` size assert patch we maintain in cef-dll-sys's binding cache). Adds a third place to track. Rejected.
+
+### C. Custom cef-runtime crate
+
+A new crate that knows how to locate / download the patched libcef and is invoked from the build pipeline. Pros: clean abstraction. Cons: overkill for one binary file with one platform; adds a Rust crate, a build dependency, and a new versioning surface. Rejected.
+
+### D. (Chosen) Shell resolver invoked from Taskfile + AppImage build script
+
+The bundle path is already shell-driven (`bundle:linux` is a Taskfile shell command, `build-appimage-linux.sh` is a shell script). Adding a `resolve-cef-runtime.sh` that prints a path to stdout is the smallest possible change. The resolver knows three locations, prefers the patched ones, falls back gracefully. Easy to read, easy to override per developer. **No new dependencies.**
+
+---
+
+## Design
+
+### `scripts/resolve-cef-runtime.sh` (new)
+
+```bash
+#!/usr/bin/env bash
+# Print the absolute path of the directory containing libcef.so + paks
+# that the bundle / AppImage build should use. Resolution order:
+#
+#   1. $AGENTMUX_CEF_RUNTIME_DIR — explicit override
+#   2. $HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64
+#      (the standard cef-build layout; documented in
+#       docs/cef-build/build-patched-libcef.md)
+#   3. The cef-dll-sys cargo cache — first match of
+#      target/{debug,release}/build/cef-dll-sys-*/out/cef_linux_x86_64
+#
+# After resolution: if the libcef.so at the chosen path lacks the
+# AgentMux patches (heuristic: file size ≥ 1 GB suggests an unpatched
+# upstream debug build, AND cef::sys::_cef_window_t was bumped 888 → 896
+# in our cef-dll-sys binding patch — the runtime ABI guard will catch
+# the mismatch but the build path can warn earlier).
+#
+# Exit 0 with the resolved dir on stdout. Exit 1 with a clear error if
+# nothing matches.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+candidates=()
+if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
+    candidates+=("$AGENTMUX_CEF_RUNTIME_DIR")
+fi
+candidates+=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
+# cef-dll-sys cache — find first match (debug or release).
+while IFS= read -r d; do
+    candidates+=("$d")
+done < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
+
+for dir in "${candidates[@]}"; do
+    if [ -f "$dir/libcef.so" ] && [ -f "$dir/icudtl.dat" ]; then
+        # Sanity: warn if libcef.so is suspiciously large (>1GB suggests
+        # unstripped upstream debug build, almost certainly unpatched).
+        size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so")
+        size_mb=$((size_bytes / 1024 / 1024))
+        if [ "$size_bytes" -gt 1073741824 ]; then
+            echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — this is likely the unpatched upstream debug build." >&2
+            echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
+            echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then set" >&2
+            echo "         AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64 to override." >&2
+            # Don't exit — let the caller decide. (CI can re-check by passing --strict.)
+        fi
+        echo "$dir"
+        exit 0
+    fi
+done
+
+echo "ERROR: could not find libcef.so in any of these locations:" >&2
+for c in "${candidates[@]}"; do echo "  - $c" >&2; done
+echo "Build the patched libcef (docs/cef-build/build-patched-libcef.md) or run \`cargo build\` to populate cef-dll-sys cache." >&2
+exit 1
+```
+
+### `Taskfile.yml::bundle:linux` (edit)
+
+```yaml
+bundle:linux:
+    internal: true
+    platforms: [linux]
+    cmds:
+        - |
+            CEF_DIR="$(bash scripts/resolve-cef-runtime.sh)"
+            echo "Using CEF runtime from: $CEF_DIR"
+            mkdir -p dist/cef/locales
+            cp -f "$CEF_DIR/libcef.so" dist/cef/
+            cp -f "$CEF_DIR/libEGL.so" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR/libGLESv2.so" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR/chrome-sandbox" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR/chrome_crashpad_handler" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR/icudtl.dat" dist/cef/
+            cp -f "$CEF_DIR/snapshot_blob.bin" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR/v8_context_snapshot.bin" dist/cef/ 2>/dev/null || true
+            cp -f "$CEF_DIR"/*.pak dist/cef/
+            cp -f "$CEF_DIR/locales/en-US.pak" dist/cef/locales/ 2>/dev/null || true
+            echo "✓ Bundled runtime for Linux"
+```
+
+Replaces the inline `find target -name "libcef.so" ...` lookup. The shell helper keeps the resolution logic in one place.
+
+### `scripts/build-appimage-linux.sh` (edit)
+
+The AppImage script doesn't currently re-pull from cef-dll-sys — it copies from `dist/cef/` after `task bundle` already ran. So the AppImage path is fine as long as `bundle:linux` is fixed. **Verify post-fix** by running `task package:linux` clean and inspecting the AppImage's `usr/bin/libcef.so` size.
+
+### `docs/cef-build/build-patched-libcef.md` (new)
+
+Build instructions consolidating the existing notes from the `cef_build_in_progress.md` memory:
+
+- Clone `agentmux/cef` (the AgentMux fork) at the `agentmux/7680-drag-rightclick-and-transparency` branch.
+- Configure with `gn gen out/Release_GN_x64 --args='is_debug=false symbol_level=1 ...'` (full args from the build memory).
+- `autoninja -C out/Release_GN_x64 cef -j 12 -l 16` (with the `-j 12 -l 16` discipline that avoided OOM-cascade reboots — see memory).
+- Set `AGENTMUX_CEF_RUNTIME_DIR=$(pwd)/out/Release_GN_x64` for downstream Taskfile commands, or move the directory to `~/cef-build/.../Release_GN_x64` to use the auto-detect path.
+- Note: this is a multi-hour build; expect ~600 MB output; intended for AgentMux maintainers, not every contributor.
+
+For non-maintainers contributing without local libcef builds, the resolver's fallback to cef-dll-sys cache means they get a usable (if drag-broken) build. The README will note this trade-off.
+
+---
+
+## Design decisions
+
+### D1. Three-tier resolution order, env var first
+
+Env var wins so a maintainer with multiple cef builds can switch between them without moving directories. Default path (`~/cef-build/...`) wins when env var is unset because that's the canonical layout the build doc produces. cef-dll-sys cache is the floor — anyone who runs `cargo build` gets *something* that boots, even if drag is broken.
+
+### D2. Warn, don't fail, on size heuristic
+
+The size check (`>1 GB → likely unpatched`) is a heuristic, not a contract. There exist legitimate scenarios where size doesn't predict patched-ness (a stripped upstream build would be small). Hard-failing on size would be wrong. Print to stderr, continue. CI can grep for the warning and fail there if desired (out of scope for this PR).
+
+### D3. No content fingerprint
+
+We considered `nm -D libcef.so | grep BeginWindowDrag` to verify the patch is actually in the binary. Two reasons against:
+
+1. The symbol is **not** exported as a dynamic symbol (it's an internal C++ method on `CefWindowImpl`, called via the `_cef_window_t` function-pointer slot). `nm -D` won't see it. Using `nm` (without `-D`) requires the binary not be stripped, which our patched build IS. So a name-based check doesn't work.
+2. The runtime ABI guard (`agentmux-cef/src/browser_pane/creation_views.rs`-style code, also in `ui_tasks.rs::StartWindowDragTask`) already catches the mismatch by reading `_cef_window_t.size` and comparing against `size_of::<_cef_window_t>()`. If the user runs an unpatched libcef, the runtime warns and silently no-ops the drag — same UX failure mode as today. Adding a build-time fingerprint adds maintenance for marginal value.
+
+The size heuristic is a soft signal; the runtime guard is the contract.
+
+### D4. Shell, not Rust
+
+A `cargo xtask` Rust binary could do the same job with stronger types and easier testing. Not chosen because:
+
+- The bundle pipeline is already shell. Adding a Rust step means a `cargo build --bin xtask` upstream of the bundle, which is slower and harder to invoke from `Taskfile.yml`.
+- The logic is ~30 useful lines of POSIX shell. Easier to read and modify than the equivalent Rust + clap + std::process plumbing.
+- No persistent state, no concurrency, no complex conditions.
+
+If the resolver grows non-trivially (e.g. checksum verification, automatic download from a build server), revisit.
+
+### D5. Out of scope: macOS / Windows
+
+The same problem theoretically exists on macOS once that build comes online (we'd need a patched `Chromium Embedded Framework.framework` for `BeginWindowDrag` there too). Windows uses the upstream libcef.dll today because the Windows pane path doesn't need `BeginWindowDrag`. **This spec is Linux-only.** macOS will need a parallel resolver when its build flow lands; the shell helper can grow a `case "$(uname)"` then.
+
+### D6. Versioning the patched libcef
+
+Today the patched libcef has no version of its own — it's whatever `5ab41b6` on `agentmux/7680-...` produced. If we bump cef-dll-sys to a new chromium release, we'd need to rebase our patches on the new base and rebuild libcef. The resolver doesn't help with that — it just locates whatever's there. **Long-term cure**: upstream `BeginWindowDrag` to chromiumembedded/cef so cef-dll-sys's prebuilt becomes sufficient. Track in a follow-up.
+
+---
+
+## Implementation plan
+
+1. Add `scripts/resolve-cef-runtime.sh` as specified above. `chmod +x`.
+2. Replace the inline `CEF_DIR=$(find target ...)` lookup in `Taskfile.yml::bundle:linux` with `CEF_DIR="$(bash scripts/resolve-cef-runtime.sh)"`.
+3. Smoke-test:
+   - `unset AGENTMUX_CEF_RUNTIME_DIR && task bundle` → resolver picks `~/cef-build/...` (patched), libcef.so in dist/cef is ~613 MB.
+   - `AGENTMUX_CEF_RUNTIME_DIR=/some/other/path task bundle` → resolver picks override.
+   - `mv ~/cef-build /tmp/hide && task bundle && mv /tmp/hide ~/cef-build` → resolver falls back to cef-dll-sys cache, prints "WARNING ... unpatched upstream" if size > 1 GB.
+4. `task package:linux` end-to-end: build AppImage, extract, verify `usr/bin/libcef.so` is the patched 613 MB version.
+5. Run agentmux from the AppImage; verify left-click drag works (the symptom that originally surfaced this issue).
+6. Commit `docs/cef-build/build-patched-libcef.md` consolidating the build memory.
+7. Bump patch version, open PR.
+
+---
+
+## Test plan
+
+- [ ] `bash scripts/resolve-cef-runtime.sh` with `AGENTMUX_CEF_RUNTIME_DIR=/tmp/no-such-dir` falls through to next candidate (silently — env var pointing at a nonexistent dir is a soft signal, treat as unset).
+- [ ] With env var set to a valid patched build dir, resolver prints that path and exits 0.
+- [ ] Without env var, resolver finds `~/cef-build/.../Release_GN_x64` and prints it.
+- [ ] After `cargo clean -p agentmux-cef && cargo build --release -p agentmux-cef && task bundle`, dist/cef/libcef.so is the patched 613 MB version, not cef-dll-sys's 1.3 GB upstream.
+- [ ] `task package:linux` builds an AppImage; extracted AppImage contains the patched libcef (size + size-of-libcef-content cross-check).
+- [ ] `task dev` no longer regresses the patched libcef on every restart (its bundle step uses the resolver too).
+- [ ] On a machine without the patched build, resolver prints a clear warning and falls back to cef-dll-sys cache; agentmux launches but left-click drag is broken (acceptable degraded mode for non-maintainer contributors).
+
+---
+
+## Risks / non-goals
+
+- **Risk: cef-dll-sys cargo cache invalidation.** If `cargo clean` wipes `target/`, the cef-dll-sys cache is gone too — but the resolver's first two candidates are independent of cargo, so the patched build is still found. Acceptable.
+- **Risk: developer with broken or stale `~/cef-build/...`.** Resolver picks it first if it exists. If the libcef.so there is a half-built or wrong-branch artifact, agentmux will crash or run with wrong behavior. Mitigation: the size warning catches the most common stale state (un-stripped debug build); content fingerprint is out of scope per D3.
+- **Non-goal: automated download of patched libcef** for non-maintainer contributors. They'll get the cef-dll-sys fallback (drag broken). Solving this requires a build server, hosting, signing — separate work.
+- **Non-goal: macOS / Windows resolver.** This PR is Linux-only.
+- **Non-goal: upstreaming `BeginWindowDrag`.** Real long-term cure but out of scope. Track separately.
+
+---
+
+## File-by-file change summary
+
+**New:**
+- `scripts/resolve-cef-runtime.sh` (~50 lines, executable).
+- `docs/cef-build/build-patched-libcef.md` (consolidate `cef_build_in_progress.md` memory; ~80 lines).
+
+**Edited:**
+- `Taskfile.yml` — `bundle:linux` task body, replace inline find with `bash scripts/resolve-cef-runtime.sh`.
+
+**Untouched:**
+- agentmux-cef Rust source (the runtime ABI guard already handles the mismatch case).
+- frontend / TS / SCSS.
+- macOS / Windows packaging.
+- `scripts/build-appimage-linux.sh` (uses `dist/cef/` post-bundle; correct as long as bundle is fixed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.718",
+  "version": "0.33.719",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.718",
+      "version": "0.33.719",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1023,7 +1023,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,7 +1039,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,7 +1055,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1074,7 +1071,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,7 +1087,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1108,7 +1103,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1125,7 +1119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,7 +1135,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1159,7 +1151,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1176,7 +1167,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1193,7 +1183,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1210,7 +1199,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,7 +1215,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1244,7 +1231,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1261,7 +1247,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,7 +1263,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1295,7 +1279,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,7 +1295,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1329,7 +1311,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1346,7 +1327,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1363,7 +1343,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1380,7 +1359,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1397,7 +1375,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,7 +1391,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1431,7 +1407,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1448,7 +1423,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1676,6 +1650,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1837,6 +1823,21 @@
         "langium": "^4.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1893,7 +1894,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1933,7 +1933,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1954,7 +1953,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1975,7 +1973,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1996,7 +1993,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2017,7 +2013,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,7 +2033,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2059,7 +2053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2080,7 +2073,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2101,7 +2093,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2122,7 +2113,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2143,7 +2133,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2164,7 +2153,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,7 +2173,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2265,7 +2252,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2279,7 +2265,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2293,7 +2278,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2307,7 +2291,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2321,7 +2304,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2335,7 +2317,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2349,7 +2330,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2363,7 +2343,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2377,7 +2356,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2391,7 +2369,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2405,7 +2382,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2419,7 +2395,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2433,7 +2408,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2447,7 +2421,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2461,7 +2434,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,7 +2447,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2489,7 +2460,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2503,7 +2473,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,7 +2486,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2531,7 +2499,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2545,7 +2512,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,7 +2525,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2573,7 +2538,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2587,7 +2551,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2601,7 +2564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3709,7 +3671,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4539,6 +4501,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4730,7 +4700,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5582,7 +5552,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5701,7 +5671,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6066,7 +6036,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6183,7 +6152,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6229,7 +6197,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6912,7 +6880,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7064,7 +7032,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7084,7 +7052,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7275,7 +7243,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7521,7 +7489,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7554,7 +7522,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7575,7 +7542,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7596,7 +7562,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7617,7 +7582,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7638,7 +7602,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7659,7 +7622,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7680,7 +7642,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7701,7 +7662,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7722,7 +7682,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7743,7 +7702,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7764,7 +7722,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7829,6 +7786,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9076,7 +9046,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9126,7 +9095,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9415,7 +9383,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9461,7 +9428,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9703,11 +9669,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10022,7 +10001,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10088,7 +10067,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10190,7 +10168,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10399,6 +10377,29 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11113,6 +11114,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11203,7 +11232,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11432,7 +11460,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11452,7 +11480,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11524,7 +11551,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11755,7 +11782,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11922,7 +11948,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11939,7 +11964,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11956,7 +11980,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11973,7 +11996,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11990,7 +12012,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12007,7 +12028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12024,7 +12044,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12041,7 +12060,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12058,7 +12076,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12075,7 +12092,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12092,7 +12108,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12109,7 +12124,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12126,7 +12140,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12143,7 +12156,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12160,7 +12172,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12177,7 +12188,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12194,7 +12204,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12211,7 +12220,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12228,7 +12236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12245,7 +12252,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12262,7 +12268,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12279,7 +12284,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12296,7 +12300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12313,7 +12316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12330,7 +12332,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12347,7 +12348,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12361,7 +12361,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12403,7 +12402,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12842,6 +12840,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.718",
+  "version": "0.33.719",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/resolve-cef-runtime.sh
+++ b/scripts/resolve-cef-runtime.sh
@@ -44,15 +44,49 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-candidates=()
+# `validate_dir <dir>` — print to stdout and exit 0 if `<dir>` has libcef.so +
+# icudtl.dat. Returns 1 (no output) if either file is missing.
+# When the directory does provide both files, also do a size sanity warning.
+validate_dir() {
+    local dir="$1"
+    if [ ! -f "$dir/libcef.so" ] || [ ! -f "$dir/icudtl.dat" ]; then
+        return 1
+    fi
+    local size_bytes
+    size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
+    local size_mb=$((size_bytes / 1024 / 1024))
+    if [ "$size_bytes" -gt 1073741824 ]; then
+        echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — likely unpatched upstream debug build." >&2
+        echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
+        echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then either" >&2
+        echo "         (a) move the result to ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64, or" >&2
+        echo "         (b) export AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64." >&2
+    fi
+    echo "$dir"
+    return 0
+}
 
-# 1. Explicit override.
+# 1. Explicit override. STRICT: if the env var is set, we trust the operator
+#    knew what they wanted. A typo or missing file is a hard error — do NOT
+#    silently fall through to the cef-dll-sys cache, because in CI / release
+#    packaging the env var is the only signal that the patched libcef should
+#    be used. Falling through would yield a successful but drag-broken bundle.
+#    (Codex P2 on PR #743.)
 if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
-    candidates+=("$AGENTMUX_CEF_RUNTIME_DIR")
+    if validate_dir "$AGENTMUX_CEF_RUNTIME_DIR"; then
+        exit 0
+    fi
+    echo "ERROR: AGENTMUX_CEF_RUNTIME_DIR=$AGENTMUX_CEF_RUNTIME_DIR" >&2
+    echo "       is set but does not contain libcef.so + icudtl.dat." >&2
+    echo "       Treating an explicit override as a hard requirement so a typo" >&2
+    echo "       in CI / release packaging doesn't silently regress to the upstream" >&2
+    echo "       cef-dll-sys fallback. Fix the path or unset the env var to use" >&2
+    echo "       auto-detection (~/cef-build → cef-dll-sys cache)." >&2
+    exit 1
 fi
 
 # 2. Standard cef-build layout under $HOME.
-candidates+=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
+candidates=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
 
 # 3. Cargo cef-dll-sys cache. Find first match in either debug or release.
 while IFS= read -r d; do
@@ -60,18 +94,7 @@ while IFS= read -r d; do
 done < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
 
 for dir in "${candidates[@]}"; do
-    if [ -f "$dir/libcef.so" ] && [ -f "$dir/icudtl.dat" ]; then
-        # Heuristic: warn on >1 GB libcef (likely unpatched upstream debug build).
-        size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
-        size_mb=$((size_bytes / 1024 / 1024))
-        if [ "$size_bytes" -gt 1073741824 ]; then
-            echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — likely unpatched upstream debug build." >&2
-            echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
-            echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then either" >&2
-            echo "         (a) move the result to ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64, or" >&2
-            echo "         (b) export AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64." >&2
-        fi
-        echo "$dir"
+    if validate_dir "$dir"; then
         exit 0
     fi
 done

--- a/scripts/resolve-cef-runtime.sh
+++ b/scripts/resolve-cef-runtime.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Print the absolute path of the directory that holds libcef.so + the CEF
+# runtime files (paks, snapshot data, GL libs, locales, etc.) that the
+# AgentMux build pipeline should bundle.
+#
+# Why this script exists
+# ----------------------
+# Linux AgentMux needs a libcef.so built from `agentmux/7680-drag-rightclick-and-transparency`
+# (a5af/cef fork) — it adds `CefWindow::BeginWindowDrag()` which AgentMux PR #663 calls
+# via raw FFI for left-click window drag on Wayland. The cef-dll-sys cargo cache holds
+# the upstream prebuilt libcef.so, which lacks that slot — when bundled, runtime falls
+# back to no-op (drag silently broken). We need a way to inject the patched libcef.so
+# into `task bundle:linux` without forking cef-dll-sys.
+#
+# Resolution order
+# ----------------
+#   1. $AGENTMUX_CEF_RUNTIME_DIR — explicit override (when set + non-empty + readable).
+#   2. $HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64 — the standard
+#      cef-build layout documented in docs/cef-build/build-patched-libcef.md.
+#   3. Cargo cef-dll-sys cache: the first match of
+#      <repo>/target/{debug,release}/build/cef-dll-sys-*/out/cef_linux_x86_64.
+#
+# Each candidate is validated by checking for libcef.so + icudtl.dat (necessary
+# minimum for a usable CEF runtime).
+#
+# Sanity check (warning, not failure)
+# -----------------------------------
+# If the chosen libcef.so is suspiciously large (>1 GB), it is almost certainly the
+# unstripped upstream debug build from cef-dll-sys, which means it lacks our
+# BeginWindowDrag patch. The runtime ABI guard in agentmux-cef will catch this and
+# log a warning at runtime, but we surface the issue at build time too so it's
+# obvious before the user clicks the binary and finds drag silently broken.
+#
+# Output
+# ------
+# stdout: absolute path of the chosen directory.
+# stderr: progress info + the size warning (if applicable) + actionable errors.
+# exit 0 on success, 1 if no candidate had libcef.so + icudtl.dat.
+#
+# Used by Taskfile.yml::bundle:linux. See docs/specs/patched-libcef-bundling-2026-05-08.md
+# for the full design.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+candidates=()
+
+# 1. Explicit override.
+if [ -n "${AGENTMUX_CEF_RUNTIME_DIR:-}" ]; then
+    candidates+=("$AGENTMUX_CEF_RUNTIME_DIR")
+fi
+
+# 2. Standard cef-build layout under $HOME.
+candidates+=("$HOME/cef-build/chromium_git/chromium/src/out/Release_GN_x64")
+
+# 3. Cargo cef-dll-sys cache. Find first match in either debug or release.
+while IFS= read -r d; do
+    candidates+=("$d")
+done < <(find "$REPO_ROOT/target" -maxdepth 6 -type d -name 'cef_linux_x86_64' 2>/dev/null)
+
+for dir in "${candidates[@]}"; do
+    if [ -f "$dir/libcef.so" ] && [ -f "$dir/icudtl.dat" ]; then
+        # Heuristic: warn on >1 GB libcef (likely unpatched upstream debug build).
+        size_bytes=$(stat -c %s "$dir/libcef.so" 2>/dev/null || stat -f %z "$dir/libcef.so" 2>/dev/null || echo 0)
+        size_mb=$((size_bytes / 1024 / 1024))
+        if [ "$size_bytes" -gt 1073741824 ]; then
+            echo "WARNING: libcef.so at $dir is ${size_mb} MB (>1 GB) — likely unpatched upstream debug build." >&2
+            echo "         AgentMux's BeginWindowDrag FFI override will silently no-op (left-click drag broken)." >&2
+            echo "         Build the patched libcef per docs/cef-build/build-patched-libcef.md, then either" >&2
+            echo "         (a) move the result to ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64, or" >&2
+            echo "         (b) export AGENTMUX_CEF_RUNTIME_DIR=/path/to/your/Release_GN_x64." >&2
+        fi
+        echo "$dir"
+        exit 0
+    fi
+done
+
+echo "ERROR: could not find libcef.so + icudtl.dat in any of these locations:" >&2
+for c in "${candidates[@]}"; do echo "  - $c" >&2; done
+echo "Build the patched libcef (see docs/cef-build/build-patched-libcef.md) or run \`cargo build -p agentmux-cef\` to populate the cef-dll-sys fallback cache." >&2
+exit 1


### PR DESCRIPTION
## Summary

\`task bundle:linux\` and \`task package:linux\` previously sourced \`libcef.so\` directly from cef-dll-sys's cargo cache, which holds the *upstream* prebuilt. AgentMux's Linux runtime needs a patched libcef built from the \`agentmux/7680-drag-rightclick-and-transparency\` branch — it adds \`CefWindow::BeginWindowDrag()\`, called via raw FFI by \`agentmux-cef/src/ui_tasks.rs::StartWindowDragTask\` for left-click window drag on Wayland (PR #663). Every clean bundle silently regressed to upstream → drag IPC silently no-opped → required a manual overlay step after every build.

## Approach

3-tier resolver invoked from \`bundle:linux\`:

1. \`\$AGENTMUX_CEF_RUNTIME_DIR\` — explicit override
2. \`~/cef-build/chromium_git/chromium/src/out/Release_GN_x64\` — standard cef-build layout
3. cef-dll-sys cargo cache — current behavior, fallback for non-maintainers

If the chosen libcef.so is >1 GB the resolver warns it's likely the unstripped upstream debug build (patched stripped build is ~613 MB), so the failure mode is debuggable at build time instead of "left-click drag broke and I don't know why".

The runtime ABI guard (\`_cef_window_t.size\` check in \`creation_views.rs\`-style code) remains the contract — this resolver is the build-time soft signal.

Three rejected alternatives are documented in the spec:
- In-tree vendor (~600 MB binary in git, infeasible)
- Fork cef-dll-sys (third place to track patches)
- Cargo xtask (overkill for one binary on one platform)

## Files

**New:**
- \`scripts/resolve-cef-runtime.sh\` — POSIX shell helper (~80 lines including comments)
- \`docs/cef-build/build-patched-libcef.md\` — how-to-build doc consolidating the cef-build machine notes (OOM-resistant ninja wrapper via \`systemd-run --user --scope\`, patcher.py idempotency gotcha, etc.)
- \`docs/specs/patched-libcef-bundling-2026-05-08.md\` — full design spec

**Edited:**
- \`Taskfile.yml::bundle:linux\` — replace inline \`find target -name libcef.so\` with \`bash scripts/resolve-cef-runtime.sh\`. Also pick up \`chrome_crashpad_handler\` + \`snapshot_blob.bin\` (needed by the AppImage build but missing from the prior bundle step).

## Verified

- \`unset AGENTMUX_CEF_RUNTIME_DIR && task bundle\` → resolver picks \`~/cef-build\`, dist/cef/libcef.so is the 613 MB patched binary.
- \`AGENTMUX_CEF_RUNTIME_DIR=/tmp/no-such-dir task bundle\` → falls through to default (bogus override = soft signal).
- Hide \`~/cef-build\`, \`task bundle\` → falls through to cef-dll-sys cache, prints WARNING about likely-unpatched libcef. Bundle still succeeds (degraded mode for non-maintainers).
- Move both away → resolver exits 1 with a clear error pointing to the build doc.

## Out of scope

- macOS / Windows resolvers (parallel work when those build flows come online).
- Automated download of patched libcef for non-maintainer contributors (build server, hosting, signing).
- Upstreaming \`BeginWindowDrag\` to chromiumembedded/cef (the real long-term cure).
- Two pre-existing Linux build bugs in main (\`process_tracker::mod\` duplicate \`pub mod stub\`, \`orphan_reconcile::classify_hwnd\` non-cfg-gated \`wh.0\` access). Separate small follow-up PR.

## Test plan

- [ ] Reviewer with their own \`~/cef-build/.../Release_GN_x64\` runs \`task bundle\` and confirms dist/cef/libcef.so is the patched build (size + behavior).
- [ ] Reviewer without a cef-build runs \`task bundle\` after a clean \`cargo build\` and gets a usable bundle (with the WARNING printed).
- [ ] Smoke-test: launched bundle has working left-click window drag (the symptom that originally surfaced this).
- [ ] \`task package:linux\` end-to-end produces an AppImage whose \`usr/bin/libcef.so\` is the patched 613 MB binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)