### PR TITLE
fix: browser-pane address-bar/page-DOM focus routing on first click

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.731"
+version = "0.33.732"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.731"
+version = "0.33.732"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.731"
+version = "0.33.732"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.731"
+version = "0.33.732"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.732"
+version = "0.33.733"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.732"
+version = "0.33.733"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.732"
+version = "0.33.733"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.732"
+version = "0.33.733"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.732"
+version = "0.33.733"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.731"
+version = "0.33.732"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.732"
+version = "0.33.733"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.731"
+version = "0.33.732"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.731"
+version = "0.33.732"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.732"
+version = "0.33.733"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.731"
+version = "0.33.732"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.732"
+version = "0.33.733"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -243,6 +243,27 @@ export class BrowserViewModel implements ViewModel {
             }
             if (payload.block_id !== this.blockId) return;
             this.diag(`clicked recv`);
+            // The pane HWND captured this click at Win32 level so React never
+            // saw it — `document.activeElement` is whatever it was before
+            // (typically the address bar, since the user usually clicks
+            // there first). If we leave that stale DOM focus, the
+            // subsequent `giveFocus()` flow sees `isMainInput=true` and
+            // tells the host to keep OS focus on the main window —
+            // bouncing focus back from the pane HWND we just gave it.
+            // The user's click on the pane is unambiguous "I want to
+            // interact with the page, not chrome" intent; explicitly blur
+            // whatever main-window input has DOM focus so giveFocus's
+            // activeElement check resolves to "not a main input" and
+            // OS focus stays on the pane HWND.
+            const active = document.activeElement as HTMLElement | null;
+            if (
+                active != null &&
+                (active.tagName === "INPUT" || active.tagName === "TEXTAREA") &&
+                !active.classList.contains("dummy-focus")
+            ) {
+                this.diag(`pane-click blur active=${active.tagName.toLowerCase()}.${active.className}`);
+                active.blur();
+            }
             refocusNode(this.blockId);
         }).then((unsub) => {
             this.diag(`sub-registered name=browser-pane-clicked`);

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -184,6 +184,23 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                     value={addressBar()}
                     onInput={(e) => setAddressBar(e.currentTarget.value)}
                     onKeyDown={handleAddressKeyDown}
+                    onMouseDown={() => {
+                        // Fire main_window_focus on mousedown — BEFORE focus
+                        // moves — so OS keyboard focus reclaims from the pane
+                        // HWND at the start of the click. Without this, the
+                        // first click on the address bar after the pane HWND
+                        // grabbed OS focus only moves DOM focus; OS focus
+                        // stays on the pane HWND and keystrokes route there
+                        // instead of reaching React. Subsequent clicks work
+                        // because OS focus has already transitioned.
+                        //
+                        // Buttons in the same nav bar work without this
+                        // because CEF/Chromium internally calls SetFocus on
+                        // <button> click; <input> doesn't get the same
+                        // treatment when the parent webview HWND lacks focus.
+                        diag(`input-mousedown value=${JSON.stringify(addressBar())}`);
+                        invokeCommand("main_window_focus", { window_label: windowLabel }).catch(() => {});
+                    }}
                     onFocus={(e) => {
                         // relatedTarget = the element that LOST focus to us
                         // (or null if focus came from outside the document,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.731",
+  "version": "0.33.732",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.731",
+      "version": "0.33.732",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.732",
+  "version": "0.33.733",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.732",
+      "version": "0.33.733",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.731",
+  "version": "0.33.732",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.732",
+  "version": "0.33.733",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two related fixes for the address-bar ↔ page-DOM focus routing in browser panes. The user reported two complementary bugs in 0.33.731 and 0.33.732:

1. **0.33.731 / before:** click address bar directly → typing doesn't reach it. Workaround: click anywhere else in the header first, then the address bar works.
2. **0.33.732 / after first fix:** address bar works, but click into google search bar → typing still goes to address bar.

Both have the same underlying cause: the pane HWND has Win32 keyboard focus, and the main webview HWND can't reclaim OS focus from a single click on its own DOM elements.

### Fix 1 — `<input>` onMouseDown calls `main_window_focus`

When the pane HWND has OS focus, clicking the address bar `<input>` updates DOM focus (React `onFocus` fires) but does not move OS keyboard focus. Buttons in the same nav bar happen to work because CEF/Chromium internally calls `SetFocus(parent)` for the focusable native control on click; `<input>` doesn't get the same treatment.

Adding `onMouseDown` that fires `main_window_focus` IPC at the start of the click — *before* React's focus event — moves OS focus to the main window early enough that the subsequent keystrokes route to React.

### Fix 2 — pane-click blurs stale main-input focus

When the user clicks the embedded page (e.g. google search), the pane HWND captures the click at Win32 level and `browser-pane-clicked` IPC fires. The frontend handler calls `refocusNode(blockId)` which eventually triggers `model.giveFocus()`. But `document.activeElement` is still the address bar `<input>` (CEF's pane click never reached the React DOM), so `giveFocus` sees `isMainInput=true` and tells the host to keep OS focus on the main window — bouncing it back from the pane HWND we just gave it.

The diag log captured this exact sequence: `emit-clicked` → `clicked recv` → `giveFocus` → typing logged into `addressBar=...sdfsdsdf` while `focused=true`.

The fix: in the `browser-pane-clicked` handler, if `document.activeElement` is a main-window input (matching the giveFocus pattern), explicitly `.blur()` it before calling `refocusNode`. Then `giveFocus` resolves to "not a main input" and OS focus stays on the pane HWND. Adds a `pane-click blur active=...` diag line for traceability.

The check matches the giveFocus shape verbatim (per the catalog rule that giveFocus must be preserved unchanged).

## Test plan

- [x] Frontend build green (`task build:frontend` succeeds; this caught the missing `TITLE_FALLBACK` barrel export pre-merge of #758 — separate hotfix #759).
- [x] All 443 frontend tests still pass.
- [x] Manual diag-log verification on 0.33.732: confirmed the bug pattern (`focused=true` while typing landed in `addressBar`).
- [ ] Manual smoke on 0.33.733: address bar works on first click AND clicking google search routes typing into the page DOM.
- [ ] Stress harness `tools/tests/pane-focus-stress.ps1`: needs a path-resolution patch to find dev-mode logs under `~/.agentmux/dev/<branch>/logs/` (currently only searches `~/.agentmux/logs/`). The harness's auto-computed click coords also didn't land on the address-bar input in our run (no `input-focus` events fired). Both are harness limitations, not blockers for this fix; tracking separately.

## Files

- `frontend/app/view/browser/browser-view.tsx` — `<input>` onMouseDown
- `frontend/app/view/browser/browser-model.ts` — pane-click blur in IPC handler
- Version bumps to 0.33.732 (mousedown) and 0.33.733 (blur)

🤖 Generated with [Claude Code](https://claude.com/claude-code)