### PR TITLE
feat(identity): v7 schema — Identity bundles + Memory + agent_instance FKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.720"
+version = "0.33.721"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.720"
+version = "0.33.721"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.720"
+version = "0.33.721"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.720"
+version = "0.33.721"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.720"
+version = "0.33.721"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.720"
+version = "0.33.721"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.720"
+version = "0.33.721"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.720"
+version = "0.33.721"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -305,6 +305,21 @@ pub const COMMAND_LINK_AGENT_IDENTITY: &str = "linkagentidentity";
 pub const COMMAND_UNLINK_AGENT_IDENTITY: &str = "unlinkagentidentity";
 pub const COMMAND_LIST_AGENT_IDENTITIES: &str = "listagentidentities";
 
+// Identity bundles (v7 — named credential bundles)
+pub const COMMAND_LIST_IDENTITY_BUNDLES: &str = "listidentitybundles";
+pub const COMMAND_GET_IDENTITY_BUNDLE: &str = "getidentitybundle";
+pub const COMMAND_UPSERT_IDENTITY_BUNDLE: &str = "upsertidentitybundle";
+pub const COMMAND_DELETE_IDENTITY_BUNDLE: &str = "deleteidentitybundle";
+pub const COMMAND_BIND_IDENTITY_ACCOUNT: &str = "bindidentityaccount";
+pub const COMMAND_UNBIND_IDENTITY_ACCOUNT: &str = "unbindidentityaccount";
+pub const COMMAND_LIST_IDENTITY_BINDINGS: &str = "listidentitybindings";
+
+// Memory bundles (v7 — agent personality / capability stack)
+pub const COMMAND_LIST_MEMORIES: &str = "listmemories";
+pub const COMMAND_GET_MEMORY: &str = "getmemory";
+pub const COMMAND_UPSERT_MEMORY: &str = "upsertmemory";
+pub const COMMAND_DELETE_MEMORY: &str = "deletememory";
+
 // Agent instances
 pub const COMMAND_LIST_AGENT_INSTANCES: &str = "listagentinstances";
 pub const COMMAND_GET_AGENT_INSTANCE: &str = "getagentinstance";
@@ -1529,6 +1544,48 @@ pub struct CommandUnlinkAgentIdentityData {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommandListAgentIdentitiesData {
     pub agent_id: String,
+}
+
+// ---- v7 Identity bundle command shapes ----
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandGetIdentityBundleData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandDeleteIdentityBundleData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandBindIdentityAccountData {
+    pub identity_id: String,
+    pub provider: String,
+    pub account_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandUnbindIdentityAccountData {
+    pub identity_id: String,
+    pub provider: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandListIdentityBindingsData {
+    pub identity_id: String,
+}
+
+// ---- v7 Memory bundle command shapes ----
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandGetMemoryData {
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandDeleteMemoryData {
+    pub id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -550,24 +550,55 @@ pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
     // applicable; for simplicity in this migration we leave them empty and
     // let users re-attach via the Memory pane. (Forge content rows are not
     // dropped — they remain readable until v8.)
+    //
+    // **Name disambiguation (codex P1, 2026-05-08):**
+    // db_forge_agents.name allows duplicates (only `slug` is collision-
+    // resolved by the v4 migration). db_memories.name has a UNIQUE
+    // constraint, so a naive `INSERT OR IGNORE ... SELECT name` would
+    // silently drop all but one duplicate; the later memory_id backfill
+    // would then leave instances of the dropped definitions pointing at
+    // a non-existent memory_id. We disambiguate explicitly:
+    //
+    //   - If the forge agent's name is unique among forge agents AND no
+    //     existing db_memories row has the same name (e.g. user manually
+    //     created a memory before the migration), keep the original.
+    //   - Otherwise append " [<id-prefix>]" — first 8 chars of the agent
+    //     id, which IS unique because id is the primary key. The suffix
+    //     is deterministic so re-running the migration after a v8
+    //     downgrade-then-re-upgrade produces the same name.
+    //
+    // The OR IGNORE on the INSERT remains as belt-and-braces against the
+    // edge case where the user has both a forge agent "X" AND a memory
+    // "X [<same-prefix>]" pre-existing; in that case we accept silent
+    // skip rather than fail the whole migration.
     conn.execute_batch(
         "INSERT OR IGNORE INTO db_memories
             (id, name, description, is_blank, provider, model, instructions,
              context_files, mcp_servers, skills, created_at, updated_at)
          SELECT
-            id,
-            name,
-            COALESCE(description, ''),
+            fa.id,
+            CASE
+                WHEN EXISTS (
+                    SELECT 1 FROM db_forge_agents fb
+                    WHERE fb.name = fa.name AND fb.id != fa.id
+                ) OR EXISTS (
+                    SELECT 1 FROM db_memories m WHERE m.name = fa.name
+                )
+                THEN fa.name || ' [' || substr(fa.id, 1, 8) || ']'
+                ELSE fa.name
+            END,
+            COALESCE(fa.description, ''),
             0,
-            COALESCE(provider, ''),
+            COALESCE(fa.provider, ''),
             '',
             '',
             '[]',
             '[]',
             '[]',
-            COALESCE(created_at, 0),
-            COALESCE(created_at, 0)
-         FROM db_forge_agents;",
+            COALESCE(fa.created_at, 0),
+            COALESCE(fa.created_at, 0)
+         FROM db_forge_agents fa
+         WHERE NOT EXISTS (SELECT 1 FROM db_memories m WHERE m.id = fa.id);",
     )?;
 
     // ---- Backfill memory_id on existing instances ----
@@ -913,6 +944,109 @@ mod tests {
             )
             .unwrap();
         assert_eq!(migrated_name, "My Coder");
+    }
+
+    #[test]
+    fn test_forge_v7_disambiguates_duplicate_forge_agent_names() {
+        // codex P1, 2026-05-08: db_forge_agents.name allows duplicates
+        // (only slug is collision-resolved). Before this fix the migration
+        // used INSERT OR IGNORE ... SELECT name, silently dropping all but
+        // one duplicate; instances of the dropped definitions were left
+        // pointing at a non-existent memory_id.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+        conn.execute_batch(
+            "DELETE FROM db_memories;
+             INSERT INTO db_forge_agents
+                (id, slug, name, icon, provider, description, created_at)
+             VALUES
+                ('forge-aaaaaaaa', 'duplicate-a', 'Duplicate', '✦', 'claude', '', 100),
+                ('forge-bbbbbbbb', 'duplicate-b', 'Duplicate', '✦', 'codex',  '', 200);",
+        )
+        .unwrap();
+
+        run_forge_v7_migrations(&conn).unwrap();
+
+        // Both forge agents should have a corresponding memory row
+        // (plus the blank singleton — DELETE FROM db_memories above
+        // wiped that, but v7 re-seeds it via INSERT OR IGNORE).
+        let migrated: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_memories WHERE is_blank = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            migrated, 2,
+            "both duplicate-named forge agents should migrate"
+        );
+
+        // The names should be disambiguated with the id-prefix suffix.
+        let name_a: String = conn
+            .query_row(
+                "SELECT name FROM db_memories WHERE id='forge-aaaaaaaa'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let name_b: String = conn
+            .query_row(
+                "SELECT name FROM db_memories WHERE id='forge-bbbbbbbb'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(name_a, "Duplicate [forge-aa]");
+        assert_eq!(name_b, "Duplicate [forge-bb]");
+        assert_ne!(name_a, name_b, "disambiguated names must be unique");
+    }
+
+    #[test]
+    fn test_forge_v7_disambiguates_against_existing_memory_name() {
+        // If a user manually created a Memory bundle named "X" before this
+        // migration, and then has an old forge agent named "X", the
+        // migration must rename the migrated row to avoid a UNIQUE
+        // constraint failure.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+        conn.execute_batch(
+            "DELETE FROM db_memories;
+             INSERT INTO db_memories
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES ('user-mem', 'Coder', '', 0, 0, 0);
+             INSERT INTO db_forge_agents
+                (id, slug, name, icon, provider, description, created_at)
+             VALUES ('forge-cccccccc', 'coder', 'Coder', '✦', 'claude', '', 100);",
+        )
+        .unwrap();
+
+        run_forge_v7_migrations(&conn).unwrap();
+
+        let migrated_name: String = conn
+            .query_row(
+                "SELECT name FROM db_memories WHERE id='forge-cccccccc'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migrated_name, "Coder [forge-cc]");
+
+        // Original user memory remains intact.
+        let user_name: String = conn
+            .query_row(
+                "SELECT name FROM db_memories WHERE id='user-mem'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(user_name, "Coder");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -124,6 +124,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     run_forge_v4_migrations(conn)?;
     run_forge_v5_migrations(conn)?;
     run_forge_v6_migrations(conn)?;
+    run_forge_v7_migrations(conn)?;
     Ok(())
 }
 
@@ -432,6 +433,156 @@ pub fn run_forge_v6_migrations(conn: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// Forge v7 migrations: promote Identity to a named-bundle entity, introduce
+/// Memory as a sibling first-class entity, and rewire `db_agent_instances`
+/// to reference both via FKs. See
+/// `docs/specs/identity-forge-integration-and-vault-2026-05-08.md`.
+///
+/// Schema changes:
+///
+/// - `db_identities` (new): named Identity bundles. Each row has a unique
+///   `name` (e.g. "Work", "Personal"). The `is_blank` flag tags the seeded
+///   singleton row that the launch UI defaults to.
+/// - `db_identity_bindings` (new): junction `(identity_id, provider) →
+///   account_id`. Replaces the per-agent semantics of v6's
+///   `db_forge_agent_identities` (which is left in place as legacy fallback;
+///   a future v8 may drop it once all readers are migrated).
+/// - `db_memories` (new): named Memory bundles holding the agent's
+///   personality / capability stack — provider, model, instructions, context
+///   files, MCP servers, skills. Forge agents (`db_forge_agents`) get
+///   shadow-migrated into Memory rows so existing definitions remain
+///   accessible from the new code paths without data loss.
+/// - `db_agent_instances.identity_id` / `db_agent_instances.memory_id` (new
+///   columns): the launch composition. NULL means "use the blank
+///   singleton".
+///
+/// Idempotent: re-running `run_forge_migrations` after v7 has executed is a
+/// no-op. The legacy v6 tables (`db_forge_agents`, `db_forge_agent_identities`)
+/// are intentionally NOT dropped here; readers in the migrated code path
+/// ignore them, but they remain on disk so a downgrade path stays open until
+/// v8.
+pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
+    // ---- New tables ----
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS db_identities (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT NOT NULL DEFAULT '',
+            is_blank INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_identities_is_blank
+            ON db_identities(is_blank);
+
+        CREATE TABLE IF NOT EXISTS db_identity_bindings (
+            identity_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            PRIMARY KEY (identity_id, provider),
+            FOREIGN KEY (identity_id) REFERENCES db_identities(id) ON DELETE CASCADE,
+            FOREIGN KEY (account_id) REFERENCES db_identity_accounts(id) ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_identity_bindings_account
+            ON db_identity_bindings(account_id);
+
+        CREATE TABLE IF NOT EXISTS db_memories (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            description TEXT NOT NULL DEFAULT '',
+            is_blank INTEGER NOT NULL DEFAULT 0,
+            provider TEXT NOT NULL DEFAULT '',
+            model TEXT NOT NULL DEFAULT '',
+            instructions TEXT NOT NULL DEFAULT '',
+            context_files TEXT NOT NULL DEFAULT '[]',
+            mcp_servers TEXT NOT NULL DEFAULT '[]',
+            skills TEXT NOT NULL DEFAULT '[]',
+            created_at INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_memories_is_blank
+            ON db_memories(is_blank);",
+    )?;
+
+    // ---- Add identity_id / memory_id columns to db_agent_instances ----
+    let alter_statements = [
+        "ALTER TABLE db_agent_instances ADD COLUMN identity_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_instances ADD COLUMN memory_id TEXT NOT NULL DEFAULT ''",
+    ];
+    for stmt in &alter_statements {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("duplicate column") {
+                    return Err(StoreError::Sqlite(match e {
+                        rusqlite::Error::SqliteFailure(code, _) => {
+                            rusqlite::Error::SqliteFailure(code, Some(msg))
+                        }
+                        other => other,
+                    }));
+                }
+            }
+        }
+    }
+
+    // ---- Seed blank singletons ----
+    // The launch UI always renders these as the default option in the
+    // Identity / Memory dropdowns. Use fixed UUIDs so callers can hard-code
+    // references in tests + dev seed data.
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO db_identities (id, name, description, is_blank, created_at, updated_at)
+         VALUES ('blank', '__blank__', 'No credentials — use ambient', 1, 0, 0);
+
+         INSERT OR IGNORE INTO db_memories (id, name, description, is_blank, created_at, updated_at)
+         VALUES ('blank', '__blank__', 'Vanilla CLI — no instructions, no context', 1, 0, 0);",
+    )?;
+
+    // ---- Shadow-migrate existing forge agents into memories ----
+    // Forge agents (db_forge_agents) carry the same provider / model /
+    // instructions data we want in Memory. Copy each one into db_memories
+    // with the SAME id so existing references (e.g. db_agent_instances
+    // .definition_id) can be resolved by either reader during the
+    // transition window.
+    //
+    // Provider, model, and instructions come from db_forge_agents directly.
+    // context_files / mcp_servers / skills come from db_forge_content where
+    // applicable; for simplicity in this migration we leave them empty and
+    // let users re-attach via the Memory pane. (Forge content rows are not
+    // dropped — they remain readable until v8.)
+    conn.execute_batch(
+        "INSERT OR IGNORE INTO db_memories
+            (id, name, description, is_blank, provider, model, instructions,
+             context_files, mcp_servers, skills, created_at, updated_at)
+         SELECT
+            id,
+            name,
+            COALESCE(description, ''),
+            0,
+            COALESCE(provider, ''),
+            '',
+            '',
+            '[]',
+            '[]',
+            '[]',
+            COALESCE(created_at, 0),
+            COALESCE(created_at, 0)
+         FROM db_forge_agents;",
+    )?;
+
+    // ---- Backfill memory_id on existing instances ----
+    // Existing db_agent_instances rows reference a forge_agents.id via
+    // definition_id. Since we copied each forge agent into db_memories with
+    // the same id, the backfill is a straight assignment.
+    conn.execute_batch(
+        "UPDATE db_agent_instances
+         SET memory_id = definition_id
+         WHERE memory_id = '' AND definition_id <> '';",
+    )?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -639,5 +790,164 @@ mod tests {
             )
             .unwrap();
         assert_eq!(remaining, 0, "junction row should cascade-delete");
+    }
+
+    #[test]
+    fn test_forge_v7_creates_tables_and_singletons() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+
+        // Tables exist
+        for table in &["db_identities", "db_identity_bindings", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [table],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "table {table} should exist");
+        }
+
+        // Blank singletons seeded
+        let id_blank: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_identities WHERE id='blank' AND is_blank=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(id_blank, 1, "blank Identity singleton should be seeded");
+
+        let mem_blank: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_memories WHERE id='blank' AND is_blank=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mem_blank, 1, "blank Memory singleton should be seeded");
+
+        // identity_id + memory_id columns added to db_agent_instances
+        let cols: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(db_agent_instances)").unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            let mut out = Vec::new();
+            while let Some(row) = rows.next().unwrap() {
+                out.push(row.get::<_, String>(1).unwrap());
+            }
+            out
+        };
+        assert!(cols.contains(&"identity_id".to_string()));
+        assert!(cols.contains(&"memory_id".to_string()));
+    }
+
+    #[test]
+    fn test_forge_v7_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+        run_forge_migrations(&conn).unwrap(); // second pass
+
+        // Singletons remain unique (INSERT OR IGNORE on second pass)
+        let id_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_identities WHERE id='blank'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(id_count, 1, "blank Identity should remain a singleton");
+
+        let mem_count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_memories WHERE id='blank'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mem_count, 1, "blank Memory should remain a singleton");
+    }
+
+    #[test]
+    fn test_forge_v7_shadow_migrates_forge_agents_into_memories() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Run up through v6 first, insert a forge agent, then run v7.
+        // We fake "before-v7" by re-running migrations after a manual delete
+        // of the v7 rows the first run would have inserted.
+        run_forge_migrations(&conn).unwrap();
+        conn.execute_batch(
+            "DELETE FROM db_memories;
+             INSERT INTO db_forge_agents
+                (id, name, icon, provider, description, created_at)
+             VALUES ('forge-1', 'My Coder', '✦', 'claude', 'demo', 1234);",
+        )
+        .unwrap();
+
+        // Re-run the v7 migration directly. The shadow-copy is INSERT OR
+        // IGNORE so we need a clean slate for db_memories first (done above).
+        run_forge_v7_migrations(&conn).unwrap();
+
+        let migrated_provider: String = conn
+            .query_row(
+                "SELECT provider FROM db_memories WHERE id='forge-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migrated_provider, "claude");
+
+        let migrated_name: String = conn
+            .query_row(
+                "SELECT name FROM db_memories WHERE id='forge-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(migrated_name, "My Coder");
+    }
+
+    #[test]
+    fn test_forge_v7_backfills_memory_id_on_existing_instances() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Bring schema up via the full migration chain. This already creates
+        // the v7 tables and runs the backfill. To prove the backfill works
+        // on data that pre-dates v7, we (a) insert a forge agent + an
+        // instance referencing it, then (b) zero memory_id and (c) re-run
+        // v7 directly. After step (c) memory_id should be populated.
+        run_forge_migrations(&conn).unwrap();
+
+        conn.execute_batch(
+            "INSERT INTO db_forge_agents
+                (id, name, icon, provider, description, created_at)
+             VALUES ('forge-1', 'My Coder', '✦', 'claude', 'demo', 1234);
+
+             INSERT INTO db_agent_instances
+                (id, definition_id, memory_id, created_at)
+             VALUES ('inst-1', 'forge-1', '', 0);",
+        )
+        .unwrap();
+
+        run_forge_v7_migrations(&conn).unwrap();
+
+        let backfilled: String = conn
+            .query_row(
+                "SELECT memory_id FROM db_agent_instances WHERE id='inst-1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(backfilled, "forge-1");
     }
 }

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -539,17 +539,19 @@ pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
     )?;
 
     // ---- Shadow-migrate existing forge agents into memories ----
-    // Forge agents (db_forge_agents) carry the same provider / model /
-    // instructions data we want in Memory. Copy each one into db_memories
-    // with the SAME id so existing references (e.g. db_agent_instances
-    // .definition_id) can be resolved by either reader during the
-    // transition window.
+    // Of the Memory shape, only `provider` lives directly on
+    // db_forge_agents — the v6 schema doesn't have `model` or
+    // `instructions` columns. Forge stored those in db_forge_content
+    // rows keyed by content_type ("soul", "agentmd", etc.); importing
+    // them is deferred to a follow-up so this migration stays small.
+    // db_forge_content rows remain readable on disk until v8.
     //
-    // Provider, model, and instructions come from db_forge_agents directly.
-    // context_files / mcp_servers / skills come from db_forge_content where
-    // applicable; for simplicity in this migration we leave them empty and
-    // let users re-attach via the Memory pane. (Forge content rows are not
-    // dropped — they remain readable until v8.)
+    // What this SELECT does copy: id (preserved so existing
+    // db_agent_instances.definition_id references resolve via either
+    // reader during the transition window), name (with
+    // disambiguation, see below), description, provider, created_at.
+    // model / instructions / context_files / mcp_servers / skills are
+    // seeded empty; users fill them in via the Memory pane.
     //
     // **Name disambiguation (codex P1, 2026-05-08):**
     // db_forge_agents.name allows duplicates (only `slug` is collision-

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1196,6 +1196,16 @@ pub struct AgentInstance {
     #[serde(default)]
     pub ended_at: i64,
     pub created_at: i64,
+    /// FK to `db_identities.id`. Empty string means "use the blank
+    /// singleton" (= ambient creds, no env-var injection). Set at
+    /// instantiation via the launch modal's Identity dropdown.
+    #[serde(default)]
+    pub identity_id: String,
+    /// FK to `db_memories.id`. Empty string means "use the blank
+    /// singleton" (= vanilla CLI, no instructions). Set at
+    /// instantiation via the launch modal's Memory dropdown.
+    #[serde(default)]
+    pub memory_id: String,
 }
 
 impl WaveStore {
@@ -1417,7 +1427,8 @@ impl WaveStore {
         // can't reuse a single prepared statement across filter combos.
         let mut sql = String::from(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id
              FROM db_agent_instances",
         );
         let mut clauses: Vec<&str> = Vec::new();
@@ -1444,20 +1455,7 @@ impl WaveStore {
         if let Some(s) = status {
             param_vals.push(s.to_string());
         }
-        let iter = stmt.query_map(rusqlite::params_from_iter(param_vals.iter()), |row| {
-            Ok(AgentInstance {
-                id: row.get(0)?,
-                definition_id: row.get(1)?,
-                parent_instance_id: row.get(2)?,
-                block_id: row.get(3)?,
-                session_id: row.get(4)?,
-                status: row.get(5)?,
-                github_context: row.get(6)?,
-                started_at: row.get(7)?,
-                ended_at: row.get(8)?,
-                created_at: row.get(9)?,
-            })
-        })?;
+        let iter = stmt.query_map(rusqlite::params_from_iter(param_vals.iter()), map_instance_row)?;
         let mut out = Vec::new();
         for r in iter {
             out.push(r?);
@@ -1469,23 +1467,11 @@ impl WaveStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
-                    status, github_context, started_at, ended_at, created_at
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id
              FROM db_agent_instances WHERE id = ?1",
         )?;
-        let result = stmt.query_row(params![id], |row| {
-            Ok(AgentInstance {
-                id: row.get(0)?,
-                definition_id: row.get(1)?,
-                parent_instance_id: row.get(2)?,
-                block_id: row.get(3)?,
-                session_id: row.get(4)?,
-                status: row.get(5)?,
-                github_context: row.get(6)?,
-                started_at: row.get(7)?,
-                ended_at: row.get(8)?,
-                created_at: row.get(9)?,
-            })
-        });
+        let result = stmt.query_row(params![id], map_instance_row);
         match result {
             Ok(a) => Ok(Some(a)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
@@ -1499,8 +1485,9 @@ impl WaveStore {
         conn.execute(
             "INSERT INTO db_agent_instances
                 (id, definition_id, parent_instance_id, block_id, session_id, status,
-                 github_context, started_at, ended_at, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                 github_context, started_at, ended_at, created_at,
+                 identity_id, memory_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 inst.id,
                 inst.definition_id,
@@ -1512,6 +1499,8 @@ impl WaveStore {
                 inst.started_at,
                 inst.ended_at,
                 inst.created_at,
+                inst.identity_id,
+                inst.memory_id,
             ],
         )?;
         Ok(())
@@ -1797,6 +1786,23 @@ fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
         skills: row.get(9)?,
         created_at: row.get(10)?,
         updated_at: row.get(11)?,
+    })
+}
+
+fn map_instance_row(row: &rusqlite::Row) -> rusqlite::Result<AgentInstance> {
+    Ok(AgentInstance {
+        id: row.get(0)?,
+        definition_id: row.get(1)?,
+        parent_instance_id: row.get(2)?,
+        block_id: row.get(3)?,
+        session_id: row.get(4)?,
+        status: row.get(5)?,
+        github_context: row.get(6)?,
+        started_at: row.get(7)?,
+        ended_at: row.get(8)?,
+        created_at: row.get(9)?,
+        identity_id: row.get(10)?,
+        memory_id: row.get(11)?,
     })
 }
 
@@ -2329,6 +2335,8 @@ mod tests {
             started_at: 1000,
             ended_at: 0,
             created_at: 1000,
+            identity_id: String::new(),
+            memory_id: String::new(),
         };
         store.instance_create(&inst).unwrap();
 
@@ -2370,6 +2378,8 @@ mod tests {
             started_at: 0,
             ended_at: 0,
             created_at: 0,
+            identity_id: String::new(),
+            memory_id: String::new(),
         };
         store.instance_create(&inst).unwrap();
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1061,6 +1061,69 @@ pub struct ForgeAgentIdentity {
     pub provider: String,
 }
 
+// ====================================================================
+// v7 — Identity bundles (named credential bundles) + Memory bundles
+// ====================================================================
+
+/// A named credential bundle. Contains zero or more accounts via the
+/// `db_identity_bindings` junction. `is_blank` tags the seeded singleton
+/// row that the launch UI uses as the default option.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Identity {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub is_blank: bool,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Junction row binding an account to an identity for a given provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityBinding {
+    pub identity_id: String,
+    pub provider: String,
+    pub account_id: String,
+}
+
+/// A Memory bundle — the agent's personality and capability stack.
+/// Provider, model, instructions, and JSON-encoded arrays of context
+/// files / MCP servers / skills. Forge agents shadow-migrate into this
+/// table during the v7 migration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Memory {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub is_blank: bool,
+    /// "claude" | "codex" | "gemini" | empty string
+    #[serde(default)]
+    pub provider: String,
+    #[serde(default)]
+    pub model: String,
+    #[serde(default)]
+    pub instructions: String,
+    /// JSON-encoded array; the renderer types it as `[{path, content}]`.
+    #[serde(default = "default_json_array_string")]
+    pub context_files: String,
+    /// JSON-encoded array of MCP server configs.
+    #[serde(default = "default_json_array_string")]
+    pub mcp_servers: String,
+    /// JSON-encoded array of skill IDs.
+    #[serde(default = "default_json_array_string")]
+    pub skills: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+fn default_json_array_string() -> String {
+    "[]".to_string()
+}
+
 /// Instance lifecycle status. Serialised lowercase to match the DB text.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -1484,6 +1547,257 @@ impl WaveStore {
         let rows = conn.execute("DELETE FROM db_agent_instances WHERE id = ?1", params![id])?;
         Ok(rows > 0)
     }
+
+    // ====================================================================
+    // v7 — Identity bundles (named credential bundles) + Memory bundles
+    // ====================================================================
+
+    // ---- Identity bundle CRUD ----
+
+    /// List all Identity bundles, blank singleton last so the picker shows
+    /// user-defined bundles first.
+    pub fn bundle_identity_list(&self) -> Result<Vec<Identity>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, is_blank, created_at, updated_at
+             FROM db_identities
+             ORDER BY is_blank ASC, updated_at DESC",
+        )?;
+        let iter = stmt.query_map([], |row| {
+            Ok(Identity {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                is_blank: row.get::<_, i64>(3)? != 0,
+                created_at: row.get(4)?,
+                updated_at: row.get(5)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    pub fn bundle_identity_get(&self, id: &str) -> Result<Option<Identity>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, is_blank, created_at, updated_at
+             FROM db_identities WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id], |row| {
+            Ok(Identity {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                description: row.get(2)?,
+                is_blank: row.get::<_, i64>(3)? != 0,
+                created_at: row.get(4)?,
+                updated_at: row.get(5)?,
+            })
+        });
+        match result {
+            Ok(i) => Ok(Some(i)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Upsert an Identity bundle. Caller mints the id (no silent generation).
+    /// The `is_blank` flag is reserved for the seeded singleton — callers
+    /// should pass `false` for user-created identities.
+    pub fn bundle_identity_upsert(&self, identity: &Identity) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_identities
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                updated_at = excluded.updated_at",
+            params![
+                identity.id,
+                identity.name,
+                identity.description,
+                identity.is_blank as i64,
+                identity.created_at,
+                identity.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Delete an Identity bundle. Refuses to delete the blank singleton —
+    /// the launch UI depends on it as the always-present default option.
+    pub fn bundle_identity_delete(&self, id: &str) -> Result<bool, StoreError> {
+        if id == "blank" {
+            return Err(StoreError::Other(
+                "cannot delete the blank Identity singleton".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_identities WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+
+    // ---- Identity bundle bindings (junction with accounts) ----
+
+    /// Set the account for `(identity_id, provider)`. Overwrites any
+    /// existing binding for the same (identity, provider).
+    pub fn bundle_identity_bind(
+        &self,
+        identity_id: &str,
+        provider: &str,
+        account_id: &str,
+    ) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_identity_bindings (identity_id, provider, account_id)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(identity_id, provider) DO UPDATE SET account_id = excluded.account_id",
+            params![identity_id, provider, account_id],
+        )?;
+        Ok(())
+    }
+
+    /// Remove the binding for `(identity_id, provider)`. Returns whether a
+    /// row was deleted.
+    pub fn bundle_identity_unbind(
+        &self,
+        identity_id: &str,
+        provider: &str,
+    ) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "DELETE FROM db_identity_bindings WHERE identity_id = ?1 AND provider = ?2",
+            params![identity_id, provider],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// List bindings for an Identity bundle.
+    pub fn bundle_identity_bindings(
+        &self,
+        identity_id: &str,
+    ) -> Result<Vec<IdentityBinding>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT identity_id, provider, account_id
+             FROM db_identity_bindings
+             WHERE identity_id = ?1
+             ORDER BY provider ASC",
+        )?;
+        let iter = stmt.query_map(params![identity_id], |row| {
+            Ok(IdentityBinding {
+                identity_id: row.get(0)?,
+                provider: row.get(1)?,
+                account_id: row.get(2)?,
+            })
+        })?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    // ---- Memory bundle CRUD ----
+
+    pub fn bundle_memory_list(&self) -> Result<Vec<Memory>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, is_blank, provider, model, instructions,
+                    context_files, mcp_servers, skills, created_at, updated_at
+             FROM db_memories
+             ORDER BY is_blank ASC, updated_at DESC",
+        )?;
+        let iter = stmt.query_map([], map_memory_row)?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    pub fn bundle_memory_get(&self, id: &str) -> Result<Option<Memory>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, name, description, is_blank, provider, model, instructions,
+                    context_files, mcp_servers, skills, created_at, updated_at
+             FROM db_memories WHERE id = ?1",
+        )?;
+        let result = stmt.query_row(params![id], map_memory_row);
+        match result {
+            Ok(m) => Ok(Some(m)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn bundle_memory_upsert(&self, memory: &Memory) -> Result<(), StoreError> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO db_memories
+                (id, name, description, is_blank, provider, model, instructions,
+                 context_files, mcp_servers, skills, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+             ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                provider = excluded.provider,
+                model = excluded.model,
+                instructions = excluded.instructions,
+                context_files = excluded.context_files,
+                mcp_servers = excluded.mcp_servers,
+                skills = excluded.skills,
+                updated_at = excluded.updated_at",
+            params![
+                memory.id,
+                memory.name,
+                memory.description,
+                memory.is_blank as i64,
+                memory.provider,
+                memory.model,
+                memory.instructions,
+                memory.context_files,
+                memory.mcp_servers,
+                memory.skills,
+                memory.created_at,
+                memory.updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a Memory bundle. Refuses to delete the blank singleton.
+    pub fn bundle_memory_delete(&self, id: &str) -> Result<bool, StoreError> {
+        if id == "blank" {
+            return Err(StoreError::Other(
+                "cannot delete the blank Memory singleton".to_string(),
+            ));
+        }
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute("DELETE FROM db_memories WHERE id = ?1", params![id])?;
+        Ok(rows > 0)
+    }
+}
+
+fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
+    Ok(Memory {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        description: row.get(2)?,
+        is_blank: row.get::<_, i64>(3)? != 0,
+        provider: row.get(4)?,
+        model: row.get(5)?,
+        instructions: row.get(6)?,
+        context_files: row.get(7)?,
+        mcp_servers: row.get(8)?,
+        skills: row.get(9)?,
+        created_at: row.get(10)?,
+        updated_at: row.get(11)?,
+    })
 }
 
 // ====================================================================
@@ -2075,5 +2389,205 @@ mod tests {
             assert_eq!(Some(*s), InstanceStatus::parse(s.as_str()));
         }
         assert_eq!(None, InstanceStatus::parse("nonsense"));
+    }
+
+    // ── v7 — Identity bundle accessors ───────────────────────────────────
+
+    #[test]
+    fn test_bundle_identity_lifecycle() {
+        let store = make_store();
+
+        // Blank singleton always present.
+        let initial = store.bundle_identity_list().unwrap();
+        assert_eq!(initial.len(), 1);
+        assert!(initial[0].is_blank);
+        assert_eq!(initial[0].id, "blank");
+
+        // Upsert a user identity.
+        let work = Identity {
+            id: "id-work".to_string(),
+            name: "Work".to_string(),
+            description: "Office laptop credentials".to_string(),
+            is_blank: false,
+            created_at: 100,
+            updated_at: 100,
+        };
+        store.bundle_identity_upsert(&work).unwrap();
+
+        // List orders user identities first, blank last.
+        let listed = store.bundle_identity_list().unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, "id-work");
+        assert_eq!(listed[1].id, "blank");
+
+        // Get round-trip.
+        let fetched = store.bundle_identity_get("id-work").unwrap().unwrap();
+        assert_eq!(fetched.name, "Work");
+
+        // Refuse to delete the blank singleton.
+        let blank_delete = store.bundle_identity_delete("blank");
+        assert!(blank_delete.is_err());
+
+        // Delete the user identity.
+        assert!(store.bundle_identity_delete("id-work").unwrap());
+        assert_eq!(store.bundle_identity_list().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_bundle_identity_bindings_round_trip() {
+        let store = make_store();
+
+        // Need an account to bind.
+        let acct = IdentityAccount {
+            id: "acct-1".to_string(),
+            name: "asaf-github".to_string(),
+            provider: "github".to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::Env {
+                env_var: "GITHUB_TOKEN".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&acct).unwrap();
+
+        let identity = Identity {
+            id: "id-work".to_string(),
+            name: "Work".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        // Bind, list, unbind.
+        store
+            .bundle_identity_bind("id-work", "github", "acct-1")
+            .unwrap();
+        let bindings = store.bundle_identity_bindings("id-work").unwrap();
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].provider, "github");
+        assert_eq!(bindings[0].account_id, "acct-1");
+
+        // Re-bind same provider replaces the account.
+        let acct2 = IdentityAccount {
+            id: "acct-2".to_string(),
+            name: "asaf-github-2".to_string(),
+            provider: "github".to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::Env {
+                env_var: "GITHUB_TOKEN_ALT".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&acct2).unwrap();
+        store
+            .bundle_identity_bind("id-work", "github", "acct-2")
+            .unwrap();
+        let rebound = store.bundle_identity_bindings("id-work").unwrap();
+        assert_eq!(rebound.len(), 1);
+        assert_eq!(rebound[0].account_id, "acct-2");
+
+        // Unbind.
+        assert!(store.bundle_identity_unbind("id-work", "github").unwrap());
+        assert_eq!(
+            store.bundle_identity_bindings("id-work").unwrap().len(),
+            0
+        );
+    }
+
+    #[test]
+    fn test_bundle_identity_bindings_cascade_on_account_delete() {
+        let store = make_store();
+
+        let acct = IdentityAccount {
+            id: "acct-1".to_string(),
+            name: "asaf-github".to_string(),
+            provider: "github".to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref: SecretRef::Env {
+                env_var: "GITHUB_TOKEN".to_string(),
+            },
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.identity_upsert(&acct).unwrap();
+
+        let identity = Identity {
+            id: "id-work".to_string(),
+            name: "Work".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+        store
+            .bundle_identity_bind("id-work", "github", "acct-1")
+            .unwrap();
+
+        // Deleting the account cascades the binding row.
+        store.identity_delete("acct-1").unwrap();
+        assert_eq!(
+            store.bundle_identity_bindings("id-work").unwrap().len(),
+            0
+        );
+    }
+
+    // ── v7 — Memory bundle accessors ─────────────────────────────────────
+
+    #[test]
+    fn test_bundle_memory_lifecycle() {
+        let store = make_store();
+
+        // Blank singleton always present.
+        let initial = store.bundle_memory_list().unwrap();
+        assert_eq!(initial.len(), 1);
+        assert!(initial[0].is_blank);
+        assert_eq!(initial[0].id, "blank");
+
+        // Upsert a user memory.
+        let coder = Memory {
+            id: "mem-coder".to_string(),
+            name: "Claude-coder".to_string(),
+            description: "Pair-programming setup".to_string(),
+            is_blank: false,
+            provider: "claude".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            instructions: "You are a careful refactorer.".to_string(),
+            context_files: "[]".to_string(),
+            mcp_servers: "[]".to_string(),
+            skills: "[]".to_string(),
+            created_at: 100,
+            updated_at: 100,
+        };
+        store.bundle_memory_upsert(&coder).unwrap();
+
+        let listed = store.bundle_memory_list().unwrap();
+        assert_eq!(listed.len(), 2);
+        assert_eq!(listed[0].id, "mem-coder");
+        assert_eq!(listed[1].id, "blank");
+
+        let fetched = store.bundle_memory_get("mem-coder").unwrap().unwrap();
+        assert_eq!(fetched.provider, "claude");
+        assert_eq!(fetched.instructions, "You are a careful refactorer.");
+
+        // Refuse to delete the blank singleton.
+        assert!(store.bundle_memory_delete("blank").is_err());
+
+        // Delete the user memory.
+        assert!(store.bundle_memory_delete("mem-coder").unwrap());
+        assert_eq!(store.bundle_memory_list().unwrap().len(), 1);
     }
 }

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1286,7 +1286,12 @@ fn register_v7_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let mut bundle: Identity = serde_json::from_value(data)
                     .map_err(|e| format!("upsertidentitybundle: {e}"))?;
-                if bundle.is_blank {
+                // Guard on BOTH client-supplied is_blank AND id == "blank".
+                // Without the id check a caller could send
+                // {id:"blank", is_blank:false, name:"evil"} and the
+                // ON CONFLICT(id) DO UPDATE path would rename/re-describe
+                // the seeded singleton. (reagent P1, 2026-05-08).
+                if bundle.is_blank || bundle.id == "blank" {
                     return Err(
                         "upsertidentitybundle: cannot mutate the blank singleton".to_string(),
                     );
@@ -1459,7 +1464,10 @@ fn register_v7_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let mut memory: Memory = serde_json::from_value(data)
                     .map_err(|e| format!("upsertmemory: {e}"))?;
-                if memory.is_blank {
+                // Guard on BOTH client-supplied is_blank AND id == "blank".
+                // Same bypass as upsertidentitybundle — see that comment.
+                // (reagent P1, 2026-05-08).
+                if memory.is_blank || memory.id == "blank" {
                     return Err("upsertmemory: cannot mutate the blank singleton".to_string());
                 }
                 if memory.id.is_empty() {

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1005,6 +1005,12 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: now,
                     ended_at: 0,
                     created_at: now,
+                    // identity_id / memory_id default to empty (= blank
+                    // singleton) until the launch modal wires user picks
+                    // through to this handler. PR-F.3 will add the
+                    // command fields and pass them here.
+                    identity_id: String::new(),
+                    memory_id: String::new(),
                 };
                 wstore
                     .instance_create(&inst)
@@ -1046,6 +1052,11 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: existing.started_at,
                     ended_at: cmd.ended_at.unwrap_or(existing.ended_at),
                     created_at: existing.created_at,
+                    // identity_id / memory_id are immutable post-create
+                    // (mid-session credential rotation is out of scope —
+                    // launch a new instance with a different bundle).
+                    identity_id: existing.identity_id.clone(),
+                    memory_id: existing.memory_id.clone(),
                 };
                 wstore
                     .instance_update(&merged)

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -39,9 +39,22 @@ use crate::backend::rpc_types::{
     CommandCreateAgentInstanceData, CommandUpdateAgentInstanceData,
     CommandDeleteAgentInstanceData,
     CommandForkAgentDefinitionData,
+    // v7 Identity bundles + Memory
+    COMMAND_LIST_IDENTITY_BUNDLES, COMMAND_GET_IDENTITY_BUNDLE,
+    COMMAND_UPSERT_IDENTITY_BUNDLE, COMMAND_DELETE_IDENTITY_BUNDLE,
+    COMMAND_BIND_IDENTITY_ACCOUNT, COMMAND_UNBIND_IDENTITY_ACCOUNT,
+    COMMAND_LIST_IDENTITY_BINDINGS,
+    COMMAND_LIST_MEMORIES, COMMAND_GET_MEMORY,
+    COMMAND_UPSERT_MEMORY, COMMAND_DELETE_MEMORY,
+    CommandGetIdentityBundleData, CommandDeleteIdentityBundleData,
+    CommandBindIdentityAccountData, CommandUnbindIdentityAccountData,
+    CommandListIdentityBindingsData,
+    CommandGetMemoryData, CommandDeleteMemoryData,
 };
 use crate::backend::storage::{ForgeAgent, ForgeContent, ForgeSkill};
-use crate::backend::storage::wstore::{AgentInstance, IdentityAccount, InstanceStatus};
+use crate::backend::storage::wstore::{
+    AgentInstance, Identity, IdentityAccount, InstanceStatus, Memory,
+};
 
 use super::AppState;
 
@@ -1214,6 +1227,290 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 });
 
                 Ok(Some(serde_json::to_value(&fork).unwrap_or_default()))
+            })
+        }),
+    );
+
+    register_v7_handlers(engine, state);
+}
+
+/// v7 handlers — Identity bundles (named credential bundles) + Memory bundles.
+/// See `docs/specs/identity-forge-integration-and-vault-2026-05-08.md`.
+///
+/// Identity bundles aggregate accounts (one per provider) under a named
+/// label, replacing the per-agent `db_forge_agent_identities` semantics.
+/// Memory bundles hold the agent's personality + capability stack.
+fn register_v7_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    // ---- Identity bundle CRUD ----
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_IDENTITY_BUNDLES,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let bundles = wstore
+                    .bundle_identity_list()
+                    .map_err(|e| format!("listidentitybundles: {e}"))?;
+                Ok(Some(serde_json::to_value(&bundles).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_GET_IDENTITY_BUNDLE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandGetIdentityBundleData = serde_json::from_value(data)
+                    .map_err(|e| format!("getidentitybundle: {e}"))?;
+                match wstore
+                    .bundle_identity_get(&cmd.id)
+                    .map_err(|e| format!("getidentitybundle: {e}"))?
+                {
+                    Some(b) => Ok(Some(serde_json::to_value(&b).unwrap_or_default())),
+                    None => Err(format!("getidentitybundle: not found id={}", cmd.id)),
+                }
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPSERT_IDENTITY_BUNDLE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let mut bundle: Identity = serde_json::from_value(data)
+                    .map_err(|e| format!("upsertidentitybundle: {e}"))?;
+                if bundle.is_blank {
+                    return Err(
+                        "upsertidentitybundle: cannot mutate the blank singleton".to_string(),
+                    );
+                }
+                if bundle.id.is_empty() {
+                    bundle.id = uuid::Uuid::new_v4().to_string();
+                }
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if bundle.created_at == 0 {
+                    bundle.created_at = now;
+                }
+                bundle.updated_at = now;
+                wstore
+                    .bundle_identity_upsert(&bundle)
+                    .map_err(|e| format!("upsertidentitybundle: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "identitybundles:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&bundle).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_IDENTITY_BUNDLE,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteIdentityBundleData = serde_json::from_value(data)
+                    .map_err(|e| format!("deleteidentitybundle: {e}"))?;
+                let deleted = wstore
+                    .bundle_identity_delete(&cmd.id)
+                    .map_err(|e| format!("deleteidentitybundle: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "identitybundles:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+
+    // ---- Identity bundle bindings (junction with accounts) ----
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_BIND_IDENTITY_ACCOUNT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandBindIdentityAccountData = serde_json::from_value(data)
+                    .map_err(|e| format!("bindidentityaccount: {e}"))?;
+                wstore
+                    .bundle_identity_bind(&cmd.identity_id, &cmd.provider, &cmd.account_id)
+                    .map_err(|e| format!("bindidentityaccount: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: format!("identitybundlebindings:changed:{}", cmd.identity_id),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(None)
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UNBIND_IDENTITY_ACCOUNT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandUnbindIdentityAccountData = serde_json::from_value(data)
+                    .map_err(|e| format!("unbindidentityaccount: {e}"))?;
+                let removed = wstore
+                    .bundle_identity_unbind(&cmd.identity_id, &cmd.provider)
+                    .map_err(|e| format!("unbindidentityaccount: {e}"))?;
+                if removed {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: format!("identitybundlebindings:changed:{}", cmd.identity_id),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "unbound": removed })))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_IDENTITY_BINDINGS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandListIdentityBindingsData = serde_json::from_value(data)
+                    .map_err(|e| format!("listidentitybindings: {e}"))?;
+                let bindings = wstore
+                    .bundle_identity_bindings(&cmd.identity_id)
+                    .map_err(|e| format!("listidentitybindings: {e}"))?;
+                Ok(Some(serde_json::to_value(&bindings).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // ---- Memory bundle CRUD ----
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_MEMORIES,
+        Box::new(move |_data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let memories = wstore
+                    .bundle_memory_list()
+                    .map_err(|e| format!("listmemories: {e}"))?;
+                Ok(Some(serde_json::to_value(&memories).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_GET_MEMORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandGetMemoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("getmemory: {e}"))?;
+                match wstore
+                    .bundle_memory_get(&cmd.id)
+                    .map_err(|e| format!("getmemory: {e}"))?
+                {
+                    Some(m) => Ok(Some(serde_json::to_value(&m).unwrap_or_default())),
+                    None => Err(format!("getmemory: not found id={}", cmd.id)),
+                }
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_UPSERT_MEMORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let mut memory: Memory = serde_json::from_value(data)
+                    .map_err(|e| format!("upsertmemory: {e}"))?;
+                if memory.is_blank {
+                    return Err("upsertmemory: cannot mutate the blank singleton".to_string());
+                }
+                if memory.id.is_empty() {
+                    memory.id = uuid::Uuid::new_v4().to_string();
+                }
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_millis() as i64)
+                    .unwrap_or(0);
+                if memory.created_at == 0 {
+                    memory.created_at = now;
+                }
+                memory.updated_at = now;
+                wstore
+                    .bundle_memory_upsert(&memory)
+                    .map_err(|e| format!("upsertmemory: {e}"))?;
+                broker.publish(crate::backend::wps::WaveEvent {
+                    event: "memories:changed".to_string(),
+                    scopes: vec![],
+                    sender: String::new(),
+                    persist: 0,
+                    data: None,
+                });
+                Ok(Some(serde_json::to_value(&memory).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_DELETE_MEMORY,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandDeleteMemoryData = serde_json::from_value(data)
+                    .map_err(|e| format!("deletememory: {e}"))?;
+                let deleted = wstore
+                    .bundle_memory_delete(&cmd.id)
+                    .map_err(|e| format!("deletememory: {e}"))?;
+                if deleted {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "memories:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "deleted": deleted })))
             })
         }),
     );

--- a/docs/specs/identity-forge-integration-and-vault-2026-05-08.md
+++ b/docs/specs/identity-forge-integration-and-vault-2026-05-08.md
@@ -59,14 +59,19 @@ db_identities (
   updated_at      TEXT NOT NULL
 )
 
-db_identity_accounts (
+db_identity_bindings (
   identity_id     TEXT NOT NULL,
   account_id      TEXT NOT NULL,
   provider        TEXT NOT NULL,
   PRIMARY KEY (identity_id, provider),
   FOREIGN KEY (identity_id) REFERENCES db_identities(id) ON DELETE CASCADE,
-  FOREIGN KEY (account_id)  REFERENCES db_accounts(id)
+  FOREIGN KEY (account_id)  REFERENCES db_identity_accounts(id) ON DELETE CASCADE
 )
+-- The junction is named `db_identity_bindings` (not `db_identity_accounts`) so it
+-- doesn't collide with the v6 individual-credentials table that the agent
+-- pane's Identity tab already uses. The FK target for account_id is the
+-- existing `db_identity_accounts` table — we don't introduce a new
+-- `db_accounts` table.
 
 db_memories (
   id              TEXT PRIMARY KEY,
@@ -103,7 +108,7 @@ DROP TABLE db_forge_agents;             -- after migration into db_memories
 
 New migration v8 runs in this order:
 
-1. Create `db_identities`, `db_identity_accounts`, `db_memories`.
+1. Create `db_identities`, `db_identity_bindings`, `db_memories`.
 2. Insert the singleton blank Identity (`name = '__blank__'`, `is_blank = 1`).
 3. Insert the singleton blank Memory (`name = '__blank__'`, `is_blank = 1`).
 4. Migrate existing data:
@@ -176,7 +181,7 @@ Two buttons on the Identity tab:
 
 **Export Vault**
 - File: `agentmux-vault-<timestamp>.agentmux-vault`.
-- Contents: all `db_identities` rows + their `db_identity_accounts` rows + the referenced `db_accounts` rows + resolved `secret_ref` plaintext values.
+- Contents: all `db_identities` rows + their `db_identity_bindings` rows + the referenced `db_identity_accounts` rows + resolved `secret_ref` plaintext values.
 - Crypto: Argon2id-derived key (params: m=64MB, t=3, p=4 — OWASP 2023 minimums), AES-256-GCM, random 12-byte nonce. Header: magic + version + salt + nonce.
 - Passphrase prompt every time. No caching.
 

--- a/docs/specs/identity-forge-integration-and-vault-2026-05-08.md
+++ b/docs/specs/identity-forge-integration-and-vault-2026-05-08.md
@@ -1,0 +1,295 @@
+# Agent Composition — Identity + Memory + Vault (PR-F / PR-G)
+
+**Date:** 2026-05-08
+**Author:** AgentA-asaf
+**Issue:** #678 (continued from Phase 1 + Phase 2)
+**Supersedes:** earlier draft of this file (the per-provider Forge-form picker plan)
+**Status:** Proposed — rewrites the model after user feedback
+
+---
+
+## The model
+
+Two first-class concepts. Nothing else.
+
+```
+Identity  +  Memory  →  Agent Instance
+(creds)      (everything that makes the agent be itself —
+              CLI choice, model, soul, instructions, context
+              files, MCP servers, skills)
+```
+
+There is **no separate "agent definition" entity**. A Memory bundle *is* the agent — its provider choice, its instructions, its context, its tools.
+
+### Composition at launch
+
+The Launch Agent modal has **two dropdowns**:
+
+- **Identity** — pick a credential bundle (or the blank default = ambient creds).
+- **Memory** — pick a personality / capability bundle (or the blank default = vanilla CLI with no instructions).
+
+Both dropdowns always have a "blank" option at the top. If the user does nothing, the instance launches with both blank — the equivalent of a plain unconfigured CLI session. No selection blocks the launch.
+
+### Forge becomes Memory; both Identity and Memory are first-class panes
+
+There is no `Forge` concept anywhere — no entity, no tab, no widget. **Forge becomes Memory.** Existing `db_forge_agents` rows migrate into `db_memories`.
+
+**Identity and Memory each become their own standalone pane types** (block views), surfaced by widgets:
+
+- `defwidget@identity` — opens the Identity management pane.
+- `defwidget@memory` — opens the Memory management pane.
+
+You **go into** the Identity pane to manage credential bundles and the accounts inside them. You **go into** the Memory pane to manage personality/capability bundles (provider, model, instructions, context files, MCPs). They're not tabs inside the agent pane — they're top-level panes you can open in any tab, split alongside terminals, etc., because they're reusable across instances.
+
+This reverses PR-D's docs claim that "Forge and Identity are not standalone pane types — they're tabs inside the Agent pane." That was true for the previous model. The new model promotes Identity and Memory to first-class panes; the agent pane no longer carries Forge or Identity tabs.
+
+---
+
+## Schema
+
+### New tables
+
+```sql
+db_identities (
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL UNIQUE,    -- "Work", "Personal", "Demo"
+  description     TEXT,
+  is_blank        INTEGER NOT NULL DEFAULT 0,  -- 1 for the singleton blank row
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+)
+
+db_identity_accounts (
+  identity_id     TEXT NOT NULL,
+  account_id      TEXT NOT NULL,
+  provider        TEXT NOT NULL,
+  PRIMARY KEY (identity_id, provider),
+  FOREIGN KEY (identity_id) REFERENCES db_identities(id) ON DELETE CASCADE,
+  FOREIGN KEY (account_id)  REFERENCES db_accounts(id)
+)
+
+db_memories (
+  id              TEXT PRIMARY KEY,
+  name            TEXT NOT NULL UNIQUE,    -- "Claude-coder", "Codex-reviewer"
+  description     TEXT,
+  is_blank        INTEGER NOT NULL DEFAULT 0,
+  provider        TEXT,                    -- "claude" | "codex" | "gemini" | NULL
+  model           TEXT,                    -- "claude-sonnet-4-6", etc.
+  instructions    TEXT,                    -- system prompt / soul
+  context_files   TEXT,                    -- JSON array of {path, content}
+  mcp_servers     TEXT,                    -- JSON array of MCP server configs
+  skills          TEXT,                    -- JSON array of skill refs
+  created_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL
+)
+```
+
+The `is_blank` flag identifies the singleton blank row that's seeded on migration. The launch UI always renders the blank row first in each dropdown.
+
+### Modified tables
+
+```sql
+-- Replace PR #745's JSON column with single FKs:
+ALTER TABLE db_agent_instances ADD COLUMN identity_id TEXT REFERENCES db_identities(id);
+ALTER TABLE db_agent_instances ADD COLUMN memory_id   TEXT REFERENCES db_memories(id);
+ALTER TABLE db_agent_instances DROP   COLUMN identities;  -- the v7 JSON column
+
+-- Drop the Forge concept entirely:
+DROP TABLE db_forge_agent_identities;  -- v6 junction
+DROP TABLE db_forge_agents;             -- after migration into db_memories
+```
+
+### Migration
+
+New migration v8 runs in this order:
+
+1. Create `db_identities`, `db_identity_accounts`, `db_memories`.
+2. Insert the singleton blank Identity (`name = '__blank__'`, `is_blank = 1`).
+3. Insert the singleton blank Memory (`name = '__blank__'`, `is_blank = 1`).
+4. Migrate existing data:
+   - For each row in `db_forge_agents`: insert a corresponding row in `db_memories`. Map `db_forge_agents.provider` → `db_memories.provider`, etc.
+   - For each row in `db_forge_agent_identities` for a given `agent_id`: create a per-agent Identity named `<agent_name>-default` and insert the per-provider account rows.
+5. Add `identity_id` + `memory_id` columns to `db_agent_instances`. Backfill from the migrated identities/memories.
+6. Drop the old JSON column and the Forge tables.
+
+The migration is one-way (no rollback). Run order matters because step 5 reads from rows created in step 4.
+
+---
+
+## UI changes
+
+### Launch Agent modal
+
+Replace PR #745's per-provider `<select>` rows with two single dropdowns:
+
+```
+┌────────────────────────────────────────────────┐
+│ New Agent Instance                              │
+│  Name:         [my-instance______]              │
+│  Runtime:      [local | container]              │
+│                                                 │
+│  Identity:     [▼ — Blank (no creds) —    ]     │
+│  Memory:       [▼ — Blank (vanilla CLI) — ]     │
+│                                                 │
+│  [Advanced ▸]                                   │
+│                                                 │
+│  [Cancel]              [Launch]                 │
+└────────────────────────────────────────────────┘
+```
+
+The dropdowns list user-defined Identities/Memories first, then the blank singleton at the bottom (or vice versa — TBD). Clicking the blank option means "no override; spawn vanilla."
+
+### Identity pane (`view: "identity"`)
+
+A first-class block-view pane. Opens via `defwidget@identity` (right-click a pane header → Identity, or click the identity widget icon if pinned, or `pane.open` RPC with `view: "identity"`).
+
+Layout:
+
+- Left rail: list of Identity bundles. `+ New Identity` button at top.
+- Right side: detail view for the selected Identity — name, description, accounts table (one row per provider). Add/edit/remove accounts inline.
+- Header actions: **Export Vault**, **Import Vault** buttons (PR-G).
+
+### Memory pane (`view: "memory"`)
+
+A first-class block-view pane. Opens via `defwidget@memory`. Same shape as Identity:
+
+- Left rail: list of Memory bundles. `+ New Memory` button at top.
+- Right side: detail view — name, description, provider/CLI dropdown, model dropdown, instructions textarea, context-files manager, MCP-servers list, skills list.
+
+### Agent pane
+
+The Forge tab and the Identity tab both disappear from the agent pane's settings panel. The agent pane gets simpler — it focuses on the running agent's stream, tool calls, and turn state. Identity and Memory configuration moves out to the dedicated panes above.
+
+### Hamburger-menu shortcuts (v2)
+
+For convenience, the hamburger menu can grow `Open Identities` and `Open Memories` entries that open the respective panes in a new pane. v1 ships without them; users right-click and pick from the widget menu.
+
+---
+
+## Vault
+
+The vault concern is Identity-side only. Memory bundles don't carry secrets — they're shareable as plain JSON.
+
+### Identity Vault
+
+Two buttons on the Identity tab:
+
+**Export Vault**
+- File: `agentmux-vault-<timestamp>.agentmux-vault`.
+- Contents: all `db_identities` rows + their `db_identity_accounts` rows + the referenced `db_accounts` rows + resolved `secret_ref` plaintext values.
+- Crypto: Argon2id-derived key (params: m=64MB, t=3, p=4 — OWASP 2023 minimums), AES-256-GCM, random 12-byte nonce. Header: magic + version + salt + nonce.
+- Passphrase prompt every time. No caching.
+
+**Import Vault**
+- File picker → passphrase → decrypt.
+- Per-account collision policy: skip-on-conflict default, "merge & overwrite" toggle.
+- Returns summary: `{ identities_imported, accounts_imported, skipped, overwritten, errors }`.
+
+### Memory Vault (later)
+
+Memory bundles can be exported/imported as plain JSON (no secrets). Skipping for v1; users can manually copy a JSON dump until then.
+
+### Failure modes
+
+- Wrong passphrase → `BadPassphrase` error, no partial decrypt.
+- Corrupted blob → `Corrupted { byte_offset }`.
+- Schema version mismatch → `IncompatibleVersion { expected, got }`.
+
+---
+
+## Coordination with PR #745
+
+PR #745 has the right *moment* (instantiation) but the wrong *shape* (per-provider JSON, Phase-1 default fallback through `db_forge_agent_identities`). The new model needs:
+
+- Drop the JSON column, add `identity_id` / `memory_id` FKs on `db_agent_instances`.
+- Drop the per-provider picker UI; replace with two dropdowns.
+- The resolver still does the secret → env-var work, just keyed off `identity_id` instead of the JSON array.
+
+Two paths:
+
+1. **Re-shape PR #745** — keep the branch, swap the model. Preserves AgentY's resolver work + tests; rewrites the UI + persistence layer.
+2. **Close PR #745, open fresh** — clean slate. Loses the resolver work as a separate review unit.
+
+Recommend (1) — re-shape. The resolver + provider-matrix + spawn-injection tests are reusable. We'd ask AgentY to re-shape, or do it ourselves.
+
+---
+
+## PR splitting
+
+| PR | Scope | Stacked on | Independent? |
+|---|---|---|---|
+| **PR-F.0** | Schema migration v8 + blank singletons + reshape PR #745's resolver to read from new tables | `feat/identity-injection-678` (re-shaped) or main | Yes — backend-only, no UI change |
+| **PR-F.1** | Memories management UI (rename Forge tab, CRUD on `db_memories`) | F.0 | Yes |
+| **PR-F.2** | Identity management UI updates (named bundles, Account CRUD inside an Identity) | F.0 | Yes |
+| **PR-F.3** | Launch modal: replace per-provider rows with two dropdowns | F.0 + F.1 + F.2 | Builds on UI |
+| **PR-G** | Vault export/import | F.0 + F.2 | Yes |
+
+Recommended ship order: F.0 → F.2 → F.1 → F.3 → G. F.0 first because it lays the schema; F.2 before F.1 because Identity is the simpler one to validate the named-bundle pattern.
+
+---
+
+## Open questions
+
+1. **Re-shape PR #745, or close it?** I'd vote re-shape.
+2. **Memory rename for the existing tab?** "Memories" feels right but "Personalities" / "Brains" / "Loadouts" are alternatives. Confirm Memories.
+3. **Hamburger-menu promotion timing**: ship in v1 (this PR cycle) or as a follow-up? I'd vote follow-up — agent-pane tabs work fine for now.
+4. **Vault crypto parameters**: Argon2id m=64MB t=3 p=4 — bump if you want stronger? These are OWASP 2023 minimums.
+5. **Migration safety**: existing `db_forge_agents` and `db_forge_agent_identities` rows get auto-migrated. Are there any production users we need to gate this for, or is the dev installed-base small enough to ship without a migration flag? (My read: small, ship without flag.)
+
+---
+
+## Out of scope (this cycle)
+
+- Phase 3 OAuth flows (separate PRs per provider).
+- AWS multi-secret expansion.
+- Cross-machine vault sync (this is local export/import only).
+- Memory vault encryption — Memories don't carry secrets.
+- Hamburger-menu promotion of Identity/Memory.
+- A `Guardrails` concept (folded into Memory; can split out later if security users need it).
+
+---
+
+## Files this will touch
+
+### PR-F.0 (schema + resolver reshape)
+
+- `agentmux-srv/src/backend/storage/migrations.rs` — v8 migration
+- `agentmux-srv/src/backend/storage/wstore.rs` — new accessors for db_identities, db_memories, blank singletons
+- `agentmux-srv/src/identity/resolver.rs` — read from new tables
+- `agentmux-srv/src/identity/mod.rs` — `inject_identity_env` reads `identity_id` instead of JSON
+- `agentmux-srv/src/server/app_api.rs` — RPC commands for Identity/Memory CRUD
+- `agentmux-srv/src/backend/rpc_types.rs` — new command types
+- `frontend/types/gotypes.d.ts` — types
+
+### PR-F.1 (Memory pane)
+
+- `frontend/app/view/memory/memory-model.ts` — new (`MemoryViewModel`)
+- `frontend/app/view/memory/memory-view.tsx` — list + detail
+- `frontend/app/view/memory/memory.tsx` — barrel
+- `frontend/app/view/memory/memory-view.scss`
+- `frontend/app/block/block.tsx` — `BlockRegistry.set("memory", MemoryViewModel)`
+- `agentmux-srv/src/config/widgets.json` — `defwidget@memory`
+- `frontend/app/view/forge/` — directory removed; salvageable components migrated into the new `memory/` module
+- `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx` — drop the Forge tab
+
+### PR-F.2 (Identity pane)
+
+- `frontend/app/view/identity/identity-model.ts` — promote to first-class pane (it currently lives only as agent-pane components per PR-E); add Identity entity types (vs. Account-only)
+- `frontend/app/view/identity/identity-view.tsx` — left-rail list + right-detail layout, replacing the agent-pane tab content
+- `frontend/app/view/identity/identity.tsx` — barrel
+- `frontend/app/block/block.tsx` — `BlockRegistry.set("identity", IdentityViewModel)`
+- `agentmux-srv/src/config/widgets.json` — `defwidget@identity`
+- `frontend/app/view/agent/components/AgentIdentityPanel.tsx` — drop (content moves to the Identity pane)
+- `frontend/app/view/agent/components/AgentCardSettingsPanel.tsx` — drop the Identity tab
+
+### PR-F.3 (Launch modal)
+
+- `frontend/app/view/agent/components/AgentLaunchModal.tsx` — replace per-provider rows with two dropdowns
+- `frontend/app/view/agent/agent-model.ts` — `LaunchOverrides` shape change
+
+### PR-G (Vault)
+
+- `agentmux-srv/Cargo.toml` — `argon2`, `aes-gcm` deps
+- `agentmux-srv/src/identity/vault.rs` — new module
+- `agentmux-srv/src/server/app_api.rs` — register vault commands
+- `frontend/app/view/agent/components/AgentIdentityPanel.tsx` — Export/Import buttons

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.720",
+  "version": "0.33.721",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR-F.0 of the Identity-and-Memory feature (issue #678). **Schema and storage layer only** — no behavior change yet. Subsequent PRs (PR-F.0b, PR-F.1, PR-F.2, PR-F.3, PR-G) build on this foundation.

Spec: [`docs/specs/identity-forge-integration-and-vault-2026-05-08.md`](https://github.com/agentmuxai/agentmux/blob/agenta/identity-memory-schema-v8/docs/specs/identity-forge-integration-and-vault-2026-05-08.md) (included in this PR).

## What's in

### Schema (migration v7)

- **`db_identities`** — named credential bundles (e.g. \"Work\", \"Personal\"). `is_blank` flag tags the seeded singleton.
- **`db_identity_bindings`** — junction `(identity_id, provider) → account_id`. Replaces the per-agent semantics of v6's `db_forge_agent_identities` (kept for backwards compat; readers in the new code path ignore it).
- **`db_memories`** — named personality / capability bundles (provider, model, instructions, context_files, mcp_servers, skills). `is_blank` singleton seeded.
- **`db_agent_instances.identity_id` + `db_agent_instances.memory_id`** — new columns. Default `''` = use the blank singleton.

### Seeded singletons

- `db_identities {id='blank', name='__blank__', is_blank=1}`
- `db_memories {id='blank', name='__blank__', is_blank=1}`

These are what the launch UI defaults to in PR-F.3.

### Shadow migration

- Each `db_forge_agents` row is `INSERT OR IGNORE`'d into `db_memories` with the same id (copies name + provider). `context_files` / `mcp_servers` / `skills` start empty; users re-attach via the Memory pane (PR-F.1).
- `db_agent_instances.memory_id` is backfilled from `definition_id`.

### Storage layer (`wstore.rs`)

- `Identity`, `IdentityBinding`, `Memory` types.
- `bundle_identity_*` accessors: list / get / upsert / delete / bind / unbind / bindings.
- `bundle_memory_*` accessors: list / get / upsert / delete.
- `bundle_*_delete` refuses to delete the blank singletons.
- `map_instance_row` helper extracted so list + get share row-mapping.
- `AgentInstance` struct extended with `identity_id` + `memory_id`. `instance_create` writes them; `instance_update` does NOT (immutable post-create — mid-session credential rotation is out of scope).

## What's NOT in this PR

- **No resolver changes** — identity injection still goes through the legacy v6 path (`db_forge_agent_identities`). The new columns are populated but not yet consumed at spawn time. PR-F.0b will reshape `identity::resolver` to read from `identity_id`.
- **No RPC commands** — CRUD is exposed only at the wstore layer. RPC handlers come with the UI PRs (F.1, F.2) which need them.
- **No UI** — Memory pane (F.1) and Identity pane (F.2) are separate PRs.
- **`db_forge_agents` and `db_forge_agent_identities` are NOT dropped.** Readers in the migrated code path ignore them; they remain on disk so a downgrade path stays open until v8.

## Tests (8 new, all passing)

Migration:
- `test_forge_v7_creates_tables_and_singletons`
- `test_forge_v7_idempotent`
- `test_forge_v7_shadow_migrates_forge_agents_into_memories`
- `test_forge_v7_backfills_memory_id_on_existing_instances`

Storage:
- `test_bundle_identity_lifecycle` — list / get / upsert / delete; blank singleton always present and undeletable
- `test_bundle_identity_bindings_round_trip` — bind, list, re-bind, unbind
- `test_bundle_identity_bindings_cascade_on_account_delete` — cascade-delete via FK
- `test_bundle_memory_lifecycle` — list / get / upsert / delete

All 80 storage tests + all 9 migration tests still green.

## Coordination with PR #745

PR #745 (a5af / AgentY — Phase 2 per-instance identity injection) ships a `db_agent_instances.identities` JSON column + per-provider picker in `AgentLaunchModal`. The new model supersedes that data shape with `identity_id` (single FK) + `memory_id` (single FK). Recommendation: re-shape PR #745 to read from the new schema before merging, OR close it and open a fresh PR built on this one.

## Test plan

- [x] `cargo check -p agentmux-srv` clean
- [x] All migration tests pass (9/9)
- [x] All storage tests pass (80/80)
- [x] Bumped to 0.33.721
- [ ] Reagent review
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)