### PR TITLE
slice #9 phase 5: diag panel UI for the reducer audit ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.737"
+version = "0.33.738"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.737"
+version = "0.33.738"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.737"
+version = "0.33.738"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.737"
+version = "0.33.738"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.737"
+version = "0.33.738"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.737"
+version = "0.33.738"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.737"
+version = "0.33.738"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.737"
+version = "0.33.738"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -21,6 +21,7 @@ import { DragOverlay } from "./drag/DragOverlay";
 import { CenteredDiv } from "./element/quickelems";
 import { ZoomIndicator } from "./element/zoomindicator";
 import { PerfHud } from "@/perf/hud";
+import { DiagPanel } from "./devtools/diag-panel";
 import { checkSeparatorParity, setupDprTracking } from "./init/dpr";
 import { NotificationBubbles } from "./notification/notificationbubbles";
 
@@ -364,6 +365,7 @@ const AppInner = () => {
                 <ZoomIndicator />
                 <Show when={isDev()}>
                     <PerfHud />
+                    <DiagPanel />
                 </Show>
             </div>
         </Show>

--- a/frontend/app/devtools/diag-panel.tsx
+++ b/frontend/app/devtools/diag-panel.tsx
@@ -48,8 +48,11 @@ const DEFAULT_DISPLAY_LIMIT = 80;
 interface DisplayRow {
     /** Index into the live records array — used for stable keys. */
     idx: number;
-    /** Wall-clock relative offset (e.g. "1.2s ago"). */
-    age: string;
+    /** Original record's wall-clock timestamp. The `age` string is
+     *  computed inline in the render so it doesn't pollute the
+     *  `rows` memo with a time dependency — see the createMemo
+     *  comment for why that matters. */
+    at: number;
     slice: string;
     /** Per-pane key, truncated to 7 chars when present. */
     keyShort: string;
@@ -75,10 +78,10 @@ function ageMs(now: number, at: number): string {
     return `${(dt / 60_000).toFixed(1)}min ago`;
 }
 
-function toRow(now: number, idx: number, rec: DispatchRecord): DisplayRow {
+function toRow(idx: number, rec: DispatchRecord): DisplayRow {
     return {
         idx,
-        age: ageMs(now, rec.at),
+        at: rec.at,
         slice: rec.slice,
         keyShort: rec.key ? rec.key.slice(0, 7) : "—",
         cmdType: commandType(rec.command),
@@ -140,12 +143,19 @@ export function DiagPanel(): JSX.Element {
     // DEFAULT_DISPLAY_LIMIT rows so a runaway dispatch (which the
     // audit ring is precisely there to catch) doesn't wedge the
     // panel itself.
+    //
+    // **Important:** this memo deliberately does NOT depend on `now()`.
+    // If it did, the 1 Hz age-tick interval would force a rebuild of
+    // every DisplayRow and `<For>` would re-create every <tr> on
+    // each tick — exactly the kind of inefficiency the panel exists
+    // to surface. The `age` cell reads `now()` inline in the render
+    // (Solid's fine-grained reactivity isolates the update to that
+    // single text node).
     const rows = createMemo<DisplayRow[]>(() => {
         const all = dispatchRecordsAtom();
         const slice = sliceFilter();
         const key = keyFilter().trim().toLowerCase();
         const filtered: DisplayRow[] = [];
-        const t = now();
         // Walk newest-to-oldest so we can stop once we've collected
         // the display limit — saves work on large rings.
         for (let i = all.length - 1; i >= 0 && filtered.length < DEFAULT_DISPLAY_LIMIT; i--) {
@@ -155,7 +165,7 @@ export function DiagPanel(): JSX.Element {
                 const recKey = (r.key ?? "").toLowerCase();
                 if (!recKey.includes(key)) continue;
             }
-            filtered.push(toRow(t, i, r));
+            filtered.push(toRow(i, r));
         }
         return filtered;
     });
@@ -296,7 +306,11 @@ export function DiagPanel(): JSX.Element {
                                 <For each={rows()}>
                                     {(row) => (
                                         <tr>
-                                            <td style={cellStyle}>{row.age}</td>
+                                            {/* Age is computed inline so only the cell
+                                                re-renders on the 1 Hz tick — the row
+                                                identity stays stable across ticks (see
+                                                the rows memo's comment). */}
+                                            <td style={cellStyle}>{ageMs(now(), row.at)}</td>
                                             <td style={cellStyle}>
                                                 <span style={{ color: "#aaa" }}>{row.slice}</span>
                                             </td>

--- a/frontend/app/devtools/diag-panel.tsx
+++ b/frontend/app/devtools/diag-panel.tsx
@@ -1,0 +1,332 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reducer-stack diagnostics panel — slice #9 Phase 5.
+ *
+ * Floating dev-mode panel that surfaces `dispatchRecordsAtom` from
+ * `command-source.ts`: every reducer dispatch across every slice
+ * (browser-pane-state, agent-pane-state, layout, launcher-event, ...)
+ * lands in this view in real time.
+ *
+ * **Why this exists:** when a multi-pane focus or pool-drift bug
+ * fires, the question is always "what happened in the last 200 ms,
+ * in what order, across which panes?". Tail-grepping host logs works
+ * but loses structure (every line is plain text, every record is
+ * spread across 5+ lines of `state-write`+`dispatch` diag entries).
+ * The audit ring already has the data structured; this panel just
+ * renders it.
+ *
+ * Toggle with **Ctrl+Shift+D**. Hidden in release builds via the
+ * `isDev()` gate at the mount site; the toggle hook is no-opped in
+ * release.
+ *
+ * Self-contained styling — same approach as the perf HUD
+ * (`frontend/perf/hud.tsx`) so the panel still works during a
+ * stylesheet-disabled investigation.
+ */
+
+import {
+    createEffect,
+    createMemo,
+    createSignal,
+    For,
+    onCleanup,
+    onMount,
+    Show,
+    type JSX,
+} from "solid-js";
+import {
+    dispatchRecordsAtom,
+    describeSource,
+    type DispatchRecord,
+    __resetDispatchLog,
+} from "@/store/command-source";
+
+const DEFAULT_DISPLAY_LIMIT = 80;
+
+interface DisplayRow {
+    /** Index into the live records array — used for stable keys. */
+    idx: number;
+    /** Wall-clock relative offset (e.g. "1.2s ago"). */
+    age: string;
+    slice: string;
+    /** Per-pane key, truncated to 7 chars when present. */
+    keyShort: string;
+    /** Command discriminator (e.g. "Navigate", "PaneClicked"). */
+    cmdType: string;
+    source: string;
+    /** Number of events emitted by the dispatch. */
+    eventCount: number;
+}
+
+function commandType(cmd: unknown): string {
+    if (cmd != null && typeof cmd === "object" && "type" in cmd) {
+        const t = (cmd as { type?: unknown }).type;
+        if (typeof t === "string") return t;
+    }
+    return "?";
+}
+
+function ageMs(now: number, at: number): string {
+    const dt = now - at;
+    if (dt < 1000) return `${dt}ms ago`;
+    if (dt < 60_000) return `${(dt / 1000).toFixed(1)}s ago`;
+    return `${(dt / 60_000).toFixed(1)}min ago`;
+}
+
+function toRow(now: number, idx: number, rec: DispatchRecord): DisplayRow {
+    return {
+        idx,
+        age: ageMs(now, rec.at),
+        slice: rec.slice,
+        keyShort: rec.key ? rec.key.slice(0, 7) : "—",
+        cmdType: commandType(rec.command),
+        source: describeSource(rec.source),
+        eventCount: rec.events.length,
+    };
+}
+
+export function DiagPanel(): JSX.Element {
+    const [visible, setVisible] = createSignal(false);
+    const [now, setNow] = createSignal(Date.now());
+    const [sliceFilter, setSliceFilter] = createSignal<string>("");
+    const [keyFilter, setKeyFilter] = createSignal<string>("");
+
+    let ageInterval: ReturnType<typeof setInterval> | null = null;
+
+    const onKey = (e: KeyboardEvent) => {
+        // Ctrl+Shift+D (or Meta+Shift+D on macOS where Ctrl is rare).
+        if (e.shiftKey && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "d") {
+            e.preventDefault();
+            setVisible((v) => !v);
+        }
+    };
+
+    onMount(() => {
+        window.addEventListener("keydown", onKey);
+    });
+
+    // Tick the displayed `age` once per second while the panel is
+    // visible. The records signal already drives re-renders on new
+    // dispatches; this just refreshes the relative-time strings on
+    // existing rows. Only runs while visible — same bounded-cost
+    // discipline as the perf HUD's setInterval gating.
+    createEffect(() => {
+        if (visible()) {
+            setNow(Date.now());
+            ageInterval = setInterval(() => setNow(Date.now()), 1000);
+        } else if (ageInterval != null) {
+            clearInterval(ageInterval);
+            ageInterval = null;
+        }
+    });
+
+    onCleanup(() => {
+        window.removeEventListener("keydown", onKey);
+        if (ageInterval != null) clearInterval(ageInterval);
+    });
+
+    // Available slices for the filter dropdown — derived from the
+    // current records. Recomputed reactively so a new slice that
+    // shows up appears in the dropdown without a manual refresh.
+    const availableSlices = createMemo(() => {
+        const seen = new Set<string>();
+        for (const r of dispatchRecordsAtom()) seen.add(r.slice);
+        return Array.from(seen).sort();
+    });
+
+    // Filtered + sliced view, newest first. Limited to
+    // DEFAULT_DISPLAY_LIMIT rows so a runaway dispatch (which the
+    // audit ring is precisely there to catch) doesn't wedge the
+    // panel itself.
+    const rows = createMemo<DisplayRow[]>(() => {
+        const all = dispatchRecordsAtom();
+        const slice = sliceFilter();
+        const key = keyFilter().trim().toLowerCase();
+        const filtered: DisplayRow[] = [];
+        const t = now();
+        // Walk newest-to-oldest so we can stop once we've collected
+        // the display limit — saves work on large rings.
+        for (let i = all.length - 1; i >= 0 && filtered.length < DEFAULT_DISPLAY_LIMIT; i--) {
+            const r = all[i];
+            if (slice !== "" && r.slice !== slice) continue;
+            if (key !== "") {
+                const recKey = (r.key ?? "").toLowerCase();
+                if (!recKey.includes(key)) continue;
+            }
+            filtered.push(toRow(t, i, r));
+        }
+        return filtered;
+    });
+
+    const totalDispatches = createMemo(() => dispatchRecordsAtom().length);
+
+    return (
+        <Show when={visible()}>
+            <div
+                style={{
+                    position: "fixed",
+                    bottom: "8px",
+                    left: "8px",
+                    "z-index": "999998", // one less than perf HUD so they don't fight
+                    "background-color": "rgba(20, 20, 20, 0.94)",
+                    color: "#d0d0d0",
+                    "font-family": "Menlo, Consolas, monospace",
+                    "font-size": "11px",
+                    padding: "8px 10px",
+                    border: "1px solid #444",
+                    "border-radius": "6px",
+                    width: "560px",
+                    "max-height": "60vh",
+                    display: "flex",
+                    "flex-direction": "column",
+                    "box-shadow": "0 4px 12px rgba(0, 0, 0, 0.5)",
+                }}
+            >
+                <div
+                    style={{
+                        display: "flex",
+                        "align-items": "center",
+                        gap: "8px",
+                        "margin-bottom": "6px",
+                    }}
+                >
+                    <div style={{ "font-weight": "bold", color: "#7af" }}>
+                        🔬 Reducer Dispatch Ring
+                    </div>
+                    <span style={{ color: "#777" }}>
+                        ({totalDispatches()} total — Ctrl+Shift+D)
+                    </span>
+                </div>
+                <div
+                    style={{
+                        display: "flex",
+                        gap: "6px",
+                        "margin-bottom": "6px",
+                        "align-items": "center",
+                    }}
+                >
+                    <select
+                        value={sliceFilter()}
+                        onInput={(e) => setSliceFilter(e.currentTarget.value)}
+                        style={{
+                            "background-color": "#222",
+                            color: "#d0d0d0",
+                            border: "1px solid #444",
+                            "border-radius": "3px",
+                            padding: "2px 4px",
+                            "font-family": "inherit",
+                            "font-size": "inherit",
+                        }}
+                    >
+                        <option value="">all slices</option>
+                        <For each={availableSlices()}>
+                            {(s) => <option value={s}>{s}</option>}
+                        </For>
+                    </select>
+                    <input
+                        type="text"
+                        placeholder="filter by key…"
+                        value={keyFilter()}
+                        onInput={(e) => setKeyFilter(e.currentTarget.value)}
+                        style={{
+                            flex: "1",
+                            "background-color": "#222",
+                            color: "#d0d0d0",
+                            border: "1px solid #444",
+                            "border-radius": "3px",
+                            padding: "2px 6px",
+                            "font-family": "inherit",
+                            "font-size": "inherit",
+                        }}
+                    />
+                    <button
+                        onClick={() => __resetDispatchLog()}
+                        style={{
+                            "background-color": "#332",
+                            color: "#d0d0d0",
+                            border: "1px solid #555",
+                            "border-radius": "3px",
+                            padding: "2px 8px",
+                            cursor: "pointer",
+                            "font-family": "inherit",
+                            "font-size": "inherit",
+                        }}
+                        title="Wipe the dispatch ring (dev only)"
+                    >
+                        clear
+                    </button>
+                </div>
+                <div
+                    style={{
+                        "overflow-y": "auto",
+                        flex: "1",
+                        "border-top": "1px solid #333",
+                        "padding-top": "4px",
+                    }}
+                >
+                    <Show
+                        when={rows().length > 0}
+                        fallback={
+                            <div style={{ color: "#888", "padding": "8px" }}>
+                                {totalDispatches() === 0
+                                    ? "No dispatches recorded yet."
+                                    : "No matches for the current filter."}
+                            </div>
+                        }
+                    >
+                        <table
+                            style={{
+                                width: "100%",
+                                "border-collapse": "collapse",
+                            }}
+                        >
+                            <thead>
+                                <tr style={{ color: "#888" }}>
+                                    <th style={hdrStyle}>age</th>
+                                    <th style={hdrStyle}>slice</th>
+                                    <th style={hdrStyle}>key</th>
+                                    <th style={hdrStyle}>command</th>
+                                    <th style={hdrStyle}>source</th>
+                                    <th style={hdrStyle}>events</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <For each={rows()}>
+                                    {(row) => (
+                                        <tr>
+                                            <td style={cellStyle}>{row.age}</td>
+                                            <td style={cellStyle}>
+                                                <span style={{ color: "#aaa" }}>{row.slice}</span>
+                                            </td>
+                                            <td style={cellStyle}>{row.keyShort}</td>
+                                            <td style={cellStyle}>
+                                                <span style={{ color: "#7af" }}>{row.cmdType}</span>
+                                            </td>
+                                            <td style={cellStyle}>{row.source}</td>
+                                            <td style={cellStyle}>{row.eventCount}</td>
+                                        </tr>
+                                    )}
+                                </For>
+                            </tbody>
+                        </table>
+                    </Show>
+                </div>
+            </div>
+        </Show>
+    );
+}
+
+const hdrStyle = {
+    "text-align": "left" as const,
+    padding: "2px 6px",
+    "font-weight": "normal",
+    "border-bottom": "1px solid #333",
+};
+
+const cellStyle = {
+    padding: "2px 6px",
+    "white-space": "nowrap" as const,
+    "vertical-align": "top" as const,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.737",
+  "version": "0.33.738",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.737",
+      "version": "0.33.738",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.737",
+  "version": "0.33.738",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 5 of slice #9 — surfaces the global \`dispatchRecordsAtom\` (already populated by every slice's \`dispatch()\` via \`recordDispatch\`) as a floating dev-mode panel. **Slice #9 is now end-to-end.**

When a multi-pane focus or pool-drift bug fires, the question is always \"what happened in the last 200 ms, in what order, across which panes?\". Tail-grepping the host log works but loses structure. The audit ring already has the data structured; this panel just renders it.

### What landed

**\`frontend/app/devtools/diag-panel.tsx\`** — new floating Solid component, ~280 LOC.

- Toggle: **Ctrl+Shift+D** (or Meta+Shift+D on macOS).
- Mounted in \`app.tsx\` alongside \`PerfHud\` behind the existing \`isDev()\` gate. Hidden in release.
- z-index 999998 (one less than perf HUD at 999999) so they don't fight if both are open.
- Self-contained inline styles (same approach as the perf HUD) — works during a stylesheet-disabled investigation.

### Display

Per-row columns:

| Column | Source |
|---|---|
| age | \`now - record.at\` formatted as \"Xms ago\" / \"X.Ys ago\" / \"X.Ymin ago\" |
| slice | \`record.slice\` (e.g. \"browser-pane-state\", \"agent-pane-state\") |
| key | \`record.key\` truncated to 7 chars (block ID prefix); — for null |
| command | \`record.command.type\` discriminator |
| source | \`describeSource(record.source)\` — system / user / agent:X |
| events | count of events the dispatch emitted |

### Filters + controls

- **Slice dropdown** — populated reactively from the slices currently in the ring; empty string means \"all\".
- **Key filter** — substring search against \`record.key\` (case-insensitive).
- **Clear button** — wipes the ring via \`__resetDispatchLog\`. Useful for isolating a specific repro window.

### Display limit + age refresh

Newest-first scan stops once we've collected \`DEFAULT_DISPLAY_LIMIT = 80\` filtered rows. The records signal already drives re-renders on every new dispatch; a separate 1 Hz \`now()\` interval refreshes the relative-age strings on existing rows. Both interval + dispatch subscription are bounded to the visible state via a \`createEffect\` that tears down the timer when the panel is hidden — same pattern as the perf HUD's visibility gating.

### What's NOT in this PR

- **Per-record event-payload expansion** — the panel shows \`record.events.length\`, not the events themselves. Click-to-expand-row is a natural enhancement; deferred so this PR stays focused on the audit ring's primary value (sequence + frequency visibility).
- **Persistent record export** — the ring is in-memory only per the existing convention. If a session needs to be inspected post-mortem, that's a separate feature with separate threat-model concerns.
- **Slice-specific renderers** — the panel renders all slices uniformly. A future enhancement could downcast \`record.command\` based on \`record.slice\` and render slice-specific detail; out of scope here.

## Test plan

- [x] Full frontend suite: **483/483 passing** (no new tests — the panel is a thin reactive view over an already-tested signal; behavior is observable via the rendered output, which is best validated in the dev-mode smoke).
- [x] \`task build:frontend\` succeeds.
- [x] No TS regressions.
- [ ] Smoke: \`task dev\`, press Ctrl+Shift+D, click in the address bar, navigate, click into google search — verify the panel shows the corresponding sequence (Navigate, UrlConfirmed, LoadFinished, PaneClicked, etc.) with correct slice/key/source attribution and the age column ticking.

## Slice #9 status after this PR

- ✅ Phase 0 — catalog
- ✅ Phase 1 — diag instrumentation (PR #738)
- ⏳ Phase 2 — characterize (manual retro pending, optional)
- ✅ Phase 3a + 3b — closed/loading/error (#756)
- ✅ Phase 3c — canGoBack/canGoForward (#757)
- ✅ Phase 3d — \`url\` danger cell (#761)
- ✅ Phase 3e — title (#758) + faviconUrl (#763)
- ✅ Phase 4 — slot store + recordDispatch + PaneClicked through reducer (#764)
- 🟡 **Phase 5 shipped** ← this PR
- ❌ Phase 6 — host-side title-change + favicon emit (the original feature; reducer cells are ready, host event subscription is the remaining gap — independent work)

The reducer-stack roadmap §5 said \"Wire \`recordDispatch\` for \`browser-pane-state\` into the existing diagnostics panel.\" There was no existing panel; this PR builds one and surfaces every slice's dispatches, not just browser-pane-state. Future slices come along for free.

## Cross-references

- \`docs/specs/browser-pane-reducer-roadmap.md\` §5
- \`frontend/app/store/command-source.ts\` — the audit ring (slice #3 from the conventions)
- \`frontend/perf/hud.tsx\` — sister panel; same toggle/visibility-gating pattern
- Predecessors in this session: #756, #757, #758, #759, #760, #761, #762, #763, #764
- Discussion: #707

🤖 Generated with [Claude Code](https://claude.com/claude-code)