### PR TITLE
perf: paint-aligned tab-switch marks at canonical setActiveTab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.744"
+version = "0.33.745"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.744"
+version = "0.33.745"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.744"
+version = "0.33.745"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.744"
+version = "0.33.745"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.744"
+version = "0.33.745"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.744"
+version = "0.33.745"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.744"
+version = "0.33.745"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.744"
+version = "0.33.745"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -5,6 +5,7 @@
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { markEnd, markStart } from "@/perf";
 import {
     getLayoutModelForStaticTab,
     LayoutTreeActionType,
@@ -866,7 +867,24 @@ export function createTab() {
 export async function setActiveTab(tabId: string): Promise<void> {
     const ws = workspace();
     if (ws == null) return;
-    await WorkspaceService.SetActiveTab(ws.oid, tabId);
+    const fromTabId = activeTabId();
+    if (fromTabId === tabId) return;
+    // Canonical chokepoint for tab-switch perf marks. Wraps every entry
+    // path: click (tabbar), keyboard (Ctrl+Tab/1..9 in keymodel),
+    // palette (command-registry), test app API (cef-api). markEnd lands
+    // two rAFs after the IPC so the duration captures user-perceived
+    // switch cost — IPC + Solid fan-out + layout + paint — not just IPC.
+    // Backend-driven switches (tearoff merge, cross-drag) bypass this
+    // function and are not measured here; they're rare and observable
+    // via the long-task timeline.
+    markStart("tab-switch", { from: fromTabId, to: tabId });
+    try {
+        await WorkspaceService.SetActiveTab(ws.oid, tabId);
+    } finally {
+        requestAnimationFrame(() =>
+            requestAnimationFrame(() => markEnd("tab-switch"))
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/app/store/global.ts
+++ b/frontend/app/store/global.ts
@@ -864,6 +864,15 @@ export function createTab() {
     });
 }
 
+// Tracks an in-flight tab-switch measurement so rapid back-to-back
+// switches (held Ctrl+Tab, programmatic bursts) don't collide on the
+// shared `tab-switch:start` mark name. performance.mark throws on
+// duplicates and the second call would silently drop its measurement.
+// Sequence guard ensures the prior switch's pending double-rAF
+// markEnd doesn't close the new switch's measurement instead.
+let tabSwitchInFlight = false;
+let tabSwitchSeq = 0;
+
 export async function setActiveTab(tabId: string): Promise<void> {
     const ws = workspace();
     if (ws == null) return;
@@ -877,12 +886,25 @@ export async function setActiveTab(tabId: string): Promise<void> {
     // Backend-driven switches (tearoff merge, cross-drag) bypass this
     // function and are not measured here; they're rare and observable
     // via the long-task timeline.
+    if (tabSwitchInFlight) {
+        // Close prior measurement (truncated) so the new markStart
+        // doesn't collide. The prior call's pending rAF markEnd will
+        // see its sequence is stale and skip.
+        markEnd("tab-switch", "interrupted");
+    }
+    const mySeq = ++tabSwitchSeq;
+    tabSwitchInFlight = true;
     markStart("tab-switch", { from: fromTabId, to: tabId });
     try {
         await WorkspaceService.SetActiveTab(ws.oid, tabId);
     } finally {
         requestAnimationFrame(() =>
-            requestAnimationFrame(() => markEnd("tab-switch"))
+            requestAnimationFrame(() => {
+                if (mySeq === tabSwitchSeq) {
+                    markEnd("tab-switch");
+                    tabSwitchInFlight = false;
+                }
+            })
         );
     }
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -25,7 +25,6 @@ import {
 } from "./tabbar-dnd";
 import { setCurrentDragPayload } from "@/app/drag/CrossWindowDragMonitor";
 import { Logger } from "@/util/logger";
-import { markEnd, markStart } from "@/perf";
 import "./tabbar.scss";
 
 export { tabItemType } from "./tabbar-dnd";
@@ -65,15 +64,7 @@ function TabBar(props: TabBarProps): JSX.Element {
 
     const handleSelect = (tabId: string) => {
         if (tabId === activeTabId()) return;
-        // Phase 0 perf instrumentation A1: time the tab-switch
-        // interaction. The `markEnd` lands one microtask after
-        // `setActiveTab` commits — it captures the synchronous
-        // dispatch path; reactive fan-out (Solid effects, IPC for
-        // pane HWND show/hide) is observed separately via the Long
-        // Tasks API and the IPC roundtrip clock.
-        markStart("tab-switch", { from: activeTabId(), to: tabId });
         setActiveTab(tabId);
-        queueMicrotask(() => markEnd("tab-switch"));
     };
 
     const handleClose = (tabId: string) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.744",
+  "version": "0.33.745",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.744",
+      "version": "0.33.745",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.744",
+  "version": "0.33.745",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The Phase 0 tab-switch perf mark in `tabbar.tsx handleSelect`:
1. Only fired on **imperative click** — keyboard (Ctrl+Tab, Cmd+1..9), command palette, and test-app-API paths bypassed it.
2. Closed via `queueMicrotask`, so the duration captured only the synchronous IPC dispatch, not the user-perceived layout + paint cost.

This PR moves the mark into the canonical `setActiveTab` chokepoint and closes it via double-`requestAnimationFrame`, so the duration reflects IPC + Solid fan-out + layout + paint.

Backend-driven switches (tearoff merge, cross-drag) bypass `setActiveTab` entirely — they're rare and observable via the long-task timeline; documented inline.

## Coverage map

| Path | File | Now instrumented? |
|---|---|---|
| Click | `tabbar.tsx handleSelect` | ✅ via setActiveTab |
| Keyboard Ctrl+Tab / Shift+Tab | `keymodel.ts switchTab` | ✅ via setActiveTab |
| Keyboard Cmd+1..9 | `keymodel.ts switchTabAbs` | ✅ via setActiveTab |
| Command palette | `command-registry.ts` | ✅ via setActiveTab |
| Test app API | `cef-api.ts setActiveTab` | ✅ via setActiveTab |
| Tearoff merge | `tabbar.tsx tearoff:merge` | ❌ backend-driven, deferred |
| Cross-window drag | `DragOverlay.tsx` | ❌ backend-driven, deferred |

## Verification

Built locally on `agenta/perf-tab-switch-marks` (v0.33.740). Tab switches in dev mode now produce `[fe] [perf] tab-switch <dur>ms` warnings (>100ms threshold) for every entry path. Empirically confirmed via dev-session log: durations track visible jank — switches into tabs hosting an agent pane are longer than browser/terminal-only switches, matching user-perceived behavior.

## Related

- Tier 1 spec: `docs/specs/SPEC_PERFORMANCE_INSTRUMENTATION_AND_OPTIMIZATION.md`
- Phase 1 retro: `docs/retro/perf-baseline-2026-05-09.md`
- Issue #769 (new-window bootstrap serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)