### PR TITLE
slice #9 phase 4: slot store + recordDispatch audit + PaneClicked through reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.736"
+version = "0.33.737"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.736"
+version = "0.33.737"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.736"
+version = "0.33.737"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.736"
+version = "0.33.737"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.736"
+version = "0.33.737"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.736"
+version = "0.33.737"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.736"
+version = "0.33.737"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.736"
+version = "0.33.737"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/browser-pane-state-store.test.ts
+++ b/frontend/app/store/browser-pane-state-store.test.ts
@@ -71,11 +71,17 @@ describe("browser-pane-state-store (slice #9 Phase 4)", () => {
         registerPane("blk-1", proj);
         dispatch("blk-1", { type: "Navigate", url: "https://x" });
         dispatch("blk-1", { type: "Navigate", url: "https://x" });
-        // Second dispatch had identical url + already-loading, but
-        // Navigate always sets loading=true (idempotent on signal write,
-        // not on reducer state). So loading should fire twice — but
-        // url is identical and faviconUrl is identical, so those
-        // shouldn't fire again.
+        // Both dispatches had reducer state.loading=true on entry from
+        // the first call onward, so the second Navigate's transition
+        // is loading=true → loading=true (no change). The slot store's
+        // projection-on-change discipline (`slot.state.loading !==
+        // prev.loading`) means loading fires exactly ONCE total — on
+        // the false → true edge from the first dispatch. Same for url
+        // and faviconUrl: first dispatch sets them, second sees
+        // identical values and skips the projection. This is the
+        // exact discipline that prevents the address-bar typing
+        // clobber PR #737 introduced.
+        expect(proj.calls.loading).toEqual([true]);
         expect(proj.calls.url).toEqual(["https://x"]);
         expect(proj.calls.faviconUrl).toEqual(["https://x/favicon.ico"]);
     });

--- a/frontend/app/store/browser-pane-state-store.test.ts
+++ b/frontend/app/store/browser-pane-state-store.test.ts
@@ -1,0 +1,156 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetAllSlots,
+    type BrowserPaneProjections,
+    dispatch,
+    registerPane,
+    setEventSink,
+    snapshot,
+    unregisterPane,
+} from "./browser-pane-state-store";
+import type { BrowserPaneEvent } from "./browser-pane-state/types";
+
+function mkProj(): BrowserPaneProjections & {
+    calls: Record<keyof BrowserPaneProjections, unknown[]>;
+} {
+    const calls = {
+        closed: [] as unknown[],
+        loading: [] as unknown[],
+        error: [] as unknown[],
+        canGoBack: [] as unknown[],
+        canGoForward: [] as unknown[],
+        title: [] as unknown[],
+        url: [] as unknown[],
+        faviconUrl: [] as unknown[],
+    };
+    return {
+        closed: (v) => calls.closed.push(v),
+        loading: (v) => calls.loading.push(v),
+        error: (v) => calls.error.push(v),
+        canGoBack: (v) => calls.canGoBack.push(v),
+        canGoForward: (v) => calls.canGoForward.push(v),
+        title: (v) => calls.title.push(v),
+        url: (v) => calls.url.push(v),
+        faviconUrl: (v) => calls.faviconUrl.push(v),
+        calls,
+    };
+}
+
+describe("browser-pane-state-store (slice #9 Phase 4)", () => {
+    afterEach(() => {
+        __resetAllSlots();
+        // Reset event sink so tests don't leak state into each other.
+        setEventSink(() => {});
+    });
+
+    it("dispatch on unregistered blockId throws (no silent drops)", () => {
+        expect(() =>
+            dispatch("nope", { type: "Navigate", url: "https://x" }),
+        ).toThrowError(/unregistered pane/);
+    });
+
+    it("registers a pane and projects state changes", () => {
+        const proj = mkProj();
+        registerPane("blk-1", proj);
+        dispatch("blk-1", { type: "Navigate", url: "https://example.com" });
+        expect(proj.calls.url).toEqual(["https://example.com"]);
+        expect(proj.calls.loading).toEqual([true]);
+        expect(proj.calls.faviconUrl).toEqual([
+            "https://example.com/favicon.ico",
+        ]);
+        // Cells that didn't change shouldn't be projected.
+        expect(proj.calls.closed).toEqual([]);
+        expect(proj.calls.title).toEqual([]);
+    });
+
+    it("does NOT project cells that didn't change between dispatches", () => {
+        const proj = mkProj();
+        registerPane("blk-1", proj);
+        dispatch("blk-1", { type: "Navigate", url: "https://x" });
+        dispatch("blk-1", { type: "Navigate", url: "https://x" });
+        // Second dispatch had identical url + already-loading, but
+        // Navigate always sets loading=true (idempotent on signal write,
+        // not on reducer state). So loading should fire twice — but
+        // url is identical and faviconUrl is identical, so those
+        // shouldn't fire again.
+        expect(proj.calls.url).toEqual(["https://x"]);
+        expect(proj.calls.faviconUrl).toEqual(["https://x/favicon.ico"]);
+    });
+
+    it("emits events through the event sink", () => {
+        const proj = mkProj();
+        const sink = vi.fn<(blockId: string, event: BrowserPaneEvent) => void>();
+        setEventSink(sink);
+        registerPane("blk-1", proj);
+        dispatch("blk-1", { type: "Navigate", url: "https://x" });
+        expect(sink).toHaveBeenCalledWith("blk-1", {
+            type: "navigate",
+            url: "https://x",
+        });
+    });
+
+    it("PaneClicked routes through the event sink without state change", () => {
+        const proj = mkProj();
+        const sink = vi.fn<(blockId: string, event: BrowserPaneEvent) => void>();
+        setEventSink(sink);
+        registerPane("blk-1", proj);
+        const before = snapshot("blk-1");
+        dispatch("blk-1", { type: "PaneClicked" });
+        const after = snapshot("blk-1");
+        expect(after).toEqual(before); // no state change
+        expect(sink).toHaveBeenCalledWith("blk-1", { type: "pane-clicked" });
+    });
+
+    it("Disposed gates subsequent dispatches", () => {
+        const proj = mkProj();
+        const sink = vi.fn<(blockId: string, event: BrowserPaneEvent) => void>();
+        setEventSink(sink);
+        registerPane("blk-1", proj);
+        dispatch("blk-1", { type: "Navigate", url: "https://x" });
+        dispatch("blk-1", { type: "Disposed" });
+        sink.mockClear();
+        const lateProjCallCount = proj.calls.url.length;
+        dispatch("blk-1", { type: "Navigate", url: "https://late" });
+        // Reducer drops the late command — no url projection.
+        expect(proj.calls.url.length).toBe(lateProjCallCount);
+        // But the post-close-command-dropped event is emitted.
+        expect(sink).toHaveBeenCalledWith("blk-1", {
+            type: "post-close-command-dropped",
+            commandType: "Navigate",
+        });
+    });
+
+    it("snapshot returns null for unknown blockId", () => {
+        expect(snapshot("nope")).toBeNull();
+    });
+
+    it("unregisterPane removes the slot", () => {
+        const proj = mkProj();
+        registerPane("blk-1", proj);
+        unregisterPane("blk-1");
+        expect(snapshot("blk-1")).toBeNull();
+    });
+
+    it("re-registering resets state to initial", () => {
+        const proj = mkProj();
+        registerPane("blk-1", proj);
+        dispatch("blk-1", { type: "Navigate", url: "https://x" });
+        expect(snapshot("blk-1")?.url).toBe("https://x");
+        registerPane("blk-1", proj);
+        expect(snapshot("blk-1")?.url).toBe("");
+    });
+
+    it("multi-pane: dispatches don't cross blockIds", () => {
+        const a = mkProj();
+        const b = mkProj();
+        registerPane("blk-a", a);
+        registerPane("blk-b", b);
+        dispatch("blk-a", { type: "Navigate", url: "https://a" });
+        dispatch("blk-b", { type: "Navigate", url: "https://b" });
+        expect(a.calls.url).toEqual(["https://a"]);
+        expect(b.calls.url).toEqual(["https://b"]);
+    });
+});

--- a/frontend/app/store/browser-pane-state-store.ts
+++ b/frontend/app/store/browser-pane-state-store.ts
@@ -1,0 +1,161 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Browser pane state store — slice #9 Phase 4 of the frontend reducer
+ * roadmap. The cell-by-cell migration (Phases 3a-3e) put every
+ * per-pane data cell behind a pure reducer; this slot store finishes
+ * the slice by externalizing state ownership from
+ * `BrowserViewModel` and routing every dispatch through the
+ * `recordDispatch` audit ring.
+ *
+ * Pattern matches slice #4 (`agent-pane-state-store.ts`) — same slot
+ * lifecycle (`registerPane` / `dispatch` / `unregisterPane`), same
+ * "throw on unregistered dispatch" rule (silent drops defeat the
+ * reducer), same projection-on-change discipline.
+ *
+ * What this enables:
+ *   - **Audit ring** — every browser-pane state transition shows up
+ *     in `dispatchRecordsAtom`, queryable by the diagnostics panel
+ *     (Phase 5) and instantly visible during multi-pane focus or
+ *     pool-drift investigations.
+ *   - **Click event through reducer** — the focus-routing fix in
+ *     PR #760 lives in the IPC handler today; once `PaneClicked`
+ *     becomes a reducer command, the side-effect (blur stale main
+ *     input + refocus block) flows through dispatch and is recorded
+ *     just like every other transition.
+ */
+
+import { update } from "./browser-pane-state/reducer";
+import {
+    BrowserPaneCommand,
+    BrowserPaneEvent,
+    BrowserPaneState,
+    initialState,
+} from "./browser-pane-state/types";
+import { type CommandSource, recordDispatch } from "./command-source";
+
+/**
+ * Setters the slot writes into when reducer state changes. The view
+ * (`BrowserViewModel`) owns the underlying SolidJS signals and passes
+ * just the setters in via `registerPane`. Readers keep using the
+ * model's existing accessors (`urlAtom`, `loadingAtom`, etc.) — only
+ * writes are routed through the slot.
+ *
+ * Mirrors the `_dispatch` projector that lived inline in the model
+ * before Phase 4. Each setter is called only when the reducer state
+ * field actually changes (referential equality), preserving the
+ * Phase 3 discipline that avoided spurious reactive churn on the
+ * address-bar typing path PR #737 regressed.
+ */
+export interface BrowserPaneProjections {
+    closed: (next: boolean) => void;
+    loading: (next: boolean) => void;
+    error: (next: string | null) => void;
+    canGoBack: (next: boolean) => void;
+    canGoForward: (next: boolean) => void;
+    title: (next: string) => void;
+    url: (next: string) => void;
+    faviconUrl: (next: string) => void;
+}
+
+interface Slot {
+    state: BrowserPaneState;
+    proj: BrowserPaneProjections;
+}
+
+const slots = new Map<string, Slot>();
+
+type EventSink = (blockId: string, event: BrowserPaneEvent) => void;
+let eventSink: EventSink = (_blockId, _event) => {
+    // Default sink is a no-op. The view layer installs a real sink
+    // via `setEventSink` to wire `pane-click-blur` (and other
+    // future view-effecting events) to the DOM blur + refocus
+    // handlers. Tests run with the no-op so the slot store is
+    // testable without DOM.
+};
+
+export function setEventSink(sink: EventSink): void {
+    eventSink = sink;
+}
+
+/**
+ * Register a pane. Call SYNCHRONOUSLY from the model's constructor,
+ * before any IPC handler can dispatch. Re-registering a blockId
+ * resets the state cell to initialState — useful for the
+ * `BrowserViewModel`'s post-dispose cleanup if a new model gets the
+ * same blockId on hot-reload.
+ */
+export function registerPane(
+    blockId: string,
+    proj: BrowserPaneProjections,
+): void {
+    slots.set(blockId, { state: initialState(), proj });
+}
+
+export function unregisterPane(blockId: string): void {
+    slots.delete(blockId);
+}
+
+/**
+ * Apply a command. Throws on unregistered blockId — silent drops
+ * would defeat the reducer's audit value (same rule as
+ * `agent-pane-state-store`).
+ *
+ * The `closed` invariant — every command after `Disposed` becomes a
+ * no-op that emits `post-close-command-dropped` — is enforced inside
+ * the pure reducer. The slot store doesn't need to special-case it.
+ */
+export function dispatch(
+    blockId: string,
+    command: BrowserPaneCommand,
+    source: CommandSource = "system",
+): BrowserPaneEvent[] {
+    const slot = slots.get(blockId);
+    if (!slot) {
+        throw new Error(
+            `[browser-pane-state] dispatch for unregistered pane ${blockId.slice(0, 7)} (cmd=${command.type}). registerPane must be called synchronously in the BrowserViewModel constructor.`,
+        );
+    }
+    const prev = slot.state;
+    const result = update(prev, command);
+    slot.state = result.state;
+
+    // Project changes — only call setters when the cell actually
+    // changed. Avoids redundant signal writes that could leak into
+    // the address-bar typing path (the PR #737 trap that motivated
+    // the cell-by-cell discipline).
+    if (slot.state.closed !== prev.closed) slot.proj.closed(slot.state.closed);
+    if (slot.state.loading !== prev.loading) slot.proj.loading(slot.state.loading);
+    if (slot.state.error !== prev.error) slot.proj.error(slot.state.error);
+    if (slot.state.canGoBack !== prev.canGoBack) slot.proj.canGoBack(slot.state.canGoBack);
+    if (slot.state.canGoForward !== prev.canGoForward) slot.proj.canGoForward(slot.state.canGoForward);
+    if (slot.state.title !== prev.title) slot.proj.title(slot.state.title);
+    if (slot.state.url !== prev.url) slot.proj.url(slot.state.url);
+    if (slot.state.faviconUrl !== prev.faviconUrl) slot.proj.faviconUrl(slot.state.faviconUrl);
+
+    for (const ev of result.events) eventSink(blockId, ev);
+
+    recordDispatch({
+        slice: "browser-pane-state",
+        key: blockId,
+        command,
+        events: result.events,
+        source,
+        at: Date.now(),
+    });
+
+    return result.events;
+}
+
+/** Snapshot — diagnostics + tests only. */
+export function snapshot(blockId: string): BrowserPaneState | null {
+    return slots.get(blockId)?.state ?? null;
+}
+
+/** Test/dev helper — clears every slot. */
+export function __resetAllSlots(): void {
+    slots.clear();
+}
+
+export type { BrowserPaneCommand, BrowserPaneEvent, BrowserPaneState };

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -450,6 +450,23 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3d + 3e co
         });
     });
 
+    describe("PaneClicked", () => {
+        it("emits pane-clicked event without changing state", () => {
+            const s0 = update(initialState(), {
+                type: "Navigate",
+                url: "https://x",
+            }).state;
+            const r = update(s0, { type: "PaneClicked" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([{ type: "pane-clicked" }]);
+        });
+
+        it("does NOT touch focus-related state (DOM/OS focus is owned outside the reducer per catalog)", () => {
+            const r = update(initialState(), { type: "PaneClicked" });
+            expect(r.state).toEqual(initialState());
+        });
+    });
+
     describe("Disposed", () => {
         it("flips closed=true and emits disposed event once", () => {
             const r = update(initialState(), { type: "Disposed" });
@@ -559,6 +576,18 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3d + 3e co
                 },
             ]);
         });
+
+        it("PaneClicked after dispose is dropped", () => {
+            const s0 = closed();
+            const r = update(s0, { type: "PaneClicked" });
+            expect(r.state).toBe(s0);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "PaneClicked",
+                },
+            ]);
+        });
     });
 
     describe("invariants across sequences", () => {
@@ -600,6 +629,7 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3d + 3e co
                 { type: "TitleChanged", title: "" },
                 { type: "UrlConfirmed", url: "https://final" },
                 { type: "UrlCleared" },
+                { type: "PaneClicked" },
                 { type: "Disposed" },
             ];
             for (const mk of starts) {

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -160,6 +160,15 @@ export function update(
             };
         }
 
+        case "PaneClicked": {
+            // Pure event — no state change. The reducer doesn't track
+            // DOM/Win32 focus (catalog rule §3); the view's event
+            // sink performs the blur+refocus side-effect when the
+            // `pane-clicked` event is delivered. Recording through
+            // dispatch lands the click in the audit ring.
+            return { state, events: [{ type: "pane-clicked" }] };
+        }
+
         case "TitleChanged": {
             const next = command.title.trim() === "" ? TITLE_FALLBACK : command.title;
             if (next === state.title) return { state, events: [] };

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -191,6 +191,20 @@ export type BrowserPaneCommand =
      */
     | { type: "UrlCleared" }
     /**
+     * The pane HWND captured a click at the Win32 level (the
+     * `browser-pane-clicked` IPC fired). Doesn't change any reducer
+     * state — DOM focus and Win32 OS focus are owned outside the
+     * reducer per the catalog rule. Emits a `pane-clicked` event
+     * whose handler performs the side-effects we ship today: blur
+     * any stale main-window input that holds DOM focus, then call
+     * `refocusNode(blockId)`. Routing through the reducer makes the
+     * click visible in the audit ring (Phase 4) so multi-pane focus
+     * investigations can see the exact sequence of clicks vs other
+     * dispatches. After dispose, a no-op (the generic post-close
+     * gate handles this).
+     */
+    | { type: "PaneClicked" }
+    /**
      * The pane is being torn down. After this command runs, every
      * subsequent command on this state is a no-op. Idempotent —
      * dispatching `Disposed` twice is a no-op the second time.
@@ -210,6 +224,7 @@ export type BrowserPaneEvent =
     | { type: "title-changed"; title: string }
     | { type: "url-confirmed"; url: string }
     | { type: "url-cleared" }
+    | { type: "pane-clicked" }
     | { type: "disposed" }
     /** Invariant fire — emitted instead of mutating state when a
      *  command targets a closed pane. Surfaced for diagnostics so

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -9,16 +9,68 @@ import { BlockNodeModel } from "@/app/block/blocktypes";
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
 import {
     type BrowserPaneCommand,
-    type BrowserPaneState,
-    initialState as browserPaneInitialState,
+    type BrowserPaneEvent,
     TITLE_FALLBACK,
-    update as browserPaneUpdate,
 } from "@/app/store/browser-pane-state";
+import {
+    type BrowserPaneProjections,
+    dispatch as bpDispatch,
+    registerPane as bpRegisterPane,
+    setEventSink as bpSetEventSink,
+    snapshot as bpSnapshot,
+    unregisterPane as bpUnregisterPane,
+} from "@/app/store/browser-pane-state-store";
 import { refocusNode } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
+
+/**
+ * One-time install of the slice #9 event sink. Hands `pane-clicked`
+ * (and any future view-effecting events) to the DOM side-effect:
+ * blur whatever main-window input held DOM focus, then call
+ * `refocusNode(blockId)` so the layout marks the block as focused.
+ *
+ * This was inline in the `browser-pane-clicked` IPC handler before
+ * Phase 4. Routing through the reducer's event sink puts the click
+ * in the audit ring (visible in Phase 5's diag panel) without
+ * changing the side-effect itself — same blur+refocus, just plumbed
+ * differently.
+ *
+ * Idempotent — checked via a module-level flag because `setEventSink`
+ * is a global setter that the last caller wins. We don't want every
+ * BrowserViewModel construction to clobber a sink the previous one
+ * just installed.
+ */
+let eventSinkInstalled = false;
+function installEventSinkOnce(): void {
+    if (eventSinkInstalled) return;
+    eventSinkInstalled = true;
+    bpSetEventSink((blockId, event: BrowserPaneEvent) => {
+        if (event.type === "pane-clicked") {
+            // The pane HWND captured this click at Win32 level so React
+            // never saw it — `document.activeElement` is whatever it was
+            // before (typically the address bar). Without blurring it,
+            // the subsequent `giveFocus()` flow sees `isMainInput=true`
+            // and tells the host to keep OS focus on the main window —
+            // bouncing focus back from the pane HWND we just gave it.
+            // See PR #760 for the full diagnosis.
+            const active = document.activeElement as HTMLElement | null;
+            if (
+                active != null &&
+                (active.tagName === "INPUT" || active.tagName === "TEXTAREA") &&
+                !active.classList.contains("dummy-focus")
+            ) {
+                console.log(
+                    `[browser-pane:diag][${blockId.slice(0, 7)}] pane-click blur active=${active.tagName.toLowerCase()}.${active.className}`,
+                );
+                active.blur();
+            }
+            refocusNode(blockId);
+        }
+    });
+}
 
 /**
  * Fallback URL for browser panes created without an explicit `meta.url`.
@@ -92,85 +144,47 @@ export class BrowserViewModel implements ViewModel {
 
     blockAtom: Accessor<Block | undefined>;
 
-    /**
-     * Slice #9 reducer state — owns every per-pane data cell from
-     * the catalog: `closed`, `loading`, `error`, `canGoBack`,
-     * `canGoForward`, `title`, `url`, `faviconUrl` (derived from
-     * `url`). The signals above are projections of this state so
-     * the SolidJS view layer keeps reactive parity. Cell-by-cell
-     * migration is **complete** with this PR; Phase 4 (slot store +
-     * `recordDispatch` audit) is the next milestone.
-     */
-    private _paneState: BrowserPaneState = browserPaneInitialState();
     /** Late callers (IPC handlers landing post-dispose, defensive guards
      *  in goBack/Forward/reload) read this to no-op instead of firing
      *  IPC against a Browser CEF is mid-destruction. See
-     *  docs/specs/SPEC_BROWSER_PANE_LIFECYCLE.md §9 step 4. */
-    get closed(): boolean { return this._paneState.closed; }
+     *  docs/specs/SPEC_BROWSER_PANE_LIFECYCLE.md §9 step 4.
+     *
+     *  Reads the slot store snapshot. Treats unregistered (post-dispose
+     *  or never-registered) as `true` so a stale reference never fires
+     *  IPC. */
+    get closed(): boolean {
+        return bpSnapshot(this.blockId)?.closed ?? true;
+    }
 
     /**
-     * Single sync point between the reducer's pure transitions and the
-     * SolidJS signals the view subscribes to. Projects every reducer
-     * cell currently in scope (`loading`, `error`, `canGoBack`,
-     * `canGoForward`, `title`, `url`) onto its signal, but only when
-     * the value actually changed — avoiding spurious reactive churn
-     * that could leak into the address-bar typing path that PR #737
-     * regressed. Diag logs preserve the prior `state-write key=...`
-     * shape so Phase-1 grep recipes still work.
+     * Wrapper around the slice's slot-store dispatch. Records the `src`
+     * tag in a per-call diag log so Phase-1 grep recipes
+     * (`muxlog host '\[browser-pane:diag\]'`) keep showing the
+     * intent-bearing source ("navigate", "nav-state", "goBack", etc.).
+     * The slot store handles state diff + projections + recordDispatch
+     * audit — the model just ferries the command in.
+     *
+     * Guards against double-dispose / post-unregister calls: the slot
+     * store throws on unregistered dispatch (no-silent-drops rule),
+     * and `dispose()` drops the slot as its final step. Calling
+     * `_dispatch` after unregister would throw — same semantics as
+     * the reducer's `post-close-command-dropped` event, just at the
+     * model layer instead of the reducer. The `closed` snapshot
+     * returns `true` for unregistered slots (the `?? true` fallback),
+     * so the same check covers both "slot exists with closed=true"
+     * and "slot unregistered" cases uniformly.
      */
     private _dispatch(cmd: BrowserPaneCommand, src: string): void {
-        const prev = this._paneState;
-        const result = browserPaneUpdate(prev, cmd);
-        this._paneState = result.state;
-        if (result.state.loading !== prev.loading) {
-            this.diag(
-                `state-write key=loading value=${result.state.loading} src=${src}`,
-            );
-            this.setLoading(result.state.loading);
+        // Drop if the slot was already unregistered (post-dispose).
+        // `bpDispatch` would throw — same semantics as the reducer's
+        // `post-close-command-dropped` event, just enforced at the
+        // model layer because the slot is gone entirely.
+        if (bpSnapshot(this.blockId) == null) {
+            this.diag(`post-close-event-dropped name=${cmd.type} src=${src}`);
+            return;
         }
-        if (result.state.error !== prev.error) {
-            this.diag(
-                `state-write key=error value=${JSON.stringify(result.state.error)} src=${src}`,
-            );
-            this.setError(result.state.error);
-        }
-        if (result.state.canGoBack !== prev.canGoBack) {
-            this.diag(
-                `state-write key=canGoBack value=${result.state.canGoBack} src=${src}`,
-            );
-            this.setCanGoBack(result.state.canGoBack);
-        }
-        if (result.state.canGoForward !== prev.canGoForward) {
-            this.diag(
-                `state-write key=canGoForward value=${result.state.canGoForward} src=${src}`,
-            );
-            this.setCanGoForward(result.state.canGoForward);
-        }
-        if (result.state.title !== prev.title) {
-            this.diag(
-                `state-write key=title value=${JSON.stringify(result.state.title)} src=${src}`,
-            );
-            this.setTitle(result.state.title);
-        }
-        if (result.state.url !== prev.url) {
-            this.diag(
-                `state-write key=url value=${JSON.stringify(result.state.url)} src=${src}`,
-            );
-            this.setUrl(result.state.url);
-        }
-        if (result.state.faviconUrl !== prev.faviconUrl) {
-            this.diag(
-                `state-write key=faviconUrl value=${JSON.stringify(result.state.faviconUrl)} src=${src}`,
-            );
-            this.setFavicon(result.state.faviconUrl);
-        }
-        for (const e of result.events) {
-            if (e.type === "post-close-command-dropped") {
-                this.diag(
-                    `post-close-command-dropped commandType=${e.commandType} src=${src}`,
-                );
-            }
-        }
+        this.diag(`dispatch type=${cmd.type} src=${src}`);
+        bpDispatch(this.blockId, cmd, "system");
     }
 
     /** Tag every diag log with the block prefix so multi-pane sessions
@@ -187,6 +201,51 @@ export class BrowserViewModel implements ViewModel {
 
         const ctorMetaUrl = (this.blockAtom()?.meta?.["url"] as string | undefined) ?? "";
         console.log(`[browser-pane:diag][${blockId.slice(0, 7)}] ctor meta.url=${JSON.stringify(ctorMetaUrl)}`);
+
+        // Register the pane in the slice's slot store SYNCHRONOUSLY before
+        // any IPC subscription can dispatch. The store throws on
+        // unregistered dispatch (silent drops would defeat the audit
+        // ring); registering here covers every code path that calls
+        // `_dispatch` after construction. Re-registering on hot reload
+        // is fine — `registerPane` resets the state to initial.
+        const projections: BrowserPaneProjections = {
+            closed: (next) => {
+                this.diag(`state-write key=closed value=${next}`);
+                // No view-side signal — `model.closed` reads the slot
+                // store snapshot directly. The diag log is the only
+                // observable of this projection.
+            },
+            loading: (next) => {
+                this.diag(`state-write key=loading value=${next}`);
+                this.setLoading(next);
+            },
+            error: (next) => {
+                this.diag(`state-write key=error value=${JSON.stringify(next)}`);
+                this.setError(next);
+            },
+            canGoBack: (next) => {
+                this.diag(`state-write key=canGoBack value=${next}`);
+                this.setCanGoBack(next);
+            },
+            canGoForward: (next) => {
+                this.diag(`state-write key=canGoForward value=${next}`);
+                this.setCanGoForward(next);
+            },
+            title: (next) => {
+                this.diag(`state-write key=title value=${JSON.stringify(next)}`);
+                this.setTitle(next);
+            },
+            url: (next) => {
+                this.diag(`state-write key=url value=${JSON.stringify(next)}`);
+                this.setUrl(next);
+            },
+            faviconUrl: (next) => {
+                this.diag(`state-write key=faviconUrl value=${JSON.stringify(next)}`);
+                this.setFavicon(next);
+            },
+        };
+        bpRegisterPane(blockId, projections);
+        installEventSinkOnce();
 
         this.viewName = createMemo(() => this.titleAtom());
 
@@ -261,28 +320,13 @@ export class BrowserViewModel implements ViewModel {
             }
             if (payload.block_id !== this.blockId) return;
             this.diag(`clicked recv`);
-            // The pane HWND captured this click at Win32 level so React never
-            // saw it — `document.activeElement` is whatever it was before
-            // (typically the address bar, since the user usually clicks
-            // there first). If we leave that stale DOM focus, the
-            // subsequent `giveFocus()` flow sees `isMainInput=true` and
-            // tells the host to keep OS focus on the main window —
-            // bouncing focus back from the pane HWND we just gave it.
-            // The user's click on the pane is unambiguous "I want to
-            // interact with the page, not chrome" intent; explicitly blur
-            // whatever main-window input has DOM focus so giveFocus's
-            // activeElement check resolves to "not a main input" and
-            // OS focus stays on the pane HWND.
-            const active = document.activeElement as HTMLElement | null;
-            if (
-                active != null &&
-                (active.tagName === "INPUT" || active.tagName === "TEXTAREA") &&
-                !active.classList.contains("dummy-focus")
-            ) {
-                this.diag(`pane-click blur active=${active.tagName.toLowerCase()}.${active.className}`);
-                active.blur();
-            }
-            refocusNode(this.blockId);
+            // Phase 4: route the click through the slice reducer as a
+            // `PaneClicked` command. The slot store fires the event
+            // sink, which performs the blur-stale-main-input +
+            // refocusNode side-effect. Both the dispatch and the
+            // event land in the audit ring, so multi-pane focus
+            // investigations can see the exact click sequence.
+            this._dispatch({ type: "PaneClicked" }, "browser-pane-clicked");
         }).then((unsub) => {
             this.diag(`sub-registered name=browser-pane-clicked`);
             if (this.closed) unsub();
@@ -401,5 +445,12 @@ export class BrowserViewModel implements ViewModel {
             this._clickUnsub();
             this._clickUnsub = null;
         }
+        // Drop the slot AFTER the Disposed dispatch — the projection
+        // for `closed:true` runs first, so any consumer reading
+        // `model.closed` mid-dispose still sees true. The unregister
+        // is the final step so future post-dispose `_dispatch` calls
+        // will throw a clear "unregistered pane" error rather than
+        // silently no-oping (the slot store's no-silent-drops rule).
+        bpUnregisterPane(this.blockId);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.736",
+  "version": "0.33.737",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.736",
+      "version": "0.33.737",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.736",
+  "version": "0.33.737",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**Slice #9 is now complete.** Phase 4 externalizes browser-pane state ownership from \`BrowserViewModel\` into \`frontend/app/store/browser-pane-state-store.ts\` and routes every dispatch through the global \`recordDispatch\` audit ring. Pattern matches slice #4 (\`agent-pane-state-store.ts\`) verbatim — same slot lifecycle, same projection-on-change discipline, same no-silent-drops rule.

Plus: the focus-routing fix from PR #760 graduates from inline-IPC-handler to a \`PaneClicked\` reducer command (the \"treat as Phase 4 task\" framing). The blur-stale-main-input + refocusNode side-effect now flows through the reducer's event sink, making the click visible in the audit ring.

### What landed

**\`frontend/app/store/browser-pane-state-store.ts\`** — new module.
- \`registerPane(blockId, projections)\` — synchronous registration; throws if the model dispatches before this runs.
- \`dispatch(blockId, cmd, source)\` — runs the pure reducer, projects state changes onto signal setters, fires events through the global event sink, records the dispatch in the \`recordDispatch\` ring.
- \`unregisterPane(blockId)\` — drops the slot. Called in \`dispose()\` after the \`Disposed\` command's projections run.
- \`setEventSink(sink)\` — global; the model installs once via \`installEventSinkOnce()\` to handle \`pane-clicked\`.
- \`snapshot(blockId)\` — diagnostics + \`closed\` getter.

**\`PaneClicked\` reducer command** — new. Doesn't change reducer state (DOM/Win32 focus is owned outside the reducer per catalog rule §3) but emits a \`pane-clicked\` event. The model's IPC handler for \`browser-pane-clicked\` now dispatches \`PaneClicked\` instead of running the inline blur+refocus.

**Event sink** in \`browser-model.ts\` handles \`pane-clicked\`:
- Blur \`document.activeElement\` if it's a main-window \`<input>\` / \`<textarea>\` (the dummy-focus exclusion preserved verbatim from PR #760).
- Call \`refocusNode(blockId)\` so layout marks the block as focused.

**\`BrowserViewModel\` refactor:**
- \`_paneState\` field + internal \`_dispatch\` projector method — gone. State lives in the slot store.
- \`closed\` getter reads \`bpSnapshot(blockId)?.closed ?? true\` (defaults true for unregistered, so a stale post-dispose reference reports closed).
- Per-cell projection callbacks emit the existing \`state-write key=X value=Y\` diag logs (Phase-1 grep recipes still match).
- New per-dispatch diag: \`dispatch type=Navigate src=navigate\` — preserves the \`src\` tag the prior internal dispatcher logged with each state-write.
- Double-dispose / post-unregister guard: \`_dispatch\` checks \`bpSnapshot == null\` and drops with the existing \`post-close-event-dropped\` log shape.

### What's NOT in this PR

- **Phase 5 (diag panel)** — the audit ring is now populated for browser-pane events, but the panel UI that surfaces \`dispatchRecordsAtom\` is a separate piece of work.
- **Phase 6 (host-side title-change + favicon emit)** — the reducer cells are ready (\`TitleChanged\` command exists, faviconUrl derives automatically); the host event subscription is the remaining gap. Independent of Phase 4.

## Test plan

- [x] **+10 new slot-store tests** (\`browser-pane-state-store.test.ts\`):
  - dispatch on unregistered blockId throws (no silent drops)
  - registers and projects state changes
  - doesn't project cells that didn't change between dispatches
  - emits events through the event sink
  - PaneClicked routes through sink without state change
  - Disposed gates subsequent dispatches (post-close-command-dropped sink emission)
  - snapshot returns null for unknown blockId
  - unregisterPane removes the slot
  - re-registering resets state to initial
  - multi-pane: dispatches don't cross blockIds
- [x] **+3 new reducer tests** (\`reducer.test.ts\`):
  - PaneClicked emits pane-clicked event without changing state
  - PaneClicked doesn't touch any state (catalog rule §3)
  - PaneClicked after dispose is dropped (post-close gating)
  - Cross-product invariant test extended (PaneClicked included).
- [x] **All existing browser-model lifecycle tests still pass** (the dispose-is-idempotent test caught a real issue: double-dispose throwing because slot was unregistered. Added \`bpSnapshot == null\` guard in \`_dispatch\` — same semantics as the reducer's post-close gate, enforced at the model layer because the slot is gone entirely.)
- [x] Full frontend suite: **483/483 passing** (was 463; +20 new).
- [x] \`task build:frontend\` succeeds.
- [ ] Smoke: \`task dev\`, open browser pane, click into google search, click address bar — verify focus routing still works (the regression scenario from PR #760).

## Roadmap status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending)
- ✅ Phase 3a + 3b — closed/loading/error (PR #756)
- ✅ Phase 3c — canGoBack/canGoForward (PR #757)
- ✅ Phase 3d — \`url\` danger cell (PR #761)
- ✅ Phase 3e — title (PR #758) + faviconUrl (PR #763)
- 🟡 **Phase 4 shipped** ← this PR
- ❌ Phase 5 — diag panel surface (audit ring is populated; UI to render it is the remaining work)
- ❌ Phase 6 — host-side title-change + favicon emit

**Slice #9 cell-by-cell + slot lifecycle = COMPLETE.** Every per-pane data cell is reducer-backed; every state transition lands in the audit ring; the focus-routing click flows through the reducer with full traceability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)