### PR TITLE
fix(menu): submenu z-order above main menu + reset state on close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.778"
+version = "0.33.779"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.778"
+version = "0.33.779"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.778"
+version = "0.33.779"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.778"
+version = "0.33.779"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.779"
+version = "0.33.780"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.779"
+version = "0.33.780"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.779"
+version = "0.33.780"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.779"
+version = "0.33.780"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.778"
+version = "0.33.779"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.779"
+version = "0.33.780"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.779"
+version = "0.33.780"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.778"
+version = "0.33.779"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.779"
+version = "0.33.780"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.778"
+version = "0.33.779"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.778"
+version = "0.33.779"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.779"
+version = "0.33.780"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -26,7 +26,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const [visibleSubMenus, setVisibleSubMenus] = createSignal<{ [key: string]: any }>({});
     const [hoveredItems, setHoveredItems] = createSignal<string[]>([]);
     const [subMenuPosition, setSubMenuPosition] = createSignal<{
-        [key: string]: { top: number; left: number; parentLeft: number; label: string };
+        [key: string]: { bottom: number; left: number; parentLeft: number; parentTop: number; label: string };
     }>({});
 
     const [isOpen, setIsOpen] = createSignal(false);
@@ -37,6 +37,11 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     let cleanupAutoUpdate: (() => void) | null = null;
 
     const onOpenChangeMenu = (open: boolean) => {
+        if (!open) {
+            setVisibleSubMenus({});
+            setHoveredItems([]);
+            setSubMenuPosition({});
+        }
         setIsOpen(open);
         props.onOpenChange?.(open);
     };
@@ -79,10 +84,11 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-        const top = itemRect.top - 2 + scrollTop;
+        const bottom = window.innerHeight + scrollTop - itemRect.bottom - 2;
         const left = itemRect.right + scrollLeft - 2;
         const parentLeft = itemRect.left + scrollLeft;
-        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, parentLeft, label } }));
+        const parentTop = itemRect.top + scrollTop;
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { bottom, left, parentLeft, parentTop, label } }));
     };
 
     const handleMouseEnterItem = (
@@ -228,7 +234,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 };
 
 type SubMenuPositionMap = {
-    [key: string]: { top: number; left: number; parentLeft: number; label: string };
+    [key: string]: { bottom: number; left: number; parentLeft: number; parentTop: number; label: string };
 };
 
 type SubMenuProps = {
@@ -261,8 +267,8 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
         if (!pos || flipped || !subMenuEl) return;
         const rect = subMenuEl.getBoundingClientRect();
         const overflowRight = rect.right - window.innerWidth;
-        const overflowBottom = rect.bottom - window.innerHeight;
-        if (overflowRight <= 0 && overflowBottom <= 0) {
+        const overflowTop = -rect.top;
+        if (overflowRight <= 0 && overflowTop <= 0) {
             flipped = true;
             return;
         }
@@ -272,10 +278,11 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             [props.parentKey]: {
                 label: pos.label,
                 parentLeft: pos.parentLeft,
+                parentTop: pos.parentTop,
                 left: overflowRight > 0 ? pos.parentLeft - rect.width + 2 : pos.left,
-                top: overflowBottom > 0
-                    ? window.innerHeight - rect.height - 10 + window.scrollY
-                    : pos.top,
+                bottom: overflowTop > 0
+                    ? window.innerHeight + window.scrollY - pos.parentTop - rect.height + 2
+                    : pos.bottom,
             },
         }));
     });
@@ -285,7 +292,7 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             ref={(el) => { subMenuEl = el; }}
             class="menu sub-menu"
             style={{
-                top: `${position()?.top ?? 0}px`,
+                bottom: `${position()?.bottom ?? 0}px`,
                 left: `${position()?.left ?? 0}px`,
                 position: "absolute",
                 "z-index": 1000,

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -26,7 +26,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const [visibleSubMenus, setVisibleSubMenus] = createSignal<{ [key: string]: any }>({});
     const [hoveredItems, setHoveredItems] = createSignal<string[]>([]);
     const [subMenuPosition, setSubMenuPosition] = createSignal<{
-        [key: string]: { bottom: number; left: number; parentLeft: number; parentTop: number; label: string };
+        [key: string]: { top: number; left: number; parentLeft: number; label: string };
     }>({});
 
     const [isOpen, setIsOpen] = createSignal(false);
@@ -84,11 +84,10 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-        const bottom = window.innerHeight + scrollTop - itemRect.bottom - 2;
+        const top = itemRect.top - 2 + scrollTop;
         const left = itemRect.right + scrollLeft - 2;
         const parentLeft = itemRect.left + scrollLeft;
-        const parentTop = itemRect.top + scrollTop;
-        setSubMenuPosition((prev) => ({ ...prev, [key]: { bottom, left, parentLeft, parentTop, label } }));
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, parentLeft, label } }));
     };
 
     const handleMouseEnterItem = (
@@ -234,7 +233,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 };
 
 type SubMenuPositionMap = {
-    [key: string]: { bottom: number; left: number; parentLeft: number; parentTop: number; label: string };
+    [key: string]: { top: number; left: number; parentLeft: number; label: string };
 };
 
 type SubMenuProps = {
@@ -267,8 +266,8 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
         if (!pos || flipped || !subMenuEl) return;
         const rect = subMenuEl.getBoundingClientRect();
         const overflowRight = rect.right - window.innerWidth;
-        const overflowTop = -rect.top;
-        if (overflowRight <= 0 && overflowTop <= 0) {
+        const overflowBottom = rect.bottom - window.innerHeight;
+        if (overflowRight <= 0 && overflowBottom <= 0) {
             flipped = true;
             return;
         }
@@ -278,11 +277,10 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             [props.parentKey]: {
                 label: pos.label,
                 parentLeft: pos.parentLeft,
-                parentTop: pos.parentTop,
                 left: overflowRight > 0 ? pos.parentLeft - rect.width + 2 : pos.left,
-                bottom: overflowTop > 0
-                    ? window.innerHeight + window.scrollY - pos.parentTop - rect.height + 2
-                    : pos.bottom,
+                top: overflowBottom > 0
+                    ? window.innerHeight - rect.height - 10 + window.scrollY
+                    : pos.top,
             },
         }));
     });
@@ -292,10 +290,9 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
             ref={(el) => { subMenuEl = el; }}
             class="menu sub-menu"
             style={{
-                bottom: `${position()?.bottom ?? 0}px`,
+                top: `${position()?.top ?? 0}px`,
                 left: `${position()?.left ?? 0}px`,
                 position: "absolute",
-                "z-index": 1000,
             }}
             data-pane-overlay
         >

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.779",
+  "version": "0.33.780",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.779",
+      "version": "0.33.780",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.778",
+  "version": "0.33.779",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.778",
+      "version": "0.33.779",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.779",
+  "version": "0.33.780",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.778",
+  "version": "0.33.779",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Two UX fixes on the hamburger menu.

### 1. Submenu z-order

The submenu div had an inline `z-index: 1000` that overrode the `.menu` class's `--z-flyout-menu: 9500` (`theme.scss:279`). So submenus painted ~8500 layers **below** the main menu (which DID read 9500). Anything stacked between 1000 and 9500 (other UI, browser-pane overlays, etc.) covered the submenu — and the 2px overlap at the submenu's left edge always hid behind the main menu's right edge.

Removed the inline override. Submenu inherits the `.menu` z-index of 9500, matching the main menu. Source order then resolves stacking among same-z Portals; the submenu Portal mounts after the main menu, so it paints on top of the overlap region.

Vertical placement is **unchanged** (submenu's top aligns with parent's top, extending down to the right). The earlier draft of this PR tried changing the vertical direction — that was a misread of the request and was reverted.

### 2. Reset submenu state on close

`onOpenChangeMenu(false)` now clears `visibleSubMenus`, `hoveredItems`, and `subMenuPosition`. Previously these maps persisted, so a user who hovered Theme → clicked away → reopened the hamburger would see both the main menu AND the Theme submenu re-mount with stale state. Now reopen shows only the main menu.

## Test plan

- [ ] Open hamburger → hover Theme → submenu opens to the right with NO visual gap or occlusion at the left edge (the 2px overlap area)
- [ ] Move cursor across the overlap → no flicker, submenu fully visible
- [ ] Open hamburger → hover Theme → click outside → click hamburger again → only main menu opens (no stale Theme submenu)
- [ ] Same flow with Opacity

🤖 Generated with [Claude Code](https://claude.com/claude-code)