### PR TITLE
feat(identity): Identity pane — first-class management of Identity bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.722"
+version = "0.33.723"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.722"
+version = "0.33.723"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.722"
+version = "0.33.723"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.722"
+version = "0.33.723"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.722"
+version = "0.33.723"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.722"
+version = "0.33.723"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.722"
+version = "0.33.723"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.722"
+version = "0.33.723"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -89,6 +89,17 @@
             }
         }
     },
+    "defwidget@identity": {
+        "display:order": 8,
+        "icon": "user",
+        "label": "identity",
+        "description": "Manage Identity bundles — named credential sets selectable at launch",
+        "blockdef": {
+            "meta": {
+                "view": "identity"
+            }
+        }
+    },
     "defwidget@help": {
         "display:order": 8,
         "icon": "circle-question",

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -101,7 +101,7 @@
         }
     },
     "defwidget@help": {
-        "display:order": 8,
+        "display:order": 9,
         "icon": "circle-question",
         "label": "help",
         "description": "Help and documentation",
@@ -112,7 +112,7 @@
         }
     },
     "defwidget@devtools": {
-        "display:order": 9,
+        "display:order": 10,
         "display:pinned": true,
         "icon": "code",
         "label": "devtools",

--- a/frontend/app/block/block.tsx
+++ b/frontend/app/block/block.tsx
@@ -17,6 +17,7 @@ import { SwarmViewModel } from "@/app/view/swarm/swarm";
 import { EditorViewModel } from "@/app/view/editor/editor";
 import { BrowserViewModel } from "@/app/view/browser/browser";
 import { MemoryViewModel } from "@/app/view/memory/memory";
+import { IdentityPaneViewModel } from "@/app/view/identity/identity-pane";
 import { invokeCommand } from "@/app/platform/ipc";
 import { ErrorBoundary } from "@/element/errorboundary";
 import { CenteredDiv } from "@/element/quickelems";
@@ -51,14 +52,17 @@ BlockRegistry.set("swarm", SwarmViewModel as any);
 BlockRegistry.set("editor", EditorViewModel as any);
 BlockRegistry.set("browser", BrowserViewModel as any);
 BlockRegistry.set("memory", MemoryViewModel as any);
+BlockRegistry.set("identity", IdentityPaneViewModel as any);
 
 function makeViewModel(blockId: string, blockView: string, nodeModel: NodeModel): ViewModel {
-    // Migration shim (v0.33.197): forge and identity are no longer standalone
-    // panes — they live inside the agent pane's floating settings panel.
-    // Old databases may still have blocks with view: "forge" or "identity";
-    // redirect them to "agent" so the user gets the picker with ⚙/👤 buttons.
-    // TODO: remove this shim after v0.34.x when all databases have been migrated.
-    const effectiveView = (blockView === "forge" || blockView === "identity") ? "agent" : blockView;
+    // Migration shim (v0.33.197): forge was folded into the agent pane;
+    // redirect old "forge" blocks to "agent" so they keep rendering.
+    //
+    // "identity" was previously redirected here too, but as of PR-F.2
+    // (#748) Identity is once again a first-class pane — `view: "identity"`
+    // resolves to IdentityPaneViewModel via the BlockRegistry above. The
+    // shim only handles "forge" now.
+    const effectiveView = blockView === "forge" ? "agent" : blockView;
     const ctor = BlockRegistry.get(effectiveView);
     if (ctor != null) {
         return new ctor(blockId, nodeModel as any);

--- a/frontend/app/view/identity/identity-pane-model.ts
+++ b/frontend/app/view/identity/identity-pane-model.ts
@@ -18,12 +18,14 @@ import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
-import { createMemo, createResource, createSignal, type Accessor } from "solid-js";
+import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 
 import {
     type Account,
+    loadAccounts,
     PROVIDER_LABELS,
     refreshAccountCache,
+    subscribeAccountChanges,
 } from "./identity-model";
 
 /** Form-state shape for editing an Identity bundle. */
@@ -90,13 +92,23 @@ export class IdentityPaneViewModel implements ViewModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
-    /** All accounts (cached); used to populate per-provider binding pickers. */
-    accountsResource: ReturnType<typeof createResource<Account[]>>;
+    /** All accounts (cached); used to populate per-provider binding pickers.
+     *  Subscribed to identity-model's account-change broadcaster so that
+     *  accounts created externally (e.g. via the agent-pane Identity tab)
+     *  appear immediately. Reagent + codex P1 (#748). */
+    private _accounts = createSignal<Account[]>([]);
+    accountsAtom: Accessor<Account[]> = this._accounts[0];
+    setAccounts = this._accounts[1];
 
     /** Bindings for the currently-selected Identity bundle. */
-    bindingsResource: ReturnType<typeof createResource<IdentityBinding[], string>>;
+    private _bindings = createSignal<IdentityBinding[]>([]);
+    bindingsAtom: Accessor<IdentityBinding[]> = this._bindings[0];
+    setBindings = this._bindings[1];
 
     selectedBundleAtom: Accessor<IdentityBundle | null>;
+
+    /** Unsubscribe handle for the account-change subscription. */
+    private _unsubscribeAccounts: (() => void) | null = null;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
@@ -113,27 +125,33 @@ export class IdentityPaneViewModel implements ViewModel {
             return this.bundlesAtom().find((b) => b.id === id) ?? null;
         });
 
-        // Load all accounts once at mount; refresh on demand.
-        this.accountsResource = createResource<Account[]>(async () => {
-            await refreshAccountCache();
-            return (await import("./identity-model")).loadAccounts();
+        // Refresh bindings whenever the selection changes. Solid memos
+        // run lazily, so use a tracked effect-style helper: we pull the
+        // selected id via createMemo and refetch on change.
+        createMemo(() => {
+            const id = this.selectedIdAtom();
+            void this.refreshBindings(id);
         });
 
-        // Bindings refresh whenever the selection changes.
-        this.bindingsResource = createResource<IdentityBinding[], string>(
-            () => this.selectedIdAtom() ?? undefined,
-            async (identity_id) => {
-                if (!identity_id) return [];
-                try {
-                    return await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
-                        identity_id,
-                    });
-                } catch (e) {
-                    this.setError(`Failed to load bindings: ${(e as Error).message ?? e}`);
-                    return [];
-                }
-            },
-        );
+        // Hydrate the account list from the shared cache, then subscribe
+        // to changes so externally-created accounts (via the agent-pane
+        // Identity tab) appear instantly without a remount.
+        void (async () => {
+            try {
+                await refreshAccountCache();
+            } catch {
+                // Cache refresh errors are non-fatal — we still subscribe
+                // and any later refresh by another consumer will populate.
+            }
+            this.setAccounts(loadAccounts());
+        })();
+        this._unsubscribeAccounts = subscribeAccountChanges((accounts) => {
+            this.setAccounts(accounts);
+        });
+        onCleanup(() => {
+            this._unsubscribeAccounts?.();
+            this._unsubscribeAccounts = null;
+        });
 
         void this.refreshBundles();
     }
@@ -227,17 +245,34 @@ export class IdentityPaneViewModel implements ViewModel {
                     account_id,
                 });
             }
-            this.bindingsResource[1].refetch();
+            await this.refreshBindings(id);
         } catch (e) {
             this.setError(`Binding update failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Re-fetch bindings for a specific identity_id. Pulls into the
+     *  bindings signal so memos that read it react. */
+    async refreshBindings(identity_id: string | null): Promise<void> {
+        if (!identity_id) {
+            this.setBindings([]);
+            return;
+        }
+        try {
+            const list = await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
+                identity_id,
+            });
+            this.setBindings(list);
+        } catch (e) {
+            this.setError(`Failed to load bindings: ${(e as Error).message ?? e}`);
+            this.setBindings([]);
         }
     }
 
     /** Account list grouped by provider, for the per-provider binding rows. */
     accountsByProvider = createMemo<Map<string, Account[]>>(() => {
         const m = new Map<string, Account[]>();
-        const accounts = this.accountsResource[0]() ?? [];
-        for (const a of accounts) {
+        for (const a of this.accountsAtom()) {
             if (!m.has(a.provider)) m.set(a.provider, []);
             m.get(a.provider)!.push(a);
         }
@@ -251,8 +286,7 @@ export class IdentityPaneViewModel implements ViewModel {
     providersForBindingRows = createMemo<string[]>(() => {
         const set = new Set<string>();
         for (const provider of this.accountsByProvider().keys()) set.add(provider);
-        const bindings = this.bindingsResource[0]() ?? [];
-        for (const b of bindings) set.add(b.provider);
+        for (const b of this.bindingsAtom()) set.add(b.provider);
         return Array.from(set).sort();
     });
 
@@ -261,6 +295,7 @@ export class IdentityPaneViewModel implements ViewModel {
     }
 
     dispose(): void {
-        // Solid resources GC with the model instance.
+        this._unsubscribeAccounts?.();
+        this._unsubscribeAccounts = null;
     }
 }

--- a/frontend/app/view/identity/identity-pane-model.ts
+++ b/frontend/app/view/identity/identity-pane-model.ts
@@ -1,0 +1,266 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Identity pane — first-class management of Identity bundles.
+//
+// An Identity bundle is a named credential set (e.g. "Work", "Personal")
+// that contains one Account per provider via the v7
+// `db_identity_bindings` junction. Bundles are reusable across many
+// agent instances — pick one in the launch modal alongside a Memory.
+//
+// This module owns the standalone-pane ViewModel (`view: "identity"`).
+// It is distinct from `identity-model.ts` which owns the Account-level
+// CRUD that the agent pane's old Identity tab used. The new pane
+// consumes Account types from that older module but does its own
+// bundle-level state management.
+
+import { BlockNodeModel } from "@/app/block/blocktypes";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
+import { createMemo, createResource, createSignal, type Accessor } from "solid-js";
+
+import {
+    type Account,
+    PROVIDER_LABELS,
+    refreshAccountCache,
+} from "./identity-model";
+
+/** Form-state shape for editing an Identity bundle. */
+export interface IdentityBundleDraft {
+    id?: string;
+    name: string;
+    description: string;
+}
+
+export function emptyBundleDraft(): IdentityBundleDraft {
+    return { id: undefined, name: "", description: "" };
+}
+
+export function bundleDraftFrom(b: IdentityBundle): IdentityBundleDraft {
+    return {
+        id: b.id,
+        name: b.name,
+        description: b.description ?? "",
+    };
+}
+
+/** Wire shape for `upsertidentitybundle`. */
+export function bundleDraftToWire(d: IdentityBundleDraft): Partial<IdentityBundle> {
+    return {
+        id: d.id,
+        name: d.name.trim(),
+        description: d.description.trim(),
+    };
+}
+
+export class IdentityPaneViewModel implements ViewModel {
+    viewType = "identity";
+    blockId: string;
+    nodeModel: BlockNodeModel;
+
+    viewIcon: Accessor<string> = () => "user";
+    viewName: Accessor<string>;
+    viewText: Accessor<string | HeaderElem[]> = () => "Identity";
+    noPadding: Accessor<boolean> = () => false;
+
+    get viewComponent(): ViewComponent {
+        return null; // overridden by the barrel
+    }
+
+    blockAtom: Accessor<Block | undefined>;
+
+    private _bundles = createSignal<IdentityBundle[]>([]);
+    bundlesAtom: Accessor<IdentityBundle[]> = this._bundles[0];
+    setBundles = this._bundles[1];
+
+    private _selectedId = createSignal<string | null>(null);
+    selectedIdAtom: Accessor<string | null> = this._selectedId[0];
+    setSelectedId = this._selectedId[1];
+
+    private _draft = createSignal<IdentityBundleDraft | null>(null);
+    draftAtom: Accessor<IdentityBundleDraft | null> = this._draft[0];
+    setDraft = this._draft[1];
+
+    private _saving = createSignal<boolean>(false);
+    savingAtom: Accessor<boolean> = this._saving[0];
+    setSaving = this._saving[1];
+
+    private _error = createSignal<string | null>(null);
+    errorAtom: Accessor<string | null> = this._error[0];
+    setError = this._error[1];
+
+    /** All accounts (cached); used to populate per-provider binding pickers. */
+    accountsResource: ReturnType<typeof createResource<Account[]>>;
+
+    /** Bindings for the currently-selected Identity bundle. */
+    bindingsResource: ReturnType<typeof createResource<IdentityBinding[], string>>;
+
+    selectedBundleAtom: Accessor<IdentityBundle | null>;
+
+    constructor(blockId: string, nodeModel: BlockNodeModel) {
+        this.blockId = blockId;
+        this.nodeModel = nodeModel;
+        this.blockAtom = getWaveObjectAtom(makeORef("block", blockId));
+        this.viewName = createMemo(() => {
+            const block = this.blockAtom();
+            return (block?.meta?.["frame:title"] as string) ?? "Identity";
+        });
+
+        this.selectedBundleAtom = createMemo(() => {
+            const id = this.selectedIdAtom();
+            if (!id) return null;
+            return this.bundlesAtom().find((b) => b.id === id) ?? null;
+        });
+
+        // Load all accounts once at mount; refresh on demand.
+        this.accountsResource = createResource<Account[]>(async () => {
+            await refreshAccountCache();
+            return (await import("./identity-model")).loadAccounts();
+        });
+
+        // Bindings refresh whenever the selection changes.
+        this.bindingsResource = createResource<IdentityBinding[], string>(
+            () => this.selectedIdAtom() ?? undefined,
+            async (identity_id) => {
+                if (!identity_id) return [];
+                try {
+                    return await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
+                        identity_id,
+                    });
+                } catch (e) {
+                    this.setError(`Failed to load bindings: ${(e as Error).message ?? e}`);
+                    return [];
+                }
+            },
+        );
+
+        void this.refreshBundles();
+    }
+
+    /** Re-fetch the bundle list. */
+    async refreshBundles(): Promise<void> {
+        try {
+            const list = await RpcApi.ListIdentityBundlesCommand(TabRpcClient, {});
+            this.setBundles(list);
+            this.setError(null);
+        } catch (e) {
+            this.setError(`Failed to load Identity bundles: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    startNew(): void {
+        this.setDraft(emptyBundleDraft());
+        this.setSelectedId(null);
+    }
+
+    startEdit(bundle: IdentityBundle): void {
+        if (bundle.is_blank) {
+            this.setError("The blank Identity is system-managed and cannot be edited.");
+            return;
+        }
+        this.setDraft(bundleDraftFrom(bundle));
+        this.setSelectedId(bundle.id);
+    }
+
+    cancelDraft(): void {
+        this.setDraft(null);
+    }
+
+    async saveDraft(): Promise<void> {
+        const draft = this.draftAtom();
+        if (!draft) return;
+        if (!draft.name.trim()) {
+            this.setError("Identity name is required.");
+            return;
+        }
+        this.setSaving(true);
+        this.setError(null);
+        try {
+            const saved = await RpcApi.UpsertIdentityBundleCommand(
+                TabRpcClient,
+                bundleDraftToWire(draft),
+            );
+            this.setDraft(null);
+            this.setSelectedId(saved.id);
+            await this.refreshBundles();
+        } catch (e) {
+            this.setError(`Save failed: ${(e as Error).message ?? e}`);
+        } finally {
+            this.setSaving(false);
+        }
+    }
+
+    async deleteBundle(id: string): Promise<void> {
+        const target = this.bundlesAtom().find((b) => b.id === id);
+        if (target?.is_blank) {
+            this.setError("The blank Identity is system-managed and cannot be deleted.");
+            return;
+        }
+        this.setError(null);
+        try {
+            await RpcApi.DeleteIdentityBundleCommand(TabRpcClient, { id });
+            if (this.selectedIdAtom() === id) this.setSelectedId(null);
+            this.setDraft(null);
+            await this.refreshBundles();
+        } catch (e) {
+            this.setError(`Delete failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Set the account binding for `(identity, provider)`. account_id =
+     *  empty string means unbind. */
+    async setBinding(provider: string, account_id: string): Promise<void> {
+        const id = this.selectedIdAtom();
+        if (!id) return;
+        this.setError(null);
+        try {
+            if (account_id === "") {
+                await RpcApi.UnbindIdentityAccountCommand(TabRpcClient, {
+                    identity_id: id,
+                    provider,
+                });
+            } else {
+                await RpcApi.BindIdentityAccountCommand(TabRpcClient, {
+                    identity_id: id,
+                    provider,
+                    account_id,
+                });
+            }
+            this.bindingsResource[1].refetch();
+        } catch (e) {
+            this.setError(`Binding update failed: ${(e as Error).message ?? e}`);
+        }
+    }
+
+    /** Account list grouped by provider, for the per-provider binding rows. */
+    accountsByProvider = createMemo<Map<string, Account[]>>(() => {
+        const m = new Map<string, Account[]>();
+        const accounts = this.accountsResource[0]() ?? [];
+        for (const a of accounts) {
+            if (!m.has(a.provider)) m.set(a.provider, []);
+            m.get(a.provider)!.push(a);
+        }
+        return m;
+    });
+
+    /** Return the providers we should render rows for: any provider that
+     *  has at least one account, plus any provider that's already bound
+     *  (so an existing binding stays visible even if the underlying
+     *  account was deleted). */
+    providersForBindingRows = createMemo<string[]>(() => {
+        const set = new Set<string>();
+        for (const provider of this.accountsByProvider().keys()) set.add(provider);
+        const bindings = this.bindingsResource[0]() ?? [];
+        for (const b of bindings) set.add(b.provider);
+        return Array.from(set).sort();
+    });
+
+    providerLabel(provider: string): string {
+        return (PROVIDER_LABELS as Record<string, string>)[provider] ?? provider;
+    }
+
+    dispose(): void {
+        // Solid resources GC with the model instance.
+    }
+}

--- a/frontend/app/view/identity/identity-pane-model.ts
+++ b/frontend/app/view/identity/identity-pane-model.ts
@@ -47,12 +47,23 @@ export function bundleDraftFrom(b: IdentityBundle): IdentityBundleDraft {
     };
 }
 
-/** Wire shape for `upsertidentitybundle`. */
-export function bundleDraftToWire(d: IdentityBundleDraft): Partial<IdentityBundle> {
+/** Wire shape for `upsertidentitybundle`.
+ *
+ *  The backend deserializes directly into the Rust `Identity` struct,
+ *  which has no serde defaults for `id`, `is_blank`, `created_at`, or
+ *  `updated_at`. Send all required fields — empty string for id (the
+ *  upsert handler mints a UUID when blank), `false` for is_blank, 0
+ *  for both timestamps (the handler server-sets created_at = now
+ *  when zero and always overwrites updated_at). Codex P1 (PR #750):
+ *  same bug as Memory upsert had on PR #749. */
+export function bundleDraftToWire(d: IdentityBundleDraft): IdentityBundle {
     return {
-        id: d.id,
+        id: d.id ?? "",
         name: d.name.trim(),
         description: d.description.trim(),
+        is_blank: false,
+        created_at: 0,
+        updated_at: 0,
     };
 }
 
@@ -255,7 +266,13 @@ export class IdentityPaneViewModel implements ViewModel {
     }
 
     /** Re-fetch bindings for a specific identity_id. Pulls into the
-     *  bindings signal so memos that read it react. */
+     *  bindings signal so memos that read it react.
+     *
+     *  Stale-response guard: rapid selection changes can land
+     *  responses out of order. After the await, drop the result if
+     *  the user has selected a different identity in the meantime —
+     *  otherwise we'd display bindings for an earlier selection on
+     *  the currently-selected identity. Reagent P1 (PR #750). */
     async refreshBindings(identity_id: string | null): Promise<void> {
         if (!identity_id) {
             this.setBindings([]);
@@ -265,10 +282,19 @@ export class IdentityPaneViewModel implements ViewModel {
             const list = await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
                 identity_id,
             });
-            this.setBindings(list);
+            // The user might have switched selection during the
+            // round-trip. Only commit if our identity_id is still the
+            // selected one.
+            if (this.selectedIdAtom() === identity_id) {
+                this.setBindings(list);
+            }
         } catch (e) {
-            this.setError(`Failed to load bindings: ${(e as Error).message ?? e}`);
-            this.setBindings([]);
+            // Same staleness guard on the error path: don't surface
+            // an error for a non-current identity.
+            if (this.selectedIdAtom() === identity_id) {
+                this.setError(`Failed to load bindings: ${(e as Error).message ?? e}`);
+                this.setBindings([]);
+            }
         }
     }
 

--- a/frontend/app/view/identity/identity-pane-model.ts
+++ b/frontend/app/view/identity/identity-pane-model.ts
@@ -18,7 +18,7 @@ import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
-import { createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
+import { createEffect, createMemo, createSignal, onCleanup, type Accessor } from "solid-js";
 
 import {
     type Account,
@@ -125,10 +125,13 @@ export class IdentityPaneViewModel implements ViewModel {
             return this.bundlesAtom().find((b) => b.id === id) ?? null;
         });
 
-        // Refresh bindings whenever the selection changes. Solid memos
-        // run lazily, so use a tracked effect-style helper: we pull the
-        // selected id via createMemo and refetch on change.
-        createMemo(() => {
+        // Refresh bindings whenever the selection changes. Use
+        // createEffect (not createMemo) — the previous version used
+        // createMemo whose return value is discarded; createMemo is
+        // lazy and only re-runs when its return value is consumed,
+        // so the effect fired exactly once at construction. Reagent
+        // P1 (PR #748).
+        createEffect(() => {
             const id = this.selectedIdAtom();
             void this.refreshBindings(id);
         });

--- a/frontend/app/view/identity/identity-pane-view.scss
+++ b/frontend/app/view/identity/identity-pane-view.scss
@@ -1,0 +1,249 @@
+// Identity pane — same shape as memory-view.scss (left rail + detail).
+
+.identity-pane {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
+    background: var(--main-bg-color);
+    color: var(--main-text-color);
+
+    .identity-pane-rail {
+        flex: 0 0 240px;
+        display: flex;
+        flex-direction: column;
+        border-right: 1px solid var(--border-color);
+        overflow: hidden;
+    }
+
+    .identity-pane-rail-header {
+        padding: 8px;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .identity-pane-new-btn {
+        width: 100%;
+        padding: 6px 10px;
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 13px;
+
+        &:hover {
+            filter: brightness(1.1);
+        }
+    }
+
+    .identity-pane-list {
+        flex: 1 1 auto;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        overflow-y: auto;
+    }
+
+    .identity-pane-list-item {
+        padding: 10px 12px;
+        cursor: pointer;
+        border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.06));
+
+        &:hover {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+
+        &.is-selected {
+            background: var(--selected-bg-color, rgba(255, 255, 255, 0.08));
+        }
+
+        &.is-blank {
+            font-style: italic;
+            color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+        }
+    }
+
+    .identity-pane-list-item-name {
+        font-size: 13px;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .identity-pane-list-item-desc {
+        font-size: 11px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.6));
+        margin-top: 2px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .identity-pane-detail {
+        flex: 1 1 auto;
+        padding: 16px 24px;
+        overflow-y: auto;
+    }
+
+    .identity-pane-error {
+        padding: 8px 12px;
+        margin-bottom: 12px;
+        background: var(--error-bg-color, rgba(255, 80, 80, 0.15));
+        color: var(--error-text-color, #ff8080);
+        border-radius: 4px;
+        font-size: 13px;
+    }
+
+    .identity-pane-empty {
+        max-width: 460px;
+        color: var(--secondary-text-color, rgba(255, 255, 255, 0.7));
+        line-height: 1.5;
+    }
+
+    .identity-pane-empty-hint {
+        font-size: 13px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+        margin-top: 8px;
+    }
+
+    // ── Read-only detail ───────────────────────────────────────────
+    .identity-pane-readonly {
+        max-width: 720px;
+    }
+
+    .identity-pane-name {
+        font-size: 20px;
+        margin: 0 0 4px;
+    }
+
+    .identity-pane-description {
+        margin: 0 0 16px;
+        color: var(--secondary-text-color);
+    }
+
+    .identity-pane-section-title {
+        font-size: 14px;
+        margin: 16px 0 8px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        color: var(--secondary-text-color);
+    }
+
+    .identity-pane-bindings {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+
+        thead th {
+            text-align: left;
+            padding: 4px 8px;
+            font-weight: 500;
+            color: var(--secondary-text-color);
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        tbody td {
+            padding: 6px 8px;
+            border-bottom: 1px solid var(--border-color-faint, rgba(255, 255, 255, 0.04));
+            vertical-align: middle;
+        }
+
+        tbody td:first-child {
+            font-weight: 500;
+            width: 140px;
+        }
+    }
+
+    .identity-pane-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 16px;
+    }
+
+    .identity-pane-edit-btn,
+    .identity-pane-delete-btn,
+    .identity-pane-cancel-btn,
+    .identity-pane-save-btn {
+        padding: 6px 14px;
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        background: transparent;
+        color: var(--main-text-color);
+        cursor: pointer;
+        font-size: 13px;
+
+        &:hover:not(:disabled) {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.04));
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    }
+
+    .identity-pane-save-btn {
+        background: var(--accent-color);
+        color: var(--accent-text-color, #fff);
+        border-color: transparent;
+    }
+
+    .identity-pane-delete-btn {
+        color: var(--error-text-color, #ff8080);
+        border-color: var(--error-text-color, #ff8080);
+    }
+
+    // ── Edit form ──────────────────────────────────────────────────
+    .identity-pane-form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-width: 720px;
+    }
+
+    .identity-pane-form-title {
+        font-size: 18px;
+        margin: 0 0 4px;
+    }
+
+    .identity-pane-field {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .identity-pane-field-label {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+    }
+
+    .identity-pane-input {
+        padding: 6px 10px;
+        background: var(--input-bg-color, rgba(0, 0, 0, 0.2));
+        color: var(--main-text-color);
+        border: 1px solid var(--border-color);
+        border-radius: 4px;
+        font-size: 13px;
+        font-family: inherit;
+
+        &:focus {
+            outline: none;
+            border-color: var(--accent-color);
+        }
+    }
+
+    .identity-pane-form-actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 8px;
+    }
+
+    .identity-pane-form-hint {
+        font-size: 11px;
+        color: var(--tertiary-text-color, rgba(255, 255, 255, 0.5));
+        margin: 4px 0 0;
+        font-style: italic;
+    }
+}

--- a/frontend/app/view/identity/identity-pane-view.tsx
+++ b/frontend/app/view/identity/identity-pane-view.tsx
@@ -1,0 +1,265 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Identity pane view — left rail (bundle list + add) + right detail
+// (bundle name/description + per-provider account-binding table).
+//
+// Compared to the Memory pane, the right side has two major sections:
+// the editable bundle metadata, and a binding table where each provider
+// row carries a dropdown of available accounts.
+
+import { For, Show, type JSX } from "solid-js";
+
+import type { IdentityPaneViewModel } from "./identity-pane-model";
+
+import "./identity-pane-view.scss";
+
+interface IdentityPaneViewProps {
+    model: IdentityPaneViewModel;
+}
+
+export const IdentityPaneView = (props: IdentityPaneViewProps): JSX.Element => {
+    const { model } = props;
+
+    const handleSelect = (bundle: IdentityBundle) => model.startEdit(bundle);
+    const handleNew = () => model.startNew();
+    const handleSave = () => void model.saveDraft();
+    const handleCancel = () => model.cancelDraft();
+
+    const handleDelete = (id: string) => {
+        const ok = window.confirm(
+            "Delete this Identity bundle? Running instances continue with their snapshot, but new launches won't see it.",
+        );
+        if (!ok) return;
+        void model.deleteBundle(id);
+    };
+
+    const updateDraft = <K extends keyof DraftShape>(key: K, value: DraftShape[K]) => {
+        const cur = model.draftAtom();
+        if (!cur) return;
+        model.setDraft({ ...cur, [key]: value });
+    };
+
+    return (
+        <div class="identity-pane">
+            <div class="identity-pane-rail">
+                <div class="identity-pane-rail-header">
+                    <button class="identity-pane-new-btn" onClick={handleNew}>
+                        + New Identity
+                    </button>
+                </div>
+                <ul class="identity-pane-list">
+                    <For each={model.bundlesAtom()}>
+                        {(bundle) => (
+                            <li
+                                class="identity-pane-list-item"
+                                classList={{
+                                    "is-selected": model.selectedIdAtom() === bundle.id,
+                                    "is-blank": !!bundle.is_blank,
+                                }}
+                                onClick={() => handleSelect(bundle)}
+                            >
+                                <div class="identity-pane-list-item-name">
+                                    {bundle.is_blank ? "— Blank (no creds) —" : bundle.name}
+                                </div>
+                                <Show when={bundle.description && !bundle.is_blank}>
+                                    <div class="identity-pane-list-item-desc">
+                                        {bundle.description}
+                                    </div>
+                                </Show>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+            </div>
+
+            <div class="identity-pane-detail">
+                <Show when={model.errorAtom()}>
+                    <div class="identity-pane-error">{model.errorAtom()}</div>
+                </Show>
+
+                <Show
+                    when={model.draftAtom()}
+                    fallback={
+                        <Show
+                            when={model.selectedBundleAtom()}
+                            fallback={
+                                <div class="identity-pane-empty">
+                                    <p>Select an Identity bundle from the list, or create a new one.</p>
+                                    <p class="identity-pane-empty-hint">
+                                        An Identity bundles together one account per provider —
+                                        e.g. your work GitHub PAT plus a work Anthropic key — so you
+                                        can pick the whole bundle at launch instead of selecting
+                                        accounts one by one.
+                                    </p>
+                                </div>
+                            }
+                        >
+                            {(bundle) => (
+                                <div class="identity-pane-readonly">
+                                    <h2 class="identity-pane-name">{bundle().name}</h2>
+                                    <Show when={bundle().description}>
+                                        <p class="identity-pane-description">{bundle().description}</p>
+                                    </Show>
+
+                                    <h3 class="identity-pane-section-title">Bound accounts</h3>
+                                    <Show
+                                        when={model.providersForBindingRows().length > 0}
+                                        fallback={
+                                            <p class="identity-pane-empty-hint">
+                                                No accounts available yet — create some via the
+                                                Identity tab in any agent pane to bind them here.
+                                            </p>
+                                        }
+                                    >
+                                        <table class="identity-pane-bindings">
+                                            <thead>
+                                                <tr>
+                                                    <th>Provider</th>
+                                                    <th>Account</th>
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                <For each={model.providersForBindingRows()}>
+                                                    {(provider) => (
+                                                        <tr>
+                                                            <td>{model.providerLabel(provider)}</td>
+                                                            <td>
+                                                                <select
+                                                                    class="identity-pane-input"
+                                                                    value={
+                                                                        model
+                                                                            .bindingsResource[0]()
+                                                                            ?.find(
+                                                                                (b) =>
+                                                                                    b.provider ===
+                                                                                    provider,
+                                                                            )?.account_id ?? ""
+                                                                    }
+                                                                    disabled={!!bundle().is_blank}
+                                                                    onChange={(e) =>
+                                                                        void model.setBinding(
+                                                                            provider,
+                                                                            e.currentTarget.value,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <option value="">— None —</option>
+                                                                    <For
+                                                                        each={
+                                                                            model
+                                                                                .accountsByProvider()
+                                                                                .get(provider) ?? []
+                                                                        }
+                                                                    >
+                                                                        {(acc) => (
+                                                                            <option value={acc.id}>
+                                                                                {acc.display_name?.trim() ||
+                                                                                    acc.name}
+                                                                            </option>
+                                                                        )}
+                                                                    </For>
+                                                                </select>
+                                                            </td>
+                                                        </tr>
+                                                    )}
+                                                </For>
+                                            </tbody>
+                                        </table>
+                                    </Show>
+
+                                    <Show when={!bundle().is_blank}>
+                                        <div class="identity-pane-actions">
+                                            <button
+                                                class="identity-pane-edit-btn"
+                                                onClick={() => model.startEdit(bundle())}
+                                            >
+                                                Edit name / description
+                                            </button>
+                                            <button
+                                                class="identity-pane-delete-btn"
+                                                onClick={() => handleDelete(bundle().id)}
+                                            >
+                                                Delete
+                                            </button>
+                                        </div>
+                                    </Show>
+                                </div>
+                            )}
+                        </Show>
+                    }
+                >
+                    {(draft) => (
+                        <form
+                            class="identity-pane-form"
+                            onSubmit={(e) => {
+                                e.preventDefault();
+                                handleSave();
+                            }}
+                        >
+                            <h2 class="identity-pane-form-title">
+                                {draft().id ? "Edit Identity" : "New Identity"}
+                            </h2>
+
+                            <label class="identity-pane-field">
+                                <span class="identity-pane-field-label">Name *</span>
+                                <input
+                                    class="identity-pane-input"
+                                    type="text"
+                                    value={draft().name}
+                                    onInput={(e) => updateDraft("name", e.currentTarget.value)}
+                                    placeholder="e.g. Work"
+                                    required
+                                />
+                            </label>
+
+                            <label class="identity-pane-field">
+                                <span class="identity-pane-field-label">Description</span>
+                                <input
+                                    class="identity-pane-input"
+                                    type="text"
+                                    value={draft().description}
+                                    onInput={(e) =>
+                                        updateDraft("description", e.currentTarget.value)
+                                    }
+                                    placeholder="Short label shown in the launch picker"
+                                />
+                            </label>
+
+                            <div class="identity-pane-form-actions">
+                                <button
+                                    type="button"
+                                    class="identity-pane-cancel-btn"
+                                    onClick={handleCancel}
+                                    disabled={model.savingAtom()}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="submit"
+                                    class="identity-pane-save-btn"
+                                    disabled={model.savingAtom() || !draft().name.trim()}
+                                >
+                                    {model.savingAtom() ? "Saving…" : "Save"}
+                                </button>
+                            </div>
+
+                            <p class="identity-pane-form-hint">
+                                After saving, you'll be able to bind accounts per provider on the
+                                detail view.
+                            </p>
+                        </form>
+                    )}
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+// Local alias mirroring `IdentityBundleDraft` from the model — see the
+// memory-view.tsx note for why we don't import it directly.
+type DraftShape = {
+    id?: string;
+    name: string;
+    description: string;
+};

--- a/frontend/app/view/identity/identity-pane-view.tsx
+++ b/frontend/app/view/identity/identity-pane-view.tsx
@@ -21,7 +21,18 @@ interface IdentityPaneViewProps {
 export const IdentityPaneView = (props: IdentityPaneViewProps): JSX.Element => {
     const { model } = props;
 
-    const handleSelect = (bundle: IdentityBundle) => model.startEdit(bundle);
+    // Clicking a list item SELECTS the bundle so the binding table
+    // becomes visible. The metadata draft (name + description) opens
+    // only via the explicit "Edit name / description" button on the
+    // detail view. Reagent + codex P1 / P2 (#748): the previous
+    // handler called startEdit which auto-opened the form, blocking
+    // the binding table; clicking the blank singleton would surface
+    // an error and leave the right panel in the empty state.
+    const handleSelect = (bundle: IdentityBundle) => {
+        model.setError(null);
+        model.cancelDraft();
+        model.setSelectedId(bundle.id);
+    };
     const handleNew = () => model.startNew();
     const handleSave = () => void model.saveDraft();
     const handleCancel = () => model.cancelDraft();
@@ -129,8 +140,8 @@ export const IdentityPaneView = (props: IdentityPaneViewProps): JSX.Element => {
                                                                     class="identity-pane-input"
                                                                     value={
                                                                         model
-                                                                            .bindingsResource[0]()
-                                                                            ?.find(
+                                                                            .bindingsAtom()
+                                                                            .find(
                                                                                 (b) =>
                                                                                     b.provider ===
                                                                                     provider,

--- a/frontend/app/view/identity/identity-pane.tsx
+++ b/frontend/app/view/identity/identity-pane.tsx
@@ -1,0 +1,17 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Identity pane barrel — wires the view component onto the standalone-
+// pane ViewModel prototype. Distinct from `identity.tsx` (if any) which
+// barrelled the legacy in-agent-pane Identity tab.
+
+import { IdentityPaneViewModel } from "./identity-pane-model";
+import { IdentityPaneView } from "./identity-pane-view";
+
+Object.defineProperty(IdentityPaneViewModel.prototype, "viewComponent", {
+    get() {
+        return IdentityPaneView;
+    },
+});
+
+export { IdentityPaneViewModel };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.722",
+  "version": "0.33.723",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR-F.2 of issue #678. Re-opening from #748 which was auto-closed when its base branch (PR-F.1's branch) was deleted on merge of PR #749.

New standalone pane (\`view: \"identity\"\`, \`defwidget@identity\`) for managing **Identity bundles** — named credential sets that aggregate one Account per provider via the v7 \`db_identity_bindings\` junction.

Now stacked directly on \`main\` (PR-F.0 #746 + PR-F.1 #749 both merged).

## What's in

### New module: \`frontend/app/view/identity/identity-pane*\`

- \`identity-pane-model.ts\` — \`IdentityPaneViewModel\`. Solid signals for the bundle list, selected row, in-flight draft, save / error state. Subscribes to identity-model's \`subscribeAccountChanges\` so externally-created accounts (via the agent-pane Identity tab) appear in binding pickers without a remount. Uses \`createEffect\` to refresh bindings whenever the selection changes (createMemo would be lazy and never re-fire).
- \`identity-pane-view.tsx\` — Left rail (list + \"+ New Identity\") + right detail (bundle metadata + per-provider account-binding table). Click-to-select sets the selected id only; the metadata edit form opens on the explicit \"Edit name / description\" button.
- \`identity-pane.tsx\` — barrel.
- \`identity-pane-view.scss\` — layout matching memory-view.scss.

### Wiring

- \`BlockRegistry.set(\"identity\", IdentityPaneViewModel)\` in \`block.tsx\`.
- New \`defwidget@identity\` in \`widgets.json\` (display:order 8, icon \"user\"). Help bumped to 9, devtools to 10.
- Migration shim in \`block.tsx\` no longer redirects \"identity\" → \"agent\".

### Review fixes from #748

All 6 prior-cycle findings are addressed:

- **P1**: handleSelect → setSelectedId only (not startEdit), so the read-only binding table is reachable for all bundles including the blank singleton.
- **P1**: accountsResource → accountsAtom signal subscribed to subscribeAccountChanges (was a one-shot createResource).
- **P1**: bindings refresh uses createEffect (was createMemo, which is lazy).
- **P2**: defwidget@identity / defwidget@help display:order conflict resolved.
- **P2**: redundant dynamic import of loadAccounts removed.
- Plus: bindingsResource → plain bindings signal with refreshBindings() helper for consistency with the new accountsAtom pattern.

## Test plan

- [x] tsc --noEmit clean for identity-pane module
- [x] Bumped to 0.33.723 (carried from previous branch)
- [ ] Reagent + codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)