### PR TITLE
slice #9 phase 3d: url cell (the danger cell) through reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.733"
+version = "0.33.734"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.733"
+version = "0.33.734"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.733"
+version = "0.33.734"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.733"
+version = "0.33.734"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1409,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.733"
+version = "0.33.734"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.733"
+version = "0.33.734"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.733"
+version = "0.33.734"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.733"
+version = "0.33.734"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
 import { initialState, TITLE_FALLBACK } from "./types";
 
-describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e)", () => {
+describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e + 3d)", () => {
     describe("Navigate", () => {
         it("sets loading=true and clears any prior error", () => {
             const s0 = update(initialState(), {
@@ -26,6 +26,118 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e)", () =
                 url: "https://x",
             });
             expect(r.state.loading && r.state.error !== null).toBe(false);
+        });
+
+        it("sets state.url atomically with the loading flip", () => {
+            const r = update(initialState(), {
+                type: "Navigate",
+                url: "https://example.com",
+            });
+            expect(r.state.url).toBe("https://example.com");
+            expect(r.state.loading).toBe(true);
+        });
+
+        it("supersedes a prior url", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://a.com",
+            }).state;
+            const r = update(s0, { type: "Navigate", url: "https://b.com" });
+            expect(r.state.url).toBe("https://b.com");
+        });
+    });
+
+    describe("UrlConfirmed", () => {
+        it("updates state.url to the host-confirmed value", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://typed-by-user",
+            }).state;
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://post-redirect-final",
+            });
+            expect(r.state.url).toBe("https://post-redirect-final");
+            expect(r.events).toEqual([
+                { type: "url-confirmed", url: "https://post-redirect-final" },
+            ]);
+        });
+
+        it("does NOT touch loading, error, or history", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const s1 = update(s0, {
+                type: "HistoryUpdated",
+                canGoBack: true,
+            }).state;
+            const r = update(s1, {
+                type: "UrlConfirmed",
+                url: "https://final",
+            });
+            expect(r.state.loading).toBe(s1.loading);
+            expect(r.state.error).toBe(s1.error);
+            expect(r.state.canGoBack).toBe(s1.canGoBack);
+            expect(r.state.canGoForward).toBe(s1.canGoForward);
+        });
+
+        it("is idempotent on identical url", () => {
+            const s0 = update(initialState(), {
+                type: "UrlConfirmed",
+                url: "https://x",
+            }).state;
+            const r = update(s0, { type: "UrlConfirmed", url: "https://x" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+    });
+
+    describe("UrlCleared", () => {
+        it("clears state.url to empty string", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const r = update(s0, { type: "UrlCleared" });
+            expect(r.state.url).toBe("");
+            expect(r.events).toEqual([{ type: "url-cleared" }]);
+        });
+
+        it("does NOT touch loading, error, history, or title", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const r = update(s0, { type: "UrlCleared" });
+            expect(r.state.loading).toBe(s0.loading);
+            expect(r.state.error).toBe(s0.error);
+            expect(r.state.canGoBack).toBe(s0.canGoBack);
+            expect(r.state.canGoForward).toBe(s0.canGoForward);
+            expect(r.state.title).toBe(s0.title);
+        });
+
+        it("is idempotent when url is already empty", () => {
+            const s0 = initialState();
+            expect(s0.url).toBe("");
+            const r = update(s0, { type: "UrlCleared" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([]);
+        });
+
+        it("models reload's force-reload pattern (clear → restore)", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://page",
+            }).state;
+            const sCleared = update(s0, { type: "UrlCleared" }).state;
+            expect(sCleared.url).toBe("");
+            const sRestored = update(sCleared, {
+                type: "Navigate",
+                url: "https://page",
+            }).state;
+            expect(sRestored.url).toBe("https://page");
+            expect(sRestored.loading).toBe(true);
         });
     });
 
@@ -347,6 +459,33 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e)", () =
                 },
             ]);
         });
+
+        it("UrlConfirmed after dispose is dropped", () => {
+            const s0 = closed();
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://late",
+            });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "UrlConfirmed",
+                },
+            ]);
+        });
+
+        it("UrlCleared after dispose is dropped", () => {
+            const s0 = closed();
+            const r = update(s0, { type: "UrlCleared" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "UrlCleared",
+                },
+            ]);
+        });
     });
 
     describe("invariants across sequences", () => {
@@ -386,6 +525,8 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e)", () =
                 { type: "HistoryUpdated", canGoBack: false },
                 { type: "TitleChanged", title: "Page" },
                 { type: "TitleChanged", title: "" },
+                { type: "UrlConfirmed", url: "https://final" },
+                { type: "UrlCleared" },
                 { type: "Disposed" },
             ];
             for (const mk of starts) {

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -3,8 +3,8 @@
 
 /**
  * Pure reducer for the browser-pane state slice (slice #9, Phases 3a +
- * 3b + 3c + 3e). See `docs/specs/browser-pane-reducer-roadmap.md` and
- * the conventions doc `frontend-reducer-conventions-2026-05-03.md`.
+ * 3b + 3c + 3e + 3d). See `docs/specs/browser-pane-reducer-roadmap.md`
+ * and the conventions doc `frontend-reducer-conventions-2026-05-03.md`.
  * This module is the exact mirror of slice #4's reducer pattern
  * (agent-pane-state) — same `update(state, command) → { state, events }`
  * shape, same idempotency rules, same no-throw policy.
@@ -16,7 +16,8 @@
  *   2. `loading` and `error` are mutually exclusive — at most one of
  *      the two is truthy at any time.
  *   3. `Navigate` always clears any prior `error` (a fresh attempt
- *      supersedes the prior failure).
+ *      supersedes the prior failure) AND updates `state.url` to the
+ *      target URL atomically with the loading flip.
  *   4. `LoadFinished` is a no-op if `loading` was already false AND
  *      `error` was already null (nothing to clear; avoids a spurious
  *      load-finished event on a steady-state pane).
@@ -27,6 +28,15 @@
  *   6. `TitleChanged` folds empty/whitespace input to
  *      `TITLE_FALLBACK` so `state.title` is never blank.
  *      Idempotent on identical (post-fold) values.
+ *   7. `UrlConfirmed` updates `state.url` only — does NOT touch
+ *      loading/error/history (those transition via the
+ *      LoadFinished/LoadFailed/HistoryUpdated dispatches that
+ *      typically accompany the same nav-state IPC event).
+ *      Idempotent on identical url.
+ *   8. `UrlCleared` sets `state.url = ""` without touching any
+ *      other cell — distinct from `UrlConfirmed { url: "" }` so the
+ *      audit ring distinguishes the reload force-reload pattern from
+ *      a host-confirmed empty URL. Idempotent (already empty → no-op).
  */
 
 import {
@@ -55,7 +65,12 @@ export function update(
     switch (command.type) {
         case "Navigate": {
             return {
-                state: { ...state, loading: true, error: null },
+                state: {
+                    ...state,
+                    loading: true,
+                    error: null,
+                    url: command.url,
+                },
                 events: [{ type: "navigate", url: command.url }],
             };
         }
@@ -112,6 +127,22 @@ export function update(
                         canGoForward: nextForward,
                     },
                 ],
+            };
+        }
+
+        case "UrlConfirmed": {
+            if (state.url === command.url) return { state, events: [] };
+            return {
+                state: { ...state, url: command.url },
+                events: [{ type: "url-confirmed", url: command.url }],
+            };
+        }
+
+        case "UrlCleared": {
+            if (state.url === "") return { state, events: [] };
+            return {
+                state: { ...state, url: "" },
+                events: [{ type: "url-cleared" }],
             };
         }
 

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -6,8 +6,8 @@
  * docs/specs/frontend-reducer-architecture-2026-05-03.md and the
  * roadmap at docs/specs/browser-pane-reducer-roadmap.md).
  *
- * **Phases 3a + 3b + 3c + 3e (title).** This reducer owns six cells
- * today:
+ * **Phases 3a + 3b + 3c + 3e (title) + 3d.** This reducer owns seven
+ * cells today:
  *   - `closed` — terminal flag set by `dispose()`. All post-close
  *     commands are no-ops.
  *   - `loading` — page-load-in-flight flag. Mutually exclusive with
@@ -20,12 +20,18 @@
  *   - `title` — page title. Falls back to `"Browser"` when the host
  *     emits empty/whitespace (mirrors the per-catalog rule that the
  *     view should never display a blank pane title).
+ *   - `url` — committed/loading URL (NOT the address-bar's
+ *     unsubmitted typing buffer — that stays in the view). The
+ *     **danger cell** that broke PR #737 — six downstream consumers
+ *     (reload's clear+restore, view-mount diag, initial addressBar,
+ *     the sync createEffect that syncs urlAtom→addressBar, onMount's
+ *     createPane, the placeholder `<Show>` gate); migration must
+ *     preserve every consumer's semantics verbatim.
  *
- * Cells not yet migrated: `url` (the danger cell — its own PR with
- * extra observability per roadmap §3d) and `faviconUrl` (derived
- * from `url`, so blocked on §3d), plus the address-bar typing buffer
- * that lives in the view. The slot store + `recordDispatch` audit
- * lands in Phase 4 once every cell is reducer-backed.
+ * Cells not yet migrated: `faviconUrl` (will be a derived projection
+ * of `url`'s origin in a follow-up PR) plus the address-bar typing
+ * buffer in the view. The slot store + `recordDispatch` audit lands
+ * in Phase 4.
  *
  * Note: Phase 6 of the roadmap is when host-side title-change events
  * (`browser-pane-title-change`) actually start emitting. Until then,
@@ -62,6 +68,15 @@ export interface BrowserPaneState {
      *  `TitleChanged` is folded to `TITLE_FALLBACK` so the view
      *  never has to know about the empty case. */
     title: string;
+    /** Committed/loading URL. Distinct from the address-bar `<input>`
+     *  typing buffer (which stays in `browser-view.tsx` per the
+     *  catalog — DOM is the source of truth for live-typing UX).
+     *  Initial `""` matches the prior signal initial value. Set by
+     *  `Navigate` (intent-bearing user/programmatic nav), cleared
+     *  transiently by `UrlCleared` (reload's force-reload pattern),
+     *  and superseded by `UrlConfirmed` (host's `browser-pane-nav-state`
+     *  reporting the post-redirect final URL). */
+    url: string;
 }
 
 /** The string the reducer projects when `TitleChanged` arrives with
@@ -78,6 +93,7 @@ export const initialState = (): BrowserPaneState => ({
     canGoBack: false,
     canGoForward: false,
     title: TITLE_FALLBACK,
+    url: "",
 });
 
 export type BrowserPaneCommand =
@@ -126,6 +142,22 @@ export type BrowserPaneCommand =
      */
     | { type: "TitleChanged"; title: string }
     /**
+     * Host's `browser-pane-nav-state` reported the post-redirect
+     * confirmed URL. Updates `state.url` only; does NOT touch
+     * loading/error (those transition via `LoadFinished`/`LoadFailed`
+     * in the same event handler). Idempotent on identical values.
+     * After dispose, a no-op.
+     */
+    | { type: "UrlConfirmed"; url: string }
+    /**
+     * Transient URL clear used by `reload()` to force an iframe
+     * reload via clear-then-restore across one frame. Sets
+     * `state.url = ""` without touching loading/error/title.
+     * Idempotent (already-empty url yields no event). After dispose,
+     * a no-op.
+     */
+    | { type: "UrlCleared" }
+    /**
      * The pane is being torn down. After this command runs, every
      * subsequent command on this state is a no-op. Idempotent —
      * dispatching `Disposed` twice is a no-op the second time.
@@ -143,6 +175,8 @@ export type BrowserPaneEvent =
           canGoForward: boolean;
       }
     | { type: "title-changed"; title: string }
+    | { type: "url-confirmed"; url: string }
+    | { type: "url-cleared" }
     | { type: "disposed" }
     /** Invariant fire — emitted instead of mutating state when a
      *  command targets a closed pane. Surfaced for diagnostics so

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -43,7 +43,23 @@ export class BrowserViewModel implements ViewModel {
     }
 
     private _url = createSignal<string>("");
-    urlAtom: Accessor<string> = this._url[0];
+    /**
+     * `urlAtom` is wrapped (not the bare signal getter) for slice #9
+     * Phase 3d observability: every consumer read is logged so we can
+     * verify the migration didn't change consumer call patterns. Per
+     * the roadmap this instrumentation is **temporary** — remove
+     * after Phase 3d ships and the log baseline is recorded.
+     *
+     * Do NOT change the accessor's reactive shape — Solid tracks the
+     * underlying signal read (`this._url[0]()`), so consumers'
+     * createEffect dependency tracking remains identical to the bare
+     * signal accessor.
+     */
+    urlAtom: Accessor<string> = () => {
+        const v = this._url[0]();
+        this.diag(`urlAtom-read value=${JSON.stringify(v)}`);
+        return v;
+    };
     setUrl = this._url[1];
 
     private _title = createSignal<string>(TITLE_FALLBACK);
@@ -85,14 +101,14 @@ export class BrowserViewModel implements ViewModel {
     blockAtom: Accessor<Block | undefined>;
 
     /**
-     * Slice #9 (Phases 3a + 3b + 3c + 3e) reducer state — owns
+     * Slice #9 (Phases 3a + 3b + 3c + 3e + 3d) reducer state — owns
      * `closed`, `loading`, `error`, `canGoBack`, `canGoForward`,
-     * `title`. The signals above are projections of this state so the
-     * SolidJS view layer keeps reactive parity. Per the roadmap at
-     * `docs/specs/browser-pane-reducer-roadmap.md`, the remaining
-     * cells (url, faviconUrl) migrate in follow-up PRs (faviconUrl
-     * is derived from url, so it lands together with §3d); the slot
-     * store + recordDispatch audit lands in Phase 4.
+     * `title`, `url`. The signals above are projections of this state
+     * so the SolidJS view layer keeps reactive parity. Per the
+     * roadmap at `docs/specs/browser-pane-reducer-roadmap.md`, the
+     * remaining cell (`faviconUrl`, derived from `url`) migrates in
+     * a follow-up PR; the slot store + recordDispatch audit lands in
+     * Phase 4.
      */
     private _paneState: BrowserPaneState = browserPaneInitialState();
     /** Late callers (IPC handlers landing post-dispose, defensive guards
@@ -105,9 +121,9 @@ export class BrowserViewModel implements ViewModel {
      * Single sync point between the reducer's pure transitions and the
      * SolidJS signals the view subscribes to. Projects every reducer
      * cell currently in scope (`loading`, `error`, `canGoBack`,
-     * `canGoForward`, `title`) onto its signal, but only when the
-     * value actually changed — avoiding spurious reactive churn that
-     * could leak into the address-bar typing path that PR #737
+     * `canGoForward`, `title`, `url`) onto its signal, but only when
+     * the value actually changed — avoiding spurious reactive churn
+     * that could leak into the address-bar typing path that PR #737
      * regressed. Diag logs preserve the prior `state-write key=...`
      * shape so Phase-1 grep recipes still work.
      */
@@ -144,6 +160,12 @@ export class BrowserViewModel implements ViewModel {
                 `state-write key=title value=${JSON.stringify(result.state.title)} src=${src}`,
             );
             this.setTitle(result.state.title);
+        }
+        if (result.state.url !== prev.url) {
+            this.diag(
+                `state-write key=url value=${JSON.stringify(result.state.url)} src=${src}`,
+            );
+            this.setUrl(result.state.url);
         }
         for (const e of result.events) {
             if (e.type === "post-close-command-dropped") {
@@ -194,8 +216,7 @@ export class BrowserViewModel implements ViewModel {
             this.diag(
                 `nav-state recv url=${JSON.stringify(payload.url)} url_only=${!!payload.url_only} can_back=${payload.can_go_back} can_forward=${payload.can_go_forward}`,
             );
-            this.diag(`state-write key=url value=${JSON.stringify(payload.url)}`);
-            this.setUrl(payload.url);
+            this._dispatch({ type: "UrlConfirmed", url: payload.url }, "nav-state");
             // `url_only` events come from `on_load_end_pane` — they arrive
             // before the navigation controller has fully committed, so the
             // `can_go_back` / `can_go_forward` values from that hook would
@@ -295,8 +316,6 @@ export class BrowserViewModel implements ViewModel {
             }
         }
 
-        this.diag(`state-write key=url value=${JSON.stringify(normalized)} src=navigate`);
-        this.setUrl(normalized);
         this._dispatch({ type: "Navigate", url: normalized }, "navigate");
         // can_go_back / can_go_forward are set by the `browser-pane-nav-state`
         // event subscription; we don't touch them here. CEF is the source of
@@ -333,12 +352,9 @@ export class BrowserViewModel implements ViewModel {
         if (this.closed) return;
         const url = this.urlAtom();
         if (url) {
-            this.diag(`state-write key=url value="" src=reload-clear`);
-            this.setUrl("");
+            this._dispatch({ type: "UrlCleared" }, "reload-clear");
             // Force iframe reload by briefly clearing then re-setting
             requestAnimationFrame(() => {
-                this.diag(`state-write key=url value=${JSON.stringify(url)} src=reload-restore`);
-                this.setUrl(url);
                 this._dispatch({ type: "Navigate", url }, "reload-restore");
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.733",
+  "version": "0.33.734",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.733",
+      "version": "0.33.734",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.733",
+  "version": "0.33.734",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3d of slice #9 — the **danger cell** that broke PR #737. Migrates `url` onto the reducer with extra observability per [`docs/specs/browser-pane-reducer-roadmap.md`](docs/specs/browser-pane-reducer-roadmap.md) §3d.

Follow-up to #758 (Phase 3e title).

### What's in scope

Three new commands plus an extension to `Navigate`:

- **`Navigate { url }`** (existing) — extended to also set `state.url` atomically with the `loading=true, error=null` flip. Same intent as before (user/programmatic nav with a known target); now the URL is part of the same reducer transition.
- **`UrlConfirmed { url }`** — new. For host's `browser-pane-nav-state` IPC reporting the post-redirect final URL. Updates `state.url` only; does NOT touch loading/error/history (those transition via the LoadFinished/HistoryUpdated dispatches that accompany the same IPC event).
- **`UrlCleared`** — new. For `reload()`'s force-reload pattern (clear-then-restore across one frame). Distinct from `UrlConfirmed { url: "" }` so the audit ring distinguishes the reload pattern from a host-confirmed empty URL.

All three are idempotent on identical values, gated post-close, and emit named events for traceability.

### Six downstream consumers — all preserved

The catalog called out 6 read sites for `urlAtom` that must keep identical semantics:

1. `browser-model.ts reload()` — read current URL to clear+restore
2. `browser-view.tsx view-mount diag` — initial log
3. `browser-view.tsx initial addressBar` — `createSignal(model.urlAtom() \|\| "")`
4. `browser-view.tsx sync createEffect` — **the typing-clobber path**, gated on `focused` (the fix kimi added in PR #484; PR #737 inadvertently broke this)
5. `browser-view.tsx onMount createPane` — fires `browser_pane_create` with the URL
6. `browser-view.tsx placeholder \`<Show>\` gate` — empty-state UI shown when no URL is set

The migration preserves all six. The signal is still a SolidJS `createSignal`; the reducer projects `state.url` onto it via `_dispatch`. Reactive dependency tracking (Solid's `createEffect` machinery) sees the same signal read it always did.

### Extra observability (temporary)

Per roadmap §3d: every read of `urlAtom` now emits a diag log line:

\`\`\`
[browser-pane:diag][${blockPrefix}] urlAtom-read value="${url}"
\`\`\`

The accessor wraps the bare signal getter; Solid still tracks the underlying `this._url[0]()` so reactive shape is unchanged. **This instrumentation is temporary** — to be removed in a follow-up cleanup PR after the log baseline is recorded and the migration is confirmed stable. Planned removal commit: same PR as the next phase (Phase 3e completion / faviconUrl) so docs aren't doc-only.

### What's NOT in scope (intentional)

- **`faviconUrl`** — derived from `url`'s origin. Lands as a derived projection in a follow-up PR (~30 LOC) — kept separate so 3d's danger-cell migration is isolated.
- **Phase 4 (slot store + `recordDispatch`)** — next major step; routes the click-handler side-effects through a `PaneClicked` reducer command per the user's "treat as Phase 4 task" framing.

### Behavior parity

All 4 prior setUrl call sites became dispatches (no behavior change beyond storage):

\| Prior call | New dispatch | Source |
\|---|---|---|
\| `setUrl(payload.url)` in nav-state IPC | `UrlConfirmed { url }` | `nav-state` |
\| `setUrl(normalized)` in navigate() | `Navigate { url: normalized }` (already existing dispatch, now also carries url) | `navigate` |
\| `setUrl("")` in reload() clear | `UrlCleared` | `reload-clear` |
\| `setUrl(url)` in reload() rAF restore | `Navigate { url }` (already existing in this path) | `reload-restore` |

The Phase-1 diag log shape is preserved (`state-write key=url value=... src=...`) so existing `muxlog host '\[browser-pane:diag\]'` recipes still work.

## Test plan

- [x] +11 new tests on the `url` cell:
  - Navigate sets url atomically with loading
  - Navigate supersedes prior url
  - UrlConfirmed updates url only (no other cells)
  - UrlConfirmed idempotent
  - UrlCleared clears to empty
  - UrlCleared touches no other cell
  - UrlCleared idempotent on already-empty
  - UrlCleared models reload's force-reload pattern (clear → restore via Navigate)
  - UrlConfirmed post-close gating
  - UrlCleared post-close gating
  - Cross-product invariant test extended (now 9 commands × reachable starts).
- [x] Full frontend suite: **454/454 passing** (was 443; +11 new).
- [x] `task build:frontend` succeeds (catches barrel-export gaps that vitest would miss — per memory `feedback_verify_before_push` after the #759 hotfix taught us this lesson).
- [ ] Smoke-test in dev mode: verify Phase 1 diag log sequence matches pre-PR baseline for fresh open + nav + reload + dispose. Specifically the address-bar `createEffect` typing-clobber path must NOT regress (the bug PR #737 hit).

## Roadmap status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending)
- ✅ Phase 3a + 3b — closed/loading/error (PR #756)
- ✅ Phase 3c — canGoBack/canGoForward (PR #757)
- ✅ Phase 3e (title) — title cell (PR #758)
- 🟡 **Phase 3d shipped** ← this PR
- ❌ Phase 3e (favicon) — derived projection of url, follow-up
- ❌ Phase 4 — slot lifecycle + recordDispatch audit
- ❌ Phase 5 — diag panel surface
- ❌ Phase 6 — title+favicon product features

## Cross-references

- Roadmap: \`docs/specs/browser-pane-reducer-roadmap.md\` (§3d explicitly tags this as the danger cell)
- Catalog: \`docs/specs/browser-pane-state-catalog.md\` (the 6 read sites)
- Predecessors: #756, #757, #758
- What not to do: PR #737 (closed) — tried to migrate this in a single big PR
- Discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)