### PR TITLE
slice #9: faviconUrl derived from url.origin + remove temporary urlAtom-read diag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.735"
+version = "0.33.736"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.735"
+version = "0.33.736"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.735"
+version = "0.33.736"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.735"
+version = "0.33.736"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.735"
+version = "0.33.736"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.735"
+version = "0.33.736"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.735"
+version = "0.33.736"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.735"
+version = "0.33.736"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state/index.ts
+++ b/frontend/app/store/browser-pane-state/index.ts
@@ -8,4 +8,4 @@ export type {
     BrowserPaneState,
     ReducerResult,
 } from "./types";
-export { initialState, TITLE_FALLBACK } from "./types";
+export { deriveFaviconUrl, initialState, TITLE_FALLBACK } from "./types";

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -3,9 +3,36 @@
 
 import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
-import { initialState, TITLE_FALLBACK } from "./types";
+import { deriveFaviconUrl, initialState, TITLE_FALLBACK } from "./types";
 
-describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e + 3d)", () => {
+describe("deriveFaviconUrl", () => {
+    it("returns empty for empty input", () => {
+        expect(deriveFaviconUrl("")).toBe("");
+    });
+
+    it("returns origin/favicon.ico for a normal https URL", () => {
+        expect(deriveFaviconUrl("https://example.com/path?q=1")).toBe(
+            "https://example.com/favicon.ico",
+        );
+    });
+
+    it("preserves port + scheme on the origin", () => {
+        expect(deriveFaviconUrl("http://localhost:3000/foo")).toBe(
+            "http://localhost:3000/favicon.ico",
+        );
+    });
+
+    it("returns empty for unparseable URLs", () => {
+        expect(deriveFaviconUrl("not a url")).toBe("");
+        expect(deriveFaviconUrl("://broken")).toBe("");
+    });
+
+    it("returns empty for about:blank (origin is 'null')", () => {
+        expect(deriveFaviconUrl("about:blank")).toBe("");
+    });
+});
+
+describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3d + 3e complete)", () => {
     describe("Navigate", () => {
         it("sets loading=true and clears any prior error", () => {
             const s0 = update(initialState(), {
@@ -44,6 +71,48 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3e + 3d)",
             }).state;
             const r = update(s0, { type: "Navigate", url: "https://b.com" });
             expect(r.state.url).toBe("https://b.com");
+        });
+    });
+
+    describe("faviconUrl derivation", () => {
+        it("Navigate sets faviconUrl from url's origin", () => {
+            const r = update(initialState(), {
+                type: "Navigate",
+                url: "https://example.com/some/page",
+            });
+            expect(r.state.faviconUrl).toBe("https://example.com/favicon.ico");
+        });
+
+        it("UrlConfirmed updates faviconUrl when origin changes (post-redirect)", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://typed-by-user.com",
+            }).state;
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://final-redirect-target.com/page",
+            });
+            expect(r.state.faviconUrl).toBe(
+                "https://final-redirect-target.com/favicon.ico",
+            );
+        });
+
+        it("UrlCleared clears faviconUrl alongside url", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://example.com",
+            }).state;
+            expect(s0.faviconUrl).toBe("https://example.com/favicon.ico");
+            const r = update(s0, { type: "UrlCleared" });
+            expect(r.state.faviconUrl).toBe("");
+        });
+
+        it("Navigate to an unparseable URL leaves faviconUrl empty", () => {
+            const r = update(initialState(), {
+                type: "Navigate",
+                url: "not a url",
+            });
+            expect(r.state.faviconUrl).toBe("");
         });
     });
 

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
 import { deriveFaviconUrl, initialState, TITLE_FALLBACK } from "./types";
 
+// Pure-function tests for the URL→favicon helper. Kept separate from
+// the reducer suite because the helper is reused by future consumers
+// (e.g. the view's globe-fallback decision) and should be testable
+// without bringing the reducer along.
 describe("deriveFaviconUrl", () => {
     it("returns empty for empty input", () => {
         expect(deriveFaviconUrl("")).toBe("");

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -3,8 +3,9 @@
 
 /**
  * Pure reducer for the browser-pane state slice (slice #9, Phases 3a +
- * 3b + 3c + 3e + 3d). See `docs/specs/browser-pane-reducer-roadmap.md`
- * and the conventions doc `frontend-reducer-conventions-2026-05-03.md`.
+ * 3b + 3c + 3d + 3e complete). See
+ * `docs/specs/browser-pane-reducer-roadmap.md` and the conventions
+ * doc `frontend-reducer-conventions-2026-05-03.md`.
  * This module is the exact mirror of slice #4's reducer pattern
  * (agent-pane-state) — same `update(state, command) → { state, events }`
  * shape, same idempotency rules, same no-throw policy.
@@ -34,9 +35,16 @@
  *      typically accompany the same nav-state IPC event).
  *      Idempotent on identical url.
  *   8. `UrlCleared` sets `state.url = ""` without touching any
- *      other cell — distinct from `UrlConfirmed { url: "" }` so the
- *      audit ring distinguishes the reload force-reload pattern from
- *      a host-confirmed empty URL. Idempotent (already empty → no-op).
+ *      other cell except `faviconUrl` (which derives from `url`).
+ *      Distinct from `UrlConfirmed { url: "" }` so the audit ring
+ *      distinguishes the reload force-reload pattern from a
+ *      host-confirmed empty URL. Idempotent (already empty → no-op).
+ *   9. `faviconUrl` is a **derived projection** of `url` — every
+ *      transition that writes `url` also writes
+ *      `faviconUrl = deriveFaviconUrl(url)`. There is no
+ *      `FaviconChanged` command; the cell is not an independent
+ *      input. Empty / unparseable URL → empty faviconUrl (view falls
+ *      back to globe icon).
  */
 
 import {
@@ -44,6 +52,7 @@ import {
     BrowserPaneState,
     ReducerResult,
     TITLE_FALLBACK,
+    deriveFaviconUrl,
 } from "./types";
 
 export function update(
@@ -70,6 +79,7 @@ export function update(
                     loading: true,
                     error: null,
                     url: command.url,
+                    faviconUrl: deriveFaviconUrl(command.url),
                 },
                 events: [{ type: "navigate", url: command.url }],
             };
@@ -133,7 +143,11 @@ export function update(
         case "UrlConfirmed": {
             if (state.url === command.url) return { state, events: [] };
             return {
-                state: { ...state, url: command.url },
+                state: {
+                    ...state,
+                    url: command.url,
+                    faviconUrl: deriveFaviconUrl(command.url),
+                },
                 events: [{ type: "url-confirmed", url: command.url }],
             };
         }
@@ -141,7 +155,7 @@ export function update(
         case "UrlCleared": {
             if (state.url === "") return { state, events: [] };
             return {
-                state: { ...state, url: "" },
+                state: { ...state, url: "", faviconUrl: "" },
                 events: [{ type: "url-cleared" }],
             };
         }

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -6,8 +6,10 @@
  * docs/specs/frontend-reducer-architecture-2026-05-03.md and the
  * roadmap at docs/specs/browser-pane-reducer-roadmap.md).
  *
- * **Phases 3a + 3b + 3c + 3e (title) + 3d.** This reducer owns seven
- * cells today:
+ * **Phases 3a + 3b + 3c + 3d + 3e (complete).** This reducer owns
+ * eight cells today — every per-pane data cell from the catalog is
+ * now reducer-backed. Slot store + `recordDispatch` audit (Phase 4)
+ * is the next milestone.
  *   - `closed` — terminal flag set by `dispose()`. All post-close
  *     commands are no-ops.
  *   - `loading` — page-load-in-flight flag. Mutually exclusive with
@@ -28,10 +30,11 @@
  *     createPane, the placeholder `<Show>` gate); migration must
  *     preserve every consumer's semantics verbatim.
  *
- * Cells not yet migrated: `faviconUrl` (will be a derived projection
- * of `url`'s origin in a follow-up PR) plus the address-bar typing
- * buffer in the view. The slot store + `recordDispatch` audit lands
- * in Phase 4.
+ * The `faviconUrl` cell is a **derived projection** of `url` — its
+ * value is computed inside every transition that touches `url`, so
+ * there's no `FaviconChanged` command. The address-bar typing buffer
+ * stays in the view (the catalog rule: DOM is the source of truth
+ * for live-typing UX).
  *
  * Note: Phase 6 of the roadmap is when host-side title-change events
  * (`browser-pane-title-change`) actually start emitting. Until then,
@@ -77,6 +80,35 @@ export interface BrowserPaneState {
      *  and superseded by `UrlConfirmed` (host's `browser-pane-nav-state`
      *  reporting the post-redirect final URL). */
     url: string;
+    /** Pane favicon URL — derived from `url`'s origin via
+     *  `${origin}/favicon.ico`. Empty string when `url` is empty or
+     *  unparseable; the view falls back to a globe icon in that case.
+     *  Computed by `deriveFaviconUrl` inside every transition that
+     *  writes `url` (Navigate, UrlConfirmed, UrlCleared) — there is
+     *  no `FaviconChanged` command, since the cell isn't an
+     *  independent input. Catalog reference: row 1.faviconUrlAtom in
+     *  `docs/specs/browser-pane-state-catalog.md`. */
+    faviconUrl: string;
+}
+
+/**
+ * Derive the favicon URL from a pane URL. Empty string when the URL
+ * is empty or unparseable — the view interprets that as "no favicon,
+ * show the globe icon" per the catalog. Pure function so it's safe to
+ * call inside reducer transitions and from tests directly.
+ */
+export function deriveFaviconUrl(url: string): string {
+    if (url === "") return "";
+    try {
+        const origin = new URL(url).origin;
+        // about:blank, file://, and other schemes that produce an
+        // origin of "null" don't have a meaningful favicon — return
+        // empty so the view shows the globe.
+        if (origin === "null" || origin === "") return "";
+        return `${origin}/favicon.ico`;
+    } catch {
+        return "";
+    }
 }
 
 /** The string the reducer projects when `TitleChanged` arrives with
@@ -94,6 +126,7 @@ export const initialState = (): BrowserPaneState => ({
     canGoForward: false,
     title: TITLE_FALLBACK,
     url: "",
+    faviconUrl: "",
 });
 
 export type BrowserPaneCommand =

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -43,28 +43,20 @@ export class BrowserViewModel implements ViewModel {
     }
 
     private _url = createSignal<string>("");
-    /**
-     * `urlAtom` is wrapped (not the bare signal getter) for slice #9
-     * Phase 3d observability: every consumer read is logged so we can
-     * verify the migration didn't change consumer call patterns. Per
-     * the roadmap this instrumentation is **temporary** — remove
-     * after Phase 3d ships and the log baseline is recorded.
-     *
-     * Do NOT change the accessor's reactive shape — Solid tracks the
-     * underlying signal read (`this._url[0]()`), so consumers'
-     * createEffect dependency tracking remains identical to the bare
-     * signal accessor.
-     */
-    urlAtom: Accessor<string> = () => {
-        const v = this._url[0]();
-        this.diag(`urlAtom-read value=${JSON.stringify(v)}`);
-        return v;
-    };
+    urlAtom: Accessor<string> = this._url[0];
     setUrl = this._url[1];
 
     private _title = createSignal<string>(TITLE_FALLBACK);
     titleAtom: Accessor<string> = this._title[0];
     setTitle = this._title[1];
+
+    private _favicon = createSignal<string>("");
+    /** Pane favicon URL. Derived projection of `state.url` per the
+     *  reducer (slice #9 §3e completion). Empty when the URL is
+     *  empty or unparseable; the view shows the globe icon in that
+     *  case. */
+    faviconUrlAtom: Accessor<string> = this._favicon[0];
+    private setFavicon = this._favicon[1];
 
     private _loading = createSignal<boolean>(false);
     loadingAtom: Accessor<boolean> = this._loading[0];
@@ -101,14 +93,13 @@ export class BrowserViewModel implements ViewModel {
     blockAtom: Accessor<Block | undefined>;
 
     /**
-     * Slice #9 (Phases 3a + 3b + 3c + 3e + 3d) reducer state — owns
-     * `closed`, `loading`, `error`, `canGoBack`, `canGoForward`,
-     * `title`, `url`. The signals above are projections of this state
-     * so the SolidJS view layer keeps reactive parity. Per the
-     * roadmap at `docs/specs/browser-pane-reducer-roadmap.md`, the
-     * remaining cell (`faviconUrl`, derived from `url`) migrates in
-     * a follow-up PR; the slot store + recordDispatch audit lands in
-     * Phase 4.
+     * Slice #9 reducer state — owns every per-pane data cell from
+     * the catalog: `closed`, `loading`, `error`, `canGoBack`,
+     * `canGoForward`, `title`, `url`, `faviconUrl` (derived from
+     * `url`). The signals above are projections of this state so
+     * the SolidJS view layer keeps reactive parity. Cell-by-cell
+     * migration is **complete** with this PR; Phase 4 (slot store +
+     * `recordDispatch` audit) is the next milestone.
      */
     private _paneState: BrowserPaneState = browserPaneInitialState();
     /** Late callers (IPC handlers landing post-dispose, defensive guards
@@ -166,6 +157,12 @@ export class BrowserViewModel implements ViewModel {
                 `state-write key=url value=${JSON.stringify(result.state.url)} src=${src}`,
             );
             this.setUrl(result.state.url);
+        }
+        if (result.state.faviconUrl !== prev.faviconUrl) {
+            this.diag(
+                `state-write key=faviconUrl value=${JSON.stringify(result.state.faviconUrl)} src=${src}`,
+            );
+            this.setFavicon(result.state.faviconUrl);
         }
         for (const e of result.events) {
             if (e.type === "post-close-command-dropped") {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.735",
+  "version": "0.33.736",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.735",
+      "version": "0.33.736",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.735",
+  "version": "0.33.736",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The **last cell** of slice #9. With this PR, every per-pane data cell from the catalog is reducer-backed and the cell-by-cell migration is complete. Phase 4 (slot store + \`recordDispatch\` audit) is the next milestone.

Two changes that ride together:

### 1. \`faviconUrl\` as a derived projection of \`url\`

Per the catalog, \`faviconUrl\` is *not* an independent input — it's \`\${origin}/favicon.ico\`, derived from whatever \`url\` is set to. So no \`FaviconChanged\` command. Instead:

- New pure helper \`deriveFaviconUrl(url: string): string\` — the URL constructor parses; on success returns \`\${origin}/favicon.ico\`, on failure / empty URL / origin === \"null\" (about:blank, file://) returns \`\"\"\`.
- The three reducer transitions that write \`url\` (\`Navigate\`, \`UrlConfirmed\`, \`UrlCleared\`) now also write \`faviconUrl\` atomically. The two cells stay in lockstep by construction — no separate event ordering to get wrong.
- New \`_favicon\` Solid signal + \`faviconUrlAtom\` accessor on \`BrowserViewModel\`. Projected from \`state.faviconUrl\` in \`_dispatch\` only when the value changes (same pattern as every other cell).

The catalog's row 1.faviconUrlAtom rule (\"empty → header globe\") is preserved at the view layer; the reducer enforces \"empty when URL is empty/unparseable\" so the view never has to know about parse errors.

### 2. Remove the temporary \`urlAtom-read\` diag instrumentation

Per the roadmap §3d, the \`urlAtom\` accessor was wrapped to log every consumer read for the duration of Phase 3d so we could verify the migration didn't change call patterns. The roadmap explicitly called this instrumentation **temporary — remove after Phase 3d ships and the log baseline is recorded.**

Baseline is recorded (the migration shipped clean in #761). The wrapper goes away; \`urlAtom\` is back to the bare signal getter (zero overhead, unchanged reactive shape — the wrapper preserved Solid tracking but the getter form is simpler).

## Test plan

- [x] +5 \`deriveFaviconUrl\` tests: empty input, normal https, port-bearing http, unparseable URL, about:blank fallback.
- [x] +4 reducer transition tests: Navigate sets faviconUrl from origin, UrlConfirmed updates faviconUrl on post-redirect, UrlCleared clears faviconUrl alongside url, Navigate to unparseable URL leaves faviconUrl empty.
- [x] Full frontend suite: **463/463 passing** (was 454; +9 new).
- [x] \`task build:frontend\` succeeds.
- [x] No TS regressions.
- [ ] Smoke: open browser pane, navigate to https://example.com — faviconUrlAtom resolves to \`https://example.com/favicon.ico\`. Navigate to about:blank — faviconUrlAtom is empty. (Header globe view-component path is wired in a follow-up; this PR ships the cell, not the view binding. The cell is exposed for future consumers.)

## Roadmap status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending)
- ✅ Phase 3a + 3b — closed/loading/error (PR #756)
- ✅ Phase 3c — canGoBack/canGoForward (PR #757)
- ✅ Phase 3d — \`url\` danger cell (PR #761)
- ✅ Phase 3e — title (PR #758) + **faviconUrl** ← this PR
- ❌ Phase 4 — slot lifecycle + recordDispatch audit
- ❌ Phase 5 — diag panel surface
- ❌ Phase 6 — host-side title-change + favicon emit (the original feature; reducer cells are ready)

**Cell-by-cell migration: COMPLETE.** Every per-pane data cell from the catalog is now reducer-backed. The slot store + audit ring (Phase 4) is the unblocker for the \"PaneClicked through reducer\" framing from the focus-fix discussion (#760).

## Cross-references

- Roadmap: \`docs/specs/browser-pane-reducer-roadmap.md\`
- Catalog: \`docs/specs/browser-pane-state-catalog.md\` row 1.faviconUrlAtom
- Predecessors: #756, #757, #758, #761
- What not to do: PR #737 (closed)
- Discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)