### PR TITLE
hotfix: re-export TITLE_FALLBACK from browser-pane-state barrel (#758 build break)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.730"
+version = "0.33.731"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.730"
+version = "0.33.731"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.730"
+version = "0.33.731"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.730"
+version = "0.33.731"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.730"
+version = "0.33.731"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.730"
+version = "0.33.731"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.730"
+version = "0.33.731"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.730"
+version = "0.33.731"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state/index.ts
+++ b/frontend/app/store/browser-pane-state/index.ts
@@ -8,4 +8,4 @@ export type {
     BrowserPaneState,
     ReducerResult,
 } from "./types";
-export { initialState } from "./types";
+export { initialState, TITLE_FALLBACK } from "./types";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.730",
+  "version": "0.33.731",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.730",
+      "version": "0.33.731",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.730",
+  "version": "0.33.731",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #758 added the `TITLE_FALLBACK` constant to `frontend/app/store/browser-pane-state/types.ts` and imported it in `frontend/app/view/browser/browser-model.ts` via the barrel (`@/app/store/browser-pane-state`), but **never re-exported it from `index.ts`**. Vitest resolves the subpath directly so unit tests passed; rollup goes through the barrel and the production build broke.

\`\`\`
error during build:
frontend/app/view/browser/browser-model.ts (14:4): "TITLE_FALLBACK" is not exported by "frontend/app/store/browser-pane-state/index.ts"
\`\`\`

## Fix

One line — add `TITLE_FALLBACK` to the named exports in `frontend/app/store/browser-pane-state/index.ts`.

## Lesson

Per memory \`feedback_verify_before_push\`: bug-fix PRs should build + smoke locally before opening the PR. I caught this on a smoke-test build right after merging #758 — should have caught it before the merge by running \`task build:frontend\` between the lockfile sync and the push. Adding to my discipline going forward.

## Test plan

- [x] \`task build:frontend\` succeeds (verified locally before pushing).
- [x] Vitest still 443/443 (the import was already wired in tests via subpath).
- [ ] Full \`task package\` succeeds (running in parallel with this PR review for the smoke-test build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)