### PR TITLE
feat(overlay): declarative data-pane-overlay auto-clip — close the menu/popover/tooltip airspace bug class

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.777"
+version = "0.33.778"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.777"
+version = "0.33.778"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.777"
+version = "0.33.778"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.777"
+version = "0.33.778"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2589,13 +2589,13 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.771"
+version = "0.33.772"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.774"
+version = "0.33.775"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -2589,13 +2589,13 @@ dependencies = [
 
 [[package]]
 name = "serial2"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.772"
+version = "0.33.773"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.773"
+version = "0.33.774"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.770"
+version = "0.33.771"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.772"
+version = "0.33.773"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.774"
+version = "0.33.775"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.770"
+version = "0.33.771"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.773"
+version = "0.33.774"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.771"
+version = "0.33.772"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.777"
+version = "0.33.778"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.772"
+version = "0.33.773"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.774"
+version = "0.33.775"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.777"
+version = "0.33.778"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.773"
+version = "0.33.774"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.770"
+version = "0.33.771"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.771"
+version = "0.33.772"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.774"
+version = "0.33.775"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.771"
+version = "0.33.772"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.777"
+version = "0.33.778"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.773"
+version = "0.33.774"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.770"
+version = "0.33.771"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.772"
+version = "0.33.773"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.770"
+version = "0.33.771"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.774"
+version = "0.33.775"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.771"
+version = "0.33.772"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.777"
+version = "0.33.778"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.772"
+version = "0.33.773"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.773"
+version = "0.33.774"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -587,6 +587,12 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     const elem = document.getElementById("main");
     render(App, elem);
     tlog("SolidJS render", t);
+
+    // Start the auto pane-overlay clip service. Any DOM element tagged
+    // `data-pane-overlay` automatically participates in browser-pane
+    // clipping. See docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md.
+    const { startPaneOverlayAutoService } = await import("@/app/platform/pane-overlay-auto");
+    startPaneOverlayAutoService();
     tlog("TOTAL initWave", t0);
 
     // Register this window's backend ID with the CEF host so on_before_close

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -179,6 +179,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
                         class={clsx("menu", props.className)}
                         ref={registerFloating}
                         style={floatingStyle()}
+                        data-pane-overlay
                     >
                         <For each={props.items}>
                             {(item, index) => {
@@ -288,6 +289,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                 "z-index": 1000,
                 visibility: props.visibleSubMenus[props.parentKey]?.visible && isPositioned() ? "visible" : "hidden",
             }}
+            data-pane-overlay
         >
             <For each={props.subItems}>
                 {(item, idx) => {

--- a/frontend/app/element/popover.tsx
+++ b/frontend/app/element/popover.tsx
@@ -169,6 +169,7 @@ const PopoverContent = (props: PopoverContentProps): JSX.Element => {
                     ref={(el) => ctx?.registerFloating(el)}
                     class={clsx("popover-content", props.className)}
                     style={ctx?.floatingStyle()}
+                    data-pane-overlay
                     {...(props as any)}
                 >
                     {props.children}

--- a/frontend/app/element/tooltip.tsx
+++ b/frontend/app/element/tooltip.tsx
@@ -112,6 +112,7 @@ function TooltipInner(props: Omit<TooltipProps, "disable">): JSX.Element {
                         class={cn(
                             "bg-gray-800 border border-border rounded-md px-2 py-1 text-xs text-foreground shadow-xl z-50"
                         )}
+                        data-pane-overlay
                     >
                         {props.content}
                     </div>

--- a/frontend/app/platform/pane-overlay-auto.test.ts
+++ b/frontend/app/platform/pane-overlay-auto.test.ts
@@ -1,0 +1,56 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { isOverlayElementVisible } from "./pane-overlay-auto";
+
+function makeEl(style: Partial<CSSStyleDeclaration>): HTMLDivElement {
+    const el = document.createElement("div");
+    Object.assign(el.style, style);
+    document.body.appendChild(el);
+    return el;
+}
+
+describe("isOverlayElementVisible", () => {
+    const created: HTMLElement[] = [];
+
+    afterEach(() => {
+        for (const el of created) el.remove();
+        created.length = 0;
+    });
+
+    function track(el: HTMLElement): HTMLElement {
+        created.push(el);
+        return el;
+    }
+
+    test("returns true for a default visible element", () => {
+        const el = track(makeEl({}));
+        expect(isOverlayElementVisible(el)).toBe(true);
+    });
+
+    test("returns false when visibility is hidden", () => {
+        const el = track(makeEl({ visibility: "hidden" }));
+        expect(isOverlayElementVisible(el)).toBe(false);
+    });
+
+    test("returns false when display is none", () => {
+        const el = track(makeEl({ display: "none" }));
+        expect(isOverlayElementVisible(el)).toBe(false);
+    });
+
+    test("returns false when opacity is 0", () => {
+        const el = track(makeEl({ opacity: "0" }));
+        expect(isOverlayElementVisible(el)).toBe(false);
+    });
+
+    test("returns true when opacity is non-zero (e.g., 0.5)", () => {
+        const el = track(makeEl({ opacity: "0.5" }));
+        expect(isOverlayElementVisible(el)).toBe(true);
+    });
+
+    test("returns true for opacity 1", () => {
+        const el = track(makeEl({ opacity: "1" }));
+        expect(isOverlayElementVisible(el)).toBe(true);
+    });
+});

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -104,6 +104,9 @@ function untrackSubtree(root: Element): void {
  */
 export function startPaneOverlayAutoService(): void {
     if (started) return;
+    if (typeof navigator !== "undefined" && !navigator.userAgent.includes("Windows")) {
+        return;
+    }
     started = true;
 
     const mo = new MutationObserver((muts) => {

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -50,7 +50,11 @@ function scheduleSweep(): void {
 function updateRect(el: Element): void {
     if (!(el instanceof HTMLElement)) return;
     const cs = window.getComputedStyle(el);
-    if (cs.visibility === "hidden" || cs.display === "none") {
+    if (
+        cs.visibility === "hidden" ||
+        cs.display === "none" ||
+        parseFloat(cs.opacity) === 0
+    ) {
         __deleteAutoOverlayRect(el);
         return;
     }

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -26,6 +26,7 @@ const SELECTOR = "[data-pane-overlay]";
 
 const tracked = new WeakSet<Element>();
 const observers = new WeakMap<Element, ResizeObserver>();
+const styleObservers = new WeakMap<Element, MutationObserver>();
 const trackedList = new Set<Element>();
 
 let started = false;
@@ -48,6 +49,11 @@ function scheduleSweep(): void {
 
 function updateRect(el: Element): void {
     if (!(el instanceof HTMLElement)) return;
+    const cs = window.getComputedStyle(el);
+    if (cs.visibility === "hidden" || cs.display === "none") {
+        __deleteAutoOverlayRect(el);
+        return;
+    }
     __setAutoOverlayRect(el, __rectFromElement(el));
 }
 
@@ -61,6 +67,9 @@ function track(el: Element): void {
     const ro = new ResizeObserver(() => updateRect(el));
     ro.observe(el);
     observers.set(el, ro);
+    const so = new MutationObserver(() => updateRect(el));
+    so.observe(el, { attributes: true, attributeFilter: ["style", "class"] });
+    styleObservers.set(el, so);
     updateRect(el);
 }
 
@@ -70,6 +79,8 @@ function untrack(el: Element): void {
     trackedList.delete(el);
     observers.get(el)?.disconnect();
     observers.delete(el);
+    styleObservers.get(el)?.disconnect();
+    styleObservers.delete(el);
     __deleteAutoOverlayRect(el);
 }
 

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -1,0 +1,123 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Auto-discovery pane-overlay clipping. See
+// docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md.
+//
+// Strategy: any DOM element that paints over a CEF browser pane HWND
+// tags itself with `data-pane-overlay`. A MutationObserver watches
+// the document for tagged elements appearing / disappearing; each
+// tagged element gets its own ResizeObserver so its rect re-measures
+// when its content changes. Window resize + scroll trigger a sweep.
+// All discovered rects flow into `pane-overlay.ts`'s shared map and
+// dispatch via the existing `browser_panes_set_overlay_clip` IPC.
+//
+// Why an attribute, not a hook: discoverable via grep, hard to
+// forget, one observer + one map for all overlays. Future overlays
+// can't accidentally regress the airspace bug; tag the root div.
+
+import {
+    __deleteAutoOverlayRect,
+    __rectFromElement,
+    __setAutoOverlayRect,
+} from "./pane-overlay";
+
+const SELECTOR = "[data-pane-overlay]";
+
+const tracked = new WeakSet<Element>();
+const observers = new WeakMap<Element, ResizeObserver>();
+const trackedList = new Set<Element>();
+
+let started = false;
+let sweepScheduled = false;
+
+function scheduleSweep(): void {
+    if (sweepScheduled) return;
+    sweepScheduled = true;
+    requestAnimationFrame(() => {
+        sweepScheduled = false;
+        for (const el of trackedList) {
+            if (!document.body.contains(el)) {
+                untrack(el);
+                continue;
+            }
+            updateRect(el);
+        }
+    });
+}
+
+function updateRect(el: Element): void {
+    if (!(el instanceof HTMLElement)) return;
+    __setAutoOverlayRect(el, __rectFromElement(el));
+}
+
+function track(el: Element): void {
+    if (tracked.has(el)) {
+        updateRect(el);
+        return;
+    }
+    tracked.add(el);
+    trackedList.add(el);
+    const ro = new ResizeObserver(() => updateRect(el));
+    ro.observe(el);
+    observers.set(el, ro);
+    updateRect(el);
+}
+
+function untrack(el: Element): void {
+    if (!tracked.has(el)) return;
+    tracked.delete(el);
+    trackedList.delete(el);
+    observers.get(el)?.disconnect();
+    observers.delete(el);
+    __deleteAutoOverlayRect(el);
+}
+
+function trackSubtree(root: Element): void {
+    if (root.matches(SELECTOR)) track(root);
+    for (const el of root.querySelectorAll(SELECTOR)) track(el);
+}
+
+function untrackSubtree(root: Element): void {
+    if (tracked.has(root)) untrack(root);
+    for (const el of root.querySelectorAll(SELECTOR)) untrack(el);
+}
+
+/**
+ * Start the auto-clip service. Call once at app startup after the
+ * DOM is ready. Idempotent — subsequent calls are no-ops.
+ */
+export function startPaneOverlayAutoService(): void {
+    if (started) return;
+    started = true;
+
+    const mo = new MutationObserver((muts) => {
+        for (const m of muts) {
+            if (m.type === "attributes" && m.target instanceof Element) {
+                if (m.target.hasAttribute("data-pane-overlay")) {
+                    track(m.target);
+                } else {
+                    untrack(m.target);
+                }
+                continue;
+            }
+            for (const node of m.addedNodes) {
+                if (node instanceof Element) trackSubtree(node);
+            }
+            for (const node of m.removedNodes) {
+                if (node instanceof Element) untrackSubtree(node);
+            }
+        }
+    });
+    mo.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ["data-pane-overlay"],
+    });
+
+    for (const el of document.querySelectorAll(SELECTOR)) track(el);
+
+    window.addEventListener("resize", scheduleSweep, { passive: true });
+    window.addEventListener("scroll", scheduleSweep, { passive: true, capture: true });
+}

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -27,6 +27,7 @@ const SELECTOR = "[data-pane-overlay]";
 const tracked = new WeakSet<Element>();
 const observers = new WeakMap<Element, ResizeObserver>();
 const styleObservers = new WeakMap<Element, MutationObserver>();
+const transitionListeners = new WeakMap<Element, () => void>();
 const trackedList = new Set<Element>();
 
 let started = false;
@@ -83,6 +84,9 @@ function track(el: Element): void {
     const so = new MutationObserver(() => updateRect(el));
     so.observe(el, { attributes: true, attributeFilter: ["style", "class"] });
     styleObservers.set(el, so);
+    const onTransitionEnd = () => updateRect(el);
+    el.addEventListener("transitionend", onTransitionEnd);
+    transitionListeners.set(el, onTransitionEnd);
     updateRect(el);
 }
 
@@ -94,6 +98,11 @@ function untrack(el: Element): void {
     observers.delete(el);
     styleObservers.get(el)?.disconnect();
     styleObservers.delete(el);
+    const tl = transitionListeners.get(el);
+    if (tl) {
+        el.removeEventListener("transitionend", tl);
+        transitionListeners.delete(el);
+    }
     __deleteAutoOverlayRect(el);
 }
 

--- a/frontend/app/platform/pane-overlay-auto.ts
+++ b/frontend/app/platform/pane-overlay-auto.ts
@@ -47,14 +47,23 @@ function scheduleSweep(): void {
     });
 }
 
-function updateRect(el: Element): void {
-    if (!(el instanceof HTMLElement)) return;
+/**
+ * True when the element is currently visible enough to clip the
+ * browser pane underneath. Exported for unit-testing the visibility
+ * filter independently of the DOM observers.
+ */
+export function isOverlayElementVisible(el: HTMLElement): boolean {
     const cs = window.getComputedStyle(el);
-    if (
+    return !(
         cs.visibility === "hidden" ||
         cs.display === "none" ||
         parseFloat(cs.opacity) === 0
-    ) {
+    );
+}
+
+function updateRect(el: Element): void {
+    if (!(el instanceof HTMLElement)) return;
+    if (!isOverlayElementVisible(el)) {
         __deleteAutoOverlayRect(el);
         return;
     }

--- a/frontend/app/platform/pane-overlay.ts
+++ b/frontend/app/platform/pane-overlay.ts
@@ -28,6 +28,12 @@ interface OverlayRect {
 const overlayRects = new Map<number, OverlayRect>();
 let nextOverlayId = 1;
 
+// Second map for rects discovered automatically by the auto-clip
+// service (pane-overlay-auto.ts), keyed by element ref. Hook callers
+// and auto-discovery feed two maps; sendClip unions them. Existing
+// hook callers do not need to migrate.
+const autoOverlayRects = new Map<Element, OverlayRect>();
+
 /**
  * Window label of the host window this frontend instance belongs to.
  * Set by the CEF launcher on each window's startup URL via `?windowLabel=`.
@@ -45,9 +51,41 @@ function currentWindowLabel(): string {
 }
 
 function sendClip(): void {
-    const rects = Array.from(overlayRects.values());
+    const rects: OverlayRect[] = [];
+    for (const r of overlayRects.values()) rects.push(r);
+    for (const r of autoOverlayRects.values()) {
+        if (r.w > 0 && r.h > 0) rects.push(r);
+    }
     const window_label = currentWindowLabel();
     invokeCommand("browser_panes_set_overlay_clip", { rects, window_label }).catch(() => {});
+}
+
+/**
+ * Auto-discovery hooks for `pane-overlay-auto.ts`. Each function
+ * mutates the shared map and calls `sendClip()`. Returns true if the
+ * map actually changed (so callers can skip redundant dispatches).
+ */
+export function __setAutoOverlayRect(el: Element, rect: OverlayRect): boolean {
+    if (rect.w <= 0 || rect.h <= 0) return __deleteAutoOverlayRect(el);
+    const prev = autoOverlayRects.get(el);
+    if (
+        prev &&
+        prev.x === rect.x && prev.y === rect.y &&
+        prev.w === rect.w && prev.h === rect.h
+    ) return false;
+    autoOverlayRects.set(el, rect);
+    sendClip();
+    return true;
+}
+
+export function __deleteAutoOverlayRect(el: Element): boolean {
+    if (!autoOverlayRects.delete(el)) return false;
+    sendClip();
+    return true;
+}
+
+export function __rectFromElement(el: HTMLElement): OverlayRect {
+    return rectFromElement(el);
 }
 
 function rectFromElement(el: HTMLElement): OverlayRect {

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -206,6 +206,7 @@ function showJsContextMenu(
                 row.appendChild(arrow);
 
                 const sub = document.createElement("div");
+                sub.setAttribute("data-pane-overlay", "");
                 Object.assign(sub.style, {
                     display: "none", position: "absolute",
                     left: "100%", top: "0", zIndex: "100000",

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -140,6 +140,7 @@ function showJsContextMenu(
     });
 
     const menuEl = document.createElement("div");
+    menuEl.setAttribute("data-pane-overlay", "");
     Object.assign(menuEl.style, {
         position: "absolute",
         left: `${position.x}px`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.772",
+  "version": "0.33.773",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.772",
+      "version": "0.33.773",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.774",
+  "version": "0.33.775",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.774",
+      "version": "0.33.775",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.771",
+  "version": "0.33.772",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.771",
+      "version": "0.33.772",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.777",
+  "version": "0.33.778",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.777",
+      "version": "0.33.778",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.773",
+  "version": "0.33.774",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.773",
+      "version": "0.33.774",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.770",
+  "version": "0.33.771",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.770",
+      "version": "0.33.771",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.773",
+  "version": "0.33.774",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.771",
+  "version": "0.33.772",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.774",
+  "version": "0.33.775",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.770",
+  "version": "0.33.771",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.772",
+  "version": "0.33.773",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.777",
+  "version": "0.33.778",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the recurring class of "DOM menu paints under native browser pane" bugs on Windows. Any DOM element tagged with `data-pane-overlay` is auto-discovered by a singleton MutationObserver + per-element ResizeObserver service. The service measures each tagged element's screen rect and feeds it into the same overlay-rect map that `usePaneOverlay()` uses, dispatching the existing `browser_panes_set_overlay_clip` IPC. The host already handles the clipping via `SetWindowRgn(hwnd, RGN_DIFF, ...)`. **No new host API; no migration forced on existing modal callers.**

## What changes

- `frontend/app/platform/pane-overlay.ts` keeps a second `Map<Element, OverlayRect>` for auto-discovered overlays, unioned into the existing rect set in `sendClip()`. Existing `usePaneOverlay()` hook callers are unchanged.
- `frontend/app/platform/pane-overlay-auto.ts` (new) is the auto-discovery service. Watches `document.body` for `[data-pane-overlay]` add/remove, attaches a per-element `ResizeObserver`, sweeps on window resize/scroll. RAF-coalesced.
- `frontend/app-init.ts` starts the service after the SolidJS render.
- `data-pane-overlay` added to:
  - FlyoutMenu main menu Portal div
  - FlyoutMenu sub-menu Portal div
  - `cef-api.ts` JS context menu (the `#cef-context-menu-overlay`'s inner menu element)
  - Tooltip Portal div
  - Popover Portal div

Modal callers (modal-v2, TabModalLayer, action-widgets, etc.) already call `usePaneOverlay()` and continue to work via the existing hook path. They could migrate to the attribute later, but no behavior change here.

## Why an attribute, not a hook?

- Discoverable via `grep data-pane-overlay`
- Hard to forget when adding new overlays — a code reader sees the attribute and knows immediately
- Centralized lifecycle (one observer, one map) vs. N hook calls + N cleanups
- Composes with existing `usePaneOverlay()` — both feed the same sendClip path

## Spec

Detailed design at `docs/specs/SPEC_PANE_OVERLAY_AUTO_CLIP_2026_05_11.md` (currently on PR #792's branch; once #792 merges, the spec is on main).

## Test plan

- [ ] Hover the hamburger ≡ over a browser pane — menu fully covers, no leak-through
- [ ] Open Theme submenu over a browser pane — both clipped
- [ ] Right-click empty tab-bar space over a browser pane — context menu clipped
- [ ] Tooltip near a browser pane — clipped
- [ ] Resize window with a menu open — clipping follows
- [ ] Existing modal regression: modal-v2 still works (uses `usePaneOverlay()` hook path)

## Stacking note

Based on `main` (will rebase onto #792 once that merges). Touches FlyoutMenu in a different region than #792 (just adds `data-pane-overlay` attribute), so the rebase conflict surface is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)