### PR TITLE
fix(tab): tag tab right-click context panel with data-pane-overlay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.780"
+version = "0.33.781"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.780"
+version = "0.33.781"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.780"
+version = "0.33.781"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.780"
+version = "0.33.781"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.780"
+version = "0.33.781"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.780"
+version = "0.33.781"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.780"
+version = "0.33.781"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.780"
+version = "0.33.781"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/tab/tab.tsx
+++ b/frontend/app/tab/tab.tsx
@@ -66,7 +66,7 @@ const TabContextPanel = (props: TabContextPanelProps): JSX.Element => {
 
     return (
         <Portal>
-            <div ref={panelRef!} class="tab-context-panel" style={style()}>
+            <div ref={panelRef!} class="tab-context-panel" style={style()} data-pane-overlay>
                 <div class="tab-context-colors">
                     <For each={TAB_COLORS}>
                         {({ name, hex }) => (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.780",
+  "version": "0.33.781",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.780",
+      "version": "0.33.781",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.780",
+  "version": "0.33.781",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The tab right-click menu (color picker / Rename / Close — rendered by `TabContextPanel` in `frontend/app/tab/tab.tsx`) renders to a Portal but wasn't tagged with `data-pane-overlay`. So on Windows it appeared behind native browser pane HWNDs — the same airspace bug that #793 closed for FlyoutMenu, tooltips, popovers, and the JS context menu overlay.

One-line fix: add `data-pane-overlay` to the panel's root div. The auto-clip service handles the rest.

## Test plan

- [ ] Open a browser pane in any tab
- [ ] Right-click a tab whose visual position overlaps the browser pane area
- [ ] Confirm the color picker / Rename / Close panel renders ON TOP of the browser pane content (not behind)
- [ ] Click outside to dismiss → no leftover clip on the pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)