### PR TITLE
revert: virtualize AgentDocumentView (#773) — redesign in spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.747"
+version = "0.33.748"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.747"
+version = "0.33.748"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.747"
+version = "0.33.748"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.747"
+version = "0.33.748"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.747"
+version = "0.33.748"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.747"
+version = "0.33.748"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.747"
+version = "0.33.748"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.747"
+version = "0.33.748"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -12,7 +12,6 @@
  */
 
 import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
-import { createVirtualizer } from "@tanstack/solid-virtual";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
@@ -59,35 +58,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     const [document] = documentAtom;
     const [documentState, setDocumentState] = documentStateAtom;
     let scrollRef!: HTMLDivElement;
-    let virtualContainerRef: HTMLDivElement | undefined;
     let autoScroll = true;
     // Guard against concurrent older-history fetches triggered by scroll
     let loadingOlderInFlight = false;
-
-    // Virtualizer over the document nodes. Replaces the old <For> that
-    // mounted every node in flow with content-visibility: auto. With
-    // long sessions (500-2000+ nodes) the layout tree alone was 8MB+ per
-    // pane and a tab-switch reflow stalled for 200ms+. Virtualization
-    // keeps only ~visible-window + overscan items in the DOM.
-    //
-    // estimateSize = 80 matches the old contain-intrinsic-size hint;
-    // measureElement re-measures actual heights via ResizeObserver as
-    // each item paints, so dynamic content (tool blocks, code diffs)
-    // settles to its real size after one frame.
-    //
-    // scrollMargin reads the virtual container's offsetTop so the
-    // loading-older banner and auth-url box (rendered as siblings above
-    // the virtualizer container) don't break scroll math.
-    const virtualizer = createVirtualizer({
-        get count() { return document().length; },
-        getScrollElement: () => scrollRef,
-        estimateSize: () => 80,
-        overscan: 5,
-        getItemKey: (index) => document()[index]?.id ?? index,
-        get scrollMargin() {
-            return virtualContainerRef?.offsetTop ?? 0;
-        },
-    });
 
     // Scroll to a node by its data-node-id attribute.
     // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
@@ -107,12 +80,16 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     // See docs/analysis/agent-pane-rich-features-structure-2026-04-13.md §1.
     const scrollToNode = (nodeId: string) => {
         if (!scrollRef) return;
-        // Under virtualization the target node may not be in the DOM
-        // until we scroll its index into the virtual window. Look up the
-        // index first; align="center" matches the old centering math.
-        const idx = document().findIndex((n) => n.id === nodeId);
-        if (idx < 0) return;
-        virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
+        const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
+        if (!el) return;
+        const elRect = el.getBoundingClientRect();
+        const containerRect = scrollRef.getBoundingClientRect();
+        // Top of el relative to scrollRef's content origin
+        const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
+        // Center the element in the visible region
+        const centerOffset =
+            offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
+        scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
         // Disable auto-scroll after a manual jump
         autoScroll = false;
     };
@@ -143,9 +120,7 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     const jumpToBottom = () => {
         if (!scrollRef) return;
         autoScroll = true;
-        const last = document().length - 1;
-        if (last < 0) return;
-        virtualizer.scrollToIndex(last, { align: "end", behavior: "auto" });
+        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "instant" });
     };
 
     if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
@@ -204,10 +179,9 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     let scrollRafId: number | null = null;
 
     const scrollToBottom = () => {
-        if (!autoScroll || !scrollRef) return;
-        const last = document().length - 1;
-        if (last < 0) return;
-        virtualizer.scrollToIndex(last, { align: "end", behavior: "auto" });
+        if (autoScroll && scrollRef) {
+            scrollRef.scrollTop = scrollRef.scrollHeight;
+        }
     };
 
     // Scroll when the document changes — throttled to one RAF per batch.
@@ -240,26 +214,17 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
             !loadingOlderInFlight &&
             !(loadingOlder?.())
         ) {
-            // Anchor by node id, not pixels. Pre-virtualization we
-            // computed the new scrollTop from the snapshot scrollHeight
-            // delta — but with measured virtual heights that delta is
-            // unreliable until every newly-rendered item has been laid
-            // out by the ResizeObserver. Re-anchoring to the same node's
-            // index after prepend is exact regardless of measurement
-            // settle time.
-            const items = virtualizer.getVirtualItems();
-            const anchorId = items.length > 0 ? document()[items[0].index]?.id : null;
+            // Snapshot scroll anchor before content is prepended
+            const snapshotScrollHeight = scrollHeight;
+            const snapshotScrollTop = scrollTop;
             loadingOlderInFlight = true;
             onLoadOlder().then(() => {
+                // Restore scroll position so the user's viewport doesn't jump.
+                // Use a RAF so the DOM has updated with the new nodes first.
                 requestAnimationFrame(() => {
-                    if (anchorId != null) {
-                        const newIdx = document().findIndex((n) => n.id === anchorId);
-                        if (newIdx >= 0) {
-                            virtualizer.scrollToIndex(newIdx, {
-                                align: "start",
-                                behavior: "auto",
-                            });
-                        }
+                    if (scrollRef) {
+                        scrollRef.scrollTop =
+                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
                     }
                     loadingOlderInFlight = false;
                 });
@@ -359,177 +324,120 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
                 }}
             </Show>
 
-            {/* Virtualized document nodes. The container takes the full
-                virtual height (sum of all measured/estimated item sizes)
-                so the native scrollbar reflects total content. Each item
-                is absolute-positioned via translateY; only the visible
-                window + overscan are mounted in the DOM. measureElement
-                hooks ResizeObserver to re-measure dynamic-height items
-                (tool blocks expanding, code diffs, etc.) after first
-                paint, so the estimate (80px) is just the initial guess. */}
-            <div
-                ref={(el) => { virtualContainerRef = el; }}
-                class="agent-document-virtualizer"
-                style={{
-                    height: `${virtualizer.getTotalSize()}px`,
-                    position: "relative",
-                    width: "100%",
-                }}
-            >
-                <For each={virtualizer.getVirtualItems()}>
-                    {(virtualItem) => {
-                        // Reactive accessor — re-reads document() on every
-                        // call so streaming updates (StreamFlush replacing a
-                        // node at the same index) reach the row even when
-                        // the row stays mounted across renders. Capturing
-                        // node as a const here would freeze the row's view
-                        // of the document at first render. (codex P1)
-                        const node = () => document()[virtualItem.index];
-                        const isBookmarked = () => {
-                            const n = node();
-                            return n ? (bookmarkedNodeIds?.().has(n.id) ?? false) : false;
-                        };
-                        const canExpand = () => {
-                            const t = node()?.type;
-                            switch (t) {
-                                case "tool":
-                                case "agent_message":
-                                case "user_message":
-                                case "section":
-                                    return true;
-                                default:
-                                    return false;
-                            }
-                        };
-                        const isExpanded = () => {
-                            const n = node();
-                            if (n == null) return false;
-                            if (n.type === "tool") return documentState().pinnedNodes.has(n.id);
-                            return !documentState().collapsedNodes.has(n.id);
-                        };
-                        const onExpand = () => {
-                            const n = node();
-                            if (n == null) return;
-                            if (n.type === "tool") togglePin(n.id);
-                            else toggleCollapse(n.id);
-                        };
-                        // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
-                        const onOpenInNewPane = () => {
-                            if (node()?.type === "tool") {
-                                console.warn("[hover-strip] open in new pane — not yet implemented");
-                            }
-                        };
-                        const onOpenInNewWindow = () =>
-                            console.warn("[hover-strip] open in new window — not yet implemented");
-                        const onNewAgentFromHere = () =>
-                            console.warn("[hover-strip] new agent from here — not yet implemented");
+            {/* Document nodes render below log lines.
+                `content-visibility: auto` on the wrapper lets the browser
+                skip layout/paint for off-screen nodes — critical for
+                long sessions where thousands of DOM elements accumulate. */}
+            <For each={document()}>
+                {(node) => {
+                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
+                    const canExpand = () => {
+                        switch (node.type) {
+                            case "tool":
+                            case "agent_message":
+                            case "user_message":
+                            case "section":
+                                return true;
+                            default:
+                                return false;
+                        }
+                    };
+                    const isExpanded = () => {
+                        if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
+                        return !documentState().collapsedNodes.has(node.id);
+                    };
+                    const onExpand = () => {
+                        if (node.type === "tool") togglePin(node.id);
+                        else toggleCollapse(node.id);
+                    };
+                    // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
+                    const onOpenInNewPane = node.type === "tool"
+                        ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
+                        : undefined;
+                    const onOpenInNewWindow = () =>
+                        console.warn("[hover-strip] open in new window — not yet implemented");
+                    const onNewAgentFromHere = () =>
+                        console.warn("[hover-strip] new agent from here — not yet implemented");
 
-                        const handleRowKey = (e: KeyboardEvent): void => {
-                            if (e.metaKey || e.ctrlKey || e.altKey) return;
-                            const n = node();
-                            if (n == null) return;
-                            switch (e.key.toLowerCase()) {
-                                case "e":
-                                    if (canExpand()) { onExpand(); e.preventDefault(); }
-                                    break;
-                                case "b":
-                                    if (onBookmark != null) { onBookmark(n); e.preventDefault(); }
-                                    break;
-                                case "p":
-                                    if (n.type === "tool") { onOpenInNewPane(); e.preventDefault(); }
-                                    break;
-                                case "w":
-                                    onOpenInNewWindow(); e.preventDefault();
-                                    break;
-                                case "n":
-                                    onNewAgentFromHere(); e.preventDefault();
-                                    break;
-                                case "escape":
-                                    (e.currentTarget as HTMLElement).blur();
-                                    e.preventDefault();
-                                    break;
-                            }
-                        };
+                    const handleRowKey = (e: KeyboardEvent): void => {
+                        if (e.metaKey || e.ctrlKey || e.altKey) return;
+                        switch (e.key.toLowerCase()) {
+                            case "e":
+                                if (canExpand()) { onExpand(); e.preventDefault(); }
+                                break;
+                            case "b":
+                                if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
+                                break;
+                            case "p":
+                                if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
+                                break;
+                            case "w":
+                                onOpenInNewWindow(); e.preventDefault();
+                                break;
+                            case "n":
+                                onNewAgentFromHere(); e.preventDefault();
+                                break;
+                            case "escape":
+                                (e.currentTarget as HTMLElement).blur();
+                                e.preventDefault();
+                                break;
+                        }
+                    };
 
-                        const handleContextMenu = (e: MouseEvent) => {
-                            if (!onBookmark) return;
-                            const sel = window.getSelection()?.toString();
-                            if (sel) return;
-                            const n = node();
-                            if (n == null) return;
-                            e.preventDefault();
-                            e.stopPropagation();
-                            ContextMenuModel.showContextMenu(
-                                [
-                                    {
-                                        label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
-                                        click: () => onBookmark(n),
-                                    },
-                                ],
-                                e,
-                            );
-                        };
-
-                        return (
-                            <div
-                                ref={(el) => virtualizer.measureElement(el)}
-                                data-index={virtualItem.index}
-                                data-node-id={node()?.id}
-                                class="hover-strip-host agent-document-node-wrapper"
-                                classList={{
-                                    "agent-node-bookmarked": isBookmarked(),
-                                    "agent-node-search-match": (() => {
-                                        const id = node()?.id;
-                                        return id != null && highlightNodeId?.() === id;
-                                    })(),
-                                }}
-                                style={{
-                                    position: "absolute",
-                                    top: "0",
-                                    left: "0",
-                                    width: "100%",
-                                    // Subtract scrollMargin so when an
-                                    // auth box / loading-older banner pushes
-                                    // the virtualizer container down,
-                                    // virtualItem.start (which already
-                                    // includes the margin) lands rows at the
-                                    // right offset within the container.
-                                    // (codex P2)
-                                    transform: `translateY(${virtualItem.start - virtualizer.options.scrollMargin}px)`,
-                                }}
-                                tabindex="0"
-                                onKeyDown={handleRowKey}
-                                onContextMenu={handleContextMenu}
-                            >
-                                <Show when={node()}>
-                                    {(n) => (<>
-                                <DocumentNodeRenderer
-                                    node={n()}
-                                    collapsed={documentState().collapsedNodes.has(n().id)}
-                                    onToggle={() => toggleCollapse(n().id)}
-                                    toolPinned={documentState().pinnedNodes.has(n().id)}
-                                    onToggleToolPin={() => togglePin(n().id)}
-                                    onSubagentClick={onSubagentClick}
-                                />
-                                <NodeHoverStrip
-                                    timestamp={(n() as any).timestamp}
-                                    nodeId={n().id}
-                                    isBookmarked={isBookmarked()}
-                                    onBookmark={onBookmark != null ? () => onBookmark(n()) : undefined}
-                                    canExpand={canExpand()}
-                                    isExpanded={isExpanded()}
-                                    onExpand={onExpand}
-                                    onOpenInNewPane={n().type === "tool" ? onOpenInNewPane : undefined}
-                                    onOpenInNewWindow={onOpenInNewWindow}
-                                    onNewAgentFromHere={onNewAgentFromHere}
-                                />
-                                    </>)}
-                                </Show>
-                            </div>
+                    const handleContextMenu = (e: MouseEvent) => {
+                        if (!onBookmark) return;
+                        // Don't show bookmark menu on top of text selections — let the parent handle those.
+                        const sel = window.getSelection()?.toString();
+                        if (sel) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        ContextMenuModel.showContextMenu(
+                            [
+                                {
+                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                                    click: () => onBookmark(node),
+                                },
+                            ],
+                            e,
                         );
-                    }}
-                </For>
-            </div>
+                    };
+
+                    return (
+                        <div
+                            class="hover-strip-host agent-document-node-wrapper"
+                            classList={{
+                                "agent-node-bookmarked": isBookmarked(),
+                                "agent-node-search-match": highlightNodeId?.() === node.id,
+                            }}
+                            data-node-id={node.id}
+                            tabindex="0"
+                            onKeyDown={handleRowKey}
+                            onContextMenu={handleContextMenu}
+                        >
+                            <DocumentNodeRenderer
+                                node={node}
+                                collapsed={documentState().collapsedNodes.has(node.id)}
+                                onToggle={() => toggleCollapse(node.id)}
+                                toolPinned={documentState().pinnedNodes.has(node.id)}
+                                onToggleToolPin={() => togglePin(node.id)}
+                                onSubagentClick={onSubagentClick}
+                            />
+                            <NodeHoverStrip
+                                timestamp={(node as any).timestamp}
+                                nodeId={node.id}
+                                isBookmarked={isBookmarked()}
+                                onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
+                                canExpand={canExpand()}
+                                isExpanded={isExpanded()}
+                                onExpand={onExpand}
+                                onOpenInNewPane={onOpenInNewPane}
+                                onOpenInNewWindow={onOpenInNewWindow}
+                                onNewAgentFromHere={onNewAgentFromHere}
+                            />
+                        </div>
+                    );
+                }}
+            </For>
         </div>
     );
 };

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -98,29 +98,13 @@
         }
     }
 
-    .agent-document-virtualizer {
-        // Container for the @tanstack/solid-virtual list. Children are
-        // absolute-positioned via translateY; the height equals the
-        // virtualizer's getTotalSize() so the native scrollbar reflects
-        // the full virtual content. See AgentDocumentView.tsx.
-        //
-        // flex-shrink: 0 — the parent .agent-document is a column flex
-        // container, so without this the wrapper would shrink to fit
-        // the viewport when getTotalSize() exceeds it. Absolutely-
-        // positioned children don't establish a content min-height to
-        // push back, so the scrollbar would lose access to off-screen
-        // messages. (codex P1)
-        position: relative;
-        width: 100%;
-        flex-shrink: 0;
-    }
-
     .agent-document-node-wrapper {
-        // Each document node is absolute-positioned by the virtualizer;
-        // `contain: layout style` isolates layout work to the item's box
-        // so a single message expanding (markdown image load, code-diff
-        // measure) doesn't reflow neighbors. content-visibility is no
-        // longer needed because off-screen items aren't in the DOM at all.
+        // Each document node gets its own containment box. Off-screen nodes
+        // are skipped by the browser via content-visibility.
+        // contain-intrinsic-size gives the browser a size estimate so scroll
+        // position stays stable when content is virtualized in/out.
+        content-visibility: auto;
+        contain-intrinsic-size: auto 80px;
         contain: layout style;
 
         &:focus {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@lobehub/icons-static-svg": "^1.90.0",
         "@observablehq/plot": "^0.6.17",
         "@solid-primitives/keyed": "^1.5.3",
-        "@tanstack/solid-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -3270,32 +3269,6 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
-      }
-    },
-    "node_modules/@tanstack/solid-virtual": {
-      "version": "3.13.24",
-      "resolved": "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.24.tgz",
-      "integrity": "sha512-sLGjpsAWLK8oxciqN+FNjs5JLs9N27DKwwoOPN8FMrmFMeXdiPQvRg3CqUAv8pYfXKD9KmcbhBxNwlmcP22a8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/virtual-core": "3.14.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "solid-js": "^1.3.0"
-      }
-    },
-    "node_modules/@tanstack/virtual-core": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
-      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.747",
+  "version": "0.33.748",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.745",
+      "version": "0.33.748",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.747",
+  "version": "0.33.748",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@lobehub/icons-static-svg": "^1.90.0",
     "@observablehq/plot": "^0.6.17",
     "@solid-primitives/keyed": "^1.5.3",
-    "@tanstack/solid-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",


### PR DESCRIPTION
## Summary

Reverts PR #773 (\`@tanstack/solid-virtual\` retrofit on \`AgentDocumentView\`).

## Why

The retrofit introduced multiple regressions in interactive use:
- **Gaps between rows** — estimateSize dominates layout until measureElement settles; even after measurement, short messages get visible padding below.
- **Tables broken** — markdown tables inside absolute-positioned virtualizer rows lose their layout context (no width to constrain against; \`table-layout: auto\` overflows).
- **Streaming content cut off** — long thinking blocks render only the first word; the wrapper's height doesn't grow chunk-by-chunk.

The deeper problem isn't any one bug — it's that virtualization was bolted on after the fact. The original component assumed every node was in the DOM (querySelector for jump, pixel-math for pagination restore, natural flex flow with gap). Each of those needed a workaround. Each workaround introduced its own edges.

## What replaces it

A redesigned virtualization layer specced separately in `docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md` (filed alongside this revert). The redesign treats virtualization as a first-class architectural concern: per-kind size estimators, scroll state in data not DOM, hybrid render (last N items unvirtualized as the streaming buffer), CSS overflow-anchor, and integrated per-kind perf probing.

The perf measurements from #773's brief life are still useful — they confirm the win is real (long-task storms during tab-switch into agent panes drop substantially when the layout tree is bounded). The redesign keeps that win while addressing the layout/streaming issues structurally.

## Impact

- Agent pane returns to pre-virtualization behavior: full DOM with `content-visibility: auto`. The 200-300ms long-task storms during tab-switch return for long sessions until the redesign ships.
- Clean main; no half-broken behavior in users' hands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)