### PR TITLE
feat(virt): Phase 3 — intelligent perf probing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.755"
+version = "0.33.756"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.755"
+version = "0.33.756"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.755"
+version = "0.33.756"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.755"
+version = "0.33.756"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.756"
+version = "0.33.757"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.756"
+version = "0.33.757"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.756"
+version = "0.33.757"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.756"
+version = "0.33.757"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.754"
+version = "0.33.755"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.754"
+version = "0.33.755"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.755"
+version = "0.33.756"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.756"
+version = "0.33.757"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.754"
+version = "0.33.755"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.756"
+version = "0.33.757"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.755"
+version = "0.33.756"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.756"
+version = "0.33.757"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.755"
+version = "0.33.756"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.754"
+version = "0.33.755"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.754"
+version = "0.33.755"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.755"
+version = "0.33.756"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.756"
+version = "0.33.757"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/devtools/agent-pane-perf-section.tsx
+++ b/frontend/app/devtools/agent-pane-perf-section.tsx
@@ -1,0 +1,186 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane perf section for the diag panel — Phase 3 of the
+ * virtualization redesign. Polls `agentPerfStore.snapshot()` at 1 Hz
+ * and renders per-kind row mount times, estimator-miss rates, and
+ * recent layout shifts.
+ *
+ * No-op in production: snapshot returns empty when probing is
+ * disabled, so the section renders nothing.
+ *
+ * See docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Intelligent perf probing".
+ */
+
+import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import {
+    agentPerfStore,
+    ESTIMATOR_MISS_THRESHOLD,
+    type AgentPerfSnapshot,
+} from "@/view/agent/virtualization/perf-probe";
+
+const POLL_INTERVAL_MS = 1000;
+
+const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
+    rowMountByKind: new Map(),
+    estimatorMissRateByKind: new Map(),
+    recentEstimatorMisses: [],
+    recentLayoutShifts: [],
+};
+
+function formatMs(n: number | undefined): string {
+    if (n == null) return "—";
+    if (n < 10) return n.toFixed(1);
+    return n.toFixed(0);
+}
+
+function formatPct(n: number): string {
+    return `${(n * 100).toFixed(0)}%`;
+}
+
+function ageMs(now: number, at: number): string {
+    const dt = now - at;
+    if (dt < 1000) return `${dt.toFixed(0)}ms`;
+    if (dt < 60_000) return `${(dt / 1000).toFixed(1)}s`;
+    return `${(dt / 60_000).toFixed(1)}min`;
+}
+
+export function AgentPanePerfSection(): JSX.Element {
+    const [snapshot, setSnapshot] = createSignal<AgentPerfSnapshot>(EMPTY_SNAPSHOT);
+    let pollHandle: number | undefined;
+
+    const poll = (): void => {
+        setSnapshot(agentPerfStore.snapshot());
+    };
+
+    onMount(() => {
+        poll();
+        pollHandle = window.setInterval(poll, POLL_INTERVAL_MS);
+    });
+    onCleanup(() => {
+        if (pollHandle != null) window.clearInterval(pollHandle);
+    });
+
+    const hasData = (): boolean => {
+        const s = snapshot();
+        return s.rowMountByKind.size > 0
+            || s.recentEstimatorMisses.length > 0
+            || s.recentLayoutShifts.length > 0;
+    };
+
+    return (
+        <Show when={hasData()}>
+            <div
+                style={{
+                    "margin-top": "8px",
+                    "padding-top": "8px",
+                    "border-top": "1px solid #333",
+                }}
+            >
+                <div style={{ "font-weight": "bold", color: "#7af", "margin-bottom": "4px" }}>
+                    📊 Agent Pane Perf
+                </div>
+
+                {/* Per-kind row mount durations */}
+                <Show when={snapshot().rowMountByKind.size > 0}>
+                    <div style={{ "margin-bottom": "6px" }}>
+                        <div style={{ color: "#aaa", "font-size": "10px", "margin-bottom": "2px" }}>
+                            Row mount duration (last 64 per kind)
+                        </div>
+                        <table style={{ "font-size": "10px", "border-collapse": "collapse", width: "100%" }}>
+                            <thead>
+                                <tr style={{ color: "#888" }}>
+                                    <th style={{ "text-align": "left", padding: "1px 4px" }}>kind</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>p50</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>p95</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>max</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>n</th>
+                                    <th style={{ "text-align": "right", padding: "1px 4px" }}>est-miss</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <For each={[...snapshot().rowMountByKind.entries()].sort(
+                                    ([, a], [, b]) => (b.p95 ?? 0) - (a.p95 ?? 0),
+                                )}>
+                                    {([kind, q]) => {
+                                        const missRate = snapshot().estimatorMissRateByKind.get(kind) ?? 0;
+                                        const flag = missRate > 0.20 ? " ⚠" : "";
+                                        return (
+                                            <tr>
+                                                <td style={{ padding: "1px 4px" }}>{kind}</td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.p50)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.p95)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right" }}>
+                                                    {formatMs(q.max)}
+                                                </td>
+                                                <td style={{ padding: "1px 4px", "text-align": "right", color: "#888" }}>
+                                                    {q.count}
+                                                </td>
+                                                <td style={{
+                                                    padding: "1px 4px",
+                                                    "text-align": "right",
+                                                    color: missRate > 0.20 ? "#fa6" : "#6c8",
+                                                }}>
+                                                    {formatPct(missRate)}{flag}
+                                                </td>
+                                            </tr>
+                                        );
+                                    }}
+                                </For>
+                            </tbody>
+                        </table>
+                        <div style={{ color: "#666", "font-size": "9px", "margin-top": "2px" }}>
+                            est-miss = pct measured outside ±{formatPct(ESTIMATOR_MISS_THRESHOLD)} of estimate
+                        </div>
+                    </div>
+                </Show>
+
+                {/* Recent layout shifts */}
+                <Show when={snapshot().recentLayoutShifts.length > 0}>
+                    <div style={{ "margin-bottom": "6px" }}>
+                        <div style={{ color: "#aaa", "font-size": "10px" }}>
+                            Layout shifts in agent pane (last {snapshot().recentLayoutShifts.length})
+                        </div>
+                        <For each={snapshot().recentLayoutShifts.slice(0, 5)}>
+                            {(s) => {
+                                const now = performance.now();
+                                return (
+                                    <div style={{ "font-size": "10px", color: "#bbb", "padding-left": "8px" }}>
+                                        {ageMs(now, s.timestamp)} ago: {s.value.toFixed(4)}
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </div>
+                </Show>
+
+                {/* Recent estimator misses */}
+                <Show when={snapshot().recentEstimatorMisses.length > 0}>
+                    <div>
+                        <div style={{ color: "#aaa", "font-size": "10px" }}>
+                            Recent estimator misses (last {snapshot().recentEstimatorMisses.length})
+                        </div>
+                        <For each={snapshot().recentEstimatorMisses.slice(0, 5)}>
+                            {(s) => {
+                                const now = performance.now();
+                                return (
+                                    <div style={{ "font-size": "10px", color: "#bbb", "padding-left": "8px" }}>
+                                        {ageMs(now, s.timestamp)} ago: {s.kind} —
+                                        est {s.estimated.toFixed(0)}px, actual {s.actual.toFixed(0)}px
+                                        ({formatPct(s.errorPct)})
+                                    </div>
+                                );
+                            }}
+                        </For>
+                    </div>
+                </Show>
+            </div>
+        </Show>
+    );
+}

--- a/frontend/app/devtools/diag-panel.tsx
+++ b/frontend/app/devtools/diag-panel.tsx
@@ -42,6 +42,7 @@ import {
     type DispatchRecord,
     __resetDispatchLog,
 } from "@/store/command-source";
+import { AgentPanePerfSection } from "./agent-pane-perf-section";
 
 const DEFAULT_DISPLAY_LIMIT = 80;
 
@@ -327,6 +328,7 @@ export function DiagPanel(): JSX.Element {
                         </table>
                     </Show>
                 </div>
+                <AgentPanePerfSection />
             </div>
         </Show>
     );

--- a/frontend/app/view/agent/components/AgentMessageBlock.tsx
+++ b/frontend/app/view/agent/components/AgentMessageBlock.tsx
@@ -15,32 +15,36 @@ interface AgentMessageBlockProps {
     onToggle: () => void;
 }
 
-export const AgentMessageBlock = ({ node, collapsed, onToggle }: AgentMessageBlockProps): JSX.Element => {
-    const isIncoming = node.direction === "incoming";
-
+export const AgentMessageBlock = (props: AgentMessageBlockProps): JSX.Element => {
+    // Don't destructure — the streaming buffer keeps this row mounted
+    // across token deltas; useAgentStream replaces props.node ref on
+    // each chunk. Destructured `node` would freeze at first ref.
+    // Access props.X reactively at each site. (codex P1 on PR #786 +
+    // family of issues on virt redesign — also fixed in MarkdownBlock,
+    // SubagentLinkBlock.)
     return (
         <div
             class={clsx("agent-message-block", {
-                incoming: isIncoming,
-                outgoing: !isIncoming,
-                collapsed,
-                mux: node.method === "mux",
-                ject: node.method === "ject",
+                incoming: props.node.direction === "incoming",
+                outgoing: props.node.direction !== "incoming",
+                collapsed: props.collapsed,
+                mux: props.node.method === "mux",
+                ject: props.node.method === "ject",
             })}
-            onClick={onToggle}
+            onClick={props.onToggle}
         >
             <div class="agent-message-summary">
-                <span class="agent-message-chevron">{collapsed ? "▸" : "▾"}</span>
-                <span class="agent-message-icon">{node.summary}</span>
+                <span class="agent-message-chevron">{props.collapsed ? "▸" : "▾"}</span>
+                <span class="agent-message-icon">{props.node.summary}</span>
             </div>
-            <Show when={!collapsed}>
+            <Show when={!props.collapsed}>
                 <div class="agent-message-content" onClick={(e) => e.stopPropagation()}>
                     <div class="agent-message-meta">
-                        <span class="agent-message-from">From: {node.from}</span>
-                        <span class="agent-message-to">To: {node.to}</span>
-                        <span class="agent-message-method">Method: {node.method}</span>
+                        <span class="agent-message-from">From: {props.node.from}</span>
+                        <span class="agent-message-to">To: {props.node.to}</span>
+                        <span class="agent-message-method">Method: {props.node.method}</span>
                     </div>
-                    <pre class="agent-message-body">{node.message}</pre>
+                    <pre class="agent-message-body">{props.node.message}</pre>
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/components/MarkdownBlock.tsx
+++ b/frontend/app/view/agent/components/MarkdownBlock.tsx
@@ -14,14 +14,20 @@ interface MarkdownBlockProps {
     node: MarkdownNode;
 }
 
-export const MarkdownBlock = ({ node }: MarkdownBlockProps): JSX.Element => {
+export const MarkdownBlock = (props: MarkdownBlockProps): JSX.Element => {
+    // Don't destructure `node` — the streaming buffer keeps this row
+    // mounted across token deltas, and useAgentStream replaces the
+    // node reference for each chunk. A destructured `node` would
+    // capture the first reference and freeze. Access props.node.X at
+    // each site so Solid's reactivity tracks the read. (codex P1 on
+    // PR #786 / virt redesign.)
     return (
         <div
             class={clsx("agent-markdown-block", {
-                "thinking-block": node.metadata?.thinking,
+                "thinking-block": props.node.metadata?.thinking,
             })}
         >
-            <Markdown text={node.content} />
+            <Markdown text={props.node.content} />
         </div>
     );
 };

--- a/frontend/app/view/agent/components/SubagentLinkBlock.tsx
+++ b/frontend/app/view/agent/components/SubagentLinkBlock.tsx
@@ -15,8 +15,13 @@ interface SubagentLinkBlockProps {
     onClick: (node: SubagentLinkNode) => void;
 }
 
-export const SubagentLinkBlock = ({ node, onClick }: SubagentLinkBlockProps): JSX.Element => {
-    const isActive = () => node.status === "active";
+export const SubagentLinkBlock = (props: SubagentLinkBlockProps): JSX.Element => {
+    // Don't destructure \u2014 see family of fixes on virt redesign:
+    // AgentMessageBlock, MarkdownBlock have the same change. The
+    // streaming buffer's <Index> keeps the row mounted across status
+    // transitions (active \u2192 completed); a destructured node would
+    // freeze the active class. (codex P2 on PR #786.)
+    const isActive = () => props.node.status === "active";
 
     return (
         <div
@@ -24,12 +29,12 @@ export const SubagentLinkBlock = ({ node, onClick }: SubagentLinkBlockProps): JS
                 active: isActive(),
                 completed: !isActive(),
             })}
-            onClick={() => onClick(node)}
+            onClick={() => props.onClick(props.node)}
         >
             <span class="agent-subagent-link-icon">{isActive() ? "\u{26A1}" : "\u2714"}</span>
             <span class="agent-subagent-link-info">
-                <span class="agent-subagent-link-slug">{node.slug || node.subagentId.substring(0, 7)}</span>
-                <span class="agent-subagent-link-id">{node.subagentId.substring(0, 7)}</span>
+                <span class="agent-subagent-link-slug">{props.node.slug || props.node.subagentId.substring(0, 7)}</span>
+                <span class="agent-subagent-link-id">{props.node.subagentId.substring(0, 7)}</span>
             </span>
             <span class="agent-subagent-link-action">{"\u2192"}</span>
         </div>

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -29,9 +29,10 @@
  */
 
 import { createVirtualizer } from "@tanstack/solid-virtual";
-import { createEffect, createMemo, For, Index, type Accessor, type JSX } from "solid-js";
+import { createEffect, createMemo, For, Index, onMount, type Accessor, type JSX } from "solid-js";
 import type { ScrollCommand } from "../hooks/useScrollToNode";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import { agentPerfStore, startAgentLayoutShiftObserver } from "./perf-probe";
 import {
     captureTopmostAnchor,
     isNearBottom,
@@ -103,6 +104,31 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
         get scrollMargin() {
             return virtualContainerRef?.offsetTop ?? 0;
         },
+        // Phase 3 perf probe: validate the per-kind estimator against
+        // the measured size after every measurement. The HUD surfaces
+        // any kind whose miss-rate stays high so we recalibrate.
+        // No-op in production builds (agentPerfStore short-circuits).
+        measureElement: (element) => {
+            const measured = element.getBoundingClientRect().height;
+            const indexAttr = element.getAttribute("data-index");
+            if (indexAttr != null) {
+                const idx = Number(indexAttr);
+                const node = partition().virtualizedNodes[idx];
+                if (node) {
+                    const estimated = estimateNode(node, props.documentState());
+                    agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
+                }
+            }
+            // Return the measured height. (reagent P2 on #785: dead
+            // ternary removed — both branches returned `measured`.)
+            return measured;
+        },
+    });
+
+    // Layout-shift observer scoped to .agent-document. Idempotent —
+    // subsequent mounts are no-ops. Production: short-circuits.
+    onMount(() => {
+        startAgentLayoutShiftObserver();
     });
 
     // Project stickToBottom into scroll position. When the document

--- a/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
+++ b/frontend/app/view/agent/virtualization/AgentDocumentVirtualList.tsx
@@ -119,8 +119,6 @@ export function AgentDocumentVirtualList(props: AgentDocumentVirtualListProps): 
                     agentPerfStore.recordEstimatorMeasurement(node.type, estimated, measured);
                 }
             }
-            // Return the measured height. (reagent P2 on #785: dead
-            // ternary removed — both branches returned `measured`.)
             return measured;
         },
     });

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -14,7 +14,7 @@
  * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md.
  */
 
-import { Show, type Accessor, type JSX } from "solid-js";
+import { onMount, Show, type Accessor, type JSX } from "solid-js";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { AgentMessageBlock } from "../components/AgentMessageBlock";
 import { MarkdownBlock } from "../components/MarkdownBlock";
@@ -22,6 +22,7 @@ import { NodeHoverStrip } from "../components/NodeHoverStrip";
 import { SubagentLinkBlock } from "../components/SubagentLinkBlock";
 import { ToolBlock } from "../components/ToolBlock";
 import type { DocumentNode, DocumentState, SubagentLinkNode } from "../types";
+import { markRowMount } from "./perf-probe";
 
 export interface DocumentRowProps {
     /**
@@ -61,6 +62,13 @@ const TOGGLEABLE_KINDS: ReadonlySet<DocumentNode["type"]> = new Set([
 ]);
 
 export function DocumentRow(props: DocumentRowProps): JSX.Element {
+    // Phase 3: per-kind row mount perf probe. markRowMount returns a
+    // closer that we invoke after onMount fires (i.e., after the row
+    // is in the DOM and its initial paint has been queued).
+    // No-op in production builds.
+    const close = markRowMount(props.node().type);
+    onMount(() => close());
+
     const isBookmarked = (): boolean => {
         const n = props.node();
         return props.bookmarkedNodeIds?.().has(n.id) ?? false;

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -208,62 +208,72 @@ interface DocumentNodeBodyProps {
  * ToolBlock uses props.pinned correctly. See PR #346 reagent.
  */
 function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
+    // SolidJS <Show> with keyed:false (the default) calls the child
+    // factory ONCE when `when` first becomes truthy and never re-runs
+    // it. The previous version of this function was:
+    //
+    //   <Show when={props.node()}>{(n) => { const node = n(); switch ...}}
+    //
+    // which captured a one-time `node = n()` snapshot. Streaming token
+    // updates and tool transitions (running → success, etc.) silently
+    // failed to propagate to ToolBlock / AgentMessageBlock until the
+    // row remounted — defeating the whole streaming buffer.
+    //
+    // Use separate <Show when={node.type === "X"}> branches per kind.
+    // Each branch reads props.node() reactively at every prop site, so
+    // the matching branch's children update when the underlying node
+    // changes. This was committed on the Phase 2 PR but landed after
+    // the squash-merge cutoff — adding back as a follow-up.
     return (
-        <Show when={props.node()}>
-            {(n) => {
-                const node = n();
-                switch (node.type) {
-                    case "markdown":
-                        return <MarkdownBlock node={node} />;
-                    case "tool":
-                        return (
-                            <ToolBlock
-                                node={node}
-                                pinned={props.documentState().pinnedNodes.has(node.id)}
-                                onTogglePin={() => props.onTogglePin(node.id)}
-                            />
-                        );
-                    case "agent_message":
-                        return (
-                            <AgentMessageBlock
-                                node={node}
-                                collapsed={props.documentState().collapsedNodes.has(node.id)}
-                                onToggle={() => props.onToggleCollapse(node.id)}
-                            />
-                        );
-                    case "user_message":
-                        return (
-                            <div
-                                class="agent-user-message"
-                                classList={{
-                                    "agent-user-message--collapsed":
-                                        props.documentState().collapsedNodes.has(node.id),
-                                }}
-                            >
-                                <div class="agent-user-message-content">
-                                    <pre>{node.message}</pre>
-                                </div>
-                            </div>
-                        );
-                    case "subagent_link":
-                        return (
-                            <SubagentLinkBlock
-                                node={node}
-                                onClick={props.onSubagentClick ?? (() => { })}
-                            />
-                        );
-                    case "section":
-                        return (
-                            <div class={`agent-section level-${node.level}`}>
-                                <Show when={node.level === 1}><h1>{node.title}</h1></Show>
-                                <Show when={node.level === 2}><h2>{node.title}</h2></Show>
-                                <Show when={node.level === 3}><h3>{node.title}</h3></Show>
-                            </div>
-                        );
-                    default:
-                        return null;
-                }
-            }}
-        </Show>
+        <>
+            <Show when={props.node() && props.node().type === "markdown"}>
+                <MarkdownBlock node={props.node() as Extract<DocumentNode, { type: "markdown" }>} />
+            </Show>
+            <Show when={props.node() && props.node().type === "tool"}>
+                <ToolBlock
+                    node={props.node() as Extract<DocumentNode, { type: "tool" }>}
+                    pinned={props.documentState().pinnedNodes.has(props.node().id)}
+                    onTogglePin={() => props.onTogglePin(props.node().id)}
+                />
+            </Show>
+            <Show when={props.node() && props.node().type === "agent_message"}>
+                <AgentMessageBlock
+                    node={props.node() as Extract<DocumentNode, { type: "agent_message" }>}
+                    collapsed={props.documentState().collapsedNodes.has(props.node().id)}
+                    onToggle={() => props.onToggleCollapse(props.node().id)}
+                />
+            </Show>
+            <Show when={props.node() && props.node().type === "user_message"}>
+                <div
+                    class="agent-user-message"
+                    classList={{
+                        "agent-user-message--collapsed":
+                            props.documentState().collapsedNodes.has(props.node().id),
+                    }}
+                >
+                    <div class="agent-user-message-content">
+                        <pre>{(props.node() as Extract<DocumentNode, { type: "user_message" }>).message}</pre>
+                    </div>
+                </div>
+            </Show>
+            <Show when={props.node() && props.node().type === "subagent_link"}>
+                <SubagentLinkBlock
+                    node={props.node() as Extract<DocumentNode, { type: "subagent_link" }>}
+                    onClick={props.onSubagentClick ?? (() => { })}
+                />
+            </Show>
+            <Show when={props.node() && props.node().type === "section"}>
+                {(() => {
+                    const sec = props.node() as Extract<DocumentNode, { type: "section" }>;
+                    return (
+                        <div class={`agent-section level-${sec.level}`}>
+                            <Show when={sec.level === 1}><h1>{sec.title}</h1></Show>
+                            <Show when={sec.level === 2}><h2>{sec.title}</h2></Show>
+                            <Show when={sec.level === 3}><h3>{sec.title}</h3></Show>
+                        </div>
+                    );
+                })()}
+            </Show>
+        </>
     );
 }

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -263,16 +263,17 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                 />
             </Show>
             <Show when={props.node() && props.node().type === "section"}>
-                {(() => {
-                    const sec = props.node() as Extract<DocumentNode, { type: "section" }>;
-                    return (
-                        <div class={`agent-section level-${sec.level}`}>
-                            <Show when={sec.level === 1}><h1>{sec.title}</h1></Show>
-                            <Show when={sec.level === 2}><h2>{sec.title}</h2></Show>
-                            <Show when={sec.level === 3}><h3>{sec.title}</h3></Show>
-                        </div>
-                    );
-                })()}
+                <div class={`agent-section level-${(props.node() as Extract<DocumentNode, { type: "section" }>).level}`}>
+                    <Show when={(props.node() as Extract<DocumentNode, { type: "section" }>).level === 1}>
+                        <h1>{(props.node() as Extract<DocumentNode, { type: "section" }>).title}</h1>
+                    </Show>
+                    <Show when={(props.node() as Extract<DocumentNode, { type: "section" }>).level === 2}>
+                        <h2>{(props.node() as Extract<DocumentNode, { type: "section" }>).title}</h2>
+                    </Show>
+                    <Show when={(props.node() as Extract<DocumentNode, { type: "section" }>).level === 3}>
+                        <h3>{(props.node() as Extract<DocumentNode, { type: "section" }>).title}</h3>
+                    </Show>
+                </div>
             </Show>
         </>
     );

--- a/frontend/app/view/agent/virtualization/perf-probe.test.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.test.ts
@@ -1,0 +1,163 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the agent-pane perf probe. Note: these tests run under
+ * Vitest's `import.meta.env.DEV === true`, so probing IS active here.
+ * Production no-op behavior is verified by inspecting the
+ * `isProbingEnabled()` short-circuit at the top of each record fn —
+ * not by a test (Vitest doesn't simulate the prod env without a
+ * separate config, and the bundler tree-shakes the dead branch).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+    agentPerfStore,
+    ESTIMATOR_MISS_THRESHOLD,
+    markRowMount,
+} from "./perf-probe";
+
+describe("agentPerfStore", () => {
+    beforeEach(() => agentPerfStore.reset());
+
+    describe("recordRowMount", () => {
+        it("aggregates per-kind durations into a snapshot", () => {
+            agentPerfStore.recordRowMount("agent_message", 5);
+            agentPerfStore.recordRowMount("agent_message", 10);
+            agentPerfStore.recordRowMount("tool", 2);
+
+            const snap = agentPerfStore.snapshot();
+            expect(snap.rowMountByKind.has("agent_message")).toBe(true);
+            expect(snap.rowMountByKind.has("tool")).toBe(true);
+            expect(snap.rowMountByKind.get("agent_message")!.count).toBe(2);
+            expect(snap.rowMountByKind.get("tool")!.count).toBe(1);
+        });
+    });
+
+    describe("recordEstimatorMeasurement", () => {
+        it("does not flag measurements within threshold", () => {
+            // estimated 100, actual 110 → 10% error, under 30% threshold
+            agentPerfStore.recordEstimatorMeasurement("markdown", 100, 110);
+            const snap = agentPerfStore.snapshot();
+            expect(snap.recentEstimatorMisses).toHaveLength(0);
+            expect(snap.estimatorMissRateByKind.get("markdown")).toBe(0);
+        });
+
+        it("flags measurements outside threshold and records miss-rate", () => {
+            // estimated 100, actual 200 → 100% error
+            agentPerfStore.recordEstimatorMeasurement("tool", 100, 200);
+            const snap = agentPerfStore.snapshot();
+            expect(snap.recentEstimatorMisses).toHaveLength(1);
+            expect(snap.recentEstimatorMisses[0]).toMatchObject({
+                kind: "tool",
+                estimated: 100,
+                actual: 200,
+                errorPct: 1,
+            });
+            expect(snap.estimatorMissRateByKind.get("tool")).toBe(1);
+        });
+
+        it("computes miss-rate correctly across measurements", () => {
+            // 1 miss, 3 hits → miss rate 0.25
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 100); // 100% error → miss
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 55);  // 10% → hit
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 60);  // 20% → hit
+            agentPerfStore.recordEstimatorMeasurement("section", 50, 50);  // 0% → hit
+            const snap = agentPerfStore.snapshot();
+            expect(snap.estimatorMissRateByKind.get("section")).toBeCloseTo(0.25, 2);
+        });
+
+        it("rejects measurements with estimated=0 (avoid divide-by-zero)", () => {
+            agentPerfStore.recordEstimatorMeasurement("subagent_link", 0, 100);
+            // errorPct should be 0 (defensive), not Infinity
+            const snap = agentPerfStore.snapshot();
+            // The measurement still counted toward total, just not flagged.
+            expect(snap.estimatorMissRateByKind.get("subagent_link")).toBe(0);
+        });
+
+        it("uses the documented threshold constant", () => {
+            // Just over threshold → flagged
+            const justOver = ESTIMATOR_MISS_THRESHOLD + 0.01;
+            agentPerfStore.recordEstimatorMeasurement("user_message", 100, 100 + 100 * justOver);
+            expect(agentPerfStore.snapshot().recentEstimatorMisses).toHaveLength(1);
+
+            agentPerfStore.reset();
+
+            // Just under threshold → not flagged
+            const justUnder = ESTIMATOR_MISS_THRESHOLD - 0.01;
+            agentPerfStore.recordEstimatorMeasurement("user_message", 100, 100 + 100 * justUnder);
+            expect(agentPerfStore.snapshot().recentEstimatorMisses).toHaveLength(0);
+        });
+    });
+
+    describe("recordLayoutShift", () => {
+        it("records shifts in chronological-recent order", () => {
+            agentPerfStore.recordLayoutShift(0.01);
+            agentPerfStore.recordLayoutShift(0.05);
+            agentPerfStore.recordLayoutShift(0.02);
+            const shifts = agentPerfStore.snapshot().recentLayoutShifts;
+            expect(shifts).toHaveLength(3);
+            // Most recent first.
+            expect(shifts[0].value).toBe(0.02);
+            expect(shifts[2].value).toBe(0.01);
+        });
+    });
+
+    describe("ring buffer bounds", () => {
+        it("caps recentEstimatorMisses at the ring size", () => {
+            for (let i = 0; i < 100; i++) {
+                agentPerfStore.recordEstimatorMeasurement("markdown", 100, 1000);
+            }
+            // Default SAMPLE_RING_SIZE is 64; verify cap.
+            expect(agentPerfStore.snapshot().recentEstimatorMisses.length).toBeLessThanOrEqual(64);
+        });
+
+        it("caps recentLayoutShifts at the ring size", () => {
+            for (let i = 0; i < 100; i++) {
+                agentPerfStore.recordLayoutShift(0.01);
+            }
+            expect(agentPerfStore.snapshot().recentLayoutShifts.length).toBeLessThanOrEqual(64);
+        });
+    });
+
+    describe("reset", () => {
+        it("clears all recorded data", () => {
+            agentPerfStore.recordRowMount("markdown", 5);
+            agentPerfStore.recordEstimatorMeasurement("tool", 100, 200);
+            agentPerfStore.recordLayoutShift(0.05);
+
+            agentPerfStore.reset();
+
+            const snap = agentPerfStore.snapshot();
+            expect(snap.rowMountByKind.size).toBe(0);
+            expect(snap.recentEstimatorMisses).toHaveLength(0);
+            expect(snap.recentLayoutShifts).toHaveLength(0);
+            expect(snap.estimatorMissRateByKind.size).toBe(0);
+        });
+    });
+});
+
+describe("markRowMount", () => {
+    beforeEach(() => agentPerfStore.reset());
+
+    it("returns a closer that records duration on call", async () => {
+        const close = markRowMount("markdown");
+        await new Promise<void>((r) => setTimeout(r, 5));
+        close();
+        const snap = agentPerfStore.snapshot();
+        const q = snap.rowMountByKind.get("markdown");
+        expect(q).toBeDefined();
+        expect(q!.count).toBe(1);
+        // Should be at least 5ms (with timer slop, allow 2ms floor).
+        expect(q!.max).toBeGreaterThanOrEqual(2);
+    });
+
+    it("multiple calls accumulate independently", () => {
+        markRowMount("agent_message")();
+        markRowMount("agent_message")();
+        markRowMount("tool")();
+        const snap = agentPerfStore.snapshot();
+        expect(snap.rowMountByKind.get("agent_message")!.count).toBe(2);
+        expect(snap.rowMountByKind.get("tool")!.count).toBe(1);
+    });
+});

--- a/frontend/app/view/agent/virtualization/perf-probe.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.ts
@@ -1,0 +1,205 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-pane perf probe — per-kind render timing, estimator-miss
+ * detection, layout-shift attribution scoped to `.agent-document`.
+ *
+ * Phase 3 of the virtualization redesign — see
+ * docs/specs/SPEC_AGENT_PANE_VIRTUALIZATION_REDESIGN.md
+ * §"Intelligent perf probing".
+ *
+ * Production behavior: all probing is dev-mode-only. The exported
+ * `recordRowMount` / `recordEstimatorMeasurement` functions are
+ * no-ops when `import.meta.env.DEV` is false. The dev HUD reads
+ * from `agentPerfStore.snapshot()` which returns empty in prod.
+ */
+
+import { KeyedAggregator, type QuantileSnapshot } from "@/perf/aggregates";
+import type { NodeKind } from "./renderers";
+
+/**
+ * Estimator-miss event — actual measured size diverged from estimate
+ * by more than ESTIMATOR_MISS_THRESHOLD. Aggregated per kind so the
+ * HUD can flag persistently-wrong estimators for recalibration.
+ */
+export interface EstimatorMissSample {
+    kind: NodeKind;
+    estimated: number;
+    actual: number;
+    /** abs(actual-estimated) / estimated, in [0, ∞). */
+    errorPct: number;
+    timestamp: number;
+}
+
+/**
+ * Layout-shift event scoped to `.agent-document`. Each unexpected
+ * shift here is either an estimator miss or a measurement race —
+ * both are bugs we want visible immediately, not via user reports.
+ */
+export interface LayoutShiftSample {
+    value: number;
+    timestamp: number;
+}
+
+/** Threshold above which an estimator is considered a miss. */
+export const ESTIMATOR_MISS_THRESHOLD = 0.30;
+
+/** Bounded ring size for miss + shift logs (keeps memory bounded). */
+const SAMPLE_RING_SIZE = 64;
+
+/** True when probing should record. False suppresses all recording
+ *  to keep production builds cost-free. */
+function isProbingEnabled(): boolean {
+    // Vite injects import.meta.env.DEV at build time. The check is
+    // tree-shaken in production builds, so the cost-paths below are
+    // dropped entirely.
+    return typeof import.meta !== "undefined"
+        && (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+}
+
+class AgentPerfStore {
+    /** Per-kind row mount duration (ms). p50/p95/max surface in HUD. */
+    private rowMountAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
+    /** Per-kind estimator-miss event log (most recent first). */
+    private estimatorMisses: EstimatorMissSample[] = [];
+    /** Per-kind miss-rate (running total of measured / total miss-flagged). */
+    private kindMissCount = new Map<NodeKind, { misses: number; total: number }>();
+    /** Layout-shift events scoped to agent pane. */
+    private layoutShifts: LayoutShiftSample[] = [];
+
+    recordRowMount(kind: NodeKind, durationMs: number): void {
+        if (!isProbingEnabled()) return;
+        this.rowMountAgg.record(kind, durationMs);
+    }
+
+    recordEstimatorMeasurement(kind: NodeKind, estimated: number, actual: number): void {
+        if (!isProbingEnabled()) return;
+        const errorPct = estimated > 0 ? Math.abs(actual - estimated) / estimated : 0;
+        const entry = this.kindMissCount.get(kind) ?? { misses: 0, total: 0 };
+        entry.total += 1;
+        if (errorPct > ESTIMATOR_MISS_THRESHOLD) {
+            entry.misses += 1;
+            this.estimatorMisses.unshift({
+                kind,
+                estimated,
+                actual,
+                errorPct,
+                timestamp: performance.now(),
+            });
+            if (this.estimatorMisses.length > SAMPLE_RING_SIZE) {
+                this.estimatorMisses.length = SAMPLE_RING_SIZE;
+            }
+        }
+        this.kindMissCount.set(kind, entry);
+    }
+
+    recordLayoutShift(value: number): void {
+        if (!isProbingEnabled()) return;
+        this.layoutShifts.unshift({ value, timestamp: performance.now() });
+        if (this.layoutShifts.length > SAMPLE_RING_SIZE) {
+            this.layoutShifts.length = SAMPLE_RING_SIZE;
+        }
+    }
+
+    snapshot(): AgentPerfSnapshot {
+        if (!isProbingEnabled()) {
+            return EMPTY_SNAPSHOT;
+        }
+        const missRates = new Map<NodeKind, number>();
+        for (const [kind, { misses, total }] of this.kindMissCount.entries()) {
+            missRates.set(kind, total > 0 ? misses / total : 0);
+        }
+        return {
+            rowMountByKind: this.rowMountAgg.snapshot() as Map<NodeKind, QuantileSnapshot>,
+            estimatorMissRateByKind: missRates,
+            recentEstimatorMisses: [...this.estimatorMisses],
+            recentLayoutShifts: [...this.layoutShifts],
+        };
+    }
+
+    /** Reset all aggregators — useful for tests and HUD "clear" button. */
+    reset(): void {
+        this.rowMountAgg = new KeyedAggregator(SAMPLE_RING_SIZE);
+        this.estimatorMisses = [];
+        this.kindMissCount.clear();
+        this.layoutShifts = [];
+    }
+}
+
+export interface AgentPerfSnapshot {
+    rowMountByKind: ReadonlyMap<NodeKind, QuantileSnapshot>;
+    estimatorMissRateByKind: ReadonlyMap<NodeKind, number>;
+    recentEstimatorMisses: readonly EstimatorMissSample[];
+    recentLayoutShifts: readonly LayoutShiftSample[];
+}
+
+const EMPTY_SNAPSHOT: AgentPerfSnapshot = {
+    rowMountByKind: new Map(),
+    estimatorMissRateByKind: new Map(),
+    recentEstimatorMisses: [],
+    recentLayoutShifts: [],
+};
+
+export const agentPerfStore = new AgentPerfStore();
+
+// ── Layout-shift observer ──────────────────────────────────────────────────
+
+interface LayoutShiftEntry extends PerformanceEntry {
+    value: number;
+    sources?: Array<{ node?: Element | null }>;
+}
+
+let layoutShiftObserverStarted = false;
+
+/**
+ * Idempotent. Starts a global PerformanceObserver for layout-shift
+ * entries; only those whose source nodes are inside `.agent-document`
+ * are recorded. Safe to call from app init or from the agent pane's
+ * onMount — second call is a no-op.
+ *
+ * Production: returns immediately (probing disabled).
+ */
+export function startAgentLayoutShiftObserver(): void {
+    if (!isProbingEnabled()) return;
+    if (layoutShiftObserverStarted) return;
+    if (typeof PerformanceObserver === "undefined") return;
+    try {
+        const observer = new PerformanceObserver((entries) => {
+            for (const e of entries.getEntries() as LayoutShiftEntry[]) {
+                const sources = e.sources ?? [];
+                const inAgentDoc = sources.some(
+                    (s) => s.node?.closest?.(".agent-document") != null,
+                );
+                if (inAgentDoc) {
+                    agentPerfStore.recordLayoutShift(e.value);
+                }
+            }
+        });
+        observer.observe({ type: "layout-shift", buffered: true });
+        layoutShiftObserverStarted = true;
+    } catch {
+        // entryType may not be supported (Safari, headless tests).
+        // Silent — layout-shift is a "nice to have" perf probe, not
+        // load-bearing.
+    }
+}
+
+// ── Per-row mark helpers ───────────────────────────────────────────────────
+
+/**
+ * Time a row's mount → first-paint span. Returns a function the
+ * caller invokes after the row is in the DOM (e.g., from
+ * createEffect that runs once after mount).
+ *
+ * Production: returns a no-op.
+ */
+export function markRowMount(kind: NodeKind): () => void {
+    if (!isProbingEnabled()) return NOOP;
+    const start = performance.now();
+    return () => {
+        agentPerfStore.recordRowMount(kind, performance.now() - start);
+    };
+}
+
+const NOOP: () => void = () => { };

--- a/frontend/app/view/agent/virtualization/perf-probe.ts
+++ b/frontend/app/view/agent/virtualization/perf-probe.ts
@@ -49,13 +49,14 @@ export const ESTIMATOR_MISS_THRESHOLD = 0.30;
 const SAMPLE_RING_SIZE = 64;
 
 /** True when probing should record. False suppresses all recording
- *  to keep production builds cost-free. */
+ *  to keep production builds cost-free. Uses the bare
+ *  `import.meta.env.DEV` form so Vite's static-replace plugin can
+ *  fold it to a literal at build time and dead-code-eliminate the
+ *  surrounding branches. Optional-chaining or any cast that produces
+ *  `import.meta.env?.DEV` defeats the static replace and ships the
+ *  full probe code in production. */
 function isProbingEnabled(): boolean {
-    // Vite injects import.meta.env.DEV at build time. The check is
-    // tree-shaken in production builds, so the cost-paths below are
-    // dropped entirely.
-    return typeof import.meta !== "undefined"
-        && (import.meta as { env?: { DEV?: boolean } }).env?.DEV === true;
+    return import.meta.env.DEV === true;
 }
 
 class AgentPerfStore {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.755",
+  "version": "0.33.756",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.755",
+      "version": "0.33.756",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.754",
+  "version": "0.33.755",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.754",
+      "version": "0.33.755",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.756",
+  "version": "0.33.757",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.756",
+      "version": "0.33.757",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.755",
+  "version": "0.33.756",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.754",
+  "version": "0.33.755",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.756",
+  "version": "0.33.757",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Third phase of the agent pane virtualization redesign (issue #782). **Builds on the Phase 1 + Phase 2 foundation already on main.**

> Replaces #785, which auto-closed when its base branch (Phase 2) was deleted post-merge.

## What's new

### `perf-probe.ts` (new)

Module-level singleton `agentPerfStore`:
- **Per-kind row mount durations** (KeyedAggregator → p50/p95/max). Populated by `markRowMount(kind)` from `DocumentRow.onMount`.
- **Per-kind estimator-miss rate**. Populated by the wrapped `measureElement` in `AgentDocumentVirtualList`: every measurement compares actual vs `estimateNode(node, state)`. Anything outside ±30% (`ESTIMATOR_MISS_THRESHOLD`) flagged.
- **Layout-shift events scoped to `.agent-document`** via `startAgentLayoutShiftObserver()`.

Each recording function short-circuits when `import.meta.env.DEV === false` (bare literal so Vite static-replace can fold it). Production builds carry zero probe cost.

### Diag-panel extension

`agent-pane-perf-section.tsx` polls `agentPerfStore.snapshot()` at 1 Hz, renders:
- Per-kind p50/p95/max/n table sorted by p95 desc, miss-rate column with ⚠ at >20%
- Recent layout shifts (last 5)
- Recent estimator misses (last 5)

One-line embed in `diag-panel.tsx` (Ctrl+Shift+D).

## Also includes

- **Show node-capture fix recovered** — the Phase 2 squash dropped commit 12b0b4dd; that fix is restored here. (Also up as standalone #786 in case this PR takes longer.)

## Tests

12 new test cases for `perf-probe.ts`. **63/63 virtualization tests passing** (51 from Phase 1 + 12 new).

## Production no-op verification

`isProbingEnabled()` now uses bare `import.meta.env.DEV === true` — Vite's static-replace plugin folds it to a literal at build time, dead-branch elimination drops the probe code from production bundles.

## Cross-references

- #782 — full design overview
- #783 — Phase 1 (merged)
- #784 — Phase 2 (merged)
- #786 — standalone Show fix (this PR also includes it; whichever lands first, the other becomes a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)