### PR TITLE
slice #9 phase 3e: title cell through browser-pane reducer (faviconUrl deferred to post-3d)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.728"
+version = "0.33.729"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.728"
+version = "0.33.729"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.728"
+version = "0.33.729"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.728"
+version = "0.33.729"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.728"
+version = "0.33.729"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.728"
+version = "0.33.729"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.728"
+version = "0.33.729"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.728"
+version = "0.33.729"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -3,9 +3,9 @@
 
 import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
-import { initialState } from "./types";
+import { initialState, TITLE_FALLBACK } from "./types";
 
-describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c)", () => {
+describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e)", () => {
     describe("Navigate", () => {
         it("sets loading=true and clears any prior error", () => {
             const s0 = update(initialState(), {
@@ -189,6 +189,82 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c)", () => {
         });
     });
 
+    describe("TitleChanged", () => {
+        it("initial state has the fallback title", () => {
+            expect(initialState().title).toBe(TITLE_FALLBACK);
+        });
+
+        it("sets a non-empty title verbatim", () => {
+            const r = update(initialState(), {
+                type: "TitleChanged",
+                title: "Example Domain",
+            });
+            expect(r.state.title).toBe("Example Domain");
+            expect(r.events).toEqual([
+                { type: "title-changed", title: "Example Domain" },
+            ]);
+        });
+
+        it("folds empty title to the fallback", () => {
+            const s0 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Example",
+            }).state;
+            const r = update(s0, { type: "TitleChanged", title: "" });
+            expect(r.state.title).toBe(TITLE_FALLBACK);
+            expect(r.events).toEqual([
+                { type: "title-changed", title: TITLE_FALLBACK },
+            ]);
+        });
+
+        it("folds whitespace-only title to the fallback", () => {
+            const s0 = initialState();
+            const r = update(s0, {
+                type: "TitleChanged",
+                title: "   \t\n",
+            });
+            // Already at fallback so no event fires (idempotent post-fold).
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+            // Force a non-fallback state then fold back.
+            const s1 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Real",
+            }).state;
+            const r2 = update(s1, { type: "TitleChanged", title: "  " });
+            expect(r2.state.title).toBe(TITLE_FALLBACK);
+        });
+
+        it("is idempotent on identical post-fold values", () => {
+            const s0 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Same",
+            }).state;
+            const r = update(s0, { type: "TitleChanged", title: "Same" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("does not interact with loading, error, or history cells", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const s1 = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+            }).state;
+            const r = update(s1, {
+                type: "TitleChanged",
+                title: "Page",
+            });
+            expect(r.state.loading).toBe(s1.loading);
+            expect(r.state.error).toBe(s1.error);
+            expect(r.state.canGoBack).toBe(s1.canGoBack);
+            expect(r.state.canGoForward).toBe(s1.canGoForward);
+        });
+    });
+
     describe("Disposed", () => {
         it("flips closed=true and emits disposed event once", () => {
             const r = update(initialState(), { type: "Disposed" });
@@ -256,6 +332,21 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c)", () => {
                 },
             ]);
         });
+
+        it("TitleChanged after dispose is dropped", () => {
+            const s0 = closed();
+            const r = update(s0, {
+                type: "TitleChanged",
+                title: "Late title",
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "TitleChanged",
+                },
+            ]);
+        });
     });
 
     describe("invariants across sequences", () => {
@@ -293,6 +384,8 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c)", () => {
                 { type: "LoadFailed", reason: "e2" },
                 { type: "HistoryUpdated", canGoBack: true, canGoForward: true },
                 { type: "HistoryUpdated", canGoBack: false },
+                { type: "TitleChanged", title: "Page" },
+                { type: "TitleChanged", title: "" },
                 { type: "Disposed" },
             ];
             for (const mk of starts) {

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -3,9 +3,9 @@
 
 /**
  * Pure reducer for the browser-pane state slice (slice #9, Phases 3a +
- * 3b + 3c). See `docs/specs/browser-pane-reducer-roadmap.md` and the
- * conventions doc `frontend-reducer-conventions-2026-05-03.md`. This
- * module is the exact mirror of slice #4's reducer pattern
+ * 3b + 3c + 3e). See `docs/specs/browser-pane-reducer-roadmap.md` and
+ * the conventions doc `frontend-reducer-conventions-2026-05-03.md`.
+ * This module is the exact mirror of slice #4's reducer pattern
  * (agent-pane-state) — same `update(state, command) → { state, events }`
  * shape, same idempotency rules, same no-throw policy.
  *
@@ -24,12 +24,16 @@
  *      the current state, return the unchanged state with no event.
  *      An omitted field leaves its cell alone (the host can emit
  *      partial updates).
+ *   6. `TitleChanged` folds empty/whitespace input to
+ *      `TITLE_FALLBACK` so `state.title` is never blank.
+ *      Idempotent on identical (post-fold) values.
  */
 
 import {
     BrowserPaneCommand,
     BrowserPaneState,
     ReducerResult,
+    TITLE_FALLBACK,
 } from "./types";
 
 export function update(
@@ -108,6 +112,15 @@ export function update(
                         canGoForward: nextForward,
                     },
                 ],
+            };
+        }
+
+        case "TitleChanged": {
+            const next = command.title.trim() === "" ? TITLE_FALLBACK : command.title;
+            if (next === state.title) return { state, events: [] };
+            return {
+                state: { ...state, title: next },
+                events: [{ type: "title-changed", title: next }],
             };
         }
 

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -6,7 +6,8 @@
  * docs/specs/frontend-reducer-architecture-2026-05-03.md and the
  * roadmap at docs/specs/browser-pane-reducer-roadmap.md).
  *
- * **Phases 3a + 3b + 3c.** This reducer owns five cells today:
+ * **Phases 3a + 3b + 3c + 3e (title).** This reducer owns six cells
+ * today:
  *   - `closed` — terminal flag set by `dispose()`. All post-close
  *     commands are no-ops.
  *   - `loading` — page-load-in-flight flag. Mutually exclusive with
@@ -16,12 +17,19 @@
  *   - `canGoBack` / `canGoForward` — history navigability flags
  *     mirrored from CEF's `on_loading_state_change_pane` events
  *     (forwarded as `browser-pane-nav-state` with `url_only=false`).
+ *   - `title` — page title. Falls back to `"Browser"` when the host
+ *     emits empty/whitespace (mirrors the per-catalog rule that the
+ *     view should never display a blank pane title).
  *
  * Cells not yet migrated: `url` (the danger cell — its own PR with
- * extra observability per roadmap §3d), `title`, `faviconUrl`, plus
- * the address-bar typing buffer that lives in the view. The slot
- * store + `recordDispatch` audit lands in Phase 4 once every cell
- * is reducer-backed.
+ * extra observability per roadmap §3d) and `faviconUrl` (derived
+ * from `url`, so blocked on §3d), plus the address-bar typing buffer
+ * that lives in the view. The slot store + `recordDispatch` audit
+ * lands in Phase 4 once every cell is reducer-backed.
+ *
+ * Note: Phase 6 of the roadmap is when host-side title-change events
+ * (`browser-pane-title-change`) actually start emitting. Until then,
+ * the reducer's `title` cell stays at its initial fallback.
  */
 
 /** Reducer state. Mutually-exclusive invariant on (loading, error). */
@@ -50,7 +58,18 @@ export interface BrowserPaneState {
      *  CEF's `can_go_forward`, same delivery + ownership notes as
      *  `canGoBack`. */
     canGoForward: boolean;
+    /** Page title. Always non-empty — empty/whitespace input from
+     *  `TitleChanged` is folded to `TITLE_FALLBACK` so the view
+     *  never has to know about the empty case. */
+    title: string;
 }
+
+/** The string the reducer projects when `TitleChanged` arrives with
+ *  empty or whitespace-only content. The view binds to `state.title`
+ *  directly, so the fallback is enforced at write time, not at read
+ *  time. Matches the catalog's "falls back to 'Browser' when empty"
+ *  rule (`docs/specs/browser-pane-state-catalog.md` row 1.titleAtom). */
+export const TITLE_FALLBACK = "Browser";
 
 export const initialState = (): BrowserPaneState => ({
     closed: false,
@@ -58,6 +77,7 @@ export const initialState = (): BrowserPaneState => ({
     error: null,
     canGoBack: false,
     canGoForward: false,
+    title: TITLE_FALLBACK,
 });
 
 export type BrowserPaneCommand =
@@ -99,6 +119,13 @@ export type BrowserPaneCommand =
           canGoForward?: boolean;
       }
     /**
+     * Host emitted a title change for this pane. The reducer folds
+     * empty/whitespace input to `TITLE_FALLBACK` so the view never
+     * sees a blank title. Idempotent — same title yields no event.
+     * After dispose, a no-op.
+     */
+    | { type: "TitleChanged"; title: string }
+    /**
      * The pane is being torn down. After this command runs, every
      * subsequent command on this state is a no-op. Idempotent —
      * dispatching `Disposed` twice is a no-op the second time.
@@ -115,6 +142,7 @@ export type BrowserPaneEvent =
           canGoBack: boolean;
           canGoForward: boolean;
       }
+    | { type: "title-changed"; title: string }
     | { type: "disposed" }
     /** Invariant fire — emitted instead of mutating state when a
      *  command targets a closed pane. Surfaced for diagnostics so

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -84,14 +84,14 @@ export class BrowserViewModel implements ViewModel {
     blockAtom: Accessor<Block | undefined>;
 
     /**
-     * Slice #9 (Phases 3a + 3b + 3c) reducer state — owns `closed`,
-     * `loading`, `error`, `canGoBack`, `canGoForward`. The signals
-     * above are projections of this state so the SolidJS view layer
-     * keeps reactive parity. Per the roadmap at
+     * Slice #9 (Phases 3a + 3b + 3c + 3e) reducer state — owns
+     * `closed`, `loading`, `error`, `canGoBack`, `canGoForward`,
+     * `title`. The signals above are projections of this state so the
+     * SolidJS view layer keeps reactive parity. Per the roadmap at
      * `docs/specs/browser-pane-reducer-roadmap.md`, the remaining
-     * cells (url, title, faviconUrl) migrate one at a time in
-     * follow-up PRs; the slot store + recordDispatch audit lands in
-     * Phase 4.
+     * cells (url, faviconUrl) migrate in follow-up PRs (faviconUrl
+     * is derived from url, so it lands together with §3d); the slot
+     * store + recordDispatch audit lands in Phase 4.
      */
     private _paneState: BrowserPaneState = browserPaneInitialState();
     /** Late callers (IPC handlers landing post-dispose, defensive guards
@@ -104,11 +104,11 @@ export class BrowserViewModel implements ViewModel {
      * Single sync point between the reducer's pure transitions and the
      * SolidJS signals the view subscribes to. Projects every reducer
      * cell currently in scope (`loading`, `error`, `canGoBack`,
-     * `canGoForward`) onto its signal, but only when the value actually
-     * changed — avoiding spurious reactive churn that could leak into
-     * the address-bar typing path that PR #737 regressed. Diag logs
-     * preserve the prior `state-write key=...` shape so Phase-1 grep
-     * recipes still work.
+     * `canGoForward`, `title`) onto its signal, but only when the
+     * value actually changed — avoiding spurious reactive churn that
+     * could leak into the address-bar typing path that PR #737
+     * regressed. Diag logs preserve the prior `state-write key=...`
+     * shape so Phase-1 grep recipes still work.
      */
     private _dispatch(cmd: BrowserPaneCommand, src: string): void {
         const prev = this._paneState;
@@ -137,6 +137,12 @@ export class BrowserViewModel implements ViewModel {
                 `state-write key=canGoForward value=${result.state.canGoForward} src=${src}`,
             );
             this.setCanGoForward(result.state.canGoForward);
+        }
+        if (result.state.title !== prev.title) {
+            this.diag(
+                `state-write key=title value=${JSON.stringify(result.state.title)} src=${src}`,
+            );
+            this.setTitle(result.state.title);
         }
         for (const e of result.events) {
             if (e.type === "post-close-command-dropped") {

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -11,6 +11,7 @@ import {
     type BrowserPaneCommand,
     type BrowserPaneState,
     initialState as browserPaneInitialState,
+    TITLE_FALLBACK,
     update as browserPaneUpdate,
 } from "@/app/store/browser-pane-state";
 import { refocusNode } from "@/app/store/global";
@@ -45,7 +46,7 @@ export class BrowserViewModel implements ViewModel {
     urlAtom: Accessor<string> = this._url[0];
     setUrl = this._url[1];
 
-    private _title = createSignal<string>("Browser");
+    private _title = createSignal<string>(TITLE_FALLBACK);
     titleAtom: Accessor<string> = this._title[0];
     setTitle = this._title[1];
 
@@ -168,10 +169,7 @@ export class BrowserViewModel implements ViewModel {
         const ctorMetaUrl = (this.blockAtom()?.meta?.["url"] as string | undefined) ?? "";
         console.log(`[browser-pane:diag][${blockId.slice(0, 7)}] ctor meta.url=${JSON.stringify(ctorMetaUrl)}`);
 
-        this.viewName = createMemo(() => {
-            const title = this.titleAtom();
-            return title || "Browser";
-        });
+        this.viewName = createMemo(() => this.titleAtom());
 
         // Subscribe to nav-state updates fired by the backend on every
         // `on_load_end_pane`. This is the source of truth for address bar +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.728",
+  "version": "0.33.729",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.728",
+      "version": "0.33.729",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.728",
+  "version": "0.33.729",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3e of slice #9, per [`docs/specs/browser-pane-reducer-roadmap.md`](docs/specs/browser-pane-reducer-roadmap.md). Migrates the `title` cell onto the reducer with the catalog's empty-string-fallback rule built in.

Follow-up to #757 (Phase 3c).

### What's in scope

- New reducer cell: `title: string` (initial value `TITLE_FALLBACK = "Browser"`).
- New command: `TitleChanged { title: string }`.
- **Empty/whitespace input is folded to `TITLE_FALLBACK` in the reducer**, not at the view layer. The catalog (`browser-pane-state-catalog.md` row 1.titleAtom) explicitly defines this rule; centralizing it in the reducer means the view never has to know about the empty case.
- `BrowserViewModel._dispatch` now projects `state.title` onto the existing `_title` SolidJS signal.

### What's NOT in scope (intentional)

- **`faviconUrl` is deferred.** Per the catalog (row 1.faviconUrlAtom) it's *derived* from `urlAtom` (\`\${origin}/favicon.ico\`). The `url` cell hasn't migrated yet — that's Phase 3d, the explicitly-tagged danger cell that needs its own dedicated PR with extra observability. Adding a faviconUrl reducer state today would either (a) duplicate the derivation logic outside the reducer, or (b) couple to a not-yet-migrated cell. Cleanest is to ship favicon as a derived projection alongside or after §3d. Roadmap header §3e was \"title + faviconUrl\" but the body section only specifies title; Phase 6 wires the host events that produce both.
- **Host-side `browser-pane-title-change` IPC subscription** — not yet wired. That's Phase 6 of the roadmap (\"Title + favicon (the original feature)\"). Until then, `state.title` stays at the fallback, and `TitleChanged` has no producer. The reducer cell is in place ready for Phase 6 to dispatch.

### Behavior parity

- `viewName` memo at line 172 reads `titleAtom`. Same accessor, same value (\"Browser\" pre-PR; \"Browser\" post-PR until Phase 6 lights up the producer).
- `setTitle` is now strictly internal (only called by `_dispatch`). No external callers existed — confirmed by grep.

### Phase-1 diag log shape preserved

When TitleChanged eventually flows (Phase 6), \`state-write key=title value=\"Page Name\" src=…\` will appear in `muxlog host '\[browser-pane:diag\]'`. Until then, no new log lines.

## Test plan

- [x] +7 new TitleChanged tests:
  - Initial state has fallback title.
  - Sets non-empty title verbatim.
  - Folds empty string → fallback.
  - Folds whitespace-only → fallback (and asserts referential equality on no-op via captured \`s0\`, NOT the vacuous \`expect(...).toBe(initialState() && r.state)\` pattern that's bitten me twice — see memory \`feedback_no_op_state_assertion.md\`).
  - Idempotent on identical post-fold values.
  - Doesn't interact with loading/error/history cells.
  - Post-close gating drops late TitleChanged events.
- [x] Cross-product invariant test extended to include TitleChanged (both empty and non-empty).
- [x] Full frontend suite: **443/443 passing** (was 436; +7 new).
- [x] No TS regressions.
- [ ] Smoke: build + verify pane title still shows \"Browser\" by default (Phase 6 not landed yet; nothing else to verify until host event lands).

## Roadmap status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending)
- ✅ Phase 3a + 3b — closed/loading/error (PR #756)
- ✅ Phase 3c — canGoBack/canGoForward (PR #757)
- ❌ Phase 3d — `url` (danger cell — own PR with extra observability)
- 🟡 **Phase 3e shipped (title only); faviconUrl deferred to post-3d** ← this PR
- ❌ Phase 4 — slot lifecycle + recordDispatch audit
- ❌ Phase 5 — diag panel surface
- ❌ Phase 6 — title+favicon product features (host emit + dispatch wiring)

## Cross-references

- Roadmap: \`docs/specs/browser-pane-reducer-roadmap.md\`
- Catalog: \`docs/specs/browser-pane-state-catalog.md\`
- Predecessors: #756, #757
- Discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)