### PR TITLE
feat(virt): Phase 3 — intelligent perf probing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.750"
+version = "0.33.751"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.750"
+version = "0.33.751"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.750"
+version = "0.33.751"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.750"
+version = "0.33.751"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.751"
+version = "0.33.752"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.752"
+version = "0.33.753"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.749"
+version = "0.33.750"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.749"
+version = "0.33.750"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.749"
+version = "0.33.750"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.749"
+version = "0.33.750"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.748"
+version = "0.33.749"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.748"
+version = "0.33.749"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.748"
+version = "0.33.749"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.748"
+version = "0.33.749"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.753"
+version = "0.33.754"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.748"
+version = "0.33.749"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.754"
+version = "0.33.755"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.750"
+version = "0.33.751"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.752"
+version = "0.33.753"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.749"
+version = "0.33.750"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.751"
+version = "0.33.752"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.753"
+version = "0.33.754"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.754"
+version = "0.33.755"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.749"
+version = "0.33.750"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.751"
+version = "0.33.752"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.752"
+version = "0.33.753"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.748"
+version = "0.33.749"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.753"
+version = "0.33.754"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.750"
+version = "0.33.751"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.748"
+version = "0.33.749"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.751"
+version = "0.33.752"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.750"
+version = "0.33.751"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.749"
+version = "0.33.750"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.753"
+version = "0.33.754"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.752"
+version = "0.33.753"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.754"
+version = "0.33.755"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.752"
+version = "0.33.753"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.753"
+version = "0.33.754"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.754"
+version = "0.33.755"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.749"
+version = "0.33.750"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.750"
+version = "0.33.751"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.751"
+version = "0.33.752"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.748"
+version = "0.33.749"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/devtools/agent-pane-perf-section.tsx
+++ b/frontend/app/devtools/agent-pane-perf-section.tsx
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane perf section for the diag panel — Phase 3 of the
+ * virtualization redesign. Polls `agentPerfStore.snapshot()` at 1 Hz
+ * and renders per-kind row mount times, estimator-miss rates, and
+ * recent layout shifts.
+ *
+ * No-op in production: snapshot returns empty when probing is
+ * disabled, so the section renders nothing.
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Intelligent perf probing".
+ */
+
+import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import {
+    agentPerfStore,
+    ESTIMATOR_MISS_THRESHOLD,
+    type AgentPerfSnapshot,
+} from "@/view/agent/virtualization/perf-probe";
+
+const POLL_INTERVAL_MS = 1000;
+
+const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
+    rowMountByKind: new Map(),
+    estimatorMissRateByKind: new Map(),
+    recentEstimatorMisses: [],
+    recentLayoutShifts: [],
+};
+
+function formatMs(n: number | undefined): string {
+    if (n == null) return "—";
+    if (n < 10) return n.toFixed(1);
+    return n.toFixed(0);
+}
+
+function formatPct(n: number): string {
+    return `${(n * 100).toFixed(0)}%`;
+}
+
+function ageMs(now: number, at: number): string {
+    const dt = now - at;
+    if (dt < 1000) return `${dt.toFixed(0)}ms`;
+    if (dt < 60_000) return `${(dt / 1000).toFixed(1)}s`;
+    return `${(dt / 60_000).toFixed(1)}min`;
+}
+
+export function AgentPanePerfSection(): JSX.Element {
+    const [snapshot, setSnapshot] = createSignal<AgentPerfSnapshot>(EMPTY_SNAPSHOT);
+    let pollHandle: number | undefined;
+
+    const poll = (): void => {
+        setSnapshot(agentPerfStore.snapshot());
+    };
+
+    onMount(() => {
+        poll();
+        pollHandle = window.setInterval(poll, POLL_INTERVAL_MS);
+    });
+    onCleanup(() => {
+        if (pollHandle != null) window.clearInterval(pollHandle);
+    });
+
+    const hasData = (): boolean => {
+        const s = snapshot();
+        return s.rowMountByKind.size > 0
+            || s.recentEstimatorMisses.length > 0
+            || s.recentLayoutShifts.length > 0;
+    };
+
+    return (
+        <Show when={hasData()}>
+            <div
+                style={{
+                    "margin-top": "8px",
+                    "padding-top": "8px",
+                    "border-top": "1px solid #333",
+                }}
+            >
+                <div style={{ "font-weight": "bold", color: "#7af", "margin-bottom": "4px" }}>
+                    📊 Agent Pane Perf
+                </div>
+
+                {/* Per-kind row mount durations */}
+                <Show when={snapshot().rowMountByKind.size > 0}>
+                    <div style={{ "margin-bottom": "6px" }}>
+                        <div style={{ color: "#aaa", "font-size": "10px", "margin-bottom": "2px" }}>
+                            Row mount duration (last 64 per kind)
+                        </div>
+                        <table style={{ "font-size": "10px", "border-collapse": "collapse", width: "100%" }}>
+                            <thead>
+                                <tr style={{ color: "#888" }}>
+                                    <th style={{ "text-align": "left", padding: "1px 4px" }}>kind</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>p50</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>p95</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>max</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>n</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>est-miss</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <For each={[...snapshot().rowMountByKind.entries()].sort(
+                                    ([, a], [, b]) => (b.p95 ?? 0) - (a.p95 ?? 0),
+                                )}>
+                                    {([kind, q]) => {
+                                        const missRate = snapshot().estimatorMissRateByKind.get(kind) ?? 0;
+                                        const flag = missRate > 0.20 ? " ⚠" : "";
+                                        return (
+                                            <tr>
+                                                <td style={{ padding: "1px 4px" }}>{kind}</td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.p50)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.p95)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.max)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right", color: "#888" }}>
+                                                    {q.count}
+                                                </td>
+                                                <td style={{
+                                                    padding: "1px 4px",
+                                                    "text-align": "right",
+                                                    color: missRate > 0.20 ? "#fa6" : "#6c8",
+                                                }}>
+                                                    {formatPct(missRate)}{flag}
+                                                </td>
+                                            </tr>
+                                        );
+                                    }}
+                                </For>
+                            </tbody>
+                        </table>
+                        <div style={{ color: "#666", "font-size": "9px", "margin-top": "2px" }}>
+                            est-miss = pct measured outside ±{formatPct(ESTIMATOR_MISS_THRESHOLD)} of estimate
+                        </div>
+                    </div>
+                </Show>
+
+                {/* Recent layout shifts */}
+                <Show when={snapshot().recentLayoutShifts.length > 0}>
+                    <div style={{ "margin-bottom": "6px" }}>
+                        <div style={{ color: "#aaa", "font-size": "10px" }}>
+                            Layout shifts in agent pane (last {snapshot().recentLayoutShifts.length})
+                        </div>
+                        <For each={snapshot().recentLayoutShifts.slice(0, 5)}>
+                            {(s) => {
+                                const now = performance.now();
+                                return (
+                                    <div style={{ "font-size": "10px", color: "#bbb", "padding-left": "8px" }}>
+                                        {ageMs(now, s.timestamp)} ago: {s.value.toFixed(4)}
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </div>
+                </Show>
+
+                {/* Recent estimator misses */}
+                <Show when={snapshot().recentEstimatorMisses.length > 0}>
+                    <div>
+                        <div style={{ color: "#aaa", "font-size": "10px" }}>
+                            Recent estimator misses (last {snapshot().recentEstimatorMisses.length})
+                        </div>
+                        <For each={snapshot().recentEstimatorMisses.slice(0, 5)}>
+                            {(s) => {
+                                const now = performance.now();
+                                return (
+                                    <div style={{ "font-size": "10px", color: "#bbb", "padding-left": "8px" }}>
+                                        {ageMs(now, s.timestamp)} ago: {s.kind} —
+                                        est {s.estimated.toFixed(0)}px, actual {s.actual.toFixed(0)}px
+                                        ({formatPct(s.errorPct)})
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </div>
+                </Show>
+            </div>
+        </Show>
+    );
+}

--- a/frontend/app/devtools/diag-panel.tsx
+++ b/frontend/app/devtools/diag-panel.tsx
@@ -42,6 +42,7 @@ import {
     type DispatchRecord,
     __resetDispatchLog,
 } from "@/store/command-source";
+import { AgentPanePerfSection } from "./agent-pane-perf-section";
 
 const DEFAULT_DISPLAY_LIMIT = 80;
 
@@ -327,6 +328,7 @@ export function DiagPanel(): JSX.Element {
                         </table>
                     </Show>
                 </div>
+                <AgentPanePerfSection />
             </div>
         </Show>
     );

--- a/frontend/app/view/agent/components/AgentDocumentView.tsx
+++ b/frontend/app/view/agent/components/AgentDocumentView.tsx
@@ -1,9 +1,17 @@
-// Copyright 2025, AgentMux Corp.
+// Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AgentDocumentView — Renders the styled document as a list of DocumentNodes.
- * Routes each node type to the appropriate block component.
+ * AgentDocumentView — owns the agent pane's data state interface
+ * (collapsed/pinned toggles, auto-collapse policy, auth-url and
+ * loading-older banner), then delegates list rendering to
+ * AgentDocumentVirtualList (Phase 2 of the virtualization redesign,
+ * see docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md).
+ *
+ * All scroll behavior — stick-to-bottom, anchor capture, jump-to-node,
+ * pagination restore — lives in the VirtualList. This component is
+ * just glue between the existing AgentAtoms contract and that new
+ * component.
  *
  * Diagnostic / launch-flow logs used to render inline at the top of this
  * scroll area. That moved to the dedicated `<ActivityLogPanel>` docked
@@ -11,16 +19,12 @@
  * `agentmux-ai/AGENT_PANE_ACTIVITY_LOG_SPEC.md`.
  */
 
-import { createEffect, createSignal, For, Show, type Accessor, type JSX, onCleanup } from "solid-js";
+import { createEffect, createSignal, Show, type Accessor, type JSX } from "solid-js";
 import type { SignalPair } from "../state";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
-import { AgentMessageBlock } from "./AgentMessageBlock";
-import { MarkdownBlock } from "./MarkdownBlock";
-import { NodeHoverStrip } from "./NodeHoverStrip";
-import { SubagentLinkBlock } from "./SubagentLinkBlock";
-import { ToolBlock } from "./ToolBlock";
-import { ContextMenuModel } from "@/app/store/contextmenu";
+import { AgentDocumentVirtualList } from "../virtualization/AgentDocumentVirtualList";
+import { createAgentViewState } from "../virtualization/state";
 
 interface AgentDocumentViewProps {
     documentAtom: SignalPair<DocumentNode[]>;
@@ -39,91 +43,27 @@ interface AgentDocumentViewProps {
     onBookmark?: (node: DocumentNode) => void;
     /**
      * Signal-based jump command. The parent owns a `useScrollToNode`
-     * hook and passes its `command` accessor here; a createEffect
+     * hook and passes its `command` accessor here; the VirtualList
      * watches for changes and scrolls the target node into view.
-     * Replaces the old mutable `scrollToNodeRef` ref pattern.
      */
     scrollCommand?: Accessor<ScrollCommand | null>;
     /**
      * Expose a scrollToBottom function to the parent so the composer can
      * bring the document to the latest content when the user starts typing.
-     * Re-enables auto-scroll as a side effect.
+     * Re-engages stick-to-bottom as a side effect.
      */
     scrollToBottomRef?: (fn: () => void) => void;
     /** The node id of the currently highlighted search match (if any). */
     highlightNodeId?: Accessor<string | null>;
 }
 
-export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, authProviderId, onSubagentClick, onLoadOlder, loadingOlder, bookmarkedNodeIds, onBookmark, scrollCommand, scrollToBottomRef, highlightNodeId }: AgentDocumentViewProps): JSX.Element => {
-    const [document] = documentAtom;
-    const [documentState, setDocumentState] = documentStateAtom;
-    let scrollRef!: HTMLDivElement;
-    let autoScroll = true;
-    // Guard against concurrent older-history fetches triggered by scroll
-    let loadingOlderInFlight = false;
+export const AgentDocumentView = (props: AgentDocumentViewProps): JSX.Element => {
+    const [documentState, setDocumentState] = props.documentStateAtom;
 
-    // Scroll to a node by its data-node-id attribute.
-    // Exposed to the parent via scrollToNodeRef so BookmarksPanel can call it.
-    //
-    // We deliberately DO NOT use `el.scrollIntoView()` here. scrollIntoView
-    // walks every scrollable ancestor and scrolls each one until the target
-    // is inside its visible region — which in our pane/tab/window nesting
-    // scrolls the outer block frame, pushing the agent pane header and
-    // adjacent pane titles out of the viewport. The symptom is "pane titles
-    // disappear across the entire app when I click a bookmark" — a real bug
-    // reported against 0.33.106.
-    //
-    // Instead, compute the target element's top relative to scrollRef and
-    // set scrollRef.scrollTop directly. That scrolls ONLY the document
-    // container and leaves every ancestor untouched.
-    //
-    // See docs/analysis/agent-pane-rich-features-structure-2026-04-13.md §1.
-    const scrollToNode = (nodeId: string) => {
-        if (!scrollRef) return;
-        const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
-        if (!el) return;
-        const elRect = el.getBoundingClientRect();
-        const containerRect = scrollRef.getBoundingClientRect();
-        // Top of el relative to scrollRef's content origin
-        const offsetWithinContainer = elRect.top - containerRect.top + scrollRef.scrollTop;
-        // Center the element in the visible region
-        const centerOffset =
-            offsetWithinContainer - scrollRef.clientHeight / 2 + el.clientHeight / 2;
-        scrollRef.scrollTo({ top: Math.max(0, centerOffset), behavior: "smooth" });
-        // Disable auto-scroll after a manual jump
-        autoScroll = false;
-    };
-
-    // React to jump commands emitted by the parent's useScrollToNode hook.
-    // We run the scroll inside our own effect (rather than exposing the
-    // function upward) so the mutable-ref pattern goes away and callers
-    // don't need to touch AgentDocumentView internals.
-    createEffect(() => {
-        const cmd = scrollCommand?.();
-        if (cmd) scrollToNode(cmd.nodeId);
-    });
-
-    // Jump to the bottom of the document and re-enable auto-scroll.
-    //
-    // Called by AgentFooter's onInput handler when the user starts typing, so
-    // their composer input is visually anchored to the latest content instead
-    // of floating offscreen at the bottom while older content sits above.
-    //
-    // Named `jumpToBottom` to distinguish from the existing `scrollToBottom`
-    // below, which is gated on `autoScroll` and only runs when new content
-    // arrives. This one is unconditional and also re-enables auto-scroll.
-    //
-    // Uses `Number.MAX_SAFE_INTEGER` instead of reading `scrollHeight` so we
-    // never force a synchronous layout on the keystroke hot path (PR #345's
-    // autoGrow regression was exactly that pattern). The browser clamps to
-    // the actual max internally during compositing.
-    const jumpToBottom = () => {
-        if (!scrollRef) return;
-        autoScroll = true;
-        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "instant" });
-    };
-
-    if (scrollToBottomRef) scrollToBottomRef(jumpToBottom);
+    // Phase 2: build the view state once per mount. Lifetime matches
+    // this component (not the agent ViewModel) — that's fine because
+    // scroll state is per-pane-mount, not per-agent-session.
+    const viewState = createAgentViewState(props.documentAtom);
 
     // Auto-collapse large user_messages on first arrival. The startup
     // session-context payload that `buildStartupPayload` sends is a huge
@@ -132,13 +72,13 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     // so we don't re-collapse after the user has explicitly expanded.
     const seenUserMessageIds = new Set<string>();
     createEffect(() => {
-        const doc = document();
+        const doc = viewState.nodes();
         const toCollapse: string[] = [];
         for (const n of doc) {
             if (n.type !== "user_message") continue;
             if (seenUserMessageIds.has(n.id)) continue;
             seenUserMessageIds.add(n.id);
-            const msg = (n as any).message ?? "";
+            const msg = (n as { message?: string }).message ?? "";
             if (msg.length > 200 || msg.includes("\n")) {
                 toCollapse.push(n.id);
             }
@@ -153,20 +93,17 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
     });
 
     // Toggle collapsed state for collapsible nodes (agent messages, sections, user messages).
-    const toggleCollapse = (nodeId: string) => {
+    const toggleCollapse = (nodeId: string): void => {
         setDocumentState((prev) => {
             const collapsed = new Set(prev.collapsedNodes);
-            if (collapsed.has(nodeId)) {
-                collapsed.delete(nodeId);
-            } else {
-                collapsed.add(nodeId);
-            }
+            if (collapsed.has(nodeId)) collapsed.delete(nodeId);
+            else collapsed.add(nodeId);
             return { ...prev, collapsedNodes: collapsed };
         });
     };
 
     // Toggle the "pinned open" state for a tool node.
-    const togglePin = (nodeId: string) => {
+    const togglePin = (nodeId: string): void => {
         setDocumentState((prev) => {
             const pinned = new Set(prev.pinnedNodes);
             if (pinned.has(nodeId)) pinned.delete(nodeId);
@@ -175,363 +112,123 @@ export const AgentDocumentView = ({ documentAtom, documentStateAtom, authUrl, au
         });
     };
 
-    // Auto-scroll to bottom when new content arrives.
-    let scrollRafId: number | null = null;
-
-    const scrollToBottom = () => {
-        if (autoScroll && scrollRef) {
-            scrollRef.scrollTop = scrollRef.scrollHeight;
-        }
-    };
-
-    // Scroll when the document changes — throttled to one RAF per batch.
-    // Activity log no longer lives in this scroll container, so its
-    // length is no longer a trigger (that panel scrolls internally).
-    createEffect(() => {
-        const _docLen = document().length;
-        if (scrollRafId == null) {
-            scrollRafId = requestAnimationFrame(() => {
-                scrollRafId = null;
-                scrollToBottom();
-            });
-        }
-    });
-
-    onCleanup(() => {
-        if (scrollRafId != null) cancelAnimationFrame(scrollRafId);
-    });
-
-    // Detect if user scrolled up (disable auto-scroll) and trigger older-history load
-    const handleScroll = () => {
-        if (!scrollRef) return;
-        const { scrollTop, scrollHeight, clientHeight } = scrollRef;
-        autoScroll = scrollHeight - scrollTop - clientHeight < 200;
-
-        // Trigger older-history load when near the top
-        if (
-            onLoadOlder &&
-            scrollTop < 50 &&
-            !loadingOlderInFlight &&
-            !(loadingOlder?.())
-        ) {
-            // Snapshot scroll anchor before content is prepended
-            const snapshotScrollHeight = scrollHeight;
-            const snapshotScrollTop = scrollTop;
-            loadingOlderInFlight = true;
-            onLoadOlder().then(() => {
-                // Restore scroll position so the user's viewport doesn't jump.
-                // Use a RAF so the DOM has updated with the new nodes first.
-                requestAnimationFrame(() => {
-                    if (scrollRef) {
-                        scrollRef.scrollTop =
-                            scrollRef.scrollHeight - snapshotScrollHeight + snapshotScrollTop;
-                    }
-                    loadingOlderInFlight = false;
-                });
-            }).catch(() => {
-                loadingOlderInFlight = false;
-            });
-        }
-    };
-
-    return (
-        <div
-            class="agent-document"
-            ref={scrollRef}
-            onScroll={handleScroll}
-        >
-            {/* Older-history loading indicator — pinned at the very top */}
-            <Show when={loadingOlder?.()}>
+    // Header slot: loading-older banner + optional auth-url box,
+    // rendered above the virtualizer inside the scroll container.
+    // VirtualList's scrollMargin (=virtualContainerRef.offsetTop)
+    // handles the offset automatically.
+    const headerSlot = (): JSX.Element => (
+        <>
+            <Show when={props.loadingOlder?.()}>
                 <div class="agent-history-loading">Loading older messages...</div>
             </Show>
-
-            {/* OAuth code-paste box, rendered at top of conversation while a
-                login flow has a pending auth URL. Previously nested inside
-                `.agent-status-log` with the activity log lines; the log
-                moved to `<ActivityLogPanel>` above the composer, so the
-                auth box stays here on its own. */}
-            <Show when={authUrl?.()}>
-                {(url) => {
-                    const [pasteCode, setPasteCode] = createSignal("");
-                    const [pasting, setPasting] = createSignal(false);
-                    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
-
-                    const handleSubmitCode = async () => {
-                        const code = pasteCode().trim();
-                        if (!code) return;
-                        setPasting(true);
-                        setPasteResult(null);
-                        try {
-                            const { getApi } = await import("@/app/store/global");
-                            await getApi().setProviderAuth(authProviderId ?? "claude", code);
-                            setPasteResult("Code accepted — waiting for confirmation...");
-                            setPasteCode("");
-                        } catch (err: any) {
-                            setPasteResult(`Error: ${err?.message ?? String(err)}`);
-                        } finally {
-                            setPasting(false);
-                        }
-                    };
-
-                    return (
-                        <div class="agent-auth-url-box">
-                            <div class="agent-auth-url-label">Open this URL to log in:</div>
-                            <div class="agent-auth-url-row">
-                                <span class="agent-auth-url-text">{url()}</span>
-                                <button
-                                    class="agent-auth-url-copy"
-                                    onClick={() => { import("@/util/clipboard").then(c => c.writeText(url())); }}
-                                    title="Copy URL"
-                                >
-                                    Copy
-                                </button>
-                            </div>
-                            <div class="agent-auth-paste-row">
-                                <input
-                                    class="agent-auth-paste-input"
-                                    type="text"
-                                    placeholder="Paste auth code from Anthropic..."
-                                    value={pasteCode()}
-                                    onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
-                                    onKeyDown={(e) => { if (e.key === "Enter") void handleSubmitCode(); }}
-                                />
-                                <button
-                                    class="agent-auth-url-copy"
-                                    title="Paste from clipboard"
-                                    onClick={() => {
-                                        import("@/util/clipboard").then(c => c.readText()).then(text => {
-                                            if (text) setPasteCode(text.trim());
-                                        }).catch(() => {
-                                            setPasteResult("Could not read clipboard — paste manually");
-                                        });
-                                    }}
-                                >
-                                    Paste
-                                </button>
-                                <button
-                                    class="agent-auth-url-copy"
-                                    onClick={handleSubmitCode}
-                                    disabled={!pasteCode().trim() || pasting()}
-                                >
-                                    {pasting() ? "..." : "Submit"}
-                                </button>
-                            </div>
-                            <Show when={pasteResult()}>
-                                <div class="agent-auth-paste-result">{pasteResult()}</div>
-                            </Show>
-                        </div>
-                    );
-                }}
+            <Show when={props.authUrl?.()}>
+                {(url) => <AuthUrlBox url={url()} authProviderId={props.authProviderId} />}
             </Show>
+        </>
+    );
 
-            {/* Document nodes render below log lines.
-                `content-visibility: auto` on the wrapper lets the browser
-                skip layout/paint for off-screen nodes — critical for
-                long sessions where thousands of DOM elements accumulate. */}
-            <For each={document()}>
-                {(node) => {
-                    const isBookmarked = () => bookmarkedNodeIds?.().has(node.id) ?? false;
-                    const canExpand = () => {
-                        switch (node.type) {
-                            case "tool":
-                            case "agent_message":
-                            case "user_message":
-                            case "section":
-                                return true;
-                            default:
-                                return false;
-                        }
-                    };
-                    const isExpanded = () => {
-                        if (node.type === "tool") return documentState().pinnedNodes.has(node.id);
-                        return !documentState().collapsedNodes.has(node.id);
-                    };
-                    const onExpand = () => {
-                        if (node.type === "tool") togglePin(node.id);
-                        else toggleCollapse(node.id);
-                    };
-                    // Phase 6: "new pane" for tool rows — deferred until a scratch view exists.
-                    const onOpenInNewPane = node.type === "tool"
-                        ? () => console.warn("[hover-strip] open in new pane — not yet implemented")
-                        : undefined;
-                    const onOpenInNewWindow = () =>
-                        console.warn("[hover-strip] open in new window — not yet implemented");
-                    const onNewAgentFromHere = () =>
-                        console.warn("[hover-strip] new agent from here — not yet implemented");
-
-                    const handleRowKey = (e: KeyboardEvent): void => {
-                        if (e.metaKey || e.ctrlKey || e.altKey) return;
-                        switch (e.key.toLowerCase()) {
-                            case "e":
-                                if (canExpand()) { onExpand(); e.preventDefault(); }
-                                break;
-                            case "b":
-                                if (onBookmark != null) { onBookmark(node); e.preventDefault(); }
-                                break;
-                            case "p":
-                                if (onOpenInNewPane) { onOpenInNewPane(); e.preventDefault(); }
-                                break;
-                            case "w":
-                                onOpenInNewWindow(); e.preventDefault();
-                                break;
-                            case "n":
-                                onNewAgentFromHere(); e.preventDefault();
-                                break;
-                            case "escape":
-                                (e.currentTarget as HTMLElement).blur();
-                                e.preventDefault();
-                                break;
-                        }
-                    };
-
-                    const handleContextMenu = (e: MouseEvent) => {
-                        if (!onBookmark) return;
-                        // Don't show bookmark menu on top of text selections — let the parent handle those.
-                        const sel = window.getSelection()?.toString();
-                        if (sel) return;
-                        e.preventDefault();
-                        e.stopPropagation();
-                        ContextMenuModel.showContextMenu(
-                            [
-                                {
-                                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
-                                    click: () => onBookmark(node),
-                                },
-                            ],
-                            e,
-                        );
-                    };
-
-                    return (
-                        <div
-                            class="hover-strip-host agent-document-node-wrapper"
-                            classList={{
-                                "agent-node-bookmarked": isBookmarked(),
-                                "agent-node-search-match": highlightNodeId?.() === node.id,
-                            }}
-                            data-node-id={node.id}
-                            tabindex="0"
-                            onKeyDown={handleRowKey}
-                            onContextMenu={handleContextMenu}
-                        >
-                            <DocumentNodeRenderer
-                                node={node}
-                                collapsed={documentState().collapsedNodes.has(node.id)}
-                                onToggle={() => toggleCollapse(node.id)}
-                                toolPinned={documentState().pinnedNodes.has(node.id)}
-                                onToggleToolPin={() => togglePin(node.id)}
-                                onSubagentClick={onSubagentClick}
-                            />
-                            <NodeHoverStrip
-                                timestamp={(node as any).timestamp}
-                                nodeId={node.id}
-                                isBookmarked={isBookmarked()}
-                                onBookmark={onBookmark != null ? () => onBookmark(node) : undefined}
-                                canExpand={canExpand()}
-                                isExpanded={isExpanded()}
-                                onExpand={onExpand}
-                                onOpenInNewPane={onOpenInNewPane}
-                                onOpenInNewWindow={onOpenInNewWindow}
-                                onNewAgentFromHere={onNewAgentFromHere}
-                            />
-                        </div>
-                    );
-                }}
-            </For>
-        </div>
+    return (
+        <AgentDocumentVirtualList
+            viewState={viewState}
+            documentState={documentState}
+            bookmarkedNodeIds={props.bookmarkedNodeIds}
+            onBookmark={props.onBookmark}
+            onSubagentClick={props.onSubagentClick}
+            onLoadOlder={props.onLoadOlder}
+            loadingOlder={props.loadingOlder}
+            highlightNodeId={props.highlightNodeId}
+            scrollCommand={props.scrollCommand}
+            scrollToBottomRef={props.scrollToBottomRef}
+            onToggleCollapse={toggleCollapse}
+            onTogglePin={togglePin}
+            headerSlot={headerSlot()}
+        />
     );
 };
 
 AgentDocumentView.displayName = "AgentDocumentView";
 
-// ── Node renderer ────────────────────────────────────────────────────────────
+// ── Auth URL box ────────────────────────────────────────────────────────────
 
-// SolidJS reactivity note: props are accessed via `props.X` and NEVER
-// destructured in the parameter list. Destructuring captures mount-time
-// values and breaks reactivity for any prop that changes without triggering
-// the parent to re-create this component. Since the tool pin state
-// (`toolPinned`) lives in documentState — separate from the document array
-// that <For> keys off — pin toggles do NOT re-create DocumentNodeRenderer,
-// so a destructured `toolPinned` would stay stale forever even though the
-// child ToolBlock uses `props.pinned` correctly.
-//
-// See commit adcec38 for the first half of this fix (ToolBlock), and the
-// reagent review on PR #346 that caught this upstream companion.
-
-interface DocumentNodeRendererProps {
-    node: DocumentNode;
-    collapsed: boolean;
-    onToggle: () => void;
-    toolPinned: boolean;
-    onToggleToolPin: () => void;
-    onSubagentClick?: (node: SubagentLinkNode) => void;
+interface AuthUrlBoxProps {
+    url: string;
+    authProviderId?: string;
 }
 
-const DocumentNodeRenderer = (props: DocumentNodeRendererProps): JSX.Element => {
-    switch (props.node.type) {
-        case "markdown":
-            return <MarkdownBlock node={props.node} />;
+/**
+ * OAuth code-paste box. Rendered at the top of the scroll container
+ * while a login flow has a pending auth URL. Previously inline in
+ * AgentDocumentView; extracted as a sibling for the Phase 2 shell.
+ */
+function AuthUrlBox(props: AuthUrlBoxProps): JSX.Element {
+    const [pasteCode, setPasteCode] = createSignal("");
+    const [pasting, setPasting] = createSignal(false);
+    const [pasteResult, setPasteResult] = createSignal<string | null>(null);
 
-        case "tool":
-            return (
-                <ToolBlock
-                    node={props.node}
-                    pinned={props.toolPinned}
-                    onTogglePin={props.onToggleToolPin}
-                />
-            );
+    const handleSubmitCode = async (): Promise<void> => {
+        const code = pasteCode().trim();
+        if (!code) return;
+        setPasting(true);
+        setPasteResult(null);
+        try {
+            const { getApi } = await import("@/app/store/global");
+            await getApi().setProviderAuth(props.authProviderId ?? "claude", code);
+            setPasteResult("Code accepted — waiting for confirmation...");
+            setPasteCode("");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            setPasteResult(`Error: ${msg}`);
+        } finally {
+            setPasting(false);
+        }
+    };
 
-        case "agent_message":
-            return (
-                <AgentMessageBlock
-                    node={props.node}
-                    collapsed={props.collapsed}
-                    onToggle={props.onToggle}
-                />
-            );
-
-        case "user_message": {
-            const node = props.node;
-            return (
-                <div
-                    class="agent-user-message"
-                    classList={{ "agent-user-message--collapsed": props.collapsed }}
+    return (
+        <div class="agent-auth-url-box">
+            <div class="agent-auth-url-label">Open this URL to log in:</div>
+            <div class="agent-auth-url-row">
+                <span class="agent-auth-url-text">{props.url}</span>
+                <button
+                    class="agent-auth-url-copy"
+                    onClick={() => { import("@/util/clipboard").then(c => c.writeText(props.url)); }}
+                    title="Copy URL"
                 >
-                    <div class="agent-user-message-content">
-                        <pre>{node.message}</pre>
-                    </div>
-                </div>
-            );
-        }
-
-        case "subagent_link":
-            return (
-                <SubagentLinkBlock
-                    node={props.node}
-                    onClick={props.onSubagentClick ?? (() => {})}
+                    Copy
+                </button>
+            </div>
+            <div class="agent-auth-paste-row">
+                <input
+                    class="agent-auth-paste-input"
+                    type="text"
+                    placeholder="Paste auth code from Anthropic..."
+                    value={pasteCode()}
+                    onInput={(e) => setPasteCode((e.target as HTMLInputElement).value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") void handleSubmitCode(); }}
                 />
-            );
-
-        case "section": {
-            const node = props.node;
-            return (
-                <div class={`agent-section level-${node.level}`}>
-                    <Show when={node.level === 1}>
-                        <h1>{node.title}</h1>
-                    </Show>
-                    <Show when={node.level === 2}>
-                        <h2>{node.title}</h2>
-                    </Show>
-                    <Show when={node.level === 3}>
-                        <h3>{node.title}</h3>
-                    </Show>
-                </div>
-            );
-        }
-
-        default:
-            return null;
-    }
-};
-
-DocumentNodeRenderer.displayName = "DocumentNodeRenderer";
+                <button
+                    class="agent-auth-url-copy"
+                    title="Paste from clipboard"
+                    onClick={() => {
+                        import("@/util/clipboard").then(c => c.readText()).then(text => {
+                            if (text) setPasteCode(text.trim());
+                        }).catch(() => {
+                            setPasteResult("Could not read clipboard — paste manually");
+                        });
+                    }}
+                >
+                    Paste
+                </button>
+                <button
+                    class="agent-auth-url-copy"
+                    onClick={() => { void handleSubmitCode(); }}
+                    disabled={!pasteCode().trim() || pasting()}
+                >
+                    {pasting() ? "..." : "Submit"}
+                </button>
+            </div>
+            <Show when={pasteResult()}>
+                <div class="agent-auth-paste-result">{pasteResult()}</div>
+            </Show>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/styles/_document.scss
+++ b/frontend/app/view/agent/styles/_document.scss
@@ -98,11 +98,71 @@
         }
     }
 
+    // === Virtualization (Phase 2 redesign) ===
+    //
+    // overflow-anchor on the scroll container is the CSS half of the
+    // anchor model — Chromium auto-pins a visible anchor element when
+    // content above it changes height (e.g., async image/font loads,
+    // tool block expand). The JS layer in AgentDocumentVirtualList
+    // handles the cases CSS can't (programmatic scroll, remount).
+    //
+    // Spec: docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+    //       §"Anchor — CSS + JS belt-and-suspenders"
+    overflow-anchor: auto;
+
+    .agent-document-virtualizer {
+        // Container for the virtualized region. Children are
+        // absolute-positioned via translateY; the height equals
+        // virtualizer.getTotalSize() so the native scrollbar reflects
+        // the full virtual content.
+        //
+        // flex-shrink: 0 — .agent-document is a column flex container,
+        // so without this the wrapper would collapse to viewport
+        // height when getTotalSize() exceeds it (codex P1 from #773).
+        position: relative;
+        width: 100%;
+        flex-shrink: 0;
+    }
+
+    .agent-document-streaming-buffer {
+        // Trailing nodes rendered in normal flex flow — no
+        // virtualization. Always mounted so streaming token batches
+        // don't have to wait for measureElement to settle.
+        display: flex;
+        flex-direction: column;
+        gap: 1px;
+        flex-shrink: 0;
+    }
+
+    .agent-document-row {
+        // Replaces the old .agent-document-node-wrapper. content-
+        // visibility is no longer needed because off-screen items
+        // (in the virtualized region) aren't in the DOM at all.
+        // contain: layout style isolates the row's layout cost so
+        // a single message expanding doesn't reflow neighbors.
+        contain: layout style;
+        // Anchor for any width-relative children (markdown tables,
+        // code diffs). Without this, absolute-positioned virtualized
+        // rows lose their layout context and tables break.
+        width: 100%;
+
+        &:focus {
+            outline: 1px solid var(--accent-color);
+            outline-offset: -1px;
+        }
+
+        // Force tables to constrain their layout to the row width.
+        // Spec: SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+        //       §"Tables and rich content"
+        :is(table, .markdown-table) {
+            width: 100%;
+            table-layout: fixed;
+        }
+    }
+
+    // Legacy class — keep for any non-virtualized callers; remove
+    // once Phase 2 is fully wired in everywhere.
     .agent-document-node-wrapper {
-        // Each document node gets its own containment box. Off-screen nodes
-        // are skipped by the browser via content-visibility.
-        // contain-intrinsic-size gives the browser a size estimate so scroll
-        // position stays stable when content is virtualized in/out.
         content-visibility: auto;
         contain-intrinsic-size: auto 80px;
         contain: layout style;

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,9 +29,10 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, createMemo, For, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, For, onMount, type Accessor, type JSX } from "solid-js";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import { agentPerfStore, startAgentLayoutShiftObserver } from "./perf-probe";
 import {
     captureTopmostAnchor,
     isNearBottom,
@@ -103,6 +104,31 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         get scrollMargin() {
             return virtualContainerRef?.offsetTop ?? 0;
         },
+        // Phase 3 perf probe: validate the per-kind estimator against
+        // the measured size after every measurement. The HUD surfaces
+        // any kind whose miss-rate stays high so we recalibrate.
+        // No-op in production builds (agentPerfStore short-circuits).
+        measureElement: (element) => {
+            const measured = element.getBoundingClientRect().height;
+            const indexAttr = element.getAttribute("data-index");
+            if (indexAttr != null) {
+                const idx = Number(indexAttr);
+                const node = partition().virtualizedNodes[idx];
+                if (node) {
+                    const estimated = estimateNode(node, props.documentState());
+                    agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
+                }
+            }
+            // Return the measured height. (reagent P2 on #785: dead
+            // ternary removed — both branches returned `measured`.)
+            return measured;
+        },
+    });
+
+    // Layout-shift observer scoped to .agent-document. Idempotent —
+    // subsequent mounts are no-ops. Production: short-circuits.
+    onMount(() => {
+        startAgentLayoutShiftObserver();
     });
 
     // Project stickToBottom into scroll position. When the document

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -119,8 +119,6 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                     agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
                 }
             }
-            // Return the measured height. (reagent P2 on #785: dead
-            // ternary removed — both branches returned `measured`.)
             return measured;
         },
     });

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,7 +29,7 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, For, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, For, type Accessor, type JSX } from "solid-js";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
 import {
@@ -73,9 +73,15 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
     // Guard against concurrent older-history fetches triggered by scroll.
     let loadingOlderInFlight = false;
 
-    const partition = (): ReturnType<typeof partitionForVirtualization> => {
+    // Memoized — partition is read inside virtualizer's reactive
+    // count getter, estimateSize, getItemKey, the streaming buffer
+    // <For>, and each virtual item's nodeAccessor. Without
+    // createMemo, every read re-slices the document (O(n)) on every
+    // token of streaming, defeating the streaming buffer's purpose.
+    // (reagent P1 on #784.)
+    const partition = createMemo(() => {
         return partitionForVirtualization(props.viewState.nodes());
-    };
+    });
 
     // Virtualizer over the virtualized head only — streaming buffer is
     // rendered separately as a normal flex list. Per-kind estimators
@@ -177,15 +183,30 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
             !loadingOlderInFlight &&
             !(props.loadingOlder?.())
         ) {
-            // Capture anchor from the topmost virtualized item — its
-            // offsetPx is virtualItem.start + scrollMargin.
+            // Capture anchor from the topmost visible node. Two cases:
+            //   1) Document is large enough to virtualize → use the
+            //      topmost virtual item. Note: in TanStack Virtual v3
+            //      `virtualItem.start` ALREADY includes scrollMargin
+            //      so we read it directly without re-adding the margin.
+            //   2) Document fits entirely in the streaming buffer
+            //      (≤ STREAMING_BUFFER_SIZE nodes) → getVirtualItems()
+            //      is empty, so fall back to the streaming buffer's
+            //      first node via DOM. This is the common initial-
+            //      pagination case (codex P2 on #784).
             const items = virtualizer.getVirtualItems();
-            const anchorId = items.length > 0
-                ? partition().virtualizedNodes[items[0].index]?.id
-                : null;
+            let anchorId: string | null = null;
+            let anchorOffsetPx = 0;
+            if (items.length > 0) {
+                anchorId = partition().virtualizedNodes[items[0].index]?.id ?? null;
+                anchorOffsetPx = items[0].start;
+            } else if (partition().streamingNodes.length > 0) {
+                anchorId = partition().streamingNodes[0].id;
+                const el = scrollRef.querySelector(
+                    `[data-node-id="${anchorId}"]`,
+                ) as HTMLElement | null;
+                anchorOffsetPx = el?.offsetTop ?? 0;
+            }
             if (anchorId != null) {
-                const items0 = items[0];
-                const anchorOffsetPx = (items0.start) + (virtualContainerRef?.offsetTop ?? 0);
                 const anchor = captureTopmostAnchor(
                     [{ id: anchorId, offsetPx: anchorOffsetPx }],
                     scrollTop,
@@ -206,12 +227,11 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                             const newP = partitionForVirtualization(props.viewState.nodes());
                             if (newIdx < newP.splitIndex) {
                                 // Still virtualized — recompute via virtualizer's offsetForIndex.
+                                // The returned offset already includes scrollMargin in v3,
+                                // so don't add virtualContainerRef.offsetTop again.
                                 const offset = virtualizer.getOffsetForIndex(newIdx, "start");
                                 if (offset != null) {
-                                    const target = restoreScrollFromAnchor(
-                                        anchor,
-                                        offset[0] + (virtualContainerRef?.offsetTop ?? 0),
-                                    );
+                                    const target = restoreScrollFromAnchor(anchor, offset[0]);
                                     scrollRef.scrollTo({ top: target, behavior: "auto" });
                                 }
                             } else {
@@ -266,6 +286,7 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                                 onToggleCollapse={props.onToggleCollapse}
                                 onTogglePin={props.onTogglePin}
                                 ref={virtualizer.measureElement}
+                                dataIndex={virtualItem.index}
                                 style={{
                                     position: "absolute",
                                     top: "0",

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -1,0 +1,304 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentDocumentVirtualList — hybrid virtualized + streaming-buffer
+ * renderer for the agent pane document. Replaces the old monolithic
+ * `<For each={document()}>` block in AgentDocumentView.
+ *
+ * Architecture (from docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md):
+ *
+ *  ┌─ scrollRef (.agent-document) ─────────────────────────┐
+ *  │  ┌─ virtualized region ─────────────────────────────┐ │
+ *  │  │  height = virtualizer.getTotalSize()             │ │
+ *  │  │  position: relative                              │ │
+ *  │  │  rows: position: absolute, translateY(start)     │ │
+ *  │  │  measureElement on each row                      │ │
+ *  │  └──────────────────────────────────────────────────┘ │
+ *  │  ┌─ streaming buffer ───────────────────────────────┐ │
+ *  │  │  trailing N nodes, normal flex flow              │ │
+ *  │  │  no virtualization → no measurement lag during   │ │
+ *  │  │  token streams                                   │ │
+ *  │  └──────────────────────────────────────────────────┘ │
+ *  └────────────────────────────────────────────────────────┘
+ *
+ * Scroll state (`stickToBottom`, `headAnchor`) lives in
+ * AgentViewState, never in scrollRef.scrollTop. Caller drives
+ * scrollToBottom / scrollToNode via props; this component projects
+ * the state into the DOM but never reads it back.
+ */
+
+import { createVirtualizer } from "@tanstack/solid-virtual";
+import { createEffect, For, type Accessor, type JSX } from "solid-js";
+import type { ScrollCommand } from "../hooks/useScrollToNode";
+import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import {
+    captureTopmostAnchor,
+    isNearBottom,
+    isNearTop,
+    restoreScrollFromAnchor,
+} from "./anchor";
+import { DocumentRow } from "./DocumentRow";
+import { estimateNode } from "./renderers";
+import type { AgentViewState } from "./state";
+import { partitionForVirtualization } from "./streaming-buffer";
+
+export interface AgentDocumentVirtualListProps {
+    viewState: AgentViewState;
+    documentState: Accessor<DocumentState>;
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    onBookmark?: (node: DocumentNode) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+    onLoadOlder?: () => Promise<void>;
+    loadingOlder?: Accessor<boolean>;
+    highlightNodeId?: Accessor<string | null>;
+    scrollCommand?: Accessor<ScrollCommand | null>;
+    /** Wire-up callback so the parent (AgentFooter via AgentDocumentView)
+     *  can invoke jumpToBottom on user keystroke. */
+    scrollToBottomRef?: (fn: () => void) => void;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    /**
+     * Content rendered inside the scroll container, above the
+     * virtualized region. Used by AgentDocumentView for the
+     * auth-url box and the loading-older banner. Affects scroll math
+     * via scrollMargin (read from virtualContainerRef.offsetTop).
+     */
+    headerSlot?: JSX.Element;
+}
+
+export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): JSX.Element {
+    let scrollRef!: HTMLDivElement;
+    let virtualContainerRef: HTMLDivElement | undefined;
+    // Guard against concurrent older-history fetches triggered by scroll.
+    let loadingOlderInFlight = false;
+
+    const partition = (): ReturnType<typeof partitionForVirtualization> => {
+        return partitionForVirtualization(props.viewState.nodes());
+    };
+
+    // Virtualizer over the virtualized head only — streaming buffer is
+    // rendered separately as a normal flex list. Per-kind estimators
+    // come from the renderer registry; measureElement settles each row
+    // to actual height after first paint.
+    const virtualizer = createVirtualizer({
+        get count() { return partition().virtualizedNodes.length; },
+        getScrollElement: () => scrollRef,
+        estimateSize: (index) => {
+            const node = partition().virtualizedNodes[index];
+            return node ? estimateNode(node, props.documentState()) : 32;
+        },
+        overscan: 5,
+        getItemKey: (index) => partition().virtualizedNodes[index]?.id ?? index,
+        // scrollMargin: any content rendered above the virtualizer
+        // container (loading-older banner, auth-url box from the
+        // parent) shifts the virtual coordinate system. Read offsetTop
+        // as a getter so it's evaluated each tick.
+        get scrollMargin() {
+            return virtualContainerRef?.offsetTop ?? 0;
+        },
+    });
+
+    // Project stickToBottom into scroll position. When the document
+    // grows AND we're sticky, scroll the streaming buffer's last item
+    // into view. Streaming-buffer items live in normal flow at the
+    // bottom of the scroll container, so MAX_SAFE_INTEGER scrollTo
+    // works reliably for them (no virtualizer reflow needed).
+    createEffect(() => {
+        // Track length changes — Solid will re-run when nodes() emits.
+        const _len = props.viewState.nodes().length;
+        if (props.viewState.stickToBottom() && scrollRef) {
+            // queueMicrotask so the new content has rendered before we scroll.
+            queueMicrotask(() => {
+                if (!scrollRef) return;
+                scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+            });
+        }
+    });
+
+    // jumpToBottom: forced scroll-to-bottom that re-engages stick.
+    // Exposed to parent so AgentFooter can call it on keystroke.
+    const jumpToBottom = (): void => {
+        if (!scrollRef) return;
+        props.viewState.engageStickToBottom();
+        scrollRef.scrollTo({ top: Number.MAX_SAFE_INTEGER, behavior: "auto" });
+    };
+    if (props.scrollToBottomRef) props.scrollToBottomRef(jumpToBottom);
+
+    // scrollToNode: jump the named node into view. Disengages stick
+    // (user wants to stay where they jumped). Routes through the
+    // virtualizer if the target is in the virtualized head, else uses
+    // the streaming buffer's natural DOM offset.
+    const scrollToNode = (nodeId: string): void => {
+        if (!scrollRef) return;
+        const idx = props.viewState.indexOf(nodeId);
+        if (idx < 0) return;
+        const p = partition();
+        if (idx < p.splitIndex) {
+            // Virtualized region — virtualizer handles ensure-visible + scroll.
+            virtualizer.scrollToIndex(idx, { align: "center", behavior: "smooth" });
+        } else {
+            // Streaming buffer — node is mounted; query DOM and scroll directly.
+            const el = scrollRef.querySelector(`[data-node-id="${nodeId}"]`) as HTMLElement | null;
+            if (!el) return;
+            const elTop = el.offsetTop;
+            const center = elTop - scrollRef.clientHeight / 2 + el.clientHeight / 2;
+            scrollRef.scrollTo({ top: Math.max(0, center), behavior: "smooth" });
+        }
+        props.viewState.disengageStickToBottom();
+    };
+
+    // React to jump commands from the parent's useScrollToNode hook.
+    createEffect(() => {
+        const cmd = props.scrollCommand?.();
+        if (cmd) scrollToNode(cmd.nodeId);
+    });
+
+    const handleScroll = (): void => {
+        if (!scrollRef) return;
+        const { scrollTop, scrollHeight, clientHeight } = scrollRef;
+
+        // Engage stick when user scrolls back near bottom; disengage
+        // otherwise. Engaging clears any captured headAnchor (atomic).
+        if (isNearBottom(scrollTop, scrollHeight, clientHeight)) {
+            if (!props.viewState.stickToBottom()) {
+                props.viewState.engageStickToBottom();
+            }
+        } else {
+            if (props.viewState.stickToBottom()) {
+                props.viewState.disengageStickToBottom();
+            }
+        }
+
+        // Older-history pagination — capture anchor, fetch, restore.
+        if (
+            props.onLoadOlder &&
+            isNearTop(scrollTop) &&
+            !loadingOlderInFlight &&
+            !(props.loadingOlder?.())
+        ) {
+            // Capture anchor from the topmost virtualized item — its
+            // offsetPx is virtualItem.start + scrollMargin.
+            const items = virtualizer.getVirtualItems();
+            const anchorId = items.length > 0
+                ? partition().virtualizedNodes[items[0].index]?.id
+                : null;
+            if (anchorId != null) {
+                const items0 = items[0];
+                const anchorOffsetPx = (items0.start) + (virtualContainerRef?.offsetTop ?? 0);
+                const anchor = captureTopmostAnchor(
+                    [{ id: anchorId, offsetPx: anchorOffsetPx }],
+                    scrollTop,
+                );
+                if (anchor) props.viewState.captureHeadAnchor(anchor);
+            }
+
+            loadingOlderInFlight = true;
+            props.onLoadOlder().then(() => {
+                requestAnimationFrame(() => {
+                    // Restore from anchor by id — partition reflects the
+                    // new prepended nodes, so the anchor's new index
+                    // gives a fresh measured offset.
+                    const anchor = props.viewState.headAnchor();
+                    if (anchor != null && scrollRef) {
+                        const newIdx = props.viewState.indexOf(anchor.nodeId);
+                        if (newIdx >= 0) {
+                            const newP = partitionForVirtualization(props.viewState.nodes());
+                            if (newIdx < newP.splitIndex) {
+                                // Still virtualized — recompute via virtualizer's offsetForIndex.
+                                const offset = virtualizer.getOffsetForIndex(newIdx, "start");
+                                if (offset != null) {
+                                    const target = restoreScrollFromAnchor(
+                                        anchor,
+                                        offset[0] + (virtualContainerRef?.offsetTop ?? 0),
+                                    );
+                                    scrollRef.scrollTo({ top: target, behavior: "auto" });
+                                }
+                            } else {
+                                // Now in streaming buffer — query DOM.
+                                const el = scrollRef.querySelector(
+                                    `[data-node-id="${anchor.nodeId}"]`,
+                                ) as HTMLElement | null;
+                                if (el) {
+                                    const target = restoreScrollFromAnchor(anchor, el.offsetTop);
+                                    scrollRef.scrollTo({ top: target, behavior: "auto" });
+                                }
+                            }
+                        }
+                    }
+                    loadingOlderInFlight = false;
+                });
+            }).catch(() => {
+                loadingOlderInFlight = false;
+            });
+        }
+    };
+
+    // Render: scroll container holds the optional header, the
+    // virtualized head, and the streaming buffer. headerSlot offsets
+    // the virtualizer; scrollMargin (above) handles that automatically.
+    return (
+        <div class="agent-document" ref={scrollRef} onScroll={handleScroll}>
+            {props.headerSlot}
+            {/* Virtualized head — only present when document > buffer size */}
+            <div
+                ref={(el) => { virtualContainerRef = el; }}
+                class="agent-document-virtualizer"
+                style={{
+                    height: `${virtualizer.getTotalSize()}px`,
+                    position: "relative",
+                    width: "100%",
+                }}
+            >
+                <For each={virtualizer.getVirtualItems()}>
+                    {(virtualItem) => {
+                        const nodeAccessor = (): DocumentNode => {
+                            return partition().virtualizedNodes[virtualItem.index];
+                        };
+                        return (
+                            <DocumentRow
+                                node={nodeAccessor}
+                                documentState={props.documentState}
+                                bookmarkedNodeIds={props.bookmarkedNodeIds}
+                                onBookmark={props.onBookmark}
+                                onSubagentClick={props.onSubagentClick}
+                                highlightNodeId={props.highlightNodeId}
+                                onToggleCollapse={props.onToggleCollapse}
+                                onTogglePin={props.onTogglePin}
+                                ref={virtualizer.measureElement}
+                                style={{
+                                    position: "absolute",
+                                    top: "0",
+                                    left: "0",
+                                    width: "100%",
+                                    transform: `translateY(${virtualItem.start - (virtualContainerRef?.offsetTop ?? 0)}px)`,
+                                }}
+                            />
+                        );
+                    }}
+                </For>
+            </div>
+
+            {/* Streaming buffer — always-mounted trailing nodes */}
+            <div class="agent-document-streaming-buffer">
+                <For each={partition().streamingNodes as DocumentNode[]}>
+                    {(node) => {
+                        const nodeAccessor = (): DocumentNode => node;
+                        return (
+                            <DocumentRow
+                                node={nodeAccessor}
+                                documentState={props.documentState}
+                                bookmarkedNodeIds={props.bookmarkedNodeIds}
+                                onBookmark={props.onBookmark}
+                                onSubagentClick={props.onSubagentClick}
+                                highlightNodeId={props.highlightNodeId}
+                                onToggleCollapse={props.onToggleCollapse}
+                                onTogglePin={props.onTogglePin}
+                            />
+                        );
+                    }}
+                </For>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -14,7 +14,7 @@
  * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
  */
 
-import { Show, type Accessor, type JSX } from "solid-js";
+import { onMount, Show, type Accessor, type JSX } from "solid-js";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { AgentMessageBlock } from "../components/AgentMessageBlock";
 import { MarkdownBlock } from "../components/MarkdownBlock";
@@ -22,6 +22,7 @@ import { NodeHoverStrip } from "../components/NodeHoverStrip";
 import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
 import { ToolBlock } from "../components/ToolBlock";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import { markRowMount } from "./perf-probe";
 
 export interface DocumentRowProps {
     /**
@@ -61,6 +62,13 @@ const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
 ]);
 
 export function DocumentRow(props: DocumentRowProps): JSX.Element {
+    // Phase 3: per-kind row mount perf probe. markRowMount returns a
+    // closer that we invoke after onMount fires (i.e., after the row
+    // is in the DOM and its initial paint has been queued).
+    // No-op in production builds.
+    const close = markRowMount(props.node().type);
+    onMount(() => close());
+
     const isBookmarked = (): boolean => {
         const n = props.node();
         return props.bookmarkedNodeIds?.().has(n.id) ?? false;

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -1,0 +1,253 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * DocumentRow — single row in the agent document list. Used by both
+ * the virtualized region and the unvirtualized streaming buffer in
+ * AgentDocumentVirtualList.
+ *
+ * Caller controls positioning (style + ref) so the same row works in
+ * absolute-positioned virtualizer slots and in the normal-flow
+ * streaming buffer without the row knowing the difference.
+ *
+ * Phase 2 of the virtualization redesign — see
+ * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
+ */
+
+import { Show, type Accessor, type JSX } from "solid-js";
+import { ContextMenuModel } from "@/app/store/contextmenu";
+import { AgentMessageBlock } from "../components/AgentMessageBlock";
+import { MarkdownBlock } from "../components/MarkdownBlock";
+import { NodeHoverStrip } from "../components/NodeHoverStrip";
+import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
+import { ToolBlock } from "../components/ToolBlock";
+import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+
+export interface DocumentRowProps {
+    /**
+     * Reactive accessor for the current node at this row's slot. Must
+     * be an accessor (not a value) so streaming updates that replace
+     * the node at the same id propagate without remount.
+     */
+    node: Accessor<DocumentNode>;
+    documentState: Accessor<DocumentState>;
+    bookmarkedNodeIds?: Accessor<Set<string>>;
+    onBookmark?: (node: DocumentNode) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+    highlightNodeId?: Accessor<string | null>;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    /** Style applied to the wrapper element. Virtualized parent
+     *  passes absolute positioning + translateY; streaming parent
+     *  passes nothing (normal flow). */
+    style?: JSX.CSSProperties;
+    /** Ref forwarded to the wrapper element. Virtualized parent
+     *  passes virtualizer.measureElement; streaming parent omits. */
+    ref?: (el: HTMLElement) => void;
+}
+
+const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
+    "tool",
+    "agent_message",
+    "user_message",
+    "section",
+]);
+
+export function DocumentRow(props: DocumentRowProps): JSX.Element {
+    const isBookmarked = (): boolean => {
+        const n = props.node();
+        return props.bookmarkedNodeIds?.().has(n.id) ?? false;
+    };
+
+    const isSearchMatch = (): boolean => {
+        return props.highlightNodeId?.() === props.node().id;
+    };
+
+    const canExpand = (): boolean => TOGGLEABLE_KINDS.has(props.node().type);
+
+    const isExpanded = (): boolean => {
+        const n = props.node();
+        const state = props.documentState();
+        if (n.type === "tool") return state.pinnedNodes.has(n.id);
+        return !state.collapsedNodes.has(n.id);
+    };
+
+    const onExpand = (): void => {
+        const n = props.node();
+        if (n.type === "tool") props.onTogglePin(n.id);
+        else props.onToggleCollapse(n.id);
+    };
+
+    // Phase 6 placeholders — match existing AgentDocumentView contract.
+    const onOpenInNewPane = (): void => {
+        if (props.node().type === "tool") {
+            console.warn("[hover-strip] open in new pane — not yet implemented");
+        }
+    };
+    const onOpenInNewWindow = (): void =>
+        console.warn("[hover-strip] open in new window — not yet implemented");
+    const onNewAgentFromHere = (): void =>
+        console.warn("[hover-strip] new agent from here — not yet implemented");
+
+    const handleRowKey = (e: KeyboardEvent): void => {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        const n = props.node();
+        switch (e.key.toLowerCase()) {
+            case "e":
+                if (canExpand()) { onExpand(); e.preventDefault(); }
+                break;
+            case "b":
+                if (props.onBookmark != null) { props.onBookmark(n); e.preventDefault(); }
+                break;
+            case "p":
+                if (n.type === "tool") { onOpenInNewPane(); e.preventDefault(); }
+                break;
+            case "w":
+                onOpenInNewWindow(); e.preventDefault();
+                break;
+            case "n":
+                onNewAgentFromHere(); e.preventDefault();
+                break;
+            case "escape":
+                (e.currentTarget as HTMLElement).blur();
+                e.preventDefault();
+                break;
+        }
+    };
+
+    const handleContextMenu = (e: MouseEvent): void => {
+        if (!props.onBookmark) return;
+        // Don't shadow text-selection menus — let the parent pane handle those.
+        const sel = window.getSelection()?.toString();
+        if (sel) return;
+        e.preventDefault();
+        e.stopPropagation();
+        const n = props.node();
+        ContextMenuModel.showContextMenu(
+            [
+                {
+                    label: isBookmarked() ? "Remove bookmark" : "Bookmark this message",
+                    click: () => props.onBookmark?.(n),
+                },
+            ],
+            e,
+        );
+    };
+
+    return (
+        <div
+            ref={props.ref}
+            class="hover-strip-host agent-document-row"
+            classList={{
+                "agent-node-bookmarked": isBookmarked(),
+                "agent-node-search-match": isSearchMatch(),
+            }}
+            data-node-id={props.node().id}
+            tabindex="0"
+            onKeyDown={handleRowKey}
+            onContextMenu={handleContextMenu}
+            style={props.style}
+        >
+            <DocumentNodeBody
+                node={props.node}
+                documentState={props.documentState}
+                onToggleCollapse={props.onToggleCollapse}
+                onTogglePin={props.onTogglePin}
+                onSubagentClick={props.onSubagentClick}
+            />
+            <NodeHoverStrip
+                timestamp={(props.node() as { timestamp?: number }).timestamp}
+                nodeId={props.node().id}
+                isBookmarked={isBookmarked()}
+                onBookmark={props.onBookmark != null ? () => props.onBookmark!(props.node()) : undefined}
+                canExpand={canExpand()}
+                isExpanded={isExpanded()}
+                onExpand={onExpand}
+                onOpenInNewPane={props.node().type === "tool" ? onOpenInNewPane : undefined}
+                onOpenInNewWindow={onOpenInNewWindow}
+                onNewAgentFromHere={onNewAgentFromHere}
+            />
+        </div>
+    );
+}
+
+interface DocumentNodeBodyProps {
+    node: Accessor<DocumentNode>;
+    documentState: Accessor<DocumentState>;
+    onToggleCollapse: (id: string) => void;
+    onTogglePin: (id: string) => void;
+    onSubagentClick?: (node: SubagentLinkNode) => void;
+}
+
+/**
+ * Routes a DocumentNode to the right block component. Each branch
+ * accesses props.node() reactively so streaming updates and state-set
+ * toggles propagate without remount.
+ *
+ * Reactivity discipline (carried over from the original
+ * DocumentNodeRenderer comment): never destructure props in this
+ * function. The toolPinned state lives in documentState (separate from
+ * the document array that the parent <For> keys off), so a
+ * destructured `toolPinned` would stay stale forever even though
+ * ToolBlock uses props.pinned correctly. See PR #346 reagent.
+ */
+function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
+    return (
+        <Show when={props.node()}>
+            {(n) => {
+                const node = n();
+                switch (node.type) {
+                    case "markdown":
+                        return <MarkdownBlock node={node} />;
+                    case "tool":
+                        return (
+                            <ToolBlock
+                                node={node}
+                                pinned={props.documentState().pinnedNodes.has(node.id)}
+                                onTogglePin={() => props.onTogglePin(node.id)}
+                            />
+                        );
+                    case "agent_message":
+                        return (
+                            <AgentMessageBlock
+                                node={node}
+                                collapsed={props.documentState().collapsedNodes.has(node.id)}
+                                onToggle={() => props.onToggleCollapse(node.id)}
+                            />
+                        );
+                    case "user_message":
+                        return (
+                            <div
+                                class="agent-user-message"
+                                classList={{
+                                    "agent-user-message--collapsed":
+                                        props.documentState().collapsedNodes.has(node.id),
+                                }}
+                            >
+                                <div class="agent-user-message-content">
+                                    <pre>{node.message}</pre>
+                                </div>
+                            </div>
+                        );
+                    case "subagent_link":
+                        return (
+                            <SubagentLinkBlock
+                                node={node}
+                                onClick={props.onSubagentClick ?? (() => { })}
+                            />
+                        );
+                    case "section":
+                        return (
+                            <div class={`agent-section level-${node.level}`}>
+                                <Show when={node.level === 1}><h1>{node.title}</h1></Show>
+                                <Show when={node.level === 2}><h2>{node.title}</h2></Show>
+                                <Show when={node.level === 3}><h3>{node.title}</h3></Show>
+                            </div>
+                        );
+                    default:
+                        return null;
+                }
+            }}
+        </Show>
+    );
+}

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -44,6 +44,13 @@ export interface DocumentRowProps {
     /** Ref forwarded to the wrapper element. Virtualized parent
      *  passes virtualizer.measureElement; streaming parent omits. */
     ref?: (el: HTMLElement) => void;
+    /**
+     * Virtual item index — set as `data-index` on the wrapper. TanStack
+     * Virtual's measureElement requires this attribute to match
+     * measurements back to virtual items. Streaming parent omits.
+     * (codex P1 on #784.)
+     */
+    dataIndex?: number;
 }
 
 const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
@@ -143,6 +150,7 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 "agent-node-search-match": isSearchMatch(),
             }}
             data-node-id={props.node().id}
+            data-index={props.dataIndex}
             tabindex="0"
             onKeyDown={handleRowKey}
             onContextMenu={handleContextMenu}

--- a/frontend/app/view/agent/virtualization/anchor.test.ts
+++ b/frontend/app/view/agent/virtualization/anchor.test.ts
@@ -1,0 +1,104 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+    captureTopmostAnchor,
+    isNearBottom,
+    isNearTop,
+    NEAR_TOP_THRESHOLD_PX,
+    restoreScrollFromAnchor,
+    STICK_TO_BOTTOM_THRESHOLD_PX,
+    type ScrollAnchor,
+} from "./anchor";
+
+describe("captureTopmostAnchor", () => {
+    it("returns null when no nodes are visible", () => {
+        expect(captureTopmostAnchor([], 100)).toBeNull();
+    });
+
+    it("captures the first visible node id and offset relative to scrollTop", () => {
+        // Topmost visible node is at offsetPx=200, scrollTop=250 →
+        // anchor's offset = 250 - 200 = +50 (node is 50px above viewport top).
+        const anchor = captureTopmostAnchor(
+            [
+                { id: "n5", offsetPx: 200 },
+                { id: "n6", offsetPx: 280 },
+            ],
+            250,
+        );
+        expect(anchor).toEqual<ScrollAnchor>({ nodeId: "n5", offsetPx: 50 });
+    });
+
+    it("handles negative offset (anchor below viewport top — rare but valid)", () => {
+        const anchor = captureTopmostAnchor([{ id: "n0", offsetPx: 500 }], 200);
+        expect(anchor).toEqual<ScrollAnchor>({ nodeId: "n0", offsetPx: -300 });
+    });
+});
+
+describe("restoreScrollFromAnchor", () => {
+    it("restores the captured offset relative to the new node position", () => {
+        // Anchor was captured at offset +50 from node n5.
+        // After prepend, n5 is now at offsetPx=520 (was 200 — 320px of new content above).
+        // Expected scrollTop: 520 + 50 = 570 (so n5 still appears 50px above viewport).
+        const anchor: ScrollAnchor = { nodeId: "n5", offsetPx: 50 };
+        expect(restoreScrollFromAnchor(anchor, 520)).toBe(570);
+    });
+
+    it("clamps negative results to 0", () => {
+        // If anchor is below viewport (-300) and node moves up to offset 100,
+        // raw result would be -200 → clamp to 0.
+        const anchor: ScrollAnchor = { nodeId: "n0", offsetPx: -300 };
+        expect(restoreScrollFromAnchor(anchor, 100)).toBe(0);
+    });
+
+    it("round-trips: captureTopmostAnchor → restoreScrollFromAnchor (no-prepend identity)", () => {
+        const visible = [{ id: "n5", offsetPx: 200 }];
+        const anchor = captureTopmostAnchor(visible, 250)!;
+        // Same node still at offsetPx=200 (no prepend). Restore should give back 250.
+        expect(restoreScrollFromAnchor(anchor, 200)).toBe(250);
+    });
+});
+
+describe("isNearBottom", () => {
+    it("returns true when within threshold of bottom", () => {
+        // scrollHeight=1000, scrollTop=850, clientHeight=100 → distance from
+        // bottom = 1000 - 850 - 100 = 50 < 200 threshold → true.
+        expect(isNearBottom(850, 1000, 100)).toBe(true);
+    });
+
+    it("returns false when far from bottom", () => {
+        expect(isNearBottom(100, 1000, 100)).toBe(false);
+    });
+
+    it("respects custom threshold", () => {
+        // distance = 50; threshold 30 → false.
+        expect(isNearBottom(850, 1000, 100, 30)).toBe(false);
+        // threshold 100 → true.
+        expect(isNearBottom(850, 1000, 100, 100)).toBe(true);
+    });
+
+    it("uses STICK_TO_BOTTOM_THRESHOLD_PX as default", () => {
+        // distance = 199, just under default 200 → true.
+        expect(isNearBottom(701, 1000, 100)).toBe(true);
+        // distance = 201 → false.
+        expect(isNearBottom(699, 1000, 100)).toBe(false);
+        expect(STICK_TO_BOTTOM_THRESHOLD_PX).toBe(200);
+    });
+});
+
+describe("isNearTop", () => {
+    it("returns true when scrollTop < threshold", () => {
+        expect(isNearTop(0)).toBe(true);
+        expect(isNearTop(49)).toBe(true);
+    });
+
+    it("returns false when scrollTop >= threshold", () => {
+        expect(isNearTop(50)).toBe(false);
+        expect(isNearTop(1000)).toBe(false);
+    });
+
+    it("uses NEAR_TOP_THRESHOLD_PX as default", () => {
+        expect(NEAR_TOP_THRESHOLD_PX).toBe(50);
+    });
+});

--- a/frontend/app/view/agent/virtualization/anchor.ts
+++ b/frontend/app/view/agent/virtualization/anchor.ts
@@ -1,0 +1,85 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure scroll-anchor math for the agent pane virtualization redesign.
+ * No DOM, no Solid — just the math the store and view layer build on.
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md §Architecture.
+ */
+
+/**
+ * Anchor for restoring scroll position after content prepends or
+ * remounts. Captured in the store; the view layer translates it back
+ * into a scrollTop using {@link restoreScrollFromAnchor}.
+ */
+export interface ScrollAnchor {
+    /** Stable id of the node we're anchored to. */
+    nodeId: string;
+    /**
+     * Pixel offset of the scroll container's top edge relative to the
+     * anchor node's top edge at capture time. Positive = anchor node
+     * was above the visible viewport; negative = below.
+     */
+    offsetPx: number;
+}
+
+/**
+ * Capture the topmost-visible node as an anchor.
+ *
+ * @param visibleNodes  Nodes currently in the viewport, ordered top-to-bottom.
+ *                      Each entry's `offsetPx` is the node's top relative to
+ *                      the scroll container's content origin (i.e., what you'd
+ *                      get from element.offsetTop).
+ * @param scrollTop     Current scroll position of the container.
+ * @returns null if no nodes are visible.
+ */
+export function captureTopmostAnchor(
+    visibleNodes: readonly { id: string; offsetPx: number }[],
+    scrollTop: number,
+): ScrollAnchor | null {
+    if (visibleNodes.length === 0) return null;
+    const top = visibleNodes[0];
+    return { nodeId: top.id, offsetPx: scrollTop - top.offsetPx };
+}
+
+/**
+ * Compute the scroll position that puts the anchor node back where it
+ * was at capture time. Caller passes the anchor's current measured
+ * offset within the (possibly grown) scroll container.
+ *
+ * @param anchor          Captured anchor.
+ * @param nodeOffsetPx    Anchor node's current top relative to content
+ *                        origin (e.g., element.offsetTop after prepend).
+ * @returns               Non-negative scrollTop to restore.
+ */
+export function restoreScrollFromAnchor(anchor: ScrollAnchor, nodeOffsetPx: number): number {
+    return Math.max(0, nodeOffsetPx + anchor.offsetPx);
+}
+
+/**
+ * Detect "near bottom" — used to flip stickToBottom on/off as the user
+ * scrolls. The 200px threshold matches the existing AgentDocumentView
+ * heuristic and gives the user a small dead-zone where minor scroll
+ * adjustments (e.g., new tool block expanding) don't break stick.
+ */
+export const STICK_TO_BOTTOM_THRESHOLD_PX = 200;
+
+export function isNearBottom(
+    scrollTop: number,
+    scrollHeight: number,
+    clientHeight: number,
+    threshold = STICK_TO_BOTTOM_THRESHOLD_PX,
+): boolean {
+    return scrollHeight - scrollTop - clientHeight < threshold;
+}
+
+/**
+ * Detect "near top" — used to trigger older-history pagination. The
+ * 50px threshold matches the existing onLoadOlder heuristic.
+ */
+export const NEAR_TOP_THRESHOLD_PX = 50;
+
+export function isNearTop(scrollTop: number, threshold = NEAR_TOP_THRESHOLD_PX): boolean {
+    return scrollTop < threshold;
+}

--- a/frontend/app/view/agent/virtualization/index.ts
+++ b/frontend/app/view/agent/virtualization/index.ts
@@ -1,0 +1,50 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Public surface of the agent-pane virtualization redesign foundation
+ * (Phase 1). Phase 2 adds the view-layer component; Phase 3 adds the
+ * perf-probe HUD; both will extend exports from here.
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
+ */
+
+export {
+    captureTopmostAnchor,
+    isNearBottom,
+    isNearTop,
+    NEAR_TOP_THRESHOLD_PX,
+    restoreScrollFromAnchor,
+    STICK_TO_BOTTOM_THRESHOLD_PX,
+    type ScrollAnchor,
+} from "./anchor";
+
+export {
+    createAgentViewState,
+    type AgentViewState,
+} from "./state";
+
+export {
+    locateIndex,
+    partitionForVirtualization,
+    STREAMING_BUFFER_SIZE,
+    type VirtualizationPartition,
+} from "./streaming-buffer";
+
+export {
+    buildRendererRegistry,
+    estimateAgentMessage,
+    estimateMarkdown,
+    estimateNode,
+    estimateSection,
+    estimateSubagentLink,
+    estimateTextHeight,
+    estimateTool,
+    estimateUserMessage,
+    STREAMING_CAPABLE,
+    type NodeKind,
+    type NodeKindRenderer,
+    type NodeOf,
+    type NodeRendererRegistry,
+    type RendererComponents,
+} from "./renderers";

--- a/frontend/app/view/agent/virtualization/perf-probe.test.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.test.ts
@@ -1,0 +1,163 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the agent-pane perf probe. Note: these tests run under
+ * Vitest's `import.meta.env.DEV === true`, so probing IS active here.
+ * Production no-op behavior is verified by inspecting the
+ * `isProbingEnabled()` short-circuit at the top of each record fn —
+ * not by a test (Vitest doesn't simulate the prod env without a
+ * separate config, and the bundler tree-shakes the dead branch).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    agentPerfStore,
+    ESTIMATOR_MISS_THRESHOLD,
+    markRowMount,
+} from "./perf-probe";
+
+describe("agentPerfStore", () => {
+    beforeEach(() => agentPerfStore.reset());
+
+    describe("recordRowMount", () => {
+        it("aggregates per-kind durations into a snapshot", () => {
+            agentPerfStore.recordRowMount("agent_message", 5);
+            agentPerfStore.recordRowMount("agent_message", 10);
+            agentPerfStore.recordRowMount("tool", 2);
+
+            const snap = agentPerfStore.snapshot();
+            expect(snap.rowMountByKind.has("agent_message")).toBe(true);
+            expect(snap.rowMountByKind.has("tool")).toBe(true);
+            expect(snap.rowMountByKind.get("agent_message")!.count).toBe(2);
+            expect(snap.rowMountByKind.get("tool")!.count).toBe(1);
+        });
+    });
+
+    describe("recordEstimatorMeasurement", () => {
+        it("does not flag measurements within threshold", () => {
+            // estimated 100, actual 110 → 10% error, under 30% threshold
+            agentPerfStore.recordEstimatorMeasurement("markdown", 100, 110);
+            const snap = agentPerfStore.snapshot();
+            expect(snap.recentEstimatorMisses).toHaveLength(0);
+            expect(snap.estimatorMissRateByKind.get("markdown")).toBe(0);
+        });
+
+        it("flags measurements outside threshold and records miss-rate", () => {
+            // estimated 100, actual 200 → 100% error
+            agentPerfStore.recordEstimatorMeasurement("tool", 100, 200);
+            const snap = agentPerfStore.snapshot();
+            expect(snap.recentEstimatorMisses).toHaveLength(1);
+            expect(snap.recentEstimatorMisses[0]).toMatchObject({
+                kind: "tool",
+                estimated: 100,
+                actual: 200,
+                errorPct: 1,
+            });
+            expect(snap.estimatorMissRateByKind.get("tool")).toBe(1);
+        });
+
+        it("computes miss-rate correctly across measurements", () => {
+            // 1 miss, 3 hits → miss rate 0.25
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 100); // 100% error → miss
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 55);  // 10% → hit
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 60);  // 20% → hit
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 50);  // 0% → hit
+            const snap = agentPerfStore.snapshot();
+            expect(snap.estimatorMissRateByKind.get("section")).toBeCloseTo(0.25, 2);
+        });
+
+        it("rejects measurements with estimated=0 (avoid divide-by-zero)", () => {
+            agentPerfStore.recordEstimatorMeasurement("subagent_link", 0, 100);
+            // errorPct should be 0 (defensive), not Infinity
+            const snap = agentPerfStore.snapshot();
+            // The measurement still counted toward total, just not flagged.
+            expect(snap.estimatorMissRateByKind.get("subagent_link")).toBe(0);
+        });
+
+        it("uses the documented threshold constant", () => {
+            // Just over threshold → flagged
+            const justOver = ESTIMATOR_MISS_THRESHOLD + 0.01;
+            agentPerfStore.recordEstimatorMeasurement("user_message", 100, 100 + 100 * justOver);
+            expect(agentPerfStore.snapshot().recentEstimatorMisses).toHaveLength(1);
+
+            agentPerfStore.reset();
+
+            // Just under threshold → not flagged
+            const justUnder = ESTIMATOR_MISS_THRESHOLD - 0.01;
+            agentPerfStore.recordEstimatorMeasurement("user_message", 100, 100 + 100 * justUnder);
+            expect(agentPerfStore.snapshot().recentEstimatorMisses).toHaveLength(0);
+        });
+    });
+
+    describe("recordLayoutShift", () => {
+        it("records shifts in chronological-recent order", () => {
+            agentPerfStore.recordLayoutShift(0.01);
+            agentPerfStore.recordLayoutShift(0.05);
+            agentPerfStore.recordLayoutShift(0.02);
+            const shifts = agentPerfStore.snapshot().recentLayoutShifts;
+            expect(shifts).toHaveLength(3);
+            // Most recent first.
+            expect(shifts[0].value).toBe(0.02);
+            expect(shifts[2].value).toBe(0.01);
+        });
+    });
+
+    describe("ring buffer bounds", () => {
+        it("caps recentEstimatorMisses at the ring size", () => {
+            for (let i = 0; i < 100; i++) {
+                agentPerfStore.recordEstimatorMeasurement("markdown", 100, 1000);
+            }
+            // Default SAMPLE_RING_SIZE is 64; verify cap.
+            expect(agentPerfStore.snapshot().recentEstimatorMisses.length).toBeLessThanOrEqual(64);
+        });
+
+        it("caps recentLayoutShifts at the ring size", () => {
+            for (let i = 0; i < 100; i++) {
+                agentPerfStore.recordLayoutShift(0.01);
+            }
+            expect(agentPerfStore.snapshot().recentLayoutShifts.length).toBeLessThanOrEqual(64);
+        });
+    });
+
+    describe("reset", () => {
+        it("clears all recorded data", () => {
+            agentPerfStore.recordRowMount("markdown", 5);
+            agentPerfStore.recordEstimatorMeasurement("tool", 100, 200);
+            agentPerfStore.recordLayoutShift(0.05);
+
+            agentPerfStore.reset();
+
+            const snap = agentPerfStore.snapshot();
+            expect(snap.rowMountByKind.size).toBe(0);
+            expect(snap.recentEstimatorMisses).toHaveLength(0);
+            expect(snap.recentLayoutShifts).toHaveLength(0);
+            expect(snap.estimatorMissRateByKind.size).toBe(0);
+        });
+    });
+});
+
+describe("markRowMount", () => {
+    beforeEach(() => agentPerfStore.reset());
+
+    it("returns a closer that records duration on call", async () => {
+        const close = markRowMount("markdown");
+        await new Promise<void>((r) => setTimeout(r, 5));
+        close();
+        const snap = agentPerfStore.snapshot();
+        const q = snap.rowMountByKind.get("markdown");
+        expect(q).toBeDefined();
+        expect(q!.count).toBe(1);
+        // Should be at least 5ms (with timer slop, allow 2ms floor).
+        expect(q!.max).toBeGreaterThanOrEqual(2);
+    });
+
+    it("multiple calls accumulate independently", () => {
+        markRowMount("agent_message")();
+        markRowMount("agent_message")();
+        markRowMount("tool")();
+        const snap = agentPerfStore.snapshot();
+        expect(snap.rowMountByKind.get("agent_message")!.count).toBe(2);
+        expect(snap.rowMountByKind.get("tool")!.count).toBe(1);
+    });
+});

--- a/frontend/app/view/agent/virtualization/perf-probe.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.ts
@@ -1,0 +1,205 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane perf probe — per-kind render timing, estimator-miss
+ * detection, layout-shift attribution scoped to `.agent-document`.
+ *
+ * Phase 3 of the virtualization redesign — see
+ * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Intelligent perf probing".
+ *
+ * Production behavior: all probing is dev-mode-only. The exported
+ * `recordRowMount` / `recordEstimatorMeasurement` functions are
+ * no-ops when `import.meta.env.DEV` is false. The dev HUD reads
+ * from `agentPerfStore.snapshot()` which returns empty in prod.
+ */
+
+import { KeyedAggregator, type QuantileSnapshot } from "@/perf/aggregates";
+import type { NodeKind } from "./renderers";
+
+/**
+ * Estimator-miss event — actual measured size diverged from estimate
+ * by more than ESTIMATOR_MISS_THRESHOLD. Aggregated per kind so the
+ * HUD can flag persistently-wrong estimators for recalibration.
+ */
+export interface EstimatorMissSample {
+    kind: NodeKind;
+    estimated: number;
+    actual: number;
+    /** abs(actual-estimated) / estimated, in [0, ∞). */
+    errorPct: number;
+    timestamp: number;
+}
+
+/**
+ * Layout-shift event scoped to `.agent-document`. Each unexpected
+ * shift here is either an estimator miss or a measurement race —
+ * both are bugs we want visible immediately, not via user reports.
+ */
+export interface LayoutShiftSample {
+    value: number;
+    timestamp: number;
+}
+
+/** Threshold above which an estimator is considered a miss. */
+export const ESTIMATOR_MISS_THRESHOLD = 0.30;
+
+/** Bounded ring size for miss + shift logs (keeps memory bounded). */
+const SAMPLE_RING_SIZE = 64;
+
+/** True when probing should record. False suppresses all recording
+ *  to keep production builds cost-free. */
+function isProbingEnabled(): boolean {
+    // Vite injects import.meta.env.DEV at build time. The check is
+    // tree-shaken in production builds, so the cost-paths below are
+    // dropped entirely.
+    return typeof import.meta !== "undefined"
+        && (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+}
+
+class AgentPerfStore {
+    /** Per-kind row mount duration (ms). p50/p95/max surface in HUD. */
+    private rowMountAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
+    /** Per-kind estimator-miss event log (most recent first). */
+    private estimatorMisses: EstimatorMissSample[] = [];
+    /** Per-kind miss-rate (running total of measured / total miss-flagged). */
+    private kindMissCount = new Map<NodeKind, { misses: number; total: number }>();
+    /** Layout-shift events scoped to agent pane. */
+    private layoutShifts: LayoutShiftSample[] = [];
+
+    recordRowMount(kind: NodeKind, durationMs: number): void {
+        if (!isProbingEnabled()) return;
+        this.rowMountAgg.record(kind, durationMs);
+    }
+
+    recordEstimatorMeasurement(kind: NodeKind, estimated: number, actual: number): void {
+        if (!isProbingEnabled()) return;
+        const errorPct = estimated > 0 ? Math.abs(actual - estimated) / estimated : 0;
+        const entry = this.kindMissCount.get(kind) ?? { misses: 0, total: 0 };
+        entry.total += 1;
+        if (errorPct > ESTIMATOR_MISS_THRESHOLD) {
+            entry.misses += 1;
+            this.estimatorMisses.unshift({
+                kind,
+                estimated,
+                actual,
+                errorPct,
+                timestamp: performance.now(),
+            });
+            if (this.estimatorMisses.length > SAMPLE_RING_SIZE) {
+                this.estimatorMisses.length = SAMPLE_RING_SIZE;
+            }
+        }
+        this.kindMissCount.set(kind, entry);
+    }
+
+    recordLayoutShift(value: number): void {
+        if (!isProbingEnabled()) return;
+        this.layoutShifts.unshift({ value, timestamp: performance.now() });
+        if (this.layoutShifts.length > SAMPLE_RING_SIZE) {
+            this.layoutShifts.length = SAMPLE_RING_SIZE;
+        }
+    }
+
+    snapshot(): AgentPerfSnapshot {
+        if (!isProbingEnabled()) {
+            return EMPTY_SNAPSHOT;
+        }
+        const missRates = new Map<NodeKind, number>();
+        for (const [kind, { misses, total }] of this.kindMissCount.entries()) {
+            missRates.set(kind, total > 0 ? misses / total : 0);
+        }
+        return {
+            rowMountByKind: this.rowMountAgg.snapshot() as Map<NodeKind, QuantileSnapshot>,
+            estimatorMissRateByKind: missRates,
+            recentEstimatorMisses: [...this.estimatorMisses],
+            recentLayoutShifts: [...this.layoutShifts],
+        };
+    }
+
+    /** Reset all aggregators — useful for tests and HUD "clear" button. */
+    reset(): void {
+        this.rowMountAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
+        this.estimatorMisses = [];
+        this.kindMissCount.clear();
+        this.layoutShifts = [];
+    }
+}
+
+export interface AgentPerfSnapshot {
+    rowMountByKind: ReadonlyMap<NodeKind, QuantileSnapshot>;
+    estimatorMissRateByKind: ReadonlyMap<NodeKind, number>;
+    recentEstimatorMisses: readonly EstimatorMissSample[];
+    recentLayoutShifts: readonly LayoutShiftSample[];
+}
+
+const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
+    rowMountByKind: new Map(),
+    estimatorMissRateByKind: new Map(),
+    recentEstimatorMisses: [],
+    recentLayoutShifts: [],
+};
+
+export const agentPerfStore = new AgentPerfStore();
+
+// ── Layout-shift observer ──────────────────────────────────────────────────
+
+interface LayoutShiftEntry extends PerformanceEntry {
+    value: number;
+    sources?: Array<{ node?: Element | null }>;
+}
+
+let layoutShiftObserverStarted = false;
+
+/**
+ * Idempotent. Starts a global PerformanceObserver for layout-shift
+ * entries; only those whose source nodes are inside `.agent-document`
+ * are recorded. Safe to call from app init or from the agent pane's
+ * onMount — second call is a no-op.
+ *
+ * Production: returns immediately (probing disabled).
+ */
+export function startAgentLayoutShiftObserver(): void {
+    if (!isProbingEnabled()) return;
+    if (layoutShiftObserverStarted) return;
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+        const observer = new PerformanceObserver((entries) => {
+            for (const e of entries.getEntries() as LayoutShiftEntry[]) {
+                const sources = e.sources ?? [];
+                const inAgentDoc = sources.some(
+                    (s) => s.node?.closest?.(".agent-document") != null,
+                );
+                if (inAgentDoc) {
+                    agentPerfStore.recordLayoutShift(e.value);
+                }
+            }
+        });
+        observer.observe({ type: "layout-shift", buffered: true });
+        layoutShiftObserverStarted = true;
+    } catch {
+        // entryType may not be supported (Safari, headless tests).
+        // Silent — layout-shift is a "nice to have" perf probe, not
+        // load-bearing.
+    }
+}
+
+// ── Per-row mark helpers ───────────────────────────────────────────────────
+
+/**
+ * Time a row's mount → first-paint span. Returns a function the
+ * caller invokes after the row is in the DOM (e.g., from
+ * createEffect that runs once after mount).
+ *
+ * Production: returns a no-op.
+ */
+export function markRowMount(kind: NodeKind): () => void {
+    if (!isProbingEnabled()) return NOOP;
+    const start = performance.now();
+    return () => {
+        agentPerfStore.recordRowMount(kind, performance.now() - start);
+    };
+}
+
+const NOOP: () => void = () => { };

--- a/frontend/app/view/agent/virtualization/perf-probe.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.ts
@@ -49,13 +49,14 @@ export const ESTIMATOR_MISS_THRESHOLD = 0.30;
 const SAMPLE_RING_SIZE = 64;
 
 /** True when probing should record. False suppresses all recording
- *  to keep production builds cost-free. */
+ *  to keep production builds cost-free. Uses the bare
+ *  `import.meta.env.DEV` form so Vite's static-replace plugin can
+ *  fold it to a literal at build time and dead-code-eliminate the
+ *  surrounding branches. Optional-chaining or any cast that produces
+ *  `import.meta.env?.DEV` defeats the static replace and ships the
+ *  full probe code in production. */
 function isProbingEnabled(): boolean {
-    // Vite injects import.meta.env.DEV at build time. The check is
-    // tree-shaken in production builds, so the cost-paths below are
-    // dropped entirely.
-    return typeof import.meta !== "undefined"
-        && (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+    return import.meta.env.DEV === true;
 }
 
 class AgentPerfStore {

--- a/frontend/app/view/agent/virtualization/renderers.test.ts
+++ b/frontend/app/view/agent/virtualization/renderers.test.ts
@@ -1,0 +1,195 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type {
+    AgentMessageNode,
+    DocumentState,
+    MarkdownNode,
+    SectionNode,
+    SubagentLinkNode,
+    ToolNode,
+    UserMessageNode,
+} from "../types";
+import {
+    estimateAgentMessage,
+    estimateMarkdown,
+    estimateNode,
+    estimateSection,
+    estimateSubagentLink,
+    estimateTextHeight,
+    estimateTool,
+    estimateUserMessage,
+    STREAMING_CAPABLE,
+} from "./renderers";
+
+const baseDocState = (): DocumentState => ({
+    collapsedNodes: new Set<string>(),
+    pinnedNodes: new Set<string>(),
+    scrollPosition: 0,
+    selectedNode: null,
+    filter: {
+        showThinking: false,
+        showSuccessfulTools: true,
+        showFailedTools: true,
+        showIncoming: true,
+        showOutgoing: true,
+    },
+});
+
+describe("estimateTextHeight", () => {
+    it("returns the minimum height for empty content", () => {
+        expect(estimateTextHeight("")).toBe(32);
+    });
+
+    it("estimates one line for short content (< chars/line)", () => {
+        expect(estimateTextHeight("short message")).toBe(32); // 1 line × 24 = 24, clamped up to MIN 32
+    });
+
+    it("scales with content length", () => {
+        // 80 chars per line, 24 px per line.
+        expect(estimateTextHeight("a".repeat(80))).toBe(32); // 1 line, clamped to MIN
+        expect(estimateTextHeight("a".repeat(160))).toBe(48); // 2 lines × 24
+        expect(estimateTextHeight("a".repeat(240))).toBe(72); // 3 lines × 24
+    });
+
+    it("caps at the max estimate to bound initial total-size", () => {
+        const huge = "x".repeat(100_000);
+        expect(estimateTextHeight(huge)).toBe(320);
+    });
+
+    it("respects custom chars/lineHeight params", () => {
+        expect(estimateTextHeight("a".repeat(40), 20, 30)).toBe(60); // 2 lines × 30 = 60
+    });
+});
+
+describe("per-kind estimators", () => {
+    describe("estimateMarkdown", () => {
+        it("uses estimateTextHeight on the content", () => {
+            const node: MarkdownNode = { type: "markdown", id: "m1", content: "a".repeat(160) };
+            expect(estimateMarkdown(node)).toBe(48);
+        });
+    });
+
+    describe("estimateSection", () => {
+        it("returns the fixed section size", () => {
+            const node: SectionNode = {
+                type: "section", id: "s1", level: 1, title: "Heading",
+                collapsible: false, collapsed: false,
+            };
+            expect(estimateSection(node)).toBe(48);
+        });
+    });
+
+    describe("estimateTool", () => {
+        const tool: ToolNode = {
+            type: "tool", id: "t1", tool: "Bash", params: { command: "ls" },
+            status: "success", collapsed: true, summary: "Bash ls",
+        };
+
+        it("returns the collapsed size when not pinned", () => {
+            expect(estimateTool(tool, baseDocState())).toBe(32);
+        });
+
+        it("returns the expanded size when pinned in DocumentState", () => {
+            const state = baseDocState();
+            state.pinnedNodes.add("t1");
+            expect(estimateTool(tool, state)).toBe(200);
+        });
+    });
+
+    describe("estimateAgentMessage", () => {
+        const node: AgentMessageNode = {
+            type: "agent_message", id: "am1", from: "a", to: "b",
+            message: "hello world".repeat(20), method: "mux", direction: "incoming",
+            timestamp: 0, collapsed: false, summary: "From a",
+        };
+
+        it("uses text-height estimate when not collapsed", () => {
+            // 11 chars × 20 = 220 chars → ceil(220/80) = 3 lines × 24 = 72
+            expect(estimateAgentMessage(node, baseDocState())).toBe(72);
+        });
+
+        it("returns the collapsed size when in collapsedNodes", () => {
+            const state = baseDocState();
+            state.collapsedNodes.add("am1");
+            expect(estimateAgentMessage(node, state)).toBe(32);
+        });
+    });
+
+    describe("estimateUserMessage", () => {
+        const node: UserMessageNode = {
+            type: "user_message", id: "um1", message: "hi", timestamp: 0,
+            collapsed: false, summary: "User",
+        };
+
+        it("uses text-height estimate when not collapsed", () => {
+            expect(estimateUserMessage(node, baseDocState())).toBe(32); // short → MIN
+        });
+
+        it("returns the collapsed size when in collapsedNodes", () => {
+            const state = baseDocState();
+            state.collapsedNodes.add("um1");
+            expect(estimateUserMessage(node, state)).toBe(32);
+        });
+    });
+
+    describe("estimateSubagentLink", () => {
+        it("returns the fixed subagent-link size", () => {
+            const node: SubagentLinkNode = {
+                type: "subagent_link", id: "sl1", subagentId: "x", slug: "y",
+                parentAgent: "p", sessionId: "s", status: "active", model: null,
+            };
+            expect(estimateSubagentLink(node)).toBe(56);
+        });
+    });
+});
+
+describe("estimateNode dispatch", () => {
+    it("dispatches to the correct per-kind estimator", () => {
+        const state = baseDocState();
+        const md: MarkdownNode = { type: "markdown", id: "m1", content: "" };
+        const sec: SectionNode = {
+            type: "section", id: "s1", level: 1, title: "T",
+            collapsible: false, collapsed: false,
+        };
+        const tool: ToolNode = {
+            type: "tool", id: "t1", tool: "Read", params: { file_path: "x" },
+            status: "success", collapsed: true, summary: "Read x",
+        };
+        const am: AgentMessageNode = {
+            type: "agent_message", id: "am", from: "a", to: "b", message: "hi",
+            method: "mux", direction: "incoming", timestamp: 0,
+            collapsed: false, summary: "S",
+        };
+        const um: UserMessageNode = {
+            type: "user_message", id: "um", message: "hi", timestamp: 0,
+            collapsed: false, summary: "S",
+        };
+        const sl: SubagentLinkNode = {
+            type: "subagent_link", id: "sl", subagentId: "x", slug: "y",
+            parentAgent: "p", sessionId: "s", status: "active", model: null,
+        };
+
+        expect(estimateNode(md, state)).toBe(estimateMarkdown(md));
+        expect(estimateNode(sec, state)).toBe(estimateSection(sec));
+        expect(estimateNode(tool, state)).toBe(estimateTool(tool, state));
+        expect(estimateNode(am, state)).toBe(estimateAgentMessage(am, state));
+        expect(estimateNode(um, state)).toBe(estimateUserMessage(um, state));
+        expect(estimateNode(sl, state)).toBe(estimateSubagentLink(sl));
+    });
+});
+
+describe("STREAMING_CAPABLE", () => {
+    it("flags markdown and agent_message as streaming-capable", () => {
+        expect(STREAMING_CAPABLE.markdown).toBe(true);
+        expect(STREAMING_CAPABLE.agent_message).toBe(true);
+    });
+
+    it("flags everything else as non-streaming", () => {
+        expect(STREAMING_CAPABLE.section).toBe(false);
+        expect(STREAMING_CAPABLE.tool).toBe(false);
+        expect(STREAMING_CAPABLE.user_message).toBe(false);
+        expect(STREAMING_CAPABLE.subagent_link).toBe(false);
+    });
+});

--- a/frontend/app/view/agent/virtualization/renderers.ts
+++ b/frontend/app/view/agent/virtualization/renderers.ts
@@ -1,0 +1,200 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-kind renderer registry — each DocumentNode kind declares its
+ * component, size estimator, and streaming behavior. Phase 2 builds
+ * the virtualizer config from this registry; Phase 3's perf probe
+ * compares each renderer's `estimatedSize` against actual measured
+ * heights to flag misses.
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Render contract".
+ */
+
+import type { Component } from "solid-js";
+import type {
+    AgentMessageNode,
+    DocumentNode,
+    DocumentState,
+    MarkdownNode,
+    SectionNode,
+    SubagentLinkNode,
+    ToolNode,
+    UserMessageNode,
+} from "../types";
+
+export type NodeKind = DocumentNode["type"];
+
+/** Map a NodeKind back to its concrete DocumentNode subtype. */
+export type NodeOf<K extends NodeKind> = Extract<DocumentNode, { type: K }>;
+
+export interface NodeKindRenderer<K extends NodeKind = NodeKind> {
+    /** SolidJS component that renders this kind. Must access props
+     *  reactively (no destructuring) so prop changes propagate. */
+    component: Component<{ node: NodeOf<K>; state: DocumentState }>;
+    /**
+     * Initial height estimate in pixels. Used until measureElement
+     * settles each row to its real size. Should be close to the p50
+     * actual height for the kind — Phase 3's perf probe surfaces
+     * estimator misses > 30% in the dev HUD so we can recalibrate.
+     */
+    estimatedSize: (node: NodeOf<K>, state: DocumentState) => number;
+    /**
+     * True if this kind receives content chunk-by-chunk during a
+     * stream (markdown, agent_message). Drives the streaming-buffer
+     * pin so the row isn't recycled mid-stream.
+     */
+    isStreamingCapable: boolean;
+    /**
+     * Rare: render in a dedicated layer above/below the virtualized
+     * region instead of in the list. Reserved for future affordances
+     * (e.g., always-visible auth box). null = normal list item.
+     */
+    pinnedLayer?: "top" | "bottom";
+}
+
+export type NodeRendererRegistry = {
+    [K in NodeKind]: NodeKindRenderer<K>;
+};
+
+// ── Estimator helpers ───────────────────────────────────────────────────────
+
+/**
+ * Approximate text-block height. Calibrated against the existing
+ * agent-pane CSS at 14px font / 1.5 line-height ≈ 21px per line +
+ * 3px gutter. Caps at 320px so a single huge message doesn't blow
+ * out the initial total-size estimate.
+ */
+const TEXT_LINE_HEIGHT_PX = 24;
+const TEXT_CHARS_PER_LINE = 80;
+const TEXT_MIN_HEIGHT_PX = 32;
+const TEXT_MAX_ESTIMATE_PX = 320;
+
+export function estimateTextHeight(
+    content: string,
+    chars = TEXT_CHARS_PER_LINE,
+    lineHeight = TEXT_LINE_HEIGHT_PX,
+): number {
+    if (!content) return TEXT_MIN_HEIGHT_PX;
+    const lines = Math.ceil(content.length / chars);
+    return Math.min(Math.max(lines * lineHeight, TEXT_MIN_HEIGHT_PX), TEXT_MAX_ESTIMATE_PX);
+}
+
+// Per-kind constants — tuned empirically. Phase 3 perf-probe HUD
+// flags any kind whose p50 actual diverges > 30% from estimate.
+const TOOL_COLLAPSED_PX = 32;
+const TOOL_EXPANDED_PX = 200;
+const SECTION_PX = 48;
+const SUBAGENT_LINK_PX = 56;
+const COLLAPSED_MESSAGE_PX = 32;
+
+// ── Per-kind estimator functions ────────────────────────────────────────────
+//
+// Exported individually so they can be unit-tested without needing the
+// real components. The full registry is constructed via
+// buildRendererRegistry() at view-mount time — registry binding to
+// concrete components is Phase 2's job.
+
+export function estimateMarkdown(node: MarkdownNode): number {
+    return estimateTextHeight(node.content);
+}
+
+export function estimateSection(_node: SectionNode): number {
+    return SECTION_PX;
+}
+
+export function estimateTool(node: ToolNode, state: DocumentState): number {
+    return state.pinnedNodes.has(node.id) ? TOOL_EXPANDED_PX : TOOL_COLLAPSED_PX;
+}
+
+export function estimateAgentMessage(node: AgentMessageNode, state: DocumentState): number {
+    if (state.collapsedNodes.has(node.id)) return COLLAPSED_MESSAGE_PX;
+    return estimateTextHeight(node.message);
+}
+
+export function estimateUserMessage(node: UserMessageNode, state: DocumentState): number {
+    if (state.collapsedNodes.has(node.id)) return COLLAPSED_MESSAGE_PX;
+    return estimateTextHeight(node.message);
+}
+
+export function estimateSubagentLink(_node: SubagentLinkNode): number {
+    return SUBAGENT_LINK_PX;
+}
+
+/** Per-kind streaming capability — straightforward map. */
+export const STREAMING_CAPABLE: Record<NodeKind, boolean> = {
+    markdown: true,
+    agent_message: true,
+    section: false,
+    tool: false,
+    user_message: false,
+    subagent_link: false,
+};
+
+// ── Registry factory ────────────────────────────────────────────────────────
+
+export interface RendererComponents {
+    Markdown: Component<{ node: MarkdownNode; state: DocumentState }>;
+    Section: Component<{ node: SectionNode; state: DocumentState }>;
+    Tool: Component<{ node: ToolNode; state: DocumentState }>;
+    AgentMessage: Component<{ node: AgentMessageNode; state: DocumentState }>;
+    UserMessage: Component<{ node: UserMessageNode; state: DocumentState }>;
+    SubagentLink: Component<{ node: SubagentLinkNode; state: DocumentState }>;
+}
+
+/**
+ * Build the registry by binding components to their estimators.
+ * Phase 2 will wire concrete components from `../components/`; tests
+ * pass stub components.
+ */
+export function buildRendererRegistry(components: RendererComponents): NodeRendererRegistry {
+    return {
+        markdown: {
+            component: components.Markdown,
+            estimatedSize: estimateMarkdown,
+            isStreamingCapable: STREAMING_CAPABLE.markdown,
+        },
+        section: {
+            component: components.Section,
+            estimatedSize: estimateSection,
+            isStreamingCapable: STREAMING_CAPABLE.section,
+        },
+        tool: {
+            component: components.Tool,
+            estimatedSize: estimateTool,
+            isStreamingCapable: STREAMING_CAPABLE.tool,
+        },
+        agent_message: {
+            component: components.AgentMessage,
+            estimatedSize: estimateAgentMessage,
+            isStreamingCapable: STREAMING_CAPABLE.agent_message,
+        },
+        user_message: {
+            component: components.UserMessage,
+            estimatedSize: estimateUserMessage,
+            isStreamingCapable: STREAMING_CAPABLE.user_message,
+        },
+        subagent_link: {
+            component: components.SubagentLink,
+            estimatedSize: estimateSubagentLink,
+            isStreamingCapable: STREAMING_CAPABLE.subagent_link,
+        },
+    };
+}
+
+/**
+ * Dispatch helper — pick the right estimator for a given node. Used
+ * by Phase 2's virtualizer config and by Phase 3's perf-probe miss
+ * detector.
+ */
+export function estimateNode(node: DocumentNode, state: DocumentState): number {
+    switch (node.type) {
+        case "markdown": return estimateMarkdown(node);
+        case "section": return estimateSection(node);
+        case "tool": return estimateTool(node, state);
+        case "agent_message": return estimateAgentMessage(node, state);
+        case "user_message": return estimateUserMessage(node, state);
+        case "subagent_link": return estimateSubagentLink(node);
+    }
+}

--- a/frontend/app/view/agent/virtualization/state.test.ts
+++ b/frontend/app/view/agent/virtualization/state.test.ts
@@ -1,0 +1,140 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { createRoot, createSignal } from "solid-js";
+import { describe, expect, it } from "vitest";
+import type { DocumentNode } from "../types";
+import { createAgentViewState } from "./state";
+
+const md = (id: string, content = id): DocumentNode => ({
+    type: "markdown",
+    id,
+    content,
+    timestamp: 0,
+});
+
+/** Helper: run a body inside createRoot and dispose cleanly. */
+function withRoot<T>(body: (dispose: () => void) => T): T {
+    return createRoot((dispose) => body(dispose));
+}
+
+describe("AgentViewState", () => {
+    describe("nodeIndex", () => {
+        it("builds an id → index map from the document", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([md("a"), md("b"), md("c")]);
+                const state = createAgentViewState(doc);
+                const idx = state.nodeIndex();
+                expect(idx.get("a")).toBe(0);
+                expect(idx.get("b")).toBe(1);
+                expect(idx.get("c")).toBe(2);
+                expect(idx.size).toBe(3);
+                dispose();
+            });
+        });
+
+        it("re-indexes when the document changes", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([md("a"), md("b")]);
+                const state = createAgentViewState(doc);
+                expect(state.indexOf("a")).toBe(0);
+
+                doc[1]([md("z"), md("a"), md("b")]); // prepend "z"
+                expect(state.indexOf("z")).toBe(0);
+                expect(state.indexOf("a")).toBe(1);
+                expect(state.indexOf("b")).toBe(2);
+                dispose();
+            });
+        });
+
+        it("returns -1 for unknown ids via indexOf", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([md("a")]);
+                const state = createAgentViewState(doc);
+                expect(state.indexOf("missing")).toBe(-1);
+                dispose();
+            });
+        });
+    });
+
+    describe("stickToBottom", () => {
+        it("starts true (initial mount expects auto-scroll)", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                expect(state.stickToBottom()).toBe(true);
+                dispose();
+            });
+        });
+
+        it("can be toggled directly", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                state.setStickToBottom(false);
+                expect(state.stickToBottom()).toBe(false);
+                state.setStickToBottom(true);
+                expect(state.stickToBottom()).toBe(true);
+                dispose();
+            });
+        });
+    });
+
+    describe("captureHeadAnchor", () => {
+        it("stores the anchor and flips stickToBottom off (atomic)", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                expect(state.stickToBottom()).toBe(true); // pre-condition
+
+                state.captureHeadAnchor({ nodeId: "n5", offsetPx: 50 });
+
+                expect(state.headAnchor()).toEqual({ nodeId: "n5", offsetPx: 50 });
+                expect(state.stickToBottom()).toBe(false);
+                dispose();
+            });
+        });
+
+        it("clearHeadAnchor drops the anchor without touching stickToBottom", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                state.captureHeadAnchor({ nodeId: "n5", offsetPx: 50 });
+                state.clearHeadAnchor();
+                expect(state.headAnchor()).toBeNull();
+                // stickToBottom stays false — caller decides when to re-engage stick.
+                expect(state.stickToBottom()).toBe(false);
+                dispose();
+            });
+        });
+    });
+
+    describe("streamingNodeId", () => {
+        it("starts null and can be set/cleared", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                expect(state.streamingNodeId()).toBeNull();
+
+                state.setStreamingNodeId("msg_1");
+                expect(state.streamingNodeId()).toBe("msg_1");
+
+                state.setStreamingNodeId(null);
+                expect(state.streamingNodeId()).toBeNull();
+                dispose();
+            });
+        });
+    });
+
+    describe("nodes pass-through", () => {
+        it("exposes the document signal directly", () => {
+            withRoot((dispose) => {
+                const initial = [md("a"), md("b")];
+                const doc = createSignal<DocumentNode[]>(initial);
+                const state = createAgentViewState(doc);
+                expect(state.nodes()).toBe(initial);
+                dispose();
+            });
+        });
+    });
+});

--- a/frontend/app/view/agent/virtualization/state.test.ts
+++ b/frontend/app/view/agent/virtualization/state.test.ts
@@ -67,14 +67,29 @@ describe("AgentViewState", () => {
             });
         });
 
-        it("can be toggled directly", () => {
+        it("disengageStickToBottom flips it off", () => {
             withRoot((dispose) => {
                 const doc = createSignal<DocumentNode[]>([]);
                 const state = createAgentViewState(doc);
-                state.setStickToBottom(false);
+                state.disengageStickToBottom();
                 expect(state.stickToBottom()).toBe(false);
-                state.setStickToBottom(true);
+                dispose();
+            });
+        });
+
+        it("engageStickToBottom flips it on AND clears any head anchor (atomic)", () => {
+            withRoot((dispose) => {
+                const doc = createSignal<DocumentNode[]>([]);
+                const state = createAgentViewState(doc);
+                state.captureHeadAnchor({ nodeId: "n5", offsetPx: 50 });
+                expect(state.stickToBottom()).toBe(false);
+                expect(state.headAnchor()).not.toBeNull();
+
+                state.engageStickToBottom();
+                // Both atomic: stick on, anchor cleared. Otherwise a later
+                // remount would restore to the stale anchor (codex P2).
                 expect(state.stickToBottom()).toBe(true);
+                expect(state.headAnchor()).toBeNull();
                 dispose();
             });
         });

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -36,7 +36,21 @@ export interface AgentViewState {
      * user scrolls back near the bottom.
      */
     stickToBottom: Accessor<boolean>;
-    setStickToBottom: Setter<boolean>;
+
+    /**
+     * Engage stick-to-bottom AND clear any captured head anchor.
+     * Atomic — these always go together because a stale anchor would
+     * later restore scroll to the wrong place after a remount.
+     * (codex P2 on PR #783.)
+     */
+    engageStickToBottom: () => void;
+
+    /**
+     * Disengage stick-to-bottom without touching the anchor. Used when
+     * the user scrolls up but hasn't yet crossed the near-top threshold
+     * that triggers anchor capture.
+     */
+    disengageStickToBottom: () => void;
 
     /**
      * Captured anchor for restoring scroll position after a prepend
@@ -70,10 +84,12 @@ export interface AgentViewState {
  * existing AgentAtoms (see ../state.ts).
  */
 export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): AgentViewState {
-    const [document] = documentAtom;
+    // Renamed from `document` to avoid shadowing the browser global
+    // (reagent P2 on PR #783).
+    const [docSignal] = documentAtom;
 
     const nodeIndex = createMemo<ReadonlyMap<string, number>>(() => {
-        const docs = document();
+        const docs = docSignal();
         const map = new Map<string, number>();
         for (let i = 0; i < docs.length; i++) {
             map.set(docs[i].id, i);
@@ -92,15 +108,28 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
 
     const clearHeadAnchor = () => setHeadAnchor(null);
 
+    // Engaging stick MUST clear any captured head anchor — otherwise
+    // a later remount would restore from the stale anchor instead of
+    // sticking to the latest. Atomic.
+    const engageStickToBottom = () => {
+        setHeadAnchor(null);
+        setStickToBottom(true);
+    };
+
+    const disengageStickToBottom = () => {
+        setStickToBottom(false);
+    };
+
     const indexOf = (nodeId: string): number => {
         return nodeIndex().get(nodeId) ?? -1;
     };
 
     return {
-        nodes: document,
+        nodes: docSignal,
         nodeIndex,
         stickToBottom,
-        setStickToBottom,
+        engageStickToBottom,
+        disengageStickToBottom,
         headAnchor,
         captureHeadAnchor,
         clearHeadAnchor,

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -1,0 +1,111 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentViewState — scroll-and-streaming state for the virtualized
+ * agent pane, kept in a Solid store so it's the single source of truth
+ * (DOM scrollTop is a projection of this, never the other way around).
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Scroll state in data".
+ *
+ * Phase 1: store + transitions only. The view layer in Phase 2 will
+ * subscribe to these signals and project them into the virtualizer.
+ */
+
+import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { DocumentNode } from "../types";
+import type { SignalPair } from "../state";
+import type { ScrollAnchor } from "./anchor";
+
+export interface AgentViewState {
+    /** Current document — pass-through from the existing documentAtom. */
+    nodes: Accessor<readonly DocumentNode[]>;
+
+    /**
+     * O(1) id → index lookup. Recomputed when `nodes` changes; tested
+     * for memo-stability so consumers don't pay quadratic costs on
+     * frequent re-reads.
+     */
+    nodeIndex: Accessor<ReadonlyMap<string, number>>;
+
+    /**
+     * True when the user is anchored to the latest message and any new
+     * tail content should auto-scroll into view. Set false when the
+     * user scrolls up; restored to true on jumpToBottom or when the
+     * user scrolls back near the bottom.
+     */
+    stickToBottom: Accessor<boolean>;
+    setStickToBottom: Setter<boolean>;
+
+    /**
+     * Captured anchor for restoring scroll position after a prepend
+     * (history pagination) or remount (tab switch). null when sticky
+     * to bottom or when no anchor has been captured.
+     */
+    headAnchor: Accessor<ScrollAnchor | null>;
+    /**
+     * Capture an anchor and flip stickToBottom off — these always go
+     * together: capturing an anchor means "user wants to stay where
+     * they are", which is the opposite of stick-to-bottom semantics.
+     */
+    captureHeadAnchor: (anchor: ScrollAnchor) => void;
+    clearHeadAnchor: () => void;
+
+    /**
+     * Id of the node currently receiving streaming content. Pinned
+     * out of the virtualizer's recycle range so its measurement isn't
+     * invalidated mid-stream. null when no stream is active.
+     */
+    streamingNodeId: Accessor<string | null>;
+    setStreamingNodeId: Setter<string | null>;
+
+    /** Convenience: lookup index by node id, or -1. */
+    indexOf: (nodeId: string) => number;
+}
+
+/**
+ * Construct a fresh AgentViewState bound to a document signal pair.
+ * Call once per agent ViewModel instance — same lifetime as the
+ * existing AgentAtoms (see ../state.ts).
+ */
+export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): AgentViewState {
+    const [document] = documentAtom;
+
+    const nodeIndex = createMemo<ReadonlyMap<string, number>>(() => {
+        const docs = document();
+        const map = new Map<string, number>();
+        for (let i = 0; i < docs.length; i++) {
+            map.set(docs[i].id, i);
+        }
+        return map;
+    });
+
+    const [stickToBottom, setStickToBottom] = createSignal(true);
+    const [headAnchor, setHeadAnchor] = createSignal<ScrollAnchor | null>(null);
+    const [streamingNodeId, setStreamingNodeId] = createSignal<string | null>(null);
+
+    const captureHeadAnchor = (anchor: ScrollAnchor) => {
+        setHeadAnchor(anchor);
+        setStickToBottom(false);
+    };
+
+    const clearHeadAnchor = () => setHeadAnchor(null);
+
+    const indexOf = (nodeId: string): number => {
+        return nodeIndex().get(nodeId) ?? -1;
+    };
+
+    return {
+        nodes: document,
+        nodeIndex,
+        stickToBottom,
+        setStickToBottom,
+        headAnchor,
+        captureHeadAnchor,
+        clearHeadAnchor,
+        streamingNodeId,
+        setStreamingNodeId,
+        indexOf,
+    };
+}

--- a/frontend/app/view/agent/virtualization/state.ts
+++ b/frontend/app/view/agent/virtualization/state.ts
@@ -13,7 +13,7 @@
  * subscribe to these signals and project them into the virtualizer.
  */
 
-import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import { batch, createMemo, createSignal, type Accessor, type Setter } from "solid-js";
 import type { DocumentNode } from "../types";
 import type { SignalPair } from "../state";
 import type { ScrollAnchor } from "./anchor";
@@ -101,19 +101,28 @@ export function createAgentViewState(documentAtom: SignalPair<DocumentNode[]>): 
     const [headAnchor, setHeadAnchor] = createSignal<ScrollAnchor | null>(null);
     const [streamingNodeId, setStreamingNodeId] = createSignal<string | null>(null);
 
+    // Both two-signal mutations wrap in batch() so subscribers don't
+    // observe the inconsistent intermediate state — without batch, an
+    // effect listening to `headAnchor` would fire while
+    // `stickToBottom` was still its old value, breaking the documented
+    // atomic-pair invariant. (reagent P1 on PR #783 fix push.)
     const captureHeadAnchor = (anchor: ScrollAnchor) => {
-        setHeadAnchor(anchor);
-        setStickToBottom(false);
+        batch(() => {
+            setHeadAnchor(anchor);
+            setStickToBottom(false);
+        });
     };
 
     const clearHeadAnchor = () => setHeadAnchor(null);
 
     // Engaging stick MUST clear any captured head anchor — otherwise
     // a later remount would restore from the stale anchor instead of
-    // sticking to the latest. Atomic.
+    // sticking to the latest. Atomic via batch().
     const engageStickToBottom = () => {
-        setHeadAnchor(null);
-        setStickToBottom(true);
+        batch(() => {
+            setHeadAnchor(null);
+            setStickToBottom(true);
+        });
     };
 
     const disengageStickToBottom = () => {

--- a/frontend/app/view/agent/virtualization/streaming-buffer.test.ts
+++ b/frontend/app/view/agent/virtualization/streaming-buffer.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import type { DocumentNode } from "../types";
+import {
+    locateIndex,
+    partitionForVirtualization,
+    STREAMING_BUFFER_SIZE,
+} from "./streaming-buffer";
+
+const md = (id: string): DocumentNode => ({ type: "markdown", id, content: id, timestamp: 0 });
+
+const range = (n: number): DocumentNode[] =>
+    Array.from({ length: n }, (_, i) => md(`n${i}`));
+
+describe("partitionForVirtualization", () => {
+    it("puts everything in streamingNodes when document <= bufferSize", () => {
+        const nodes = range(10);
+        const p = partitionForVirtualization(nodes, 50);
+        expect(p.virtualizedNodes).toHaveLength(0);
+        expect(p.streamingNodes).toBe(nodes); // identity — no slicing
+        expect(p.splitIndex).toBe(0);
+    });
+
+    it("splits at length - bufferSize when document > bufferSize", () => {
+        const nodes = range(70); // 50 streaming, 20 virtualized
+        const p = partitionForVirtualization(nodes, 50);
+        expect(p.virtualizedNodes).toHaveLength(20);
+        expect(p.streamingNodes).toHaveLength(50);
+        expect(p.splitIndex).toBe(20);
+        // Virtualized side is the head (oldest); streaming side is the tail (newest).
+        expect(p.virtualizedNodes[0].id).toBe("n0");
+        expect(p.virtualizedNodes[19].id).toBe("n19");
+        expect(p.streamingNodes[0].id).toBe("n20");
+        expect(p.streamingNodes[49].id).toBe("n69");
+    });
+
+    it("handles exactly bufferSize nodes (boundary)", () => {
+        const nodes = range(50);
+        const p = partitionForVirtualization(nodes, 50);
+        expect(p.virtualizedNodes).toHaveLength(0);
+        expect(p.streamingNodes).toBe(nodes);
+        expect(p.splitIndex).toBe(0);
+    });
+
+    it("handles bufferSize+1 (smallest case where virtualization activates)", () => {
+        const nodes = range(51);
+        const p = partitionForVirtualization(nodes, 50);
+        expect(p.virtualizedNodes).toHaveLength(1);
+        expect(p.streamingNodes).toHaveLength(50);
+        expect(p.virtualizedNodes[0].id).toBe("n0");
+    });
+
+    it("uses STREAMING_BUFFER_SIZE as default", () => {
+        const nodes = range(STREAMING_BUFFER_SIZE + 10);
+        const p = partitionForVirtualization(nodes);
+        expect(p.virtualizedNodes).toHaveLength(10);
+        expect(p.streamingNodes).toHaveLength(STREAMING_BUFFER_SIZE);
+    });
+
+    it("handles empty document", () => {
+        const p = partitionForVirtualization([]);
+        expect(p.virtualizedNodes).toHaveLength(0);
+        expect(p.streamingNodes).toHaveLength(0);
+        expect(p.splitIndex).toBe(0);
+    });
+});
+
+describe("locateIndex", () => {
+    it("locates indices in the virtualized region", () => {
+        const p = partitionForVirtualization(range(70), 50);
+        // splitIndex=20; index 0 is virtualized, relativeIndex=0.
+        expect(locateIndex(0, p)).toEqual({ side: "virtualized", relativeIndex: 0 });
+        expect(locateIndex(19, p)).toEqual({ side: "virtualized", relativeIndex: 19 });
+    });
+
+    it("locates indices in the streaming region", () => {
+        const p = partitionForVirtualization(range(70), 50);
+        // splitIndex=20; index 20 is streaming side, relativeIndex 0.
+        expect(locateIndex(20, p)).toEqual({ side: "streaming", relativeIndex: 0 });
+        expect(locateIndex(69, p)).toEqual({ side: "streaming", relativeIndex: 49 });
+    });
+
+    it("returns null for out-of-range indices", () => {
+        const p = partitionForVirtualization(range(70), 50);
+        expect(locateIndex(-1, p)).toBeNull();
+        expect(locateIndex(70, p)).toBeNull();
+        expect(locateIndex(999, p)).toBeNull();
+    });
+
+    it("handles empty partition", () => {
+        const p = partitionForVirtualization([]);
+        expect(locateIndex(0, p)).toBeNull();
+    });
+
+    it("locates the only index in a single-node streaming partition", () => {
+        const p = partitionForVirtualization(range(1));
+        expect(locateIndex(0, p)).toEqual({ side: "streaming", relativeIndex: 0 });
+    });
+});

--- a/frontend/app/view/agent/virtualization/streaming-buffer.ts
+++ b/frontend/app/view/agent/virtualization/streaming-buffer.ts
@@ -21,6 +21,14 @@ import type { DocumentNode } from "../types";
  */
 export const STREAMING_BUFFER_SIZE = 50;
 
+/**
+ * Module-level empty array reused on the short-path branch. Returning
+ * the same reference each call lets reactive memos compare by
+ * reference and skip re-runs when the document hasn't grown past the
+ * buffer threshold. (reagent P2 on PR #783 fix push.)
+ */
+const EMPTY_NODES: readonly DocumentNode[] = Object.freeze([]);
+
 export interface VirtualizationPartition {
     /** Nodes that go through the virtualizer (may be empty). */
     virtualizedNodes: readonly DocumentNode[];
@@ -45,7 +53,7 @@ export function partitionForVirtualization(
 ): VirtualizationPartition {
     if (nodes.length <= bufferSize) {
         return {
-            virtualizedNodes: [],
+            virtualizedNodes: EMPTY_NODES,
             streamingNodes: nodes,
             splitIndex: 0,
         };

--- a/frontend/app/view/agent/virtualization/streaming-buffer.ts
+++ b/frontend/app/view/agent/virtualization/streaming-buffer.ts
@@ -1,0 +1,79 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Streaming-buffer partition — splits the document into a virtualized
+ * head (off-screen safe to recycle) and an unvirtualized tail
+ * (streaming buffer; always mounted to avoid measurement lag during
+ * token streams).
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Hybrid virtualization".
+ */
+
+import type { DocumentNode } from "../types";
+
+/**
+ * Number of trailing nodes to render unvirtualized. Sized to cover a
+ * typical assistant turn (assistant message + multiple tool calls +
+ * thinking) so streaming content is never evicted mid-flight. Tuned
+ * empirically in Phase 4.
+ */
+export const STREAMING_BUFFER_SIZE = 50;
+
+export interface VirtualizationPartition {
+    /** Nodes that go through the virtualizer (may be empty). */
+    virtualizedNodes: readonly DocumentNode[];
+    /** Trailing nodes rendered as a normal flex list. */
+    streamingNodes: readonly DocumentNode[];
+    /**
+     * Index in the original document at which the streaming buffer
+     * starts. Useful for jump-to-index lookups: any index >= splitIndex
+     * lands in the streaming buffer.
+     */
+    splitIndex: number;
+}
+
+/**
+ * Pure split — no allocation if the document is shorter than the
+ * buffer (whole list is streaming buffer). Otherwise slices out the
+ * trailing N nodes.
+ */
+export function partitionForVirtualization(
+    nodes: readonly DocumentNode[],
+    bufferSize: number = STREAMING_BUFFER_SIZE,
+): VirtualizationPartition {
+    if (nodes.length <= bufferSize) {
+        return {
+            virtualizedNodes: [],
+            streamingNodes: nodes,
+            splitIndex: 0,
+        };
+    }
+    const splitIndex = nodes.length - bufferSize;
+    return {
+        virtualizedNodes: nodes.slice(0, splitIndex),
+        streamingNodes: nodes.slice(splitIndex),
+        splitIndex,
+    };
+}
+
+/**
+ * Resolve which side of the partition a given absolute index falls on,
+ * and the relative index within that side. Returns null for
+ * out-of-range indices.
+ */
+export function locateIndex(
+    absoluteIndex: number,
+    partition: VirtualizationPartition,
+): { side: "virtualized" | "streaming"; relativeIndex: number } | null {
+    const total = partition.virtualizedNodes.length + partition.streamingNodes.length;
+    if (absoluteIndex < 0 || absoluteIndex >= total) return null;
+    if (absoluteIndex < partition.splitIndex) {
+        return { side: "virtualized", relativeIndex: absoluteIndex };
+    }
+    return {
+        side: "streaming",
+        relativeIndex: absoluteIndex - partition.splitIndex,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.749",
+  "version": "0.33.750",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.749",
+      "version": "0.33.750",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.748",
+  "version": "0.33.749",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.748",
+      "version": "0.33.749",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.752",
+  "version": "0.33.753",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.752",
+      "version": "0.33.753",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.750",
+  "version": "0.33.751",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.750",
+      "version": "0.33.751",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.753",
+  "version": "0.33.754",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.753",
+      "version": "0.33.754",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.751",
+  "version": "0.33.752",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.751",
+      "version": "0.33.752",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@lobehub/icons-static-svg": "^1.90.0",
         "@observablehq/plot": "^0.6.17",
         "@solid-primitives/keyed": "^1.5.3",
+        "@tanstack/solid-virtual": "^3.13.24",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-serialize": "^0.14.0",
@@ -3269,6 +3270,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7"
+      }
+    },
+    "node_modules/@tanstack/solid-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmjs.org/@tanstack/solid-virtual/-/solid-virtual-3.13.24.tgz",
+      "integrity": "sha512-sLGjpsAWLK8oxciqN+FNjs5JLs9N27DKwwoOPN8FMrmFMeXdiPQvRg3CqUAv8pYfXKD9KmcbhBxNwlmcP22a8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "solid-js": "^1.3.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tsconfig/node10": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.754",
+  "version": "0.33.755",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.754",
+      "version": "0.33.755",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@lobehub/icons-static-svg": "^1.90.0",
     "@observablehq/plot": "^0.6.17",
     "@solid-primitives/keyed": "^1.5.3",
+    "@tanstack/solid-virtual": "^3.13.24",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.751",
+  "version": "0.33.752",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.749",
+  "version": "0.33.750",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.753",
+  "version": "0.33.754",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.752",
+  "version": "0.33.753",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.754",
+  "version": "0.33.755",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.748",
+  "version": "0.33.749",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.750",
+  "version": "0.33.751",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third phase of the agent pane virtualization redesign (issue #782, spec at `docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md`). **Builds on Phase 2 (PR #784).**

> **Base branch is `agenta/virt-redesign-phase-2`** to keep the diff focused. Will rebase as #783 → #784 → main lands.

## What's new

### `perf-probe.ts` (new)

Module-level singleton `agentPerfStore` collecting:

- **Per-kind row mount durations** (KeyedAggregator → p50/p95/max). Populated by `markRowMount(kind)` called from `DocumentRow.onMount`.
- **Per-kind estimator-miss rate**. Populated by the wrapped `measureElement` in `AgentDocumentVirtualList`: every measurement compares actual height against `estimateNode(node, state)` from Phase 1's registry. Anything outside ±30% (`ESTIMATOR_MISS_THRESHOLD`) flagged.
- **Layout-shift events scoped to `.agent-document`**. Started via idempotent `startAgentLayoutShiftObserver()` in VirtualList's `onMount`. Filters layout-shift PerformanceObserver entries to only those whose source node is inside the agent pane.

Each recording function short-circuits when `import.meta.env.DEV === false`. Vite tree-shakes the dead branches at build time, so production builds carry zero probe cost.

### Diag-panel extension

- New `agent-pane-perf-section.tsx` — polls `agentPerfStore.snapshot()` at 1 Hz, renders:
  - Per-kind p50/p95/max/n table sorted by p95 desc, with estimator miss-rate column (⚠ at >20%)
  - Recent layout shifts (last 5)
  - Recent estimator misses (last 5, with kind + estimated vs actual + error %)
- Section auto-hides when there's no data (fresh pane).
- One-line embed in `diag-panel.tsx` — same Ctrl+Shift+D toggle as slice #9.

## Why this matters

The reverted #773 had multiple regressions (gaps from `estimateSize` misses, tables broken, streaming cut-off) that surfaced via user reports — slow, low-fidelity feedback. With Phase 3, the same class of bug becomes immediately visible during development:

- Estimator miss-rate >30% on a kind → recalibrate the per-kind size in `renderers.ts`
- Layout shift spike → measurement race or estimator drift, caught at the source
- High p95 row-mount on a kind → component-level perf regression

This is what "intelligent perf probing" means: the probe knows what to measure (per-kind, per-mount, per-shift) and what to flag (estimator misses), not just generic Long Tasks.

## Tests

12 new test cases for `perf-probe.ts`:
- Per-kind aggregation correctness
- Estimator-miss threshold boundary (just over / just under 30%)
- Divide-by-zero guard for estimated=0
- Ring-buffer caps (100 records → max 64 retained)
- Reset clears all state
- `markRowMount` closure pattern

**63/63 virtualization tests passing** (51 from Phase 1 + 12 new from Phase 3).

## Production no-op verification

The `isProbingEnabled()` gate uses `import.meta.env.DEV`, which Vite injects as a literal at build time. The branches below the gate are tree-shaken in production builds. Verified by inspecting the gate at the top of each `record*` function and the `markRowMount` factory.

## Cross-references

- PR #783 — Phase 1 (foundation: store, anchor, registry, partition)
- PR #784 — Phase 2 (virt layer: VirtualList, DocumentRow, CSS, wiring)
- This PR — Phase 3 (perf probing + HUD)
- Issue #782 — full design overview
- Spec: `docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md`

## Phase 4

The original spec called for a Phase 4 (production hardening: streaming-buffer-size tuning, smoke against 2000+ node session, tab-switch perf regression test). With Phase 3's HUD live, much of the tuning becomes data-driven and can happen incrementally as we use the app. I'll defer Phase 4 unless a specific regression appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)