### PR TITLE
perf phase 0: instrumentation infrastructure (marks + observers + IPC clock + dev HUD)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.734"
+version = "0.33.735"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.734"
+version = "0.33.735"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.734"
+version = "0.33.735"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.734"
+version = "0.33.735"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.734"
+version = "0.33.735"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.734"
+version = "0.33.735"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.734"
+version = "0.33.735"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.734"
+version = "0.33.735"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md
+++ b/docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md
@@ -1,0 +1,246 @@
+# Performance instrumentation + optimization strategy
+
+**Status:** Proposed
+**Owner:** AgentA
+**Date:** 2026-05-09
+**Driving observation:** Tab switching and pane resizing both have visibly long delays. AgentMux's brand promise is **ultra-snappy responsiveness**; today we have neither numerical baselines nor a structured way to find bottlenecks.
+
+## Goals
+
+1. **Numerical targets** — every user-initiated interaction lands inside the [Web Vitals "Good INP" budget](https://web.dev/articles/inp): **P75 INP ≤ 200 ms, P95 ≤ 500 ms**. Internal "snappy" target: **P50 ≤ 100 ms, P95 ≤ 200 ms** for tab switch and pane resize specifically.
+2. **Repeatable measurement** — every PR that touches a hot path captures a before/after profile. No "felt faster" merges.
+3. **Always-on bottleneck visibility** — a perf HUD in dev mode shows recent INP, frame budget overrun count, and IPC roundtrip distribution.
+4. **No regression discipline** — once we hit a target, capture a baseline trace that future PRs are measured against.
+
+Snappy-by-default is a structural property — it has to be designed into the dispatch path, not added at the end. The output of this work is an instrumented runtime, not "an optimization PR". Every fix lands as evidence-driven incremental change.
+
+## Scope (in priority order)
+
+### Tier 1 — user-initiated interactions (tracked from day one)
+
+| Interaction | Initiator | Hypothesized hot paths |
+|---|---|---|
+| **Tab switch** | click on tab in title bar | `activeTabId` atom update → all per-tab Solid effects re-evaluate; per-block visibility toggling; pane HWND show/hide IPC fan-out (browser, terminal); focus shuffle |
+| **Pane resize (drag)** | mouse drag on splitter | continuous `getBoundingClientRect` (forces layout) per frame; `ResizeObserver` callback fires; `browser_pane_resize` IPC roundtrip per pane per frame; Win32 `SetWindowPos` per pane HWND |
+| **Block focus** | click into a pane | `refocusNode(blockId)` → layout reducer dispatch → `giveFocus()` → IPC; the focus path we just instrumented for slice #9's pane-click bug |
+
+### Tier 2 — secondary interactions (instrument once Tier 1 is solved)
+
+| Interaction | Notes |
+|---|---|
+| Agent message send (`agent.send`) | Streaming output paint cost; reactive fan-out per chunk |
+| Terminal keystroke | xterm.js render, per-key IPC for shell stdin |
+| Pane open/close | Block create/dispose; HWND attach/detach |
+| Window create | New OS window + main webview spin-up |
+
+### Out of scope (first pass)
+
+- GPU compositor frame timing (`gpu/RenderCompositorFrame`) — kick in once we've eliminated CPU-bound bottlenecks.
+- Memory pressure / GC pauses — separate investigation; only chase if traces show GC events ≥10 ms during interactions.
+- Sidecar query latency — `agentmux-srv` isn't on the synchronous interaction path for tab switch / pane resize. Defer.
+
+## Measurement methodology
+
+Every interaction is a **trace span** with a known start and end. Three complementary tools cover the JS-renderer / Win32 / Rust-host axes.
+
+### A. Renderer-side (main webview React + each pane CEF)
+
+#### A1. `performance.mark()` / `performance.measure()` — primary signal
+
+Wrap every Tier 1 interaction with named marks. Example for tab switch:
+
+```ts
+// At click handler entry
+performance.mark("tab-switch:start", { detail: { from: prev, to: next } });
+// At end of layout commit (createEffect end of cycle)
+performance.mark("tab-switch:committed");
+performance.measure("tab-switch:total", "tab-switch:start", "tab-switch:committed");
+```
+
+The measures are visible in the Performance Panel timeline (under "Timings") and queryable via `PerformanceObserver`.
+
+#### A2. Long Tasks API observer — always-on alarm
+
+Subscribe at app startup to log any task >50 ms:
+
+```ts
+new PerformanceObserver((list) => {
+    for (const entry of list.getEntries()) {
+        if (entry.duration > 50) {
+            console.warn(`[perf] long-task ${entry.duration.toFixed(1)}ms`, entry);
+        }
+    }
+}).observe({ type: "longtask", buffered: true });
+```
+
+Long tasks are the single best proxy for "frame budget violations". One alarm per frame > 50 ms. Logs route through the `[fe]` pipe to host so they show in `muxlog host '\[perf\]'`.
+
+#### A3. INP-specific observer
+
+The browser exposes `event` + `first-input` entry types via `PerformanceObserver`. Subscribe and track P50/P75/P95 INP per interaction-target (button name, atom name, blockId). Expose in dev-mode HUD.
+
+#### A4. Chromium tracing via CDP — heavyweight on-demand
+
+The host already has CDP access to every CEF browser ([`agentmux-cef/src/browser_api/`](../../agentmux-cef/src/browser_api/)). Add an endpoint pair to start/stop a [Chromium trace](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/) and write a `.json.gz` to disk:
+
+```
+POST /agentmux/perf/trace_start { window_label?, categories: ["devtools.timeline","blink","cc","gpu","v8.execute"] }
+POST /agentmux/perf/trace_stop  → returns path to trace file
+```
+
+Output drops in [Perfetto UI](https://ui.perfetto.dev) for analysis. This is the single most powerful tool — gives compositor frames, paint timing, layout cost, JS sample profile, IPC routing, all on one timeline.
+
+Categories table:
+
+| Category | Use for |
+|---|---|
+| `devtools.timeline` | high-level events shown in DevTools Performance panel |
+| `blink` | layout, paint, style invalidations |
+| `cc` | compositor/raster/GPU |
+| `v8.execute` | JS sample profile |
+| `disabled-by-default-ipc.flow` | IPC routing across processes (heavy — only for IPC investigations) |
+| `disabled-by-default-cpu_profiler` | sample-based CPU profile |
+
+#### A5. SolidJS effect-run counter (dev-only)
+
+Add a `wrapEffect()` helper that wraps `createEffect` and increments a per-effect run counter. Expose the counter table via the dev HUD. Identifies effect-storm patterns ([feedback_solidjs_reactive_leak](../../../../../../Users/area54/.claude/projects/C--Systems/memory/feedback_solidjs_reactive_leak.md) bit us before; this catches it pre-flight).
+
+### B. Host-side (Rust — agentmux-cef + agentmux-srv)
+
+#### B1. `tracing` spans at IPC boundaries — already partially in place
+
+We already use `tracing` everywhere; what's missing is consistent instrumentation at IPC entry/exit. Add `#[tracing::instrument(level = "debug")]` to every JSON-RPC handler in `agentmux-cef/src/commands/` and to `agentmux-srv` RPC handlers. Span enter/exit timestamps give per-IPC roundtrip latency.
+
+#### B2. Chrome-trace-format export from Rust
+
+[`tracing-chrome`](https://crates.io/crates/tracing-chrome) writes `tracing` spans into a `.json` consumable by [Perfetto UI](https://ui.perfetto.dev). Combine with renderer-side trace (A4) — load both into the same Perfetto session, see the full picture across processes.
+
+Gate behind `--features perf-trace` so release builds don't pay the cost. Dev mode opt-in.
+
+#### B3. Win32 message pump timing (lighter than ETW)
+
+For pane resize the bottleneck is likely `SetWindowPos` calls in series. Instrument `pane/hwnd.rs::resize()` with `tracing::trace!` spans; the existing `[pane-wndproc] key msg=` infrastructure shows the pattern. Trace pump turnaround time per `SetWindowPos`.
+
+### C. Cross-process (renderer ↔ host)
+
+#### C1. IPC roundtrip clock
+
+Today `invokeCommand` (CEF JS bridge) doesn't time its own roundtrip. Add bookend marks:
+
+```ts
+// frontend/app/platform/ipc.ts
+async function invokeCommand(name, args) {
+    const t0 = performance.now();
+    const result = await rawInvoke(name, args);
+    const dt = performance.now() - t0;
+    if (dt > 16) console.warn(`[perf] ipc ${name} ${dt.toFixed(1)}ms`, args);
+    return result;
+}
+```
+
+16 ms = one frame at 60 Hz. Anything over is a frame-budget threat. This single change reveals the chatty-IPC class of issues that bit Slack and VSCode (per Electron community write-ups — same applies here even though we're CEF, not Electron).
+
+## Hypotheses going in (to be confirmed by traces)
+
+These guide instrumentation priority but **the traces are authoritative** — don't optimize before measuring.
+
+### H1. Pane resize is dominated by per-frame IPC
+
+`browser-view.tsx:syncPosition()` fires on every `ResizeObserver` callback and calls `browser_pane_resize`. With N panes and 60 Hz drag, that's 60×N IPC roundtrips per second per drag. Each roundtrip is at least one main-thread message hop on each side; even 1 ms × 60 × N = 60 ms × N spent on IPC alone per second. **Likely fix candidates** (decide after traces): debounce/coalesce per frame, batch all pane resizes into a single IPC, switch to a non-IPC geometry sync via shared state.
+
+### H2. Tab switch has effect-storm fan-out
+
+Switching `activeTabId` triggers per-tab visibility memos in every block. With N tabs × M blocks/tab, the dependency graph re-runs O(NM). Most of those are no-ops (visibility didn't change for that block), but the createEffect runs anyway. Measure with A5 (effect-run counter) and confirm.
+
+### H3. Pane HWND show/hide is serialized through the host UI thread
+
+Tab switch needs to hide all browser-pane HWNDs of the previous tab and show the next tab's. Today these go through `browser_pane_hide` / `browser_pane_show` IPCs one at a time. Each one needs a Win32 `SetWindowPos` with `SWP_HIDEWINDOW`/`SWP_SHOWWINDOW` plus a parent HWND lock. If serialized, that's N × pump-roundtrip latency. **Possible fix:** batch HWND visibility into one IPC handler that calls `BeginDeferWindowPos` / `DeferWindowPos` / `EndDeferWindowPos` to atomically reposition them all.
+
+### H4. Long synchronous Solid memos in render path
+
+Per [our own past incident](../../../../../../Users/area54/.claude/projects/C--Systems/memory/feedback_solidjs_reactive_leak.md), a single bad signal-getter in a shared utility can cascade through the reactive graph. Worth ruling out via A5 before assuming it's gone.
+
+## Phased plan
+
+### Phase 0 — Instrumentation infrastructure (no behavior change)
+
+One PR. Adds A1, A2, A3, A5 plus a dev-mode perf HUD. Adds B1 to IPC handlers. Adds C1 to `invokeCommand`. Behind a `[perf]` log tag so existing recipes are unaffected.
+
+**Acceptance:** running `task dev`, opening `muxlog host '\[perf\]'`, and reproducing a tab switch / pane resize shows clean `tab-switch:total=Xms` measure entries plus IPC roundtrip warnings if any are >16 ms.
+
+**Effort:** ~300 LOC, 0.5 day.
+
+### Phase 1 — Baseline measurement
+
+No code change. Capture and document baselines for the Tier 1 interactions in [`docs/retro/perf-baseline-2026-05-09.md`](../retro/) (or whatever date this lands). For each interaction:
+
+- 5+ trials, P50/P75/P95
+- 1 representative Chromium trace + 1 `tracing-chrome` trace per interaction
+- Long-tasks log
+- Initial hypothesis correlation: do the traces match H1–H4?
+
+**Effort:** 0.5 day with the harness from Phase 0.
+
+### Phase 2 — Hypothesis-driven optimization (one fix per PR)
+
+Each PR:
+
+1. Cite the baseline trace + the bottleneck identified.
+2. Implement the targeted fix.
+3. Capture an after-trace under the same workload.
+4. Prove the improvement quantitatively (P75 dropped from X to Y).
+5. Ship as a single PR with the trace-pair attached as a `docs/retro/` entry.
+
+**No "let me also fix this thing" combos.** One bottleneck per PR; bundling makes regression bisection painful and review complexity grows superlinearly.
+
+**Effort:** ~1 day per fix. Estimate 3–5 fixes to hit the Tier 1 targets.
+
+### Phase 3 — Continuous monitoring + regression guards
+
+- Dev-mode perf HUD: floating panel showing recent INP, long-task count, IPC P95. Toggle with a keyboard shortcut. Hidden in release builds.
+- Optional CI perf-regression test: programmatic harness (using the existing browser API + new `/agentmux/perf/*` endpoints) that captures traces for a fixed workload and fails if INP exceeds threshold. Ride this with the implementation when it lands; doc-only spec for now.
+
+**Effort:** HUD ~0.5 day; regression CI deferred.
+
+## Dev-mode perf HUD (sketch)
+
+A small floating panel in the corner, toggled by `Ctrl+Shift+P`. Shows:
+
+```
+─── Perf ───
+Recent INP:  P50 47ms  P75 89ms  P95 230ms
+Long tasks:  3 in last 5s (max 187ms)
+IPC P95:     12ms (browser_pane_resize)
+Effects:     128 runs/s (top: BlockFrame.visibility 47/s)
+```
+
+Backed by `PerformanceObserver` aggregations. Refreshes every second. Click to expand to a full timeline of recent interactions. Hidden behind `is_dev` check; the existing `agentmux-cef` dev-mode plumbing covers this.
+
+## Threat model / cost
+
+The instrumentation itself adds cost. We must not let measurement BE the bottleneck.
+
+- `performance.mark/measure`: ~50 ns each. Negligible at our call counts (<1000/s).
+- Long Tasks API: zero cost — the browser already tracks tasks; we just observe.
+- INP observer: zero cost (browser-internal).
+- IPC roundtrip wrap: 1 perf.now() pair per call. Negligible.
+- Chromium tracing (A4): **expensive** — slows the renderer 2–5×. Off by default; on-demand only.
+- `tracing-chrome` (B2): minor (~1 µs/span). Off by default; gated behind `--features perf-trace`.
+
+Phase 0 instrumentation should be net-zero in release (gated by `is_dev` checks where it isn't free).
+
+## Out-of-scope / explicit non-goals
+
+- **No WebPageTest / Lighthouse integration.** Those tools target public web pages; we're an embedded app with private auth. The Performance Panel + Perfetto UI are the right tools.
+- **No bundle-size optimization** (this round). Code-splitting is a separate concern and the current frontend bundle is already past the immediate-startup horizon.
+- **No premature React → preact / Solid → vanilla rewrite.** Slice-by-slice fixes against measured bottlenecks first. Architectural changes need traces to justify.
+
+## Cross-references
+
+- Web Vitals INP: [https://web.dev/articles/inp](https://web.dev/articles/inp)
+- Chromium trace tool: [https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/](https://www.chromium.org/developers/how-tos/trace-event-profiling-tool/)
+- Perfetto UI: [https://ui.perfetto.dev](https://ui.perfetto.dev)
+- Long Tasks API: [https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming)
+- Electron perf community wisdom: [https://palette.dev/blog/improving-performance-of-electron-apps](https://palette.dev/blog/improving-performance-of-electron-apps)
+- Past incident — Solid reactive leak: see memory `feedback_solidjs_reactive_leak.md`
+- Reducer-stack work parallel: GitHub Discussion #707

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -20,6 +20,7 @@ import { CrossWindowDragMonitor } from "./drag/CrossWindowDragMonitor.platform";
 import { DragOverlay } from "./drag/DragOverlay";
 import { CenteredDiv } from "./element/quickelems";
 import { ZoomIndicator } from "./element/zoomindicator";
+import { PerfHud } from "@/perf/hud";
 import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
 
@@ -361,6 +362,9 @@ const AppInner = () => {
                     <NotificationBubbles />
                 </Show>
                 <ZoomIndicator />
+                <Show when={isDev()}>
+                    <PerfHud />
+                </Show>
             </div>
         </Show>
     );

--- a/frontend/app/platform/ipc.ts
+++ b/frontend/app/platform/ipc.ts
@@ -33,7 +33,13 @@ export async function invokeCommand<T = any>(cmd: string, args?: Record<string, 
     // → host response). 16 ms = one frame at 60 Hz; the recorder
     // logs anything over that. Cost is one perf.now() pair plus a
     // map insert, well under perf budget at our call rates.
-    const t0 = typeof performance !== "undefined" ? performance.now() : 0;
+    //
+    // No `typeof performance` guard: every CEF browser AgentMux
+    // bundles ships the Performance API, and the prior half-guarded
+    // form (guarded `t0` but unguarded `.now()` calls below) made
+    // the guard a footgun rather than a safety net. If we ever ship
+    // a runtime without it, fail visibly here, not silently.
+    const t0 = performance.now();
 
     switch (host) {
         case "cef": {

--- a/frontend/app/platform/ipc.ts
+++ b/frontend/app/platform/ipc.ts
@@ -7,6 +7,8 @@
 // CEF host: HTTP POST to localhost IPC server for commands (JS→Rust),
 //           CustomEvent dispatch for events (Rust→JS).
 
+import { recordIpcRoundtrip } from "@/perf";
+
 /**
  * Detect the current host environment.
  */
@@ -27,6 +29,11 @@ export function detectHost(): HostType {
  */
 export async function invokeCommand<T = any>(cmd: string, args?: Record<string, any>): Promise<T> {
     const host = detectHost();
+    // Component C1 of perf phase 0 — record the IPC roundtrip (start
+    // → host response). 16 ms = one frame at 60 Hz; the recorder
+    // logs anything over that. Cost is one perf.now() pair plus a
+    // map insert, well under perf budget at our call rates.
+    const t0 = typeof performance !== "undefined" ? performance.now() : 0;
 
     switch (host) {
         case "cef": {
@@ -44,9 +51,11 @@ export async function invokeCommand<T = any>(cmd: string, args?: Record<string, 
                 body: JSON.stringify({ cmd, args: args ?? {} }),
             });
             if (!resp.ok) {
+                recordIpcRoundtrip(cmd, performance.now() - t0);
                 throw new Error(`IPC HTTP error: ${resp.status} ${resp.statusText}`);
             }
             const parsed = await resp.json();
+            recordIpcRoundtrip(cmd, performance.now() - t0);
             if (parsed.success) {
                 return parsed.data as T;
             }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -25,6 +25,7 @@ import {
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { Logger } from "@/util/logger";
+import { markEnd, markStart } from "@/perf";
 import "./tabbar.scss";
 
 export { tabItemType } from "./tabbar-dnd";
@@ -63,7 +64,16 @@ function TabBar(props: TabBarProps): JSX.Element {
     };
 
     const handleSelect = (tabId: string) => {
-        if (tabId !== activeTabId()) setActiveTab(tabId);
+        if (tabId === activeTabId()) return;
+        // Phase 0 perf instrumentation A1: time the tab-switch
+        // interaction. The `markEnd` lands one microtask after
+        // `setActiveTab` commits — it captures the synchronous
+        // dispatch path; reactive fan-out (Solid effects, IPC for
+        // pane HWND show/hide) is observed separately via the Long
+        // Tasks API and the IPC roundtrip clock.
+        markStart("tab-switch", { from: activeTabId(), to: tabId });
+        setActiveTab(tabId);
+        queueMicrotask(() => markEnd("tab-switch"));
     };
 
     const handleClose = (tabId: string) => {

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -9,10 +9,17 @@ import { initLogPipe } from "./log/log-pipe";
 import { setupCefApi } from "./cef-init";
 import { initApp } from "./app-init";
 import { benchMark } from "@/util/startup-bench";
+import { initPerf } from "@/perf";
 
 // Pipe all console.log/warn/error to the Rust host log file.
 // Must run before any other code so early messages are captured.
 initLogPipe();
+
+// Phase 0 perf instrumentation: Long Tasks observer + INP/event
+// observer. Must run before any user-interactive code so we never
+// miss a "first interaction" sample. See
+// docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md.
+initPerf();
 
 // ── GPU context loss recovery ───────────────────────────────────────────────
 // Recover from GPU context loss (driver reset, DXGI device removal, display

--- a/frontend/layout/lib/layoutResize.ts
+++ b/frontend/layout/lib/layoutResize.ts
@@ -11,6 +11,7 @@ import {
     ResizeHandleProps,
 } from "./types";
 import type { LayoutModel } from "./layoutModel";
+import { markEnd, markStart } from "@/perf";
 
 export interface ResizeContext {
     handleId: string;
@@ -52,6 +53,14 @@ export function createStopContainerResizing(model: LayoutModel) {
  * @param y The Y coordinate of the pointer device, in CSS pixels.
  */
 export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps, x: number, y: number) {
+    // Phase 0 perf instrumentation A1: time the splitter-drag hot
+    // path. Each call is one mousemove → tree-size-recompute pass;
+    // hypothesis H1 in the perf spec is that this is where pane
+    // resize feels slow because every iteration fires a
+    // browser_pane_resize IPC per pane via the model's effect chain.
+    // The Long Tasks observer + IPC roundtrip clock cover the
+    // downstream cost; this mark covers the synchronous compute.
+    markStart("pane-resize-tick");
     const parentIsRow = resizeHandle.flexDirection === FlexDirection.Row;
 
     // If the resize context is out of date, update it and save it for future events.
@@ -114,6 +123,7 @@ export function onResizeMove(model: LayoutModel, resizeHandle: ResizeHandleProps
 
     model.treeReducer(setPendingAction);
     model.updateTree(false);
+    markEnd("pane-resize-tick");
 }
 
 /**

--- a/frontend/perf/aggregates.test.ts
+++ b/frontend/perf/aggregates.test.ts
@@ -1,0 +1,75 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { Aggregator, KeyedAggregator } from "./aggregates";
+
+describe("Aggregator", () => {
+    it("returns zeroes when empty", () => {
+        const a = new Aggregator(8);
+        expect(a.quantiles()).toEqual({ count: 0, p50: 0, p75: 0, p95: 0, max: 0 });
+    });
+
+    it("computes quantiles on a partially-filled buffer", () => {
+        const a = new Aggregator(100);
+        for (let i = 1; i <= 10; i++) a.record(i);
+        const q = a.quantiles();
+        expect(q.count).toBe(10);
+        expect(q.p50).toBe(6); // Math.floor(0.5 * 10) = 5 → sorted[5] = 6
+        expect(q.max).toBe(10);
+    });
+
+    it("rolls over the ring buffer when full", () => {
+        const a = new Aggregator(4);
+        a.record(1);
+        a.record(2);
+        a.record(3);
+        a.record(4);
+        a.record(100); // overwrites slot 0
+        const q = a.quantiles();
+        expect(q.count).toBe(4);
+        expect(q.max).toBe(100);
+    });
+
+    it("p95 lands at the top of the distribution", () => {
+        const a = new Aggregator(100);
+        for (let i = 1; i <= 100; i++) a.record(i);
+        const q = a.quantiles();
+        // P95 of [1..100]: floor(0.95 * 100) = 95 → sorted[95] = 96
+        expect(q.p95).toBe(96);
+    });
+
+    it("reset clears the buffer", () => {
+        const a = new Aggregator(4);
+        a.record(1);
+        a.record(2);
+        a.reset();
+        expect(a.quantiles().count).toBe(0);
+    });
+});
+
+describe("KeyedAggregator", () => {
+    it("records per-key values independently", () => {
+        const k = new KeyedAggregator(64);
+        k.record("a", 10);
+        k.record("a", 20);
+        k.record("b", 100);
+        const snap = k.snapshot();
+        expect(snap.get("a")?.count).toBe(2);
+        expect(snap.get("b")?.count).toBe(1);
+        expect(snap.get("b")?.max).toBe(100);
+    });
+
+    it("topByP95 ranks descending", () => {
+        const k = new KeyedAggregator(64);
+        for (let i = 0; i < 20; i++) {
+            k.record("slow", 100);
+            k.record("medium", 50);
+            k.record("fast", 5);
+        }
+        const top = k.topByP95(2);
+        expect(top.length).toBe(2);
+        expect(top[0].key).toBe("slow");
+        expect(top[1].key).toBe("medium");
+    });
+});

--- a/frontend/perf/aggregates.ts
+++ b/frontend/perf/aggregates.ts
@@ -1,0 +1,103 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Streaming quantile aggregator over a fixed-size sliding window
+ * (Phase 0, spec component A3). Used by the INP observer and the IPC
+ * roundtrip clock.
+ *
+ * Implementation note: a true online P95 is non-trivial; for our
+ * purposes (a few hundred recent samples, displayed in a HUD that
+ * refreshes once a second) a simple ring buffer + sort-on-read is
+ * fine. The cost is `O(n log n)` per HUD refresh (~1 Hz), well under
+ * the perf budget the HUD itself is supposed to monitor.
+ *
+ * `record()` is `O(1)`. `quantiles()` is `O(n log n)` and only called
+ * when the HUD refreshes.
+ */
+
+const DEFAULT_WINDOW_SIZE = 256;
+
+export interface QuantileSnapshot {
+    count: number;
+    p50: number;
+    p75: number;
+    p95: number;
+    max: number;
+}
+
+export class Aggregator {
+    private samples: number[];
+    private write = 0;
+    private full = false;
+
+    constructor(private windowSize: number = DEFAULT_WINDOW_SIZE) {
+        this.samples = new Array(windowSize);
+    }
+
+    record(value: number): void {
+        this.samples[this.write] = value;
+        this.write = (this.write + 1) % this.windowSize;
+        if (this.write === 0) this.full = true;
+    }
+
+    quantiles(): QuantileSnapshot {
+        const n = this.full ? this.windowSize : this.write;
+        if (n === 0) return { count: 0, p50: 0, p75: 0, p95: 0, max: 0 };
+        const sorted = this.samples.slice(0, n).sort((a, b) => a - b);
+        const at = (q: number) =>
+            sorted[Math.min(Math.floor(q * n), n - 1)];
+        return {
+            count: n,
+            p50: at(0.5),
+            p75: at(0.75),
+            p95: at(0.95),
+            max: sorted[n - 1],
+        };
+    }
+
+    reset(): void {
+        this.write = 0;
+        this.full = false;
+    }
+}
+
+/**
+ * Per-key aggregator map. Used to track INP per interaction-target,
+ * IPC roundtrip per command name, etc. `record(key, value)` lazily
+ * creates the per-key Aggregator.
+ */
+export class KeyedAggregator {
+    private aggs = new Map<string, Aggregator>();
+
+    constructor(private windowSize: number = DEFAULT_WINDOW_SIZE) {}
+
+    record(key: string, value: number): void {
+        let agg = this.aggs.get(key);
+        if (!agg) {
+            agg = new Aggregator(this.windowSize);
+            this.aggs.set(key, agg);
+        }
+        agg.record(value);
+    }
+
+    snapshot(): Map<string, QuantileSnapshot> {
+        const out = new Map<string, QuantileSnapshot>();
+        for (const [k, v] of this.aggs) {
+            out.set(k, v.quantiles());
+        }
+        return out;
+    }
+
+    /** Return the top-N keys ranked by P95, descending. Useful for HUD
+     *  display when the keyspace is large (many distinct IPC commands).
+     */
+    topByP95(n: number): Array<{ key: string; q: QuantileSnapshot }> {
+        const all: Array<{ key: string; q: QuantileSnapshot }> = [];
+        for (const [k, v] of this.aggs) {
+            all.push({ key: k, q: v.quantiles() });
+        }
+        all.sort((a, b) => b.q.p95 - a.q.p95);
+        return all.slice(0, n);
+    }
+}

--- a/frontend/perf/hud.tsx
+++ b/frontend/perf/hud.tsx
@@ -1,0 +1,141 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Dev-mode perf HUD. Floating panel in the bottom-right corner that
+ * shows aggregated stats from `perfStore`. Toggle with Ctrl+Shift+P.
+ *
+ * Polls `perfStore.snapshot()` once per second when visible. Hidden in
+ * release builds via the `import.meta.env.DEV` gate; the toggle hook
+ * is also no-opped in release.
+ *
+ * No styling system imports — keeps the HUD self-contained so it
+ * still works during a perf investigation that disables the main
+ * stylesheet.
+ */
+
+import { createSignal, onCleanup, onMount, Show, type JSX, For } from "solid-js";
+import { perfStore } from "./store";
+
+interface HudSnapshot {
+    longTasks: { count: number; p50: number; p75: number; p95: number; max: number };
+    longTasksLast5s: number;
+    interactionsTopLatency: Array<{ key: string; p75: number; p95: number; max: number }>;
+    ipcTopByP95: Array<{ key: string; p95: number; max: number; count: number }>;
+}
+
+function flatten(snap: ReturnType<typeof perfStore.snapshot>): HudSnapshot {
+    const interactionsArr: Array<{
+        key: string;
+        p75: number;
+        p95: number;
+        max: number;
+    }> = [];
+    for (const [key, q] of snap.interactions) {
+        interactionsArr.push({ key, p75: q.p75, p95: q.p95, max: q.max });
+    }
+    interactionsArr.sort((a, b) => b.p95 - a.p95);
+    return {
+        longTasks: snap.longTasks,
+        longTasksLast5s: snap.longTasksLast5s,
+        interactionsTopLatency: interactionsArr.slice(0, 5),
+        ipcTopByP95: snap.ipcTopByP95.map((r) => ({
+            key: r.key,
+            p95: r.q.p95,
+            max: r.q.max,
+            count: r.q.count,
+        })),
+    };
+}
+
+export function PerfHud(): JSX.Element {
+    const [visible, setVisible] = createSignal(false);
+    const [snap, setSnap] = createSignal<HudSnapshot>(flatten(perfStore.snapshot()));
+    let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+    const onKey = (e: KeyboardEvent) => {
+        // Ctrl+Shift+P (or Meta+Shift+P on macOS where Ctrl is rare).
+        if (e.shiftKey && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "p") {
+            e.preventDefault();
+            setVisible((v) => !v);
+        }
+    };
+
+    onMount(() => {
+        window.addEventListener("keydown", onKey);
+        pollInterval = setInterval(() => {
+            if (visible()) setSnap(flatten(perfStore.snapshot()));
+        }, 1000);
+    });
+
+    onCleanup(() => {
+        window.removeEventListener("keydown", onKey);
+        if (pollInterval) clearInterval(pollInterval);
+    });
+
+    return (
+        <Show when={visible()}>
+            <div
+                style={{
+                    position: "fixed",
+                    bottom: "8px",
+                    right: "8px",
+                    "z-index": "999999",
+                    "background-color": "rgba(20, 20, 20, 0.92)",
+                    color: "#d0d0d0",
+                    "font-family": "Menlo, Consolas, monospace",
+                    "font-size": "11px",
+                    padding: "8px 10px",
+                    border: "1px solid #444",
+                    "border-radius": "6px",
+                    "max-width": "320px",
+                    "box-shadow": "0 4px 12px rgba(0,0,0,0.5)",
+                    "pointer-events": "none",
+                }}
+            >
+                <div style={{ "font-weight": "bold", color: "#7af", "margin-bottom": "4px" }}>
+                    ⏱ Perf HUD &nbsp;
+                    <span style={{ color: "#777", "font-weight": "normal" }}>
+                        (Ctrl+Shift+P)
+                    </span>
+                </div>
+                <div style={{ "margin-top": "4px" }}>
+                    <span style={{ color: "#999" }}>Long tasks:</span>{" "}
+                    {snap().longTasksLast5s} in last 5s
+                    <Show when={snap().longTasks.count > 0}>
+                        {" "}
+                        (max {snap().longTasks.max.toFixed(0)}ms,
+                        P95 {snap().longTasks.p95.toFixed(0)}ms)
+                    </Show>
+                </div>
+                <Show when={snap().interactionsTopLatency.length > 0}>
+                    <div style={{ "margin-top": "6px", color: "#999" }}>
+                        Interactions (top by P95):
+                    </div>
+                    <For each={snap().interactionsTopLatency}>
+                        {(row) => (
+                            <div style={{ "padding-left": "8px" }}>
+                                <span style={{ color: "#aaa" }}>{row.key}</span>{" "}
+                                P75 {row.p75.toFixed(0)}ms{" "}
+                                P95 {row.p95.toFixed(0)}ms
+                            </div>
+                        )}
+                    </For>
+                </Show>
+                <Show when={snap().ipcTopByP95.length > 0}>
+                    <div style={{ "margin-top": "6px", color: "#999" }}>
+                        IPC (top by P95):
+                    </div>
+                    <For each={snap().ipcTopByP95}>
+                        {(row) => (
+                            <div style={{ "padding-left": "8px" }}>
+                                <span style={{ color: "#aaa" }}>{row.key}</span>{" "}
+                                P95 {row.p95.toFixed(0)}ms ({row.count} samples)
+                            </div>
+                        )}
+                    </For>
+                </Show>
+            </div>
+        </Show>
+    );
+}

--- a/frontend/perf/hud.tsx
+++ b/frontend/perf/hud.tsx
@@ -14,7 +14,7 @@
  * stylesheet.
  */
 
-import { createSignal, onCleanup, onMount, Show, type JSX, For } from "solid-js";
+import { createEffect, createSignal, onCleanup, onMount, Show, type JSX, For } from "solid-js";
 import { perfStore } from "./store";
 
 interface HudSnapshot {
@@ -63,14 +63,31 @@ export function PerfHud(): JSX.Element {
 
     onMount(() => {
         window.addEventListener("keydown", onKey);
-        pollInterval = setInterval(() => {
-            if (visible()) setSnap(flatten(perfStore.snapshot()));
-        }, 1000);
+    });
+
+    // Only run the 1 Hz poll when the HUD is visible. Otherwise the
+    // timer fires every second forever for a panel nobody can see —
+    // small individually but the kind of waste this very HUD exists
+    // to surface. createEffect re-runs whenever `visible()` flips,
+    // setting up / tearing down the interval cleanly.
+    createEffect(() => {
+        if (visible()) {
+            // Refresh once immediately so the panel doesn't show stale
+            // data on the first toggle-on after a long hidden period.
+            setSnap(flatten(perfStore.snapshot()));
+            pollInterval = setInterval(
+                () => setSnap(flatten(perfStore.snapshot())),
+                1000,
+            );
+        } else if (pollInterval != null) {
+            clearInterval(pollInterval);
+            pollInterval = null;
+        }
     });
 
     onCleanup(() => {
         window.removeEventListener("keydown", onKey);
-        if (pollInterval) clearInterval(pollInterval);
+        if (pollInterval != null) clearInterval(pollInterval);
     });
 
     return (

--- a/frontend/perf/index.ts
+++ b/frontend/perf/index.ts
@@ -1,0 +1,57 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Phase 0 perf instrumentation public API. See
+ * `docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md`.
+ *
+ * Surface area:
+ *   - `initPerf()` — call once at bootstrap. Idempotent.
+ *   - `markStart` / `markEnd` / `timeBlock` / `timeAsync` — interaction
+ *     instrumentation primitives (component A1).
+ *   - `recordIpcRoundtrip` — called by the `invokeCommand` wrapper
+ *     (component C1).
+ *   - `perfStore` — read-only aggregated stats; the HUD polls this.
+ */
+
+import { startAllObservers } from "./observers";
+import { perfStore } from "./store";
+
+export { markStart, markEnd, timeBlock, timeAsync } from "./marks";
+export { perfStore } from "./store";
+export type { QuantileSnapshot } from "./aggregates";
+
+let initialized = false;
+
+/**
+ * Idempotent. Wires up Long Tasks + INP observers at app startup.
+ * The IPC roundtrip wrapper is installed by `invokeCommand` itself
+ * (no global hook needed).
+ *
+ * Cost in steady state: zero. The observers fire only on rare events
+ * (long tasks ≥50 ms, events with interactionId).
+ */
+export function initPerf(): void {
+    if (initialized) return;
+    initialized = true;
+    startAllObservers();
+    // Surface a one-line confirmation in the host log so we can confirm
+    // initialization order from `muxlog host '\[perf\]'`.
+    console.info("[perf] phase-0 instrumentation initialized");
+}
+
+/**
+ * Called by the `invokeCommand` wrapper in `frontend/app/platform/ipc.ts`
+ * after each completed roundtrip. Centralized here so the wrapper
+ * stays dependency-free and the perf store is the single sink for
+ * all timing telemetry.
+ */
+export function recordIpcRoundtrip(command: string, durationMs: number): void {
+    perfStore.recordIpc(command, durationMs);
+    // 16 ms = one frame at 60 Hz. Anything over is a frame-budget
+    // threat — surface immediately to the host log so investigators
+    // don't have to wait for the HUD's 1 Hz refresh.
+    if (durationMs > 16) {
+        console.warn(`[perf] ipc ${command} ${durationMs.toFixed(1)}ms`);
+    }
+}

--- a/frontend/perf/marks.ts
+++ b/frontend/perf/marks.ts
@@ -1,0 +1,87 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `performance.mark` / `performance.measure` thin wrappers (Phase 0,
+ * spec component A1). Every Tier 1 interaction wraps its hot path with
+ * a paired `markStart` + `markEnd` so the resulting `measure` shows up
+ * in the Performance Panel timeline AND in the dev-mode HUD's recent
+ * interactions list.
+ *
+ * Naming convention: `<interaction>:<phase>` — e.g. `tab-switch:start`,
+ * `tab-switch:committed`, `pane-resize:drag-end`. The HUD groups
+ * measures by `<interaction>` (everything before the first colon).
+ *
+ * Costs ~50 ns per call. Cheap enough to leave on in production.
+ */
+
+const PERF_LOG_PREFIX = "[perf]";
+
+/** Best-effort guard: missing Performance API → noop wrappers. */
+const HAS_PERF =
+    typeof performance !== "undefined" &&
+    typeof performance.mark === "function" &&
+    typeof performance.measure === "function";
+
+export function markStart(interaction: string, detail?: unknown): void {
+    if (!HAS_PERF) return;
+    try {
+        performance.mark(`${interaction}:start`, detail !== undefined ? { detail } : undefined);
+    } catch {
+        // Browsers throw on duplicate mark names with strict-mode entry-types.
+        // Swallow — the measurement is best-effort, never blocking.
+    }
+}
+
+/**
+ * Close the measurement. Reads back the `:start` mark's wall-clock and
+ * emits a measure entry of the same `<interaction>` name. Returns the
+ * elapsed milliseconds (or `null` if the start mark wasn't found —
+ * happens when initPerf races the first interaction).
+ */
+export function markEnd(interaction: string, suffix: string = "end"): number | null {
+    if (!HAS_PERF) return null;
+    const startName = `${interaction}:start`;
+    const endName = `${interaction}:${suffix}`;
+    try {
+        performance.mark(endName);
+        const startEntries = performance.getEntriesByName(startName, "mark");
+        if (startEntries.length === 0) return null;
+        const m = performance.measure(interaction, startName, endName);
+        // `measure` returns the entry directly in modern browsers; older
+        // ones return undefined and require a getEntriesByName lookup.
+        const dur = m?.duration ?? null;
+        if (dur != null && dur > 100) {
+            // Surface long interactions in the host log immediately so we
+            // don't have to wait for the HUD to refresh.
+            console.warn(`${PERF_LOG_PREFIX} ${interaction} ${dur.toFixed(1)}ms`);
+        }
+        return dur;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * One-shot convenience: time a synchronous block. Use when start/end
+ * straddle a single function — `markStart`/`markEnd` is preferred when
+ * the boundaries are in different call sites (typical for interaction
+ * tracking).
+ */
+export function timeBlock<T>(interaction: string, fn: () => T): T {
+    markStart(interaction);
+    try {
+        return fn();
+    } finally {
+        markEnd(interaction);
+    }
+}
+
+export async function timeAsync<T>(interaction: string, fn: () => Promise<T>): Promise<T> {
+    markStart(interaction);
+    try {
+        return await fn();
+    } finally {
+        markEnd(interaction);
+    }
+}

--- a/frontend/perf/marks.ts
+++ b/frontend/perf/marks.ts
@@ -13,18 +13,21 @@
  * measures by `<interaction>` (everything before the first colon).
  *
  * Costs ~50 ns per call. Cheap enough to leave on in production.
+ *
+ * **Bounded user-timing buffer** — `markEnd` clears the start mark and
+ * the measure entry it just emitted. On hot paths like
+ * `pane-resize-tick` (called up to 60×/s during a drag) the User
+ * Timing buffer would otherwise grow without bound across a long
+ * session. The HUD reads via `perfStore`, not by querying user-timing
+ * directly, so clearing the buffer is safe — Performance Panel users
+ * still see the live measure during a recording window.
  */
+
+import { perfStore } from "./store";
 
 const PERF_LOG_PREFIX = "[perf]";
 
-/** Best-effort guard: missing Performance API → noop wrappers. */
-const HAS_PERF =
-    typeof performance !== "undefined" &&
-    typeof performance.mark === "function" &&
-    typeof performance.measure === "function";
-
 export function markStart(interaction: string, detail?: unknown): void {
-    if (!HAS_PERF) return;
     try {
         performance.mark(`${interaction}:start`, detail !== undefined ? { detail } : undefined);
     } catch {
@@ -34,28 +37,47 @@ export function markStart(interaction: string, detail?: unknown): void {
 }
 
 /**
- * Close the measurement. Reads back the `:start` mark's wall-clock and
- * emits a measure entry of the same `<interaction>` name. Returns the
+ * Close the measurement. Reads back the `:start` mark's wall-clock,
+ * emits a measure entry, **records the duration in perfStore so it
+ * appears in the HUD**, and clears both the start mark and the
+ * measure to bound the user-timing buffer on hot paths. Returns the
  * elapsed milliseconds (or `null` if the start mark wasn't found —
  * happens when initPerf races the first interaction).
  */
 export function markEnd(interaction: string, suffix: string = "end"): number | null {
-    if (!HAS_PERF) return null;
     const startName = `${interaction}:start`;
     const endName = `${interaction}:${suffix}`;
     try {
         performance.mark(endName);
         const startEntries = performance.getEntriesByName(startName, "mark");
-        if (startEntries.length === 0) return null;
+        if (startEntries.length === 0) {
+            // No paired start — clear the dangling end mark so it
+            // doesn't accumulate either.
+            performance.clearMarks(endName);
+            return null;
+        }
         const m = performance.measure(interaction, startName, endName);
         // `measure` returns the entry directly in modern browsers; older
         // ones return undefined and require a getEntriesByName lookup.
         const dur = m?.duration ?? null;
-        if (dur != null && dur > 100) {
-            // Surface long interactions in the host log immediately so we
-            // don't have to wait for the HUD to refresh.
-            console.warn(`${PERF_LOG_PREFIX} ${interaction} ${dur.toFixed(1)}ms`);
+        if (dur != null) {
+            // Push into perfStore so the HUD's "Interactions" panel can
+            // show A1 measures alongside the INP observer's PerformanceEventTiming
+            // samples. Without this the HUD's interaction list stays empty
+            // because the INP observer only fires on event-driven entries.
+            perfStore.recordInteraction(interaction, dur);
+            if (dur > 100) {
+                // Surface long interactions in the host log immediately so we
+                // don't have to wait for the HUD to refresh.
+                console.warn(`${PERF_LOG_PREFIX} ${interaction} ${dur.toFixed(1)}ms`);
+            }
         }
+        // Bounded user-timing: drop the marks + measure now that the
+        // duration is captured. Otherwise hot paths like pane-resize-tick
+        // accumulate thousands of entries per minute.
+        performance.clearMarks(startName);
+        performance.clearMarks(endName);
+        performance.clearMeasures(interaction);
         return dur;
     } catch {
         return null;

--- a/frontend/perf/observers.ts
+++ b/frontend/perf/observers.ts
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `PerformanceObserver` subscriptions for Long Tasks (A2) and INP /
+ * event timing (A3). Fed into the global perf store so the HUD can
+ * read aggregated stats without each consumer subscribing
+ * individually.
+ *
+ * Frame budget at 60 Hz is 16.67 ms. Long Tasks API surfaces any
+ * single task >50 ms — by the time we hit that we've already missed
+ * 3 frames, so `longtask` events are always interesting.
+ *
+ * INP observer uses `event` (not the older `first-input`) — it covers
+ * every interaction, not just the first.
+ */
+
+import { perfStore } from "./store";
+
+const PERF_LOG_PREFIX = "[perf]";
+
+/** Browser-feature gates. Long Tasks API isn't in every embed; INP
+ *  observer takes the same `event` entry type that's been stable in
+ *  Chromium since 109. */
+function supportsObserver(type: string): boolean {
+    if (typeof PerformanceObserver === "undefined") return false;
+    const supported = (PerformanceObserver as any).supportedEntryTypes as string[] | undefined;
+    return Array.isArray(supported) && supported.includes(type);
+}
+
+export function startLongTaskObserver(): (() => void) | null {
+    if (!supportsObserver("longtask")) {
+        console.info(`${PERF_LOG_PREFIX} longtask observer unavailable in this runtime`);
+        return null;
+    }
+    const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+            // Anything ≥50 ms is a long task by definition. Surface
+            // immediately — don't let the HUD's 1 Hz refresh delay
+            // diagnostic info during active investigation.
+            console.warn(
+                `${PERF_LOG_PREFIX} long-task ${entry.duration.toFixed(1)}ms ` +
+                    `name=${entry.name} startTime=${entry.startTime.toFixed(1)}`,
+            );
+            perfStore.recordLongTask(entry.duration);
+        }
+    });
+    try {
+        observer.observe({ type: "longtask", buffered: true });
+    } catch (e) {
+        console.warn(`${PERF_LOG_PREFIX} longtask observer failed to attach:`, e);
+        return null;
+    }
+    return () => observer.disconnect();
+}
+
+export function startEventObserver(): (() => void) | null {
+    // The `event` entry type covers every event-driven interaction
+    // (click, keydown, pointerdown, etc.) and reports the
+    // interactionId — so we can group multi-event interactions (a
+    // pointerdown + click that share an interactionId).
+    //
+    // The `durationThreshold` filter is supported on Chromium ≥106;
+    // 16 ms = one frame. Below that we don't care.
+    if (!supportsObserver("event")) {
+        console.info(`${PERF_LOG_PREFIX} event observer unavailable in this runtime`);
+        return null;
+    }
+    const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries() as PerformanceEventTiming[]) {
+            // Skip events with no interactionId — those are paint-only
+            // events (scrollstart, etc.) that don't reflect user input.
+            const interactionId =
+                (entry as { interactionId?: number }).interactionId ?? 0;
+            if (interactionId === 0) continue;
+            perfStore.recordInteraction(entry.name, entry.duration);
+        }
+    });
+    try {
+        observer.observe({
+            type: "event",
+            buffered: true,
+            // Don't fire below 16 ms — frame budget. Saves a lot of
+            // observer churn on fast pointer/keyboard events.
+            durationThreshold: 16,
+        } as any);
+    } catch (e) {
+        console.warn(`${PERF_LOG_PREFIX} event observer failed to attach:`, e);
+        return null;
+    }
+    return () => observer.disconnect();
+}
+
+/**
+ * Attach all Phase-0 observers. Call once at startup. Returns a cleanup
+ * function that disconnects them — primarily for tests; production never
+ * tears these down.
+ */
+export function startAllObservers(): () => void {
+    const stops = [startLongTaskObserver(), startEventObserver()].filter(
+        (f): f is () => void => f != null,
+    );
+    return () => {
+        for (const s of stops) s();
+    };
+}

--- a/frontend/perf/store.ts
+++ b/frontend/perf/store.ts
@@ -1,0 +1,70 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Module-level singleton store for the perf observers' aggregated
+ * data. The HUD subscribes here for its 1 Hz refresh; the observers
+ * push samples in. No SolidJS reactivity at this layer (the store is
+ * polled, not reactive) — the HUD wraps a Solid signal around the
+ * snapshot at read time.
+ *
+ * Three tracks today:
+ *   - `longTasks` — every Long Tasks API entry's duration. Counted so
+ *     the HUD can show "N long tasks in last 5 s" without re-querying
+ *     the buffer.
+ *   - `interactions` — INP-style interaction durations, keyed by event
+ *     name (click, keydown, pointerdown). Populated by the
+ *     PerformanceEventTiming observer.
+ *   - `ipc` — IPC roundtrip durations, keyed by command name. Populated
+ *     by the `invokeCommand` wrapper.
+ */
+
+import { Aggregator, KeyedAggregator, type QuantileSnapshot } from "./aggregates";
+
+class PerfStore {
+    private longTaskAgg = new Aggregator(64);
+    private interactionAgg = new KeyedAggregator(64);
+    private ipcAgg = new KeyedAggregator(128);
+    /** Long-task count over a sliding 5 s window. */
+    private longTaskTimestamps: number[] = [];
+
+    recordLongTask(duration: number): void {
+        this.longTaskAgg.record(duration);
+        const now = performance.now();
+        this.longTaskTimestamps.push(now);
+        // Trim entries older than 5 s. This is a small array (long
+        // tasks are rare); linear filter is fine.
+        const cutoff = now - 5000;
+        this.longTaskTimestamps = this.longTaskTimestamps.filter(
+            (t) => t >= cutoff,
+        );
+    }
+
+    recordInteraction(name: string, duration: number): void {
+        this.interactionAgg.record(name, duration);
+    }
+
+    recordIpc(command: string, duration: number): void {
+        this.ipcAgg.record(command, duration);
+    }
+
+    snapshot(): {
+        longTasks: QuantileSnapshot;
+        longTasksLast5s: number;
+        interactions: Map<string, QuantileSnapshot>;
+        ipcTopByP95: Array<{ key: string; q: QuantileSnapshot }>;
+    } {
+        const now = performance.now();
+        const cutoff = now - 5000;
+        return {
+            longTasks: this.longTaskAgg.quantiles(),
+            longTasksLast5s: this.longTaskTimestamps.filter(
+                (t) => t >= cutoff,
+            ).length,
+            interactions: this.interactionAgg.snapshot(),
+            ipcTopByP95: this.ipcAgg.topByP95(5),
+        };
+    }
+}
+
+export const perfStore = new PerfStore();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.734",
+  "version": "0.33.735",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.734",
+      "version": "0.33.735",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.734",
+  "version": "0.33.735",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,9 @@
             "@/store/*": ["frontend/app/store/*"],
             "@/view/*": ["frontend/app/view/*"],
             "@/element/*": ["frontend/app/element/*"],
-            "@/shadcn/*": ["frontend/app/shadcn/*"]
+            "@/shadcn/*": ["frontend/app/shadcn/*"],
+            "@/perf": ["frontend/perf/index.ts"],
+            "@/perf/*": ["frontend/perf/*"]
         },
         "lib": ["dom", "dom.iterable", "es6"],
         "types": ["vite/client"],


### PR DESCRIPTION
## Summary

Phase 0 of the performance work, per the spec also included in this PR (\`docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md\`). **No behavior change** — just measurement infrastructure that gives us the numbers to drive every subsequent optimization PR.

### What landed (5 components)

**A1 — `performance.mark` / `performance.measure` helpers** \`frontend/perf/marks.ts\`. \`markStart\` + \`markEnd\` pairs at the synchronous entry/exit of Tier-1 interactions. Wrapped tab switch (\`tabbar.tsx:handleSelect\`) and splitter drag (\`layoutResize.ts:onResizeMove\`). \`> 100 ms\` measures auto-warn to host log.

**A2 — Long Tasks observer** \`frontend/perf/observers.ts\`. Subscribes via \`PerformanceObserver({ type: \"longtask\" })\`. Every task ≥50 ms (3+ frame budget violations) immediately logs \`[perf] long-task Xms\` to host log. Counts kept in a sliding 5-second window for the HUD.

**A3 — INP / event observer** \`frontend/perf/observers.ts\`. Subscribes via \`PerformanceObserver({ type: \"event\", durationThreshold: 16 })\`. Filters to events with \`interactionId\` (real user interactions, not paint-only). Per-event-name P50/P75/P95 aggregations (\`click\`, \`keydown\`, \`pointerdown\`).

**C1 — IPC roundtrip clock** \`frontend/app/platform/ipc.ts\`. \`invokeCommand\` wraps each call with \`performance.now()\` before/after and pushes into \`perfStore\`. \`> 16 ms\` (one frame at 60 Hz) logs \`[perf] ipc <cmd> Xms\` immediately.

**Dev-mode HUD** \`frontend/perf/hud.tsx\`. Floating panel in bottom-right, toggled by \`Ctrl+Shift+P\`. Polls \`perfStore.snapshot()\` once per second. Shows: long-task count in last 5 s, top 5 interactions by P95, top 5 IPC commands by P95. Hidden in release via the existing \`isDev()\` gate. \`pointer-events: none\` so the HUD never intercepts user input.

### Aggregator design

\`Aggregator\` is a fixed-window ring buffer (\`O(1)\` record, \`O(n log n)\` quantile read) — quantiles computed lazily at HUD refresh time (1 Hz), not per sample. \`KeyedAggregator\` lazily creates per-key Aggregators. Window sizes tuned so memory is small (~100 KB total for the perfStore even with 10s of distinct IPC commands).

### Naming conventions for marks

\`<interaction>:<phase>\` — e.g. \`tab-switch:start\`, \`tab-switch:end\`. The HUD groups measures by \`<interaction>\` (everything before the first \`:\`). This way new instrumentation lands in a predictable namespace and the HUD's per-interaction view stays useful as more sites get instrumented.

### What's NOT in this PR (intentional, deferred)

- **A4 Chromium tracing via CDP** (\`/agentmux/perf/trace_start\`, \`/agentmux/perf/trace_stop\`) — requires Rust-side handlers; ride with the future host-API spec PR (\`SPEC_HOST_API_AND_WIN32_PROBES.md\`) so we don't open two perf-IPC surfaces back-to-back.
- **A5 Solid effect-run counter** — useful for hypothesis H4 in the spec (\"hidden Solid reactive leak\") but only matters once Phase 1 baseline traces show effect storms. Ship in a focused follow-up if that hypothesis fires.
- **B1 \`#[tracing::instrument]\` on Rust IPC handlers** — the IPC roundtrip clock (C1) gives us renderer-side latency right now; B1 is needed only when we need to attribute roundtrip cost to host-side vs. wire latency. Cheap to add later when a bottleneck demands it.

The phased rule was \"ship infrastructure, then measure.\" This PR is the infrastructure. Phase 1 (baseline retro) is a separate doc-only retro that rides with the first optimization PR.

## Test plan

- [x] +7 unit tests on \`Aggregator\` / \`KeyedAggregator\`: empty buffer, partial fill, ring-buffer rollover, P95 correctness, reset, per-key independence, top-by-P95 ranking.
- [x] Full frontend suite: **461/461 passing** (was 454; +7 new).
- [x] \`task build:frontend\` succeeds with the new \`@/perf\` tsconfig path alias (memory: \`feedback_verify_before_push\`).
- [x] No TS regressions in touched files.
- [ ] Smoke: \`task dev\`, open browser pane, switch tabs, drag a splitter, press Ctrl+Shift+P. HUD shows non-zero stats. \`muxlog host '\\[perf\\]'\` shows long-task warnings + IPC roundtrips > 16 ms.

## Cost analysis (steady state)

- \`performance.mark/measure\`: ~50 ns/call. Negligible.
- Long Tasks API: zero — browser-internal, we just observe.
- INP observer: zero (filtered to durationThreshold ≥ 16 ms).
- IPC roundtrip wrap: one \`performance.now()\` pair per call. Negligible.
- HUD: only renders when visible (toggled). Polls \`perfStore\` once/sec.

Net: instrumentation is effectively free in steady state. None of it is gated behind \`isDev()\` because the cost is below noise — except the HUD itself, which IS dev-only.

## Files

\`\`\`
docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md  (rides with implementation)
frontend/perf/index.ts          — public API + initPerf()
frontend/perf/marks.ts          — mark/measure helpers
frontend/perf/observers.ts      — Long Tasks + INP observers
frontend/perf/store.ts          — perfStore singleton
frontend/perf/aggregates.ts     — Aggregator + KeyedAggregator
frontend/perf/aggregates.test.ts — 7 unit tests
frontend/perf/hud.tsx           — dev-mode HUD component
frontend/bootstrap.ts           — initPerf() wired after initLogPipe()
frontend/app/app.tsx            — <PerfHud /> mounted in dev
frontend/app/platform/ipc.ts    — invokeCommand wraps with C1 clock
frontend/app/tab/tabbar.tsx     — tab-switch interaction marks
frontend/layout/lib/layoutResize.ts — pane-resize-tick interaction marks
tsconfig.json                   — @/perf path alias
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)