### PR TITLE
feat(identity): launch modal bundle pickers + spawn-time env injection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.724"
+version = "0.33.725"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.724"
+version = "0.33.725"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.724"
+version = "0.33.725"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.724"
+version = "0.33.725"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.724"
+version = "0.33.725"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.724"
+version = "0.33.725"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.724"
+version = "0.33.725"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.724"
+version = "0.33.725"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1608,6 +1608,15 @@ pub struct CommandCreateAgentInstanceData {
     pub block_id: String,
     #[serde(default)]
     pub parent_instance_id: String,
+    /// FK to db_identities. Empty = blank singleton (no env-var
+    /// injection; agent inherits ambient creds). Set by the launch
+    /// modal's Identity dropdown.
+    #[serde(default)]
+    pub identity_id: String,
+    /// FK to db_memories. Empty = blank singleton. Set by the launch
+    /// modal's Memory dropdown.
+    #[serde(default)]
+    pub memory_id: String,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1537,11 +1537,12 @@ impl WaveStore {
         Ok(rows > 0)
     }
 
-    /// Look up the most-recently-created running instance for a block.
-    /// Used at CLI spawn time to find the AgentInstance row whose
-    /// identity_id / memory_id should be applied to the new
-    /// subprocess's env. Returns None if no row matches — callers
-    /// fall back to ambient credentials.
+    /// Look up the most-recently-created **active** instance for a
+    /// block — `active` = status in (running, paused). Stopped and
+    /// crashed instances are skipped: when a user closes a pane and
+    /// re-opens it (creating a fresh instance), the resolver should
+    /// see the NEW row's identity_id / memory_id, not bleed creds
+    /// from the prior stopped one. Reagent P2 (PR #751).
     pub fn instance_get_active_for_block(
         &self,
         block_id: &str,
@@ -1552,7 +1553,7 @@ impl WaveStore {
                     status, github_context, started_at, ended_at, created_at,
                     identity_id, memory_id
              FROM db_agent_instances
-             WHERE block_id = ?1
+             WHERE block_id = ?1 AND status IN ('running', 'paused')
              ORDER BY created_at DESC
              LIMIT 1",
         )?;

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1537,6 +1537,33 @@ impl WaveStore {
         Ok(rows > 0)
     }
 
+    /// Look up the most-recently-created running instance for a block.
+    /// Used at CLI spawn time to find the AgentInstance row whose
+    /// identity_id / memory_id should be applied to the new
+    /// subprocess's env. Returns None if no row matches — callers
+    /// fall back to ambient credentials.
+    pub fn instance_get_active_for_block(
+        &self,
+        block_id: &str,
+    ) -> Result<Option<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id
+             FROM db_agent_instances
+             WHERE block_id = ?1
+             ORDER BY created_at DESC
+             LIMIT 1",
+        )?;
+        let result = stmt.query_row(params![block_id], map_instance_row);
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     // ====================================================================
     // v7 — Identity bundles (named credential bundles) + Memory bundles
     // ====================================================================

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity injection at agent CLI spawn time.
+//!
+//! When an agent instance is launched, the launch modal records an
+//! `identity_id` on the `db_agent_instances` row (v7 schema). Right
+//! before the CLI subprocess starts, this module:
+//!
+//! 1. Looks up the active instance for the spawning block.
+//! 2. Reads its `identity_id`. Empty / "blank" / not-found → noop
+//!    (the agent inherits ambient credentials).
+//! 3. Reads the bindings for that Identity bundle.
+//! 4. For each binding: looks up the Account row, resolves its
+//!    `SecretRef` to a plaintext value, looks up the provider →
+//!    env-var matrix, and merges those env vars into the spawn
+//!    `env_vars` HashMap.
+//!
+//! Failure mode is **warn-don't-block**: missing accounts, env-var
+//! resolution errors, unknown providers — all logged and skipped.
+//! The agent CLI launches with whatever ambient credentials remain.
+//! This is intentional: identity injection is a convenience, not a
+//! security gate. The caller flags hard-required-creds workflows
+//! separately.
+//!
+//! Closes Phase 2 of issue #678 (the per-instance injection layer).
+//! Phase 1 (Account registry + UI) and the v7 schema reshape (Bundle
+//! entity) were prerequisites; Phase 3 (encrypted vault, OAuth flows)
+//! is deferred.
+
+pub mod resolver;
+
+pub use resolver::inject_identity_env;

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -29,6 +29,9 @@ pub enum ResolverError {
     #[error("AWS Secrets Manager backend not yet supported (Phase 3)")]
     SecretsManagerUnsupported,
 
+    #[error("PlaintextDev secrets are disabled in release builds")]
+    PlaintextDevDisabledInRelease,
+
     #[error("storage error: {0}")]
     Storage(#[from] StoreError),
 }
@@ -57,16 +60,30 @@ pub fn provider_env_vars(provider: &str) -> Vec<&'static str> {
 /// - **Env**: read `env_var` from the srv process's own environment.
 ///   Caller is expected to have set this in their shell or a
 ///   .env-style loader before launching AgentMux.
-/// - **PlaintextDev**: return the literal stored string. Dev-only —
-///   intentionally rough so it's obvious why the password is in the
-///   DB. Shipping a vault is Phase 3.
+/// - **PlaintextDev**: return the literal stored string. **Debug
+///   builds only** — guarded behind `cfg(debug_assertions)`. In
+///   release builds, the same call returns
+///   [`ResolverError::PlaintextDevDisabledInRelease`] so a forgotten
+///   dev-secret never leaks into a packaged binary. Reagent P1 on
+///   PR #751 caught the missing guard. Phase 3's encrypted vault is
+///   the production path.
 /// - **SecretsManager**: deferred. Returns
 ///   [`ResolverError::SecretsManagerUnsupported`].
 pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolverError> {
     match secret_ref {
         SecretRef::Env { env_var } => std::env::var(env_var)
             .map_err(|_| ResolverError::EnvVarMissing(env_var.clone())),
-        SecretRef::PlaintextDev { plaintext_dev } => Ok(plaintext_dev.clone()),
+        SecretRef::PlaintextDev { plaintext_dev } => {
+            #[cfg(debug_assertions)]
+            {
+                Ok(plaintext_dev.clone())
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                let _ = plaintext_dev;
+                Err(ResolverError::PlaintextDevDisabledInRelease)
+            }
+        }
         SecretRef::SecretsManager { .. } => Err(ResolverError::SecretsManagerUnsupported),
     }
 }

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -204,6 +204,7 @@ pub fn inject_identity_env(
             }
         };
 
+        let env_key_count = env_keys.len();
         for key in env_keys {
             env_vars.insert(key.to_string(), secret.clone());
         }
@@ -211,7 +212,7 @@ pub fn inject_identity_env(
         tracing::info!(
             target: "identity",
             "injected {} env var(s) for provider {} (identity={}, account={})",
-            provider_env_vars(&binding.provider).len(),
+            env_key_count,
             binding.provider,
             instance.identity_id,
             binding.account_id,
@@ -276,6 +277,14 @@ mod tests {
         assert!(provider_env_vars("unknown").is_empty());
     }
 
+    // PlaintextDev-using tests are gated behind cfg(debug_assertions)
+    // because release builds reject PlaintextDev with
+    // ResolverError::PlaintextDevDisabledInRelease, so the assertions
+    // below would fail under `cargo test --release`. Reagent P2
+    // (PR #751). The Env / SecretsManager / unknown-provider paths
+    // are tested separately and have no debug-only dependency.
+
+    #[cfg(debug_assertions)]
     #[test]
     fn resolve_plaintext_dev() {
         let s = resolve_secret(&SecretRef::PlaintextDev {
@@ -347,6 +356,7 @@ mod tests {
         assert!(env.is_empty());
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     fn inject_full_round_trip_plaintext_dev() {
         let store = make_store();
@@ -430,6 +440,7 @@ mod tests {
         );
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     fn inject_partial_success_skips_failed_bindings() {
         let store = make_store();
@@ -507,6 +518,7 @@ mod tests {
         assert!(env.get("ANTHROPIC_API_KEY").is_none());
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     fn inject_unknown_provider_is_skipped() {
         let store = make_store();

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -1,0 +1,551 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Identity → env-var resolver.
+//!
+//! Per-provider matrix of which env vars carry which credential. The
+//! GitHub PAT becomes both `GITHUB_TOKEN` and `GH_TOKEN` because both
+//! the official `gh` CLI and direct API consumers (curl, oct.js) read
+//! one or the other; emitting both is the lowest-friction way to make
+//! every common workflow Just Work.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::backend::storage::error::StoreError;
+use crate::backend::storage::wstore::{SecretRef, WaveStore};
+
+/// Errors specific to the resolver. Every variant is recoverable
+/// (the spawn proceeds with whatever env vars resolved successfully)
+/// — they exist for tracing visibility, not control flow.
+#[derive(Debug, thiserror::Error)]
+pub enum ResolverError {
+    #[error("account not found: {0}")]
+    AccountNotFound(String),
+
+    #[error("env var not set in srv environment: {0}")]
+    EnvVarMissing(String),
+
+    #[error("AWS Secrets Manager backend not yet supported (Phase 3)")]
+    SecretsManagerUnsupported,
+
+    #[error("storage error: {0}")]
+    Storage(#[from] StoreError),
+}
+
+/// Map a `(provider, secret-string)` pair to the env vars that should
+/// receive it. Returning a Vec lets a single secret populate multiple
+/// var names — github writes both GITHUB_TOKEN and GH_TOKEN, AWS
+/// writes its standard triplet (today only the access-key-id slot is
+/// expressed; multi-secret AWS modeled as three separate accounts is
+/// the documented workaround until the matrix learns multi-var
+/// emission).
+pub fn provider_env_vars(provider: &str) -> Vec<&'static str> {
+    match provider {
+        "github" => vec!["GITHUB_TOKEN", "GH_TOKEN"],
+        "anthropic" => vec!["ANTHROPIC_API_KEY"],
+        "openai" => vec!["OPENAI_API_KEY"],
+        "kimi" => vec!["MOONSHOT_API_KEY"],
+        "aws" => vec!["AWS_ACCESS_KEY_ID"],
+        _ => Vec::new(),
+    }
+}
+
+/// Resolve a `SecretRef` to the plaintext credential string. Each
+/// backend has a distinct path:
+///
+/// - **Env**: read `env_var` from the srv process's own environment.
+///   Caller is expected to have set this in their shell or a
+///   .env-style loader before launching AgentMux.
+/// - **PlaintextDev**: return the literal stored string. Dev-only —
+///   intentionally rough so it's obvious why the password is in the
+///   DB. Shipping a vault is Phase 3.
+/// - **SecretsManager**: deferred. Returns
+///   [`ResolverError::SecretsManagerUnsupported`].
+pub fn resolve_secret(secret_ref: &SecretRef) -> Result<String, ResolverError> {
+    match secret_ref {
+        SecretRef::Env { env_var } => std::env::var(env_var)
+            .map_err(|_| ResolverError::EnvVarMissing(env_var.clone())),
+        SecretRef::PlaintextDev { plaintext_dev } => Ok(plaintext_dev.clone()),
+        SecretRef::SecretsManager { .. } => Err(ResolverError::SecretsManagerUnsupported),
+    }
+}
+
+/// Inject identity-derived env vars into the spawn map for a block.
+///
+/// This is the public entry point called from the CLI-spawn paths
+/// (`AgentInputCommand` in websocket.rs and `AgentSendCommand` in
+/// app_api.rs). Resolution flow:
+///
+/// 1. Look up the active `AgentInstance` for this block. If none
+///    exists, the caller didn't go through the launch modal — return
+///    immediately, no injection.
+/// 2. Read its `identity_id`. Empty / "blank" → no injection (the
+///    user picked the blank singleton at launch, meaning "use ambient
+///    creds").
+/// 3. Read the `db_identity_bindings` rows for that identity_id.
+/// 4. For each binding: fetch the account, resolve its `SecretRef`,
+///    look up the provider's env-var matrix, write each var into
+///    `env_vars`. Any per-binding failure is logged and skipped —
+///    other bindings still inject. The agent CLI launches with
+///    whatever resolved cleanly plus whatever ambient env was already
+///    in the spawn map.
+///
+/// This function is intentionally infallible at the top level. It
+/// has no `Result`, just side-effects on `env_vars` and `tracing::warn`
+/// for every per-binding error. The spawn never aborts because a
+/// secret didn't resolve.
+pub fn inject_identity_env(
+    wstore: Arc<WaveStore>,
+    block_id: &str,
+    env_vars: &mut HashMap<String, String>,
+) {
+    // Step 1: instance lookup.
+    let instance = match wstore.instance_get_active_for_block(block_id) {
+        Ok(Some(i)) => i,
+        Ok(None) => {
+            // Block has no agent instance row — nothing to inject.
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(target: "identity", "instance lookup failed for block {}: {}", block_id, e);
+            return;
+        }
+    };
+
+    // Step 2: identity_id check.
+    if instance.identity_id.is_empty() || instance.identity_id == "blank" {
+        // Blank singleton or unset → ambient creds.
+        return;
+    }
+
+    // Step 3: bindings.
+    let bindings = match wstore.bundle_identity_bindings(&instance.identity_id) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(
+                target: "identity",
+                "bindings lookup failed for identity {}: {}",
+                instance.identity_id,
+                e,
+            );
+            return;
+        }
+    };
+
+    if bindings.is_empty() {
+        // Identity exists but has no accounts bound. Nothing to inject.
+        return;
+    }
+
+    // Step 4: per-binding resolution + env-var write.
+    for binding in &bindings {
+        let env_keys = provider_env_vars(&binding.provider);
+        if env_keys.is_empty() {
+            tracing::warn!(
+                target: "identity",
+                "no env-var mapping for provider {} (binding for identity {})",
+                binding.provider,
+                instance.identity_id,
+            );
+            continue;
+        }
+
+        let account = match wstore.identity_get(&binding.account_id) {
+            Ok(Some(a)) => a,
+            Ok(None) => {
+                tracing::warn!(
+                    target: "identity",
+                    "account {} bound to identity {} but row not found — skipping",
+                    binding.account_id,
+                    instance.identity_id,
+                );
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "identity",
+                    "account lookup failed for {}: {}",
+                    binding.account_id,
+                    e,
+                );
+                continue;
+            }
+        };
+
+        let secret = match resolve_secret(&account.secret_ref) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(
+                    target: "identity",
+                    "secret resolution failed for account {} (provider {}): {} — skipping",
+                    binding.account_id,
+                    binding.provider,
+                    e,
+                );
+                continue;
+            }
+        };
+
+        for key in env_keys {
+            env_vars.insert(key.to_string(), secret.clone());
+        }
+
+        tracing::info!(
+            target: "identity",
+            "injected {} env var(s) for provider {} (identity={}, account={})",
+            provider_env_vars(&binding.provider).len(),
+            binding.provider,
+            instance.identity_id,
+            binding.account_id,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backend::storage::wstore::{
+        AgentInstance, Identity, IdentityAccount, InstanceStatus, SecretRef,
+    };
+
+    fn make_store() -> Arc<WaveStore> {
+        Arc::new(WaveStore::open_in_memory().unwrap())
+    }
+
+    fn make_account(
+        id: &str,
+        provider: &str,
+        secret_ref: SecretRef,
+    ) -> IdentityAccount {
+        IdentityAccount {
+            id: id.to_string(),
+            name: format!("{}-{}", provider, id),
+            provider: provider.to_string(),
+            kind: "pat".to_string(),
+            display_name: String::new(),
+            secret_ref,
+            context: serde_json::json!({}),
+            status: "unknown".to_string(),
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    fn make_instance(block_id: &str, identity_id: &str) -> AgentInstance {
+        AgentInstance {
+            id: format!("inst-{block_id}"),
+            definition_id: "def-1".to_string(),
+            parent_instance_id: String::new(),
+            block_id: block_id.to_string(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at: 0,
+            ended_at: 0,
+            created_at: 0,
+            identity_id: identity_id.to_string(),
+            memory_id: String::new(),
+        }
+    }
+
+    #[test]
+    fn provider_env_vars_matrix() {
+        assert_eq!(provider_env_vars("github"), vec!["GITHUB_TOKEN", "GH_TOKEN"]);
+        assert_eq!(provider_env_vars("anthropic"), vec!["ANTHROPIC_API_KEY"]);
+        assert_eq!(provider_env_vars("openai"), vec!["OPENAI_API_KEY"]);
+        assert_eq!(provider_env_vars("kimi"), vec!["MOONSHOT_API_KEY"]);
+        assert_eq!(provider_env_vars("aws"), vec!["AWS_ACCESS_KEY_ID"]);
+        assert!(provider_env_vars("unknown").is_empty());
+    }
+
+    #[test]
+    fn resolve_plaintext_dev() {
+        let s = resolve_secret(&SecretRef::PlaintextDev {
+            plaintext_dev: "ghp_test123".to_string(),
+        })
+        .unwrap();
+        assert_eq!(s, "ghp_test123");
+    }
+
+    #[test]
+    fn resolve_env_var_missing() {
+        let res = resolve_secret(&SecretRef::Env {
+            env_var: "AGENTMUX_TEST_NEVER_SET_X9Q".to_string(),
+        });
+        assert!(matches!(res, Err(ResolverError::EnvVarMissing(_))));
+    }
+
+    #[test]
+    fn resolve_secrets_manager_unsupported() {
+        let res = resolve_secret(&SecretRef::SecretsManager {
+            sm_path: "ignored".to_string(),
+            sm_json_path: None,
+        });
+        assert!(matches!(res, Err(ResolverError::SecretsManagerUnsupported)));
+    }
+
+    #[test]
+    fn inject_no_instance_does_nothing() {
+        let store = make_store();
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store, "block-no-instance", &mut env);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn inject_blank_identity_does_nothing() {
+        let store = make_store();
+        // Need a definition for the FK on db_agent_instances.
+        let mut def = crate::backend::storage::wstore::ForgeAgent {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+        };
+        store.forge_insert(&mut def).unwrap();
+
+        let mut inst = make_instance("block-blank", "blank");
+        store.instance_create(&inst).unwrap();
+        let _ = inst; // keep clippy happy
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store, "block-blank", &mut env);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn inject_full_round_trip_plaintext_dev() {
+        let store = make_store();
+
+        // Forge agent (definition).
+        let mut def = crate::backend::storage::wstore::ForgeAgent {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+        };
+        store.forge_insert(&mut def).unwrap();
+
+        // Identity bundle.
+        let identity = Identity {
+            id: "id-work".to_string(),
+            name: "Work".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        // GitHub account (PlaintextDev for test simplicity).
+        let github = make_account(
+            "acct-gh",
+            "github",
+            SecretRef::PlaintextDev {
+                plaintext_dev: "ghp_round_trip".to_string(),
+            },
+        );
+        store.identity_upsert(&github).unwrap();
+        store
+            .bundle_identity_bind("id-work", "github", "acct-gh")
+            .unwrap();
+
+        // Anthropic account.
+        let anthropic = make_account(
+            "acct-anth",
+            "anthropic",
+            SecretRef::PlaintextDev {
+                plaintext_dev: "sk-ant-round_trip".to_string(),
+            },
+        );
+        store.identity_upsert(&anthropic).unwrap();
+        store
+            .bundle_identity_bind("id-work", "anthropic", "acct-anth")
+            .unwrap();
+
+        // Instance for the block, pointing at id-work.
+        let inst = make_instance("block-1", "id-work");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store, "block-1", &mut env);
+
+        // GitHub writes both standard env-var names from one secret.
+        assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_round_trip"));
+        assert_eq!(env.get("GH_TOKEN").map(String::as_str), Some("ghp_round_trip"));
+        // Anthropic writes its single env var.
+        assert_eq!(
+            env.get("ANTHROPIC_API_KEY").map(String::as_str),
+            Some("sk-ant-round_trip"),
+        );
+    }
+
+    #[test]
+    fn inject_partial_success_skips_failed_bindings() {
+        let store = make_store();
+
+        let mut def = crate::backend::storage::wstore::ForgeAgent {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+        };
+        store.forge_insert(&mut def).unwrap();
+
+        let identity = Identity {
+            id: "id-mixed".to_string(),
+            name: "Mixed".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        // Working account.
+        let good = make_account(
+            "acct-good",
+            "github",
+            SecretRef::PlaintextDev {
+                plaintext_dev: "ghp_good".to_string(),
+            },
+        );
+        store.identity_upsert(&good).unwrap();
+        store
+            .bundle_identity_bind("id-mixed", "github", "acct-good")
+            .unwrap();
+
+        // Account whose Env-backed secret references a missing var.
+        let bad = make_account(
+            "acct-bad",
+            "anthropic",
+            SecretRef::Env {
+                env_var: "AGENTMUX_TEST_DEFINITELY_NOT_SET_4242".to_string(),
+            },
+        );
+        store.identity_upsert(&bad).unwrap();
+        store
+            .bundle_identity_bind("id-mixed", "anthropic", "acct-bad")
+            .unwrap();
+
+        let inst = make_instance("block-mixed", "id-mixed");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store, "block-mixed", &mut env);
+
+        // GitHub injection succeeded.
+        assert_eq!(env.get("GITHUB_TOKEN").map(String::as_str), Some("ghp_good"));
+        assert_eq!(env.get("GH_TOKEN").map(String::as_str), Some("ghp_good"));
+        // Anthropic was skipped (env var missing) but didn't abort.
+        assert!(env.get("ANTHROPIC_API_KEY").is_none());
+    }
+
+    #[test]
+    fn inject_unknown_provider_is_skipped() {
+        let store = make_store();
+
+        let mut def = crate::backend::storage::wstore::ForgeAgent {
+            id: "def-1".to_string(),
+            slug: String::new(),
+            name: "T".to_string(),
+            icon: "✦".to_string(),
+            provider: "claude".to_string(),
+            description: String::new(),
+            working_directory: String::new(),
+            shell: String::new(),
+            provider_flags: String::new(),
+            auto_start: 0,
+            restart_on_crash: 0,
+            idle_timeout_minutes: 0,
+            created_at: 0,
+            agent_type: String::new(),
+            environment: String::new(),
+            agent_bus_id: String::new(),
+            is_seeded: 0,
+            accounts: String::new(),
+            parent_id: String::new(),
+            branch_label: String::new(),
+        };
+        store.forge_insert(&mut def).unwrap();
+
+        let identity = Identity {
+            id: "id-future".to_string(),
+            name: "Future".to_string(),
+            description: String::new(),
+            is_blank: false,
+            created_at: 0,
+            updated_at: 0,
+        };
+        store.bundle_identity_upsert(&identity).unwrap();
+
+        let custom = make_account(
+            "acct-custom",
+            "custom",
+            SecretRef::PlaintextDev {
+                plaintext_dev: "ignored".to_string(),
+            },
+        );
+        store.identity_upsert(&custom).unwrap();
+        store
+            .bundle_identity_bind("id-future", "custom", "acct-custom")
+            .unwrap();
+
+        let inst = make_instance("block-future", "id-future");
+        store.instance_create(&inst).unwrap();
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        inject_identity_env(store, "block-future", &mut env);
+        // No env-var matrix for "custom" — nothing injected, no panic.
+        assert!(env.is_empty());
+    }
+}

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod config;
 mod event_log;
+mod identity;
 mod persist;
 mod persist_subscriber;
 mod reducer;

--- a/agentmux-srv/src/server/app_api.rs
+++ b/agentmux-srv/src/server/app_api.rs
@@ -454,13 +454,20 @@ fn register_agent_send(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     _ => vec![],
                 };
                 let working_dir = obj::meta_get_string(&block.meta, "cmd:cwd", "");
-                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                let mut env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
                     Some(serde_json::Value::Object(obj)) => obj
                         .iter()
                         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
+                // Identity injection — same path as websocket.rs's
+                // AgentInputCommand. See identity/resolver.rs.
+                crate::identity::inject_identity_env(
+                    wstore.clone(),
+                    &cmd.block_id,
+                    &mut env_vars,
+                );
                 let session_id_field = obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1018,12 +1018,12 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: now,
                     ended_at: 0,
                     created_at: now,
-                    // identity_id / memory_id default to empty (= blank
-                    // singleton) until the launch modal wires user picks
-                    // through to this handler. PR-F.3 will add the
-                    // command fields and pass them here.
-                    identity_id: String::new(),
-                    memory_id: String::new(),
+                    // PR-F.3: launch modal passes through Identity +
+                    // Memory bundle picks. Empty string = blank
+                    // singleton (no override; the resolver returns
+                    // immediately on either "" or "blank").
+                    identity_id: cmd.identity_id,
+                    memory_id: cmd.memory_id,
                 };
                 wstore
                     .instance_create(&inst)

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -817,13 +817,24 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 let working_dir = crate::backend::obj::meta_get_string(
                     &block.meta, "cmd:cwd", "",
                 );
-                let env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
+                let mut env_vars: std::collections::HashMap<String, String> = match block.meta.get("cmd:env") {
                     Some(serde_json::Value::Object(obj)) => obj
                         .iter()
                         .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_string())))
                         .collect(),
                     _ => std::collections::HashMap::new(),
                 };
+                // Identity injection: look up the active AgentInstance for
+                // this block, resolve its identity_id's bindings, and merge
+                // each per-provider env var into the spawn map. Failures
+                // are logged and skipped — the agent CLI launches with
+                // whatever resolved cleanly plus the static cmd:env block.
+                // See agentmux-srv/src/identity/resolver.rs.
+                crate::identity::inject_identity_env(
+                    wstore.clone(),
+                    &cmd.blockid,
+                    &mut env_vars,
+                );
                 let session_id_field = crate::backend::obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -762,7 +762,15 @@ class RpcApiType {
     // command "createagentinstance" [call]
     CreateAgentInstanceCommand(
         client: RpcClient,
-        data: { definition_id: string; block_id?: string; parent_instance_id?: string },
+        data: {
+            definition_id: string;
+            block_id?: string;
+            parent_instance_id?: string;
+            /** v7 — Identity bundle FK. Empty = blank singleton (no creds override). */
+            identity_id?: string;
+            /** v7 — Memory bundle FK. Empty = blank singleton. */
+            memory_id?: string;
+        },
         opts?: RpcOpts,
     ): Promise<AgentInstance> {
         return client.rpcCall("createagentinstance", data, opts);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -458,6 +458,11 @@ export class AgentViewModel implements ViewModel {
                 const inst = await RpcApi.CreateAgentInstanceCommand(TabRpcClient, {
                     definition_id: agent.id,
                     block_id: blockId,
+                    // PR-F.3: launch modal carries the user's bundle
+                    // picks. Empty / "blank" → backend resolver short-
+                    // circuits so the agent inherits ambient creds.
+                    identity_id: overrides?.identityId,
+                    memory_id: overrides?.memoryId,
                 });
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref,

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -194,11 +194,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                     </fieldset>
 
                     <fieldset class="agent-launch-modal-field agent-launch-modal-bundles">
-                        <legend class="agent-launch-modal-label">Identity & Memory</legend>
+                        <legend class="agent-launch-modal-label">Identity</legend>
                         <span class="agent-launch-modal-hint">
-                            Identity bundles credentials per provider; Memory bundles the
-                            agent's instructions, context files, and tools. Pick the
-                            blanks for vanilla CLI with ambient credentials.
+                            Identity bundles credentials per provider. Pick a bundle to
+                            inject its accounts as env vars at launch (e.g. GITHUB_TOKEN,
+                            ANTHROPIC_API_KEY); pick blank to use whatever's already in
+                            your environment.
                         </span>
 
                         <label class="agent-launch-modal-bundle-row">
@@ -222,7 +223,21 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                             </select>
                         </label>
 
-                        <label class="agent-launch-modal-bundle-row">
+                        {/*
+                         * Memory dropdown is parked here pending the
+                         * spawn-time content-injection layer (provider
+                         * override, instructions, context files, MCP
+                         * servers, skills). Until that lands, picking
+                         * a non-blank Memory would be cosmetic — codex
+                         * P2 on PR #751 caught this. The state hooks
+                         * below stay in place; memoryId is forced to
+                         * "blank" on the wire so the backend writes a
+                         * blank reference. The Memory pane is still
+                         * usable for managing bundles; the launch
+                         * picker comes back in PR-F.4.
+                         */}
+
+                        <label class="agent-launch-modal-bundle-row" style={{ display: "none" }}>
                             <span class="agent-launch-modal-bundle-row-label">Memory</span>
                             <select
                                 class="agent-launch-modal-input"

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -13,9 +13,11 @@
  * panel only. See docs/specs/launch-modal-rearchitecture-2026-05-01.md.
  */
 
-import { createMemo, createSignal, Show, type JSX } from "solid-js";
+import { createMemo, createResource, createSignal, For, Show, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { buildInstanceSlug, slugifyInstanceName } from "../defaults/instance-slug";
@@ -31,6 +33,10 @@ export interface LaunchOverrides {
     environment: "local" | "docker";
     /** Only set when agentType === "container". */
     containerImage?: string;
+    /** v7 — selected Identity bundle. "blank" = use ambient creds. */
+    identityId?: string;
+    /** v7 — selected Memory bundle. "blank" = vanilla CLI. */
+    memoryId?: string;
 }
 
 interface AgentLaunchModalPanelProps {
@@ -49,6 +55,28 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
     const [showAdvanced, setShowAdvanced] = createSignal(false);
+
+    // v7 — Identity + Memory bundle pickers. Both default to "blank"
+    // which the resolver short-circuits as "no override". Lists fetched
+    // once at mount; the blank singleton is always present. See
+    // docs/specs/identity-forge-integration-and-vault-2026-05-08.md.
+    const [identityId, setIdentityId] = createSignal<string>("blank");
+    const [memoryId, setMemoryId] = createSignal<string>("blank");
+
+    const [identities] = createResource<IdentityBundle[]>(async () => {
+        try {
+            return await RpcApi.ListIdentityBundlesCommand(TabRpcClient, {});
+        } catch {
+            return [];
+        }
+    });
+    const [memories] = createResource<Memory[]>(async () => {
+        try {
+            return await RpcApi.ListMemoriesCommand(TabRpcClient, {});
+        } catch {
+            return [];
+        }
+    });
 
     const hasName = () => name().trim().length > 0;
     const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
@@ -70,6 +98,8 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                 agentType: runtime(),
                 environment: runtime() === "container" ? "docker" : "local",
                 containerImage: runtime() === "container" ? resolvedImage() : undefined,
+                identityId: identityId(),
+                memoryId: memoryId(),
             });
             // Success: layer closes the panel; we leave `submitting`
             // true so the button keeps its "Launching…" label until
@@ -160,6 +190,57 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         : "Not available for this agent."}
                                 </span>
                             </span>
+                        </label>
+                    </fieldset>
+
+                    <fieldset class="agent-launch-modal-field agent-launch-modal-bundles">
+                        <legend class="agent-launch-modal-label">Identity & Memory</legend>
+                        <span class="agent-launch-modal-hint">
+                            Identity bundles credentials per provider; Memory bundles the
+                            agent's instructions, context files, and tools. Pick the
+                            blanks for vanilla CLI with ambient credentials.
+                        </span>
+
+                        <label class="agent-launch-modal-bundle-row">
+                            <span class="agent-launch-modal-bundle-row-label">Identity</span>
+                            <select
+                                class="agent-launch-modal-input"
+                                value={identityId()}
+                                onChange={(e) => setIdentityId(e.currentTarget.value)}
+                                disabled={submitting()}
+                                aria-label="Identity bundle"
+                            >
+                                <For each={identities() ?? []}>
+                                    {(bundle) => (
+                                        <option value={bundle.id}>
+                                            {bundle.is_blank
+                                                ? "— Blank (no creds) —"
+                                                : bundle.name}
+                                        </option>
+                                    )}
+                                </For>
+                            </select>
+                        </label>
+
+                        <label class="agent-launch-modal-bundle-row">
+                            <span class="agent-launch-modal-bundle-row-label">Memory</span>
+                            <select
+                                class="agent-launch-modal-input"
+                                value={memoryId()}
+                                onChange={(e) => setMemoryId(e.currentTarget.value)}
+                                disabled={submitting()}
+                                aria-label="Memory bundle"
+                            >
+                                <For each={memories() ?? []}>
+                                    {(memory) => (
+                                        <option value={memory.id}>
+                                            {memory.is_blank
+                                                ? "— Blank (vanilla CLI) —"
+                                                : memory.name}
+                                        </option>
+                                    )}
+                                </For>
+                            </select>
                         </label>
                     </fieldset>
 

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -190,3 +190,26 @@
     opacity: 0.6;
 }
 
+// v7 — Identity + Memory bundle pickers. Two compact dropdown rows
+// rendered between the runtime fieldset and the advanced disclosure.
+// Layout mirrors the rest of the modal; the leading label keeps the
+// rows self-explanatory at a glance.
+.agent-launch-modal-bundles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1-5);
+}
+
+.agent-launch-modal-bundle-row {
+    display: grid;
+    grid-template-columns: 80px 1fr;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.agent-launch-modal-bundle-row-label {
+    font-size: 12px;
+    color: var(--main-text-color);
+    font-weight: 500;
+}
+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.724",
+  "version": "0.33.725",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR-F.3 of issue #678. Closes the loop on the Identity + Memory bundle model: the launch modal now lets users pick a bundle of each, and the spawning CLI subprocess receives the resolved credentials as env vars.

**Supersedes PR #745** (Phase 2's per-provider picker). The new model uses single FK columns (identity_id, memory_id) on db_agent_instances instead of the v7 JSON column #745 introduced; the resolver shape is similar but reads via the v7 db_identity_bindings junction. With this PR landed, #745 should be closed.

## Backend

### New module: \`agentmux-srv/src/identity/\`

- **\`resolver.rs\`** — \`inject_identity_env(wstore, block_id, &mut env_vars)\`:
  - Looks up the active AgentInstance for the block.
  - Reads identity_id; empty / \"blank\" → noop (ambient creds).
  - Reads bundle bindings for the identity.
  - For each binding: fetches the account, resolves SecretRef, looks up provider→env-var matrix, writes each var into env_vars.
  - All failures are logged and skipped — the spawn never aborts.

### Provider matrix

| Provider | Env vars |
|---|---|
| \`github\` | \`GITHUB_TOKEN\`, \`GH_TOKEN\` |
| \`anthropic\` | \`ANTHROPIC_API_KEY\` |
| \`openai\` | \`OPENAI_API_KEY\` |
| \`kimi\` | \`MOONSHOT_API_KEY\` |
| \`aws\` | \`AWS_ACCESS_KEY_ID\` |

\`SecretRef\` backends supported: \`Env\` (read from srv's environment), \`PlaintextDev\` (literal value, dev-only). \`SecretsManager\` returns \`Unsupported\` pending Phase 3's encrypted vault.

### Wired into both spawn paths

- \`AgentInputCommand\` in \`websocket.rs\` (per-message send to a running agent CLI)
- \`AgentSendCommand\` in \`app_api.rs\` (App API tier-1 send)

Both call \`inject_identity_env\` after reading the static \`cmd:env\` block from block meta and before passing \`env_vars\` to the controller.

### Schema/RPC

- \`CommandCreateAgentInstanceData\` gains \`identity_id\` + \`memory_id\` (both optional, default empty = blank singleton).
- forge_handlers.rs CreateAgentInstance handler persists them onto the new db_agent_instances row instead of hardcoding empty strings.
- New helper: \`WaveStore::instance_get_active_for_block\` — returns the most-recently-created instance row for a block, used by the resolver.

## Frontend

### AgentLaunchModal.tsx

Two new dropdowns between the runtime fieldset and Advanced disclosure:

```
Identity:  [▼ — Blank (no creds) —    ]
Memory:    [▼ — Blank (vanilla CLI) — ]
```

Both default to \`blank\`. Lists fetched once at mount via \`createResource\` + \`ListIdentityBundlesCommand\` / \`ListMemoriesCommand\`. \`LaunchOverrides\` gains \`identityId\` / \`memoryId\` fields, passed through to \`launchForgeAgent\` → \`CreateAgentInstanceCommand\`.

\`RpcApi.CreateAgentInstanceCommand\` typed wrapper accepts \`identity_id\` / \`memory_id\` as optional fields.

## Tests

**9 new resolver tests, all passing:**

- \`provider_env_vars_matrix\` — every supported provider + unknown
- \`resolve_plaintext_dev\` / \`resolve_env_var_missing\` / \`resolve_secrets_manager_unsupported\`
- \`inject_no_instance_does_nothing\`
- \`inject_blank_identity_does_nothing\` — empty / \"blank\" identity_id
- \`inject_full_round_trip_plaintext_dev\` — github (multi-var) + anthropic together
- \`inject_partial_success_skips_failed_bindings\` — one good account + one Env-backed missing-var account; only the good one injects, no abort
- \`inject_unknown_provider_is_skipped\` — provider not in the matrix

## Test plan

- [x] cargo check + cargo test resolver — all green
- [x] tsc --noEmit clean for AgentLaunchModal + agent-model
- [x] Bumped to 0.33.724
- [ ] Local task dev smoke: open agent picker → click definition → modal shows two dropdowns, default to blank, picks persist on launch, env vars visible in spawned shell via \`env | grep -E 'GITHUB|ANTHROPIC'\`
- [ ] Reagent + codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)