### PR TITLE
docs(spec): rename "Interpane coordination" → "Interagent coordination"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.746"
+version = "0.33.747"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.746"
+version = "0.33.747"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.746"
+version = "0.33.747"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.746"
+version = "0.33.747"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.746"
+version = "0.33.747"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.746"
+version = "0.33.747"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.746"
+version = "0.33.747"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.746"
+version = "0.33.747"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.746",
+  "version": "0.33.747",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.746",
+      "version": "0.33.745",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.746",
+  "version": "0.33.747",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md
+++ b/specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md
@@ -138,7 +138,7 @@ ForgeAgent(slug="agentx-pr-455-fork", parent_id="agentx-id")   ← branched defi
     └─ Instance C  [block:pane-2, running, parent_instance_id: Instance A]
 ```
 
-- **Interpane coordination:** `db_agent_instances.block_id` lets the bus know which pane
+- **Interagent coordination:** `db_agent_instances.block_id` lets the bus know which pane
   an instance lives in; broadcast messages can target by `definition_id` (all instances of
   this agent) or `instance_id` (specific one)
 - **GitHub async:** `github_context` on the instance (not the definition) captures what


### PR DESCRIPTION
## Summary

Per the user-direction terminology change rolled out in agentmuxai/agentmux-docs#13 and agentmuxai/agentmux-landing#86: "interpane" describes the mechanism (panes), "interagent" describes the feature (agents). One straggler reference in \`specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md\` (a historical spec) updated for consistency.

## What changed

| File | Change |
|---|---|
| \`specs/SPEC_FORGE_IDENTITY_AGENT_INSTANCES_2026_04_20.md:141\` | "Interpane coordination" → "Interagent coordination" — single bullet in the agent-instance bus section. The mechanism described (\`block_id\`-based pane lookup for the bus) hasn't changed; this is purely a terminology rename. |

## Version bump

\`0.33.745\` → \`0.33.747\` (skipping \`0.33.746\` which is reserved by #776). When #776 merges first, main goes to .746; this PR's .747 is the next consecutive version. If #776 lands second, this PR will need a rebase.

## Verification

- [x] \`grep -rn -i "interpane"\` across the source repo (specs, docs, frontend, agentmux-srv, agentmux-cef, agentmux-launcher, agentmux-common, README.md, CLAUDE.md) returns nothing.

## Context

Last "interpane" reference anywhere across the three AgentMux repos. Was deferred from the docs/landing rename PRs since this is a historical spec — low priority but worth closing out for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)