### PR TITLE
hotfix: perf IPC clock feedback loop — exclude log-pipe IPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.738"
+version = "0.33.739"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.738"
+version = "0.33.739"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.738"
+version = "0.33.739"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.738"
+version = "0.33.739"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.738"
+version = "0.33.739"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.738"
+version = "0.33.739"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.738"
+version = "0.33.739"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.738"
+version = "0.33.739"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/perf/index.ts
+++ b/frontend/perf/index.ts
@@ -46,11 +46,15 @@ export function initPerf(): void {
  * stays dependency-free and the perf store is the single sink for
  * all timing telemetry.
  */
+// Skip the log-pipe and other perf-self IPCs; warning on these would
+// trigger another fe_log_structured IPC, which would warn, which would
+// trigger another. Feedback loop saturates the IPC server; observed
+// 283k storm in dev mode, 700-1500ms ambient IPC latency, drag broken.
+const PERF_IPC_BLOCKLIST = new Set(["fe_log_structured", "fe_log"]);
+
 export function recordIpcRoundtrip(command: string, durationMs: number): void {
+    if (PERF_IPC_BLOCKLIST.has(command)) return;
     perfStore.recordIpc(command, durationMs);
-    // 16 ms = one frame at 60 Hz. Anything over is a frame-budget
-    // threat — surface immediately to the host log so investigators
-    // don't have to wait for the HUD's 1 Hz refresh.
     if (durationMs > 16) {
         console.warn(`[perf] ipc ${command} ${durationMs.toFixed(1)}ms`);
     }

--- a/frontend/perf/index.ts
+++ b/frontend/perf/index.ts
@@ -40,18 +40,18 @@ export function initPerf(): void {
     console.info("[perf] phase-0 instrumentation initialized");
 }
 
-/**
- * Called by the `invokeCommand` wrapper in `frontend/app/platform/ipc.ts`
- * after each completed roundtrip. Centralized here so the wrapper
- * stays dependency-free and the perf store is the single sink for
- * all timing telemetry.
- */
-// Skip the log-pipe and other perf-self IPCs; warning on these would
-// trigger another fe_log_structured IPC, which would warn, which would
-// trigger another. Feedback loop saturates the IPC server; observed
-// 283k storm in dev mode, 700-1500ms ambient IPC latency, drag broken.
+/** Self-IPCs that must not be measured — see PERF_IPC_BLOCKLIST. */
 const PERF_IPC_BLOCKLIST = new Set(["fe_log_structured", "fe_log"]);
 
+/**
+ * Called by the `invokeCommand` wrapper after each completed
+ * roundtrip. Records timing into `perfStore` and warns when the
+ * frame budget (16 ms) is exceeded.
+ *
+ * Blocklisted commands skip both recording AND warning — the log
+ * pipe's own IPCs would feed back through the warn → console.warn
+ * → log-pipe → invokeCommand cycle.
+ */
 export function recordIpcRoundtrip(command: string, durationMs: number): void {
     if (PERF_IPC_BLOCKLIST.has(command)) return;
     perfStore.recordIpc(command, durationMs);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.738",
+  "version": "0.33.739",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.738",
+      "version": "0.33.739",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.738",
+  "version": "0.33.739",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR #762's IPC roundtrip clock created a feedback loop with the log-pipe. Symptom user hit: tab-bar drag stops working — \`get_window_position\` IPC takes 700-1500 ms instead of <1 ms because the IPC server is saturated with self-generated traffic.

## The loop

\`\`\`
slow IPC > 16ms → recordIpcRoundtrip → console.warn(\"[perf] ipc X Yms\")
  → log-pipe monkey-patched console.warn → invokeCommand(\"fe_log_structured\")
  → recordIpcRoundtrip on the fe_log_structured call itself
  → if THAT was >16ms (because pipe is now saturated) → console.warn
  → log-pipe → fe_log_structured → recordIpcRoundtrip → …
\`\`\`

Observed in dev mode: **283,469 \`fe_log_structured\` warnings** in ~10 minutes; ambient IPC latency 700-1500 ms; \`get_window_position\` queues behind the storm and takes 700+ ms; the click-and-release window is shorter than that, so \`useWindowDrag.win32.ts\`'s race guard cancels every drag attempt.

Desktop portables predate PR #762, which is why they don't show this regression — confirmed by user.

## Fix

Blocklist \`fe_log_structured\` and \`fe_log\` in \`recordIpcRoundtrip\` — those are the log-pipe's own IPCs and must not be measured (their cost IS the measurement infrastructure; measuring them = measuring the meter). Two-line change.

## Test plan

- [x] Frontend perf tests pass (7/7).
- [x] \`task build:frontend\` succeeds.
- [ ] Smoke: with this PR built into a fresh \`task dev\`, drag the title bar — should work without delay; \`get_window_position\` should be <1 ms.

## Lesson

Phase-0 spec said \"instrumentation should be effectively free.\" This was a self-introduced violation. The class is \"don't measure your own measurement infrastructure.\" Memory note will be added so future instrumentation tools (long-task observer, INP observer when its own callbacks log) get the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)