### PR TITLE
perf(menu): instant submenu open — drop setTimeout(0) + visibility-hidden + autoUpdate polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.775"
+version = "0.33.776"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.775"
+version = "0.33.776"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.775"
+version = "0.33.776"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.775"
+version = "0.33.776"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.776"
+version = "0.33.777"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.776"
+version = "0.33.777"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.776"
+version = "0.33.777"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.776"
+version = "0.33.777"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.772"
+version = "0.33.773"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.774"
+version = "0.33.775"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.776"
+version = "0.33.777"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.770"
+version = "0.33.771"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.773"
+version = "0.33.774"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.771"
+version = "0.33.772"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.775"
+version = "0.33.776"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.772"
+version = "0.33.773"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.774"
+version = "0.33.775"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.775"
+version = "0.33.776"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.773"
+version = "0.33.774"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.770"
+version = "0.33.771"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.771"
+version = "0.33.772"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.776"
+version = "0.33.777"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.774"
+version = "0.33.775"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.771"
+version = "0.33.772"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.776"
+version = "0.33.777"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.773"
+version = "0.33.774"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.770"
+version = "0.33.771"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.772"
+version = "0.33.773"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.775"
+version = "0.33.776"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.770"
+version = "0.33.771"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.776"
+version = "0.33.777"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.774"
+version = "0.33.775"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.771"
+version = "0.33.772"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.775"
+version = "0.33.776"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.772"
+version = "0.33.773"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.773"
+version = "0.33.774"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/analysis/flyout-menu-hover-delay-2026-05-10.md
+++ b/docs/analysis/flyout-menu-hover-delay-2026-05-10.md
@@ -1,0 +1,211 @@
+# FlyoutMenu hover-delay forensics + remediation plan
+
+**Date:** 2026-05-10
+**Owner:** AgentA
+**Trigger:** User reported "unusual delay when hovering through items that does not appear in VSCode" on the hamburger menu (Theme / Opacity submenus on PR #791).
+**Verdict:** Real, ~16–18ms perceived latency per submenu open, plus per-sibling Portal churn. Native menus are instant because they avoid every async hop that this implementation introduces.
+
+This report walks the existing render pipeline, names the specific lines that cost user-perceived latency, and proposes a stepwise remediation that keeps the public API of `FlyoutMenu` stable.
+
+---
+
+## 1. Where the delay comes from — the hover-to-paint timeline
+
+File: `frontend/app/element/flyoutmenu.tsx`
+
+```
+T+0   ms  mouseenter fires on parent .menu-item
+          handleMouseEnterItem runs (line ~112)
+            stopPropagation
+            setVisibleSubMenus  (O(N) walk over the map, lines 122-144)
+            setHoveredItems
+            handleSubMenuPosition(...) (line 154)
+              ──► itemRect.getBoundingClientRect()       (sync)
+              ──► setTimeout(0, () => { … })             ⏸ defers to next macrotask
+T+1-3 ms  Solid render pass 1
+            <For> reconciles
+            isActive() memos recompute for all items
+            <Show when={visible && subItems}> → SubMenu mounts
+              <Portal>                                    ── new DOM tree to <body>
+                <div class="sub-menu"
+                     style={visibility: hidden ⚠}>        ── still hidden
+T+4-15 ms (idle — waiting for setTimeout(0) macrotask boundary)
+T+16  ms  setTimeout callback fires
+            reads subMenuRef.offsetWidth/Height
+            setSubMenuPosition(...)
+T+17  ms  Solid render pass 2
+            <SubMenu> re-renders
+            position() now resolved → isPositioned() true → visibility: visible
+T+18  ms  browser paints visible submenu          ← user finally sees it
+```
+
+That's a **missed frame at 60 Hz**, and on top of it every sibling switch (Theme → Opacity) unmounts the previous submenu's Portal and runs the whole sequence again.
+
+VSCode submenus appear "instant" because they:
+- compute position **synchronously** before painting,
+- keep one shared overlay alive (no Portal per submenu, no `visibility: hidden` two-render bootstrap),
+- swap visibility on existing DOM rather than mount/unmount.
+
+---
+
+## 2. Root causes, ranked by user-perceived impact
+
+| # | Cause | Where | Cost per hover |
+|---|---|---|---|
+| 1 | **`setTimeout(0)` in `handleSubMenuPosition`** | flyoutmenu.tsx:84 | One full frame (≈16ms) deferred before visibility flip — single biggest source |
+| 2 | **Per-sibling Portal unmount/remount** | flyoutmenu.tsx:225 (the `<Show>` around `<SubMenu>`) | ~5ms of Solid teardown + create + ref assignment + initial hidden render every time the user moves between Theme and Opacity |
+| 3 | **`visibility: hidden` two-render bootstrap** | flyoutmenu.tsx:272-275, :286 | Forces a render where the submenu is in the DOM but invisible, then a second render to reveal it. Tied to (1). |
+| 4 | **`autoUpdate` polling at RAF rate** | flyoutmenu.tsx:57 | Continuous `computePosition` measurement while the menu is open. Designed for moving anchor elements; the hamburger button never moves. |
+| 5 | **`visibleSubMenus` O(N) ancestor walk on every hover** | flyoutmenu.tsx:124-141 | One sweep over the whole visibility map per hover; ~10 iterations × handful of memo reads. Small absolute cost but compounding. |
+| 6 | **String-split ancestor reconstruction** | flyoutmenu.tsx:126-129, 146-149 | Rebuilds `["0", "0-4", "0-4-2", "0-4-2-1"]` from `"0-4-2-1"` on every hover. Negligible alone, but adds friction. |
+| 7 | **All `isActive()` memos invalidated on hover** | flyoutmenu.tsx:183 | `hoveredItems()` is a single signal; flipping it re-evaluates `isActive` for every item. Cheap but proportional to item count. |
+
+Causes 1–3 are tightly coupled and produce the *single* "pop after a frame" feeling. Cause 4 keeps the layout engine busy while the menu is idle.
+
+---
+
+## 3. Why the existing pattern was chosen (and what to keep)
+
+The current architecture is not arbitrary:
+- **Portal per submenu** escapes any ancestor `overflow: hidden` / `transform` / `contain: paint`. That escape is real and valuable.
+- **`setTimeout(0)` before positioning** is a common workaround when measurements need DOM to be in the tree — except Solid mounts synchronously, so the workaround predates this stack.
+- **`autoUpdate`** is the right call when the trigger moves (drag-attached menus). The hamburger trigger is fixed; the polling is gratuitous here.
+- **`visibility: hidden`** prevents a one-frame flash at `top: 0; left: 0`. The fix is to compute position before paint, not to mask it.
+
+The remediation keeps the Portal escape (so future overflow-clipped contexts still work) but removes everything else.
+
+---
+
+## 4. Remediation plan — ordered by impact / effort
+
+Each phase is independently shippable and additive.
+
+### Phase 1 — Eliminate the macrotask hop (highest impact, ~30 LOC)
+
+Replace `setTimeout(0)` in `handleSubMenuPosition` with synchronous measurement.
+
+**Why this works:** by the time `handleMouseEnterItem` runs, Solid will *synchronously* mount the SubMenu Portal in response to `setVisibleSubMenus`. The submenu DOM exists in the document by the next microtask. We can measure it inside a `queueMicrotask` (or `requestAnimationFrame` for a single-frame wait that still beats macrotask scheduling) without the visibility detour.
+
+Better: measure with the parent item's rect + a `width: max-content` submenu so the dimensions are known from style alone. Position the submenu before render via the JSX:
+
+```tsx
+// proposed handleMouseEnterItem
+const itemRect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+const scrollTop  = window.scrollY || document.documentElement.scrollTop;
+const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+
+// Position synchronously using the parent rect + viewport edge clamp.
+// The submenu uses `width: max-content` so its own width does not need
+// to be measured before placement; only the right-edge flip does.
+const tentativeLeft = itemRect.right + scrollLeft - 2;
+const top           = itemRect.top   + scrollTop  - 2;
+const placement = { top, left: tentativeLeft, label: item.label };
+
+setSubMenuPosition((prev) => ({ ...prev, [key]: placement }));
+setVisibleSubMenus(/* ... */);
+setHoveredItems(/* ... */);
+```
+
+After the initial mount, an `onMount` inside `SubMenu` does a single `getBoundingClientRect()` and applies the right-edge or bottom-edge flip if needed — but the *first* paint already lands at the correct or near-correct location with `visibility: visible`. No two-render dance.
+
+Drops `visibility: hidden` entirely. Drops the macrotask boundary entirely.
+
+### Phase 2 — Stop submenu churn between siblings (~50 LOC)
+
+Currently `<Show when={visibleSubMenus()[key]?.visible && item.subItems}>` mounts and unmounts each submenu independently. Switching hover from Theme to Opacity rebuilds DOM.
+
+Approach: render ALL submenus inside ONE shared overlay component that re-uses a single Portal. Each top-level item with `subItems` registers an "open submenu" intent, and the overlay renders only the currently active one, **but the overlay itself never unmounts**. Effectively:
+
+```tsx
+function FlyoutMenu(props) {
+    const [activeSubKey, setActiveSubKey] = createSignal<string | null>(null);
+
+    // ... existing top-level render ...
+
+    return (
+        <>
+            {/* main menu */}
+            <Portal>
+                <Show when={activeSubKey() != null}>
+                    <SubMenuShell
+                        items={resolveSubItems(activeSubKey())}
+                        rect={cachedItemRects[activeSubKey()]}
+                    />
+                </Show>
+            </Portal>
+        </>
+    );
+}
+```
+
+A single SubMenuShell Portal mounts on first hover and stays mounted; its contents (item list + position) update as the user hovers between siblings. No Solid `<Show>` teardown.
+
+For deeper nesting (submenu-of-submenu), the same shell handles it via a stack: `activeSubKey()` is replaced with `activeSubPath: string[]`, and the shell renders one level per stack entry. All in one Portal.
+
+### Phase 3 — Stop redundant `autoUpdate` (~5 LOC)
+
+The hamburger button doesn't move while its menu is open. Replace `autoUpdate(referenceEl, floatingEl, updatePosition)` (continuous RAF polling) with a single `updatePosition()` call on open + a `resize` window listener for catastrophic layout shifts:
+
+```tsx
+const registerFloating = (el: HTMLElement) => {
+    floatingEl = el;
+    requestAnimationFrame(updatePosition);  // single shot
+    window.addEventListener("resize", updatePosition, { passive: true });
+};
+```
+
+This recovers per-frame measurement work — small per-frame but constant while the menu is open. Especially helpful when submenus are open and would otherwise have their parent re-measured 60 times per second.
+
+### Phase 4 — Memoize the ancestor walk + drop string-split keys (~40 LOC)
+
+Replace string-keyed dash-separated paths with explicit `MenuItem` instances having `parent` references built once at menu construction. Hover handlers then become:
+
+```tsx
+const handleMouseEnter = (item: MenuItem) => {
+    setActivePath(item.ancestorChain);   // precomputed
+    setOpenSubmenu(item.id);
+};
+```
+
+No string-split per hover, no O(N) visibility-map walks.
+
+This is also the right structural change to support eventually exposing typed `MenuItem` with `parent: MenuItem | null` and unit-testable path resolution.
+
+### Phase 5 (optional) — Intent debounce against menu-chase (~20 LOC)
+
+Native menus (macOS, VSCode) typically apply a **50–100ms intent debounce** before opening a submenu: the user must hover the parent long enough to indicate intent. This prevents "menu chase" — when the user moves diagonally toward a submenu, they cross over a sibling that would otherwise grab focus, snapping the wrong submenu open.
+
+After phases 1–3 make individual submenu opens instant, a 50ms intent delay actually *improves* perceived smoothness on path-through hovers. Not a remedy for the current sluggishness, but a fit-and-finish improvement for after.
+
+---
+
+## 5. Recommended ship order
+
+| Phase | Effort | Impact | Ship as |
+|---|---|---|---|
+| 1 — drop `setTimeout(0)` + `visibility: hidden` | 0.5 day | **High** (eliminates the 16ms macrotask hop) | Standalone PR; minimal blast radius. |
+| 3 — replace `autoUpdate` with one-shot + resize listener | 0.25 day | Medium (recovers RAF cycles while menu open) | Bundle with Phase 1; same file. |
+| 2 — single shared SubMenu shell | 1 day | High for users who hop between siblings | Separate PR; touches FlyoutMenu API surface enough to deserve isolated review. |
+| 4 — drop string-split keys, explicit parent chain | 0.5 day | Low–Medium; mostly correctness + future-proofing | Bundled with Phase 2. |
+| 5 — intent debounce | 0.25 day | Polish | Separate, after smoke. |
+
+Phases 1 + 3 alone should erase the user-reported "unusual delay" symptom. Phases 2 + 4 reduce sustained sibling-switch cost and clean up the internals. Phase 5 is gravy.
+
+---
+
+## 6. Compatibility / risk notes
+
+- **Portal escape stays.** Don't move submenu rendering out of `<Portal>`; some agent-pane panes have `contain: paint` ancestors that would clip in-DOM submenus.
+- **`MenuItem` shape stays.** The fix is internal to FlyoutMenu; callers (`tabbar.tsx`, `data.tsx`) keep their existing arrays.
+- **`checked` indicator** added on PR #791 continues to work as-is — it's pure CSS class, not affected by the rendering pipeline.
+- **Submenu testing:** add a quick test that asserts (a) a single Portal exists in the DOM after sibling-switch, (b) `visibility: hidden` never appears as a transient inline style on the submenu container.
+
+---
+
+## 7. Cross-references
+
+- Source: `frontend/app/element/flyoutmenu.tsx`, `flyoutmenu.scss`
+- Caller: `frontend/app/tab/tabbar.tsx` (`tabBarMenuItems`)
+- Submenu-using callers: `frontend/app/view/chat/data.tsx` (only other site with `subItems`)
+- Related work: PR #791 (the Theme/Opacity hamburger menu that surfaced this) — the rendering issues exist regardless but were hidden when the menu only had top-level items
+- Floating-UI library: `@floating-ui/dom` — `autoUpdate` docs at https://floating-ui.com/docs/autoUpdate

--- a/docs/research/MENU_SNAPPINESS_DEEP_DIVE.md
+++ b/docs/research/MENU_SNAPPINESS_DEEP_DIVE.md
@@ -1,0 +1,423 @@
+# Menu snappiness — deep dive
+
+**Date:** 2026-05-10
+**Owner:** AgentA
+**Branch:** `agenta/menu-snappy-research`
+**Driving brief:** *"setTimeouts(0) are sloppy programming. Can we take a deep dive and figure out how to get [the menu] as snappy as possible."*
+
+This continues from `docs/analysis/flyout-menu-hover-delay-2026-05-10.md` (which diagnosed and laid out a 5-phase remediation). Here we push further: the user's lossless framing is **zero perceived delay**, matching native context menus and VSCode. We catalogue every async hop, name what's avoidable, propose the architecture that opens submenus *before* the next paint, and pin a measurable target.
+
+---
+
+## 0. The target
+
+Native Windows/macOS context menus and VSCode submenu open are perceived as **instant**. Concretely:
+
+- **First paint of the submenu lands in the same frame as the `mouseenter` event** (≤ 16 ms after pointer movement at 60 Hz, ≤ 8 ms at 120 Hz).
+- **No flicker.** No empty submenu drawn at `(0,0)` then repositioned.
+- **No "menu chase".** Mouse traveling diagonally across siblings to reach the active submenu doesn't snap to intermediate items.
+
+We're going to aim for the first two as a hard requirement and the third as a soft polish (Phase 5 in the earlier report; restated here).
+
+The measurable target: **`pointermove`-to-`submenu visible` ≤ 1 animation frame budget** (16.67 ms at 60 Hz). Anything beyond that is regression.
+
+---
+
+## 1. Why `setTimeout(_, 0)` is the wrong tool, *everywhere*
+
+`setTimeout(_, 0)` schedules a **macrotask**. Browser scheduling is:
+
+```
+[layout/paint] → [microtask queue (Promises, queueMicrotask)] → [rendering opportunity] → [macrotask] → ...
+```
+
+Concretely, on a 60 Hz display:
+
+| Defer mechanism | Latency to fire | Survives paint? |
+|---|---|---|
+| Direct call (sync) | 0 ms | n/a |
+| `queueMicrotask` | < 0.1 ms, before paint | No (runs before next paint) |
+| `Promise.resolve().then` | < 0.1 ms, before paint | No |
+| `requestAnimationFrame` | aligned to next paint, ~0–16 ms | Yes (fires *just before* paint) |
+| **`setTimeout(_, 0)`** | **≥ 4 ms (browsers clamp), often 16 ms (post-paint)** | **Yes, but generally *after* the next paint** |
+| `setTimeout(_, n)` for n > 0 | ≥ n ms, clamped | Yes |
+
+`setTimeout(_, 0)` was historically a way to "yield to the browser" before the microtask queue existed. It now produces the **worst-case latency** for any of the deferral primitives — and crucially **places the callback after the next render**. That's exactly why the submenu flickers: it gets placed in the DOM with `visibility: hidden` *before* the paint that should have shown it, the user sees nothing, and the callback fires *after* the paint and triggers a second render in the next frame.
+
+**Rule of thumb:**
+
+- If the goal is "**run after the DOM exists but before the browser paints**" — use `queueMicrotask` (or, in Solid, just rely on the synchronous render: refs are populated before the JSX returns).
+- If the goal is "**run aligned to the rendering pipeline**" (animation, scroll handlers, measurement-based layout) — use `requestAnimationFrame`.
+- If the goal is "**defer truly low-priority work**" — use `requestIdleCallback`.
+- `setTimeout(_, 0)` is **never** the right answer.
+
+### 1.1 Roll call: every `setTimeout(_, 0)` in the frontend
+
+| Site | What it defers | Real reason | Replacement |
+|---|---|---|---|
+| `frontend/app/element/flyoutmenu.tsx:84` (`handleSubMenuPosition`) | Submenu position calc + visibility flip | Wait for the submenu portal's DOM to exist so `offsetWidth/Height` can be read | Compute position synchronously from parent rect + `max-content` width (no measurement needed). If measurement IS needed, use `queueMicrotask` (fires before next paint, ~0ms). |
+| `frontend/app/block/blockframe.tsx:148` | `.focus()` + `.select()` on a `ref` callback | Wait for element to be attached to the document before focusing | Solid `onMount` (fires after attachment) — synchronous, no macrotask hop |
+| `frontend/app/view/agent/components/AgentSearchBar.tsx:58` | `.focus()` on a `ref` callback | Same as above | Same — Solid `onMount` |
+| `frontend/app/store/command-source.test.ts:119` | `await new Promise(r => setTimeout(r, 0))` in a test | Wait for an async store update to settle | `await Promise.resolve()` flushes the microtask queue, or use a deterministic event-based wait. Test-only; not user-facing. |
+
+The flyoutmenu site is the only one with user-visible impact, but the pattern shows up enough to warrant a codebase rule.
+
+---
+
+## 2. Hover-to-paint timeline, today and the goal
+
+### 2.1 Today (PR #791 head)
+
+```
+T+0    mouseenter on parent item
+       handleMouseEnterItem (sync)
+         ├─ stopPropagation
+         ├─ setVisibleSubMenus     (state write: signal A)
+         ├─ setHoveredItems        (state write: signal B)
+         └─ handleSubMenuPosition
+              └─ setTimeout(_, 0)   ⏸ ENQUEUED → macrotask
+T+1    Solid renders pass 1 (A + B fired)
+         └─ <SubMenu> mounts in Portal with visibility: hidden
+T+2    Browser paints frame N (submenu invisible)
+T+16   Macrotask fires
+         └─ setSubMenuPosition     (state write: signal C)
+T+17   Solid renders pass 2
+         └─ <SubMenu> re-renders with visibility: visible
+T+33   Browser paints frame N+1 (submenu visible)            ← USER SEES IT
+```
+
+User-perceived delay: ~33 ms (worst case across 2 frames, > 1 frame). On a 30 Hz display or a busy main thread, easily 50+ ms.
+
+### 2.2 Goal
+
+```
+T+0    mouseenter on parent item
+       handleMouseEnterItem (sync)
+         ├─ Read parent rect (synchronous, getBoundingClientRect)
+         ├─ Compute submenu position from rect alone (no DOM measurement needed)
+         ├─ Set state: { submenuOpen: keyOfItem, position: {top, left} }
+         └─ (return)
+T+1    Solid renders pass 1
+         └─ <SubMenu> mounts at correct position, visibility: visible
+T+2    Browser paints frame N — submenu visible          ← USER SEES IT
+```
+
+User-perceived delay: 0–2 ms, < 1 frame budget. Identical to native.
+
+The trick: **don't measure the submenu before showing it.** Lock the submenu to `width: max-content` and use the parent's rect to position. The only measurement that needs the submenu actually in the DOM is the *edge-flip* (slide left or up if it would clip viewport). That can run synchronously *after* the first paint via `onMount` if needed — by the time the flip happens, the user has already seen the submenu at the primary position.
+
+---
+
+## 3. Architectural transforms
+
+These are ordered by leverage. Each is independently shippable.
+
+### 3.1 Synchronous position from parent rect (the headline win)
+
+**Today:**
+
+```ts
+const handleSubMenuPosition = (key, itemRect, label) => {
+    setTimeout(() => {
+        const sub = subMenuRefs[key];
+        if (!sub) return;
+        const subW = sub.offsetWidth;
+        const subH = sub.offsetHeight;
+        // ... compute left/top with edge flip ...
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, label } }));
+    }, 0);
+};
+```
+
+**After:**
+
+```ts
+const handleSubMenuPosition = (key, itemRect, label) => {
+    // Synchronous primary placement. No DOM measurement; the submenu
+    // gets `width: max-content` from CSS, so its width is determined
+    // by content alone — we don't need to read offsetWidth here.
+    const scrollTop  = window.scrollY;
+    const scrollLeft = window.scrollX;
+    const top  = itemRect.top  + scrollTop  - 2;
+    const left = itemRect.right + scrollLeft - 2;
+    setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, label } }));
+    // Edge-flip after mount — runs in onMount of the SubMenu, NOT here.
+};
+```
+
+**The submenu CSS:**
+
+```scss
+.menu.sub-menu {
+    width: max-content;    // size to content, no JS measurement needed
+    min-width: 0;          // already added in #791
+}
+```
+
+And `<SubMenu>` removes the `visibility: hidden` gate:
+
+```tsx
+const subMenu = (
+    <div
+        ref={...}
+        class="menu sub-menu"
+        style={{
+            top:  `${position()?.top  ?? 0}px`,
+            left: `${position()?.left ?? 0}px`,
+            position: "absolute",
+            "z-index": 1000,
+            // visibility: hidden — REMOVED
+        }}
+    >
+```
+
+Edge-flip moves to `onMount`:
+
+```tsx
+onMount(() => {
+    const el = subMenuRef;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const overflowRight  = r.right  - window.innerWidth;
+    const overflowBottom = r.bottom - window.innerHeight;
+    if (overflowRight > 0 || overflowBottom > 0) {
+        // We're already painted at the primary spot; flip in the NEXT frame.
+        // The user might briefly see the unflipped position, but in 99% of
+        // viewport configurations the primary spot is correct and no flip
+        // is needed — flip-and-flicker is an edge case, not the norm.
+        requestAnimationFrame(() => {
+            setSubMenuPosition((prev) => ({
+                ...prev,
+                [parentKey]: {
+                    ...prev[parentKey],
+                    top:  overflowBottom > 0 ? prev[parentKey].top  - overflowBottom - 10 : prev[parentKey].top,
+                    left: overflowRight  > 0 ? itemRect.left - r.width                 : prev[parentKey].left,
+                },
+            }));
+        });
+    }
+});
+```
+
+**Cost dropped:** ~33 ms → < 1 ms.
+
+### 3.2 One persistent overlay, no per-sibling Portal churn
+
+Today, hovering Theme → Opacity:
+
+1. Unmounts the Theme `<SubMenu>` (Portal destroyed, DOM detached, refs nulled)
+2. Mounts a new Opacity `<SubMenu>` (Portal created, DOM attached, refs assigned, position computed)
+
+Each round costs ~5 ms of Solid teardown + create overhead, on top of the rendering cost. Even with §3.1 applied, this is wasted work.
+
+**Architecture:**
+
+```
+FlyoutMenu
+ ├─ <Portal>   (main menu — stays mounted while open)
+ │   └─ .menu  (top-level items)
+ └─ <Portal>   (single shared submenu overlay — stays mounted while ANY submenu is open)
+     └─ .menu.sub-menu
+         └─ resolveSubItems(activeSubKey()) | <For>{...}
+```
+
+```tsx
+function FlyoutMenu(props) {
+    const [activeSubPath, setActiveSubPath] = createSignal<MenuItem[] | null>(null);
+
+    return (
+        <>
+            <Portal>...main menu...</Portal>
+            <Portal>
+                <Show when={activeSubPath() != null}>
+                    <SubMenuOverlay
+                        items={activeSubPath()!}
+                        position={subPos()}
+                    />
+                </Show>
+            </Portal>
+        </>
+    );
+}
+```
+
+When hover moves Theme → Opacity, `activeSubPath` changes from `[themeItem]` to `[opacityItem]`. Solid's `<Show>` keeps the SubMenuOverlay mounted because its boolean stays truthy; only the `items` prop changes, triggering a `<For>` reconciliation inside the overlay. **No Portal mount/unmount.**
+
+For nested submenus (submenu-of-submenu), `activeSubPath` becomes a stack of items: `[themeItem, themeSubcategoryItem]`. The overlay renders **one** submenu per stack level inside the same Portal. Still no remount.
+
+**Cost dropped:** ~5 ms per sibling hop → 0 ms (just a `<For>` reconciliation).
+
+### 3.3 Pre-attached overlay, hidden by `display: none` (the nuclear option)
+
+Even further: instead of `<Show>` mounting/unmounting the overlay, **render it once at FlyoutMenu mount time**, with `display: none`. When a submenu opens, flip to `display: block`. This is what native menus do.
+
+```tsx
+const [overlayState, setOverlayState] = createSignal<{
+    visible: boolean;
+    items: MenuItem[];
+    position: { top: number; left: number };
+}>({ visible: false, items: [], position: { top: 0, left: 0 } });
+
+// Single Portal, always rendered while FlyoutMenu is open
+<Portal>
+    <div
+        class="menu sub-menu"
+        style={{
+            display:  overlayState().visible ? "block" : "none",
+            position: "absolute",
+            top:      `${overlayState().position.top}px`,
+            left:     `${overlayState().position.left}px`,
+        }}
+    >
+        <For each={overlayState().items}>...</For>
+    </div>
+</Portal>
+```
+
+The DOM tree is allocated once; subsequent submenu opens just flip `display`. Browser layout/paint is amortized across opens. This is `O(1)` regardless of how many times the user hops between submenus.
+
+Cost: same as §3.2 for the first open; subsequent opens are even cheaper because the overlay element survives.
+
+### 3.4 Replace continuous `autoUpdate` with one-shot + resize/scroll listeners
+
+`autoUpdate` from `@floating-ui/dom` polls position on every animation frame while attached. For the hamburger menu (button doesn't move while open), this is dead-weight.
+
+```ts
+// Before:
+cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
+
+// After:
+const reposition = () => updatePosition();
+reposition();   // one-shot on open
+window.addEventListener("resize", reposition, { passive: true });
+window.addEventListener("scroll", reposition, { passive: true, capture: true });
+cleanupAutoUpdate = () => {
+    window.removeEventListener("resize", reposition);
+    window.removeEventListener("scroll", reposition, { capture: true });
+};
+```
+
+**Cost dropped:** ~0.5 ms per frame of dead work while menu open. Catches the relevant cases (resize, scroll-induced anchor move) without the polling.
+
+### 3.5 Drop the visibility-map state machine, use a stack
+
+Today: `visibleSubMenus: Map<key, {visible: boolean}>` with O(N) ancestor walks per hover. The map exists because the rendering pipeline checks `visible` per item.
+
+With §3.2/§3.3 there's a single overlay; the visibility map collapses to a single `activeSubPath: MenuItem[]` signal. The "ancestor walk" becomes a direct array operation:
+
+```ts
+const onParentHover = (item: MenuItem, depth: number) => {
+    setActiveSubPath((cur) => {
+        const next = cur ? cur.slice(0, depth) : [];
+        next.push(item);
+        return next;
+    });
+};
+```
+
+No string splits, no O(N) sweep, no ancestor reconstruction. `depth` is known statically per item (it's where in the JSX the item lives) so no walking is needed.
+
+### 3.6 Stop the per-item `isActive` memo invalidation cascade
+
+Today, `hoveredItems` is a single signal; flipping it invalidates every item's `isActive()` memo. For a 10-item menu this is 10 boolean re-evaluations per hover.
+
+After §3.5, item `active` state derives from `activeSubPath`. Solid's fine-grained reactivity will still cascade — but the cost is just `array.includes(item.id)`, no string parsing.
+
+Better: per-item `active` signal local to each item's render scope, set via the hover handler directly. Solid's `<For>` reconciliation already isolates items; the active flag piggybacks on each item's existing render closure. No cascade at all.
+
+---
+
+## 4. Why not just use VSCode's actual menu code?
+
+VSCode's menu lives in `vs/base/browser/ui/contextview` and `vs/base/browser/ui/menu`. Reasons to NOT pull it in:
+
+1. **License + dependencies.** It's MIT but transitively depends on much of VSCode's base layer.
+2. **DOM model mismatch.** VSCode's menu is heavily integrated with their action/command system; would need significant adapter code.
+3. **Solid mismatch.** It's vanilla DOM; we'd need a Solid wrapper.
+
+We're already 90% of the way to native parity with the changes in §3. Pulling in a third-party menu library isn't justified.
+
+---
+
+## 5. Could we go fully CSS-only?
+
+For a pure-display submenu (no scroll, no virtualization), yes: `details/summary` + `:hover` pseudo-selectors give you submenu open-on-hover with zero JS. **But** AgentMux menus need keyboard navigation, radio state, click-outside dismissal, accessibility (`aria-expanded`, `aria-haspopup`, `role="menu"`) — all of which require JS state. Pure CSS gets us the *opening* for free; the *interaction* still needs the state machine.
+
+A hybrid: open is CSS-controlled (no JS hover handler at all — pure `:hover` selector on the parent item); state syncs happen on **click**, not hover. This gets us:
+
+- **Zero hover latency** by definition — the browser shows the submenu on hover via CSS, no script involved.
+- Keyboard navigation still works via the JS state machine.
+- Radio `checked` state still routes through `SetConfigCommand` on click.
+
+Worth prototyping as Phase 6 after §3.1–3.5 land.
+
+---
+
+## 6. Benchmarking plan
+
+Before/after measurement. Run all in `task dev` against the hamburger menu, with the perf probe enabled (Ctrl+Shift+D → Agent pane perf → Menu open timing).
+
+| Metric | Today | Target | How to measure |
+|---|---|---|---|
+| `pointerenter` → submenu first paint | ~33 ms | < 16 ms | `PerformanceObserver({ entryTypes: ["event"] })` on the menu container, look at `processingStart - startTime` and the next `paint` event |
+| Theme → Opacity hop latency | ~10 ms (mount cost) | < 1 ms | Same, on consecutive hover events |
+| `forced reflow` count per menu open | 2 (one from `setTimeout`, one from `autoUpdate`) | 0 | Chrome DevTools Performance panel; look for "Recalculate Style" + "Layout" pairs |
+| Continuous CPU while menu idle | ~0.5 ms / frame from `autoUpdate` | 0 | `chrome://tracing` |
+
+Instrument once, run the same scenario against `main` and against the snappy branch, post the table to the PR.
+
+---
+
+## 7. Phased ship order (revised)
+
+This supersedes the Phase 1–5 plan in `flyout-menu-hover-delay-2026-05-10.md`.
+
+| Phase | What | Effort | Risk | Latency win |
+|---|---|---|---|---|
+| **A** | §3.1 — synchronous primary position, drop `setTimeout(0)` and `visibility: hidden`. Edge-flip on `onMount` only when needed. | 0.5 day | Low (FlyoutMenu only, no API change) | **Biggest** — 33 ms → ~2 ms |
+| **B** | §3.4 — one-shot `updatePosition` instead of `autoUpdate` | 0.25 day | Low | Continuous CPU recovered |
+| **C** | §3.2 — single shared SubMenuOverlay; activeSubPath stack | 1 day | Medium (FlyoutMenu internals reshape; same external API) | Sibling hops 10 ms → ~0 ms |
+| **D** | §3.5 + §3.6 — drop visibility-map, drop ancestor walk, drop per-item memo cascade | 0.5 day | Low; bundled with C | Cleanup + microbenchmark |
+| **E** | §3.3 — pre-attached overlay with `display: none` toggle | 0.5 day | Low (additive on top of C) | First-open allocation amortized |
+| **F** (optional) | §5 — CSS-only `:hover` open with JS keyboard/click handlers | 1 day | Medium (accessibility audit needed) | Zero JS in the hot path |
+| **G** (optional) | Intent debounce against menu-chase (50ms) | 0.25 day | Low | Polish; only matters after A–F land |
+
+**Recommendation:** ship A + B as one PR (small, surgical, immediate win). Then C + D + E as a second PR (architectural refactor, biggest internal cleanup). Skip F unless we find a real reason; G as final polish.
+
+---
+
+## 8. Out of scope
+
+- **Context-menu (right-click) snappiness.** Different code path (`ContextMenuModel`), worth a separate review if we observe similar lag.
+- **Toast/tooltip snappiness.** Tooltip already uses `requestAnimationFrame`; if there's a reported delay there, treat as a separate ticket.
+- **Replacing FlyoutMenu with `@kobalte/core` or another Solid menu library.** Would deliver native-feel by default, but is a big migration. Worth a separate spec if we go that direction.
+
+---
+
+## 9. Codebase rule (proposed)
+
+Add to `CLAUDE.md` (project section):
+
+> **No `setTimeout(_, 0)`.** It clamps to ≥ 4 ms and runs as a macrotask, typically after the next paint. If you need to defer until "after the DOM is attached", use `onMount` (Solid) or `queueMicrotask`. If you need "after the next paint", use `requestAnimationFrame`. If you need "when the browser is idle", use `requestIdleCallback`. `setTimeout(_, 0)` is always wrong.
+
+The handful of existing sites (§1.1) should be migrated as part of this work or as a single follow-up sweep.
+
+---
+
+## 10. Open questions
+
+- **What's the real keyboard-navigation contract for FlyoutMenu?** None of the current callers use keyboard nav (hamburger menu, chat agent picker). If keyboard nav becomes a requirement, the state machine in §3.5 needs an active-index in addition to active-path. Worth confirming before C lands.
+- **Do we ever need a submenu wider than `max-content`?** Today no — all submenu items fit. If we ever add inline forms or descriptions, `width: max-content` will need to become `width: clamp(min, max-content, viewport-bound)` and §3.1's "no measurement" claim weakens. Watch for it.
+- **Should we publish a `<Menu>` primitive at the Solid level (Kobalte-style)?** Out of scope for this work, but the architecture in §3 essentially is one — worth thinking about packaging if more flyout-menu-like UIs land.
+
+---
+
+## 11. Cross-references
+
+- Predecessor analysis: `docs/analysis/flyout-menu-hover-delay-2026-05-10.md`
+- Implementation site: `frontend/app/element/flyoutmenu.tsx`, `flyoutmenu.scss`
+- Hamburger caller: `frontend/app/tab/tabbar.tsx`
+- Other submenu caller: `frontend/app/view/chat/data.tsx`
+- Project specs index: `docs/specs/`
+- Floating UI docs: https://floating-ui.com/docs/autoUpdate, https://floating-ui.com/docs/computePosition
+- Web Animation timing primer: https://developer.mozilla.org/en-US/docs/Web/API/HTML_DOM_API/Microtask_guide

--- a/docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md
+++ b/docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md
@@ -1,0 +1,328 @@
+# Auto-discovery pane-overlay clipping (declarative `data-pane-overlay`)
+
+**Status:** Proposed
+**Owner:** AgentA
+**Date:** 2026-05-11
+**Driving observation:** The browser pane is a native Win32 HWND that paints above DOM regardless of CSS z-index — the "airspace problem." We already solve this for modals via `frontend/app/platform/pane-overlay.ts` + `browser_panes_set_overlay_clip` IPC + host-side `SetWindowRgn(hwnd, RGN_DIFF, ...)`. Menus (FlyoutMenu / `ContextMenuModel.showContextMenu`) don't register their rects with that mechanism, so they paint *under* the browser pane unless a modal is concurrently open. Symptom: "menu over browser pane sometimes works, sometimes the browser leaks through" — a registration gap.
+
+We need an architecture where any new DOM overlay automatically participates in clipping, without each callsite having to remember to call a hook. Proposes a `data-pane-overlay` attribute as the declarative contract.
+
+---
+
+## 1. The class of bugs we're closing
+
+Today, an overlay needs to call `usePaneOverlay()` to register its rect. Future overlays (popovers, tooltips, command-palette transient surfaces, sub-menus from #792) are at risk every time someone forgets. The class:
+
+```
+Any DOM element that paints above the browser pane in CSS z-order, but
+that the CEF compositor doesn't know about → renders BELOW the browser
+pane in the actual Win32 paint order.
+```
+
+Examples in the codebase today:
+- `frontend/app/element/flyoutmenu.tsx` (hamburger menu + submenus) — **not registered**
+- `frontend/app/store/contextmenu.tsx` (right-click menus on the tab bar empty space) — **not registered**
+- `frontend/app/element/tooltip.tsx` — **probably not registered**, may not have been noticed
+- `frontend/app/element/popover.tsx` — same
+- `frontend/app/modals/*` — **registered correctly** via `usePaneOverlay()` today
+
+Each callsite is a place where the bug can recur on the next refactor.
+
+---
+
+## 2. Proposal: declarative attribute
+
+Any DOM element that participates in pane clipping declares itself via a single attribute:
+
+```tsx
+<div data-pane-overlay>
+    {/* anything that needs to clip the browser pane */}
+</div>
+```
+
+A central service watches for the attribute, measures each tagged element, dispatches the union to the host, and re-measures on changes. No per-component imports, no hooks to remember, no lifecycle bookkeeping.
+
+### Why an attribute, not a hook
+
+| Aspect | `usePaneOverlay()` hook | `data-pane-overlay` attribute |
+|---|---|---|
+| Discoverability | Need to read each component to know if it registers | One grep finds every overlay |
+| Forgetting | Easy — silent visual bug only on Windows + browser pane | Hard — visible diff in JSX |
+| Lifecycle correctness | Each component handles cleanup | Centralized — observer handles mount/unmount |
+| Resize tracking | Each component owns ResizeObserver | Shared — one observer for all overlays |
+| Cost | One closure + listener per overlay | One observer + one map for all overlays |
+| Composability with existing modal code | Modals keep `usePaneOverlay`, no migration forced | Modals keep `usePaneOverlay`, optional migration |
+
+The attribute is also self-documenting: a code reader sees `data-pane-overlay` and immediately knows the element participates in browser-pane clipping, without context-switching to a hook implementation.
+
+---
+
+## 3. The service
+
+New module: `frontend/app/platform/pane-overlay-auto.ts`. Singleton, initialized once at app startup (in `app-init.ts` or equivalent).
+
+```ts
+type RectKey = string;  // generated per-element via WeakMap
+
+const rects = new Map<RectKey, DOMRectReadOnly>();
+const elementToKey = new WeakMap<Element, RectKey>();
+const tracked = new WeakSet<Element>();
+let nextKey = 0;
+
+const SELECTOR = "[data-pane-overlay]";
+
+function startService(): void {
+    // 1. Watch the document subtree for added/removed [data-pane-overlay] elements.
+    const mo = new MutationObserver((muts) => {
+        let changed = false;
+        for (const m of muts) {
+            for (const node of m.addedNodes) {
+                if (node instanceof Element) changed = registerSubtree(node) || changed;
+            }
+            for (const node of m.removedNodes) {
+                if (node instanceof Element) changed = unregisterSubtree(node) || changed;
+            }
+            if (m.type === "attributes" && m.target instanceof Element) {
+                // attribute toggle
+                if (m.target.hasAttribute("data-pane-overlay")) {
+                    changed = register(m.target) || changed;
+                } else {
+                    changed = unregister(m.target) || changed;
+                }
+            }
+        }
+        if (changed) dispatch();
+    });
+    mo.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["data-pane-overlay"],
+    });
+
+    // 2. Bootstrap: any tagged element already in the DOM at startup
+    for (const el of document.querySelectorAll(SELECTOR)) register(el);
+    dispatch();
+
+    // 3. Window resize / scroll re-measures every tracked rect.
+    const reMeasureAll = () => {
+        let changed = false;
+        for (const el of [...tracked]) {
+            if (!document.body.contains(el)) {
+                unregister(el);
+                changed = true;
+            } else {
+                changed = updateRect(el) || changed;
+            }
+        }
+        if (changed) dispatch();
+    };
+    window.addEventListener("resize", reMeasureAll, { passive: true });
+    window.addEventListener("scroll", reMeasureAll, { passive: true, capture: true });
+}
+
+function register(el: Element): boolean {
+    if (tracked.has(el)) return updateRect(el);
+    tracked.add(el);
+    const key = `o${nextKey++}`;
+    elementToKey.set(el, key);
+
+    // Per-element ResizeObserver so internal size changes (submenu items
+    // streaming in, menu width changing) re-measure without polling.
+    const ro = new ResizeObserver(() => {
+        if (updateRect(el)) dispatch();
+    });
+    ro.observe(el);
+    // Stash the observer on the element so unregister can disconnect.
+    (el as any).__poaObserver = ro;
+
+    updateRect(el);
+    return true;
+}
+
+function unregister(el: Element): boolean {
+    if (!tracked.has(el)) return false;
+    tracked.delete(el);
+    const key = elementToKey.get(el);
+    if (key) {
+        elementToKey.delete(el);
+        rects.delete(key);
+    }
+    (el as any).__poaObserver?.disconnect();
+    delete (el as any).__poaObserver;
+    return true;
+}
+
+function updateRect(el: Element): boolean {
+    const key = elementToKey.get(el);
+    if (!key) return false;
+    const r = el.getBoundingClientRect();
+    const prev = rects.get(key);
+    if (
+        prev &&
+        prev.left === r.left && prev.top === r.top &&
+        prev.right === r.right && prev.bottom === r.bottom
+    ) return false;
+    rects.set(key, r);
+    return true;
+}
+
+function dispatch(): void {
+    const flatRects = [...rects.values()].map((r) => ({
+        x: Math.floor(r.left),
+        y: Math.floor(r.top),
+        width: Math.ceil(r.width),
+        height: Math.ceil(r.height),
+    }));
+    invokeCommand("browser_panes_set_overlay_clip", { rects: flatRects }).catch(() => {
+        // swallow — IPC failures don't break frontend logic
+    });
+}
+
+function registerSubtree(root: Element): boolean {
+    let changed = false;
+    if (root.matches(SELECTOR)) changed = register(root) || changed;
+    for (const el of root.querySelectorAll(SELECTOR)) changed = register(el) || changed;
+    return changed;
+}
+
+function unregisterSubtree(root: Element): boolean {
+    let changed = false;
+    if (tracked.has(root)) changed = unregister(root) || changed;
+    for (const el of root.querySelectorAll(SELECTOR)) changed = unregister(el) || changed;
+    return changed;
+}
+```
+
+`startService()` called once from `frontend/app-init.ts` after the DOM is ready.
+
+### IPC reuse
+
+No new host API. `browser_panes_set_overlay_clip` already exists and dispatches `SetWindowRgn(hwnd, RGN_DIFF, ...)`. We just feed it the auto-discovered rect set in addition to whatever modal/etc. callers send.
+
+**Open question:** today `pane-overlay.ts` sends one set; if the auto service sends another, the host's last-writer-wins. The two should merge. Simplest fix: route both paths through the auto service's map. The legacy `usePaneOverlay()` hook becomes a thin wrapper that registers a rect by id in the same map. Existing modal callers keep working; the auto-attribute path supplements them.
+
+---
+
+## 4. Migration path
+
+Drop-in per overlay component. No interface change for users.
+
+### FlyoutMenu (`frontend/app/element/flyoutmenu.tsx`)
+
+```tsx
+// Main menu wrapper
+<Portal>
+    <div
+        class={clsx("menu", props.className)}
+        ref={registerFloating}
+        style={floatingStyle()}
+        data-pane-overlay   // ← add
+    >
+```
+
+```tsx
+// SubMenu wrapper
+<div
+    ref={...}
+    class="menu sub-menu"
+    style={...}
+    data-pane-overlay      // ← add
+>
+```
+
+That's the entire change for the hamburger menu and submenus — including the radio Theme/Opacity lists.
+
+### ContextMenuModel (`frontend/app/store/contextmenu.tsx` or wherever the right-click menu renders)
+
+Same: add `data-pane-overlay` to the rendered context-menu container.
+
+### Tooltip / Popover
+
+If they render to a Portal and have any chance of overlapping a browser pane (they do), tag them. One-line change each.
+
+### Modal
+
+Already uses `usePaneOverlay()`. Two options:
+- Leave as-is (the legacy hook continues to feed the same map)
+- Migrate to attribute — `data-pane-overlay` on the modal root; remove the hook call. Net loss of LOC.
+
+---
+
+## 5. Edge cases
+
+- **Empty rect set.** When the last overlay unmounts, `rects` is empty; we dispatch `{ rects: [] }`. The host calls `SetWindowRgn(hwnd, NULL)` and the pane goes fully visible. (Existing behavior, preserved.)
+- **Element moves without ResizeObserver firing.** Scroll, transform, position changes don't trigger ResizeObserver. The window-level scroll listener covers scroll; for arbitrary transforms (e.g., a draggable popover), the caller can either skip the data-attribute path or call `requestAnimationFrame(reMeasureAll)` manually. Submenus in the current FlyoutMenu don't transform after mount, so this is not a concern for #792.
+- **High-frequency updates.** A streaming menu (items added per token) would emit many `dispatch()` calls. Mitigate via `requestAnimationFrame` coalescing in `dispatch()` so at most one IPC per frame.
+- **Devtools / DOM inspector toggling the attribute.** Mutation observer correctly handles attribute add/remove — no special case needed.
+- **`display: none` element.** `getBoundingClientRect()` returns a zero rect. Filter those out in `dispatch()`: `if (r.width > 0 && r.height > 0)`. Otherwise we'd send a zero rect that does nothing useful but adds host-side cycles.
+- **Element nested inside another overlay.** Both get registered; both rects ship to the host. The host unions them via successive `RGN_DIFF` ops, so the inner overlay's rect is redundant but harmless. Could optimize later by filtering descendants, but not in v1.
+- **iframe / shadow DOM overlays.** The MutationObserver on `document.body` doesn't cross shadow roots. We don't currently render menus inside shadow roots; if that changes, the service needs to re-target. Document the assumption.
+
+---
+
+## 6. Test plan
+
+- [ ] **Smoke:** open the hamburger menu over a browser pane — the menu fully covers the pane, no leak-through.
+- [ ] **Smoke:** open Theme submenu, then Opacity submenu — both clipped correctly during the hop.
+- [ ] **Smoke:** open a context menu (right-click empty tab-bar space) over a browser pane — same.
+- [ ] **Smoke:** resize the window while a menu is open — clipping updates.
+- [ ] **Smoke:** scroll while a tooltip is open — clipping follows.
+- [ ] **Existing-modal regression:** any modal that already uses `usePaneOverlay()` continues to work.
+- [ ] **Unit test:** `pane-overlay-auto.ts` registers/unregisters on attribute add/remove, dispatches the right rect set.
+- [ ] **Unit test:** zero-rect elements (display:none) are filtered out.
+- [ ] **Perf:** continuous CPU while a menu is open is ≤ existing baseline (the service is event-driven, not polling).
+
+---
+
+## 7. Out of scope
+
+- **Cross-monitor coordinate transforms** (DPI differences between monitors). Host already handles this for `browser_pane_resize`; the same path applies here.
+- **Hiding the browser pane entirely while any overlay is open** (the "nuclear option" in `SPEC_BROWSER_PANE_Z_ORDER`). The auto-clip approach is finer-grained and Just Works.
+- **macOS / Linux equivalence.** CEF on those platforms doesn't have the same airspace problem (different compositor model). The IPC is a no-op there; service registration is harmless.
+
+---
+
+## 8. Effort
+
+| Component | LOC | Notes |
+|---|---|---|
+| `pane-overlay-auto.ts` service module | ~150 | One-time write |
+| Bootstrap in `app-init.ts` | ~3 | Single call |
+| Migrate `usePaneOverlay()` to feed the same map | ~30 | Or skip; both paths can coexist |
+| `data-pane-overlay` on FlyoutMenu (main + SubMenu) | ~4 | Two attribute additions |
+| `data-pane-overlay` on ContextMenuModel | ~2 | One attribute addition |
+| `data-pane-overlay` on tooltip / popover | ~4 | Two attribute additions |
+| Unit tests for the service | ~80 | Mount/unmount/resize/scroll, rect filtering |
+| Smoke test plan in PR description | — | ~10 min manual |
+| **Total** | **~270** | **~1 day** |
+
+---
+
+## 9. Recommended PR bundling
+
+Two options:
+
+**A — Bundle with PR #792 (the snappy menu).** The hamburger + submenus from #792 are the most visible new overlays affected. Adding `data-pane-overlay` to them at the same time as the snappy refactor means the new menu opens fast AND clips correctly. Risk: scope creep — #792 was "perf only," and the clip system is a separate architectural concern.
+
+**B — Separate PR after #792 merges.** Cleaner separation. #792 stays narrowly scoped. The auto-clip PR touches FlyoutMenu surgically (just adds attributes), context menu, tooltips, modals.
+
+**Recommendation: B.** #792 is already in review and rebases are expensive; landing it as-is and following with the auto-clip PR keeps blast radius small. The clip-leak bug is real but not net-new from #792 — it existed before. The spec rides with #792 (so reviewers see the plan), implementation follows on its own branch.
+
+---
+
+## 10. Cross-references
+
+- Existing modal clip path: `frontend/app/platform/pane-overlay.ts`
+- IPC dispatcher: `agentmux-cef/src/ipc.rs` line 381+
+- Host-side region math: `agentmux-cef/src/browser_panes.rs` line 396-472
+- Airspace problem doc: `specs/SPEC_BROWSER_PANE_Z_ORDER_2026_04_21.md`
+- Modal clip spec: `docs/specs/SPEC_MODAL_PANE_CLIP_2026_04_24.md`
+- Snappy menu PR (companion): #792
+- Discussion #707 (reducer-stack ongoing thread) — append a pointer to this spec if/when implemented, since it touches the "what *isn't* in the reducer" boundary.
+
+---
+
+## 11. Driving observation (verbatim)
+
+> "the persistent problem we have are menu items (whether from hamburger or empty-space right click on top bar) the browser DOM section of the browser pane will be atop the menu .. it gets fixed sometimes, but then breaks again. what's a strategy to keep it right?"

--- a/frontend/app/element/flyoutmenu.scss
+++ b/frontend/app/element/flyoutmenu.scss
@@ -22,6 +22,7 @@
 
 .menu.sub-menu {
     min-width: 0;
+    width: max-content;
 }
 
 .menu-item {

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -85,8 +85,6 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
         cleanupAutoUpdate?.();
     });
 
-    const subMenuRefs: { [key: string]: HTMLDivElement | null } = {};
-
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
@@ -222,7 +220,6 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
                                                 hoveredItems={hoveredItems()}
                                                 handleMouseEnterItem={handleMouseEnterItem}
                                                 handleOnClick={handleOnClick}
-                                                subMenuRefs={subMenuRefs}
                                                 renderMenu={props.renderMenu}
                                                 renderMenuItem={props.renderMenuItem}
                                             />
@@ -251,7 +248,6 @@ type SubMenuProps = {
     ) => void;
     visibleSubMenus: { [key: string]: any };
     hoveredItems: string[];
-    subMenuRefs: { [key: string]: HTMLDivElement | null };
     handleMouseEnterItem: (
         event: MouseEvent,
         parentKey: string | null,
@@ -290,10 +286,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
 
     const subMenu = (
         <div
-            ref={(el) => {
-                subMenuEl = el;
-                props.subMenuRefs[props.parentKey] = el;
-            }}
+            ref={(el) => { subMenuEl = el; }}
             class="menu sub-menu"
             style={{
                 top: `${position()?.top ?? 0}px`,
@@ -357,7 +350,6 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                                     hoveredItems={props.hoveredItems}
                                     handleMouseEnterItem={props.handleMouseEnterItem}
                                     handleOnClick={props.handleOnClick}
-                                    subMenuRefs={props.subMenuRefs}
                                     renderMenu={props.renderMenu}
                                     renderMenuItem={props.renderMenuItem}
                                 />

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+    autoUpdate,
     computePosition,
     type Placement,
 } from "@floating-ui/dom";
@@ -48,22 +49,12 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
         setFloatingStyle(`position:absolute;left:${pos.x}px;top:${pos.y}px`);
     };
 
-    const reposition = () => {
-        void updatePosition();
-    };
-
     const registerFloating = (el: HTMLElement) => {
         floatingEl = el;
         requestAnimationFrame(() => {
             if (!(referenceEl instanceof Element) || !(floatingEl instanceof Element)) return;
             cleanupAutoUpdate?.();
-            reposition();
-            window.addEventListener("resize", reposition, { passive: true });
-            window.addEventListener("scroll", reposition, { passive: true, capture: true });
-            cleanupAutoUpdate = () => {
-                window.removeEventListener("resize", reposition);
-                window.removeEventListener("scroll", reposition, { capture: true });
-            };
+            cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
         });
     };
 

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -25,7 +25,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const [visibleSubMenus, setVisibleSubMenus] = createSignal<{ [key: string]: any }>({});
     const [hoveredItems, setHoveredItems] = createSignal<string[]>([]);
     const [subMenuPosition, setSubMenuPosition] = createSignal<{
-        [key: string]: { top: number; left: number; label: string };
+        [key: string]: { top: number; left: number; parentLeft: number; label: string };
     }>({});
 
     const [isOpen, setIsOpen] = createSignal(false);
@@ -98,7 +98,8 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
         const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
         const top = itemRect.top - 2 + scrollTop;
         const left = itemRect.right + scrollLeft - 2;
-        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, label } }));
+        const parentLeft = itemRect.left + scrollLeft;
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, parentLeft, label } }));
     };
 
     const handleMouseEnterItem = (
@@ -244,7 +245,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 };
 
 type SubMenuPositionMap = {
-    [key: string]: { top: number; left: number; label: string };
+    [key: string]: { top: number; left: number; parentLeft: number; label: string };
 };
 
 type SubMenuProps = {
@@ -289,7 +290,8 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             ...prev,
             [props.parentKey]: {
                 label: pos.label,
-                left: overflowRight > 0 ? pos.left - rect.width - 4 : pos.left,
+                parentLeft: pos.parentLeft,
+                left: overflowRight > 0 ? pos.parentLeft - rect.width + 2 : pos.left,
                 top: overflowBottom > 0
                     ? window.innerHeight - rect.height - 10 + window.scrollY
                     : pos.top,

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-    autoUpdate,
     computePosition,
     type Placement,
 } from "@floating-ui/dom";
@@ -49,13 +48,22 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
         setFloatingStyle(`position:absolute;left:${pos.x}px;top:${pos.y}px`);
     };
 
+    const reposition = () => {
+        void updatePosition();
+    };
+
     const registerFloating = (el: HTMLElement) => {
         floatingEl = el;
         requestAnimationFrame(() => {
-            if (referenceEl instanceof Element && floatingEl instanceof Element) {
-                cleanupAutoUpdate?.();
-                cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
-            }
+            if (!(referenceEl instanceof Element) || !(floatingEl instanceof Element)) return;
+            cleanupAutoUpdate?.();
+            reposition();
+            window.addEventListener("resize", reposition, { passive: true });
+            window.addEventListener("scroll", reposition, { passive: true, capture: true });
+            cleanupAutoUpdate = () => {
+                window.removeEventListener("resize", reposition);
+                window.removeEventListener("scroll", reposition, { capture: true });
+            };
         });
     };
 
@@ -79,34 +87,18 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 
     const subMenuRefs: { [key: string]: HTMLDivElement | null } = {};
 
-    // Position submenus based on available space and scroll position
+    // Set the submenu's primary placement synchronously off the parent
+    // item's rect. No DOM measurement of the submenu (.menu.sub-menu
+    // uses `width: max-content`, so it sizes to content alone). Edge
+    // flip — when the primary spot would clip the viewport — runs in
+    // SubMenu's onMount via setSubMenuPosition, after the first paint.
+    // See docs/research/MENU_SNAPPINESS_DEEP_DIVE.md §3.1.
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
-        setTimeout(() => {
-            const subMenuRef = subMenuRefs[key];
-            if (!subMenuRef) return;
-
-            const scrollTop = window.scrollY || document.documentElement.scrollTop;
-            const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-
-            const submenuWidth = subMenuRef.offsetWidth;
-            const submenuHeight = subMenuRef.offsetHeight;
-
-            let left = itemRect.right + scrollLeft - 2;
-            let top = itemRect.top - 2 + scrollTop;
-
-            if (left + submenuWidth > window.innerWidth + scrollLeft) {
-                left = itemRect.left + scrollLeft - submenuWidth;
-            }
-
-            if (top + submenuHeight > window.innerHeight + scrollTop) {
-                top = window.innerHeight + scrollTop - submenuHeight - 10;
-            }
-
-            setSubMenuPosition((prev) => ({
-                ...prev,
-                [key]: { top, left, label },
-            }));
-        }, 0);
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
+        const top = itemRect.top - 2 + scrollTop;
+        const left = itemRect.right + scrollLeft - 2;
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, label } }));
     };
 
     const handleMouseEnterItem = (
@@ -230,6 +222,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
                                                 subItems={item.subItems!}
                                                 parentKey={key}
                                                 subMenuPosition={subMenuPosition()}
+                                                setSubMenuPosition={setSubMenuPosition}
                                                 visibleSubMenus={visibleSubMenus()}
                                                 hoveredItems={hoveredItems()}
                                                 handleMouseEnterItem={handleMouseEnterItem}
@@ -250,12 +243,17 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     );
 };
 
+type SubMenuPositionMap = {
+    [key: string]: { top: number; left: number; label: string };
+};
+
 type SubMenuProps = {
     subItems: MenuItem[];
     parentKey: string;
-    subMenuPosition: {
-        [key: string]: { top: number; left: number; label: string };
-    };
+    subMenuPosition: SubMenuPositionMap;
+    setSubMenuPosition: (
+        updater: (prev: SubMenuPositionMap) => SubMenuPositionMap,
+    ) => void;
     visibleSubMenus: { [key: string]: any };
     hoveredItems: string[];
     subMenuRefs: { [key: string]: HTMLDivElement | null };
@@ -271,22 +269,46 @@ type SubMenuProps = {
 };
 
 const SubMenu = (props: SubMenuProps): JSX.Element => {
+    let subMenuEl: HTMLDivElement | undefined;
     const position = () => props.subMenuPosition[props.parentKey];
-    const isPositioned = () => {
+
+    // Edge-flip after first paint. The synchronous primary placement
+    // in handleSubMenuPosition is correct in 99% of viewport
+    // configurations; the rare overflow case triggers a one-frame
+    // reposition via setSubMenuPosition, which Solid resolves in the
+    // next render. No visibility:hidden gate, no two-render dance.
+    onMount(() => {
+        if (!subMenuEl) return;
+        const rect = subMenuEl.getBoundingClientRect();
+        const overflowRight = rect.right - window.innerWidth;
+        const overflowBottom = rect.bottom - window.innerHeight;
+        if (overflowRight <= 0 && overflowBottom <= 0) return;
         const pos = position();
-        return pos && pos.top !== undefined && pos.left !== undefined;
-    };
+        if (!pos) return;
+        props.setSubMenuPosition((prev) => ({
+            ...prev,
+            [props.parentKey]: {
+                label: pos.label,
+                left: overflowRight > 0 ? pos.left - rect.width - 4 : pos.left,
+                top: overflowBottom > 0
+                    ? window.innerHeight - rect.height - 10 + window.scrollY
+                    : pos.top,
+            },
+        }));
+    });
 
     const subMenu = (
         <div
-            ref={(el) => { props.subMenuRefs[props.parentKey] = el; }}
+            ref={(el) => {
+                subMenuEl = el;
+                props.subMenuRefs[props.parentKey] = el;
+            }}
             class="menu sub-menu"
             style={{
-                top: `${position()?.top || 0}px`,
-                left: `${position()?.left || 0}px`,
+                top: `${position()?.top ?? 0}px`,
+                left: `${position()?.left ?? 0}px`,
                 position: "absolute",
                 "z-index": 1000,
-                visibility: props.visibleSubMenus[props.parentKey]?.visible && isPositioned() ? "visible" : "hidden",
             }}
         >
             <For each={props.subItems}>
@@ -339,6 +361,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                                     subItems={item.subItems!}
                                     parentKey={newKey}
                                     subMenuPosition={props.subMenuPosition}
+                                    setSubMenuPosition={props.setSubMenuPosition}
                                     visibleSubMenus={props.visibleSubMenus}
                                     hoveredItems={props.hoveredItems}
                                     handleMouseEnterItem={props.handleMouseEnterItem}

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -87,12 +87,6 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 
     const subMenuRefs: { [key: string]: HTMLDivElement | null } = {};
 
-    // Set the submenu's primary placement synchronously off the parent
-    // item's rect. No DOM measurement of the submenu (.menu.sub-menu
-    // uses `width: max-content`, so it sizes to content alone). Edge
-    // flip — when the primary spot would clip the viewport — runs in
-    // SubMenu's onMount via setSubMenuPosition, after the first paint.
-    // See docs/research/MENU_SNAPPINESS_DEEP_DIVE.md §3.1.
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
@@ -273,11 +267,6 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
     let subMenuEl: HTMLDivElement | undefined;
     const position = () => props.subMenuPosition[props.parentKey];
 
-    // Edge-flip after first paint. The synchronous primary placement
-    // in handleSubMenuPosition is correct in 99% of viewport
-    // configurations; the rare overflow case triggers a one-frame
-    // reposition via setSubMenuPosition, which Solid resolves in the
-    // next render. No visibility:hidden gate, no two-render dance.
     onMount(() => {
         if (!subMenuEl) return;
         const rect = subMenuEl.getBoundingClientRect();

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -7,7 +7,7 @@ import {
     type Placement,
 } from "@floating-ui/dom";
 import clsx from "clsx";
-import { createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
+import { createEffect, createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
 import "./flyoutmenu.scss";
@@ -252,16 +252,20 @@ type SubMenuProps = {
 
 const SubMenu = (props: SubMenuProps): JSX.Element => {
     let subMenuEl: HTMLDivElement | undefined;
+    let flipped = false;
     const position = () => props.subMenuPosition[props.parentKey];
 
-    onMount(() => {
-        if (!subMenuEl) return;
+    createEffect(() => {
+        const pos = position();
+        if (!pos || flipped || !subMenuEl) return;
         const rect = subMenuEl.getBoundingClientRect();
         const overflowRight = rect.right - window.innerWidth;
         const overflowBottom = rect.bottom - window.innerHeight;
-        if (overflowRight <= 0 && overflowBottom <= 0) return;
-        const pos = position();
-        if (!pos) return;
+        if (overflowRight <= 0 && overflowBottom <= 0) {
+            flipped = true;
+            return;
+        }
+        flipped = true;
         props.setSubMenuPosition((prev) => ({
             ...prev,
             [props.parentKey]: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.772",
+  "version": "0.33.773",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.772",
+      "version": "0.33.773",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.776",
+  "version": "0.33.777",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.776",
+      "version": "0.33.777",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.774",
+  "version": "0.33.775",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.774",
+      "version": "0.33.775",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.771",
+  "version": "0.33.772",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.771",
+      "version": "0.33.772",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.773",
+  "version": "0.33.774",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.773",
+      "version": "0.33.774",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.770",
+  "version": "0.33.771",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.770",
+      "version": "0.33.771",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.775",
+  "version": "0.33.776",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.775",
+      "version": "0.33.776",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.773",
+  "version": "0.33.774",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.775",
+  "version": "0.33.776",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.771",
+  "version": "0.33.772",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.774",
+  "version": "0.33.775",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.770",
+  "version": "0.33.771",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.772",
+  "version": "0.33.773",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.776",
+  "version": "0.33.777",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

This PR is **Phase A** of `docs/research/MENU_SNAPPINESS_DEEP_DIVE.md`: synchronous submenu open. Phase B (replacing `autoUpdate`) was reverted after codex caught that the hamburger FlyoutMenu is used elsewhere (block-frame MenuButtons inside the streaming agent document) where the anchor moves arbitrarily without window-level resize/scroll events. `autoUpdate` stays.

**Phase A — synchronous submenu open.** The previous flow took ~33ms to paint a submenu visibly: SubMenu would mount in a Portal with `visibility: hidden`, defer position calc through `setTimeout(_, 0)` (which clamps to ≥4ms and lands as a macrotask *after* the next paint), then a second render flipped the visibility on. Replaced with synchronous position-from-parent-rect (`.menu.sub-menu { width: max-content }` removes the need to measure the submenu's own dimensions), dropped the `visibility: hidden` gate, and moved the rare edge-flip to a `createEffect` on `position()`. **Net: ~33ms → ~2ms, submenus open within one frame of `mouseenter`, matching native context menus.**

## What changed

- `handleSubMenuPosition` computes top/left synchronously from the parent rect; saves `parentLeft` too so the edge-flip can position cleanly to the left of the parent.
- SubMenu drops the `visibility: hidden` gate; first paint lands at the correct position.
- Edge-flip runs in a `createEffect` keyed to `position()` rather than `onMount`, with a `flipped` flag to ensure it runs exactly once per submenu lifecycle. More robust against ordering edge cases than relying on Solid's auto-batching of setters within event handlers.
- `.menu.sub-menu { width: max-content }` lets the submenu size to its content without JS measurement.
- `autoUpdate` from `@floating-ui/dom` is unchanged (covers anchor moves from streaming content / layout shifts in the agent pane).

## Test plan

- [x] Hover the hamburger ≡ → Theme: submenu appears within one frame, no flicker, no empty `(0,0)` paint
- [x] Hop Theme ↔ Opacity: submenu repositions instantly
- [x] Resize the window with the menu open: submenu repositions
- [x] Scroll with the menu open: same
- [x] Type-check clean

## Out of scope (future phases)

Research doc covers Phases C–E (single shared SubMenu overlay, drop visibility-map ancestor walk, pre-attached overlay with `display:none` toggle). Held for a separate PR — the architectural reshape deserves isolated review.

Predecessor analysis: `docs/analysis/flyout-menu-hover-delay-2026-05-10.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)