### PR TITLE
feat(identity): Memory pane — first-class management of Memory bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.721"
+version = "0.33.722"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.721"
+version = "0.33.722"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.721"
+version = "0.33.722"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.721"
+version = "0.33.722"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.721"
+version = "0.33.722"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.721"
+version = "0.33.722"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.721"
+version = "0.33.722"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.721"
+version = "0.33.722"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -78,6 +78,17 @@
             }
         }
     },
+    "defwidget@memory": {
+        "display:order": 7,
+        "icon": "brain",
+        "label": "memory",
+        "description": "Manage Memory bundles — agent personality + capability stacks",
+        "blockdef": {
+            "meta": {
+                "view": "memory"
+            }
+        }
+    },
     "defwidget@help": {
         "display:order": 8,
         "icon": "circle-question",

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -16,6 +16,7 @@ import { SubagentViewModel } from "@/app/view/subagent/subagent";
 import { SwarmViewModel } from "@/app/view/swarm/swarm";
 import { EditorViewModel } from "@/app/view/editor/editor";
 import { BrowserViewModel } from "@/app/view/browser/browser";
+import { MemoryViewModel } from "@/app/view/memory/memory";
 import { invokeCommand } from "@/app/platform/ipc";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
@@ -49,6 +50,7 @@ BlockRegistry.set("subagent", SubagentViewModel as any);
 BlockRegistry.set("swarm", SwarmViewModel as any);
 BlockRegistry.set("editor", EditorViewModel as any);
 BlockRegistry.set("browser", BrowserViewModel as any);
+BlockRegistry.set("memory", MemoryViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
     // Migration shim (v0.33.197): forge and identity are no longer standalone

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -638,6 +638,109 @@ class RpcApiType {
         return client.rpcCall("listagentidentities", data, opts);
     }
 
+    // ────────────────────────────────────────────────────────────────────
+    // v7 — Identity bundles + Memory bundles
+    // ────────────────────────────────────────────────────────────────────
+
+    // command "listidentitybundles" [call]
+    ListIdentityBundlesCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<IdentityBundle[]> {
+        return client.rpcCall("listidentitybundles", data, opts);
+    }
+
+    // command "getidentitybundle" [call]
+    GetIdentityBundleCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<IdentityBundle> {
+        return client.rpcCall("getidentitybundle", data, opts);
+    }
+
+    // command "upsertidentitybundle" [call]
+    UpsertIdentityBundleCommand(
+        client: RpcClient,
+        data: Partial<IdentityBundle>,
+        opts?: RpcOpts,
+    ): Promise<IdentityBundle> {
+        return client.rpcCall("upsertidentitybundle", data, opts);
+    }
+
+    // command "deleteidentitybundle" [call]
+    DeleteIdentityBundleCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("deleteidentitybundle", data, opts);
+    }
+
+    // command "bindidentityaccount" [call]
+    BindIdentityAccountCommand(
+        client: RpcClient,
+        data: { identity_id: string; provider: string; account_id: string },
+        opts?: RpcOpts,
+    ): Promise<void> {
+        return client.rpcCall("bindidentityaccount", data, opts);
+    }
+
+    // command "unbindidentityaccount" [call]
+    UnbindIdentityAccountCommand(
+        client: RpcClient,
+        data: { identity_id: string; provider: string },
+        opts?: RpcOpts,
+    ): Promise<{ unbound: boolean }> {
+        return client.rpcCall("unbindidentityaccount", data, opts);
+    }
+
+    // command "listidentitybindings" [call]
+    ListIdentityBindingsCommand(
+        client: RpcClient,
+        data: { identity_id: string },
+        opts?: RpcOpts,
+    ): Promise<IdentityBinding[]> {
+        return client.rpcCall("listidentitybindings", data, opts);
+    }
+
+    // command "listmemories" [call]
+    ListMemoriesCommand(
+        client: RpcClient,
+        data: Record<string, never> = {},
+        opts?: RpcOpts,
+    ): Promise<Memory[]> {
+        return client.rpcCall("listmemories", data, opts);
+    }
+
+    // command "getmemory" [call]
+    GetMemoryCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<Memory> {
+        return client.rpcCall("getmemory", data, opts);
+    }
+
+    // command "upsertmemory" [call]
+    UpsertMemoryCommand(
+        client: RpcClient,
+        data: Partial<Memory>,
+        opts?: RpcOpts,
+    ): Promise<Memory> {
+        return client.rpcCall("upsertmemory", data, opts);
+    }
+
+    // command "deletememory" [call]
+    DeleteMemoryCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ deleted: boolean }> {
+        return client.rpcCall("deletememory", data, opts);
+    }
+
     // command "listagentinstances" [call]
     ListAgentInstancesCommand(
         client: RpcClient,

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -1,0 +1,232 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Memory pane — first-class management of Memory bundles.
+//
+// A Memory bundle is the agent's personality + capability stack:
+// provider/CLI choice, model, system instructions, context files, MCP
+// servers, skills. Bundles are reusable across many agent instances —
+// pick one in the launch modal alongside an Identity bundle.
+//
+// This module is the ViewModel for `view: "memory"` panes. It owns the
+// list of memories, the currently-selected one, and the in-flight edit
+// draft. CRUD goes through the v7 RPC commands
+// (listmemories / upsertmemory / deletememory).
+
+import { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { createMemo, createSignal, type Accessor } from "solid-js";
+
+/** What the form fields look like in flight. Maps 1:1 to the Memory
+ *  shape but with everything optional + JSON-array fields exposed as
+ *  parsed arrays for ergonomic editing. The shape is converted back to
+ *  Memory on save. */
+export interface MemoryDraft {
+    id?: string;
+    name: string;
+    description: string;
+    provider: string;          // "" | "claude" | "codex" | "gemini"
+    model: string;
+    instructions: string;
+    /** Edited as `[{ path, content }]`; serialized to JSON on save. */
+    context_files: Array<{ path: string; content: string }>;
+    /** Edited as raw JSON string for now (advanced). */
+    mcp_servers: string;
+    /** Edited as comma-separated ids for now. */
+    skills: string;
+}
+
+/** Empty draft for the "+ New Memory" flow. */
+export function emptyDraft(): MemoryDraft {
+    return {
+        id: undefined,
+        name: "",
+        description: "",
+        provider: "",
+        model: "",
+        instructions: "",
+        context_files: [],
+        mcp_servers: "[]",
+        skills: "",
+    };
+}
+
+/** Hydrate a draft from a stored Memory. JSON fields are parsed; on
+ *  parse failure we fall back to safe empties so the UI stays usable
+ *  even if the row is malformed. */
+export function draftFromMemory(m: Memory): MemoryDraft {
+    let context_files: Array<{ path: string; content: string }> = [];
+    try {
+        const parsed = JSON.parse(m.context_files ?? "[]");
+        if (Array.isArray(parsed)) context_files = parsed;
+    } catch {
+        // Fall back to empty list; user can re-add files.
+    }
+    return {
+        id: m.id,
+        name: m.name,
+        description: m.description ?? "",
+        provider: m.provider ?? "",
+        model: m.model ?? "",
+        instructions: m.instructions ?? "",
+        context_files,
+        mcp_servers: m.mcp_servers ?? "[]",
+        skills: m.skills ?? "",
+    };
+}
+
+/** Serialize a draft into the wire shape for `upsertmemory`. */
+export function draftToWire(d: MemoryDraft): Partial<Memory> {
+    return {
+        id: d.id,
+        name: d.name.trim(),
+        description: d.description.trim(),
+        provider: d.provider,
+        model: d.model.trim(),
+        instructions: d.instructions,
+        context_files: JSON.stringify(d.context_files),
+        mcp_servers: d.mcp_servers || "[]",
+        skills: d.skills,
+    };
+}
+
+export class MemoryViewModel implements ViewModel {
+    viewType = "memory";
+    blockId: string;
+    nodeModel: BlockNodeModel;
+
+    viewIcon: Accessor<string> = () => "brain";
+    viewName: Accessor<string>;
+    viewText: Accessor<string | HeaderElem[]> = () => "Memory";
+    noPadding: Accessor<boolean> = () => false;
+
+    get viewComponent(): ViewComponent {
+        return null; // overridden by the barrel via Object.defineProperty
+    }
+
+    blockAtom: Accessor<Block | undefined>;
+
+    private _memories = createSignal<Memory[]>([]);
+    memoriesAtom: Accessor<Memory[]> = this._memories[0];
+    setMemories = this._memories[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<MemoryDraft | null>(null);
+    draftAtom: Accessor<MemoryDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    /** Memo: the currently-selected Memory row, or null. */
+    selectedAtom: Accessor<Memory | null>;
+
+    constructor(blockId: string, nodeModel: BlockNodeModel) {
+        this.blockId = blockId;
+        this.nodeModel = nodeModel;
+        this.blockAtom = getWaveObjectAtom(makeORef("block", blockId));
+        this.viewName = createMemo(() => {
+            const block = this.blockAtom();
+            return (block?.meta?.["frame:title"] as string) ?? "Memory";
+        });
+        this.selectedAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.memoriesAtom().find((m) => m.id === id) ?? null;
+        });
+
+        // Kick off initial load. Errors land in errorAtom for UI surfacing.
+        void this.refresh();
+    }
+
+    /** Re-fetch the full list. Called on mount and after each mutation. */
+    async refresh(): Promise<void> {
+        try {
+            const list = await RpcApi.ListMemoriesCommand(TabRpcClient, {});
+            this.setMemories(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load memories: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Open the form for a new memory. */
+    startNew(): void {
+        this.setDraft(emptyDraft());
+        this.setSelectedId(null);
+    }
+
+    /** Open the form for editing an existing memory. Refuses on the blank
+     *  singleton because the backend rejects mutations to it anyway —
+     *  better to show a disabled UI than to surface a backend error after
+     *  the user types. */
+    startEdit(memory: Memory): void {
+        if (memory.is_blank) {
+            this.setError("The blank Memory is system-managed and cannot be edited.");
+            return;
+        }
+        this.setDraft(draftFromMemory(memory));
+        this.setSelectedId(memory.id);
+    }
+
+    /** Discard the current draft. */
+    cancelDraft(): void {
+        this.setDraft(null);
+    }
+
+    /** Persist the current draft (creates if id is empty, else updates). */
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Memory name is required.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.UpsertMemoryCommand(TabRpcClient, draftToWire(draft));
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteMemory(id: string): Promise<void> {
+        const target = this.memoriesAtom().find((m) => m.id === id);
+        if (target?.is_blank) {
+            this.setError("The blank Memory is system-managed and cannot be deleted.");
+            return;
+        }
+        this.setError(null);
+        try {
+            await RpcApi.DeleteMemoryCommand(TabRpcClient, { id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refresh();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** ViewModel teardown — Solid signals are GC'd with the instance. */
+    dispose(): void {
+        // No-op for now. If we add a wave-event subscription later (to
+        // refresh on `memories:changed` from other clients), unsubscribe
+        // here.
+    }
+}

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -38,7 +38,12 @@ export interface MemoryDraft {
     skills: string;
 }
 
-/** Empty draft for the "+ New Memory" flow. */
+/** Empty draft for the "+ New Memory" flow.
+ *
+ *  All JSON-array fields default to `"[]"` (not `""`). The backend's
+ *  `db_memories.skills` column is JSON-encoded; a literal `""` would
+ *  trip downstream `JSON.parse(skills)` readers. Reagent P1 on
+ *  PR #747 (2026-05-08). */
 export function emptyDraft(): MemoryDraft {
     return {
         id: undefined,
@@ -49,7 +54,7 @@ export function emptyDraft(): MemoryDraft {
         instructions: "",
         context_files: [],
         mcp_servers: "[]",
-        skills: "",
+        skills: "[]",
     };
 }
 
@@ -73,7 +78,7 @@ export function draftFromMemory(m: Memory): MemoryDraft {
         instructions: m.instructions ?? "",
         context_files,
         mcp_servers: m.mcp_servers ?? "[]",
-        skills: m.skills ?? "",
+        skills: m.skills && m.skills.trim().length > 0 ? m.skills : "[]",
     };
 }
 
@@ -88,7 +93,9 @@ export function draftToWire(d: MemoryDraft): Partial<Memory> {
         instructions: d.instructions,
         context_files: JSON.stringify(d.context_files),
         mcp_servers: d.mcp_servers || "[]",
-        skills: d.skills,
+        // Same JSON-array invariant as mcp_servers — never write an
+        // empty string to the skills column. Reagent P1 (PR #747).
+        skills: d.skills || "[]",
     };
 }
 
@@ -160,8 +167,10 @@ export class MemoryViewModel implements ViewModel {
         }
     }
 
-    /** Open the form for a new memory. */
+    /** Open the form for a new memory. Clears any stale error so the
+     *  user starts on a clean banner. */
     startNew(): void {
+        this.setError(null);
         this.setDraft(emptyDraft());
         this.setSelectedId(null);
     }
@@ -169,12 +178,16 @@ export class MemoryViewModel implements ViewModel {
     /** Open the form for editing an existing memory. Refuses on the blank
      *  singleton because the backend rejects mutations to it anyway —
      *  better to show a disabled UI than to surface a backend error after
-     *  the user types. */
+     *  the user types. Successful entry clears any stale error from a
+     *  previous failed action (e.g. clicking the blank singleton, then
+     *  clicking a real memory should not leave the "system-managed"
+     *  banner showing alongside the new edit form). Reagent P2 (#747). */
     startEdit(memory: Memory): void {
         if (memory.is_blank) {
             this.setError("The blank Memory is system-managed and cannot be edited.");
             return;
         }
+        this.setError(null);
         this.setDraft(draftFromMemory(memory));
         this.setSelectedId(memory.id);
     }

--- a/frontend/app/view/memory/memory-view.scss
+++ b/frontend/app/view/memory/memory-view.scss
@@ -1,0 +1,252 @@
+// Memory pane — matches the swarm/forge SCSS conventions for layout
+// (left rail + right detail). Colors come from the global theme tokens.
+
+.memory-view {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+
+    .memory-view-rail {
+        flex: 0 0 240px;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid var(--border-color);
+        overflow: hidden;
+    }
+
+    .memory-view-rail-header {
+        padding: 8px;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .memory-view-new-btn {
+        width: 100%;
+        padding: 6px 10px;
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+
+        &:hover {
+            filter: brightness(1.1);
+        }
+    }
+
+    .memory-view-list {
+        flex: 1 1 auto;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+    }
+
+    .memory-view-list-item {
+        padding: 10px 12px;
+        cursor: pointer;
+        border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
+
+        &:hover {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+
+        &.is-selected {
+            background: var(--selected-bg-color, rgba(255, 255, 255, 0.08));
+        }
+
+        &.is-blank {
+            font-style: italic;
+            color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+        }
+    }
+
+    .memory-view-list-item-name {
+        font-size: 13px;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .memory-view-list-item-provider {
+        font-size: 11px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+        margin-top: 2px;
+    }
+
+    .memory-view-detail {
+        flex: 1 1 auto;
+        padding: 16px 24px;
+        overflow-y: auto;
+    }
+
+    .memory-view-error {
+        padding: 8px 12px;
+        margin-bottom: 12px;
+        background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
+        color: var(--error-text-color, #ff8080);
+        border-radius: 4px;
+        font-size: 13px;
+    }
+
+    .memory-view-empty {
+        max-width: 460px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.7));
+        line-height: 1.5;
+    }
+
+    .memory-view-empty-hint {
+        font-size: 13px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+        margin-top: 8px;
+    }
+
+    // ── Read-only detail ────────────────────────────────────────────
+    .memory-view-readonly {
+        max-width: 720px;
+    }
+
+    .memory-view-name {
+        font-size: 20px;
+        margin: 0 0 4px;
+    }
+
+    .memory-view-description {
+        margin: 0 0 16px;
+        color: var(--secondary-text-color);
+    }
+
+    .memory-view-fields {
+        display: grid;
+        grid-template-columns: 140px 1fr;
+        column-gap: 16px;
+        row-gap: 8px;
+        margin: 0 0 16px;
+
+        dt {
+            color: var(--secondary-text-color);
+            font-size: 13px;
+        }
+
+        dd {
+            margin: 0;
+            font-size: 13px;
+        }
+    }
+
+    .memory-view-instructions-readonly pre {
+        margin: 0;
+        padding: 8px;
+        background: var(--code-bg-color, rgba(0, 0, 0, 0.2));
+        border-radius: 4px;
+        white-space: pre-wrap;
+        font-family: var(--mono-font, "JetBrains Mono", monospace);
+        font-size: 12px;
+        max-height: 240px;
+        overflow-y: auto;
+    }
+
+    .memory-view-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 16px;
+    }
+
+    .memory-view-edit-btn,
+    .memory-view-delete-btn,
+    .memory-view-cancel-btn,
+    .memory-view-save-btn {
+        padding: 6px 14px;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        background: transparent;
+        color: var(--main-text-color);
+        cursor: pointer;
+        font-size: 13px;
+
+        &:hover:not(:disabled) {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+
+    .memory-view-save-btn {
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        border-color: transparent;
+    }
+
+    .memory-view-delete-btn {
+        color: var(--error-text-color, #ff8080);
+        border-color: var(--error-text-color, #ff8080);
+    }
+
+    // ── Edit form ───────────────────────────────────────────────────
+    .memory-view-form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-width: 720px;
+    }
+
+    .memory-view-form-title {
+        font-size: 18px;
+        margin: 0 0 4px;
+    }
+
+    .memory-view-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .memory-view-field-label {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+    }
+
+    .memory-view-input,
+    .memory-view-textarea {
+        padding: 6px 10px;
+        background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        font-size: 13px;
+        font-family: inherit;
+
+        &:focus {
+            outline: none;
+            border-color: var(--accent-color);
+        }
+    }
+
+    .memory-view-textarea {
+        font-family: var(--mono-font, "JetBrains Mono", monospace);
+        font-size: 12px;
+        resize: vertical;
+        min-height: 120px;
+    }
+
+    .memory-view-form-actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 8px;
+    }
+
+    .memory-view-form-hint {
+        font-size: 11px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+        margin: 4px 0 0;
+        font-style: italic;
+    }
+}

--- a/frontend/app/view/memory/memory-view.tsx
+++ b/frontend/app/view/memory/memory-view.tsx
@@ -1,0 +1,282 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Memory pane view — left rail (list + add) + right detail (editable form).
+//
+// Layout:
+//
+// ┌─────────────────────────────────────────────────────────────────┐
+// │  Memories                                                        │
+// │  ┌──────────────────┬─────────────────────────────────────────┐ │
+// │  │  + New Memory    │  Detail / Edit form                      │ │
+// │  │  ───────────     │                                          │ │
+// │  │  Claude-coder    │  Name        [_______________]           │ │
+// │  │  Codex-reviewer  │  Description [_______________]           │ │
+// │  │  __blank__       │  Provider    [▼ claude        ]          │ │
+// │  │                  │  Model       [_______________]           │ │
+// │  │                  │  Instructions                            │ │
+// │  │                  │  ┌────────────────────────────────────┐  │ │
+// │  │                  │  │ ...                                │  │ │
+// │  │                  │  └────────────────────────────────────┘  │ │
+// │  │                  │  Context files [+ Add]                   │ │
+// │  │                  │  …                                       │ │
+// │  │                  │  [Cancel]                  [Save]        │ │
+// │  └──────────────────┴─────────────────────────────────────────┘ │
+// └─────────────────────────────────────────────────────────────────┘
+
+import { For, Show, type JSX } from "solid-js";
+
+import type { MemoryViewModel } from "./memory-model";
+
+import "./memory-view.scss";
+
+interface MemoryViewProps {
+    model: MemoryViewModel;
+}
+
+export const MemoryView = (props: MemoryViewProps): JSX.Element => {
+    const { model } = props;
+
+    const handleSelect = (memory: Memory) => {
+        model.startEdit(memory);
+    };
+
+    const handleNew = () => model.startNew();
+
+    const handleSave = () => {
+        void model.saveDraft();
+    };
+
+    const handleCancel = () => model.cancelDraft();
+
+    const handleDelete = (id: string) => {
+        // Confirm via the most boring possible dialog. Memory bundles can
+        // be referenced by running instances; deletion is an explicit user
+        // intent we don't want to fast-path.
+        const ok = window.confirm("Delete this Memory bundle? Running instances continue with their snapshot, but new launches won't see it.");
+        if (!ok) return;
+        void model.deleteMemory(id);
+    };
+
+    const updateDraft = <K extends keyof MemoryDraftExternal>(
+        key: K,
+        value: MemoryDraftExternal[K],
+    ) => {
+        const current = model.draftAtom();
+        if (!current) return;
+        model.setDraft({ ...current, [key]: value });
+    };
+
+    return (
+        <div class="memory-view">
+            <div class="memory-view-rail">
+                <div class="memory-view-rail-header">
+                    <button class="memory-view-new-btn" onClick={handleNew}>
+                        + New Memory
+                    </button>
+                </div>
+                <ul class="memory-view-list">
+                    <For each={model.memoriesAtom()}>
+                        {(memory) => (
+                            <li
+                                class="memory-view-list-item"
+                                classList={{
+                                    "is-selected": model.selectedIdAtom() === memory.id,
+                                    "is-blank": !!memory.is_blank,
+                                }}
+                                onClick={() => handleSelect(memory)}
+                            >
+                                <div class="memory-view-list-item-name">
+                                    {memory.is_blank ? "— Blank (vanilla CLI) —" : memory.name}
+                                </div>
+                                <Show when={!memory.is_blank}>
+                                    <div class="memory-view-list-item-provider">
+                                        {memory.provider || "no provider"}
+                                    </div>
+                                </Show>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </div>
+
+            <div class="memory-view-detail">
+                <Show when={model.errorAtom()}>
+                    <div class="memory-view-error">{model.errorAtom()}</div>
+                </Show>
+
+                <Show
+                    when={model.draftAtom()}
+                    fallback={
+                        <Show
+                            when={model.selectedAtom()}
+                            fallback={
+                                <div class="memory-view-empty">
+                                    <p>Select a Memory bundle from the list, or create a new one.</p>
+                                    <p class="memory-view-empty-hint">
+                                        A Memory holds an agent's CLI choice, model, system instructions,
+                                        context files, MCP servers, and skills. Pick one at launch time
+                                        alongside an Identity to compose an agent instance.
+                                    </p>
+                                </div>
+                            }
+                        >
+                            {(memory) => (
+                                <div class="memory-view-readonly">
+                                    <h2 class="memory-view-name">{memory().name}</h2>
+                                    <Show when={memory().description}>
+                                        <p class="memory-view-description">{memory().description}</p>
+                                    </Show>
+                                    <dl class="memory-view-fields">
+                                        <dt>Provider</dt>
+                                        <dd>{memory().provider || "—"}</dd>
+                                        <dt>Model</dt>
+                                        <dd>{memory().model || "—"}</dd>
+                                        <dt>Instructions</dt>
+                                        <dd class="memory-view-instructions-readonly">
+                                            <pre>{memory().instructions || "(none)"}</pre>
+                                        </dd>
+                                    </dl>
+                                    <Show when={!memory().is_blank}>
+                                        <div class="memory-view-actions">
+                                            <button
+                                                class="memory-view-edit-btn"
+                                                onClick={() => model.startEdit(memory())}
+                                            >
+                                                Edit
+                                            </button>
+                                            <button
+                                                class="memory-view-delete-btn"
+                                                onClick={() => handleDelete(memory().id)}
+                                            >
+                                                Delete
+                                            </button>
+                                        </div>
+                                    </Show>
+                                </div>
+                            )}
+                        </Show>
+                    }
+                >
+                    {(draft) => (
+                        <form
+                            class="memory-view-form"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                handleSave();
+                            }}
+                        >
+                            <h2 class="memory-view-form-title">
+                                {draft().id ? "Edit Memory" : "New Memory"}
+                            </h2>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">Name *</span>
+                                <input
+                                    class="memory-view-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => updateDraft("name", e.currentTarget.value)}
+                                    placeholder="e.g. Claude-coder"
+                                    required
+                                />
+                            </label>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">Description</span>
+                                <input
+                                    class="memory-view-input"
+                                    type="text"
+                                    value={draft().description}
+                                    onInput={(e) =>
+                                        updateDraft("description", e.currentTarget.value)
+                                    }
+                                    placeholder="Short label shown in the launch picker"
+                                />
+                            </label>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">Provider</span>
+                                <select
+                                    class="memory-view-input"
+                                    value={draft().provider}
+                                    onChange={(e) =>
+                                        updateDraft("provider", e.currentTarget.value)
+                                    }
+                                >
+                                    <option value="">(none — vanilla shell)</option>
+                                    <option value="claude">Claude Code</option>
+                                    <option value="codex">Codex CLI</option>
+                                    <option value="gemini">Gemini CLI</option>
+                                </select>
+                            </label>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">Model</span>
+                                <input
+                                    class="memory-view-input"
+                                    type="text"
+                                    value={draft().model}
+                                    onInput={(e) => updateDraft("model", e.currentTarget.value)}
+                                    placeholder="e.g. claude-sonnet-4-6"
+                                />
+                            </label>
+
+                            <label class="memory-view-field">
+                                <span class="memory-view-field-label">Instructions</span>
+                                <textarea
+                                    class="memory-view-textarea"
+                                    rows={8}
+                                    value={draft().instructions}
+                                    onInput={(e) =>
+                                        updateDraft("instructions", e.currentTarget.value)
+                                    }
+                                    placeholder="System prompt. The agent's soul."
+                                />
+                            </label>
+
+                            <div class="memory-view-form-actions">
+                                <button
+                                    type="button"
+                                    class="memory-view-cancel-btn"
+                                    onClick={handleCancel}
+                                    disabled={model.savingAtom()}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="submit"
+                                    class="memory-view-save-btn"
+                                    disabled={model.savingAtom() || !draft().name.trim()}
+                                >
+                                    {model.savingAtom() ? "Saving…" : "Save"}
+                                </button>
+                            </div>
+
+                            <p class="memory-view-form-hint">
+                                Context files, MCP servers, and skills will be editable in a follow-up — the
+                                fields are persisted as JSON today and round-trip cleanly through the form.
+                            </p>
+                        </form>
+                    )}
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+// Local alias so the type-narrow `updateDraft` helper has a name to refer to;
+// importing the interface from the model would create a TS-circular reference
+// because the barrel imports from both files. The shape mirrors `MemoryDraft`
+// exactly — keep them in sync.
+type MemoryDraftExternal = {
+    id?: string;
+    name: string;
+    description: string;
+    provider: string;
+    model: string;
+    instructions: string;
+    context_files: Array<{ path: string; content: string }>;
+    mcp_servers: string;
+    skills: string;
+};

--- a/frontend/app/view/memory/memory.tsx
+++ b/frontend/app/view/memory/memory.tsx
@@ -1,0 +1,17 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Memory module barrel — wires the view component onto the model
+// prototype to avoid a circular import between memory-model.ts and
+// memory-view.tsx.
+
+import { MemoryViewModel } from "./memory-model";
+import { MemoryView } from "./memory-view";
+
+Object.defineProperty(MemoryViewModel.prototype, "viewComponent", {
+    get() {
+        return MemoryView;
+    },
+});
+
+export { MemoryViewModel };

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -279,6 +279,50 @@ declare global {
         provider: string;
     };
 
+    // ── v7 — Identity bundles + Memory bundles ────────────────────────
+
+    /** A named credential bundle. Aggregates accounts (one per provider)
+     *  via IdentityBinding rows. The blank singleton (id = "blank",
+     *  is_blank = true) is always present and undeletable; it represents
+     *  "use ambient credentials" in the launch dropdown. */
+    type IdentityBundle = {
+        id: string;
+        name: string;
+        description?: string;
+        is_blank?: boolean;
+        created_at: number;
+        updated_at: number;
+    };
+
+    /** Junction row binding an account to an Identity bundle for a given
+     *  provider. Each (identity_id, provider) pair has at most one account. */
+    type IdentityBinding = {
+        identity_id: string;
+        provider: string;
+        account_id: string;
+    };
+
+    /** A Memory bundle — the agent's personality and capability stack:
+     *  provider/CLI choice, model, system instructions, context files,
+     *  MCP servers, skills. The blank singleton represents "vanilla CLI". */
+    type Memory = {
+        id: string;
+        name: string;
+        description?: string;
+        is_blank?: boolean;
+        provider?: string;            // "claude" | "codex" | "gemini" | ""
+        model?: string;
+        instructions?: string;
+        /** JSON-encoded array of `{ path, content }`. */
+        context_files?: string;
+        /** JSON-encoded array of MCP server configs. */
+        mcp_servers?: string;
+        /** JSON-encoded array of skill IDs. */
+        skills?: string;
+        created_at: number;
+        updated_at: number;
+    };
+
     type AgentInstanceStatus = "running" | "paused" | "stopped" | "crashed" | "detached";
 
     type GitHubContext = {
@@ -301,6 +345,10 @@ declare global {
         started_at: number;
         ended_at?: number;
         created_at: number;
+        /** v7 — FK to db_identities. Empty string = blank singleton. */
+        identity_id?: string;
+        /** v7 — FK to db_memories. Empty string = blank singleton. */
+        memory_id?: string;
     };
 
     // ForgeContent

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.721",
+  "version": "0.33.722",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR-F.1 of issue #678. New standalone pane (`view: \"memory\"`, `defwidget@memory`) for managing **Memory bundles** — the agent's CLI choice + model + system instructions + context files + MCP servers + skills.

**Stacked on PR #746** (PR-F.0 — schema + RPC handlers). Once #746 lands, this rebases cleanly onto main and the diff is just the frontend module + the widget JSON entry.

Spec: [`identity-forge-integration-and-vault-2026-05-08.md`](https://github.com/agentmuxai/agentmux/blob/agenta/identity-memory-schema-v8/docs/specs/identity-forge-integration-and-vault-2026-05-08.md)

## What's in

### New module: `frontend/app/view/memory/`

- **`memory-model.ts`** — `MemoryViewModel` with Solid signals for the memory list, selected row, in-flight draft, and save / error state. CRUD via the v7 RPC commands (`listmemories`, `upsertmemory`, `deletememory`). Refuses to mutate the blank singleton (the backend rejects it anyway; surfacing in the UI is friendlier).
- **`memory-view.tsx`** — Left rail (list + \"+ New Memory\" button) + right detail (read-only summary + edit form). Form fields: name, description, provider (dropdown), model, instructions. `context_files` / `mcp_servers` / `skills` are persisted as JSON today and round-trip cleanly; ergonomic editors come later.
- **`memory.tsx`** — barrel wiring `viewComponent` onto the prototype.
- **`memory-view.scss`** — left-rail + detail layout matching swarm / forge conventions.

### Wiring

- `BlockRegistry.set(\"memory\", MemoryViewModel)` in `block.tsx`.
- New `defwidget@memory` in `widgets.json` — icon \"brain\", display:order 7, view \"memory\".
- `RpcApi` gets typed wrappers for **all 11 v7 commands** (Identity bundle CRUD + bindings + Memory CRUD) so PR-F.2 + PR-F.3 don't have to re-add them.
- `gotypes.d.ts` gets `IdentityBundle`, `IdentityBinding`, `Memory` types. `AgentInstance` extended with `identity_id` + `memory_id`.

## What's NOT in this PR

- **`AgentCardSettingsPanel.tsx` still shows the Forge tab** (and Identity tab). Both tabs come out together when PR-F.2 lands. Touching it here would be premature scope creep.
- **Context-files / MCP-server / skill editors** — JSON round-trips cleanly today; ergonomic editors land in a follow-up.
- **The `forge` → `agent` migration shim** in `block.tsx` stays. \"forge\" stays redirected permanently (Forge is removed); \"identity\" loses its redirect in PR-F.2 when Identity becomes a first-class pane again.

## How to verify

In `task dev`:

1. Restart the sidecar (`task build:backend`, restart `task dev`) so the v7 migration runs and the blank Memory singleton is seeded.
2. Right-click a pane header → widget menu → **memory**, or open the More dropdown in the widget rail.
3. The Memory pane opens with the blank singleton listed. Click \"+ New Memory\" to create one. Save, verify it appears in the list. Edit it, save again. Delete a non-blank one. Try to delete the blank one — should surface a friendly error.

Backend log line: `[forge] memories:changed` should fire on each mutation.

## Type-check

`tsc --noEmit` clean for the `memory/` module. Pre-existing errors in unrelated test files (`layoutTree.test.ts`, `keyutil.ts`, `launcher-events.test.ts`) are not from this PR.

## Test plan

- [x] `tsc --noEmit` clean for memory module
- [x] `cargo check -p agentmux-srv` clean (no backend changes here, but confirmed)
- [x] Bumped to 0.33.722
- [ ] Local `task dev` smoke test — open Memory pane, create / edit / delete bundle
- [ ] Reagent review
- [ ] Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)