### PR TITLE
feat: per-instance identity injection at spawn (#678 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -2936,9 +2936,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.718"
+version = "0.33.719"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.718"
+version = "0.33.719"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1551,6 +1551,12 @@ pub struct CommandCreateAgentInstanceData {
     pub block_id: String,
     #[serde(default)]
     pub parent_instance_id: String,
+    /// Per-instance identity overrides (issue #678 Phase 2). Each entry
+    /// references one `db_identity_accounts` row scoped to one provider.
+    /// Empty (or absent) → backend falls back to the agent definition's
+    /// `db_forge_agent_identities` (definition-level) bindings at spawn.
+    #[serde(default)]
+    pub identities: Vec<crate::backend::storage::wstore::InstanceIdentity>,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -124,6 +124,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     run_forge_v4_migrations(conn)?;
     run_forge_v5_migrations(conn)?;
     run_forge_v6_migrations(conn)?;
+    run_forge_v7_migrations(conn)?;
     Ok(())
 }
 
@@ -432,6 +433,42 @@ pub fn run_forge_v6_migrations(conn: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// v7 — per-instance identity overrides (issue #678 Phase 2).
+///
+/// Adds an `identities` JSON column to `db_agent_instances`. Each row
+/// encodes the agent definition's identity assignments AT LAUNCH TIME,
+/// independent of the live `db_forge_agent_identities` (definition-level)
+/// junction. This is what makes per-instance credential isolation work:
+/// two simultaneously-running instances of the same definition can use
+/// different accounts.
+///
+/// Shape of the JSON value:
+///   `[{"account_id": "<uuid>", "provider": "github"}, ...]`
+///
+/// Empty array means "fall back to the definition-level junction at
+/// spawn time" (Phase 1 behavior). Non-empty array means "use exactly
+/// these identities for this instance, ignoring the definition default."
+pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
+    match conn.execute_batch(
+        "ALTER TABLE db_agent_instances ADD COLUMN identities TEXT NOT NULL DEFAULT '[]'",
+    ) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("duplicate column") {
+                Ok(())
+            } else {
+                Err(StoreError::Sqlite(match e {
+                    rusqlite::Error::SqliteFailure(code, _) => {
+                        rusqlite::Error::SqliteFailure(code, Some(msg))
+                    }
+                    other => other,
+                }))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -639,5 +676,57 @@ mod tests {
             )
             .unwrap();
         assert_eq!(remaining, 0, "junction row should cascade-delete");
+    }
+
+    #[test]
+    fn test_forge_v7_migrations_adds_identities_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+        run_forge_migrations(&conn).unwrap();
+
+        let cols: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(db_agent_instances)").unwrap();
+            stmt.query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert!(
+            cols.contains(&"identities".to_string()),
+            "db_agent_instances must have identities column after v7"
+        );
+
+        // Default value applies on insert: existing INSERT without identities column
+        // should still work and produce '[]'.
+        conn.execute(
+            "INSERT INTO db_forge_agents (id, name, provider, description, slug)
+             VALUES ('ag1', 'AgentX', 'claude', '', 'agentx')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO db_agent_instances (id, definition_id, status, started_at)
+             VALUES ('inst1', 'ag1', 'running', 0)",
+            [],
+        )
+        .unwrap();
+        let identities: String = conn
+            .query_row(
+                "SELECT identities FROM db_agent_instances WHERE id='inst1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(identities, "[]");
+    }
+
+    #[test]
+    fn test_forge_v7_migrations_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+        run_forge_migrations(&conn).unwrap();
+        run_forge_migrations(&conn).unwrap(); // second pass must not error
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1133,6 +1133,22 @@ pub struct AgentInstance {
     #[serde(default)]
     pub ended_at: i64,
     pub created_at: i64,
+    /// Per-instance identity overrides (issue #678 Phase 2). Snapshot
+    /// taken at launch — independent of the live
+    /// `db_forge_agent_identities` (definition-level) junction so two
+    /// instances of the same definition can use different accounts.
+    /// Empty vec means "fall back to definition default at spawn time."
+    #[serde(default)]
+    pub identities: Vec<InstanceIdentity>,
+}
+
+/// One per-provider identity binding owned by an `AgentInstance`. The
+/// `account_id` references `db_identity_accounts`, the `provider`
+/// scopes the binding (one identity per provider per instance).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InstanceIdentity {
+    pub account_id: String,
+    pub provider: String,
 }
 
 impl WaveStore {
@@ -1354,7 +1370,7 @@ impl WaveStore {
         // can't reuse a single prepared statement across filter combos.
         let mut sql = String::from(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at
+                    status, github_context, started_at, ended_at, created_at, identities
              FROM db_agent_instances",
         );
         let mut clauses: Vec<&str> = Vec::new();
@@ -1382,6 +1398,7 @@ impl WaveStore {
             param_vals.push(s.to_string());
         }
         let iter = stmt.query_map(rusqlite::params_from_iter(param_vals.iter()), |row| {
+            let identities_json: String = row.get(10).unwrap_or_else(|_| "[]".to_string());
             Ok(AgentInstance {
                 id: row.get(0)?,
                 definition_id: row.get(1)?,
@@ -1393,6 +1410,7 @@ impl WaveStore {
                 started_at: row.get(7)?,
                 ended_at: row.get(8)?,
                 created_at: row.get(9)?,
+                identities: serde_json::from_str(&identities_json).unwrap_or_default(),
             })
         })?;
         let mut out = Vec::new();
@@ -1402,14 +1420,25 @@ impl WaveStore {
         Ok(out)
     }
 
-    pub fn instance_get(&self, id: &str) -> Result<Option<AgentInstance>, StoreError> {
+    /// Find the most recently-created running instance for a block.
+    /// Used at subprocess spawn time to look up per-instance identity
+    /// overrides (issue #678 Phase 2). Returns `None` for blocks that
+    /// have no active instance — falls back to ambient host credentials.
+    pub fn instance_get_active_for_block(
+        &self,
+        block_id: &str,
+    ) -> Result<Option<AgentInstance>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at
-             FROM db_agent_instances WHERE id = ?1",
+                    status, github_context, started_at, ended_at, created_at, identities
+             FROM db_agent_instances
+             WHERE block_id = ?1 AND status = 'running'
+             ORDER BY created_at DESC
+             LIMIT 1",
         )?;
-        let result = stmt.query_row(params![id], |row| {
+        let result = stmt.query_row(params![block_id], |row| {
+            let identities_json: String = row.get(10).unwrap_or_else(|_| "[]".to_string());
             Ok(AgentInstance {
                 id: row.get(0)?,
                 definition_id: row.get(1)?,
@@ -1421,6 +1450,37 @@ impl WaveStore {
                 started_at: row.get(7)?,
                 ended_at: row.get(8)?,
                 created_at: row.get(9)?,
+                identities: serde_json::from_str(&identities_json).unwrap_or_default(),
+            })
+        });
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn instance_get(&self, id: &str) -> Result<Option<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at, identities
+             FROM db_agent_instances WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id], |row| {
+            let identities_json: String = row.get(10).unwrap_or_else(|_| "[]".to_string());
+            Ok(AgentInstance {
+                id: row.get(0)?,
+                definition_id: row.get(1)?,
+                parent_instance_id: row.get(2)?,
+                block_id: row.get(3)?,
+                session_id: row.get(4)?,
+                status: row.get(5)?,
+                github_context: row.get(6)?,
+                started_at: row.get(7)?,
+                ended_at: row.get(8)?,
+                created_at: row.get(9)?,
+                identities: serde_json::from_str(&identities_json).unwrap_or_default(),
             })
         });
         match result {
@@ -1433,11 +1493,13 @@ impl WaveStore {
     /// Insert a new instance row. Caller is responsible for the id (UUID).
     pub fn instance_create(&self, inst: &AgentInstance) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
+        let identities_json =
+            serde_json::to_string(&inst.identities).unwrap_or_else(|_| "[]".to_string());
         conn.execute(
             "INSERT INTO db_agent_instances
                 (id, definition_id, parent_instance_id, block_id, session_id, status,
-                 github_context, started_at, ended_at, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                 github_context, started_at, ended_at, created_at, identities)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
             params![
                 inst.id,
                 inst.definition_id,
@@ -1449,6 +1511,7 @@ impl WaveStore {
                 inst.started_at,
                 inst.ended_at,
                 inst.created_at,
+                identities_json,
             ],
         )?;
         Ok(())
@@ -2015,12 +2078,19 @@ mod tests {
             started_at: 1000,
             ended_at: 0,
             created_at: 1000,
+            identities: vec![InstanceIdentity {
+                account_id: "acc1".to_string(),
+                provider: "github".to_string(),
+            }],
         };
         store.instance_create(&inst).unwrap();
 
         let fetched = store.instance_get("inst1").unwrap().expect("row");
         assert_eq!(fetched.block_id, "block-abc");
         assert_eq!(fetched.status, "running");
+        assert_eq!(fetched.identities.len(), 1);
+        assert_eq!(fetched.identities[0].account_id, "acc1");
+        assert_eq!(fetched.identities[0].provider, "github");
 
         // Update status → stopped
         let mut updated = fetched.clone();
@@ -2056,6 +2126,7 @@ mod tests {
             started_at: 0,
             ended_at: 0,
             created_at: 0,
+            identities: vec![],
         };
         store.instance_create(&inst).unwrap();
 

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -1,0 +1,102 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity resolution at subprocess spawn time.
+//!
+//! Issue #678 Phase 2 — turns `(instance.identities[], db_identity_accounts)`
+//! into a `HashMap<String, String>` of env vars to merge into the spawn
+//! config. Secrets never enter block metadata or the JSON IPC bus; the
+//! resolver runs locally in `agentmux-srv` and writes directly into the
+//! `Command::env()` map at spawn time.
+//!
+//! Phase 2 supports two `SecretRef` backends:
+//!   - `Env { env_var }`     — read from agentmux-srv's process env
+//!   - `PlaintextDev { ... }`— literal value (dev/test only; warns on use)
+//!
+//! `SecretsManager` (cloud secrets) is reserved for Phase 3 alongside
+//! the encrypted vault.
+
+pub mod resolver;
+
+pub use resolver::{
+    InjectionEnvVars, ResolveError, build_injection_env, provider_env_vars, resolve_secret,
+};
+
+use std::collections::HashMap;
+
+use crate::backend::storage::wstore::{InstanceIdentity, WaveStore};
+
+/// Resolve and merge identity-derived env vars into the spawn env map.
+///
+/// Looks up the active running instance for `block_id`, falls back to
+/// the agent definition's `db_forge_agent_identities` junction if the
+/// instance has no identity overrides, then resolves each identity's
+/// secret and writes the value into `env_vars`. Identity-derived vars
+/// take precedence over anything already in `env_vars` (e.g. a
+/// hand-edited `cmd:env` entry — the explicit identity selection
+/// always wins).
+///
+/// Failures are logged but never abort the spawn — the issue spec's
+/// "warn, don't block" decision. Callers don't need to handle errors.
+pub fn inject_identity_env(
+    wstore: &WaveStore,
+    block_id: &str,
+    env_vars: &mut HashMap<String, String>,
+) {
+    let identities = match resolve_identities_for_block(wstore, block_id) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(block_id = %block_id, error = %e, "failed to load identities for block");
+            return;
+        }
+    };
+
+    if identities.is_empty() {
+        return;
+    }
+
+    let (resolved, errs) = build_injection_env(wstore, &identities);
+    for (k, v) in resolved {
+        env_vars.insert(k, v);
+    }
+    for (account_id, err) in errs {
+        tracing::warn!(
+            block_id = %block_id,
+            account_id = %account_id,
+            error = %err,
+            "identity resolution failed; falling back to ambient credentials for this slot"
+        );
+    }
+}
+
+/// Find the identities to inject for a given block. Per-instance
+/// overrides take precedence; falls back to the definition-level
+/// `db_forge_agent_identities` junction when the instance has none.
+fn resolve_identities_for_block(
+    wstore: &WaveStore,
+    block_id: &str,
+) -> Result<Vec<InstanceIdentity>, String> {
+    let instance = match wstore
+        .instance_get_active_for_block(block_id)
+        .map_err(|e| e.to_string())?
+    {
+        Some(i) => i,
+        None => return Ok(Vec::new()),
+    };
+
+    if !instance.identities.is_empty() {
+        return Ok(instance.identities);
+    }
+
+    // Fall back to the definition-level junction.
+    let rows = wstore
+        .agent_identity_list_for_agent(&instance.definition_id)
+        .map_err(|e| e.to_string())?;
+    Ok(rows
+        .into_iter()
+        .map(|r| InstanceIdentity {
+            account_id: r.account_id,
+            provider: r.provider,
+        })
+        .collect())
+}

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -1,0 +1,287 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Secret resolution + provider→env-var mapping.
+
+use std::collections::HashMap;
+
+use crate::backend::storage::wstore::{
+    IdentityAccount, InstanceIdentity, SecretRef, WaveStore,
+};
+
+/// What each `IdentityAccount` resolves into. Output of `build_injection_env`.
+pub type InjectionEnvVars = HashMap<String, String>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResolveError {
+    #[error("secret env var not set in agentmux-srv environment: {0}")]
+    EnvVarMissing(String),
+    #[error("identity account {0} not found")]
+    AccountNotFound(String),
+    #[error("secrets-manager backend not yet supported (Phase 3): {0}")]
+    SecretsManagerUnsupported(String),
+    #[error("wstore error: {0}")]
+    Store(String),
+}
+
+/// Resolve a `SecretRef` to its plaintext value. The Phase 2 backends are
+/// `Env` (read from `agentmux-srv`'s process env) and `PlaintextDev`
+/// (literal value baked into the SecretRef — dev/test convenience).
+pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolveError> {
+    match secret_ref {
+        SecretRef::Env { env_var } => std::env::var(env_var)
+            .map_err(|_| ResolveError::EnvVarMissing(env_var.clone())),
+        SecretRef::PlaintextDev { plaintext_dev } => Ok(plaintext_dev.clone()),
+        SecretRef::SecretsManager { sm_path, .. } => {
+            Err(ResolveError::SecretsManagerUnsupported(sm_path.clone()))
+        }
+    }
+}
+
+/// Provider → list of env var names that should receive the resolved
+/// secret. The mapping is a stable contract between agentmux-srv and the
+/// CLIs it spawns. Issue #678 Phase 2 spec, "Credential Injection at
+/// Spawn" matrix.
+///
+/// Most providers inject a single env var. GitHub gets two (`GITHUB_TOKEN`
+/// + `GH_TOKEN`) because both are widely consumed depending on which
+/// `gh` / Octokit version is in PATH.
+///
+/// Returns an empty slice for unknown providers — the caller logs a
+/// warning but does not error (forward compatibility for new provider
+/// kinds added by users).
+pub fn provider_env_vars(provider: &str) -> &'static [&'static str] {
+    match provider {
+        "github" => &["GITHUB_TOKEN", "GH_TOKEN"],
+        "anthropic" => &["ANTHROPIC_API_KEY"],
+        "openai" => &["OPENAI_API_KEY"],
+        "kimi" => &["MOONSHOT_API_KEY"],
+        // AWS multi-secret accounts (access key + secret + session) are a
+        // Phase 3 concern — for now, treat the resolved value as the
+        // access key id. Real AWS workflows go through the env_ref kind
+        // pointing at AWS_ACCESS_KEY_ID directly.
+        "aws" => &["AWS_ACCESS_KEY_ID"],
+        _ => &[],
+    }
+}
+
+/// Build the env-var injection map for an instance's identity bindings.
+///
+/// For each `(account_id, provider)` pair:
+///   1. Look up the `IdentityAccount` in `db_identity_accounts`.
+///   2. Resolve its `secret_ref` to a plaintext value.
+///   3. Map the `provider` to its env-var slot(s) and write the value.
+///
+/// Failures are partial — one bad identity does not abort the whole
+/// merge. The function returns the successfully-resolved map plus a
+/// list of `(account_id, error)` pairs the caller can log. This matches
+/// the issue spec's "Missing identity at launch: warn, don't block —
+/// fall back to ambient host credentials" decision.
+pub fn build_injection_env(
+    wstore: &WaveStore,
+    identities: &[InstanceIdentity],
+) -> (InjectionEnvVars, Vec<(String, ResolveError)>) {
+    let mut env: InjectionEnvVars = HashMap::new();
+    let mut errors: Vec<(String, ResolveError)> = Vec::new();
+
+    for ident in identities {
+        let account = match wstore.identity_get(&ident.account_id) {
+            Ok(Some(a)) => a,
+            Ok(None) => {
+                errors.push((
+                    ident.account_id.clone(),
+                    ResolveError::AccountNotFound(ident.account_id.clone()),
+                ));
+                continue;
+            }
+            Err(e) => {
+                errors.push((ident.account_id.clone(), ResolveError::Store(e.to_string())));
+                continue;
+            }
+        };
+
+        let value = match resolve_secret(&account.secret_ref) {
+            Ok(v) => v,
+            Err(e) => {
+                errors.push((ident.account_id.clone(), e));
+                continue;
+            }
+        };
+
+        let target_vars = provider_env_vars(&ident.provider);
+        if target_vars.is_empty() {
+            // Unknown provider — log via the error channel but do not
+            // fail. Account.context may carry a hint but we don't fall
+            // back to it in Phase 2.
+            tracing::warn!(
+                account_id = %ident.account_id,
+                provider = %ident.provider,
+                "no env-var mapping for provider; identity has no effect this turn"
+            );
+            // Keep the loop going so other identities still inject.
+            let _ = account; // silence unused warning when no vars target it
+            continue;
+        }
+        for var in target_vars {
+            env.insert((*var).to_string(), value.clone());
+        }
+    }
+
+    (env, errors)
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::wstore::IdentityAccount;
+
+    fn dev_account(provider: &str, value: &str) -> IdentityAccount {
+        IdentityAccount {
+            id: format!("acc-{provider}"),
+            name: format!("dev-{provider}"),
+            provider: provider.to_string(),
+            kind: "api_key".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::PlaintextDev {
+                plaintext_dev: value.to_string(),
+            },
+            context: serde_json::Value::Object(serde_json::Map::new()),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn resolve_plaintext_dev_returns_literal() {
+        let s = SecretRef::PlaintextDev {
+            plaintext_dev: "abc123".to_string(),
+        };
+        assert_eq!(resolve_secret(&s).unwrap(), "abc123");
+    }
+
+    #[test]
+    fn resolve_env_var_missing_errors() {
+        let s = SecretRef::Env {
+            env_var: "AGENTMUX_TEST_DOES_NOT_EXIST_ZZZ".to_string(),
+        };
+        let r = resolve_secret(&s);
+        assert!(matches!(r, Err(ResolveError::EnvVarMissing(_))));
+    }
+
+    #[test]
+    fn resolve_env_var_present_returns_value() {
+        // SAFETY: setting a process-scoped env var inside the test binary.
+        // Keep the var name unlikely-to-collide.
+        unsafe {
+            std::env::set_var("AGENTMUX_TEST_RESOLVE_OK", "yep");
+        }
+        let s = SecretRef::Env {
+            env_var: "AGENTMUX_TEST_RESOLVE_OK".to_string(),
+        };
+        assert_eq!(resolve_secret(&s).unwrap(), "yep");
+        unsafe {
+            std::env::remove_var("AGENTMUX_TEST_RESOLVE_OK");
+        }
+    }
+
+    #[test]
+    fn resolve_secrets_manager_returns_unsupported() {
+        let s = SecretRef::SecretsManager {
+            sm_path: "/foo/bar".to_string(),
+            sm_json_path: None,
+        };
+        let r = resolve_secret(&s);
+        assert!(matches!(r, Err(ResolveError::SecretsManagerUnsupported(_))));
+    }
+
+    #[test]
+    fn provider_env_vars_known_providers() {
+        assert_eq!(provider_env_vars("github"), &["GITHUB_TOKEN", "GH_TOKEN"]);
+        assert_eq!(provider_env_vars("anthropic"), &["ANTHROPIC_API_KEY"]);
+        assert_eq!(provider_env_vars("openai"), &["OPENAI_API_KEY"]);
+        assert_eq!(provider_env_vars("kimi"), &["MOONSHOT_API_KEY"]);
+        assert!(provider_env_vars("unknown-provider").is_empty());
+    }
+
+    #[test]
+    fn build_injection_env_resolves_known_provider() {
+        let store = WaveStore::open_in_memory().unwrap();
+        let acc = dev_account("github", "ghp_test");
+        store.identity_upsert(&acc).unwrap();
+
+        let (env, errs) = build_injection_env(
+            &store,
+            &[InstanceIdentity {
+                account_id: acc.id.clone(),
+                provider: "github".to_string(),
+            }],
+        );
+
+        assert!(errs.is_empty());
+        assert_eq!(env.get("GITHUB_TOKEN"), Some(&"ghp_test".to_string()));
+        assert_eq!(env.get("GH_TOKEN"), Some(&"ghp_test".to_string()));
+    }
+
+    #[test]
+    fn build_injection_env_records_unknown_account() {
+        let store = WaveStore::open_in_memory().unwrap();
+        let (env, errs) = build_injection_env(
+            &store,
+            &[InstanceIdentity {
+                account_id: "ghost".to_string(),
+                provider: "github".to_string(),
+            }],
+        );
+        assert!(env.is_empty());
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].0, "ghost");
+        assert!(matches!(errs[0].1, ResolveError::AccountNotFound(_)));
+    }
+
+    #[test]
+    fn build_injection_env_partial_success_other_identities_still_inject() {
+        let store = WaveStore::open_in_memory().unwrap();
+        let acc = dev_account("github", "ghp_ok");
+        store.identity_upsert(&acc).unwrap();
+
+        let (env, errs) = build_injection_env(
+            &store,
+            &[
+                InstanceIdentity {
+                    account_id: "ghost".to_string(),
+                    provider: "anthropic".to_string(),
+                },
+                InstanceIdentity {
+                    account_id: acc.id.clone(),
+                    provider: "github".to_string(),
+                },
+            ],
+        );
+
+        assert_eq!(env.get("GITHUB_TOKEN"), Some(&"ghp_ok".to_string()));
+        assert_eq!(errs.len(), 1);
+    }
+
+    #[test]
+    fn build_injection_env_unknown_provider_skipped_silently() {
+        let store = WaveStore::open_in_memory().unwrap();
+        let acc = dev_account("custom-foo", "x");
+        store.identity_upsert(&acc).unwrap();
+
+        let (env, errs) = build_injection_env(
+            &store,
+            &[InstanceIdentity {
+                account_id: acc.id.clone(),
+                provider: "custom-foo".to_string(),
+            }],
+        );
+        assert!(env.is_empty());
+        // Unknown provider = warn-only, no error returned to caller.
+        assert!(errs.is_empty());
+    }
+}

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod config;
 mod event_log;
+mod identity;
 mod persist;
 mod persist_subscriber;
 mod reducer;

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -454,13 +454,16 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     _ => vec![],
                 };
                 let working_dir = obj::meta_get_string(&block.meta, "cmd:cwd", "");
-                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                let mut env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
                     Some(serde_json::Value::Object(obj)) => obj
                         .iter()
                         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
+                // Issue #678 Phase 2 — merge identity-resolved secrets.
+                // See identity::inject_identity_env doc for fallback rules.
+                crate::identity::inject_identity_env(&wstore, &cmd.block_id, &mut env_vars);
                 let session_id_field = obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1005,6 +1005,7 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: now,
                     ended_at: 0,
                     created_at: now,
+                    identities: cmd.identities,
                 };
                 wstore
                     .instance_create(&inst)
@@ -1046,6 +1047,9 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: existing.started_at,
                     ended_at: cmd.ended_at.unwrap_or(existing.ended_at),
                     created_at: existing.created_at,
+                    // Identities are immutable for the lifetime of an instance
+                    // (issue #678 spec — "mid-session rotation not supported").
+                    identities: existing.identities,
                 };
                 wstore
                     .instance_update(&merged)

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -817,13 +817,17 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let working_dir = crate::backend::obj::meta_get_string(
                     &block.meta, "cmd:cwd", "",
                 );
-                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                let mut env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
                     Some(serde_json::Value::Object(obj)) => obj
                         .iter()
                         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
+                // Issue #678 Phase 2 — resolve identity-bound secrets and
+                // merge into the env map at spawn time. Secrets never
+                // enter `cmd:env` (block metadata) or the JSON IPC bus.
+                crate::identity::inject_identity_env(&wstore, &cmd.blockid, &mut env_vars);
                 let session_id_field = crate::backend::obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -659,7 +659,15 @@ class RpcApiType {
     // command "createagentinstance" [call]
     CreateAgentInstanceCommand(
         client: RpcClient,
-        data: { definition_id: string; block_id?: string; parent_instance_id?: string },
+        data: {
+            definition_id: string;
+            block_id?: string;
+            parent_instance_id?: string;
+            /** Per-instance identity overrides (issue #678 Phase 2). Empty
+             *  array (or absent) → backend falls back to the agent
+             *  definition's db_forge_agent_identities bindings. */
+            identities?: InstanceIdentity[];
+        },
         opts?: RpcOpts,
     ): Promise<AgentInstance> {
         return client.rpcCall("createagentinstance", data, opts);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -458,6 +458,10 @@ export class AgentViewModel implements ViewModel {
                 const inst = await RpcApi.CreateAgentInstanceCommand(TabRpcClient, {
                     definition_id: agent.id,
                     block_id: blockId,
+                    // Per-instance identity overrides (issue #678 Phase 2).
+                    // Empty array → backend falls back to definition-level
+                    // db_forge_agent_identities at spawn time.
+                    identities: overrides?.identities ?? [],
                 });
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref,

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -13,9 +13,13 @@
  * panel only. See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
-import { createMemo, createSignal, Show, type JSX } from "solid-js";
+import { createMemo, createResource, createSignal, For, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import type { Account } from "@/app/view/identity/identity-model";
+import { loadAccounts } from "@/app/view/identity/identity-model";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slug";
@@ -31,6 +35,10 @@ export interface LaunchOverrides {
     environment: "local" | "docker";
     /** Only set when agentType === "container". */
     containerImage?: string;
+    /** Per-instance identity overrides (issue #678 Phase 2). One entry
+     *  per provider; absence means "use the definition default" (the
+     *  backend falls back to db_forge_agent_identities). */
+    identities?: { account_id: string; provider: string }[];
 }
 
 interface AgentLaunchModalPanelProps {
@@ -49,6 +57,68 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
     const [showAdvanced, setShowAdvanced] = createSignal(false);
+
+    // ── Identity picker (issue #678 Phase 2) ──────────────────────────
+    // Per-provider account selection. `null` for a provider means "use
+    // the definition default" (backend falls back to
+    // db_forge_agent_identities). The map key is the provider id.
+    const [identityChoice, setIdentityChoice] = createSignal<Record<string, string | null>>({});
+
+    // Load the definition-level bindings so we can pre-fill the picker.
+    // The list is small (one row per provider) so the call is cheap.
+    const [agentBindings] = createResource(
+        () => props.agent.id,
+        async (agentId) => {
+            try {
+                return await RpcApi.ListAgentIdentitiesCommand(TabRpcClient, { agent_id: agentId });
+            } catch {
+                return [] as ForgeAgentIdentity[];
+            }
+        },
+    );
+
+    const allAccounts = createMemo<Account[]>(() => loadAccounts());
+
+    // Group accounts by provider — drives the picker rows. We only
+    // render rows for providers that have at least one account; users
+    // who want a provider that has no accounts go to the identity
+    // widget to add one.
+    const accountsByProvider = createMemo<Map<string, Account[]>>(() => {
+        const m = new Map<string, Account[]>();
+        for (const a of allAccounts()) {
+            if (!m.has(a.provider)) m.set(a.provider, []);
+            m.get(a.provider)!.push(a);
+        }
+        return m;
+    });
+
+    // Pre-fill identityChoice from agent bindings whenever they load.
+    // We only initialize entries we haven't already touched (so the
+    // resource refresh doesn't clobber a user's pick).
+    createMemo(() => {
+        const bindings = agentBindings();
+        if (!bindings) return;
+        const current = identityChoice();
+        const next: Record<string, string | null> = { ...current };
+        let changed = false;
+        for (const b of bindings) {
+            if (next[b.provider] === undefined) {
+                next[b.provider] = b.account_id;
+                changed = true;
+            }
+        }
+        if (changed) setIdentityChoice(next);
+    });
+
+    /** Build the LaunchOverrides.identities array from the picker state. */
+    const collectIdentities = (): { account_id: string; provider: string }[] => {
+        const choice = identityChoice();
+        const out: { account_id: string; provider: string }[] = [];
+        for (const [provider, account_id] of Object.entries(choice)) {
+            if (account_id) out.push({ account_id, provider });
+        }
+        return out;
+    };
 
     const hasName = () => name().trim().length > 0;
     const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
@@ -70,6 +140,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                 agentType: runtime(),
                 environment: runtime() === "container" ? "docker" : "local",
                 containerImage: runtime() === "container" ? resolvedImage() : undefined,
+                identities: collectIdentities(),
             });
             // Success: layer closes the panel; we leave `submitting`
             // true so the button keeps its "Launching…" label until
@@ -162,6 +233,47 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                             </span>
                         </label>
                     </fieldset>
+
+                    <Show when={accountsByProvider().size > 0}>
+                        <fieldset class="agent-launch-modal-field agent-launch-modal-identities">
+                            <legend class="agent-launch-modal-label">Identity</legend>
+                            <span class="agent-launch-modal-hint">
+                                Credentials to inject when this instance launches. Pre-filled
+                                from the agent's defaults; override per-launch as needed.
+                            </span>
+                            <For each={Array.from(accountsByProvider().entries())}>
+                                {([provider, accounts]) => (
+                                    <div class="agent-launch-modal-identity-row">
+                                        <label class="agent-launch-modal-identity-provider">
+                                            {provider}
+                                        </label>
+                                        <select
+                                            class="agent-launch-modal-input"
+                                            value={identityChoice()[provider] ?? ""}
+                                            onChange={(e) => {
+                                                const v = e.currentTarget.value;
+                                                setIdentityChoice((prev) => ({
+                                                    ...prev,
+                                                    [provider]: v === "" ? null : v,
+                                                }));
+                                            }}
+                                            disabled={submitting()}
+                                            aria-label={`Identity for ${provider}`}
+                                        >
+                                            <option value="">— None (use ambient) —</option>
+                                            <For each={accounts}>
+                                                {(acc) => (
+                                                    <option value={acc.id}>
+                                                        {acc.display_name?.trim() || acc.name}
+                                                    </option>
+                                                )}
+                                            </For>
+                                        </select>
+                                    </div>
+                                )}
+                            </For>
+                        </fieldset>
+                    </Show>
 
                     <Show when={error()}>
                         <div class="agent-launch-modal-error">{error()}</div>

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -190,3 +190,25 @@
     opacity: 0.6;
 }
 
+
+// Identity picker (issue #678 Phase 2). Sits between the runtime
+// fieldset and the advanced details. One row per provider with at
+// least one account.
+.agent-launch-modal-identities {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.agent-launch-modal-identity-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.agent-launch-modal-identity-provider {
+    text-transform: capitalize;
+    min-width: 80px;
+    font-size: 12px;
+    color: var(--secondary-text-color);
+}

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -301,6 +301,15 @@ declare global {
         started_at: number;
         ended_at?: number;
         created_at: number;
+        /** Per-instance identity overrides (issue #678 Phase 2).
+         *  Empty array → backend falls back to db_forge_agent_identities. */
+        identities?: InstanceIdentity[];
+    };
+
+    /** One per-provider identity binding owned by an AgentInstance. */
+    type InstanceIdentity = {
+        account_id: string;
+        provider: string;
     };
 
     // ForgeContent

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.718",
+  "version": "0.33.719",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Closes **Phase 2** of issue #678. Wires user-selected identities through to env vars at agent CLI subprocess spawn — secrets never enter block metadata or the JSON IPC bus.

Phase 1 (account registry UI + DB tables) was already shipped. Phase 3 (OAuth login + encrypted vault) is tracked as separate follow-up issues.

## What it does end-to-end

1. User picks an identity per provider in the launch modal (pre-filled from agent's defaults).
2. Frontend passes `identities: [{ account_id, provider }]` to `CreateAgentInstanceCommand`.
3. Backend stores it on the new `db_agent_instances.identities` column.
4. When the CLI subprocess spawns, `inject_identity_env` looks up the active instance, resolves each `SecretRef` to a plaintext value, and merges target env vars (e.g. `GITHUB_TOKEN`, `ANTHROPIC_API_KEY`) into the spawn map.
5. If the instance has no overrides, the resolver falls back to the agent definition's `db_forge_agent_identities` junction (Phase 1 default).

## Backend (Rust)

| Layer | Change |
|-------|--------|
| Migration | **v7**: `identities` JSON column on `db_agent_instances` (default `'[]'`, additive — old rows unaffected) |
| Model | `AgentInstance.identities: Vec<InstanceIdentity>`; new `InstanceIdentity { account_id, provider }` |
| RPC | `CommandCreateAgentInstanceData.identities` accepted; create handler persists; update treats as immutable per spec ('mid-session rotation not supported') |
| WaveStore | `instance_get_active_for_block(block_id)` helper; instance JSON round-trip in list/get/create |
| `identity::resolver` | New module: `resolve_secret(SecretRef)` for Env + PlaintextDev; `provider_env_vars()` matrix (github → `GITHUB_TOKEN`/`GH_TOKEN`, anthropic → `ANTHROPIC_API_KEY`, openai → `OPENAI_API_KEY`, kimi → `MOONSHOT_API_KEY`, aws → `AWS_ACCESS_KEY_ID`); `build_injection_env()` partial-success merge |
| Spawn injection | `identity::inject_identity_env(wstore, block_id, &mut env_vars)` wired into both `AgentInputCommand` (`websocket.rs:820`) and `AgentSendCommand` (`app_api.rs:457`) — secrets are resolved locally and merged into the spawn `env_vars` HashMap, never written to block metadata |

`SecretsManager` (cloud secrets) returns `Unsupported` — reserved for Phase 3.

## Frontend (TS / SolidJS)

| File | Change |
|------|--------|
| `AgentLaunchModal.tsx` | Identity picker `<fieldset>` between runtime selector and advanced details. One `<select>` per provider with ≥1 account. Pre-fills from agent's definition-level bindings via `ListAgentIdentitiesCommand`. |
| `LaunchOverrides.identities` | New optional field; `agent-model.ts` passes through to `CreateAgentInstanceCommand` |
| `_launch-modal-body.scss` | Minimal styling for `.agent-launch-modal-identity-row` |
| `rpc-api.ts` | `CreateAgentInstanceCommand` data type extended |
| `gotypes.d.ts` | `AgentInstance.identities` + `InstanceIdentity` types |

## Failure mode

\"Warn, don't block\" per spec:
- Missing account → log + skip slot, other identities still inject
- `SecretRef::Env` env var not set in `agentmux-srv` env → log + skip
- Unknown provider → log + skip silently (forward-compatible with custom providers)
- The agent CLI launches with whatever ambient credentials remain

## Tests

- 11 new Rust unit tests:
  - 2× migration v7 (column added, idempotent)
  - 9× resolver (each `SecretRef` backend, provider matrix, partial success, unknown account, unknown provider)
- All existing tests still pass (`cargo check` clean, frontend `tsc --noEmit` clean)

## What's NOT in this PR (deferred)

- **Phase 3** — OAuth login flows + encrypted Argon2id+AES-256-GCM vault. Will be split: vault core, then one provider per follow-up PR.
- **AWS multi-secret support** — current matrix uses single env-var injection. Real AWS workflows need `AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY + AWS_SESSION_TOKEN`; users can model this today via three `env_ref` accounts pointing at each var.

## Test plan

- [ ] Open identity widget, add a github account with `secret_ref: { backend: \"plaintext_dev\", value: \"ghp_test\" }` (dev only)
- [ ] Launch an agent; pick that identity in the modal
- [ ] Verify the running CLI subprocess sees `GITHUB_TOKEN=ghp_test` and `GH_TOKEN=ghp_test` in its env (e.g. `printenv` via shell tool)
- [ ] Launch a second instance of the same definition with a different identity; confirm both run simultaneously with different credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)