### PR TITLE
perf: virtualize AgentDocumentView with @tanstack/solid-virtual

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.743"
+version = "0.33.744"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.743"
+version = "0.33.744"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.743"
+version = "0.33.744"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.743"
+version = "0.33.744"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.742"
+version = "0.33.743"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.742"
+version = "0.33.743"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.742"
+version = "0.33.743"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.742"
+version = "0.33.743"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.741"
+version = "0.33.742"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.741"
+version = "0.33.742"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.741"
+version = "0.33.742"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.741"
+version = "0.33.742"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.741"
+version = "0.33.742"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.742"
+version = "0.33.743"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.743"
+version = "0.33.744"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.741"
+version = "0.33.742"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.742"
+version = "0.33.743"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.743"
+version = "0.33.744"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.741"
+version = "0.33.742"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.742"
+version = "0.33.743"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.743"
+version = "0.33.744"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.741"
+version = "0.33.742"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.743"
+version = "0.33.744"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.742"
+version = "0.33.743"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -12,6 +12,7 @@
  */
 
 import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createVirtualizer } from "@tanstack/solid-virtual";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -58,9 +59,35 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
+    let virtualContainerRef: HTMLDivElement | undefined;
     let autoScroll = true;
     // Guard against concurrent older-history fetches triggered by scroll
     let loadingOlderInFlight = false;
+
+    // Virtualizer over the document nodes. Replaces the old <For> that
+    // mounted every node in flow with content-visibility: auto. With
+    // long sessions (500-2000+ nodes) the layout tree alone was 8MB+ per
+    // pane and a tab-switch reflow stalled for 200ms+. Virtualization
+    // keeps only ~visible-window + overscan items in the DOM.
+    //
+    // estimateSize = 80 matches the old contain-intrinsic-size hint;
+    // measureElement re-measures actual heights via ResizeObserver as
+    // each item paints, so dynamic content (tool blocks, code diffs)
+    // settles to its real size after one frame.
+    //
+    // scrollMargin reads the virtual container's offsetTop so the
+    // loading-older banner and auth-url box (rendered as siblings above
+    // the virtualizer container) don't break scroll math.
+    const virtualizer = createVirtualizer({
+        get count() { return document().length; },
+        getScrollElement: () => scrollRef,
+        estimateSize: () => 80,
+        overscan: 5,
+        getItemKey: (index) => document()[index]?.id ?? index,
+        get scrollMargin() {
+            return virtualContainerRef?.offsetTop ?? 0;
+        },
+    });
 
     // Scroll to a node by its data-node-id attribute.
     // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
@@ -80,16 +107,12 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     // See docs/analysis/agent-pane-rich-features-structure-2026-04-13.md §1.
     const scrollToNode = (nodeId: string) => {
         if (!scrollRef) return;
-        const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
-        if (!el) return;
-        const elRect = el.getBoundingClientRect();
-        const containerRect = scrollRef.getBoundingClientRect();
-        // Top of el relative to scrollRef's content origin
-        const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
-        // Center the element in the visible region
-        const centerOffset =
-            offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
-        scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
+        // Under virtualization the target node may not be in the DOM
+        // until we scroll its index into the virtual window. Look up the
+        // index first; align="center" matches the old centering math.
+        const idx = document().findIndex((n) => n.id === nodeId);
+        if (idx < 0) return;
+        virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
         // Disable auto-scroll after a manual jump
         autoScroll = false;
     };
@@ -120,7 +143,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     const jumpToBottom = () => {
         if (!scrollRef) return;
         autoScroll = true;
-        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "instant" });
+        const last = document().length - 1;
+        if (last < 0) return;
+        virtualizer.scrollToIndex(last, { align: "end", behavior: "auto" });
     };
 
     if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
@@ -179,9 +204,10 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     let scrollRafId: number | null = null;
 
     const scrollToBottom = () => {
-        if (autoScroll && scrollRef) {
-            scrollRef.scrollTop = scrollRef.scrollHeight;
-        }
+        if (!autoScroll || !scrollRef) return;
+        const last = document().length - 1;
+        if (last < 0) return;
+        virtualizer.scrollToIndex(last, { align: "end", behavior: "auto" });
     };
 
     // Scroll when the document changes — throttled to one RAF per batch.
@@ -214,17 +240,26 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
             !loadingOlderInFlight &&
             !(loadingOlder?.())
         ) {
-            // Snapshot scroll anchor before content is prepended
-            const snapshotScrollHeight = scrollHeight;
-            const snapshotScrollTop = scrollTop;
+            // Anchor by node id, not pixels. Pre-virtualization we
+            // computed the new scrollTop from the snapshot scrollHeight
+            // delta — but with measured virtual heights that delta is
+            // unreliable until every newly-rendered item has been laid
+            // out by the ResizeObserver. Re-anchoring to the same node's
+            // index after prepend is exact regardless of measurement
+            // settle time.
+            const items = virtualizer.getVirtualItems();
+            const anchorId = items.length > 0 ? document()[items[0].index]?.id : null;
             loadingOlderInFlight = true;
             onLoadOlder().then(() => {
-                // Restore scroll position so the user's viewport doesn't jump.
-                // Use a RAF so the DOM has updated with the new nodes first.
                 requestAnimationFrame(() => {
-                    if (scrollRef) {
-                        scrollRef.scrollTop =
-                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
+                    if (anchorId != null) {
+                        const newIdx = document().findIndex((n) => n.id === anchorId);
+                        if (newIdx >= 0) {
+                            virtualizer.scrollToIndex(newIdx, {
+                                align: "start",
+                                behavior: "auto",
+                            });
+                        }
                     }
                     loadingOlderInFlight = false;
                 });
@@ -324,120 +359,144 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
                 }}
             </Show>
 
-            {/* Document nodes render below log lines.
-                `content-visibility: auto` on the wrapper lets the browser
-                skip layout/paint for off-screen nodes — critical for
-                long sessions where thousands of DOM elements accumulate. */}
-            <For each={document()}>
-                {(node) => {
-                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
-                    const canExpand = () => {
-                        switch (node.type) {
-                            case "tool":
-                            case "agent_message":
-                            case "user_message":
-                            case "section":
-                                return true;
-                            default:
-                                return false;
-                        }
-                    };
-                    const isExpanded = () => {
-                        if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
-                        return !documentState().collapsedNodes.has(node.id);
-                    };
-                    const onExpand = () => {
-                        if (node.type === "tool") togglePin(node.id);
-                        else toggleCollapse(node.id);
-                    };
-                    // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
-                    const onOpenInNewPane = node.type === "tool"
-                        ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
-                        : undefined;
-                    const onOpenInNewWindow = () =>
-                        console.warn("[hover-strip] open in new window — not yet implemented");
-                    const onNewAgentFromHere = () =>
-                        console.warn("[hover-strip] new agent from here — not yet implemented");
-
-                    const handleRowKey = (e: KeyboardEvent): void => {
-                        if (e.metaKey || e.ctrlKey || e.altKey) return;
-                        switch (e.key.toLowerCase()) {
-                            case "e":
-                                if (canExpand()) { onExpand(); e.preventDefault(); }
-                                break;
-                            case "b":
-                                if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
-                                break;
-                            case "p":
-                                if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
-                                break;
-                            case "w":
-                                onOpenInNewWindow(); e.preventDefault();
-                                break;
-                            case "n":
-                                onNewAgentFromHere(); e.preventDefault();
-                                break;
-                            case "escape":
-                                (e.currentTarget as HTMLElement).blur();
-                                e.preventDefault();
-                                break;
-                        }
-                    };
-
-                    const handleContextMenu = (e: MouseEvent) => {
-                        if (!onBookmark) return;
-                        // Don't show bookmark menu on top of text selections — let the parent handle those.
-                        const sel = window.getSelection()?.toString();
-                        if (sel) return;
-                        e.preventDefault();
-                        e.stopPropagation();
-                        ContextMenuModel.showContextMenu(
-                            [
-                                {
-                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
-                                    click: () => onBookmark(node),
-                                },
-                            ],
-                            e,
-                        );
-                    };
-
-                    return (
-                        <div
-                            class="hover-strip-host agent-document-node-wrapper"
-                            classList={{
-                                "agent-node-bookmarked": isBookmarked(),
-                                "agent-node-search-match": highlightNodeId?.() === node.id,
-                            }}
-                            data-node-id={node.id}
-                            tabindex="0"
-                            onKeyDown={handleRowKey}
-                            onContextMenu={handleContextMenu}
-                        >
-                            <DocumentNodeRenderer
-                                node={node}
-                                collapsed={documentState().collapsedNodes.has(node.id)}
-                                onToggle={() => toggleCollapse(node.id)}
-                                toolPinned={documentState().pinnedNodes.has(node.id)}
-                                onToggleToolPin={() => togglePin(node.id)}
-                                onSubagentClick={onSubagentClick}
-                            />
-                            <NodeHoverStrip
-                                timestamp={(node as any).timestamp}
-                                nodeId={node.id}
-                                isBookmarked={isBookmarked()}
-                                onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
-                                canExpand={canExpand()}
-                                isExpanded={isExpanded()}
-                                onExpand={onExpand}
-                                onOpenInNewPane={onOpenInNewPane}
-                                onOpenInNewWindow={onOpenInNewWindow}
-                                onNewAgentFromHere={onNewAgentFromHere}
-                            />
-                        </div>
-                    );
+            {/* Virtualized document nodes. The container takes the full
+                virtual height (sum of all measured/estimated item sizes)
+                so the native scrollbar reflects total content. Each item
+                is absolute-positioned via translateY; only the visible
+                window + overscan are mounted in the DOM. measureElement
+                hooks ResizeObserver to re-measure dynamic-height items
+                (tool blocks expanding, code diffs, etc.) after first
+                paint, so the estimate (80px) is just the initial guess. */}
+            <div
+                ref={(el) => { virtualContainerRef = el; }}
+                class="agent-document-virtualizer"
+                style={{
+                    height: `${virtualizer.getTotalSize()}px`,
+                    position: "relative",
+                    width: "100%",
                 }}
-            </For>
+            >
+                <For each={virtualizer.getVirtualItems()}>
+                    {(virtualItem) => {
+                        const node = document()[virtualItem.index];
+                        if (!node) return null;
+                        const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+                        const canExpand = () => {
+                            switch (node.type) {
+                                case "tool":
+                                case "agent_message":
+                                case "user_message":
+                                case "section":
+                                    return true;
+                                default:
+                                    return false;
+                            }
+                        };
+                        const isExpanded = () => {
+                            if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
+                            return !documentState().collapsedNodes.has(node.id);
+                        };
+                        const onExpand = () => {
+                            if (node.type === "tool") togglePin(node.id);
+                            else toggleCollapse(node.id);
+                        };
+                        // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
+                        const onOpenInNewPane = node.type === "tool"
+                            ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
+                            : undefined;
+                        const onOpenInNewWindow = () =>
+                            console.warn("[hover-strip] open in new window — not yet implemented");
+                        const onNewAgentFromHere = () =>
+                            console.warn("[hover-strip] new agent from here — not yet implemented");
+
+                        const handleRowKey = (e: KeyboardEvent): void => {
+                            if (e.metaKey || e.ctrlKey || e.altKey) return;
+                            switch (e.key.toLowerCase()) {
+                                case "e":
+                                    if (canExpand()) { onExpand(); e.preventDefault(); }
+                                    break;
+                                case "b":
+                                    if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
+                                    break;
+                                case "p":
+                                    if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
+                                    break;
+                                case "w":
+                                    onOpenInNewWindow(); e.preventDefault();
+                                    break;
+                                case "n":
+                                    onNewAgentFromHere(); e.preventDefault();
+                                    break;
+                                case "escape":
+                                    (e.currentTarget as HTMLElement).blur();
+                                    e.preventDefault();
+                                    break;
+                            }
+                        };
+
+                        const handleContextMenu = (e: MouseEvent) => {
+                            if (!onBookmark) return;
+                            const sel = window.getSelection()?.toString();
+                            if (sel) return;
+                            e.preventDefault();
+                            e.stopPropagation();
+                            ContextMenuModel.showContextMenu(
+                                [
+                                    {
+                                        label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                                        click: () => onBookmark(node),
+                                    },
+                                ],
+                                e,
+                            );
+                        };
+
+                        return (
+                            <div
+                                ref={(el) => virtualizer.measureElement(el)}
+                                data-index={virtualItem.index}
+                                data-node-id={node.id}
+                                class="hover-strip-host agent-document-node-wrapper"
+                                classList={{
+                                    "agent-node-bookmarked": isBookmarked(),
+                                    "agent-node-search-match": highlightNodeId?.() === node.id,
+                                }}
+                                style={{
+                                    position: "absolute",
+                                    top: "0",
+                                    left: "0",
+                                    width: "100%",
+                                    transform: `translateY(${virtualItem.start}px)`,
+                                }}
+                                tabindex="0"
+                                onKeyDown={handleRowKey}
+                                onContextMenu={handleContextMenu}
+                            >
+                                <DocumentNodeRenderer
+                                    node={node}
+                                    collapsed={documentState().collapsedNodes.has(node.id)}
+                                    onToggle={() => toggleCollapse(node.id)}
+                                    toolPinned={documentState().pinnedNodes.has(node.id)}
+                                    onToggleToolPin={() => togglePin(node.id)}
+                                    onSubagentClick={onSubagentClick}
+                                />
+                                <NodeHoverStrip
+                                    timestamp={(node as any).timestamp}
+                                    nodeId={node.id}
+                                    isBookmarked={isBookmarked()}
+                                    onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
+                                    canExpand={canExpand()}
+                                    isExpanded={isExpanded()}
+                                    onExpand={onExpand}
+                                    onOpenInNewPane={onOpenInNewPane}
+                                    onOpenInNewWindow={onOpenInNewWindow}
+                                    onNewAgentFromHere={onNewAgentFromHere}
+                                />
+                            </div>
+                        );
+                    }}
+                </For>
+            </div>
         </div>
     );
 };

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -378,11 +378,20 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
             >
                 <For each={virtualizer.getVirtualItems()}>
                     {(virtualItem) => {
-                        const node = document()[virtualItem.index];
-                        if (!node) return null;
-                        const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+                        // Reactive accessor — re-reads document() on every
+                        // call so streaming updates (StreamFlush replacing a
+                        // node at the same index) reach the row even when
+                        // the row stays mounted across renders. Capturing
+                        // node as a const here would freeze the row's view
+                        // of the document at first render. (codex P1)
+                        const node = () => document()[virtualItem.index];
+                        const isBookmarked = () => {
+                            const n = node();
+                            return n ? (bookmarkedNodeIds?.().has(n.id) ?? false) : false;
+                        };
                         const canExpand = () => {
-                            switch (node.type) {
+                            const t = node()?.type;
+                            switch (t) {
                                 case "tool":
                                 case "agent_message":
                                 case "user_message":
@@ -393,17 +402,23 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
                             }
                         };
                         const isExpanded = () => {
-                            if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
-                            return !documentState().collapsedNodes.has(node.id);
+                            const n = node();
+                            if (n == null) return false;
+                            if (n.type === "tool") return documentState().pinnedNodes.has(n.id);
+                            return !documentState().collapsedNodes.has(n.id);
                         };
                         const onExpand = () => {
-                            if (node.type === "tool") togglePin(node.id);
-                            else toggleCollapse(node.id);
+                            const n = node();
+                            if (n == null) return;
+                            if (n.type === "tool") togglePin(n.id);
+                            else toggleCollapse(n.id);
                         };
                         // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
-                        const onOpenInNewPane = node.type === "tool"
-                            ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
-                            : undefined;
+                        const onOpenInNewPane = () => {
+                            if (node()?.type === "tool") {
+                                console.warn("[hover-strip] open in new pane — not yet implemented");
+                            }
+                        };
                         const onOpenInNewWindow = () =>
                             console.warn("[hover-strip] open in new window — not yet implemented");
                         const onNewAgentFromHere = () =>
@@ -411,15 +426,17 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
 
                         const handleRowKey = (e: KeyboardEvent): void => {
                             if (e.metaKey || e.ctrlKey || e.altKey) return;
+                            const n = node();
+                            if (n == null) return;
                             switch (e.key.toLowerCase()) {
                                 case "e":
                                     if (canExpand()) { onExpand(); e.preventDefault(); }
                                     break;
                                 case "b":
-                                    if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
+                                    if (onBookmark != null) { onBookmark(n); e.preventDefault(); }
                                     break;
                                 case "p":
-                                    if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
+                                    if (n.type === "tool") { onOpenInNewPane(); e.preventDefault(); }
                                     break;
                                 case "w":
                                     onOpenInNewWindow(); e.preventDefault();
@@ -438,13 +455,15 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
                             if (!onBookmark) return;
                             const sel = window.getSelection()?.toString();
                             if (sel) return;
+                            const n = node();
+                            if (n == null) return;
                             e.preventDefault();
                             e.stopPropagation();
                             ContextMenuModel.showContextMenu(
                                 [
                                     {
                                         label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
-                                        click: () => onBookmark(node),
+                                        click: () => onBookmark(n),
                                     },
                                 ],
                                 e,
@@ -455,43 +474,57 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
                             <div
                                 ref={(el) => virtualizer.measureElement(el)}
                                 data-index={virtualItem.index}
-                                data-node-id={node.id}
+                                data-node-id={node()?.id}
                                 class="hover-strip-host agent-document-node-wrapper"
                                 classList={{
                                     "agent-node-bookmarked": isBookmarked(),
-                                    "agent-node-search-match": highlightNodeId?.() === node.id,
+                                    "agent-node-search-match": (() => {
+                                        const id = node()?.id;
+                                        return id != null && highlightNodeId?.() === id;
+                                    })(),
                                 }}
                                 style={{
                                     position: "absolute",
                                     top: "0",
                                     left: "0",
                                     width: "100%",
-                                    transform: `translateY(${virtualItem.start}px)`,
+                                    // Subtract scrollMargin so when an
+                                    // auth box / loading-older banner pushes
+                                    // the virtualizer container down,
+                                    // virtualItem.start (which already
+                                    // includes the margin) lands rows at the
+                                    // right offset within the container.
+                                    // (codex P2)
+                                    transform: `translateY(${virtualItem.start - virtualizer.options.scrollMargin}px)`,
                                 }}
                                 tabindex="0"
                                 onKeyDown={handleRowKey}
                                 onContextMenu={handleContextMenu}
                             >
+                                <Show when={node()}>
+                                    {(n) => (<>
                                 <DocumentNodeRenderer
-                                    node={node}
-                                    collapsed={documentState().collapsedNodes.has(node.id)}
-                                    onToggle={() => toggleCollapse(node.id)}
-                                    toolPinned={documentState().pinnedNodes.has(node.id)}
-                                    onToggleToolPin={() => togglePin(node.id)}
+                                    node={n()}
+                                    collapsed={documentState().collapsedNodes.has(n().id)}
+                                    onToggle={() => toggleCollapse(n().id)}
+                                    toolPinned={documentState().pinnedNodes.has(n().id)}
+                                    onToggleToolPin={() => togglePin(n().id)}
                                     onSubagentClick={onSubagentClick}
                                 />
                                 <NodeHoverStrip
-                                    timestamp={(node as any).timestamp}
-                                    nodeId={node.id}
+                                    timestamp={(n() as any).timestamp}
+                                    nodeId={n().id}
                                     isBookmarked={isBookmarked()}
-                                    onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
+                                    onBookmark={onBookmark != null ? () => onBookmark(n()) : undefined}
                                     canExpand={canExpand()}
                                     isExpanded={isExpanded()}
                                     onExpand={onExpand}
-                                    onOpenInNewPane={onOpenInNewPane}
+                                    onOpenInNewPane={n().type === "tool" ? onOpenInNewPane : undefined}
                                     onOpenInNewWindow={onOpenInNewWindow}
                                     onNewAgentFromHere={onNewAgentFromHere}
                                 />
+                                    </>)}
+                                </Show>
                             </div>
                         );
                     }}

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -98,13 +98,21 @@
         }
     }
 
+    .agent-document-virtualizer {
+        // Container for the @tanstack/solid-virtual list. Children are
+        // absolute-positioned via translateY; the height equals the
+        // virtualizer's getTotalSize() so the native scrollbar reflects
+        // the full virtual content. See AgentDocumentView.tsx.
+        position: relative;
+        width: 100%;
+    }
+
     .agent-document-node-wrapper {
-        // Each document node gets its own containment box. Off-screen nodes
-        // are skipped by the browser via content-visibility.
-        // contain-intrinsic-size gives the browser a size estimate so scroll
-        // position stays stable when content is virtualized in/out.
-        content-visibility: auto;
-        contain-intrinsic-size: auto 80px;
+        // Each document node is absolute-positioned by the virtualizer;
+        // `contain: layout style` isolates layout work to the item's box
+        // so a single message expanding (markdown image load, code-diff
+        // measure) doesn't reflow neighbors. content-visibility is no
+        // longer needed because off-screen items aren't in the DOM at all.
         contain: layout style;
 
         &:focus {

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -103,8 +103,16 @@
         // absolute-positioned via translateY; the height equals the
         // virtualizer's getTotalSize() so the native scrollbar reflects
         // the full virtual content. See AgentDocumentView.tsx.
+        //
+        // flex-shrink: 0 — the parent .agent-document is a column flex
+        // container, so without this the wrapper would shrink to fit
+        // the viewport when getTotalSize() exceeds it. Absolutely-
+        // positioned children don't establish a content min-height to
+        // push back, so the scrollbar would lose access to off-screen
+        // messages. (codex P1)
         position: relative;
         width: 100%;
+        flex-shrink: 0;
     }
 
     .agent-document-node-wrapper {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.743",
+  "version": "0.33.744",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.743",
+      "version": "0.33.744",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.741",
+  "version": "0.33.742",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.741",
+      "version": "0.33.742",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@lobehub/icons-static-svg": "^1.90.0",
         "@observablehq/plot": "^0.6.17",
         "@solid-primitives/keyed": "^1.5.3",
+        "@tanstack/solid-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -3269,6 +3270,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/solid-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.24.tgz",
+      "integrity": "sha512-sLGjpsAWLK8oxciqN+FNjs5JLs9N27DKwwoOPN8FMrmFMeXdiPQvRg3CqUAv8pYfXKD9KmcbhBxNwlmcP22a8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.3.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.742",
+  "version": "0.33.743",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.742",
+      "version": "0.33.743",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@lobehub/icons-static-svg": "^1.90.0",
     "@observablehq/plot": "^0.6.17",
     "@solid-primitives/keyed": "^1.5.3",
+    "@tanstack/solid-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.741",
+  "version": "0.33.742",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.743",
+  "version": "0.33.744",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.742",
+  "version": "0.33.743",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Virtualize the agent message list (`AgentDocumentView`) using `@tanstack/solid-virtual` so only the visible window + 5-item overscan is mounted in the DOM. Resolves Issue 4 from the agent-pane perf report (DOM virtualization).

**Driving symptom:** in long agent sessions (500-2000+ document nodes), the layout tree alone reaches ~8MB per pane. Tab-switches *into* a pane hosting an active agent stalled for 200ms+ (multiple long-tasks per switch, worst observed 269ms). Switching b↔c (no agent) is fast; switching a↔b (agent in `a`) is slow. Confirmed live in the dev session that drove this work (#769 file).

## What changed

- `frontend/app/view/agent/components/AgentDocumentView.tsx` — replaced `<For each={document()}>` with virtualizer-driven absolute-positioned items.
- `frontend/app/view/agent/styles/_document.scss` — removed `content-visibility: auto` / `contain-intrinsic-size` from `.agent-document-node-wrapper` (no longer needed, items aren't in the DOM at all when off-screen). Added `.agent-document-virtualizer` for the `position: relative` wrapper.
- `package.json` / `package-lock.json` — added `@tanstack/solid-virtual` ^3.13.

## Three reworked flows

These read DOM directly under the old `<For>` and had to be reauthored:

| Flow | Old | New |
|---|---|---|
| `scrollToNode` (jump-to-bookmark / search) | `querySelector + getBoundingClientRect`, smooth-scroll to centerOffset | Resolve index first; `virtualizer.scrollToIndex(idx, { align: 'center' })`. Old approach failed if target was outside virtual window. |
| `jumpToBottom` / `scrollToBottom` | `scrollTop = MAX_SAFE_INTEGER` (deliberately, to avoid sync layout read on keystroke hot path) | `virtualizer.scrollToIndex(last, { align: 'end' })` — also avoids sync layout reads. |
| `handleScroll` older-history load | Snapshot `scrollHeight + scrollTop`, restore via `new_scrollTop = new_scrollHeight - old_scrollHeight + old_scrollTop` | Anchor by node id. Pre-virt the pixel-delta math was reliable; with measured virtual heights it isn't, until every newly-rendered item settles. Re-anchoring to the same node's index after prepend is exact regardless of measurement timing. |

## Risk surfaces considered

| Concern | Status |
|---|---|
| **Variable item heights** (tool blocks 32→400px when pinned, code diffs 500+px) | TanStack supports dynamic sizing via `measureElement` + ResizeObserver. estimateSize=80 matches old contain-intrinsic-size hint; real heights settle on first paint. |
| **Collapse/expand state** (`collapsedNodes`, `pinnedNodes` Sets in DocumentState) | Held in **parent** state, not child — already accessed via reactive accessors per existing comment at line 449. Re-mount during scroll preserves state. |
| **Tool-pin overlay portal** (Tool blocks render `<Portal>` to body when pinned, measure via getBoundingClientRect) | Items in the virtual window have valid refs. Pinning a tool that's in the visible region works. Off-screen pin is not a user-reachable action (the pin button is on the row, which means the row is visible). |
| **Truncate-suppression grace window** (5000ms post-SessionStart in reducer) | View-only change — reducer logic untouched. |
| **DOM export / copy via getSelection()** | Native selection unaffected by re-mount of off-screen items. |
| **scrollMargin for loading-older banner / auth-url box** | `scrollMargin` getter reads `virtualContainerRef.offsetTop` so virtualizer scroll math accounts for content rendered above the virtual list. |
| **`<For>` keying of virtualItems** | `getItemKey: (idx) => document()[idx]?.id` provides stable keys across reorder/prepend; SolidJS For's reference identity is stable when the underlying nodes don't change. |

## Untested scenarios I want reviewers to flag

- **Very long pinned tool block with code diff inside.** measureElement should settle to the full expanded height after one frame, but if the inner DiffViewer mounts async (Suspense, dynamic import, or its own virtualization), the measure might shoot up after several frames. Smoke this with a long bash output that's pinned-open.
- **Prepend-while-scrolling** — user scrolls toward top, history loads, then user keeps scrolling before the rAF anchor restore fires. The anchor logic is correct but the brief frame between prepend and anchor-restore could show jump.
- **Search-jump to a node deep in history** — the new `findIndex(node.id)` does an O(n) scan; at 2000 nodes it's fast but worth confirming.

## Local smoke

Type-check passes. Local dev smoke deferred — ran in a `git worktree` so I didn't disrupt the user's running test session for #772. Would appreciate a smoke pass from a reviewer with a long agent session.

## Cross-references

- Agent pane perf report (driving doc): not in repo, summary in PR description.
- Issue 4 (the relevant excerpt): "No DOM virtualization in AgentDocumentView. SolidJS `<For>` is fine-grained but does not remove DOM nodes for off-screen items. With `content-visibility: auto`, the browser skips painting off-screen nodes but still maintains them in the layout tree and retains their JS closures."
- Tab-switch mark coverage (PR #772) — measures the user-perceived switch cost this PR is trying to reduce. After both land, the same long-task instrumentation will show whether the agent-pane reflow on tab-switch drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)