### PR TITLE
slice #9 phase 3c: canGoBack/canGoForward through browser-pane reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.727"
+version = "0.33.728"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.727"
+version = "0.33.728"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.727"
+version = "0.33.728"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.727"
+version = "0.33.728"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.727"
+version = "0.33.728"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.727"
+version = "0.33.728"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.727"
+version = "0.33.728"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.727"
+version = "0.33.728"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -107,6 +107,88 @@ describe("browser-pane-state reducer (slice #9, Phase 3a + 3b)", () => {
         });
     });
 
+    describe("HistoryUpdated", () => {
+        it("co-updates both flags in one transition", () => {
+            const r = update(initialState(), {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: true,
+            });
+            expect(r.state.canGoBack).toBe(true);
+            expect(r.state.canGoForward).toBe(true);
+            expect(r.events).toEqual([
+                {
+                    type: "history-updated",
+                    canGoBack: true,
+                    canGoForward: true,
+                },
+            ]);
+        });
+
+        it("leaves an omitted field alone", () => {
+            const s0 = update(initialState(), {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: true,
+            }).state;
+            const r = update(s0, {
+                type: "HistoryUpdated",
+                canGoForward: false,
+            });
+            expect(r.state.canGoBack).toBe(true);
+            expect(r.state.canGoForward).toBe(false);
+            expect(r.events).toEqual([
+                {
+                    type: "history-updated",
+                    canGoBack: true,
+                    canGoForward: false,
+                },
+            ]);
+        });
+
+        it("is idempotent when both fields match current state", () => {
+            const s0 = update(initialState(), {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: false,
+            }).state;
+            const r = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: false,
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("is idempotent when only the supplied field matches", () => {
+            const s0 = update(initialState(), {
+                type: "HistoryUpdated",
+                canGoBack: true,
+            }).state;
+            const r = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("does not interact with loading or error cells", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const r = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: true,
+            });
+            expect(r.state.loading).toBe(true);
+            expect(r.state.error).toBeNull();
+        });
+    });
+
     describe("Disposed", () => {
         it("flips closed=true and emits disposed event once", () => {
             const r = update(initialState(), { type: "Disposed" });
@@ -158,6 +240,22 @@ describe("browser-pane-state reducer (slice #9, Phase 3a + 3b)", () => {
                 },
             ]);
         });
+
+        it("HistoryUpdated after dispose is dropped", () => {
+            const s0 = closed();
+            const r = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+                canGoForward: true,
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "HistoryUpdated",
+                },
+            ]);
+        });
     });
 
     describe("invariants across sequences", () => {
@@ -193,6 +291,8 @@ describe("browser-pane-state reducer (slice #9, Phase 3a + 3b)", () => {
                 { type: "LoadStarted" },
                 { type: "LoadFinished" },
                 { type: "LoadFailed", reason: "e2" },
+                { type: "HistoryUpdated", canGoBack: true, canGoForward: true },
+                { type: "HistoryUpdated", canGoBack: false },
                 { type: "Disposed" },
             ];
             for (const mk of starts) {

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
 import { initialState } from "./types";
 
-describe("browser-pane-state reducer (slice #9, Phase 3a + 3b)", () => {
+describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c)", () => {
     describe("Navigate", () => {
         it("sets loading=true and clears any prior error", () => {
             const s0 = update(initialState(), {

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Pure reducer for the browser-pane state slice (slice #9, Phase 3a + 3b).
- * See `docs/specs/browser-pane-reducer-roadmap.md` and the conventions
- * doc `frontend-reducer-conventions-2026-05-03.md`. This module is the
- * exact mirror of slice #4's reducer pattern (agent-pane-state) — same
- * `update(state, command) → { state, events }` shape, same idempotency
- * rules, same no-throw policy.
+ * Pure reducer for the browser-pane state slice (slice #9, Phases 3a +
+ * 3b + 3c). See `docs/specs/browser-pane-reducer-roadmap.md` and the
+ * conventions doc `frontend-reducer-conventions-2026-05-03.md`. This
+ * module is the exact mirror of slice #4's reducer pattern
+ * (agent-pane-state) — same `update(state, command) → { state, events }`
+ * shape, same idempotency rules, same no-throw policy.
  *
  * Invariants enforced:
  *   1. Once `closed` flips true, every subsequent command emits
@@ -20,6 +20,10 @@
  *   4. `LoadFinished` is a no-op if `loading` was already false AND
  *      `error` was already null (nothing to clear; avoids a spurious
  *      load-finished event on a steady-state pane).
+ *   5. `HistoryUpdated` is idempotent: if the supplied fields match
+ *      the current state, return the unchanged state with no event.
+ *      An omitted field leaves its cell alone (the host can emit
+ *      partial updates).
  */
 
 import {
@@ -73,6 +77,37 @@ export function update(
             return {
                 state: { ...state, loading: false, error: command.reason },
                 events: [{ type: "load-failed", reason: command.reason }],
+            };
+        }
+
+        case "HistoryUpdated": {
+            const nextBack =
+                command.canGoBack !== undefined
+                    ? command.canGoBack
+                    : state.canGoBack;
+            const nextForward =
+                command.canGoForward !== undefined
+                    ? command.canGoForward
+                    : state.canGoForward;
+            if (
+                nextBack === state.canGoBack &&
+                nextForward === state.canGoForward
+            ) {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    canGoBack: nextBack,
+                    canGoForward: nextForward,
+                },
+                events: [
+                    {
+                        type: "history-updated",
+                        canGoBack: nextBack,
+                        canGoForward: nextForward,
+                    },
+                ],
             };
         }
 

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -6,21 +6,22 @@
  * docs/specs/frontend-reducer-architecture-2026-05-03.md and the
  * roadmap at docs/specs/browser-pane-reducer-roadmap.md).
  *
- * **Phase 3a + 3b only.** This reducer owns three cells today:
+ * **Phases 3a + 3b + 3c.** This reducer owns five cells today:
  *   - `closed` — terminal flag set by `dispose()`. All post-close
  *     commands are no-ops.
  *   - `loading` — page-load-in-flight flag. Mutually exclusive with
  *     `error` (one or the other; never both).
  *   - `error` — page-load failure message. Mutually exclusive with
  *     `loading`.
+ *   - `canGoBack` / `canGoForward` — history navigability flags
+ *     mirrored from CEF's `on_loading_state_change_pane` events
+ *     (forwarded as `browser-pane-nav-state` with `url_only=false`).
  *
- * Other browser-pane state cells (url, title, favicon, canGoBack,
- * canGoForward, plus the address-bar typing buffer that lives in
- * the view) are **not yet migrated** — the roadmap calls out
- * sequential single-cell migrations because cross-cutting moves
- * (PR #737) regressed the typing path. Cells 3c → 3e land in
- * follow-up PRs; the slot store + `recordDispatch` audit lands in
- * Phase 4 once every cell is reducer-backed.
+ * Cells not yet migrated: `url` (the danger cell — its own PR with
+ * extra observability per roadmap §3d), `title`, `faviconUrl`, plus
+ * the address-bar typing buffer that lives in the view. The slot
+ * store + `recordDispatch` audit lands in Phase 4 once every cell
+ * is reducer-backed.
  */
 
 /** Reducer state. Mutually-exclusive invariant on (loading, error). */
@@ -39,12 +40,24 @@ export interface BrowserPaneState {
      *  (success path). Mutually exclusive with `loading` per
      *  Invariant 2. */
     error: string | null;
+    /** Whether the embedded browser has back-history. Mirror of
+     *  CEF's `can_go_back` from `on_loading_state_change_pane`,
+     *  delivered to the renderer via the `browser-pane-nav-state`
+     *  event with `url_only=false`. CEF is the source of truth; the
+     *  reducer only persists the latest mirrored value. */
+    canGoBack: boolean;
+    /** Whether the embedded browser has forward-history. Mirror of
+     *  CEF's `can_go_forward`, same delivery + ownership notes as
+     *  `canGoBack`. */
+    canGoForward: boolean;
 }
 
 export const initialState = (): BrowserPaneState => ({
     closed: false,
     loading: false,
     error: null,
+    canGoBack: false,
+    canGoForward: false,
 });
 
 export type BrowserPaneCommand =
@@ -74,6 +87,18 @@ export type BrowserPaneCommand =
      */
     | { type: "LoadFailed"; reason: string }
     /**
+     * Co-update of the history-navigability flags. Either field may
+     * be omitted — the host emits whichever values its
+     * `on_loading_state_change_pane` hook gave us, and the reducer
+     * leaves an undefined field alone. Identical-to-state values
+     * yield no event (idempotent). After dispose, a no-op.
+     */
+    | {
+          type: "HistoryUpdated";
+          canGoBack?: boolean;
+          canGoForward?: boolean;
+      }
+    /**
      * The pane is being torn down. After this command runs, every
      * subsequent command on this state is a no-op. Idempotent —
      * dispatching `Disposed` twice is a no-op the second time.
@@ -85,6 +110,11 @@ export type BrowserPaneEvent =
     | { type: "load-started" }
     | { type: "load-finished" }
     | { type: "load-failed"; reason: string }
+    | {
+          type: "history-updated";
+          canGoBack: boolean;
+          canGoForward: boolean;
+      }
     | { type: "disposed" }
     /** Invariant fire — emitted instead of mutating state when a
      *  command targets a closed pane. Surfaced for diagnostics so

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -84,13 +84,14 @@ export class BrowserViewModel implements ViewModel {
     blockAtom: Accessor<Block | undefined>;
 
     /**
-     * Slice #9 (Phase 3a + 3b) reducer state — owns `closed`, `loading`,
-     * `error`. The signals above are projections of this state so the
-     * SolidJS view layer keeps reactive parity. Per the roadmap at
-     * `docs/specs/browser-pane-reducer-roadmap.md`, the remaining cells
-     * (url, title, faviconUrl, canGoBack, canGoForward) migrate one at
-     * a time in follow-up PRs; the slot store + recordDispatch audit
-     * lands in Phase 4.
+     * Slice #9 (Phases 3a + 3b + 3c) reducer state — owns `closed`,
+     * `loading`, `error`, `canGoBack`, `canGoForward`. The signals
+     * above are projections of this state so the SolidJS view layer
+     * keeps reactive parity. Per the roadmap at
+     * `docs/specs/browser-pane-reducer-roadmap.md`, the remaining
+     * cells (url, title, faviconUrl) migrate one at a time in
+     * follow-up PRs; the slot store + recordDispatch audit lands in
+     * Phase 4.
      */
     private _paneState: BrowserPaneState = browserPaneInitialState();
     /** Late callers (IPC handlers landing post-dispose, defensive guards
@@ -101,12 +102,13 @@ export class BrowserViewModel implements ViewModel {
 
     /**
      * Single sync point between the reducer's pure transitions and the
-     * SolidJS signals the view subscribes to. Projects the new
-     * `loading` and `error` cells onto their signals only when the
-     * value actually changed (avoids spurious reactive churn that
-     * could leak into the address-bar typing path that PR #737
-     * regressed). Diag logs preserve the prior `state-write key=...`
-     * shape so Phase-1 grep recipes still work.
+     * SolidJS signals the view subscribes to. Projects every reducer
+     * cell currently in scope (`loading`, `error`, `canGoBack`,
+     * `canGoForward`) onto its signal, but only when the value actually
+     * changed — avoiding spurious reactive churn that could leak into
+     * the address-bar typing path that PR #737 regressed. Diag logs
+     * preserve the prior `state-write key=...` shape so Phase-1 grep
+     * recipes still work.
      */
     private _dispatch(cmd: BrowserPaneCommand, src: string): void {
         const prev = this._paneState;

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -124,6 +124,18 @@ export class BrowserViewModel implements ViewModel {
             );
             this.setError(result.state.error);
         }
+        if (result.state.canGoBack !== prev.canGoBack) {
+            this.diag(
+                `state-write key=canGoBack value=${result.state.canGoBack} src=${src}`,
+            );
+            this.setCanGoBack(result.state.canGoBack);
+        }
+        if (result.state.canGoForward !== prev.canGoForward) {
+            this.diag(
+                `state-write key=canGoForward value=${result.state.canGoForward} src=${src}`,
+            );
+            this.setCanGoForward(result.state.canGoForward);
+        }
         for (const e of result.events) {
             if (e.type === "post-close-command-dropped") {
                 this.diag(
@@ -185,15 +197,19 @@ export class BrowserViewModel implements ViewModel {
             // authoritative values come from `on_loading_state_change_pane`
             // which CEF invokes with direct params. Skip touching the
             // back/forward atoms on `url_only` events.
-            if (!payload.url_only) {
-                if (payload.can_go_back !== undefined) {
-                    this.diag(`state-write key=canGoBack value=${payload.can_go_back}`);
-                    this.setCanGoBack(payload.can_go_back);
-                }
-                if (payload.can_go_forward !== undefined) {
-                    this.diag(`state-write key=canGoForward value=${payload.can_go_forward}`);
-                    this.setCanGoForward(payload.can_go_forward);
-                }
+            if (
+                !payload.url_only &&
+                (payload.can_go_back !== undefined ||
+                    payload.can_go_forward !== undefined)
+            ) {
+                this._dispatch(
+                    {
+                        type: "HistoryUpdated",
+                        canGoBack: payload.can_go_back,
+                        canGoForward: payload.can_go_forward,
+                    },
+                    "nav-state",
+                );
             }
             this._dispatch({ type: "LoadFinished" }, "nav-state");
             // Persist the real URL to block meta so pane restore lands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.727",
+  "version": "0.33.728",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.727",
+      "version": "0.33.728",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.727",
+  "version": "0.33.728",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3c of slice #9, per [`docs/specs/browser-pane-reducer-roadmap.md`](docs/specs/browser-pane-reducer-roadmap.md). Migrates the two history-navigability cells onto the reducer.

Follow-up to #756 (Phase 3a + 3b).

### Cells migrated

| Cell | Owner | Source |
|---|---|---|
| `canGoBack` | reducer | CEF's `on_loading_state_change_pane` → host emit `browser-pane-nav-state` (with `url_only=false`) |
| `canGoForward` | reducer | same |

Both cells co-update in a single transition via the new `HistoryUpdated` command. Either field is optional (the host can emit a partial nav-state) — an omitted field leaves its cell alone. Identical-to-state values produce no event (idempotent).

### Cells NOT migrated (intentional)

- `url` (3d) — the danger cell that PR #737 broke. Reserved for its own dedicated PR with extra observability per roadmap §3d.
- `title` + `faviconUrl` (3e) — follow-up.
- `addressBar` typing buffer — must stay component-local per the catalog.

### Behavior parity

The pre-PR call site:

```ts
if (!payload.url_only) {
    if (payload.can_go_back !== undefined) this.setCanGoBack(payload.can_go_back);
    if (payload.can_go_forward !== undefined) this.setCanGoForward(payload.can_go_forward);
}
```

becomes:

```ts
if (!payload.url_only && (payload.can_go_back !== undefined || payload.can_go_forward !== undefined)) {
    this._dispatch({
        type: "HistoryUpdated",
        canGoBack: payload.can_go_back,
        canGoForward: payload.can_go_forward,
    }, "nav-state");
}
```

The `url_only` gate (kimi's race-condition fix) is preserved verbatim. SolidJS signals are written through only when the reducer's value differs from prior state — same observable behavior as before.

### Phase-1 diag log shape preserved

`state-write key=canGoBack value=true src=nav-state` and `state-write key=canGoForward value=… src=nav-state` continue to appear in `muxlog host '\[browser-pane:diag\]'`. No grep recipe changes.

## Test plan

- [x] +6 new HistoryUpdated tests — co-update, omitted-field, idempotency on both fields and on a single supplied field, isolation from loading/error cells, post-close gating.
- [x] Cross-product invariant test (every command from every reachable state) extended to include HistoryUpdated.
- [x] Full frontend suite: **436/436 passing** (was 430 before this PR; all prior tests still green).
- [x] No TS regressions in touched files.
- [ ] Smoke test via portable build — verify back/forward buttons enable/disable correctly across navigation, history clears between domains.

## Roadmap status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending)
- ✅ Phase 3a + 3b — closed/loading/error (PR #756)
- 🟡 **Phase 3c shipped** ← this PR
- ❌ Phase 3d — `url` (danger cell)
- ❌ Phase 3e — `title`+`faviconUrl`
- ❌ Phase 4 — slot lifecycle + recordDispatch audit
- ❌ Phase 5 — diag panel surface
- ❌ Phase 6 — title+favicon product features

## Cross-references

- Roadmap: `docs/specs/browser-pane-reducer-roadmap.md`
- Catalog: `docs/specs/browser-pane-state-catalog.md`
- Predecessor: #756
- Discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)