### PR TITLE
feat(virt): Phase 2 — virtualization layer + streaming buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.752"
+version = "0.33.753"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.751"
+version = "0.33.752"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.753"
+version = "0.33.754"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.751"
+version = "0.33.752"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.752"
+version = "0.33.753"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.753"
+version = "0.33.754"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.751"
+version = "0.33.752"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.753"
+version = "0.33.754"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.752"
+version = "0.33.753"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.752"
+version = "0.33.753"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.753"
+version = "0.33.754"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.751"
+version = "0.33.752"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -1,9 +1,17 @@
-// Copyright 2025, AgentMux Corp.
+// Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentDocumentView — Renders the styled document as a list of DocumentNodes.
- * Routes each node type to the appropriate block component.
+ * AgentDocumentView — owns the agent pane's data state interface
+ * (collapsed/pinned toggles, auto-collapse policy, auth-url and
+ * loading-older banner), then delegates list rendering to
+ * AgentDocumentVirtualList (Phase 2 of the virtualization redesign,
+ * see docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md).
+ *
+ * All scroll behavior — stick-to-bottom, anchor capture, jump-to-node,
+ * pagination restore — lives in the VirtualList. This component is
+ * just glue between the existing AgentAtoms contract and that new
+ * component.
  *
  * Diagnostic / launch-flow logs used to render inline at the top of this
  * scroll area. That moved to the dedicated `<ActivityLogPanel>` docked
@@ -11,16 +19,12 @@
  * `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createEffect, createSignal, Show, type Accessor, type JSX } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
-import { AgentMessageBlock } from "./AgentMessageBlock";
-import { MarkdownBlock } from "./MarkdownBlock";
-import { NodeHoverStrip } from "./NodeHoverStrip";
-import { SubagentLinkBlock } from "./SubagentLinkBlock";
-import { ToolBlock } from "./ToolBlock";
-import { ContextMenuModel } from "@/app/store/contextmenu";
+import { AgentDocumentVirtualList } from "../virtualization/AgentDocumentVirtualList";
+import { createAgentViewState } from "../virtualization/state";
 
 interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;
@@ -39,91 +43,27 @@ interface AgentDocumentViewProps {
     onBookmark?: (node: DocumentNode) => void;
     /**
      * Signal-based jump command. The parent owns a `useScrollToNode`
-     * hook and passes its `command` accessor here; a createEffect
+     * hook and passes its `command` accessor here; the VirtualList
      * watches for changes and scrolls the target node into view.
-     * Replaces the old mutable `scrollToNodeRef` ref pattern.
      */
     scrollCommand?: Accessor<ScrollCommand | null>;
     /**
      * Expose a scrollToBottom function to the parent so the composer can
      * bring the document to the latest content when the user starts typing.
-     * Re-enables auto-scroll as a side effect.
+     * Re-engages stick-to-bottom as a side effect.
      */
     scrollToBottomRef?: (fn: () => void) => void;
     /** The node id of the currently highlighted search match (if any). */
     highlightNodeId?: Accessor<string | null>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, authProviderId, onSubagentClick, onLoadOlder, loadingOlder, bookmarkedNodeIds, onBookmark, scrollCommand, scrollToBottomRef, highlightNodeId }: AgentDocumentViewProps): JSX.Element => {
-    const [document] = documentAtom;
-    const [documentState, setDocumentState] = documentStateAtom;
-    let scrollRef!: HTMLDivElement;
-    let autoScroll = true;
-    // Guard against concurrent older-history fetches triggered by scroll
-    let loadingOlderInFlight = false;
+export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element => {
+    const [documentState, setDocumentState] = props.documentStateAtom;
 
-    // Scroll to a node by its data-node-id attribute.
-    // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
-    //
-    // We deliberately DO NOT use `el.scrollIntoView()` here. scrollIntoView
-    // walks every scrollable ancestor and scrolls each one until the target
-    // is inside its visible region — which in our pane/tab/window nesting
-    // scrolls the outer block frame, pushing the agent pane header and
-    // adjacent pane titles out of the viewport. The symptom is "pane titles
-    // disappear across the entire app when I click a bookmark" — a real bug
-    // reported against 0.33.106.
-    //
-    // Instead, compute the target element's top relative to scrollRef and
-    // set scrollRef.scrollTop directly. That scrolls ONLY the document
-    // container and leaves every ancestor untouched.
-    //
-    // See docs/analysis/agent-pane-rich-features-structure-2026-04-13.md §1.
-    const scrollToNode = (nodeId: string) => {
-        if (!scrollRef) return;
-        const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
-        if (!el) return;
-        const elRect = el.getBoundingClientRect();
-        const containerRect = scrollRef.getBoundingClientRect();
-        // Top of el relative to scrollRef's content origin
-        const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
-        // Center the element in the visible region
-        const centerOffset =
-            offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
-        scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
-        // Disable auto-scroll after a manual jump
-        autoScroll = false;
-    };
-
-    // React to jump commands emitted by the parent's useScrollToNode hook.
-    // We run the scroll inside our own effect (rather than exposing the
-    // function upward) so the mutable-ref pattern goes away and callers
-    // don't need to touch AgentDocumentView internals.
-    createEffect(() => {
-        const cmd = scrollCommand?.();
-        if (cmd) scrollToNode(cmd.nodeId);
-    });
-
-    // Jump to the bottom of the document and re-enable auto-scroll.
-    //
-    // Called by AgentFooter's onInput handler when the user starts typing, so
-    // their composer input is visually anchored to the latest content instead
-    // of floating offscreen at the bottom while older content sits above.
-    //
-    // Named `jumpToBottom` to distinguish from the existing `scrollToBottom`
-    // below, which is gated on `autoScroll` and only runs when new content
-    // arrives. This one is unconditional and also re-enables auto-scroll.
-    //
-    // Uses `Number.MAX_SAFE_INTEGER` instead of reading `scrollHeight` so we
-    // never force a synchronous layout on the keystroke hot path (PR #345's
-    // autoGrow regression was exactly that pattern). The browser clamps to
-    // the actual max internally during compositing.
-    const jumpToBottom = () => {
-        if (!scrollRef) return;
-        autoScroll = true;
-        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "instant" });
-    };
-
-    if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
+    // Phase 2: build the view state once per mount. Lifetime matches
+    // this component (not the agent ViewModel) — that's fine because
+    // scroll state is per-pane-mount, not per-agent-session.
+    const viewState = createAgentViewState(props.documentAtom);
 
     // Auto-collapse large user_messages on first arrival. The startup
     // session-context payload that `buildStartupPayload` sends is a huge
@@ -132,13 +72,13 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     // so we don't re-collapse after the user has explicitly expanded.
     const seenUserMessageIds = new Set<string>();
     createEffect(() => {
-        const doc = document();
+        const doc = viewState.nodes();
         const toCollapse: string[] = [];
         for (const n of doc) {
             if (n.type !== "user_message") continue;
             if (seenUserMessageIds.has(n.id)) continue;
             seenUserMessageIds.add(n.id);
-            const msg = (n as any).message ?? "";
+            const msg = (n as { message?: string }).message ?? "";
             if (msg.length > 200 || msg.includes("\n")) {
                 toCollapse.push(n.id);
             }
@@ -153,20 +93,17 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     });
 
     // Toggle collapsed state for collapsible nodes (agent messages, sections, user messages).
-    const toggleCollapse = (nodeId: string) => {
+    const toggleCollapse = (nodeId: string): void => {
         setDocumentState((prev) => {
             const collapsed = new Set(prev.collapsedNodes);
-            if (collapsed.has(nodeId)) {
-                collapsed.delete(nodeId);
-            } else {
-                collapsed.add(nodeId);
-            }
+            if (collapsed.has(nodeId)) collapsed.delete(nodeId);
+            else collapsed.add(nodeId);
             return { ...prev, collapsedNodes: collapsed };
         });
     };
 
     // Toggle the "pinned open" state for a tool node.
-    const togglePin = (nodeId: string) => {
+    const togglePin = (nodeId: string): void => {
         setDocumentState((prev) => {
             const pinned = new Set(prev.pinnedNodes);
             if (pinned.has(nodeId)) pinned.delete(nodeId);
@@ -175,363 +112,123 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
         });
     };
 
-    // Auto-scroll to bottom when new content arrives.
-    let scrollRafId: number | null = null;
-
-    const scrollToBottom = () => {
-        if (autoScroll && scrollRef) {
-            scrollRef.scrollTop = scrollRef.scrollHeight;
-        }
-    };
-
-    // Scroll when the document changes — throttled to one RAF per batch.
-    // Activity log no longer lives in this scroll container, so its
-    // length is no longer a trigger (that panel scrolls internally).
-    createEffect(() => {
-        const _docLen = document().length;
-        if (scrollRafId == null) {
-            scrollRafId = requestAnimationFrame(() => {
-                scrollRafId = null;
-                scrollToBottom();
-            });
-        }
-    });
-
-    onCleanup(() => {
-        if (scrollRafId != null) cancelAnimationFrame(scrollRafId);
-    });
-
-    // Detect if user scrolled up (disable auto-scroll) and trigger older-history load
-    const handleScroll = () => {
-        if (!scrollRef) return;
-        const { scrollTop, scrollHeight, clientHeight } = scrollRef;
-        autoScroll = scrollHeight - scrollTop - clientHeight < 200;
-
-        // Trigger older-history load when near the top
-        if (
-            onLoadOlder &&
-            scrollTop < 50 &&
-            !loadingOlderInFlight &&
-            !(loadingOlder?.())
-        ) {
-            // Snapshot scroll anchor before content is prepended
-            const snapshotScrollHeight = scrollHeight;
-            const snapshotScrollTop = scrollTop;
-            loadingOlderInFlight = true;
-            onLoadOlder().then(() => {
-                // Restore scroll position so the user's viewport doesn't jump.
-                // Use a RAF so the DOM has updated with the new nodes first.
-                requestAnimationFrame(() => {
-                    if (scrollRef) {
-                        scrollRef.scrollTop =
-                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
-                    }
-                    loadingOlderInFlight = false;
-                });
-            }).catch(() => {
-                loadingOlderInFlight = false;
-            });
-        }
-    };
-
-    return (
-        <div
-            class="agent-document"
-            ref={scrollRef}
-            onScroll={handleScroll}
-        >
-            {/* Older-history loading indicator — pinned at the very top */}
-            <Show when={loadingOlder?.()}>
+    // Header slot: loading-older banner + optional auth-url box,
+    // rendered above the virtualizer inside the scroll container.
+    // VirtualList's scrollMargin (=virtualContainerRef.offsetTop)
+    // handles the offset automatically.
+    const headerSlot = (): JSX.Element => (
+        <>
+            <Show when={props.loadingOlder?.()}>
                 <div class="agent-history-loading">Loading older messages...</div>
             </Show>
-
-            {/* OAuth code-paste box, rendered at top of conversation while a
-                login flow has a pending auth URL. Previously nested inside
-                `.agent-status-log` with the activity log lines; the log
-                moved to `<ActivityLogPanel>` above the composer, so the
-                auth box stays here on its own. */}
-            <Show when={authUrl?.()}>
-                {(url) => {
-                    const [pasteCode, setPasteCode] = createSignal("");
-                    const [pasting, setPasting] = createSignal(false);
-                    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
-
-                    const handleSubmitCode = async () => {
-                        const code = pasteCode().trim();
-                        if (!code) return;
-                        setPasting(true);
-                        setPasteResult(null);
-                        try {
-                            const { getApi } = await import("@/app/store/global");
-                            await getApi().setProviderAuth(authProviderId ?? "claude", code);
-                            setPasteResult("Code accepted — waiting for confirmation...");
-                            setPasteCode("");
-                        } catch (err: any) {
-                            setPasteResult(`Error: ${err?.message ?? String(err)}`);
-                        } finally {
-                            setPasting(false);
-                        }
-                    };
-
-                    return (
-                        <div class="agent-auth-url-box">
-                            <div class="agent-auth-url-label">Open this URL to log in:</div>
-                            <div class="agent-auth-url-row">
-                                <span class="agent-auth-url-text">{url()}</span>
-                                <button
-                                    class="agent-auth-url-copy"
-                                    onClick={() => { import("@/util/clipboard").then(c => c.writeText(url())); }}
-                                    title="Copy URL"
-                                >
-                                    Copy
-                                </button>
-                            </div>
-                            <div class="agent-auth-paste-row">
-                                <input
-                                    class="agent-auth-paste-input"
-                                    type="text"
-                                    placeholder="Paste auth code from Anthropic..."
-                                    value={pasteCode()}
-                                    onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
-                                    onKeyDown={(e) => { if (e.key === "Enter") void handleSubmitCode(); }}
-                                />
-                                <button
-                                    class="agent-auth-url-copy"
-                                    title="Paste from clipboard"
-                                    onClick={() => {
-                                        import("@/util/clipboard").then(c => c.readText()).then(text => {
-                                            if (text) setPasteCode(text.trim());
-                                        }).catch(() => {
-                                            setPasteResult("Could not read clipboard — paste manually");
-                                        });
-                                    }}
-                                >
-                                    Paste
-                                </button>
-                                <button
-                                    class="agent-auth-url-copy"
-                                    onClick={handleSubmitCode}
-                                    disabled={!pasteCode().trim() || pasting()}
-                                >
-                                    {pasting() ? "..." : "Submit"}
-                                </button>
-                            </div>
-                            <Show when={pasteResult()}>
-                                <div class="agent-auth-paste-result">{pasteResult()}</div>
-                            </Show>
-                        </div>
-                    );
-                }}
+            <Show when={props.authUrl?.()}>
+                {(url) => <AuthUrlBox url={url()} authProviderId={props.authProviderId} />}
             </Show>
+        </>
+    );
 
-            {/* Document nodes render below log lines.
-                `content-visibility: auto` on the wrapper lets the browser
-                skip layout/paint for off-screen nodes — critical for
-                long sessions where thousands of DOM elements accumulate. */}
-            <For each={document()}>
-                {(node) => {
-                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
-                    const canExpand = () => {
-                        switch (node.type) {
-                            case "tool":
-                            case "agent_message":
-                            case "user_message":
-                            case "section":
-                                return true;
-                            default:
-                                return false;
-                        }
-                    };
-                    const isExpanded = () => {
-                        if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
-                        return !documentState().collapsedNodes.has(node.id);
-                    };
-                    const onExpand = () => {
-                        if (node.type === "tool") togglePin(node.id);
-                        else toggleCollapse(node.id);
-                    };
-                    // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
-                    const onOpenInNewPane = node.type === "tool"
-                        ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
-                        : undefined;
-                    const onOpenInNewWindow = () =>
-                        console.warn("[hover-strip] open in new window — not yet implemented");
-                    const onNewAgentFromHere = () =>
-                        console.warn("[hover-strip] new agent from here — not yet implemented");
-
-                    const handleRowKey = (e: KeyboardEvent): void => {
-                        if (e.metaKey || e.ctrlKey || e.altKey) return;
-                        switch (e.key.toLowerCase()) {
-                            case "e":
-                                if (canExpand()) { onExpand(); e.preventDefault(); }
-                                break;
-                            case "b":
-                                if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
-                                break;
-                            case "p":
-                                if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
-                                break;
-                            case "w":
-                                onOpenInNewWindow(); e.preventDefault();
-                                break;
-                            case "n":
-                                onNewAgentFromHere(); e.preventDefault();
-                                break;
-                            case "escape":
-                                (e.currentTarget as HTMLElement).blur();
-                                e.preventDefault();
-                                break;
-                        }
-                    };
-
-                    const handleContextMenu = (e: MouseEvent) => {
-                        if (!onBookmark) return;
-                        // Don't show bookmark menu on top of text selections — let the parent handle those.
-                        const sel = window.getSelection()?.toString();
-                        if (sel) return;
-                        e.preventDefault();
-                        e.stopPropagation();
-                        ContextMenuModel.showContextMenu(
-                            [
-                                {
-                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
-                                    click: () => onBookmark(node),
-                                },
-                            ],
-                            e,
-                        );
-                    };
-
-                    return (
-                        <div
-                            class="hover-strip-host agent-document-node-wrapper"
-                            classList={{
-                                "agent-node-bookmarked": isBookmarked(),
-                                "agent-node-search-match": highlightNodeId?.() === node.id,
-                            }}
-                            data-node-id={node.id}
-                            tabindex="0"
-                            onKeyDown={handleRowKey}
-                            onContextMenu={handleContextMenu}
-                        >
-                            <DocumentNodeRenderer
-                                node={node}
-                                collapsed={documentState().collapsedNodes.has(node.id)}
-                                onToggle={() => toggleCollapse(node.id)}
-                                toolPinned={documentState().pinnedNodes.has(node.id)}
-                                onToggleToolPin={() => togglePin(node.id)}
-                                onSubagentClick={onSubagentClick}
-                            />
-                            <NodeHoverStrip
-                                timestamp={(node as any).timestamp}
-                                nodeId={node.id}
-                                isBookmarked={isBookmarked()}
-                                onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
-                                canExpand={canExpand()}
-                                isExpanded={isExpanded()}
-                                onExpand={onExpand}
-                                onOpenInNewPane={onOpenInNewPane}
-                                onOpenInNewWindow={onOpenInNewWindow}
-                                onNewAgentFromHere={onNewAgentFromHere}
-                            />
-                        </div>
-                    );
-                }}
-            </For>
-        </div>
+    return (
+        <AgentDocumentVirtualList
+            viewState={viewState}
+            documentState={documentState}
+            bookmarkedNodeIds={props.bookmarkedNodeIds}
+            onBookmark={props.onBookmark}
+            onSubagentClick={props.onSubagentClick}
+            onLoadOlder={props.onLoadOlder}
+            loadingOlder={props.loadingOlder}
+            highlightNodeId={props.highlightNodeId}
+            scrollCommand={props.scrollCommand}
+            scrollToBottomRef={props.scrollToBottomRef}
+            onToggleCollapse={toggleCollapse}
+            onTogglePin={togglePin}
+            headerSlot={headerSlot()}
+        />
     );
 };
 
 AgentDocumentView.displayName = "AgentDocumentView";
 
-// ── Node renderer ────────────────────────────────────────────────────────────
+// ── Auth URL box ────────────────────────────────────────────────────────────
 
-// SolidJS reactivity note: props are accessed via `props.X` and NEVER
-// destructured in the parameter list. Destructuring captures mount-time
-// values and breaks reactivity for any prop that changes without triggering
-// the parent to re-create this component. Since the tool pin state
-// (`toolPinned`) lives in documentState — separate from the document array
-// that <For> keys off — pin toggles do NOT re-create DocumentNodeRenderer,
-// so a destructured `toolPinned` would stay stale forever even though the
-// child ToolBlock uses `props.pinned` correctly.
-//
-// See commit adcec38 for the first half of this fix (ToolBlock), and the
-// reagent review on PR #346 that caught this upstream companion.
-
-interface DocumentNodeRendererProps {
-    node: DocumentNode;
-    collapsed: boolean;
-    onToggle: () => void;
-    toolPinned: boolean;
-    onToggleToolPin: () => void;
-    onSubagentClick?: (node: SubagentLinkNode) => void;
+interface AuthUrlBoxProps {
+    url: string;
+    authProviderId?: string;
 }
 
-const DocumentNodeRenderer = (props: DocumentNodeRendererProps): JSX.Element => {
-    switch (props.node.type) {
-        case "markdown":
-            return <MarkdownBlock node={props.node} />;
+/**
+ * OAuth code-paste box. Rendered at the top of the scroll container
+ * while a login flow has a pending auth URL. Previously inline in
+ * AgentDocumentView; extracted as a sibling for the Phase 2 shell.
+ */
+function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
+    const [pasteCode, setPasteCode] = createSignal("");
+    const [pasting, setPasting] = createSignal(false);
+    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
 
-        case "tool":
-            return (
-                <ToolBlock
-                    node={props.node}
-                    pinned={props.toolPinned}
-                    onTogglePin={props.onToggleToolPin}
-                />
-            );
+    const handleSubmitCode = async (): Promise<void> => {
+        const code = pasteCode().trim();
+        if (!code) return;
+        setPasting(true);
+        setPasteResult(null);
+        try {
+            const { getApi } = await import("@/app/store/global");
+            await getApi().setProviderAuth(props.authProviderId ?? "claude", code);
+            setPasteResult("Code accepted — waiting for confirmation...");
+            setPasteCode("");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            setPasteResult(`Error: ${msg}`);
+        } finally {
+            setPasting(false);
+        }
+    };
 
-        case "agent_message":
-            return (
-                <AgentMessageBlock
-                    node={props.node}
-                    collapsed={props.collapsed}
-                    onToggle={props.onToggle}
-                />
-            );
-
-        case "user_message": {
-            const node = props.node;
-            return (
-                <div
-                    class="agent-user-message"
-                    classList={{ "agent-user-message--collapsed": props.collapsed }}
+    return (
+        <div class="agent-auth-url-box">
+            <div class="agent-auth-url-label">Open this URL to log in:</div>
+            <div class="agent-auth-url-row">
+                <span class="agent-auth-url-text">{props.url}</span>
+                <button
+                    class="agent-auth-url-copy"
+                    onClick={() => { import("@/util/clipboard").then(c => c.writeText(props.url)); }}
+                    title="Copy URL"
                 >
-                    <div class="agent-user-message-content">
-                        <pre>{node.message}</pre>
-                    </div>
-                </div>
-            );
-        }
-
-        case "subagent_link":
-            return (
-                <SubagentLinkBlock
-                    node={props.node}
-                    onClick={props.onSubagentClick ?? (() => {})}
+                    Copy
+                </button>
+            </div>
+            <div class="agent-auth-paste-row">
+                <input
+                    class="agent-auth-paste-input"
+                    type="text"
+                    placeholder="Paste auth code from Anthropic..."
+                    value={pasteCode()}
+                    onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") void handleSubmitCode(); }}
                 />
-            );
-
-        case "section": {
-            const node = props.node;
-            return (
-                <div class={`agent-section level-${node.level}`}>
-                    <Show when={node.level === 1}>
-                        <h1>{node.title}</h1>
-                    </Show>
-                    <Show when={node.level === 2}>
-                        <h2>{node.title}</h2>
-                    </Show>
-                    <Show when={node.level === 3}>
-                        <h3>{node.title}</h3>
-                    </Show>
-                </div>
-            );
-        }
-
-        default:
-            return null;
-    }
-};
-
-DocumentNodeRenderer.displayName = "DocumentNodeRenderer";
+                <button
+                    class="agent-auth-url-copy"
+                    title="Paste from clipboard"
+                    onClick={() => {
+                        import("@/util/clipboard").then(c => c.readText()).then(text => {
+                            if (text) setPasteCode(text.trim());
+                        }).catch(() => {
+                            setPasteResult("Could not read clipboard — paste manually");
+                        });
+                    }}
+                >
+                    Paste
+                </button>
+                <button
+                    class="agent-auth-url-copy"
+                    onClick={() => { void handleSubmitCode(); }}
+                    disabled={!pasteCode().trim() || pasting()}
+                >
+                    {pasting() ? "..." : "Submit"}
+                </button>
+            </div>
+            <Show when={pasteResult()}>
+                <div class="agent-auth-paste-result">{pasteResult()}</div>
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -21,6 +21,14 @@
         // mutations inside the scroll container don't invalidate layout
         // outside it.
         contain: layout style paint;
+        // overflow-anchor on the actual scroll container (this element).
+        // Chromium auto-pins a visible anchor element when content above
+        // it changes height (e.g., async image/font loads, tool block
+        // expand). The JS layer in AgentDocumentVirtualList handles the
+        // cases CSS can't (programmatic scroll, remount).
+        // Spec: docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+        //       §"Anchor — CSS + JS belt-and-suspenders"
+        overflow-anchor: auto;
     }
 
     // Shared hover-strip anchor. Any element that renders a `.node-strip`
@@ -99,16 +107,9 @@
     }
 
     // === Virtualization (Phase 2 redesign) ===
-    //
-    // overflow-anchor on the scroll container is the CSS half of the
-    // anchor model — Chromium auto-pins a visible anchor element when
-    // content above it changes height (e.g., async image/font loads,
-    // tool block expand). The JS layer in AgentDocumentVirtualList
-    // handles the cases CSS can't (programmatic scroll, remount).
-    //
-    // Spec: docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
-    //       §"Anchor — CSS + JS belt-and-suspenders"
-    overflow-anchor: auto;
+    // (overflow-anchor lives on .agent-document above — the actual
+    // scroll container — not here at the .agent-view level. reagent
+    // P2 on #784 caught the wrong nesting.)
 
     .agent-document-virtualizer {
         // Container for the virtualized region. Children are

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -98,11 +98,71 @@
         }
     }
 
+    // === Virtualization (Phase 2 redesign) ===
+    //
+    // overflow-anchor on the scroll container is the CSS half of the
+    // anchor model — Chromium auto-pins a visible anchor element when
+    // content above it changes height (e.g., async image/font loads,
+    // tool block expand). The JS layer in AgentDocumentVirtualList
+    // handles the cases CSS can't (programmatic scroll, remount).
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+    //       §"Anchor — CSS + JS belt-and-suspenders"
+    overflow-anchor: auto;
+
+    .agent-document-virtualizer {
+        // Container for the virtualized region. Children are
+        // absolute-positioned via translateY; the height equals
+        // virtualizer.getTotalSize() so the native scrollbar reflects
+        // the full virtual content.
+        //
+        // flex-shrink: 0 — .agent-document is a column flex container,
+        // so without this the wrapper would collapse to viewport
+        // height when getTotalSize() exceeds it (codex P1 from #773).
+        position: relative;
+        width: 100%;
+        flex-shrink: 0;
+    }
+
+    .agent-document-streaming-buffer {
+        // Trailing nodes rendered in normal flex flow — no
+        // virtualization. Always mounted so streaming token batches
+        // don't have to wait for measureElement to settle.
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        flex-shrink: 0;
+    }
+
+    .agent-document-row {
+        // Replaces the old .agent-document-node-wrapper. content-
+        // visibility is no longer needed because off-screen items
+        // (in the virtualized region) aren't in the DOM at all.
+        // contain: layout style isolates the row's layout cost so
+        // a single message expanding doesn't reflow neighbors.
+        contain: layout style;
+        // Anchor for any width-relative children (markdown tables,
+        // code diffs). Without this, absolute-positioned virtualized
+        // rows lose their layout context and tables break.
+        width: 100%;
+
+        &:focus {
+            outline: 1px solid var(--accent-color);
+            outline-offset: -1px;
+        }
+
+        // Force tables to constrain their layout to the row width.
+        // Spec: SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+        //       §"Tables and rich content"
+        :is(table, .markdown-table) {
+            width: 100%;
+            table-layout: fixed;
+        }
+    }
+
+    // Legacy class — keep for any non-virtualized callers; remove
+    // once Phase 2 is fully wired in everywhere.
     .agent-document-node-wrapper {
-        // Each document node gets its own containment box. Off-screen nodes
-        // are skipped by the browser via content-visibility.
-        // contain-intrinsic-size gives the browser a size estimate so scroll
-        // position stays stable when content is virtualized in/out.
         content-visibility: auto;
         contain-intrinsic-size: auto 80px;
         contain: layout style;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,7 +29,7 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, createMemo, For, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, For, Index, type Accessor, type JSX } from "solid-js";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import {
@@ -300,25 +300,33 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                 </For>
             </div>
 
-            {/* Streaming buffer — always-mounted trailing nodes */}
+            {/* Streaming buffer — always-mounted trailing nodes.
+                Uses <Index> not <For> because Solid's <For> reconciles
+                by item REFERENCE: each streaming token replaces the
+                active node's object (immutable update preserves id but
+                gives a new ref), and <For> would treat that as a new
+                item and unmount/remount the row on every token —
+                exactly the regression we wanted the streaming buffer
+                to prevent. <Index> keys by position and passes the
+                item as a Solid signal accessor, so the same
+                DocumentRow stays mounted while its `props.node()`
+                reactively re-reads the current value. (reagent P1 on
+                #784.) */}
             <div class="agent-document-streaming-buffer">
-                <For each={partition().streamingNodes as DocumentNode[]}>
-                    {(node) => {
-                        const nodeAccessor = (): DocumentNode => node;
-                        return (
-                            <DocumentRow
-                                node={nodeAccessor}
-                                documentState={props.documentState}
-                                bookmarkedNodeIds={props.bookmarkedNodeIds}
-                                onBookmark={props.onBookmark}
-                                onSubagentClick={props.onSubagentClick}
-                                highlightNodeId={props.highlightNodeId}
-                                onToggleCollapse={props.onToggleCollapse}
-                                onTogglePin={props.onTogglePin}
-                            />
-                        );
-                    }}
-                </For>
+                <Index each={partition().streamingNodes as DocumentNode[]}>
+                    {(nodeAccessor) => (
+                        <DocumentRow
+                            node={nodeAccessor}
+                            documentState={props.documentState}
+                            bookmarkedNodeIds={props.bookmarkedNodeIds}
+                            onBookmark={props.onBookmark}
+                            onSubagentClick={props.onSubagentClick}
+                            highlightNodeId={props.highlightNodeId}
+                            onToggleCollapse={props.onToggleCollapse}
+                            onTogglePin={props.onTogglePin}
+                        />
+                    )}
+                </Index>
             </div>
         </div>
     );

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,7 +29,7 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, For, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, For, type Accessor, type JSX } from "solid-js";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import {
@@ -73,9 +73,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // Guard against concurrent older-history fetches triggered by scroll.
     let loadingOlderInFlight = false;
 
-    const partition = (): ReturnType<typeof partitionForVirtualization> => {
+    // Memoized — partition is read inside virtualizer's reactive
+    // count getter, estimateSize, getItemKey, the streaming buffer
+    // <For>, and each virtual item's nodeAccessor. Without
+    // createMemo, every read re-slices the document (O(n)) on every
+    // token of streaming, defeating the streaming buffer's purpose.
+    // (reagent P1 on #784.)
+    const partition = createMemo(() => {
         return partitionForVirtualization(props.viewState.nodes());
-    };
+    });
 
     // Virtualizer over the virtualized head only — streaming buffer is
     // rendered separately as a normal flex list. Per-kind estimators
@@ -177,15 +183,30 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             !loadingOlderInFlight &&
             !(props.loadingOlder?.())
         ) {
-            // Capture anchor from the topmost virtualized item — its
-            // offsetPx is virtualItem.start + scrollMargin.
+            // Capture anchor from the topmost visible node. Two cases:
+            //   1) Document is large enough to virtualize → use the
+            //      topmost virtual item. Note: in TanStack Virtual v3
+            //      `virtualItem.start` ALREADY includes scrollMargin
+            //      so we read it directly without re-adding the margin.
+            //   2) Document fits entirely in the streaming buffer
+            //      (≤ STREAMING_BUFFER_SIZE nodes) → getVirtualItems()
+            //      is empty, so fall back to the streaming buffer's
+            //      first node via DOM. This is the common initial-
+            //      pagination case (codex P2 on #784).
             const items = virtualizer.getVirtualItems();
-            const anchorId = items.length > 0
-                ? partition().virtualizedNodes[items[0].index]?.id
-                : null;
+            let anchorId: string | null = null;
+            let anchorOffsetPx = 0;
+            if (items.length > 0) {
+                anchorId = partition().virtualizedNodes[items[0].index]?.id ?? null;
+                anchorOffsetPx = items[0].start;
+            } else if (partition().streamingNodes.length > 0) {
+                anchorId = partition().streamingNodes[0].id;
+                const el = scrollRef.querySelector(
+                    `[data-node-id="${anchorId}"]`,
+                ) as HTMLElement | null;
+                anchorOffsetPx = el?.offsetTop ?? 0;
+            }
             if (anchorId != null) {
-                const items0 = items[0];
-                const anchorOffsetPx = (items0.start) + (virtualContainerRef?.offsetTop ?? 0);
                 const anchor = captureTopmostAnchor(
                     [{ id: anchorId, offsetPx: anchorOffsetPx }],
                     scrollTop,
@@ -206,12 +227,11 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                             const newP = partitionForVirtualization(props.viewState.nodes());
                             if (newIdx < newP.splitIndex) {
                                 // Still virtualized — recompute via virtualizer's offsetForIndex.
+                                // The returned offset already includes scrollMargin in v3,
+                                // so don't add virtualContainerRef.offsetTop again.
                                 const offset = virtualizer.getOffsetForIndex(newIdx, "start");
                                 if (offset != null) {
-                                    const target = restoreScrollFromAnchor(
-                                        anchor,
-                                        offset[0] + (virtualContainerRef?.offsetTop ?? 0),
-                                    );
+                                    const target = restoreScrollFromAnchor(anchor, offset[0]);
                                     scrollRef.scrollTo({ top: target, behavior: "auto" });
                                 }
                             } else {
@@ -266,6 +286,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                 onToggleCollapse={props.onToggleCollapse}
                                 onTogglePin={props.onTogglePin}
                                 ref={virtualizer.measureElement}
+                                dataIndex={virtualItem.index}
                                 style={{
                                     position: "absolute",
                                     top: "0",

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -1,0 +1,304 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentDocumentVirtualList — hybrid virtualized + streaming-buffer
+ * renderer for the agent pane document. Replaces the old monolithic
+ * `<For each={document()}>` block in AgentDocumentView.
+ *
+ * Architecture (from docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md):
+ *
+ *  ┌─ scrollRef (.agent-document) ─────────────────────────┐
+ *  │  ┌─ virtualized region ─────────────────────────────┐ │
+ *  │  │  height = virtualizer.getTotalSize()             │ │
+ *  │  │  position: relative                              │ │
+ *  │  │  rows: position: absolute, translateY(start)     │ │
+ *  │  │  measureElement on each row                      │ │
+ *  │  └──────────────────────────────────────────────────┘ │
+ *  │  ┌─ streaming buffer ───────────────────────────────┐ │
+ *  │  │  trailing N nodes, normal flex flow              │ │
+ *  │  │  no virtualization → no measurement lag during   │ │
+ *  │  │  token streams                                   │ │
+ *  │  └──────────────────────────────────────────────────┘ │
+ *  └────────────────────────────────────────────────────────┘
+ *
+ * Scroll state (`stickToBottom`, `headAnchor`) lives in
+ * AgentViewState, never in scrollRef.scrollTop. Caller drives
+ * scrollToBottom / scrollToNode via props; this component projects
+ * the state into the DOM but never reads it back.
+ */
+
+import { createVirtualizer } from "@tanstack/solid-virtual";
+import { createEffect, For, type Accessor, type JSX } from "solid-js";
+import type { ScrollCommand } from "../hooks/useScrollToNode";
+import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import {
+    captureTopmostAnchor,
+    isNearBottom,
+    isNearTop,
+    restoreScrollFromAnchor,
+} from "./anchor";
+import { DocumentRow } from "./DocumentRow";
+import { estimateNode } from "./renderers";
+import type { AgentViewState } from "./state";
+import { partitionForVirtualization } from "./streaming-buffer";
+
+export interface AgentDocumentVirtualListProps {
+    viewState: AgentViewState;
+    documentState: Accessor<DocumentState>;
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    onBookmark?: (node: DocumentNode) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+    onLoadOlder?: () => Promise<void>;
+    loadingOlder?: Accessor<boolean>;
+    highlightNodeId?: Accessor<string | null>;
+    scrollCommand?: Accessor<ScrollCommand | null>;
+    /** Wire-up callback so the parent (AgentFooter via AgentDocumentView)
+     *  can invoke jumpToBottom on user keystroke. */
+    scrollToBottomRef?: (fn: () => void) => void;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    /**
+     * Content rendered inside the scroll container, above the
+     * virtualized region. Used by AgentDocumentView for the
+     * auth-url box and the loading-older banner. Affects scroll math
+     * via scrollMargin (read from virtualContainerRef.offsetTop).
+     */
+    headerSlot?: JSX.Element;
+}
+
+export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): JSX.Element {
+    let scrollRef!: HTMLDivElement;
+    let virtualContainerRef: HTMLDivElement | undefined;
+    // Guard against concurrent older-history fetches triggered by scroll.
+    let loadingOlderInFlight = false;
+
+    const partition = (): ReturnType<typeof partitionForVirtualization> => {
+        return partitionForVirtualization(props.viewState.nodes());
+    };
+
+    // Virtualizer over the virtualized head only — streaming buffer is
+    // rendered separately as a normal flex list. Per-kind estimators
+    // come from the renderer registry; measureElement settles each row
+    // to actual height after first paint.
+    const virtualizer = createVirtualizer({
+        get count() { return partition().virtualizedNodes.length; },
+        getScrollElement: () => scrollRef,
+        estimateSize: (index) => {
+            const node = partition().virtualizedNodes[index];
+            return node ? estimateNode(node, props.documentState()) : 32;
+        },
+        overscan: 5,
+        getItemKey: (index) => partition().virtualizedNodes[index]?.id ?? index,
+        // scrollMargin: any content rendered above the virtualizer
+        // container (loading-older banner, auth-url box from the
+        // parent) shifts the virtual coordinate system. Read offsetTop
+        // as a getter so it's evaluated each tick.
+        get scrollMargin() {
+            return virtualContainerRef?.offsetTop ?? 0;
+        },
+    });
+
+    // Project stickToBottom into scroll position. When the document
+    // grows AND we're sticky, scroll the streaming buffer's last item
+    // into view. Streaming-buffer items live in normal flow at the
+    // bottom of the scroll container, so MAX_SAFE_INTEGER scrollTo
+    // works reliably for them (no virtualizer reflow needed).
+    createEffect(() => {
+        // Track length changes — Solid will re-run when nodes() emits.
+        const _len = props.viewState.nodes().length;
+        if (props.viewState.stickToBottom() && scrollRef) {
+            // queueMicrotask so the new content has rendered before we scroll.
+            queueMicrotask(() => {
+                if (!scrollRef) return;
+                scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+            });
+        }
+    });
+
+    // jumpToBottom: forced scroll-to-bottom that re-engages stick.
+    // Exposed to parent so AgentFooter can call it on keystroke.
+    const jumpToBottom = (): void => {
+        if (!scrollRef) return;
+        props.viewState.engageStickToBottom();
+        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+    };
+    if (props.scrollToBottomRef) props.scrollToBottomRef(jumpToBottom);
+
+    // scrollToNode: jump the named node into view. Disengages stick
+    // (user wants to stay where they jumped). Routes through the
+    // virtualizer if the target is in the virtualized head, else uses
+    // the streaming buffer's natural DOM offset.
+    const scrollToNode = (nodeId: string): void => {
+        if (!scrollRef) return;
+        const idx = props.viewState.indexOf(nodeId);
+        if (idx < 0) return;
+        const p = partition();
+        if (idx < p.splitIndex) {
+            // Virtualized region — virtualizer handles ensure-visible + scroll.
+            virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
+        } else {
+            // Streaming buffer — node is mounted; query DOM and scroll directly.
+            const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
+            if (!el) return;
+            const elTop = el.offsetTop;
+            const center = elTop - scrollRef.clientHeight / 2 + el.clientHeight / 2;
+            scrollRef.scrollTo({ top: Math.max(0, center), behavior: "smooth" });
+        }
+        props.viewState.disengageStickToBottom();
+    };
+
+    // React to jump commands from the parent's useScrollToNode hook.
+    createEffect(() => {
+        const cmd = props.scrollCommand?.();
+        if (cmd) scrollToNode(cmd.nodeId);
+    });
+
+    const handleScroll = (): void => {
+        if (!scrollRef) return;
+        const { scrollTop, scrollHeight, clientHeight } = scrollRef;
+
+        // Engage stick when user scrolls back near bottom; disengage
+        // otherwise. Engaging clears any captured headAnchor (atomic).
+        if (isNearBottom(scrollTop, scrollHeight, clientHeight)) {
+            if (!props.viewState.stickToBottom()) {
+                props.viewState.engageStickToBottom();
+            }
+        } else {
+            if (props.viewState.stickToBottom()) {
+                props.viewState.disengageStickToBottom();
+            }
+        }
+
+        // Older-history pagination — capture anchor, fetch, restore.
+        if (
+            props.onLoadOlder &&
+            isNearTop(scrollTop) &&
+            !loadingOlderInFlight &&
+            !(props.loadingOlder?.())
+        ) {
+            // Capture anchor from the topmost virtualized item — its
+            // offsetPx is virtualItem.start + scrollMargin.
+            const items = virtualizer.getVirtualItems();
+            const anchorId = items.length > 0
+                ? partition().virtualizedNodes[items[0].index]?.id
+                : null;
+            if (anchorId != null) {
+                const items0 = items[0];
+                const anchorOffsetPx = (items0.start) + (virtualContainerRef?.offsetTop ?? 0);
+                const anchor = captureTopmostAnchor(
+                    [{ id: anchorId, offsetPx: anchorOffsetPx }],
+                    scrollTop,
+                );
+                if (anchor) props.viewState.captureHeadAnchor(anchor);
+            }
+
+            loadingOlderInFlight = true;
+            props.onLoadOlder().then(() => {
+                requestAnimationFrame(() => {
+                    // Restore from anchor by id — partition reflects the
+                    // new prepended nodes, so the anchor's new index
+                    // gives a fresh measured offset.
+                    const anchor = props.viewState.headAnchor();
+                    if (anchor != null && scrollRef) {
+                        const newIdx = props.viewState.indexOf(anchor.nodeId);
+                        if (newIdx >= 0) {
+                            const newP = partitionForVirtualization(props.viewState.nodes());
+                            if (newIdx < newP.splitIndex) {
+                                // Still virtualized — recompute via virtualizer's offsetForIndex.
+                                const offset = virtualizer.getOffsetForIndex(newIdx, "start");
+                                if (offset != null) {
+                                    const target = restoreScrollFromAnchor(
+                                        anchor,
+                                        offset[0] + (virtualContainerRef?.offsetTop ?? 0),
+                                    );
+                                    scrollRef.scrollTo({ top: target, behavior: "auto" });
+                                }
+                            } else {
+                                // Now in streaming buffer — query DOM.
+                                const el = scrollRef.querySelector(
+                                    `[data-node-id="${anchor.nodeId}"]`,
+                                ) as HTMLElement | null;
+                                if (el) {
+                                    const target = restoreScrollFromAnchor(anchor, el.offsetTop);
+                                    scrollRef.scrollTo({ top: target, behavior: "auto" });
+                                }
+                            }
+                        }
+                    }
+                    loadingOlderInFlight = false;
+                });
+            }).catch(() => {
+                loadingOlderInFlight = false;
+            });
+        }
+    };
+
+    // Render: scroll container holds the optional header, the
+    // virtualized head, and the streaming buffer. headerSlot offsets
+    // the virtualizer; scrollMargin (above) handles that automatically.
+    return (
+        <div class="agent-document" ref={scrollRef} onScroll={handleScroll}>
+            {props.headerSlot}
+            {/* Virtualized head — only present when document > buffer size */}
+            <div
+                ref={(el) => { virtualContainerRef = el; }}
+                class="agent-document-virtualizer"
+                style={{
+                    height: `${virtualizer.getTotalSize()}px`,
+                    position: "relative",
+                    width: "100%",
+                }}
+            >
+                <For each={virtualizer.getVirtualItems()}>
+                    {(virtualItem) => {
+                        const nodeAccessor = (): DocumentNode => {
+                            return partition().virtualizedNodes[virtualItem.index];
+                        };
+                        return (
+                            <DocumentRow
+                                node={nodeAccessor}
+                                documentState={props.documentState}
+                                bookmarkedNodeIds={props.bookmarkedNodeIds}
+                                onBookmark={props.onBookmark}
+                                onSubagentClick={props.onSubagentClick}
+                                highlightNodeId={props.highlightNodeId}
+                                onToggleCollapse={props.onToggleCollapse}
+                                onTogglePin={props.onTogglePin}
+                                ref={virtualizer.measureElement}
+                                style={{
+                                    position: "absolute",
+                                    top: "0",
+                                    left: "0",
+                                    width: "100%",
+                                    transform: `translateY(${virtualItem.start - (virtualContainerRef?.offsetTop ?? 0)}px)`,
+                                }}
+                            />
+                        );
+                    }}
+                </For>
+            </div>
+
+            {/* Streaming buffer — always-mounted trailing nodes */}
+            <div class="agent-document-streaming-buffer">
+                <For each={partition().streamingNodes as DocumentNode[]}>
+                    {(node) => {
+                        const nodeAccessor = (): DocumentNode => node;
+                        return (
+                            <DocumentRow
+                                node={nodeAccessor}
+                                documentState={props.documentState}
+                                bookmarkedNodeIds={props.bookmarkedNodeIds}
+                                onBookmark={props.onBookmark}
+                                onSubagentClick={props.onSubagentClick}
+                                highlightNodeId={props.highlightNodeId}
+                                onToggleCollapse={props.onToggleCollapse}
+                                onTogglePin={props.onTogglePin}
+                            />
+                        );
+                    }}
+                </For>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -1,0 +1,253 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DocumentRow — single row in the agent document list. Used by both
+ * the virtualized region and the unvirtualized streaming buffer in
+ * AgentDocumentVirtualList.
+ *
+ * Caller controls positioning (style + ref) so the same row works in
+ * absolute-positioned virtualizer slots and in the normal-flow
+ * streaming buffer without the row knowing the difference.
+ *
+ * Phase 2 of the virtualization redesign — see
+ * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
+ */
+
+import { Show, type Accessor, type JSX } from "solid-js";
+import { ContextMenuModel } from "@/app/store/contextmenu";
+import { AgentMessageBlock } from "../components/AgentMessageBlock";
+import { MarkdownBlock } from "../components/MarkdownBlock";
+import { NodeHoverStrip } from "../components/NodeHoverStrip";
+import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
+import { ToolBlock } from "../components/ToolBlock";
+import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+
+export interface DocumentRowProps {
+    /**
+     * Reactive accessor for the current node at this row's slot. Must
+     * be an accessor (not a value) so streaming updates that replace
+     * the node at the same id propagate without remount.
+     */
+    node: Accessor<DocumentNode>;
+    documentState: Accessor<DocumentState>;
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    onBookmark?: (node: DocumentNode) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+    highlightNodeId?: Accessor<string | null>;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    /** Style applied to the wrapper element. Virtualized parent
+     *  passes absolute positioning + translateY; streaming parent
+     *  passes nothing (normal flow). */
+    style?: JSX.CSSProperties;
+    /** Ref forwarded to the wrapper element. Virtualized parent
+     *  passes virtualizer.measureElement; streaming parent omits. */
+    ref?: (el: HTMLElement) => void;
+}
+
+const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
+    "tool",
+    "agent_message",
+    "user_message",
+    "section",
+]);
+
+export function DocumentRow(props: DocumentRowProps): JSX.Element {
+    const isBookmarked = (): boolean => {
+        const n = props.node();
+        return props.bookmarkedNodeIds?.().has(n.id) ?? false;
+    };
+
+    const isSearchMatch = (): boolean => {
+        return props.highlightNodeId?.() === props.node().id;
+    };
+
+    const canExpand = (): boolean => TOGGLEABLE_KINDS.has(props.node().type);
+
+    const isExpanded = (): boolean => {
+        const n = props.node();
+        const state = props.documentState();
+        if (n.type === "tool") return state.pinnedNodes.has(n.id);
+        return !state.collapsedNodes.has(n.id);
+    };
+
+    const onExpand = (): void => {
+        const n = props.node();
+        if (n.type === "tool") props.onTogglePin(n.id);
+        else props.onToggleCollapse(n.id);
+    };
+
+    // Phase 6 placeholders — match existing AgentDocumentView contract.
+    const onOpenInNewPane = (): void => {
+        if (props.node().type === "tool") {
+            console.warn("[hover-strip] open in new pane — not yet implemented");
+        }
+    };
+    const onOpenInNewWindow = (): void =>
+        console.warn("[hover-strip] open in new window — not yet implemented");
+    const onNewAgentFromHere = (): void =>
+        console.warn("[hover-strip] new agent from here — not yet implemented");
+
+    const handleRowKey = (e: KeyboardEvent): void => {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        const n = props.node();
+        switch (e.key.toLowerCase()) {
+            case "e":
+                if (canExpand()) { onExpand(); e.preventDefault(); }
+                break;
+            case "b":
+                if (props.onBookmark != null) { props.onBookmark(n); e.preventDefault(); }
+                break;
+            case "p":
+                if (n.type === "tool") { onOpenInNewPane(); e.preventDefault(); }
+                break;
+            case "w":
+                onOpenInNewWindow(); e.preventDefault();
+                break;
+            case "n":
+                onNewAgentFromHere(); e.preventDefault();
+                break;
+            case "escape":
+                (e.currentTarget as HTMLElement).blur();
+                e.preventDefault();
+                break;
+        }
+    };
+
+    const handleContextMenu = (e: MouseEvent): void => {
+        if (!props.onBookmark) return;
+        // Don't shadow text-selection menus — let the parent pane handle those.
+        const sel = window.getSelection()?.toString();
+        if (sel) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const n = props.node();
+        ContextMenuModel.showContextMenu(
+            [
+                {
+                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                    click: () => props.onBookmark?.(n),
+                },
+            ],
+            e,
+        );
+    };
+
+    return (
+        <div
+            ref={props.ref}
+            class="hover-strip-host agent-document-row"
+            classList={{
+                "agent-node-bookmarked": isBookmarked(),
+                "agent-node-search-match": isSearchMatch(),
+            }}
+            data-node-id={props.node().id}
+            tabindex="0"
+            onKeyDown={handleRowKey}
+            onContextMenu={handleContextMenu}
+            style={props.style}
+        >
+            <DocumentNodeBody
+                node={props.node}
+                documentState={props.documentState}
+                onToggleCollapse={props.onToggleCollapse}
+                onTogglePin={props.onTogglePin}
+                onSubagentClick={props.onSubagentClick}
+            />
+            <NodeHoverStrip
+                timestamp={(props.node() as { timestamp?: number }).timestamp}
+                nodeId={props.node().id}
+                isBookmarked={isBookmarked()}
+                onBookmark={props.onBookmark != null ? () => props.onBookmark!(props.node()) : undefined}
+                canExpand={canExpand()}
+                isExpanded={isExpanded()}
+                onExpand={onExpand}
+                onOpenInNewPane={props.node().type === "tool" ? onOpenInNewPane : undefined}
+                onOpenInNewWindow={onOpenInNewWindow}
+                onNewAgentFromHere={onNewAgentFromHere}
+            />
+        </div>
+    );
+}
+
+interface DocumentNodeBodyProps {
+    node: Accessor<DocumentNode>;
+    documentState: Accessor<DocumentState>;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+}
+
+/**
+ * Routes a DocumentNode to the right block component. Each branch
+ * accesses props.node() reactively so streaming updates and state-set
+ * toggles propagate without remount.
+ *
+ * Reactivity discipline (carried over from the original
+ * DocumentNodeRenderer comment): never destructure props in this
+ * function. The toolPinned state lives in documentState (separate from
+ * the document array that the parent <For> keys off), so a
+ * destructured `toolPinned` would stay stale forever even though
+ * ToolBlock uses props.pinned correctly. See PR #346 reagent.
+ */
+function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
+    return (
+        <Show when={props.node()}>
+            {(n) => {
+                const node = n();
+                switch (node.type) {
+                    case "markdown":
+                        return <MarkdownBlock node={node} />;
+                    case "tool":
+                        return (
+                            <ToolBlock
+                                node={node}
+                                pinned={props.documentState().pinnedNodes.has(node.id)}
+                                onTogglePin={() => props.onTogglePin(node.id)}
+                            />
+                        );
+                    case "agent_message":
+                        return (
+                            <AgentMessageBlock
+                                node={node}
+                                collapsed={props.documentState().collapsedNodes.has(node.id)}
+                                onToggle={() => props.onToggleCollapse(node.id)}
+                            />
+                        );
+                    case "user_message":
+                        return (
+                            <div
+                                class="agent-user-message"
+                                classList={{
+                                    "agent-user-message--collapsed":
+                                        props.documentState().collapsedNodes.has(node.id),
+                                }}
+                            >
+                                <div class="agent-user-message-content">
+                                    <pre>{node.message}</pre>
+                                </div>
+                            </div>
+                        );
+                    case "subagent_link":
+                        return (
+                            <SubagentLinkBlock
+                                node={node}
+                                onClick={props.onSubagentClick ?? (() => { })}
+                            />
+                        );
+                    case "section":
+                        return (
+                            <div class={`agent-section level-${node.level}`}>
+                                <Show when={node.level === 1}><h1>{node.title}</h1></Show>
+                                <Show when={node.level === 2}><h2>{node.title}</h2></Show>
+                                <Show when={node.level === 3}><h3>{node.title}</h3></Show>
+                            </div>
+                        );
+                    default:
+                        return null;
+                }
+            }}
+        </Show>
+    );
+}

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -44,6 +44,13 @@ export interface DocumentRowProps {
     /** Ref forwarded to the wrapper element. Virtualized parent
      *  passes virtualizer.measureElement; streaming parent omits. */
     ref?: (el: HTMLElement) => void;
+    /**
+     * Virtual item index — set as `data-index` on the wrapper. TanStack
+     * Virtual's measureElement requires this attribute to match
+     * measurements back to virtual items. Streaming parent omits.
+     * (codex P1 on #784.)
+     */
+    dataIndex?: number;
 }
 
 const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
@@ -143,6 +150,7 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 "agent-node-search-match": isSearchMatch(),
             }}
             data-node-id={props.node().id}
+            data-index={props.dataIndex}
             tabindex="0"
             onKeyDown={handleRowKey}
             onContextMenu={handleContextMenu}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.752",
+  "version": "0.33.753",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.752",
+      "version": "0.33.753",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.753",
+  "version": "0.33.754",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.753",
+      "version": "0.33.754",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.751",
+  "version": "0.33.752",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.751",
+      "version": "0.33.752",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@lobehub/icons-static-svg": "^1.90.0",
         "@observablehq/plot": "^0.6.17",
         "@solid-primitives/keyed": "^1.5.3",
+        "@tanstack/solid-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -3269,6 +3270,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/solid-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.24.tgz",
+      "integrity": "sha512-sLGjpsAWLK8oxciqN+FNjs5JLs9N27DKwwoOPN8FMrmFMeXdiPQvRg3CqUAv8pYfXKD9KmcbhBxNwlmcP22a8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.3.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@lobehub/icons-static-svg": "^1.90.0",
     "@observablehq/plot": "^0.6.17",
     "@solid-primitives/keyed": "^1.5.3",
+    "@tanstack/solid-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.751",
+  "version": "0.33.752",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.753",
+  "version": "0.33.754",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.752",
+  "version": "0.33.753",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Second phase of the agent pane virtualization redesign (issue #782, spec at `docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md`). **Builds on Phase 1 (PR #783).**

> **Base branch is `agenta/virt-redesign-phase-1`** so the diff stays focused. Once #783 merges to main, this PR will rebase onto main automatically.

## What's new

### Components (`frontend/app/view/agent/virtualization/`)

- **`DocumentRow.tsx`** — single row component used by both regions. Caller controls positioning (style + ref), so the same row works in absolute-positioned virtualizer slots and normal-flow streaming buffer without knowing the difference.
- **`AgentDocumentVirtualList.tsx`** — hybrid renderer:
  - `@tanstack/solid-virtual` for the virtualized head (per-kind estimators from Phase 1's registry, `measureElement` for dynamic heights, `scrollMargin` for the optional header slot)
  - Plain `<For>` for the trailing 50-node streaming buffer — **no virtualization, no measurement lag during token streams** (eliminates the streaming-cut-off bug class from #773)
  - Scroll state read from `AgentViewState` via the atomic `engageStickToBottom` / `disengageStickToBottom` / `captureHeadAnchor` API

### CSS (`_document.scss`)

- `overflow-anchor: auto` on `.agent-document` (CSS half of the anchor)
- `.agent-document-virtualizer` — `position: relative; flex-shrink: 0`
- `.agent-document-streaming-buffer` — flex column with gap, also `flex-shrink: 0`
- `.agent-document-row` — `contain: layout style; width: 100%`
- **`:is(table, .markdown-table) → table-layout: fixed; width: 100%`** — fixes the table-distortion class from #773

### `AgentDocumentView` rewritten as thin shell

Owns data-state interface (auto-collapse policy, `toggleCollapse`, `togglePin`, the auth-url box) and delegates list rendering to `AgentDocumentVirtualList` via the `headerSlot` prop. All scroll behavior (jumpToBottom, scrollToNode, anchor capture, pagination restore) lives in the VirtualList — single source of truth.

## Bug-class coverage (vs reverted #773)

| Bug from #773 | Why this PR doesn't have it |
|---|---|
| Gaps from estimateSize miss | Per-kind estimators (`estimateAgentMessage`, `estimateTool`, etc.) tuned per type |
| Tables broken | `table-layout: fixed; width: 100%` on every row's tables |
| Thinking cut-off mid-stream | Last 50 nodes always in unvirtualized streaming buffer; measureElement never recycles them mid-stream |
| Scroll-restore fragile | Anchor model (`headAnchor` in store) replaces pixel-delta math; restore via `getOffsetForIndex` (virtualized) or `el.offsetTop` (streaming) |
| Jump-to-node fails for off-screen | `scrollToIndex` first when target is in virtualized region; DOM query when in streaming buffer |
| Stale stick-to-bottom anchor | Phase 1's atomic `engageStickToBottom` clears anchor (codex P2 fix) |

## Re-adds dependency

`@tanstack/solid-virtual` ^3.13 — same dep that was removed in PR #781. This time the design accommodates it from the start, so the eval contract is much cleaner.

## Test status

- Phase 1's 51 tests still pass.
- Phase 2 deliberately doesn't add new view-layer tests — Phase 3 will add the perf-probe HUD which validates render correctness empirically against an active session.
- TypeScript check passes for all new files (the pre-existing TS errors in `frontend/layout/`, `frontend/app/tab/tab-presets.ts`, `frontend/util/keyutil.ts` are unrelated to this PR).

## Next: Phase 3

Per-kind perf marks, estimator-validation HUD, layout-shift attribution scoped to the agent pane. Will surface estimator misses > 30% so we can tune the per-kind sizes empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)