### PR TITLE
docs: align README + CLAUDE.md with current widget catalog and providers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,16 +84,30 @@ This means:
 
 Widgets are defined in `agentmux-srv/src/config/widgets.json`. These are the **only** widget types — do not invent or reference widgets that don't exist here.
 
-| Widget Key | View | Label | Opens in Pane? |
-|------------|------|-------|----------------|
-| `defwidget@agent` | `agent` | agent | Yes |
-| `defwidget@browser` | `browser` | browser | Yes |
-| `defwidget@editor` | `editor` | editor | Yes |
-| `defwidget@swarm` | `swarm` | swarm | Yes (hidden by default) |
-| `defwidget@terminal` | `term` | terminal | Yes |
-| `defwidget@sysinfo` | `sysinfo` | sysinfo | Yes |
-| `defwidget@help` | `help` | help | Yes |
-| `defwidget@devtools` | `devtools` | devtools | No — toggles browser inspector |
+The widget bar's visibility logic is in `frontend/app/window/action-widgets.tsx`: pinned widgets (`"display:pinned": true`) appear directly in the bar; everything else lives in the **More** dropdown. Both tiers are user-facing.
+
+| Widget Key | View | Label | Tier |
+|------------|------|-------|------|
+| `defwidget@agent` | `agent` | agent | Pinned |
+| `defwidget@browser` | `browser` | browser | Pinned |
+| `defwidget@terminal` | `term` | terminal | Pinned |
+| `defwidget@sysinfo` | `sysinfo` | sysinfo | Pinned |
+| `defwidget@devtools` | `devtools` | devtools | Pinned (toggles Chromium DevTools — does not open a pane) |
+| `defwidget@editor` | `editor` | editor | More dropdown |
+| `defwidget@swarm` | `swarm` | swarm | More dropdown |
+| `defwidget@help` | `help` | help | More dropdown |
+
+### Not widgets
+
+These views exist in the codebase but are **not** widget-bar entries — do not describe them as widgets to users:
+
+| Surface | How it's reached |
+|---|---|
+| **Forge** | Tab inside an Agent pane (cog → settings panel → Forge tab). Folded into the agent pane in v0.33.197 — old `forge` blocks are redirected to `agent` by `block.tsx`. |
+| **Identity** | Tab inside an Agent pane (cog → settings panel → Identity tab). The `view: "identity"` registration and `IdentityPaneViewModel` exist for `pane.open` RPC and right-click menu paths; no widget-bar entry. |
+| **Memory** | Same shape as Identity — tab inside an Agent pane, view registered for programmatic access only. |
+| **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in the user's default editor. |
+| **Subagent** | Spawned by clicking a sub-agent in the Swarm pane's overview. Not a top-level pane type the user opens directly. |
 
 ---
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.740"
+version = "0.33.741"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.740"
+version = "0.33.741"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.740"
+version = "0.33.741"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.740"
+version = "0.33.741"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ Cross-platform (Windows, macOS, Linux). 100% Rust backend (Tokio + Axum). CEF ho
 - **Live agent monitoring** — Watch every tool call and decision step as it happens. Catch an agent undoing correct work mid-task and redirect it before the damage compounds.
 - **Multi-agent orchestration** — Run parallel agents and see all of them at once. Spot conflicts before synthesis. Redirect any agent without killing the others.
 - **Guardrail observability** — See which constraints are active and firing. Tune your agent system from live signal, not post-mortem guesswork.
-- **Multi-provider agent support** — Claude Code, Codex CLI, and Gemini CLI as first-class providers, alongside terminals, editor, browser, and system metrics.
-- **Forge widget** — Agent picker wired to live Forge data for orchestration workflows.
-- **App API** — Local WebSocket RPC so external tools and agents can open panes, send messages, and read output. See [`docs/api/getting-started.md`](./docs/api/getting-started.md).
+- **Multi-provider agent support** — Claude Code, Codex CLI, Gemini CLI, OpenClaw, Kimi Code CLI, GitHub Copilot CLI, and Pi as first-class providers, alongside terminals, editor, browser, and system metrics.
+- **Identity bundles** — Named credential sets (GitHub PAT, AWS profile, Anthropic key, etc.) that you assign per agent at launch. Survives renames; swappable without restart.
+- **Memory bundles** — Reusable agent personality + capability stacks (provider, model, instructions, MCP, skills). Manage via the Memory pane inside an Agent pane's settings; launch-modal selection arrives with the spawn-time content-injection layer (PR-F.4).
+- **Browser pane** — Native `CefBrowserView` embedded as a child window of the AgentMux frame — full Chromium fidelity (links, popups, DRM) without iframe limitations.
+- **App API** — Local WebSocket RPC with both an intent-based layer (`agent.open`, `agent.send`, `pane.open`) and a low-level command catalog (block, file, event, conn). External tools and agents can drive the host directly.
+- **Audited dispatch** — 4-layer reducer stack (launcher / host / sidecar / frontend slices) with structured event logs at every layer, so "what mutated this state?" has exactly one place to look.
 - **Drag and drop** — Rearrange panes by dragging headers, reorder tabs, drag panes and tabs across windows.
 - **Per-pane zoom** — Independent zoom level per pane, plus global chrome zoom.
 - **Real PTY support** — Authentic terminal emulation via xterm.js and portable-pty.
@@ -64,25 +67,34 @@ task dev           # CEF host + Vite hot reload
 
 ```bash
 task package           # Portable ZIP for the host platform
-task package:macos     # macOS DMG
-task package:linux     # Linux AppImage / deb
-task package:msix      # Windows MSIX installer
+task package:linux     # Linux AppImage (writes to ~/Desktop)
 ```
+
+`task package:macos` and `task package:msix` are TODO stubs in `Taskfile.yml`. The full release artifact set is produced by `agentmuxai/agentmux-builder` — see §Releases below.
 
 ## Widgets
 
-Available from the top bar (right side) or the window header right-click menu:
+The widget bar shows pinned widgets directly; the rest live in a **More** dropdown. Pin/unpin any widget by right-clicking it. The canonical list is `agentmux-srv/src/config/widgets.json`.
 
-| Widget | Icon | Description |
-|--------|------|-------------|
-| **Agent** | sparkles | AI agent with streaming output and tool execution |
-| **Forge** | hammer | Create and manage your agents |
-| **Swarm** | bee | Multi-agent orchestration |
-| **Terminal** | square-terminal | Terminal with xterm.js and real PTY |
-| **Sysinfo** | chart-line | Live system metrics (CPU, memory, network, disk) |
-| **Settings** | cog | Open settings in external editor |
-| **Help** | circle-question | Built-in documentation and help |
-| **DevTools** | code | Toggle WebView developer tools |
+| Widget | Icon | View | Description | Tier |
+|--------|------|------|-------------|------|
+| **Agent** | sparkles | `agent` | AI agent with streaming output and tool execution | Pinned |
+| **Browser** | globe | `browser` | Embedded native `CefBrowserView` | Pinned |
+| **Terminal** | square-terminal | `term` | Terminal with xterm.js and real PTY | Pinned |
+| **Sysinfo** | chart-line | `sysinfo` | Live system metrics (CPU, memory, network, disk) | Pinned |
+| **DevTools** | code | `devtools` | Toggle Chromium DevTools (does not open a pane) | Pinned |
+| **Editor** | file-code | `editor` | Code editor with syntax highlighting | More |
+| **Swarm** | bee | `swarm` | Multi-agent orchestration overview | More |
+| **Help** | circle-question | `help` | Built-in documentation and help | More |
+
+### Not widgets — opened from elsewhere
+
+| Surface | How to reach it |
+|---|---|
+| **Forge** | Tab inside an Agent pane (cog → settings → Forge). Configure the agent's provider, soul, instructions, MCP, env. |
+| **Identity** | Tab inside an Agent pane (cog → settings → Identity). Manage the credential bundle assigned to this instance. |
+| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle. |
+| **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in your default editor. |
 
 ## Agents
 
@@ -124,29 +136,48 @@ ws.send(JSON.stringify({
 
 ## Architecture
 
+AgentMux is a four-process desktop app. Each process owns one concern, end-to-end. See [Architecture overview](https://docs.agentmux.ai/architecture-overview/) for the full topology.
+
 ```
-                    ┌─────────────────────────────────┐
-                    │           Frontend               │
-                    │   SolidJS + xterm.js             │
-                    └──────────────────┬───────────────┘
-                                       │
-                    ┌──────────────────▼───────────────┐
-                    │           CEF Host                │
-                    │   Bundled Chromium 146 (cef-rs)   │
-                    │   IPC bridge + window management  │
-                    └──────────────────┬───────────────┘
-                                       │
-                    ┌──────────────────▼───────────────┐
-                    │       Backend Sidecar             │
-                    │   agentmux-srv (Rust)           │
-                    │   Tokio + Axum + SQLite           │
-                    │   terminals, WebSocket, RPC       │
-                    └──────────────────────────────────┘
+┌──────────────────┐        named pipe        ┌──────────────────┐
+│  agentmux-       │ ◀────────────────────────▶│  agentmux-cef    │
+│  launcher        │                          │  (the "host")    │
+│  (≈325 KB shim)  │                          │                  │
+└────────┬─────────┘                          └────────┬─────────┘
+         │ spawns                                      │ embeds
+         │                                             ▼
+         │                                      ┌──────────────────┐
+         │                                      │  Chromium 146    │
+         │                                      │  (CEF renderer)  │
+         │                                      └────────┬─────────┘
+         │                                               │ JS bridge
+         │                                               ▼
+         │                                      ┌──────────────────┐
+         │                                      │  SolidJS app     │
+         │                                      │  (the frontend)  │
+         │                                      └────────┬─────────┘
+         │                                               │ websocket
+         ▼                                               ▼
+┌─────────────────────────────────────────────────────────┐
+│                     agentmux-srv                         │
+│                       (sidecar)                          │
+│   • RPC engine (websocket)   • SQLite persistence        │
+│   • saga coordinator         • event bus                 │
+└─────────────────────────────────────────────────────────┘
 ```
 
+| Process | Crate | Role |
+|---|---|---|
+| **launcher** | `agentmux-launcher` | Sets DLL search path; spawns the host; tracks Window Reality Reconciliation; durable event log for OS-level facts. |
+| **host** | `agentmux-cef` | Embeds Chromium via CEF; owns the OS window, the browser panes, the JS bridge, and IPC fan-out to the renderer. |
+| **sidecar** | `agentmux-srv` | App domain: workspaces, tabs, blocks, layouts, agents, identity. Persists to SQLite. Auto-spawned by the host on a dynamic port. |
+| **renderer** | `frontend/` | SolidJS UI running inside CEF. Stateless — projects what the sidecar/host expose, dispatches user actions back through them. |
+
+A fifth crate, `agentmux-common`, provides shared utilities (path resolution, runtime mode detection) consumed by all the above.
+
 **Stack:**
-- **Frontend:** SolidJS + TypeScript + Vite (state via SolidJS signals)
-- **Desktop:** CEF 146 via cef-rs — bundles its own Chromium (~148 MB ZIP, ~150 ms startup)
+- **Frontend:** SolidJS + TypeScript + Vite (state via SolidJS signals + a 4-layer reducer stack)
+- **Desktop:** CEF 146 via cef-rs — bundles its own Chromium (~148 MB ZIP package, ~150 ms startup, 150–350 MB resident)
 - **Backend:** Rust (Tokio + Axum + SQLite + portable-pty)
 - **Terminal:** xterm.js
 
@@ -165,9 +196,14 @@ ws.send(JSON.stringify({
 
 ### Build Outputs
 
-| Platform | Artifact |
-|----------|----------|
-| **Windows** | `dist/agentmux-cef-*-x64-portable.zip` |
+Local build outputs from `task package` on the host platform:
+
+| Platform | Task | Artifact |
+|----------|------|----------|
+| **Windows** | `task package` | `dist/agentmux-cef-*-x64-portable.zip` |
+| **Linux** | `task package:linux` | `~/Desktop/AgentMux_*_amd64.AppImage` |
+
+Other platform tasks (`task package:macos`, `task package:msix`) are TODO stubs in `Taskfile.yml`. The full release artifact set (macOS DMG, Windows installer, Windows MSIX, Linux .deb) is produced by [`agentmuxai/agentmux-builder`](https://github.com/agentmuxai/agentmux-builder) — see [§Releases](#releases) for the artifact catalog.
 
 ## Version Management
 

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.740"
+version = "0.33.741"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.740"
+version = "0.33.741"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.740"
+version = "0.33.741"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.740"
+version = "0.33.741"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.740",
+  "version": "0.33.741",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.740",
+      "version": "0.33.741",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.740",
+  "version": "0.33.741",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Brings README and CLAUDE.md in sync with the user-visible widget catalog (per the visibility logic in \`frontend/app/window/action-widgets.tsx\`) and with the canonical provider registry at \`frontend/app/view/agent/providers/index.ts:PROVIDERS\`.

**Replaces #771** — that PR was based on the \`agent1/widget-catalog-cleanup-2026-05-09\` branch (now deleted after #770 merged) and was auto-closed. This branch is recreated against current \`main\`.

## What changed

### README.md

| Section | Change |
|---|---|
| §What AgentMux Does | Lists all 7 providers (was 3). Adds Identity bundles, Memory bundles (with PR-F.4 caveat that launch-modal picker is hidden until then), Browser pane, audited dispatch bullets. Drops "Forge widget" bullet. |
| §Quick Start → Production Build | Drops \`task package:macos\` and \`task package:msix\` (TODO stubs). Keeps \`task package:linux\`. |
| §Widgets | Replaces the 8-row table that mixed widgets with non-widgets (Forge, Settings) with the actual user-visible catalog: 5 pinned + 3 in More. Adds a "Not widgets — opened from elsewhere" subsection covering Forge, Identity, Memory, Settings. |
| §Architecture | Replaces 3-process diagram with the canonical 4-process diagram (launcher / host / sidecar / renderer). Adds a process-role table and notes \`agentmux-common\` is a fifth shared crate. |
| §Stack | Clarifies package size (148 MB ZIP) vs runtime memory (150–350 MB resident). |
| §Build Outputs | Corrected to reflect what \`task package:*\` actually produces locally (Windows ZIP, Linux AppImage to \`~/Desktop\`). Full release artifact set (DMG, MSIX, .deb) noted as coming from \`agentmux-builder\`. |

### CLAUDE.md

| Section | Change |
|---|---|
| Widgets table | 8 rows organized by tier (Pinned vs More dropdown). Adds a paragraph explaining the visibility rule and pointing at \`action-widgets.tsx\`. |
| New "Not widgets" section | Enumerates Forge, Identity, Memory, Settings, Subagent and how each is reached. Stops Claude agents from suggesting "open the Memory widget" or "use the Settings widget" — those surfaces don't exist. |

### Version

Bumped 0.33.740 → 0.33.741.

## Verification

- [x] No claim that Forge or Settings is a widget anywhere in README/CLAUDE.md
- [x] All 7 providers (\`claude\`, \`codex\`, \`gemini\`, \`openclaw\`, \`kimi\`, \`copilot\`, \`pi\`) appear in README
- [x] Widget table count matches \`widgets.json\` (8 entries) and the \`getPinnedKeys\`/\`getMoreWidgets\` rules in \`action-widgets.tsx\`
- [x] Architecture diagram shows 4 processes, names match crate names
- [x] App API cross-references (\`docs/api/getting-started.md\`, \`docs/specs/app-api-extension.md\`, \`docs/specs/app-api-status.md\`) all exist on main
- [x] No \`task package:macos\` or \`task package:msix\` recommendations (those are TODO stubs)
- [x] Memory launch claim qualified with PR-F.4 caveat (matches \`AgentLaunchModal.tsx:240\` reality)

## Context

Part of the four-PR docs-alignment effort tracked in \`SPEC_DOCS_ALIGNMENT_2026_05_09.md\`. Already merged: #770 (widgets.json cleanup), agentmux-docs#12 (architecture alignment), agentmux-landing#85 (landing refresh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)