### PR TITLE
fix(linux): pane crash + DOM blink + flag audit + extract-once-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.760"
+version = "0.33.761"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.760"
+version = "0.33.761"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.760"
+version = "0.33.761"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.760"
+version = "0.33.761"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.761"
+version = "0.33.762"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.761"
+version = "0.33.762"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.761"
+version = "0.33.762"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.761"
+version = "0.33.762"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.760"
+version = "0.33.761"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.761"
+version = "0.33.762"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -74,6 +74,31 @@ wrap_window_delegate! {
                     window_label = %label,
                     "[browser-pane] registered Window in state.windows for pane attachment"
                 );
+
+                // Startup pool fill — Windows uses the launcher saga path
+                // (saga_dispatch.rs::LiveActionRunner is cfg(windows) only).
+                //
+                // On Linux/Wayland: DISABLED. POOL_OFFSCREEN_X = -32000 in
+                // window_pool.rs is a Win32/X11-era hack that the Wayland
+                // compositor ignores — pool windows appear ON SCREEN as
+                // blank/empty windows because Wayland doesn't let clients
+                // dictate position. Until pool windows can be properly
+                // hidden on Wayland (xdg_toplevel.set_minimized? transparent
+                // surfaces? a separate `--headless` renderer pool?), spawning
+                // them at startup creates visible blank windows that consume
+                // CPU/RAM and confuse the user. Tear-off takes the cold path
+                // on first use as a result. See
+                // docs/specs/linux-pool-startup-fill-2026-05-08.md
+                // (open question now answered: Wayland positioning).
+                //
+                // On macOS: enabled. NSWindow off-screen positioning works.
+                // (Untested by the same operator who tested Linux; revisit
+                // if the macOS build shows visible pool windows too.)
+                #[cfg(target_os = "macos")]
+                if label == "main" {
+                    tracing::info!("[pool] kicking off startup pool fill (macOS)");
+                    crate::commands::window_pool::spawn_pool_window(state);
+                }
             }
 
             // Chrome-style windows (DevTools popups) are shown immediately.
@@ -360,12 +385,16 @@ wrap_app! {
                 // the app in a zombie white-screen state on GPU context loss with
                 // no recovery path. Removed in v0.33.66.
 
-                // Cap renderer subprocesses. In Alloy mode the frontend runs
-                // in the browser process (no renderer spawned), but DevTools
-                // popups can spawn additional renderers at ~100GB VA each.
-                let rpl_key = CefString::from("renderer-process-limit");
-                let rpl_val = CefString::from("1");
-                cmd.append_switch_with_value(Some(&rpl_key), Some(&rpl_val));
+                // NOTE: `--renderer-process-limit=1` was previously set here to
+                // protect against DevTools popups spawning extra renderers under
+                // an Alloy-mode assumption. The current Linux CEF build is NOT
+                // Alloy-mode for the user-visible UI: main window, every pool
+                // window, every tear-off window, and every browser-pane gets
+                // its own renderer process. Capping all of them to ONE shared
+                // renderer process serializes their JS event loops on a single
+                // thread, which manifests as hover/animation lag in the user-
+                // visible UI when pool windows are doing idle work. Removed
+                // 2026-05-09. See docs/specs/linux-cef-flags-audit-2026-05-08.md.
             }
         }
 

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -78,27 +78,21 @@ wrap_window_delegate! {
                 // Startup pool fill — Windows uses the launcher saga path
                 // (saga_dispatch.rs::LiveActionRunner is cfg(windows) only).
                 //
-                // On Linux/Wayland: DISABLED. POOL_OFFSCREEN_X = -32000 in
-                // window_pool.rs is a Win32/X11-era hack that the Wayland
-                // compositor ignores — pool windows appear ON SCREEN as
-                // blank/empty windows because Wayland doesn't let clients
-                // dictate position. Until pool windows can be properly
-                // hidden on Wayland (xdg_toplevel.set_minimized? transparent
-                // surfaces? a separate `--headless` renderer pool?), spawning
-                // them at startup creates visible blank windows that consume
-                // CPU/RAM and confuse the user. Tear-off takes the cold path
-                // on first use as a result. See
-                // docs/specs/linux-pool-startup-fill-2026-05-08.md
-                // (open question now answered: Wayland positioning).
+                // Non-Windows: DISABLED entirely. Two separate blockers, both
+                // documented in docs/specs/linux-pool-startup-fill-2026-05-08.md:
+                //   1. promote_pool_window in commands/window_pool.rs has a
+                //      `cfg(not(target_os = "windows"))` impl that always
+                //      returns None — tear-off can't consume a pool window
+                //      on macOS or Linux, so any pre-warmed windows are
+                //      strictly wasted RAM. Codex P2 on PR #788 caught this
+                //      for the macOS path that an earlier revision enabled.
+                //   2. (Linux/Wayland only) POOL_OFFSCREEN_X = -32000 is a
+                //      Win32/X11 hack that the Wayland compositor ignores —
+                //      pool windows would appear on-screen as blank windows.
                 //
-                // On macOS: enabled. NSWindow off-screen positioning works.
-                // (Untested by the same operator who tested Linux; revisit
-                // if the macOS build shows visible pool windows too.)
-                #[cfg(target_os = "macos")]
-                if label == "main" {
-                    tracing::info!("[pool] kicking off startup pool fill (macOS)");
-                    crate::commands::window_pool::spawn_pool_window(state);
-                }
+                // Either blocker alone makes startup pool fill the wrong
+                // call here. When the platform pool implementation lands
+                // (Phase 7), this is the right place to re-enable.
             }
 
             // Chrome-style windows (DevTools popups) are shown immediately.

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -78,10 +78,31 @@ pub fn on_after_created_browser_pane(state: &Arc<AppState>, browser: &Browser) {
 /// been removed from `state.browsers` and the label has been identified
 /// as a pane label (prefix `browser-pane-*`).
 ///
-/// Drains the lifecycle entry from `BrowserPaneManager` so a re-create
-/// with the same block_id gets a fresh Live state. Idempotent — if the
-/// explicit `close()` path already drained it, this is a no-op.
+/// On Linux/macOS, runs the deferred `OverlayController::destroy()` for
+/// any controller that `detach_browser_pane_view` stashed — see the long
+/// comment on `state.pending_overlay_destroy` for why destroy can't run
+/// synchronously with the close request. Drains the reducer entry next so
+/// a re-create with the same block_id gets a fresh Live state. Idempotent
+/// — if the explicit `close()` path already drained the reducer, the
+/// drain is a no-op; if no controller was stashed (Windows or already
+/// destroyed), the destroy step is a no-op.
 pub fn on_before_close_browser_pane(state: &Arc<AppState>, label: &str) {
+    // Step 1 (Linux/macOS): destroy the deferred OverlayController.
+    // Safe now because the Browser is fully torn down and Chromium has
+    // drained any queued tasks holding `WeakPtr<View>` to its BrowserView.
+    #[cfg(not(target_os = "windows"))]
+    {
+        let stashed = state.pending_overlay_destroy.lock().remove(label);
+        if let Some(controller) = stashed {
+            controller.destroy();
+            tracing::info!(
+                label = %label,
+                "[browser-pane] views: deferred OverlayController destroyed at on_before_close"
+            );
+        }
+    }
+
+    // Step 2: drain the reducer's pane entry (idempotent).
     state.browser_panes.drain_closed_label(state, label);
 
     // Labels are `browser-pane-<uuid>-<seq>`; strip prefix + trailing `-<seq>`

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -304,28 +304,39 @@ pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
         return;
     };
 
-    // Stash the controller BEFORE close_browser. Although close_browser is
-    // async (it queues a task; on_before_close fires later), keeping the
-    // ordering "stash → close" makes the contract trivially correct: by
-    // the time on_before_close runs, the entry is guaranteed present.
-    state
-        .pending_overlay_destroy
-        .lock()
-        .insert(label.to_string(), controller);
+    // Whether to defer destroy depends on whether there's a live Browser.
+    //   - Live Browser + host: close_browser(force=1) fires; on_before_close
+    //     will land asynchronously; stash so the callback finds the
+    //     controller and runs destroy() then. (Synchronous destroy here
+    //     races Chromium's queued WeakPtr<View> tasks → weak_ptr.h:250
+    //     FATAL; that's the whole reason for this dance.)
+    //   - No live Browser (already drained, or host gone): on_before_close
+    //     won't fire — stashing would leak the controller in
+    //     pending_overlay_destroy forever (reagent P1 on PR #788).
+    //     No Browser means no queued WeakPtr tasks against this view, so
+    //     destroying synchronously is safe.
+    let live_host = state
+        .get_browser(label)
+        .and_then(|mut b| b.host());
 
-    // Ask the Browser to die. force=1 skips beforeunload; pane is going.
-    if let Some(browser) = state.get_browser(label) {
-        if let Some(host) = browser.host() {
-            host.close_browser(1);
-            tracing::info!(
-                label = %label,
-                "[browser-pane] views: close_browser(force=1) requested; OverlayController stashed for deferred destroy"
-            );
-        }
-    } else {
-        tracing::warn!(
+    if let Some(host) = live_host {
+        state
+            .pending_overlay_destroy
+            .lock()
+            .insert(label.to_string(), controller);
+        host.close_browser(1);
+        tracing::info!(
             label = %label,
-            "[browser-pane] views: no Browser registered at detach — controller stashed but on_before_close may not fire (potential overlay leak)"
+            "[browser-pane] views: close_browser(force=1) requested; OverlayController stashed for deferred destroy at on_before_close"
+        );
+    } else {
+        // No Browser / no host → on_before_close won't fire. Destroy now to
+        // avoid the leak. No race risk: there's no live Browser holding
+        // WeakPtrs to our BrowserView.
+        controller.destroy();
+        tracing::info!(
+            label = %label,
+            "[browser-pane] views: no live Browser at detach — OverlayController destroyed synchronously"
         );
     }
 }

--- a/agentmux-cef/src/browser_pane/creation_views.rs
+++ b/agentmux-cef/src/browser_pane/creation_views.rs
@@ -273,22 +273,25 @@ pub fn resize_browser_pane_view(state: &Arc<AppState>, label: &str, rect: Rect) 
     );
 }
 
-/// Detach + drop a Views-based browser pane (Linux/macOS only).
+/// Detach a Views-based browser pane (Linux/macOS only).
 ///
 /// Called from `BrowserPaneManager::close` on non-Windows. Order matters:
 ///
-///   1. Look up the underlying `Browser` for this label and call
-///      `BrowserHost::close_browser(force=1)`. Empirically `OverlayController::destroy`
-///      DOES eventually trigger `on_before_close`, but per CEF's documentation
-///      the destroy path is layout-tracking only and the Browser's lifecycle
-///      is independent — without the explicit close request a Browser can
-///      survive its overlay's destruction and stay registered in `state.browsers`
-///      with stale callbacks (PR #682 codex P2).
-///   2. Destroy the OverlayController to remove the overlay from the parent.
-///   3. Drop the cached handle. `on_before_close` fires asynchronously on the
-///      Browser and the existing `callbacks::on_before_close_browser_pane`
-///      drains state.browsers + the reducer's pane map. If close_browser
-///      fails (already-gone race), the destroy still cleans up the overlay.
+///   1. Pop the controller out of `state.browser_pane_overlays` so future
+///      resize / focus / overlay-clip calls become no-ops.
+///   2. Stash the controller in `state.pending_overlay_destroy`. Keeping it
+///      alive here is critical: dropping or destroying it now would yank
+///      the BrowserView out of its parent Window's hierarchy while
+///      Chromium still has UI-thread tasks holding `WeakPtr<View>` to it,
+///      tripping `weak_ptr.h:250 Check failed: ref_.IsValid()` and FATALing
+///      the host. Reproducers: pane-close-then-pool-spawn (0.33.721) and
+///      tab tear-off (0.33.722).
+///   3. Call `BrowserHost::close_browser(force=1)`. This triggers async
+///      Browser teardown; CEF will eventually call our `on_before_close`
+///      handler, which drains `pending_overlay_destroy[label]` and runs
+///      the actual `controller.destroy()` — by that point the Browser is
+///      fully gone and any queued WeakPtr-bearing tasks have drained, so
+///      destroy can no longer race.
 ///
 /// Must run on the CEF UI thread.
 pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
@@ -301,24 +304,28 @@ pub fn detach_browser_pane_view(state: &Arc<AppState>, label: &str) {
         return;
     };
 
-    // Step 1: ask the Browser to close BEFORE destroying its overlay.
+    // Stash the controller BEFORE close_browser. Although close_browser is
+    // async (it queues a task; on_before_close fires later), keeping the
+    // ordering "stash → close" makes the contract trivially correct: by
+    // the time on_before_close runs, the entry is guaranteed present.
+    state
+        .pending_overlay_destroy
+        .lock()
+        .insert(label.to_string(), controller);
+
+    // Ask the Browser to die. force=1 skips beforeunload; pane is going.
     if let Some(browser) = state.get_browser(label) {
         if let Some(host) = browser.host() {
-            host.close_browser(1); // force=1 — pane is going away regardless
-            tracing::debug!(label = %label, "[browser-pane] views: close_browser(force=1) requested");
+            host.close_browser(1);
+            tracing::info!(
+                label = %label,
+                "[browser-pane] views: close_browser(force=1) requested; OverlayController stashed for deferred destroy"
+            );
         }
     } else {
-        tracing::debug!(
+        tracing::warn!(
             label = %label,
-            "[browser-pane] views: no Browser registered at detach (already drained?)"
+            "[browser-pane] views: no Browser registered at detach — controller stashed but on_before_close may not fire (potential overlay leak)"
         );
     }
-
-    // Step 2: destroy the overlay.
-    controller.destroy();
-    tracing::info!(
-        label = %label,
-        "[browser-pane] views: OverlayController destroyed"
-    );
-    drop(controller);
 }

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -314,12 +314,22 @@ impl BrowserPaneManager {
         );
         tracing::info!(block_id, label, "browser pane closed");
 
-        // PR #6 H.7 kick — the pane is fully closed; if any pool refill
-        // was deferred by `any_browser_pane_closing()` while we were mid-close,
-        // top up now. `spawn_pool_window` is internally idempotent
-        // (single-flight semaphore + below-target check via reducer), so
-        // calling it always-on-pane-close is safe even when no refill is
-        // needed.
+        // PR #6 H.7 kick — top up the pool now that this pane has closed.
+        // `spawn_pool_window` is internally idempotent (single-flight +
+        // below-target check), so calling on every pane close is safe.
+        //
+        // Windows-only path: HWND was destroyed synchronously above so the
+        // pane really is fully gone here. Refill immediately.
+        //
+        // Linux/macOS: the Views detach is async-queued (line above), and
+        // creating a new pool window in the same UI tick caused a Chromium
+        // `weak_ptr.h:250` FATAL — Views' focus chain still holds tasks
+        // referencing the destroyed OverlayController while the new pool
+        // browser's focus traversal also runs. Skip the immediate refill;
+        // `drain_closed_label` (called from `on_before_close_browser_pane`
+        // after the Browser is fully torn down) already calls
+        // `spawn_pool_window` for us, with no race.
+        #[cfg(target_os = "windows")]
         crate::commands::window_pool::spawn_pool_window(state);
     }
 

--- a/agentmux-cef/src/browser_panes.rs
+++ b/agentmux-cef/src/browser_panes.rs
@@ -318,18 +318,19 @@ impl BrowserPaneManager {
         // `spawn_pool_window` is internally idempotent (single-flight +
         // below-target check), so calling on every pane close is safe.
         //
-        // Windows-only path: HWND was destroyed synchronously above so the
-        // pane really is fully gone here. Refill immediately.
-        //
-        // Linux/macOS: the Views detach is async-queued (line above), and
-        // creating a new pool window in the same UI tick caused a Chromium
-        // `weak_ptr.h:250` FATAL — Views' focus chain still holds tasks
-        // referencing the destroyed OverlayController while the new pool
-        // browser's focus traversal also runs. Skip the immediate refill;
-        // `drain_closed_label` (called from `on_before_close_browser_pane`
-        // after the Browser is fully torn down) already calls
-        // `spawn_pool_window` for us, with no race.
-        #[cfg(target_os = "windows")]
+        // Cross-platform: the original `weak_ptr.h:250` race that prompted
+        // an earlier Windows-only cfg-gate is gone. With the deferred
+        // OverlayController destroy (see
+        // browser_pane/creation_views.rs::detach_browser_pane_view),
+        // close() no longer destroys the controller synchronously — it
+        // just stashes it for on_before_close to destroy later. Creating
+        // a new pool window here therefore can't race a synchronous
+        // destroy of the just-closed pane's View. drain_closed_label's
+        // pool kick can't be relied on as the sole refill source either:
+        // CompleteBrowserPaneClose (dispatched above) already removed the
+        // reducer entry, so DrainBrowserPaneByLabel inside
+        // drain_closed_label is a no-op and never reaches its
+        // spawn_pool_window() call (codex P2 on PR #788).
         crate::commands::window_pool::spawn_pool_window(state);
     }
 

--- a/agentmux-cef/src/commands/orphan_reconcile.rs
+++ b/agentmux-cef/src/commands/orphan_reconcile.rs
@@ -399,22 +399,28 @@ fn ui_thread_reconcile(state: &Arc<AppState>) {
 fn classify_hwnd(browser: &Browser) -> HwndStatus {
     let mut b = browser.clone();
     let Some(host) = b.host() else { return HwndStatus::Hostless };
-    let wh = host.window_handle();
-    if wh.0.is_null() {
-        return HwndStatus::Dead;
-    }
     #[cfg(target_os = "windows")]
     unsafe {
         use windows_sys::Win32::Foundation::HWND;
         use windows_sys::Win32::UI::WindowsAndMessaging::IsWindow;
+        let wh = host.window_handle();
+        if wh.0.is_null() {
+            return HwndStatus::Dead;
+        }
         if IsWindow(wh.0 as HWND) == 0 {
             HwndStatus::Dead
         } else {
             HwndStatus::Live
         }
     }
+    // On Linux/macOS `cef_window_handle_t` is `u64` (X11 XID / NSView ptr),
+    // not the Win32 HWND tuple-struct, so `wh.0.is_null()` doesn't typecheck.
+    // We don't have an `IsWindow` equivalent here either — treat any host
+    // with a Browser as Live for orphan-reconcile classification. The Win32
+    // path keeps the strict liveness check that landed in #702.
     #[cfg(not(target_os = "windows"))]
     {
+        let _ = host;
         HwndStatus::Live
     }
 }

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -342,7 +342,10 @@ async fn route_command(
             let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let w = args.get("width").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let h = args.get("height").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-            tracing::info!(
+            // debug! not info! — fires on every pixel during a window-resize
+            // drag (the lastSentRect gate skips no-op calls but a real drag
+            // emits many genuine rect changes). Reagent P2 on PR #788.
+            tracing::debug!(
                 "[ipc] browser_pane_resize block_id={} rect=({},{},{},{})",
                 block_id, x, y, w, h
             );

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -342,6 +342,10 @@ async fn route_command(
             let y = args.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let w = args.get("width").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             let h = args.get("height").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+            tracing::info!(
+                "[ipc] browser_pane_resize block_id={} rect=({},{},{},{})",
+                block_id, x, y, w, h
+            );
             state.browser_panes.resize(block_id, cef::Rect { x, y, width: w, height: h }, state);
             Ok(serde_json::json!(true))
         }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -568,6 +568,29 @@ pub struct AppState {
     pub browser_pane_overlays:
         Mutex<std::collections::HashMap<String, (String, cef::OverlayController)>>,
 
+    /// Linux/macOS only — OverlayControllers awaiting deferred destroy.
+    ///
+    /// Calling `OverlayController::destroy()` synchronously on the same UI
+    /// tick as `BrowserHost::close_browser(force=1)` races CEF/Chromium's
+    /// internal Views focus traversal — pending tasks hold
+    /// `base::WeakPtr<View>` to the BrowserView, and yanking the view out
+    /// of the Window's hierarchy before those tasks drain trips
+    /// `weak_ptr.h:250 Check failed: ref_.IsValid()` and FATALs the host.
+    /// Two confirmed reproducers: closing a pane while a pool window is
+    /// being spawned (PR #743 follow-up) and tearing off a tab (a tear-off
+    /// closes the pane in the source workspace then immediately creates a
+    /// new top-level window for the torn tab).
+    ///
+    /// Fix: detach moves the controller out of `browser_pane_overlays`
+    /// (so future resize/clip calls miss), calls `close_browser(force=1)`,
+    /// and stashes the controller here. `on_before_close_browser_pane`
+    /// then drains this map and runs `destroy()` — by that point the
+    /// Browser is fully torn down and Chromium has drained the queued
+    /// tasks that referenced its View, so destroy can't race anything.
+    #[cfg(not(target_os = "windows"))]
+    pub pending_overlay_destroy:
+        Mutex<std::collections::HashMap<String, cef::OverlayController>>,
+
     /// Tear-off Phase 6 — pre-warmed pool of hidden CEF windows ready for
     /// instant promotion on tear-off. Each entry is a label of a window
     /// that's already painted, has its renderer connected, and is sitting
@@ -665,6 +688,8 @@ impl Default for AppState {
             windows: Mutex::new(HashMap::new()),
             #[cfg(not(target_os = "windows"))]
             browser_pane_overlays: Mutex::new(HashMap::new()),
+            #[cfg(not(target_os = "windows"))]
+            pending_overlay_destroy: Mutex::new(HashMap::new()),
             // window_pool / unpromoted_pool_labels / window_pool_respawn_in_flight
             // deleted (PR #5 H.4) — see HostState.pool.
             // is_quitting deleted (PR #5 H.5) — see HostState.quit_state.

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.761"
+version = "0.33.762"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.760"
+version = "0.33.761"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.760"
+version = "0.33.761"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.761"
+version = "0.33.762"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.761"
+version = "0.33.762"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.760"
+version = "0.33.761"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/process_tracker/mod.rs
+++ b/agentmux-srv/src/backend/process_tracker/mod.rs
@@ -32,8 +32,11 @@ pub mod registry;
 #[cfg(windows)]
 pub mod windows;
 
-#[cfg(not(windows))]
-pub mod stub;
+// `pub mod stub;` (file-form) was here. Removed: `stub.rs` doesn't exist
+// in the tree — only the two inline `pub mod stub { ... }` definitions
+// below (cfg(not(windows)) and cfg(windows)) define the module. On Linux
+// the file-form line collided with the inline non-Windows definition →
+// E0428 "the name `stub` is defined multiple times" → broke `task dev`.
 
 /// A single process tracked by the host — PID + metadata enriched
 /// per-platform. The frontend renders one row per entry.

--- a/docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md
+++ b/docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md
@@ -1,0 +1,336 @@
+# Linux AppImage cold-launch tax
+
+**Status:** Draft.
+**Author:** runtime investigation 2026-05-08.
+**Owner:** TBD.
+**Affects:** Linux AppImage builds. macOS .app and Windows MSIX likely
+unaffected (different distribution + mount semantics).
+
+---
+
+## Problem
+
+Every AppImage launch — including the second / third / nth launch with the
+cef-cache fully populated — pays a ~2.4-2.6 second tax between page-load
+start and main window interactivity. Total perceived launch time from user
+double-click to "AgentMux is usable" is ~3-3.5 seconds. Users coming from
+`task dev` (Vite dev server) experience this as a regression because dev
+mode is sub-second.
+
+This is not a regression — it's the inherent overhead of how AppImage works
+on Linux, and it has always existed for AppImage builds. But it's worth
+documenting and worth fixing because the Windows portable ZIP starts in
+under a second and we should match that target.
+
+---
+
+## Evidence
+
+Three consecutive launches of the same `AgentMux_0.33.723_amd64.AppImage`
+in one session, cef-cache stays populated across launches:
+
+| launch | T+0 = page-load | setupCefApi-done | fonts-ready | mainwin-done |
+|--------|----------------|-------------------|--------------|---------------|
+| 19:29:24 (first)  |  0ms | 1957ms | 2296ms | 2425ms |
+| 19:31:24 (second) |  0ms | 1908ms | 2268ms | 2408ms |
+| (tear-off win)    |  0ms | 1207ms | 1606ms | 1746ms |
+
+The cef-cache was 18MB on first launch, grows over the session, but second
+launch timing is essentially identical to first. **Caching is not the
+dominant variable.** The tear-off-window column is faster because the
+launcher process is already paged in and the host process is already
+running — only the renderer is cold.
+
+Add ~1 second of pre-page-load CEF initialization (libcef.so dlopen, GPU
+process spawn, network process spawn, frontend HTTP server bind) → ~3.4s
+total. Matches user-perceived "3+ seconds".
+
+---
+
+## Root cause
+
+AppImage execution model on Linux:
+
+1. Launcher binary self-extracts a SquashFS archive into
+   `/tmp/.mount_AgentM*` via `squashfuse` (FUSE).
+2. SquashFS files are **decompressed on-demand** on first read, even
+   though the FUSE mount has been there since the previous launch — but
+   actually no, the mount is destroyed when the prior launch exits, so
+   each launch starts with a *fresh* mount.
+3. Every read of every file touches:
+   - FUSE userspace round-trip → kernel.
+   - SquashFS zstd block decompression.
+   - Kernel page cache (helps for repeated reads within a single launch).
+4. `libcef.so` alone is ~613MB stripped. dlopen + relocations on this
+   library account for several hundred ms.
+5. The frontend bundle (~5-10MB JS, ~10MB fonts, etc.) lives in the same
+   SquashFS and is fetched by the in-process HTTP server on each cold
+   start. V8 parses + compiles + runs this bundle.
+
+V8 also has its own per-launch costs:
+
+- No bytecode cache between launches by default. Each launch reparses
+  `index-*.js` from source.
+- Hot-spot JIT compilation profiles are not preserved.
+
+Disk doesn't help here: the AppImage file itself sits on disk and is
+mmaped for the SquashFS read; subsequent launches have the same disk-
+sectors-already-cached situation but still pay the FUSE round-trip and
+SquashFS decompression on read.
+
+---
+
+## Options considered
+
+### Option A — `--appimage-extract-and-run`
+
+AppImage built-in flag. On launch, extracts the entire SquashFS to a temp
+directory, then exec's the binary from there. Subsequent file reads bypass
+FUSE and SquashFS — they're plain-disk files in a tmpfs or ext4 dir.
+
+**Pros:** Single-flag change. Eliminates FUSE + SquashFS overhead. Probably
+brings cold-launch within 200-400ms of dev-mode parity.
+
+**Cons:** Doubles disk usage (AppImage + extracted dir). `/tmp` may be
+tmpfs (RAM-backed) on some distros — extraction allocates ~200MB of RAM
+per launch, recycled at exit. Extraction itself is a one-time cost per
+launch (~500ms-1s) → first interactive may not actually improve unless
+extraction is amortized across launches. Negates AppImage's "one file"
+distribution simplicity.
+
+### Option B — Pre-extract to `~/.local/share/agentmux/extracted/<version>/`
+
+On first launch, the AppImage extracts itself to a per-version folder
+under the user's home. Subsequent launches detect the extracted folder
+and exec from there directly. The AppImage file becomes a one-time
+installer.
+
+**Pros:** Eliminates per-launch extraction cost (only first launch pays
+it). Preserves the "one file you can put anywhere" distribution model.
+Works inside `flatpak`-style sandboxes if extraction target is in user
+data dir.
+
+**Cons:** Custom logic to write. Need version-aware cleanup so old
+extracted versions don't leak. First-launch experience is slow then
+self-improving — confusing for evaluators. Solo-user assumption: in
+multi-user installs the extraction directory must be per-user.
+
+### Option C — `.deb` package distribution
+
+Stop shipping AppImage on Linux. Distribute via `.deb` (Ubuntu/Debian)
+and `.rpm` (Fedora/RHEL). Files install directly to `/opt/agentmux/`,
+mmaped from disk on each launch with kernel page cache fully effective.
+
+**Pros:** Zero runtime overhead vs. native disk binaries. Same cold-launch
+profile as Windows portable ZIP. Easier integration with system desktop
+files / icons / mime types.
+
+**Cons:** Loses AppImage's distro-agnostic single-file model. Need to
+maintain separate `.deb` and `.rpm` build pipelines. AppImage is currently
+the only Linux distribution channel — moving away from it is a strategic
+call, not a perf fix.
+
+### Option D — V8 code-cache persistence
+
+Use `--js-flags=--code-cache=...` to write V8 bytecode to disk on first
+parse and reuse on subsequent launches.
+
+**Pros:** Cuts ~200-400ms off the parse/compile phase of subsequent
+launches. Stays orthogonal to FUSE/SquashFS issues.
+
+**Cons:** Only addresses the V8 phase, not the FUSE phase. Marginal on
+its own. CEF has limited support for V8 code caching across browser
+processes; needs investigation.
+
+### Option E — Frontend bundle code-splitting + lazy load
+
+Trim the synchronously-loaded JS at startup; defer non-critical code
+(modals, settings, devtools panes) to dynamic imports.
+
+**Pros:** Reduces parse/compile work in critical path. Pure frontend
+change, no infra touch.
+
+**Cons:** Significant refactor. Each split point needs UX consideration
+(loading states, error boundaries). Doesn't help the FUSE I/O cost
+because dynamic imports still go through SquashFS — they just defer the
+cost from main-thread blocking to interaction-time.
+
+### Option F — `usrmerge` portable directory
+
+Ship a portable `.tar.gz` instead of AppImage. User extracts once,
+launches the binary from the extracted folder. Same model as Windows
+portable ZIP today.
+
+**Pros:** Trivial: extract once, run forever. No FUSE, no overlay. Same
+performance as `.deb` for non-installer use cases.
+
+**Cons:** Loses AppImage's "double-click to run" UX. Power-user only.
+Could ship alongside AppImage as a "fast launch" option.
+
+---
+
+## Recommendation
+
+**Phase 1 (immediate):** Try `--appimage-extract-and-run` (Option A) as a
+build-time default and measure end-to-end cold-launch time. If it brings
+launch under ~1.5s, ship it as-is.
+
+**Phase 2 (if Phase 1 is insufficient):** Implement Option B (pre-extract
+on first launch, exec from cached extraction on subsequent launches).
+This is the AppImage equivalent of "install once, launch forever".
+
+**Phase 3 (longer term):** Stack Option D (V8 code cache) on top of
+whatever Phase 1/2 delivers. Diminishing returns but cumulative.
+
+**Defer:** Options C (deb/rpm), E (code-split), F (portable tarball).
+These are larger projects with their own design questions; revisit if
+Phases 1-3 still leave us above target.
+
+### Why not just go to Phase 2 directly?
+
+Phase 1 is a one-line build change. If `--appimage-extract-and-run`
+already gets us where we want (sub-1.5s warm launch), Phase 2's complexity
+is unjustified. Measure first.
+
+---
+
+## Implementation outline (Phase 1 spike)
+
+`scripts/build-appimage-linux.sh` invokes `appimagetool` to produce the
+`AgentMux_*.AppImage` artifact. The artifact's first arg parsing is
+controlled by the runtime ELF embedded by `appimagetool` (the
+`type2-runtime`).
+
+`type2-runtime` already supports `--appimage-extract-and-run` as a CLI
+flag — but we want it to be the *default*, with no user flag required.
+Two options:
+
+1. **Patch the runtime:** rebuild `type2-runtime` with the default flag
+   set to "extract first". Heavy — would need a maintained fork.
+
+2. **Wrap the AppImage:** ship a tiny shell script wrapper that invokes
+   the AppImage with `--appimage-extract-and-run` baked in. Two-file
+   distribution (the .AppImage + the .sh) breaks AppImage's
+   one-file-distribution premise.
+
+3. **Generate a wrapper at the user's `agentmux.desktop` Exec= line:**
+   the desktop file we install via `scripts/install-linux-desktop.sh`
+   already does `Exec=…AppImage`. Change to
+   `Exec=…AppImage --appimage-extract-and-run`. Affects launch from
+   GNOME Shell / KDE / shortcuts, but NOT from `./AgentMux_*.AppImage`
+   directly in a terminal. Gradient migration: developers / CI still
+   get fast paths via the desktop file; raw `.AppImage` execution stays
+   "classic" for compatibility.
+
+Recommendation: **(3)** as the spike. If it benchmarks well, then revisit
+(1) for true universal default.
+
+### Bench harness
+
+The host already emits `[startup-bench]` events with millisecond offsets
+relative to page load. To measure the full process-spawn → mainwin-done
+window, also need:
+
+- Timestamp at AppImage launcher exec (write to env or file before exec).
+- Timestamp at host process `main()` entry.
+- Existing `[startup-bench]` events from page-load onward.
+
+A simple addition: the launcher already logs `[launcher]` events; add a
+"launched at" timestamp + emit it via stderr early. Compare wall-clock
+launch → mainwin-done before / after `--appimage-extract-and-run`.
+
+---
+
+## Validation plan
+
+### Cold launch (worst case)
+
+1. Reboot or `echo 3 > /proc/sys/vm/drop_caches`. Empty page cache.
+2. Double-click `AgentMux_0.33.X_amd64.AppImage` from a file manager that
+   uses the desktop file's `Exec=` line.
+3. Stopwatch from click → main window first paint visible.
+4. Compare to current 0.33.723 baseline (~3.5s) and target (~1.5s).
+
+### Warm launch
+
+1. Quit app.
+2. Relaunch within 30s (page cache still warm).
+3. Stopwatch.
+4. Compare to current 0.33.723 baseline (~3.0s) and target (~1.0s).
+
+### Regressions to watch
+
+- **Disk usage:** `--appimage-extract-and-run` stages content in `/tmp`.
+  If `/tmp` is tmpfs and small (<2GB), extraction may OOM. Guard: if free
+  `/tmp` < 500MB, fall back to direct AppImage invocation.
+- **Permissions:** extraction creates files owned by the launching user.
+  Multi-user shared install scenarios — out of scope for AppImage anyway.
+- **Update flow:** when a new AppImage is dropped, the per-version
+  cached extraction directory becomes stale and should auto-clean. For
+  Phase 1 (always-extract-fresh) this is moot. For Phase 2 (cached
+  extraction) this is a real concern — design `~/.local/share/agentmux/
+  extracted/<version>/` so old `<version>` dirs get reaped on next launch
+  by a small cleanup pass.
+
+### Metrics
+
+Track in CI:
+
+- `cold_launch_ms` (post-`drop_caches`, time-to-first-paint).
+- `warm_launch_ms` (immediate relaunch).
+- `extraction_overhead_ms` (Phase 1 only — extra cost per launch).
+
+Goals after Phase 1:
+
+- `cold_launch_ms` ≤ 2000.
+- `warm_launch_ms` ≤ 1500.
+
+After Phase 2:
+
+- `cold_launch_ms` ≤ 1500.
+- `warm_launch_ms` ≤ 800.
+
+---
+
+## Risks / open questions
+
+- **`type2-runtime` flag interaction:** does `--appimage-extract-and-run`
+  pass the rest of `argv` through cleanly? Verify by running `AgentMux*.
+  AppImage --appimage-extract-and-run --version` and checking that
+  `--version` is consumed by the host, not the runtime.
+- **`/tmp` extraction collisions:** two parallel users / two parallel
+  AppImages could collide on `/tmp/.mount_AgentMux-*` (FUSE) or
+  `/tmp/appimage_extracted_*` (extract mode). Verify the runtime adds a
+  unique suffix per launch.
+- **CEF cache directory unrelated:** the `~/.agentmux/versions/*/cef-cache`
+  directory is independent of how the binary is launched. Both Phase 1
+  and Phase 2 leave it alone.
+- **AppImage updater compatibility:** if AppImage zsync auto-update lands,
+  is the extracted-and-cached version Phase 2 still updateable? Probably
+  yes — the AppImage file itself updates, the extraction directory just
+  rebuilds on next launch.
+
+---
+
+## Out of scope (referenced for completeness)
+
+- **First-time user perception:** even a 1.5s cold launch may feel slow
+  versus modern web apps. UX-side mitigations (launch splash, partial-
+  paint of the chrome before bundle is ready) belong in a separate spec.
+- **macOS .app cold launch:** macOS uses dyld-shared-cache pre-warming
+  for system frameworks; the per-app cold-launch overhead is structurally
+  different. Tracked separately.
+- **Windows portable cold launch:** Windows portable ZIP launches in
+  ~700ms today (per anecdotal report). Windows installer (MSIX) is
+  out-of-tree; not relevant.
+
+---
+
+## See also
+
+- `scripts/build-appimage-linux.sh` — current AppImage build pipeline.
+- `scripts/install-linux-desktop.sh` — current desktop file install.
+- `docs/specs/linux-pool-startup-fill-2026-05-08.md` — sister spec for
+  Linux tear-off latency. **Note: pool startup fill solves *tear-off*
+  cold-path; this spec solves *app launch* cold-path. Both contribute to
+  user-perceived "Linux feels slow."**

--- a/docs/specs/linux-cef-flags-audit-2026-05-08.md
+++ b/docs/specs/linux-cef-flags-audit-2026-05-08.md
@@ -1,0 +1,382 @@
+# Linux CEF flags audit and cleanup
+
+**Status:** Draft.
+**Author:** runtime investigation 2026-05-08, prompted by user-reported UI
+lag (hover latency in hamburger dropdown, slow startup) on AgentMux Linux
+AppImage while VSCode (also Chromium-based) feels instant on the same VM.
+**Out of scope:** macOS .app, Windows portable. Same audit may be valuable
+there but the flag inventories differ.
+
+---
+
+## Problem
+
+We accumulated environment variables and CEF command-line switches across
+two distinct eras:
+
+1. **Tauri / WebKitGTK era** (pre-March 2026, pre-CEF migration). Workarounds
+   for WebKit's DMABUF renderer, GTK input methods, IBus quirks, etc.
+2. **CEF era** (March 2026 onward). New switches for Chromium GPU init,
+   subprocess limits, sandbox configuration.
+
+When we migrated from Tauri to CEF (commit `12333fa2`), the WebKit-era env
+vars in `scripts/linux-apprun.sh` were carried forward unchanged. Most of
+them target a runtime that no longer exists in this codebase (WebKitGTK is
+gone; we ship 100% CEF/Chromium on Linux). Some are dead (CEF doesn't read
+WebKit env vars at all). Some are still active but were never reconsidered
+for CEF and may be tuning CEF for the wrong target.
+
+User-visible symptoms suggesting these stale settings now matter:
+
+- Hover lag on dropdown menus that doesn't appear in VSCode (Electron / same
+  Chromium core / same VM / same GPU).
+- ~3s cold launch even on a warmed CEF cache.
+- WebGL blocklisting in the GPU process despite VSCode showing accelerated
+  paint on the same machine.
+
+Goal of this audit: identify every Linux-specific flag we currently set,
+classify each as *required for CEF* / *Tauri-era leftover* / *unclear, needs
+test*, and propose a minimal-risk cleanup that returns us to "best CEF
+defaults" with explicit overrides only where needed.
+
+---
+
+## Inventory
+
+### A. AppImage `AppRun` script (`scripts/linux-apprun.sh`)
+
+```bash
+export APPDIR="$this_dir"                                          # (1)
+export WEBKIT_DISABLE_DMABUF_RENDERER=1                            # (2)
+if [ -n "$WAYLAND_DISPLAY" ]; then export GDK_BACKEND=wayland       # (3)
+else export GDK_BACKEND=x11; fi
+export XMODIFIERS=""                                                # (4)
+export GTK_IM_MODULE=gtk-im-context-simple                          # (5)
+bash "$this_dir/install-linux-desktop.sh" "$APPIMAGE" || true       # (6)
+export LD_LIBRARY_PATH="$this_dir/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"  # (7)
+exec "$this_dir/usr/bin/agentmux" "$@"                              # (8)
+```
+
+| # | Var / call | Era | Effect on CEF | Verdict |
+|---|------------|-----|---------------|---------|
+| 1 | `APPDIR` export | both | Used by AppImage tooling + our `install-linux-desktop.sh`. | **Keep** |
+| 2 | `WEBKIT_DISABLE_DMABUF_RENDERER=1` | **Tauri/WebKitGTK** | **Zero effect on CEF.** WebKit-only env var. CEF doesn't read it. | **Remove** |
+| 3 | `GDK_BACKEND=wayland|x11` | both | Affects GTK widgets only. CEF uses its own Wayland/X11 path via Ozone, controlled by `--ozone-platform=...` (auto-detected by libcef). The host process does link GTK, but the relevant Linux-side window code in agentmux-cef is delegated to CEF Views, not GTK. | **Remove** (let CEF auto-detect; no GTK widgets to bias) |
+| 4 | `XMODIFIERS=""` | **Tauri/WebKitGTK** | Disables IBus on GTK. Originally a WebKitGTK input-glitch workaround. CEF uses its own IME path on Linux (`InputMethodAuralinux`), not GTK's IM module. Keeping this empty potentially blocks Asian-language input on text fields (CTRL+SPACE etc.) for CEF users. | **Remove** |
+| 5 | `GTK_IM_MODULE=gtk-im-context-simple` | **Tauri/WebKitGTK** | Same theme as (4). Forces GTK to a stripped IME that drops dead-keys / compose keys for international users. Irrelevant for CEF. | **Remove** |
+| 6 | `install-linux-desktop.sh` invocation | CEF era | Registers `~/.local/share/applications/agentmux.desktop`. | **Keep** |
+| 7 | `LD_LIBRARY_PATH` | CEF era | Required: `libcef.so` is colocated with `agentmux-cef` and the binary is built without RPATH. The dynamic linker won't find libcef without this. | **Keep** |
+| 8 | `exec` | CEF era | Required boilerplate. | **Keep** |
+
+### B. Explicit CEF switches set in code (`agentmux-cef/src/app.rs:347-388`)
+
+| Switch | Set with | Reason given in code | Verdict |
+|--------|----------|---------------------|---------|
+| `--disable-features=CalculateNativeWinOcclusion` | `cmd.append_switch_with_value` | "Prevent empty browser on visibility change (CEF #3638)." | **Keep** — still relevant. |
+| `--background-color=ff222222` | same | "Set initial background color via CLI." | **Keep** — UX-driven. |
+| `--remote-allow-origins=*` | same | "Allow the DevTools inspector page (served from the remote debugging server) to open its own WebSocket connection back to that same server." | **Keep** — still required for our DevTools server. |
+| `--renderer-process-limit=1` | same | "Cap renderer subprocesses. In Alloy mode the frontend runs in the browser process (no renderer spawned), but DevTools popups can spawn additional renderers at ~100GB VA each." | **Investigate** — see § Hot Issues below. |
+
+### C. Switches added by libcef / cef-dll-sys (visible in `cef-debug.log` Crash keys)
+
+These appear at runtime but are not set by our code. We get them by being a
+CEF app:
+
+```
+--ozone-platform=wayland            (auto-selected by Ozone based on env)
+--render-node-override=/dev/dri/renderD128   (DRI render node, auto)
+--no-sandbox                        (we don't ship a setuid SUID helper)
+--disable-features=...,EyeDropper   (libcef adds EyeDropper to our list)
+--lang=en-US
+--remote-debugging-port=9222
+--log-severity=info
+--user-data-dir=...
+--locales-dir-path=...
+--resources-dir-path=...
+--browser-subprocess-path=...
+--variations-seed-version
+--enable-crash-reporter=,
+--change-stack-guard-on-fork=enable
+--metrics-shmem-handle=...
+--field-trial-handle=...
+--pseudonymization-salt-handle=...
+--trace-process-track-uuid=...
+--shared-files=...
+--service-sandbox-type=...
+```
+
+These are libcef-internal plumbing. Don't touch.
+
+### D. GPU / WebGL state (from `cef-debug.log`)
+
+```
+gpu-gl-renderer = "ANGLE (VMware Inc., SVGA3D; build: RELEASE; LLVM;,
+                   OpenGL ES 3.1 Mesa 25.2.8-0ubuntu0.24.04.1)"
+gpu-gl-vendor   = "Google Inc. (VMware, Inc.)"
+gpu_count       = "0"
+[ERROR:gpu/command_buffer/service/context_group.cc:138] WebGL1 blocklisted
+```
+
+Chromium has detected the VMware SVGA3D adapter and put it on the WebGL
+blocklist. WebGL1 fails to initialize → 2D compositing falls back to a path
+that may or may not be hardware-accelerated. VSCode on the same machine
+uses Electron's defaults and visibly does NOT show this lag, so the
+blocklist alone isn't sufficient explanation; whatever VSCode does to side-
+step it (we don't yet know which switch / feature flag), we can probably
+adopt.
+
+---
+
+## Hot issues (suspected lag contributors)
+
+### Issue 1 — `--renderer-process-limit=1`
+
+The comment justifies this with the Tauri/Alloy-era assumption that "the
+frontend runs in the browser process (no renderer spawned), but DevTools
+popups can spawn additional renderers at ~100GB VA each."
+
+In our **current Linux CEF build**, this is wrong:
+
+- The frontend is loaded into a top-level browser window with its own
+  renderer process (not Alloy mode for the user-visible UI — verified by the
+  zygote/utility/network process tree we observe).
+- We have **at least 4 renderers concurrently in normal use**: main
+  window + 2 pool windows + any open browser-pane (sub-renderer per pane).
+- `--renderer-process-limit=1` forces ALL of them to share ONE renderer
+  process. Every JS event loop competes with every other.
+
+Hover-event handler (e.g. dropdown highlight) on the main window has to
+schedule against pool-window idle JS, browser-pane idle JS, etc., on a
+single thread. Hover lag is exactly what this looks like under contention.
+
+**Verdict:** **Remove.** Default is "no cap"; let Chromium spawn one
+renderer per top-level + per OOPIF as designed.
+
+VA-space concern: Chromium is 64-bit on Linux x86-64. The "100GB VA per
+renderer" cited in the comment is virtual address space, not physical
+memory. On Linux 64-bit there is effectively unlimited VA and Chromium
+relies on this. There is no real-world cost to letting renderers spawn.
+
+### Issue 2 — `WEBKIT_DISABLE_DMABUF_RENDERER` confusion
+
+The CLAUDE.md memory reads:
+
+> `WEBKIT_DISABLE_DMABUF_RENDERER=1` is required for AppImage to work on
+> this system. `window.show()` hangs without it (DMA-BUF renderer
+> incompatibility)
+
+That note was correct **for the Tauri/WebKitGTK build**. The current
+CEF build's `window.show()` doesn't go through WebKit at all. The
+"requirement" is folklore that needs to be retested under CEF and removed
+from memory if it doesn't reproduce.
+
+**Action:** Remove the env var from AppRun, build a fresh AppImage, launch.
+Two outcomes:
+
+1. **Window appears normally** → confirm the var was inert under CEF, drop
+   it permanently, update CLAUDE.md memory to scrub the obsolete advice.
+2. **Window hangs at show()** → some path in CEF 146.7.0 is incidentally
+   reading this env (unlikely but possible — Chromium has hundreds of
+   conditional code paths checking various WebKit-named env vars for
+   compatibility), or there's a NEW required workaround. File a separate
+   bug + keep the env var for now with a "WHY" comment.
+
+### Issue 3 — IBus / IM module disable (`XMODIFIERS=""`, `GTK_IM_MODULE=...`)
+
+CEF on Linux uses `InputMethodAuralinux`, which integrates with
+`IBus` and `fcitx` directly via D-Bus, not via GTK's IM module. Disabling
+GTK IM modules has zero effect on CEF text input. Empty `XMODIFIERS` was
+historically a WebKitGTK input-glitch workaround.
+
+Side effects of keeping these for CEF users:
+
+- Asian-language users (CJK) lose IBus on the host process's GTK widgets if
+  any are visible (probably none in our codebase, but worth verifying).
+- Compose-key sequences (`<dead_acute>` + `e` → `é`) may not fire.
+
+**Verdict:** Remove. If we discover a CEF-specific input bug after removal,
+we'll address it with a CEF-aware workaround, not a WebKit-era one.
+
+### Issue 4 — `GDK_BACKEND=wayland|x11`
+
+CEF on Linux uses Ozone, which auto-detects the platform from
+`WAYLAND_DISPLAY` / `DISPLAY` env vars and from `--ozone-platform=` switch
+(libcef sets this for us). GDK_BACKEND influences GTK widget code only.
+
+Our host process links GTK as a transitive dep of CEF, but our code
+doesn't draw GTK widgets directly. If GDK_BACKEND has any observable
+effect on our app, it's incidental to GTK init paths in Chromium itself.
+
+**Verdict:** Remove. Reasoning: forcing the GDK backend at AppRun time is
+a Tauri-era hack that biases GTK in a direction CEF may not want. Let the
+defaults work, observe behavior. If something breaks, we have a real
+GTK-related issue worth its own investigation.
+
+---
+
+## Comparison with VSCode (Electron) on the same machine
+
+Both AgentMux and VSCode embed Chromium. Same VM, same Mesa, same
+WebGL-blocklisted GPU. VSCode hover is instant; AgentMux hover lags.
+
+What VSCode does that we don't (preliminary, needs deeper diff):
+
+- VSCode does NOT set `--renderer-process-limit=1`. Each major UI surface
+  gets its own renderer.
+- VSCode does NOT set `WEBKIT_*` env vars (Electron isn't WebKit).
+- VSCode does NOT touch `GTK_IM_MODULE` / `XMODIFIERS`.
+- VSCode lets Electron's defaults handle Wayland / IBus / IM — modern
+  Electron has tuned this stack.
+
+This audit's recommended cleanup essentially **moves us toward VSCode's
+flag profile**.
+
+---
+
+## Cleanup proposal (single PR)
+
+### Touch list
+
+1. **`scripts/linux-apprun.sh`** — replace WebKit-era env-var block with a
+   minimal CEF-appropriate version:
+
+   ```bash
+   #!/usr/bin/env bash
+   # AppImage AppRun for AgentMux on Linux (CEF runtime).
+   # See docs/specs/linux-cef-flags-audit-2026-05-08.md for what is and
+   # isn't set here, and why.
+   set -e
+   this_dir="$(readlink -f "$(dirname "$0")")"
+   export APPDIR="$this_dir"
+   if [ -n "$APPIMAGE" ] && [ -x "$this_dir/install-linux-desktop.sh" ]; then
+       bash "$this_dir/install-linux-desktop.sh" "$APPIMAGE" || true
+   fi
+   # libcef.so + EGL/GLESv2 sit in usr/bin alongside agentmux-cef. Binary
+   # is built without RPATH so we set LD_LIBRARY_PATH explicitly.
+   export LD_LIBRARY_PATH="$this_dir/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+   exec "$this_dir/usr/bin/agentmux" "$@"
+   ```
+
+   Removed: `WEBKIT_DISABLE_DMABUF_RENDERER`, `GDK_BACKEND`,
+   `XMODIFIERS`, `GTK_IM_MODULE`. Kept: `APPDIR`, desktop registration,
+   `LD_LIBRARY_PATH`, `exec`.
+
+2. **`agentmux-cef/src/app.rs::on_before_command_line_processing`** —
+   delete the `--renderer-process-limit=1` switch. Update the surrounding
+   comment to reflect that we now allow per-top-level renderers because
+   the user-visible Linux build is no longer Alloy-mode and the VA-space
+   concern is mooted on 64-bit.
+
+3. **CLAUDE.md memory** (`/home/snowbark/.claude/projects/-home-snowbark/memory/`)
+   — scrub the "WEBKIT_DISABLE_DMABUF_RENDERER required for AppImage to
+   work" entry, replace with a pointer to this spec.
+
+### Why one PR, not four
+
+These flags are all entangled — the diagnosis of each one only makes sense
+in the context of the others. Splitting them would force the reviewer to
+mentally reconstruct the full audit four times.
+
+---
+
+## Test plan
+
+### Sequence
+
+For each of the four flag removals, do an isolated test build:
+
+| Build | What removed | Pass criteria |
+|-------|--------------|---------------|
+| T1 | `WEBKIT_DISABLE_DMABUF_RENDERER` only | Window appears, no `window.show()` hang |
+| T2 | + `GDK_BACKEND` | Same as T1 + Wayland/X11 detection works either way |
+| T3 | + `XMODIFIERS` + `GTK_IM_MODULE` | T2 passes + plain ASCII input works in any text field |
+| T4 | + `--renderer-process-limit=1` removal | T3 passes + hover lag measurably reduced; pool windows have separate PIDs |
+
+If any test fails, stop the cascade and document which flag is actually
+required for CEF. (The rest of the cleanup still ships.)
+
+### Quantitative metrics to track
+
+- **Cold launch ms** (page-load → mainwin-done): currently ~2.4s on a warmed
+  cache. Target: ≤ 1.5s after `--renderer-process-limit` removal.
+- **Hover lag on hamburger dropdown**: currently visibly perceptible
+  (~50-150ms), VSCode hover on same machine ~10-20ms. Target: < 30ms.
+- **Process count after launch**: currently ~7 (1 host + 1 srv + 5 zygote/
+  utility). After fix: + 2-3 renderer processes (one per pool window, one
+  per main window).
+- **Tear-off elapsed time** with full pool: reported separately in
+  `linux-pool-startup-fill-2026-05-08.md`. Should improve once renderers
+  aren't queued behind each other.
+
+### Smoke checks (every build)
+
+1. App window appears. Frontend loads.
+2. Click into a text field, type ASCII — letters arrive.
+3. Open the hamburger menu, hover items — repaints crisp.
+4. Open a browser pane, navigate — content loads.
+5. Tear off a tab — new window opens (cold path acceptable for now).
+6. Close pane — host stays alive (already verified in 0.33.723 smoke).
+
+---
+
+## Risks
+
+### Risk: removing `WEBKIT_DISABLE_DMABUF_RENDERER` makes window.show() hang on this exact VM
+
+If true, the env var was inadvertently load-bearing through some
+Chromium-side conditional check. Unlikely but possible. Mitigation: T1 is
+the first build; if it hangs, we keep the var and document why explicitly
+in a comment.
+
+### Risk: removing `GDK_BACKEND=wayland` causes Wayland → X11 fallback
+
+If GTK in our process incidentally creates a top-level (it shouldn't, but
+some menu / dialog paths in Chromium do), the GDK-default of X11 might
+apply to it. The user-visible main window is Wayland-correct because CEF's
+Ozone path drives it. Worst case: a side-popup looks slightly off-position.
+
+### Risk: removing `--renderer-process-limit=1` increases memory
+
+Each renderer adds ~30-50MB RSS (real, not VA). With 3 windows + 1 pane,
+peak could grow by ~150MB. Acceptable on modern desktops. Worth measuring
+on tear-off-heavy sessions.
+
+### Risk: input method removal breaks IBus on some specific desktop env
+
+CEF's `InputMethodAuralinux` is supposed to handle this, but reports of
+IBus regressions in Chromium-on-Linux are real. Mitigation: T3 explicitly
+tests text input. If it regresses, we re-add the IBus-adjacent vars with
+a "WHY" comment.
+
+---
+
+## Open questions
+
+- **Why does VSCode work and we don't on this VM?** This audit *narrows*
+  the question (most of our extra flags are stale and identical between
+  Linux distros), but doesn't fully answer it. After the cleanup lands,
+  if hover lag persists, the next thing to investigate is GPU-process
+  initialization differences (Chromium has many `--use-gl=*` modes;
+  VSCode/Electron may pick a different default than libcef does).
+- **Does removing `--renderer-process-limit=1` introduce a CEF lifecycle
+  bug we haven't seen?** The original commit message implied an Alloy-mode
+  reason. We're no longer Alloy on Linux, but verify by looking at
+  current `frontend` integration mode under CEF before removal.
+- **Does VSCode use code caching, code splitting, or other startup
+  optimizations we're not?** That's relevant to the cold-launch tax but
+  separate from this flag audit.
+
+---
+
+## See also
+
+- `docs/specs/linux-pool-startup-fill-2026-05-08.md` — startup pool fill
+  (already merged in 0.33.724).
+- `docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md` — the FUSE /
+  SquashFS / V8-cold-cache tax (separate fix, not this PR).
+- `scripts/linux-apprun.sh` — file under review.
+- `agentmux-cef/src/app.rs::on_before_command_line_processing` — file under
+  review.
+- `CLAUDE.md` (root) and the auto-memory file in
+  `~/.claude/projects/-home-snowbark/memory/MEMORY.md` — both reference the
+  removed env vars and need follow-up edits.

--- a/docs/specs/linux-pool-startup-fill-2026-05-08.md
+++ b/docs/specs/linux-pool-startup-fill-2026-05-08.md
@@ -1,0 +1,297 @@
+# Linux/macOS: wire startup-time window-pool fill
+
+**Status:** Draft.
+**Author:** runtime investigation 2026-05-08.
+**Owner:** TBD.
+**Affects:** Linux + macOS AppImage / .app builds.
+**Out of scope:** Windows (already correct).
+
+---
+
+## Problem
+
+On Linux (and presumably macOS), the window pool is **never seeded at app
+startup**. It sits at zero until incidentally refilled by a pane-close path.
+Tear-off therefore always takes the cold-path: a fresh top-level CefWindow +
+Browser + Renderer + frontend-bundle load on each tear, instead of promoting a
+pre-warmed pool window.
+
+User-visible symptom: tear-off takes ~3-3.7 seconds on Linux. On Windows the
+same operation is "instant" because the pool is full at boot.
+
+---
+
+## Evidence
+
+From `~/.agentmux/versions/0.33.723/logs/agentmux-host-v0.33.723.log.2026-05-08`,
+session starting `19:29:24` (fresh process), filtering pool events:
+
+```
+19:29:24.209  BrowserRegistered  label=main  kind=TopLevel { is_pool: false }   ← only registration in startup
+19:29:33.052  [dnd:cef] start_cross_drag
+19:29:33.247  WARN [pool] pool exhausted on tear-off — frontend will cold-path
+19:29:33.399  WARN [fe] [dnd:cross] pool promote failed, cold-pathing {"error":"Error: pool_exhausted"}
+19:29:33.423  [create-window] task entered UI thread          ← cold path begins
+19:29:33.461  browser_view_create returned
+19:29:33.537  Window registered (the new top-level)
+19:29:35.935  [initTauriNewWindow] tear-off                   ← +2.4s of frontend cold-load
+19:29:36.767  DragOverlay listening on the new window         ← user-visible "done", T+3.7s
+```
+
+Cross-checked `0.33.721` log: the only pool spawn observed across the entire
+session was `19:02:55.120 [pool] spawning pool window` — and that was triggered
+*after a pane close*, not at startup. The post-close path
+(`browser_panes.rs:333`) is currently the only pool refill source on Linux.
+
+Result: every fresh session's first tear-off cold-paths. After that, the pool
+gets opportunistically filled by pane-close churn — not by design.
+
+---
+
+## Root cause
+
+`agentmux-cef/src/saga_dispatch.rs:325`
+
+```rust
+#[cfg(target_os = "windows")]
+pub struct LiveActionRunner { … }
+
+#[cfg(target_os = "windows")]
+impl SagaActionRunner for LiveActionRunner {
+    fn spawn_pool_window(&self) -> String {
+        crate::commands::window_pool::spawn_pool_window(&self.state);
+        String::new()
+    }
+    …
+}
+```
+
+`LiveActionRunner` is the only production impl of `SagaActionRunner`, and it
+is **Windows-only**. The launcher-driven saga path that fires
+`SpawnPoolWindow` commands at startup on Windows has no production receiver
+on Linux/macOS, so the saga commands fire into the void.
+
+The doc comment on `commands/window_pool.rs:25` even acknowledges the
+intended trigger:
+
+```
+// - App startup → spawn N pool windows after primary first-paint.
+```
+
+That trigger is unwired on non-Windows. The comment describes the design;
+the implementation only delivers it on Windows.
+
+`spawn_pool_window` itself is fully cross-platform (it uses CEF directly with
+no platform-specific gates inside the function body). So the bug is a missing
+caller, not a missing implementation.
+
+---
+
+## Options considered
+
+### Option A — Add a Linux/macOS `LiveActionRunner` impl
+
+Make `LiveActionRunner` available on all platforms, route pool-fill saga
+commands through `launcher_ipc.rs` on Linux/macOS too.
+
+**Pros:** Architecturally consistent across platforms. Reuses the existing
+saga dispatch + report machinery.
+
+**Cons:** On Linux/macOS there is no `agentmux-launcher` binary — the
+AppImage / .app *is* the host. Sagas are designed to be sent from the
+launcher to the host over IPC; without a launcher there's nothing to issue
+the saga. Either the host has to issue the saga to itself (awkward) or we
+have to build a launcher binary for non-Windows. Both are large.
+
+### Option B — Direct startup-time call from the host
+
+After the main window's renderer first-paints, call
+`spawn_pool_window(state)` `POOL_TARGET_SIZE` times directly. Skips the
+saga path entirely; the host owns its own pool fill on platforms with no
+launcher.
+
+**Pros:** Tiny change. Single file touched. Honors `is_quitting` /
+`any_browser_pane_closing` gates already inside `spawn_pool_window`.
+Idempotent in-flight semaphore prevents over-fill if called concurrently
+with any other refill source.
+
+**Cons:** Slightly diverges from the Windows architecture (host self-fires
+instead of launcher-fires). Tolerable: the host ALREADY self-fires from
+`browser_panes.rs::close` and `drain_closed_label`; this just adds a third
+self-fire site, the startup one.
+
+### Option C — Defer to first user activity
+
+Fill the pool on first hover over the tab strip, on first tab create, etc.
+Avoids paying any pre-warm cost when the user never tears.
+
+**Pros:** Saves ~50-100MB RSS on users who never tear off.
+
+**Cons:** Doesn't actually solve the latency for the *first* tear-off,
+which is the user-reported regression. And anyone who tears at all ends up
+paying the cold cost on the first tear anyway. Better tackled as a separate
+"lazy pool" change later, if the RSS cost matters.
+
+### Recommendation
+
+**Option B.** Smallest change, exact behavior parity with the Windows pool
+once the seeds land, and the gating logic that already lives inside
+`spawn_pool_window` makes it safe to call freely.
+
+---
+
+## Implementation
+
+### Where to call from
+
+`agentmux-cef/src/app.rs::AgentMuxWindowDelegate::on_window_created` is the
+right hook. The Linux/macOS-only `state.windows` registration block already
+runs there (lines 70-77). Immediately after registering the *main* window
+(label `"main"`), kick off pool fill.
+
+```rust
+#[cfg(not(target_os = "windows"))]
+if let Some((state, label)) = self.window_registration.as_ref() {
+    state.windows.lock().insert(label.clone(), window.clone());
+    tracing::info!(
+        window_label = %label,
+        "[browser-pane] registered Window in state.windows for pane attachment"
+    );
+
+    // Linux/macOS startup pool fill — Windows uses the launcher saga path
+    // (saga_dispatch.rs::LiveActionRunner is cfg(windows) only). On
+    // platforms without a separate launcher binary, the host has to seed
+    // the pool itself or first-tear-off cold-paths every time. See
+    // docs/specs/linux-pool-startup-fill-2026-05-08.md.
+    if label == "main" {
+        for _ in 0..crate::commands::window_pool::POOL_TARGET_SIZE {
+            crate::commands::window_pool::spawn_pool_window(state);
+        }
+    }
+}
+```
+
+Why `label == "main"`: sub-windows (tear-off targets, pop-up windows, pool
+windows themselves) all flow through the same `on_window_created` callback.
+Filling the pool only when the first main window registers prevents
+secondary windows from re-triggering pool fill.
+
+Why `POOL_TARGET_SIZE` direct calls (not just one): `spawn_pool_window`'s
+in-flight semaphore single-flights — concurrent calls collapse to one
+spawn-in-flight at a time. Each call seeds **at most one** new pool entry.
+Calling it twice in a tight loop won't fill two slots; only the first call
+runs, the second early-outs against the in-flight flag. The correct
+loop-with-callback pattern is: fire one, and rely on the
+`mark_pool_window_renderer_ready` → `spawn_pool_window` recursion in
+`window_pool.rs:401` to keep refilling until target is reached.
+
+So the loop above is wrong. Use one call:
+
+```rust
+if label == "main" {
+    crate::commands::window_pool::spawn_pool_window(state);
+}
+```
+
+That single call kicks off the recursion that fills the pool to target. The
+internal capacity check at `window_pool.rs:128` (`pool_queue_size() >=
+POOL_TARGET_SIZE` → return) provides the upper bound.
+
+Verify this assumption during implementation by reading
+`mark_pool_window_renderer_ready` end-to-end. If the recursion is broken /
+gated, the right fix may be to add a startup-only loop that polls
+`pool_queue_size()` until target.
+
+### Timing — should it be deferred?
+
+The user-visible main window first-paint happens around `+2.4s` from process
+start (per startup-bench). Spawning a pool window takes ~370ms (per the
+tear-off trace `[create-window] task entered UI thread → window_create_top_level returned`).
+Two pool windows in a tight chain after main first-paint adds ~700ms of
+background CPU work on the UI thread.
+
+Options for when:
+
+1. **Immediately after main-window registration (`on_window_created`):**
+   simplest; pool fill races slightly with main-window's own first-paint.
+   Risk: paint of main window is delayed by the off-screen pool window's
+   construction. Should measure.
+
+2. **After main window's `on_load_end` fires:** pool fill starts ~50ms after
+   the user can already see and click on the main window. No paint contention.
+   Slightly more wiring (callback in `client/mod.rs` or `callbacks.rs`).
+
+3. **Delayed task, ~500ms post first-paint:** absolute simplest, no risk of
+   contention; but adds ~500ms latency before pool is ready, which matters
+   if the user tears off immediately.
+
+Recommendation: **(2) — fire from `on_load_end` of the main window**, with
+a `cfg(not(target_os = "windows"))` guard. Lowest contention risk; pool is
+ready ~1s after first paint.
+
+---
+
+## Validation plan
+
+### Functional
+
+1. Fresh launch of an AppImage with no warmed pool. Wait for first paint.
+2. `muxlog host '[pool]'` should show `[pool] spawning pool window` twice
+   (or `POOL_TARGET_SIZE` times) within ~1-2 seconds of `on_load_end`.
+3. Reducer events: two `BrowserRegistered` entries with
+   `kind=TopLevel { is_pool: true }`.
+4. Tear off a tab. Should NOT see `pool exhausted on tear-off`. Should see
+   `[pool] promote` instead, and a single `[pool] spawning pool window` for
+   the refill.
+
+### Performance
+
+Measure end-to-end tear-off latency before and after:
+
+- Before (current 0.33.723): `start_cross_drag → DragOverlay listening` =
+  ~3.7s on cold AppImage, ~2.5s on warm cache.
+- Target after fix: ~500-800ms (the time to assign the pre-warmed window's
+  workspace + frontend's pool-promote handshake). Close to Windows parity.
+
+### Regressions to watch
+
+- **Quitting:** `spawn_pool_window` already early-outs on `is_quitting()`.
+  Verify by quitting the app while pool windows are still spawning — should
+  drain cleanly with `[wrr] quit_state=Draining (drain mode)`.
+- **Pane-mid-close:** `H.7 invariant` gate at `window_pool.rs:111` already
+  defers refill if a pane is mid-close. The startup fill must respect this.
+  Trivial because we use the existing `spawn_pool_window` entry point.
+- **Multiple top-level windows:** if user opens a second top-level (not via
+  tear-off, e.g. a sub-window), the `on_load_end` for that window must NOT
+  re-trigger the startup fill. Hence the `label == "main"` guard.
+
+---
+
+## Risks / open questions
+
+- **Does `spawn_pool_window` actually self-recurse to fill to target?**
+  Code path goes through `mark_pool_window_renderer_ready →
+  spawn_pool_window` (window_pool.rs:401) when each pool window's renderer
+  reports ready. Verify experimentally: does a single call from `on_load_end`
+  end up with two pool windows in the queue, or just one? If just one, add
+  an explicit loop driven by reducer's pool_queue_size.
+- **Does pool spawning on Wayland have the same WeakPtr race as tear-off
+  did?** The pool windows are created off-screen; if their creation overlaps
+  any pending pane teardown, the same crash class might trip. The deferred-
+  destroy fix (PR landed in 0.33.723) should cover this — but the startup
+  fill happens before any panes have closed, so no race window exists at
+  startup time.
+- **Memory cost:** each pool window is a full CefWindow + Browser + Renderer
+  process. Two pool windows ≈ 100-150MB RSS. Document this; may be worth
+  making `POOL_TARGET_SIZE` configurable for memory-constrained users.
+
+---
+
+## See also
+
+- `agentmux-cef/src/commands/window_pool.rs` — pool implementation.
+- `agentmux-cef/src/saga_dispatch.rs` — Windows launcher saga path.
+- `agentmux-cef/src/app.rs::AgentMuxWindowDelegate` — main window
+  registration site.
+- `docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md` — sister spec
+  for the orthogonal AppImage cold-launch issue.

--- a/docs/specs/linux-pool-startup-fill-2026-05-08.md
+++ b/docs/specs/linux-pool-startup-fill-2026-05-08.md
@@ -1,10 +1,23 @@
 # Linux/macOS: wire startup-time window-pool fill
 
-**Status:** Draft.
+**Status:** BLOCKED — see "Blockers" below. Investigation 2026-05-08; reclassified 2026-05-10 after PR #788 round-2 codex review.
 **Author:** runtime investigation 2026-05-08.
 **Owner:** TBD.
 **Affects:** Linux + macOS AppImage / .app builds.
 **Out of scope:** Windows (already correct).
+
+---
+
+## Blockers (added 2026-05-10)
+
+Two independent blockers — fixing one doesn't unblock startup pool fill.
+
+1. **`promote_pool_window` is `cfg(target_os = "windows")` only.** The non-Windows impl at `agentmux-cef/src/commands/window_pool.rs:872-886` always returns `None` with the comment "Non-Windows: pool isn't built yet (Phase 7). Caller falls back to the cold path." Any pre-warmed pool windows on Linux or macOS can never be consumed by tear-off — they're strictly wasted RAM + CPU. Codex P2 on PR #788 caught this for the macOS path; the same applies to Linux.
+2. **(Linux/Wayland only)** `POOL_OFFSCREEN_X = -32000` in `window_pool.rs` is a Win32/X11-era hack that the Wayland compositor ignores. Pool windows appear ON SCREEN as visible blank windows because Wayland doesn't let clients dictate position.
+
+Blocker (1) alone makes startup pool fill the wrong call on any non-Windows platform until Phase 7 lands a working `promote_pool_window`. Blocker (2) additionally requires a Wayland-correct hide mechanism (`xdg_toplevel.set_minimized`? transparent surfaces? `--headless` renderer pool?) before any visible-side approach works.
+
+**Implementation status:** the cfg(macos)-only version of the startup pool fill that landed in PR #788 was reverted in the same PR after the codex finding. App.rs no longer fires `spawn_pool_window` from `on_window_created`; the call site is intentionally absent. When Phase 7 implements `promote_pool_window` for non-Windows platforms, this spec is the right place to re-enable startup fill.
 
 ---
 

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -50,6 +50,13 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     let placeholderRef: HTMLDivElement | undefined;
     let resizeObserver: ResizeObserver | null = null;
     let positionInterval: ReturnType<typeof setInterval> | null = null;
+    // Last rect we actually sent to the host. syncPosition compares against
+    // this and skips the IPC when nothing changed. Without this gate the
+    // safety-net interval fired browser_pane_resize 5 ×/sec even when the
+    // pane was steady, and each call ran controller.set_size +
+    // set_position + window.layout() on the UI thread — visible as a 200ms
+    // DOM blink as Views relayouted on every tick.
+    let lastSentRect: { x: number; y: number; width: number; height: number } | null = null;
     // SolidJS signal — must be reactive so <Show when={!paneCreated()}> re-runs
     // when the pane is created and hides the empty-state placeholder.
     const [paneCreated, setPaneCreated] = createSignal(false);
@@ -71,9 +78,20 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
 
     const syncPosition = () => {
         if (!placeholderRef || !paneCreated() || model.closed) return;
+        const rect = paneRect();
+        if (
+            lastSentRect &&
+            lastSentRect.x === rect.x &&
+            lastSentRect.y === rect.y &&
+            lastSentRect.width === rect.width &&
+            lastSentRect.height === rect.height
+        ) {
+            return;
+        }
+        lastSentRect = rect;
         invokeCommand("browser_pane_resize", {
             block_id: model.blockId,
-            ...paneRect(),
+            ...rect,
         }).catch(() => {});
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.761",
+  "version": "0.33.762",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.761",
+      "version": "0.33.762",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.760",
+  "version": "0.33.761",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.760",
+      "version": "0.33.761",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1024,7 +1024,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,7 +1040,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1056,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1072,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1120,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1136,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1152,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1168,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1184,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1200,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1216,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1232,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1248,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1264,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1280,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1328,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1344,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1360,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1376,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1392,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1408,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1424,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,6 +1651,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1838,6 +1824,21 @@
         "langium": "^4.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1894,7 +1895,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1934,7 +1934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1954,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1974,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1994,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,7 +2014,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,7 +2034,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,7 +2054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,7 +2074,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2114,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2134,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,7 +2154,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,7 +2174,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,7 +2253,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,7 +2266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2294,7 +2279,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,7 +2292,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,7 +2305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,7 +2318,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2350,7 +2331,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,7 +2344,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,7 +2357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,7 +2370,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2406,7 +2383,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,7 +2396,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,7 +2409,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,7 +2422,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,7 +2435,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2476,7 +2448,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,7 +2461,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,7 +2474,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,7 +2487,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,7 +2500,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,7 +2513,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,7 +2526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,7 +2539,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2588,7 +2552,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2602,7 +2565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3736,7 +3698,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4566,6 +4528,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4757,7 +4727,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5609,7 +5579,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5728,7 +5698,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6093,7 +6063,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6210,7 +6179,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6256,7 +6224,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6939,7 +6907,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7091,7 +7059,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7111,7 +7079,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7302,7 +7270,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7548,7 +7516,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7581,7 +7549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7602,7 +7569,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7623,7 +7589,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7644,7 +7609,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7665,7 +7629,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7686,7 +7649,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7707,7 +7669,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7728,7 +7689,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7749,7 +7709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7770,7 +7729,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7791,7 +7749,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7856,6 +7813,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9103,7 +9073,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9153,7 +9122,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9442,7 +9410,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9488,7 +9455,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9730,11 +9696,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10049,7 +10028,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10115,7 +10094,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10217,7 +10195,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10426,6 +10404,29 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11140,6 +11141,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11230,7 +11259,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11459,7 +11487,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11479,7 +11507,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11551,7 +11578,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11782,7 +11809,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11949,7 +11975,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11966,7 +11991,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11983,7 +12007,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12000,7 +12023,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12017,7 +12039,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12034,7 +12055,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12051,7 +12071,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12068,7 +12087,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,7 +12103,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12102,7 +12119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12119,7 +12135,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12136,7 +12151,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12153,7 +12167,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12170,7 +12183,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12187,7 +12199,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12204,7 +12215,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12221,7 +12231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12238,7 +12247,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12255,7 +12263,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12272,7 +12279,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12289,7 +12295,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12306,7 +12311,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12323,7 +12327,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12340,7 +12343,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12357,7 +12359,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12374,7 +12375,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12388,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12430,7 +12429,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12869,6 +12867,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.761",
+  "version": "0.33.762",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.760",
+  "version": "0.33.761",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/build-appimage-linux.sh
+++ b/scripts/build-appimage-linux.sh
@@ -123,6 +123,13 @@ if [ -d dist/schema ]; then
     cp -r dist/schema "$APPDIR/usr/share/agentmux/"
 fi
 
+# --- 6b. VERSION marker — read by AppRun to key the extract-once-cache.
+#         AppRun re-execs from $HOME/.local/share/agentmux/extracted/<VERSION>/
+#         on second+ launches to skip SquashFS decompression. Spec:
+#         docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md (Phase 2).
+mkdir -p "$APPDIR/usr/share/agentmux"
+echo "$VERSION" > "$APPDIR/usr/share/agentmux/VERSION"
+
 # --- 7. AppRun + helper script + assets the installer reads ---
 cp scripts/linux-apprun.sh "$APPDIR/AppRun"
 chmod +x "$APPDIR/AppRun"

--- a/scripts/linux-apprun.sh
+++ b/scripts/linux-apprun.sh
@@ -1,32 +1,31 @@
 #!/usr/bin/env bash
-# AppImage AppRun script for AgentMux on Linux.
-# Replaces linuxdeploy's default AppRun which forces GDK_BACKEND=x11 and
-# does not set WEBKIT_DISABLE_DMABUF_RENDERER=1.
+# AppImage AppRun for AgentMux on Linux (CEF runtime).
+#
+# Why this is so short:
+#   Earlier versions set WEBKIT_DISABLE_DMABUF_RENDERER, XMODIFIERS,
+#   GTK_IM_MODULE, and GDK_BACKEND. Those were workarounds for the
+#   Tauri/WebKitGTK era. None of them apply to the current CEF/Chromium
+#   build — CEF doesn't read WebKit env vars, has its own IME path
+#   (InputMethodAuralinux), and uses Ozone (not GDK) for Wayland/X11.
+#   Carrying them forward biased CEF toward stale Tauri-era behavior.
+#   Audit + rationale: docs/specs/linux-cef-flags-audit-2026-05-08.md.
 #
 # Icon / desktop registration:
 #   The agentmux-cef binary sets xdg_toplevel.app_id="agentmux" via
 #   WindowDelegate::linux_window_properties (agentmux-cef/src/app.rs).
 #   This script registers a matching ~/.local/share/applications/agentmux.desktop
-#   so window managers can show the AgentMux logo. Registration is delegated
-#   to install-linux-desktop.sh — the same script used by `task dev` and
-#   portable-bundle installs, so all three run modes share one source of truth.
+#   so window managers can show the AgentMux logo. Registration is
+#   delegated to install-linux-desktop.sh — also used by `task dev` and
+#   portable-bundle installs, so all three run modes share one source of
+#   truth.
 set -e
 this_dir="$(readlink -f "$(dirname "$0")")"
 export APPDIR="$this_dir"
-export WEBKIT_DISABLE_DMABUF_RENDERER=1
-# Use native Wayland when available; fall back to X11 for pure X11 sessions.
-if [ -n "$WAYLAND_DISPLAY" ]; then
-    export GDK_BACKEND=wayland
-else
-    export GDK_BACKEND=x11
-fi
-export XMODIFIERS=""
-export GTK_IM_MODULE=gtk-im-context-simple
 if [ -n "$APPIMAGE" ] && [ -x "$this_dir/install-linux-desktop.sh" ]; then
     bash "$this_dir/install-linux-desktop.sh" "$APPIMAGE" || true
 fi
-# libcef.so + EGL/GLESv2 live in usr/bin alongside agentmux-cef per CEF's
-# colocation convention. The binary is built without RPATH, so the dynamic
-# linker needs LD_LIBRARY_PATH to find them.
+# libcef.so + EGL/GLESv2 sit in usr/bin alongside agentmux-cef per CEF's
+# colocation convention. The binary is built without RPATH, so the
+# dynamic linker needs LD_LIBRARY_PATH to find them.
 export LD_LIBRARY_PATH="$this_dir/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 exec "$this_dir/usr/bin/agentmux" "$@"

--- a/scripts/linux-apprun.sh
+++ b/scripts/linux-apprun.sh
@@ -58,11 +58,24 @@ if [ ! -x "$EXTRACT_DIR/usr/bin/agentmux" ]; then
         # Extract to a temp dir, then rename. If interrupted, the next run
         # sees a missing or partial $EXTRACT_DIR and retries; the final
         # destination is only created on full success.
+        # PID-scoped temp so two simultaneous first-runs don't share state.
         TMP_DIR="${EXTRACT_DIR}.tmp.$$"
         rm -rf "$TMP_DIR" 2>/dev/null || true
         echo "[agentmux] First-run extraction of v${VERSION} → ${EXTRACT_DIR} (one-time, ~2-3s)" >&2
         if cp -a "$this_dir/." "$TMP_DIR/" 2>/dev/null; then
-            mv "$TMP_DIR" "$EXTRACT_DIR"
+            # Concurrent-launch race: two simultaneous first-runs both
+            # pass the existence check above. `mv -T` is strict rename —
+            # it fails if target exists rather than nesting into it. We
+            # tolerate that failure: the winning instance's $EXTRACT_DIR
+            # is already valid for us to re-exec from. `set -e` at the
+            # top of the script would otherwise abort the loser. (Codex
+            # P2 round-2 on PR #788.)
+            if mv -T "$TMP_DIR" "$EXTRACT_DIR" 2>/dev/null; then
+                : # we won the race
+            else
+                echo "[agentmux] Cache populated by a concurrent instance; reusing" >&2
+                rm -rf "$TMP_DIR" 2>/dev/null || true
+            fi
             # Best-effort cleanup of older extractions. Keep the two most
             # recently modified version dirs (the current one plus the
             # immediately previous, in case the user is running both

--- a/scripts/linux-apprun.sh
+++ b/scripts/linux-apprun.sh
@@ -1,31 +1,90 @@
 #!/usr/bin/env bash
 # AppImage AppRun for AgentMux on Linux (CEF runtime).
 #
-# Why this is so short:
-#   Earlier versions set WEBKIT_DISABLE_DMABUF_RENDERER, XMODIFIERS,
-#   GTK_IM_MODULE, and GDK_BACKEND. Those were workarounds for the
-#   Tauri/WebKitGTK era. None of them apply to the current CEF/Chromium
-#   build — CEF doesn't read WebKit env vars, has its own IME path
-#   (InputMethodAuralinux), and uses Ozone (not GDK) for Wayland/X11.
-#   Carrying them forward biased CEF toward stale Tauri-era behavior.
-#   Audit + rationale: docs/specs/linux-cef-flags-audit-2026-05-08.md.
+# Design notes:
+#   - Earlier versions set WEBKIT_DISABLE_DMABUF_RENDERER, XMODIFIERS,
+#     GTK_IM_MODULE, GDK_BACKEND. Those were Tauri/WebKitGTK workarounds.
+#     CEF doesn't read WebKit env vars, has its own IME path
+#     (InputMethodAuralinux), and uses Ozone (not GDK) for Wayland/X11.
+#     Carrying them forward biased CEF toward stale Tauri-era behavior.
+#     Audit + rationale: docs/specs/linux-cef-flags-audit-2026-05-08.md.
 #
-# Icon / desktop registration:
-#   The agentmux-cef binary sets xdg_toplevel.app_id="agentmux" via
-#   WindowDelegate::linux_window_properties (agentmux-cef/src/app.rs).
-#   This script registers a matching ~/.local/share/applications/agentmux.desktop
-#   so window managers can show the AgentMux logo. Registration is
-#   delegated to install-linux-desktop.sh — also used by `task dev` and
-#   portable-bundle installs, so all three run modes share one source of
-#   truth.
+#   - **Extract-once-cache (Phase 2 of cold-launch tax fix).** When the
+#     AppImage is launched for the first time, its SquashFS gets mounted
+#     via FUSE and every file read decompresses on demand → ~3s cold
+#     start. This script extracts the contents to
+#     $HOME/.local/share/agentmux/extracted/<VERSION>/ on first run, then
+#     re-execs from there. Subsequent launches see the cache and skip
+#     extraction → ~1s warm start. Spec:
+#     docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md (Phase 2).
+#
+#   - Icon / desktop registration: the agentmux-cef binary sets
+#     xdg_toplevel.app_id="agentmux"; this script registers a matching
+#     ~/.local/share/applications/agentmux.desktop via
+#     install-linux-desktop.sh.
 set -e
 this_dir="$(readlink -f "$(dirname "$0")")"
-export APPDIR="$this_dir"
-if [ -n "$APPIMAGE" ] && [ -x "$this_dir/install-linux-desktop.sh" ]; then
-    bash "$this_dir/install-linux-desktop.sh" "$APPIMAGE" || true
+
+# ---- run_normally: shared body for both "ran from extract dir" and
+# ---- "ran from FUSE mount as fallback". Sets env, registers desktop file,
+# ---- exec's the host binary. ------------------------------------------
+run_normally() {
+    export APPDIR="$this_dir"
+    if [ -n "$APPIMAGE" ] && [ -x "$this_dir/install-linux-desktop.sh" ]; then
+        bash "$this_dir/install-linux-desktop.sh" "$APPIMAGE" || true
+    fi
+    # libcef.so + EGL/GLESv2 sit in usr/bin alongside agentmux-cef. Binary
+    # is built without RPATH so we set LD_LIBRARY_PATH explicitly.
+    export LD_LIBRARY_PATH="$this_dir/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    exec "$this_dir/usr/bin/agentmux" "$@"
+}
+
+# ---- Detect a re-exec from the cache so we don't loop. ----------------
+VERSION="$(cat "$this_dir/usr/share/agentmux/VERSION" 2>/dev/null || echo unknown)"
+EXTRACT_DIR="$HOME/.local/share/agentmux/extracted/$VERSION"
+
+if [ "${AGENTMUX_EXTRACTED_RUN:-0}" = "1" ] || [ "$this_dir" = "$EXTRACT_DIR" ]; then
+    # We're already running from the extracted cache (or marked as such).
+    # Just run the host binary; no extraction work to do.
+    run_normally "$@"
 fi
-# libcef.so + EGL/GLESv2 sit in usr/bin alongside agentmux-cef per CEF's
-# colocation convention. The binary is built without RPATH, so the
-# dynamic linker needs LD_LIBRARY_PATH to find them.
-export LD_LIBRARY_PATH="$this_dir/usr/bin${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-exec "$this_dir/usr/bin/agentmux" "$@"
+
+# ---- First run on a FUSE mount. Try to extract to disk. ---------------
+# If extraction succeeds, we re-exec from the cached copy. If it fails for
+# any reason (no $HOME, full disk, denied perms), fall through to running
+# from the FUSE mount unchanged — slow but correct.
+if [ ! -x "$EXTRACT_DIR/usr/bin/agentmux" ]; then
+    if mkdir -p "$(dirname "$EXTRACT_DIR")" 2>/dev/null; then
+        # Extract to a temp dir, then rename. If interrupted, the next run
+        # sees a missing or partial $EXTRACT_DIR and retries; the final
+        # destination is only created on full success.
+        TMP_DIR="${EXTRACT_DIR}.tmp.$$"
+        rm -rf "$TMP_DIR" 2>/dev/null || true
+        echo "[agentmux] First-run extraction of v${VERSION} → ${EXTRACT_DIR} (one-time, ~2-3s)" >&2
+        if cp -a "$this_dir/." "$TMP_DIR/" 2>/dev/null; then
+            mv "$TMP_DIR" "$EXTRACT_DIR"
+            # Best-effort cleanup of older extractions. Keep the two most
+            # recently modified version dirs (the current one plus the
+            # immediately previous, in case the user is running both
+            # concurrently). Fail silently — this is hygiene, not critical.
+            (
+                cd "$(dirname "$EXTRACT_DIR")" 2>/dev/null || exit 0
+                ls -1t 2>/dev/null | tail -n +3 | while IFS= read -r old; do
+                    [ -d "$old" ] && [ "$old" != "$VERSION" ] && rm -rf "$old"
+                done
+            ) || true
+        else
+            echo "[agentmux] Extraction failed; running from FUSE mount" >&2
+            rm -rf "$TMP_DIR" 2>/dev/null || true
+        fi
+    fi
+fi
+
+# If extraction succeeded, re-exec from the cached copy.
+if [ -x "$EXTRACT_DIR/usr/bin/agentmux" ] && [ -x "$EXTRACT_DIR/AppRun" ]; then
+    export AGENTMUX_EXTRACTED_RUN=1
+    exec "$EXTRACT_DIR/AppRun" "$@"
+fi
+
+# Fallback: extraction unavailable, run from FUSE mount.
+run_normally "$@"


### PR DESCRIPTION
## Summary

Five distinct Linux fixes batched together because they share investigative context and one of them (the WeakPtr crash) blocks a class of pane operations.

- **Browser-pane WeakPtr crash on close / tab tear-off** (`weak_ptr.h:250 Check failed: ref_.IsValid()`). `detach_browser_pane_view` now stashes the OverlayController in `state.pending_overlay_destroy` and defers `destroy()` to `on_before_close_browser_pane` — by which point the Browser is fully torn down and Chromium has drained the queued tasks holding `WeakPtr<View>` to the BrowserView. **Verified live:** smoke test on 0.33.723 captured both expected log lines (stash → deferred destroy at on_before_close, 22ms gap, host alive). Fixes a FATAL that took down the whole host.
- **200ms DOM blink on browser-pane** (5×/sec re-layout). The renderer's safety-net `setInterval(syncPosition, 200)` was firing `browser_pane_resize` IPC unconditionally; each call re-ran `controller.set_size + set_position + window.layout()`. Added `lastSentRect` cache; IPC now no-ops in steady state. Plus `tracing::info!` on `browser_pane_resize` so future silent IPC pumps surface in the log. Confirmed H1 hypothesis from `perf-baseline-2026-05-09.md`.
- **Linux flag audit + cleanup.** Removed Tauri/WebKitGTK-era leftovers from `scripts/linux-apprun.sh`: `WEBKIT_DISABLE_DMABUF_RENDERER`, `XMODIFIERS=""`, `GTK_IM_MODULE=gtk-im-context-simple`, `GDK_BACKEND`. Removed `--renderer-process-limit=1` from `agentmux-cef/src/app.rs`. Spec: `docs/specs/linux-cef-flags-audit-2026-05-08.md`. Notably the cap forced ALL renderers (main + pool windows + tear-off windows + browser panes) to share one event loop → suspected hover-lag contributor; on Linux that justification (DevTools popup VA-overflow under Alloy mode) was wrong because the Linux build isn't Alloy.
- **Pool startup-fill cfg-gated to macOS.** On Linux/Wayland, `POOL_OFFSCREEN_X = -32000` is ignored by the compositor — pool windows appear ON SCREEN as visible blank windows. Until pool windows can be properly hidden on Wayland (xdg_toplevel.set_minimized? transparent surfaces? --headless renderer pool?), startup pool fill on Linux is disabled. Tear-off takes the cold path on first use as a result. Spec: `docs/specs/linux-pool-startup-fill-2026-05-08.md` (the open question got an answer: Wayland positioning).
- **AppImage extract-once-cache (Phase 2 of cold-launch tax).** AppRun extracts the FUSE-mounted SquashFS to `$HOME/.local/share/agentmux/extracted/<VERSION>/` on first run and re-execs from there. Subsequent launches skip SquashFS decompression entirely. VERSION marker written by `build-appimage-linux.sh` step 6b. Atomic-ish extract (tmp → rename), best-effort cleanup of older versions, fallback to FUSE mode on failure. Spec: `docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md`.

Bonus pre-existing Linux build fixes that were blocking `task dev` / `task package:linux` on this machine (cfg-gating regressions in `process_tracker/mod.rs` and `orphan_reconcile.rs`) — small, separate first commit so they can be cherry-picked if needed.

## Test plan

- [x] cargo check -p agentmux-cef — clean
- [x] task package:linux — produces 0.33.746 AppImage (187 MB)
- [x] **WeakPtr crash fix verified live in 0.33.723 smoke** (precursor to this branch): close pane → host alive, both deferred-destroy log lines fire 22ms apart
- [x] Blink fix verified live in 0.33.723: pane open → 1 resize IPC in 1s (down from ~5)
- [ ] **Smoke test on 0.33.746 (this branch's build):** open pane → close pane → no crash; tear off pane (will cold-path because pool is disabled on Linux) → no crash
- [ ] **Cold-launch tax test:** time first launch (extracts) and second launch (cache hit) — should drop from ~3s to ~1s on second+
- [ ] **Hover lag test with perf HUD** (now landed in main): measure hamburger dropdown hover INP / long tasks before vs after `--renderer-process-limit=1` removal
- [ ] **Input test:** type ASCII into a text field — verifies IM module env-var removal didn't break input

## Specs

Three new specs in this PR (rides with code per `feedback_no_doc_only_prs`):
- `docs/specs/linux-cef-flags-audit-2026-05-08.md`
- `docs/specs/linux-pool-startup-fill-2026-05-08.md`
- `docs/specs/linux-appimage-cold-launch-tax-2026-05-08.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)