### PR TITLE
docs(readme,claude): drop Forge from "Not widgets" tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,9 +103,8 @@ These views exist in the codebase but are **not** widget-bar entries — do not 
 
 | Surface | How it's reached |
 |---|---|
-| **Forge** | Tab inside an Agent pane (cog → settings panel → Forge tab). Folded into the agent pane in v0.33.197 — old `forge` blocks are redirected to `agent` by `block.tsx`. |
 | **Identity** | Tab inside an Agent pane (cog → settings panel → Identity tab). The `view: "identity"` registration and `IdentityPaneViewModel` exist for `pane.open` RPC and right-click menu paths; no widget-bar entry. |
-| **Memory** | Same shape as Identity — tab inside an Agent pane, view registered for programmatic access only. |
+| **Memory** | Tab inside an Agent pane (cog → settings panel → Memory tab). Same shape as Identity — view registered for programmatic access only. Replaces the old Forge concept; `db_forge_agents` rows migrated into `db_memories` in the v7 schema. The `block.tsx` migration shim still redirects `view: "forge"` blocks to `view: "agent"` for backward compatibility. |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in the user's default editor. |
 | **Subagent** | Spawned by clicking a sub-agent in the Swarm pane's overview. Not a top-level pane type the user opens directly. |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.745"
+version = "0.33.746"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.745"
+version = "0.33.746"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.745"
+version = "0.33.746"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.745"
+version = "0.33.746"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ The widget bar shows pinned widgets directly; the rest live in a **More** dropdo
 
 | Surface | How to reach it |
 |---|---|
-| **Forge** | Tab inside an Agent pane (cog → settings → Forge). Configure the agent's provider, soul, instructions, MCP, env. |
 | **Identity** | Tab inside an Agent pane (cog → settings → Identity). Manage the credential bundle assigned to this instance. |
-| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle. |
+| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle (provider, model, instructions, MCP, skills). Replaces the old Forge concept — `db_forge_agents` rows migrated into `db_memories` in the v7 schema. |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in your default editor. |
 
 ## Agents
@@ -107,7 +106,7 @@ Each agent has two names:
 
 ### How to rename an agent
 
-1. Open the **Forge** widget (or hover an agent card in the Agent picker).
+1. Hover an agent card in the Agent picker.
 2. Click the ✏ pencil icon next to the agent's name.
 3. Type the new display name and press **Enter** (or click ✓). Press **Esc** to cancel.
 4. The picker card and any open pane titles update immediately.

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.745"
+version = "0.33.746"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.745"
+version = "0.33.746"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.745"
+version = "0.33.746"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.745"
+version = "0.33.746"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.745",
+  "version": "0.33.746",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.745",
+      "version": "0.33.746",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.745",
+  "version": "0.33.746",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Per \`docs/specs/identity-forge-integration-and-vault-2026-05-08.md\`:

> "There is no Forge concept anywhere — no entity, no tab, no widget. Forge becomes Memory. Existing \`db_forge_agents\` rows migrate into \`db_memories\`."

PR #770 / #775 left a stale Forge row in the "Not widgets" tables, and PR #771 still had "Open the Forge widget" in the §Agents rename recipe. This PR cleans both up.

## What changed

### README.md

- **§Not widgets — opened from elsewhere**: dropped the Forge row. The Memory row gains a sentence explaining it replaces the old Forge concept and references the v7 schema migration.
- **§How to rename an agent step 1**: "Open the Forge widget" → "Hover an agent card in the Agent picker." (Forge widget no longer exists; the rename UX is on the agent card itself.)

### CLAUDE.md

- **§Not widgets**: dropped the Forge row. The Memory row gains the same historical-reference sentence, plus a note that the migration shim in \`block.tsx\` still redirects \`view: "forge"\` blocks to \`view: "agent"\` for backward compatibility (so old workspaces keep loading).

## Verification

- [x] \`bump verify\` passes (\`0.33.745\` → \`0.33.746\`)
- [x] \`grep -n "Forge\\|forge" README.md CLAUDE.md\` returns only intentional historical-reference mentions ("Replaces the old Forge concept", "\`db_forge_agents\` rows migrated into \`db_memories\`", \`view: "forge"\` migration shim)

## Context

Companion to docs PR agentmuxai/agentmux-docs#13 (the docs reorg also cleared stale Forge link anchors in the public docs). This source-repo PR is the equivalent cleanup for README and the agent-facing CLAUDE.md.

Out of scope:
- Deeper "Forge as concept" rewrite in agentmux-docs (sections like "Open The Forge" in quickstart.md, "Create an Agent in The Forge" in first-agent.md, "Memory vs the Forge" in memory.md). Those are user-facing narrative — separate follow-up PR.
- Single \`interpane\` reference in \`specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md\` — historical spec, low priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)