### PR TITLE
feat(linux): enable CEF Wayland window transparency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.786"
+version = "0.33.787"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.786"
+version = "0.33.787"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.786"
+version = "0.33.787"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.786"
+version = "0.33.787"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.791"
+version = "0.33.792"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.791"
+version = "0.33.792"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.791"
+version = "0.33.792"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.791"
+version = "0.33.792"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.787"
+version = "0.33.788"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.787"
+version = "0.33.788"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.787"
+version = "0.33.788"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.787"
+version = "0.33.788"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.788"
+version = "0.33.789"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.788"
+version = "0.33.789"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.788"
+version = "0.33.789"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.788"
+version = "0.33.789"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.790"
+version = "0.33.791"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.788"
+version = "0.33.789"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.787"
+version = "0.33.788"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.786"
+version = "0.33.787"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.789"
+version = "0.33.790"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.791"
+version = "0.33.792"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -370,6 +370,17 @@ wrap_app! {
                 let bg_val = CefString::from("00000000");
                 cmd.append_switch_with_value(Some(&bg_key), Some(&bg_val));
 
+                // Disable LCD text rendering — LCD subpixel anti-aliasing
+                // requires opaque backgrounds, so Chromium force-sets
+                // contents_opaque=true on every compositor layer that contains
+                // LCD-rendered text. With opaque layers, even CSS alpha<1
+                // backgrounds get rasterized as fully opaque, defeating the
+                // whole transparency cascade. Grayscale text AA on a
+                // translucent UI is the standard tradeoff for window
+                // transparency.
+                let lcd_key = CefString::from("disable-lcd-text");
+                cmd.append_switch(Some(&lcd_key));
+
                 // Allow the DevTools inspector page (served from the remote
                 // debugging server) to open its own WebSocket connection back
                 // to that same server.  Without this flag Chromium 107+ blocks

--- a/agentmux-cef/src/app.rs
+++ b/agentmux-cef/src/app.rs
@@ -356,9 +356,18 @@ wrap_app! {
                 let val = CefString::from("CalculateNativeWinOcclusion");
                 cmd.append_switch_with_value(Some(&key), Some(&val));
 
-                // Set initial background color via CLI.
+                // Initial background color, ARGB hex. alpha=00 → fully
+                // transparent → first-frame paint is alpha-aware so the
+                // CSS body background's rgba() composes with the desktop
+                // wallpaper. ff222222 here would clobber the alpha=0 we set
+                // via CefSettings.background_color in main.rs and force the
+                // first frame opaque (visible as a brief flash even after
+                // the renderer flips to ARGB on the first commit).
+                // Pair with: main.rs CefSettings.background_color = 0,
+                // app.rs BrowserSettings.background_color = 0, and the
+                // is_frameless main window delegate.
                 let bg_key = CefString::from("background-color");
-                let bg_val = CefString::from("ff222222");
+                let bg_val = CefString::from("00000000");
                 cmd.append_switch_with_value(Some(&bg_key), Some(&bg_val));
 
                 // Allow the DevTools inspector page (served from the remote
@@ -427,9 +436,13 @@ wrap_browser_process_handler! {
             // Browser settings.
             let settings = BrowserSettings {
                 windowless_frame_rate: 60,
-                // Dark background to match app theme — prevents white bleed-through
-                // when terminal panes use transparency.
-                background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
+                // ARGB: alpha=0 → SK_AlphaTRANSPARENT → enables Views-framework
+                // transparency in the patched libcef.so. Pair with the
+                // CefSettings::background_color flip in main.rs and the
+                // is_frameless=true main window delegate. See
+                // docs/research/cef-transparency-research-2026-05-10.md and
+                // docs/retros/cef-transparency-empirical-2026-05-11.md.
+                background_color: 0x00000000,
                 ..Default::default()
             };
 

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -464,7 +464,15 @@ fn main() {
 
     let settings = Settings {
         no_sandbox: 1,
-        background_color: 0xFF000000, // ARGB: opaque black (matches pre-transparency-experiment baseline)
+        // ARGB: alpha=0 → SK_AlphaTRANSPARENT → triggers the transparency
+        // cascade in the patched libcef.so (see cef commits b921ffe18 +
+        // 68e0dc668). The CSS layer's rgba(_,_,_,<1) body bg then composites
+        // with the desktop instead of being clamped to opaque white.
+        // Pair: BrowserSettings.background_color must also be 0 (app.rs).
+        // Pair: WindowDelegate must return is_frameless=true (already does
+        // for the main window).
+        // Spec: docs/research/cef-transparency-research-2026-05-10.md.
+        background_color: 0x00000000,
         remote_debugging_port: debug_port as i32,
         root_cache_path: cache_dir,
         resources_dir_path: resources_dir,

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.791"
+version = "0.33.792"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.788"
+version = "0.33.789"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.787"
+version = "0.33.788"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.790"
+version = "0.33.791"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.786"
+version = "0.33.787"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.789"
+version = "0.33.790"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.786"
+version = "0.33.787"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.788"
+version = "0.33.789"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.787"
+version = "0.33.788"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.789"
+version = "0.33.790"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.791"
+version = "0.33.792"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.790"
+version = "0.33.791"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.790"
+version = "0.33.791"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.789"
+version = "0.33.790"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.786"
+version = "0.33.787"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.791"
+version = "0.33.792"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.788"
+version = "0.33.789"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.787"
+version = "0.33.788"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/research/cef-transparency-research-2026-05-10.md
+++ b/docs/research/cef-transparency-research-2026-05-10.md
@@ -1,0 +1,167 @@
+# CEF Wayland transparency — consolidated research + plan
+
+**Date:** 2026-05-10
+**Status:** Research consolidated; implementation not started.
+**Driving question:** Make the AgentMux main window transparent on Linux/Wayland so the CSS layer's `rgba(_,_,_,0.5)` body background composites with the desktop instead of clamping to opaque black.
+**Origin:** Six weeks of intermittent work scattered across specs, retros, archive handoffs, and one local CEF source build. This doc reconciles what's confirmed vs. what's folklore vs. what's untried.
+
+---
+
+## TL;DR
+
+CSS-side transparency works. Patched `libcef.so` exists, claims to include Chad Nelson's `SetBackgroundOpaque(false)` plumbing, and now ships in the AppImage via PR #743. The IPC handler `set_window_transparency` is wired through to the host on every platform — but the **Linux branch of the handler is a literal no-op**. One unverified gap stands between "doesn't work" and "might just work."
+
+---
+
+## What's confirmed working today
+
+### CSS layer (pure frontend, no IPC)
+
+- `xterm` theme background set to `#00000000` (`frontend/util/termutil.ts`).
+- Block container background set to a semi-transparent theme color (e.g., `#1e1e1e80`) via the `blockBg` memo in `termViewModel.ts`.
+- AppBackground div renders the tab wallpaper / gradient over an alpha-aware base.
+- Body background sits at `rgba(34,34,34, var(--window-opacity))`. With `--window-opacity` unset, that resolves opaque; with it set, partially transparent.
+
+### Windows transparency end-to-end
+
+- `agentmux-cef/src/commands/window.rs::set_window_transparency` iterates `state.browsers`, finds each top-level HWND via `GetAncestor(GA_ROOT)`, applies `WS_EX_LAYERED` + `SetLayeredWindowAttributes` for alpha, applies `DwmSetWindowAttribute` for Mica/Acrylic backdrop. Both apply and remove paths exist.
+
+### CEF build artifacts on disk
+
+- `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so`, ~613 MB stripped, BuildID `b22aa49bc6b17bfa`. Built 2026-05-01.
+- Source fork: `github.com/a5af/cef`, branch `agentmux/7680-drag-rightclick-and-transparency`, HEAD `5ab41b6`.
+- Two patches on top of upstream CEF 7680:
+  1. `CefWindow::BeginWindowDrag()` — **verified working in production** (PR #663, drag retro).
+  2. Transparency broadening (claimed to bring Chad Nelson's `SetBackgroundOpaque(false)` IPC support into views-hosted browsers) — **not exercised yet**.
+
+### Distribution
+
+- PR #743's `scripts/resolve-cef-runtime.sh` finds the patched libcef.so and ships it inside the AppImage. As of 0.33.761 the AppImage on Desktop carries the patched binary.
+
+---
+
+## What's confirmed NOT working
+
+- Linux/Wayland window transparency: the CEF window paints opaque ~black (`0xFF222222` from our `--background-color=ff222222` switch in `app.rs::on_before_command_line_processing`) regardless of CSS layer alpha. The desktop is never visible through the window.
+- The Linux branch of `set_window_transparency` is literally:
+  ```rust
+  #[cfg(not(target_os = "windows"))]
+  let _ = (transparent, opacity);
+  ```
+  It accepts the IPC and discards both arguments.
+
+### Why (per the 35-day-old root-cause memory; not freshly verified)
+
+The renderer's `cc::LayerTreeHost` defaults to `has_transparent_background = false`. With that flag false, the compositor clamps all per-pixel alpha to 1.0 in the final Wayland surface buffer. Reaching `has_transparent_background = true` requires the IPC chain `Browser::SetBackgroundColor(0) → RenderWidgetHostViewBase::SetBackgroundColor(0) → SetBackgroundOpaque(false)`.
+
+The 35-day-old memory cites CEF PR #4086 (unmerged upstream) as the patch that adds this. The local fork's transparency commit claims to be the same plumbing rebased onto 7680, but **the call from AgentMux to trigger the renderer-side change is never issued**.
+
+---
+
+## Tried and failed (with reason, sourced from the docs)
+
+| What was tried | Outcome | Why it failed |
+|----------------|---------|---------------|
+| CSS-only transparency on CEF (no window-level changes) | Showed AgentMux's dark body bg, not the desktop | CEF Views window background is hardcoded opaque before any CSS paints |
+| Widget-layer opacity patches (`kOpaque → kTranslucent`) | Cited as ✓ in the root-cause memory | Necessary but not sufficient — Views surface format change without renderer alpha is invisible |
+| LD_PRELOAD shim to NULL the opaque region passed to Wayland | Cited as ✓ in the root-cause memory | Necessary but not sufficient — same reason; renderer still emits RGB |
+| Verifying renderer CAN emit alpha via CDP screenshot | ✓ | Proves the renderer is *capable*; doesn't make the surface ARGB |
+| Building patched `libcef.so` from `a5af/cef` `agentmux/7680-...` (2026-05-01) | ✓ Built (`5ab41b6`) | Build succeeded; **no integration test from AgentMux side** |
+| Bundling the patched libcef in the AppImage (PR #743, 2026-05-08) | ✓ Shipping | Resolver picks it up, AppImage contains it; **still no integration test** |
+| `windowless_rendering_enabled` (off-screen rendering) | Not attempted | Documented (`cef-transparency-architecture.md` Option C) as a complete architectural rewrite. Out of scope. |
+| `wl_subsurface` embedding (upstream CEF #2804) | Not attempted | Not implemented upstream; even if implemented, lacks Hide/Show/SetBounds (`cef-pane-research-2026-05-03.md`) |
+
+---
+
+## The single unverified gap
+
+We don't actually know:
+1. Whether the transparency commit on `agentmux/7680-...` is *exactly* Chad Nelson's PR #4086, *rebased and adjusted* for 7680, or something else entirely.
+2. Whether the patched libcef.so exposes a stable C API for AgentMux to call (e.g., a new `cef_browser_host_t` method, or just a `CefBrowserSettings::background_color` field that takes alpha values).
+3. Whether `Browser::SetBackgroundColor(0)` via the existing cef-dll-sys bindings actually reaches the renderer (the bindings were not regenerated for the patched libcef — same situation as `BeginWindowDrag` before its raw-FFI override).
+
+Until (1)–(3) are answered, every minute spent designing the AgentMux-side wiring is gambling.
+
+---
+
+## Proposed plan (in order, each step has its own pass/fail)
+
+### Step 1 — Read the patch
+
+**Action:** Read the actual transparency commit in `~/cef-build/chromium_git/cef/` (and the mirrored copy at `chromium_git/chromium/src/cef/` if they've drifted). Identify:
+- Which CEF API surface it adds (new method? new setting field? new feature flag?).
+- Whether the C-side header `include/capi/...` has a new entry (cef-dll-sys would expose it) or if it's renderer-internal only (we'd need a different trigger).
+- Whether there's a CLI switch / `--enable-features=...` toggle required at startup.
+
+**Pass:** Single concrete API name + call site identified.
+**Fail:** Patch is incomplete or doesn't expose a public surface → block on rebuilding libcef with the proper PR #4086.
+**Time budget:** 30 min.
+
+### Step 2 — Verify the API is callable from AgentMux
+
+**Action:** Check whether the identified API is in cef-dll-sys's generated bindings. If yes, use directly. If no, follow the `BeginWindowDrag` precedent: raw FFI override + a one-file patch to cef-dll-sys (see memory `agentmux_drag_fix.md`).
+
+**Pass:** A Rust call site compiles and links against the patched libcef.so.
+**Fail:** Bindings are missing AND can't be raw-FFI'd (e.g., the API is C++-only). → block on a different transparency approach.
+**Time budget:** 30 min.
+
+### Step 3 — Wire the Linux branch of `set_window_transparency`
+
+**Action:** Replace the no-op in `agentmux-cef/src/commands/window.rs` with:
+- Iterate `state.browsers` (mirror Windows path).
+- For the main browser(s), post a UI-thread task that calls the API identified in Step 1.
+- For `transparent = false`, call the inverse (set background to the default opaque dark).
+
+**Pass:** Code compiles. IPC fires when the user toggles transparency in settings. The host log shows the API call landing on the UI thread.
+**Fail:** Compile error (Step 2 wrong) or no IPC fires (Step 1 wrong).
+**Time budget:** 1 hour.
+
+### Step 4 — Test end-to-end
+
+**Action:** Run the AppImage. Enable transparency in settings. Look at the screen.
+
+**Pass:** Desktop visible through the AgentMux window. CSS alpha layers actually composite with the desktop wallpaper.
+**Fail (case A — opaque):** Renderer didn't switch to ARGB. Capture the Wayland surface buffer (`weston-screenshot`, `wlrctl`, or compositor-debug) to confirm format. Likely cause: patched libcef.so doesn't actually plumb the IPC; rebuild with a known-good PR #4086 application.
+**Fail (case B — black/white flash):** Views layer paints opaque before renderer takes over. Documented in `cef-white-flash-on-startup.md`; needs an additional widget-layer patch (`kOpaque → kTranslucent` on the root NonClientView).
+**Time budget:** 30 min for the happy path, multi-hour debug if it fails.
+
+### Step 5 — Retro / spec
+
+**Action:** Write a retro doc capturing what worked, what didn't, what additional CEF patches were needed, and the verified API surface. Replace the 35-day-old memory entry.
+
+---
+
+## Risks and known gotchas
+
+- **`tools/patcher.py` is NOT idempotent** (memory: `cef_build_in_progress.md`). If we need to amend the transparency patch, always `git reset --hard HEAD && find . -name '*.rej' -delete` first.
+- **CEF rebuild cost:** 3–6 hours wall-clock on a 32-core box if we have to amend the transparency patch.
+- **OOM avoidance:** `ninja -j 12 -l 16` under `systemd-run --user --scope` (memory: `cef_build_in_progress.md`). Default `-j` cascades into reboots.
+- **DWM equivalent on Wayland:** there is no Wayland-side "Mica / Acrylic" effect. The closest is a compositor-side blur (KWin / Hyprland) requested via `--enable-features=WaylandBlur` or similar; we'd be at the mercy of each compositor. Mutter (GNOME) does not implement client-requested blur.
+- **The cefclient sample app's transparency demo was disabled in our rebase** (memory: `cef_build_in_progress.md` — `use_transparent_painting` flag in `main_context_impl.cc`). If we want a smoke test that ISN'T AgentMux, we have to re-enable that flag in a follow-up commit on the fork.
+- **`--background-color=ff222222`** is set unconditionally in `agentmux-cef/src/app.rs::on_before_command_line_processing`. If the renderer reads this *before* the IPC-driven alpha switch fires, it may paint opaque dark on first frame regardless. Likely needs to change to `00000000` when transparency is enabled — or be removed and let CSS dictate.
+
+---
+
+## Files cited (verify before quoting)
+
+- `agentmux-cef/src/commands/window.rs` — `set_window_transparency` handler (Linux no-op currently).
+- `agentmux-cef/src/app.rs` — `on_before_command_line_processing` (where `--background-color=ff222222` is set).
+- `frontend/app/app.tsx::AppSettingsUpdater` — sends the IPC.
+- `frontend/util/cef-api.ts` — IPC wrapper.
+- `scripts/resolve-cef-runtime.sh` — selects the patched libcef.so for bundling.
+- `docs/cef-build/build-patched-libcef.md` — how to rebuild if Step 1 reveals a missing piece.
+- `docs/specs/cef-transparency-architecture.md` — 2026-03-29 Tauri-era spec; useful for the CSS-layer diagram but most "current state" claims are stale.
+- `docs/analysis/opacity-inconsistency.md` — Windows-side fix already shipped; not directly relevant to Wayland.
+- `docs/research/cef-pane-research-2026-05-03.md` — cites the Wayland subsurface limitations.
+- Memory `cef_transparency_root_cause.md` (35 days old) — IPC chain documented; not re-verified against current libcef.so.
+- Memory `cef_build_in_progress.md` (9 days old) — build infrastructure + gotchas; libcef.so location + branch verified.
+
+---
+
+## Open questions to resolve before any AgentMux-side code changes
+
+1. **What API does the patched libcef.so expose?** Step 1 above.
+2. **Is the CLI switch `--background-color=ff222222` going to fight us?** Need to read the call order in libcef; possibly route the value through the IPC too so transparency=on switches it to `0x00000000`.
+3. **Does the patch require a feature flag?** Read the patch's `--enable-features=` annotations if any.
+4. **What's the cefclient demo's status post-rebase?** Per memory, the demo flag was dropped during the rebase fixup; re-enabling it gives us a smoke test that's not AgentMux.
+5. **Compositor-side considerations:** Mutter vs. KWin vs. Hyprland may differ in how they handle ARGB surfaces. The user's machine is Mutter. Document the spectrum, scope to Mutter for the initial validation.

--- a/docs/retros/cef-transparency-empirical-2026-05-11.md
+++ b/docs/retros/cef-transparency-empirical-2026-05-11.md
@@ -1,0 +1,291 @@
+# CEF Wayland transparency — empirical test results
+
+**Date:** 2026-05-11 00:01 PDT (updated 05:30 PDT — patch committed + rebuild in flight)
+**Status:** Root cause identified, CEF source patch committed as `68e0dc668` ("views: complete the transparency cascade — propagate to WebContents") on the `agentmux/7680-drag-rightclick-and-transparency` branch. libcef.so rebuild in progress. AgentMux side flipped from `0xFF000000` → `0x00000000` at all three sites (CefSettings.background_color in main.rs, BrowserSettings.background_color in app.rs, `--background-color` CLI switch in app.rs).
+**Related:** [`docs/research/cef-transparency-research-2026-05-10.md`](../research/cef-transparency-research-2026-05-10.md).
+
+---
+
+## What we did
+
+End-to-end smoke test of the patched libcef.so transparency support, with the canonical CEF test apps (`cefsimple`, `cefclient`) and the test page (`transparent_views.html`) that the Chad Nelson patch shipped with. The goal: verify the source build works at the libcef level *before* wiring AgentMux.
+
+Screenshots collected at `/tmp/transparency-test/cef{client,simple}-*.png`.
+
+---
+
+## What we verified is correct
+
+### Source build
+
+- Working tree: `~/cef-build/chromium_git/cef`, branch `agentmux/7680-drag-rightclick-and-transparency`, HEAD `d13654696`. All 6 fork commits applied (drag×4, transparency×1, right-click×1).
+- Mirror tree under `chromium/src/cef/` — git HEAD is stale (`053d0a3cc`) but the rsync pipeline means the **working files are current**. Verified by diff'ing key transparency files between fork and mirror: identical.
+- libcef.so on disk: 642MB, built May 2 07:38 from the current mirror.
+
+### Patch presence in the binary
+
+`strings libcef.so | grep -E 'is_transparent|SetBackgroundOpaque'` finds:
+
+- `is_transparent` (the renamed parameter from `b921ffe18`'s context.cc change)
+- `RenderViewHostImpl::SetBackgroundOpaque`
+- `WebFrameWidgetImpl::SetBackgroundOpaque`
+- `FrameWidgetProxy::SetBackgroundOpaque`
+- `blink::mojom::FrameWidget::SetBackgroundOpaque_Sym` + the full Mojo IPC machinery
+
+The renderer-side IPC chain (`SetBackgroundColor → SetBackgroundOpaque → cc::LayerTreeHost.has_transparent_background = true`) **is present** in libcef.so.
+
+### Triggering path works at the CEF level
+
+`cefsimple --no-sandbox --hide-frame --url=...transparent_views.html`:
+
+- **Window is frameless** (no GNOME titlebar) → `IsFrameless()` is being honored at CefWindowDelegate level.
+- The inner 600×400 rounded div renders correctly with `opacity:0.8` translucency (lighter grey than fully opaque). CSS-layer alpha works inside the page.
+- `CefSettings::background_color` defaults to 0 (uninitialized zero-struct → alpha=0). Per the patched `CefContext::GetBackgroundColor`, this means `is_translucent = true` at Views Widget creation time, `params.opacity = kTranslucent`, `GetCefWindow()->SetBackgroundColor(SK_ColorTRANSPARENT)`.
+
+In short: **every CEF-side step works.**
+
+### cefclient adds an extra flag layer
+
+`cefclient --use-views --hide-frame --transparent-painting-enabled --background-color=00000000`:
+
+- Same outcome as cefsimple.
+- `--transparent-painting-enabled` keeps `browser_background_color_` at 0, which means `MainContextImpl::PopulateSettings` doesn't override `settings->background_color` away from its zero-default.
+- The "Using Chrome style; Views-hosted window; Windowed rendering" log line confirms the mode is correct.
+
+---
+
+## What we verified does NOT work — and why
+
+**The Wayland surface is still opaque** in all four test screenshots, despite every CEF-side step succeeding. The CSS-layer alpha inside the window renders, but the window background outside the rounded div is opaque white.
+
+### The actual blocker — Chromium-Wayland integration
+
+The cefclient + cefsimple logs both show the same sequence of `Not implemented reached` errors followed by GPU compositing failure:
+
+```
+ERROR:ui/ozone/platform/wayland/host/wayland_seat.cc:91]
+  Not implemented reached in WaylandSeat::OnName
+
+ERROR:ui/ozone/platform/wayland/host/wayland_zwp_linux_dmabuf.cc:395]
+  Not implemented reached in WaylandZwpLinuxDmabuf::OnTrancheFlags
+
+ERROR:ui/ozone/platform/wayland/host/wayland_screen.cc:461]
+  Not implemented reached in WaylandScreen::IsScreenSaverActive
+
+ERROR:ui/ozone/platform/wayland/host/xdg_toplevel.cc:282]
+  Not implemented reached in XdgToplevel::OnConfigureBounds
+
+ERROR:ui/ozone/platform/wayland/host/xdg_toplevel.cc:289]
+  Not implemented reached in XdgToplevel::OnWmCapabilities
+
+ERROR:media/gpu/vaapi/vaapi_wrapper.cc:1640]
+  vaInitialize failed: unknown libva error
+
+ERROR:gpu/ipc/client/command_buffer_proxy_impl.cc:285]
+  ContextResult::kTransientFailure: Failed to send GpuControl.CreateCommandBuffer
+
+ERROR:services/viz/public/cpp/gpu/context_provider_command_buffer.cc:268]
+  GpuChannelHost failed to create command buffer
+```
+
+The chain (best interpretation):
+
+1. Mutter on this VM advertises Wayland protocol features (`zwp_linux_dmabuf_feedback_v1::tranche_flags`, `xdg_wm_base::wm_capabilities`, etc.) that Chromium 146.0.7680's Ozone-Wayland implementation doesn't handle.
+2. Chromium logs the "Not implemented reached" diagnostics and falls back to a degraded path.
+3. dmabuf import / GPU buffer sharing breaks → GPU context creation fails (`Failed to send GpuControl.CreateCommandBuffer`).
+4. With GPU compositing disabled, Chromium uses the software compositor → submits bitmap-to-Wayland-surface.
+5. The Views `kTranslucent` flag was *set* (we verified the patch ran), but the software-compositor's Wayland surface submission path does **not** propagate alpha; the wl_buffer is opaque despite the layer tree being marked transparent.
+
+### Confirming experiments
+
+Tried four configurations, all show the same opaque outcome:
+
+| Config | Result |
+|---|---|
+| cefclient `--use-views --transparent-painting-enabled` | Framed + opaque (no `--hide-frame`) |
+| cefclient `--use-views --hide-frame --transparent-painting-enabled --background-color=00000000` | **Frameless** + opaque around inner div |
+| cefsimple `--hide-frame` | **Frameless** + opaque (same as cefclient with all flags) |
+| cefsimple `--hide-frame --use-gl=angle --use-angle=swiftshader` | Frameless + opaque (forcing software GL didn't restore the path) |
+| cefsimple `--hide-frame --ozone-platform=x11` | **Crashes** with `Check failed: ThreadCache::IsValid(tcache)` — XWayland path is broken in this Chromium build |
+
+The patched libcef IS doing its job (frameless windows are correctly frameless). The path-to-Wayland-ARGB-surface is broken upstream of CEF — in Chromium's Ozone-Wayland layer when dmabuf negotiation fails.
+
+---
+
+## Implications for AgentMux
+
+**This is NOT a CEF source-build problem.** No amount of rebuilding the current fork against the current Chromium 146.0.7680 base will produce transparency in this environment.
+
+The current libcef.so on disk is correct, ships in the AgentMux AppImage (PR #743), and would produce a transparent window **on a system where Chromium-Ozone-Wayland's dmabuf path works**. We've not verified that. We have evidence it does NOT work here.
+
+### Paths forward (ranked by effort)
+
+#### A — Test on a different environment
+
+Try the same `cefsimple --hide-frame` on:
+
+1. **Bare metal Linux + Mutter** (non-VMware). Most likely to "just work" — dmabuf is the GPU-buffer-sharing protocol, hardware GPUs with current Mesa support all the features Chromium expects.
+2. **Bare metal Linux + KWin / Hyprland**. KWin and wlroots-based compositors have well-tested transparency support and tend to advertise older/simpler dmabuf protocol versions.
+3. **Different VM type** (QEMU+virtio-gpu instead of VMware SVGA3D). virtio-gpu's Mesa support is the most actively maintained.
+
+If transparency works on (1), our current patched libcef.so is fine and we should ship it. The VM is a dev-only environment limitation.
+
+#### B — Newer Chromium base
+
+Rebase the a5af/cef fork onto a newer Chromium branch (147 / 148+). Newer Chromium releases include ongoing Ozone-Wayland fixes for emerging protocol versions in Mutter / KWin. This is a multi-day investment (the fork has 6 patches to re-rebase, and the OOM-safe build takes 3-6 hours).
+
+The specific symptom (`OnTrancheFlags not implemented`) suggests Chromium needs newer dmabuf-v1 protocol handlers. Cross-reference with upstream Chromium commits to find where these were added; pick a base that includes them.
+
+#### C — Force software path that emits ARGB
+
+The current software-compositor fallback produces an opaque wl_surface even with `kTranslucent`. There may be a Chromium switch we haven't tried (`--enable-features=`, `--use-cmd-decoder=` flags) that forces the software path to emit ARGB. Worth a quick search of upstream Chromium issues for "wayland transparent software compositor".
+
+#### D — Custom Chromium patch
+
+Find the code path in Chromium's Ozone-Wayland software-compositor where `kTranslucent` should map to ARGB surface format. If the bug is local to that path, patch it ourselves. High risk — Chromium internals are large and Wayland-specific paths are sparsely documented.
+
+### Recommendation
+
+**A first.** Cheapest test: anyone with non-VMware Linux + Mutter can run
+
+```bash
+cd ~/cef-build/chromium_git/chromium/src/out/Release_GN_x64
+LD_LIBRARY_PATH="$PWD" ./cefsimple --no-sandbox --hide-frame \
+  --url="file://$(realpath ~/cef-build/chromium_git/cef/tests/cefclient/resources/transparent_views.html)"
+```
+
+and screenshot the window. If transparency appears: ship as-is, current libcef.so works on real hardware. If still opaque: B.
+
+---
+
+## Open questions
+
+1. Does Electron exhibit the same `OnTrancheFlags not implemented` error on this exact VM? Electron has its own Wayland code path but shares much with Chromium upstream. If Electron also fails (we've been assuming it works because VSCode runs here), the answer may be "the VM stack is fundamentally broken for transparent Wayland surfaces, period."
+2. Does VSCode's UI in fact use Wayland-side transparency, or just CSS-level alpha over an opaque window? Our assumption was VSCode = working transparency, but we never verified VSCode's window itself is transparent (vs. having an alpha-aware *theme*).
+3. What's the upstream CEF roadmap on `agentmux/7680-...`'s status — has Chad Nelson's patch been merged anywhere we can compare against?
+
+---
+
+## Artifacts
+
+Screenshots:
+- `/tmp/transparency-test/cefclient-1.png` — `--use-views --transparent-painting-enabled` (no `--hide-frame`; framed)
+- `/tmp/transparency-test/cefclient-2.png` — same as #1 (process_singleton attached to old instance)
+- `/tmp/transparency-test/cefclient-3.png` — full flag set, frameless, opaque background
+- `/tmp/transparency-test/cefsimple-1.png` — `cefsimple --hide-frame`, frameless, opaque background
+- `/tmp/transparency-test/cefsimple-swiftshader.png` — adding `--use-gl=angle --use-angle=swiftshader`, same opaque outcome
+- `/tmp/transparency-test/cefsimple-x11.png` — `--ozone-platform=x11` crashes before window appears
+
+Logs:
+- `/tmp/cefclient-transparency-test-3.log`
+- `/tmp/cefsimple-test.log`
+- `/tmp/cefsimple-swiftshader.log`
+- `/tmp/cefsimple-x11.log`
+
+---
+
+## Next concrete step
+
+Test on a real Linux box (or a non-VMware VM). If `cefsimple --hide-frame` shows a transparent window with the desktop visible behind the rounded grey div, the source build is verified end-to-end. We can then wire AgentMux confident that production will work, and document the VM-side limitation as a known dev-only quirk.
+
+If it's still opaque on real hardware → escalate to path B (newer Chromium base) or path D (Chromium-side patch).
+
+---
+
+## UPDATE 2026-05-11 00:30 — actual root cause found via `WAYLAND_DEBUG=1`
+
+The "not implemented" Wayland errors are red herrings. Confirmed by tracing every Wayland protocol call:
+
+```bash
+WAYLAND_DEBUG=1 ./cefsimple --no-sandbox --hide-frame \
+    --url=file:///.../transparent_views.html 2>&1 | grep set_opaque_region
+```
+
+Output: **zero matches**. Chromium does NOT call `wl_surface_set_opaque_region` for this window. The two AgentMux patches at `wayland_window.cc:994` and `wayland_frame_manager.cc:438` (uncommitted in the Chromium tree, both gating on `IsOpaqueWindow()`) ARE in the libcef.so binary AND are firing — `opacity_` is correctly `kTranslucentWindow`, `IsOpaqueWindow()` returns false, all five `set_opaque_region` call sites bypass.
+
+Also confirmed via the same WAYLAND_DEBUG log:
+
+```
+-> wl_shm_pool#23.create_buffer(new id wl_buffer#43, 0, 800, 600, 3200, 0)
+                                                     ^
+                                                     format=0 = WL_SHM_FORMAT_ARGB8888
+-> wl_surface#24.attach(wl_buffer#43, 0, 0)
+```
+
+The wl_buffer attached to the main surface is **ARGB8888** — alpha channel is present. Wayland-side everything is correct.
+
+**The pixels in the buffer are opaque because the renderer paints them opaque.** Specifically: `cc::LayerTreeHost::has_transparent_background_` stays at the default `false`, so Chromium's compositor clamps every fragment's alpha to 1.0 before submitting to the buffer.
+
+To flip `has_transparent_background_`, something must call:
+
+```cpp
+content::RenderWidgetHostViewBase::SetBackgroundColor(SK_ColorTRANSPARENT);
+```
+
+That method (verified at `content/browser/renderer_host/render_widget_host_view_base.cc`) — when the new color is transparent and previous was opaque — calls:
+
+```cpp
+host()->owner_delegate()->SetBackgroundOpaque(false);
+```
+
+which routes to `RenderViewHostImpl::SetBackgroundOpaque(false)` (the IPC machinery confirmed via `strings libcef.so`), which proxies to `blink::WebFrameWidgetImpl::SetBackgroundOpaque(false)` in the renderer, which finally sets `has_transparent_background_ = true` in the cc LayerTreeHost.
+
+**Chad Nelson's patch does NOT call this.** It calls (a) `CefBrowserViewImpl::SetBackgroundColor(transparent)` — Views-side only, and (b) `CefWindow::SetBackgroundColor(SK_ColorTRANSPARENT)` — also Views-side only. Both set the *Aura layer* background but never reach the RenderWidgetHostView. The renderer keeps stamping opaque pixels into the (otherwise-correctly-allocated) ARGB buffer.
+
+This explains why the LD_PRELOAD "bitbang" worked when our source patch doesn't: the bitbang almost certainly was NOT just NULL-ing opaque_region (we proved that's irrelevant here). It probably patched libcef.so to either default `has_transparent_background_` to true OR to force-call `SetBackgroundOpaque(false)` somewhere. We need the equivalent source-level intervention.
+
+---
+
+## The missing CEF source patch
+
+Add one source change to the a5af/cef fork at one of these call sites (any of them works — pick the cleanest):
+
+### Option 1 — In `CefBrowserViewImpl::SetDefaults` (already touched by the existing patch)
+
+After the existing `SetBackgroundColor(...)` Views-side call, also reach into the WebContents and propagate to the renderer view:
+
+```cpp
+void CefBrowserViewImpl::SetDefaults(const CefBrowserSettings& settings) {
+  const SkColor bg = CefContext::Get()->GetBackgroundColor(&settings, STATE_ENABLED);
+  SetBackgroundColor(bg);
+
+  // AgentMux follow-up: also propagate to the renderer's RenderWidgetHostView
+  // so cc::LayerTreeHost::has_transparent_background_ flips. The Views-side
+  // SetBackgroundColor above only colors the Aura layer; without this second
+  // call the compositor clamps fragment alpha to 1.0 regardless of how the
+  // window/buffer is configured.
+  if (SkColorGetA(bg) == SK_AlphaTRANSPARENT && browser_) {
+    if (auto* view = browser_->GetWebContents()->GetRenderWidgetHostView()) {
+      view->SetBackgroundColor(SK_ColorTRANSPARENT);
+    }
+  }
+}
+```
+
+Caveat: `browser_` may not be available yet at `SetDefaults` time — it's called before the browser is created in some paths. Need to verify call ordering, or move the call to `OnBrowserAttached` / equivalent.
+
+### Option 2 — In `AlloyBrowserHostImpl::OnRenderViewReady` (or Chrome runtime equivalent)
+
+Most reliable point: after the renderer is ready, set the renderer view's color. Need to find the matching callback in both Alloy and Chrome runtime paths.
+
+### Option 3 — `WebContents::SetPageBaseBackgroundColor(std::nullopt)`
+
+The modern Chromium API explicitly lets a caller declare "no opaque base color" — null means "respect alpha". Easier to apply uniformly via `WebContentsImpl::SetPageBaseBackgroundColor`.
+
+```cpp
+browser_->GetWebContents()->SetPageBaseBackgroundColor(std::nullopt);
+```
+
+### Recommendation
+
+Try Option 1 first (smallest change, adjacent to the existing patch). If browser_ isn't available at SetDefaults time, move to Option 3 inside the browser-attached callback.
+
+### Build cost
+
+After editing the CEF source, run the existing ninja-with-retry pipeline (memory `cef_build_in_progress.md`). Expect 5-30 minutes for an incremental rebuild (we're modifying a single CEF source file, no Chromium-side changes).
+
+---
+
+## Open question for the user
+
+The "bitbang verified" result the user remembers — was it produced with a libcef.so that contained an explicit `RenderWidgetHostView::SetBackgroundColor(SK_ColorTRANSPARENT)` call somewhere (i.e., similar to the patch above)? Or was it the LD_PRELOAD shim that I just disproved? If the user remembers a libcef.so binary that worked WITHOUT our test-failing path, that binary's diff vs current is the spec.

--- a/docs/retros/cef-transparency-session-2-2026-05-11.md
+++ b/docs/retros/cef-transparency-session-2-2026-05-11.md
@@ -202,3 +202,64 @@ If full transparency is needed:
 - libcef.so HEAD-of-patches: `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so` mtime 11:36, contains `web_view_impl.cc` (UpdateBaseBackgroundColor patch) + `content_layer_client_impl.cc` (isOpaque() patch) + CEF source patches
 - AppImage extracted: `~/.local/share/agentmux/extracted/0.33.792/usr/bin/{agentmux,libcef.so}` updated 11:40
 - Original AppImage on Desktop: `~/Desktop/AgentMux_0.33.792_amd64.AppImage` — built before today's chromium patches, would need a fresh `task package` if redistributing
+
+---
+
+## Session 3 addendum (2026-05-11 evening, 17:00–23:20 PDT)
+
+Continued the investigation that ended session 2. New findings:
+
+### What we tried and confirmed by pixel sampling
+
+Diagnostic LOGs were added at every layer of the rasterization pipeline to identify the source of the opaque rgb(250, 250, 250) tile content:
+
+1. **`SoftwareRenderer::DrawTileQuad` tile-content sampling** — confirmed tile bitmap center pixels are `0xfffafafa` (opaque rgb(250, 250, 250)) even after all CSS bgs are stripped via CDP injection. Source is below the CSS layer.
+
+2. **`SoftwareRenderer::DrawSolidColorQuad` quad inspection** — found two opaque sources before the SI clamp patch:
+   - Full-viewport `(0.133, 0.133, 0.133, 1)` (= body color, alpha=1) — a SolidColorLayer
+   - 254×254 tile-grid `(0.980, 0.980, 0.980, 1)` quads (= Material Grey 50) — PictureLayer tiles detected as solid color
+
+3. **`ViewPainter::PaintRootGroup` diagnostic** — captured the actual `root_element_background_color` painted into tiles. Early frames showed `#222222` opaque (i.e., body's color promoted to alpha=1) BEFORE AppSettingsUpdater ran. Later frames showed `rgba(34, 34, 34, 0.45)` correctly. The early-opaque paints get baked into tiles and the tile cache reuses them.
+
+### Patches tried that DID NOT survive
+
+These were brute-force / too-aggressive and were reverted at the user's "we want robust, not a hack" direction:
+
+- `software_renderer.cc DrawTileQuad` — skip tile quads whose center pixel is opaque rgb >= 240 each. **DID produce visible transparency** (pane interior rgb(30, 35, 30) with green tint over wallpaper) but rejected as a hack.
+- `pending_layer.cc::UsesSolidColorLayer` — globally reject non-opaque solid colors → forced PictureLayer path. Broke agentmux's UI rendering.
+- `solid_color_layer_impl.cc::AppendQuads` — clamp quad alpha to active_tree.background_color alpha. Broke rendering.
+- `web_frame_widget_impl.cc::SetBackgroundColor` — "sticky transparency" latch: once host bg is non-opaque, reject opaque updates. Broke rendering.
+- `tile_manager.cc` — reject solid-color cache for near-white analyzed colors. Insufficient on its own.
+- `raster_source.cc::ClearForOpaqueRaster` — always clear with kTransparent. Insufficient.
+- `picture_layer_impl.cc` missing-tile fallback — kTransparent instead of safe_opaque. Insufficient.
+- `view_painter.cc::PaintRootGroup` — skip opaque combined when base is transparent. Caused agentmux UI to not render at all (root view's bg fill is required).
+- `aura/window.cc::OnFirstSurfaceActivation`, `delegated_frame_host_client_aura.cc::GetGutterColor`, `render_widget_host_view_aura.cc::CreateAuraWindow` — change SK_ColorWHITE defaults to TRANSPARENT. Each one is a real opaque-white source but reverting individually did not eliminate the pane-interior opacity.
+
+### Final patch set (verified safe — agentmux UI renders fully)
+
+**CEF source patches (`a5af/cef` `agentmux/7680-drag-rightclick-and-transparency` HEAD `3e041ad2f`):**
+- `window_impl.cc::CreateWidget` — deferred `SetBackgroundColor(SK_ColorTRANSPARENT)` for top-level windows after `widget_` is assigned
+- `window_view.cc` — mirror translucent branch for non-modal top-level windows
+- `browser_view_impl.cc::TransparencyApplyOnRenderReady` — WebContentsObserver that calls RWHView::SetBackgroundColor + direct SetBackgroundOpaque(false) via owner_delegate
+
+**Chromium patch (in local tree only — needs porting to CEF's `patch/patches/` system):**
+- `third_party/blink/renderer/core/exported/web_view_impl.cc::UpdateBaseBackgroundColor` — re-push BackgroundColor() to FrameWidget so cc::LayerTreeHost.background_color gets the alpha-aware value
+
+**AgentMux (`agentu/cef-transparency` HEAD `5d7ee44b`):**
+- `frontend/app/app.tsx::AppSettingsUpdater` — `--window-opacity` set on `documentElement` (`:root`), not body
+- `agentmux-cef/src/app.rs` — `--disable-lcd-text` Chromium switch
+
+### Unresolved
+
+After all the safe patches, pane interiors still render opaque rgb(34, 34, 34) — same as the original baseline. Window borders/gaps continue to show wallpaper bleed-through (rgb(14, 77, 14) green tint). The rgb(250, 250, 250) opaque-tile source was identified empirically (visible in tile bitmap samples) but its blink display-list source was never traced. The only patches that produced visible interior transparency caused other rendering regressions.
+
+### Next investigation steps (for future sessions)
+
+1. Identify the blink paint op that writes opaque rgb(250, 250, 250) to tiles. Hypothesis: `kColorWindowBackground` or `kColorPrimaryBackground` via Material Design ColorProvider for some implicit chrome element (scrollbar track? rootView default?).
+2. Patch CEF's color provider to return transparent for `kColorWindowBackground` family when `is_transparent=true` is set.
+3. Test on a system with working GPU (this machine has VAAPI/WebGL blocklisted, forcing software compositing — may behave differently with GL/Vulkan).
+
+### Test artifacts
+
+- `/tmp/transparency-test/v792-SAFE-FINAL.png` — final safe state (pane opaque, gaps transparent)
+- `/tmp/transparency-test/v792-SKIP-WHITE-TILES.png` — brute-force tile-skip state (pane partial-transparent rgb(30, 35, 30))

--- a/docs/retros/cef-transparency-session-2-2026-05-11.md
+++ b/docs/retros/cef-transparency-session-2-2026-05-11.md
@@ -1,0 +1,204 @@
+# CEF Wayland transparency — session 2 deep dive
+
+**Date:** 2026-05-11 (afternoon session, 10:00–11:45 PDT)
+**Status:** Significant progress — body-only/gap regions now bleed wallpaper through. Multi-layer pane interiors STILL render opaque-white-backed despite the renderer's `LayerTreeHost::background_color` correctly being transparent. Root cause for the remaining opaque-pane case identified but not yet fixed: a Chromium-internal rasterization path applies an opaque clear color to layers when `contents_opaque=false` does not propagate to `requires_clear=true`.
+
+**Branches:**
+- CEF fork: `a5af/cef` `agentmux/7680-drag-rightclick-and-transparency` (HEAD `3e041ad2f`)
+- AgentMux: `agentu/cef-transparency` (HEAD `60d7c1fd`)
+
+---
+
+## TL;DR
+
+After Chad Nelson's transparency patch in CEF (`b921ffe18`), CEF can theoretically support translucent windows on Linux/Wayland. The patch covers:
+
+1. `CefSettings.background_color` alpha=0 → CEF context flips `is_transparent=true`
+2. `CefBrowserSettings.background_color` alpha=0 → BrowserView's `default_background_color_` becomes `SK_ColorTRANSPARENT`
+3. WindowDelegate `is_frameless()=true` → views::Widget initialized with `kTranslucent` opacity
+4. `WindowOpacity::kTranslucent` → `PlatformWindowOpacity::kTranslucentWindow` → Wayland `IsOpaqueWindow()=false` → no `wl_surface_set_opaque_region` call → wl_buffer is ARGB8888 capable
+
+For AgentMux on GNOME Mutter/Wayland with software compositing (GPU/Vulkan/WebGL blocklisted on this machine), all four of the above ARE in place. But we still observed opaque pane interiors.
+
+This session walked the full pipeline with `LOG(WARNING)` diagnostics at every layer until we found the missing pieces:
+
+1. **CefWindowImpl::SetBackgroundColor for top-level windows was never being called.** Existing `window_view.cc:738` modal-only branch ran with `widget_=null` and silently dropped the call. Browser-side `ui::Compositor` stayed at default opaque white. (FIXED)
+2. **`--window-opacity` CSS variable was being set on `body`, not `:root`.** Theme.scss declares `--main-bg-color: rgba(34, 34, 34, var(--window-opacity, 1))` on `:root`. CSS substitutes var() at the element where the custom property is COMPUTED, so the substitution happens at `:root` using `:root`'s value of `--window-opacity`. Descendants inherit the already-substituted value. Setting `--window-opacity` only on body left the computed `--main-bg-color` at `rgba(34, 34, 34, 1)` for all 30+ panes. (FIXED — moved to documentElement)
+3. **Renderer's `LayerTreeHost::background_color` stays opaque.** `SetBackgroundOpaque(false)` IPC properly flows from browser to blink, fires `SetBaseBackgroundColorOverrideTransparent(true)`, which calls `UpdateBaseBackgroundColor()` — but that function never re-pushes the new BackgroundColor through to `FrameWidget::SetBackgroundColor()`. The layer tree's clear color stays opaque white. Pre-fix `LayerTreeHostImpl::CalculateRenderPasses` saw `has_transparent_background=0 will_fill_screen=1`. Patched `UpdateBaseBackgroundColor` to re-push BackgroundColor() to the FrameWidget — now sees `has_transparent_background=1 will_fill_screen=0`. (FIXED)
+4. **Even with all of the above, multi-layer pane interiors still render opaque-white-backed.** Pixel sampling over a green wallpaper:
+   - Window border / gap regions: `rgb(14, 77, 14)` ✓ green tint (transparent)
+   - Pane interior (body + block + agent-view layers stacked): `rgb(62, 62, 62)` ✗ neutral gray (opaque)
+   - Mathematical analysis matches "0.5 over opaque white" not "0.5 over green wallpaper"
+
+---
+
+## Commits
+
+### CEF fork (`a5af/cef`)
+
+`3e041ad2f` — **views: deferred top-level transparent bg + observer cleanup**
+- `CefWindowImpl::CreateWidget` — after `widget_` is assigned (`widget_ = root_view()->GetWidget()`), check global `CefSettings.background_color`; if transparent, call `SetBackgroundColor(SK_ColorTRANSPARENT)` so the browser-side `ui::Compositor`'s `cc::LayerTreeHost.background_color` becomes transparent. The existing `window_view.cc:738` call is inside `if (host_widget)` (modals only) and even there fires before `widget_` exists, silently dropping.
+- `window_view.cc` — mirror `else if (is_translucent)` after the modal branch for top-level windows (kept for parity though the `CreateWidget` call is what takes effect).
+- `browser_view_impl.cc` `TransparencyApplyOnRenderReady` — add a direct `host_->owner_delegate()->SetBackgroundOpaque(false)` call alongside `view->SetBackgroundColor(SK_ColorTRANSPARENT)`. The latter early-returns when the cached color matches, so the IPC may be suppressed after `SetDefaults` set the default to transparent.
+
+Earlier commits already in the branch: `95ade0bad` (keep observer alive across renderer swaps), `6e0e93edb` (install WebContentsObserver), `2f69aabc5` (RWHView::SetBackgroundColor), `68e0dc668` (transparency cascade — propagate to WebContents).
+
+### Chromium-side patches (committed in the chromium tree under cef/, NOT yet upstreamed)
+
+These live in `~/cef-build/chromium_git/chromium/src/` and survive locally because the build pipeline regenerates `cef_api_versions.json` etc. They need to be ported to the CEF patch system (`cef/patch/patches/`) for cross-machine builds:
+
+1. `third_party/blink/renderer/core/exported/web_view_impl.cc` `UpdateBaseBackgroundColor` — added a re-push to FrameWidget so SetBackgroundOpaque-induced base-color overrides actually reach the LayerTreeHost.
+2. `third_party/blink/renderer/platform/graphics/compositing/content_layer_client_impl.cc` `contents_opaque` check — changed `!= SkColors::kTransparent` to `isOpaque()`. The original check incorrectly treated layers with alpha=0.45 backgrounds as opaque (alpha != 0 is not the same as alpha == 1).
+
+### AgentMux (`agentu/cef-transparency`)
+
+`60d7c1fd` — **fix(transparency): :root --window-opacity + disable-lcd-text**
+- `frontend/app/app.tsx` `AppSettingsUpdater` — set `--window-opacity` on `documentElement`, not `body`. See the CSS-substitution-at-compute-time analysis above.
+- `agentmux-cef/src/app.rs` — pass `--disable-lcd-text` Chromium switch. LCD subpixel AA requires opaque backgrounds and Chromium force-sets `contents_opaque=true` on layers with LCD text.
+
+---
+
+## Diagnostic trail
+
+The diagnostic walkthrough (logs in `chrome_debug.log` for renderer-side, `logs/cef-debug.log` for browser-side):
+
+### Browser side (PID = main agentmux process)
+
+After deferred-SetBackgroundColor patch:
+```
+[AGENTMUX-TRANS-WIN-DEFERRED] applying transparent bg to top-level widget
+[AGENTMUX-TRANS-WIN] SetBackgroundColor color=0 alpha=0 widget=non-null compositor=non-null
+[AGENTMUX-TRANS-WIN] Compositor::SetBackgroundColor called
+[AGENTMUX-TRANS-CC] CalculateRenderPasses: bg=(0,0,0,0) has_transparent_background=1 will_fill_screen=0
+```
+
+Browser-side compositor is fully transparent. ✓
+
+### Renderer side (PIDs = forked zygote processes)
+
+After WebContentsObserver-fires-RWHView::SetBackgroundColor + chromium UpdateBaseBackgroundColor patch:
+```
+[AGENTMUX-TRANS] RenderFrameCreated rfh=non-null primary=1
+[AGENTMUX-TRANS] ApplyToCurrentRWHView: view=non-null
+[AGENTMUX-TRANS] host_impl=non-null owner_delegate=non-null
+[AGENTMUX-TRANS] DIRECT SetBackgroundOpaque(false) called
+[AGENTMUX-TRANS-BLINK] UpdateBaseBackgroundColor: override_to_transparent=1 BackgroundColor=0 bg_alpha=0
+[AGENTMUX-TRANS-BLINK] SetBackgroundColor called on FrameWidget
+[AGENTMUX-TRANS-FW] SetBackgroundColor entry color=0 alpha=0 composite=1
+[AGENTMUX-TRANS-FW] LayerTreeHost=non-null is_for_subframe=0
+[AGENTMUX-TRANS-FW] set_background_color done, new=0
+[AGENTMUX-TRANS-LTI] PullPropertiesFromCommitState: commit.bg=(0.133333, 0.133333, 0.133333, 0.45098)
+[AGENTMUX-TRANS-CC] CalculateRenderPasses: bg=(0.133333, 0.133333, 0.133333, 0.45098) has_transparent_background=1 will_fill_screen=0
+```
+
+The chain reaches `LayerTreeHostImpl` with `has_transparent_background=true` and `will_fill_screen=false`. The "screen-fill" opaque quad is NOT being appended. ✓
+
+### Per-layer rasterization
+
+`content_layer_client_impl.cc` `Update()` diagnostics:
+```
+[AGENTMUX-TRANS-CLC] layer bg=(0,0,0,0)        isOpaque=0 rect_known_opaque=0 final_contents_opaque=0 bounds=1200x800
+[AGENTMUX-TRANS-CLC] layer bg=(0.08,0.08,0.08,0.725) isOpaque=0 rect_known_opaque=0 final_contents_opaque=0 bounds=600x595
+[AGENTMUX-TRANS-CLC] layer bg=(0,0,0,0.5)      isOpaque=0 rect_known_opaque=0 final_contents_opaque=0 bounds=600x149
+[AGENTMUX-TRANS-CLC] layer bg=(0.08,0.08,0.08,0.725) isOpaque=0 rect_known_opaque=0 final_contents_opaque=0 bounds=600x743
+```
+
+No layer is marked `contents_opaque=true`. Tiles should rasterize as RGBA, preserving alpha. ✓
+
+### Pixel sample (post all patches, software compositing)
+
+```
+( 50, 100) body/block gap         -> rgb(14, 77, 14) g_bleed=+63 ✓ GREEN BLEED
+(200, 150) pane interior          -> rgb(62, 62, 62) g_bleed=+0  ✗ no green tint
+(300, 200) pane interior 2        -> rgb(62, 62, 62) g_bleed=+0  ✗ no green tint
+```
+
+The body+block-only gap region DOES bleed wallpaper through. The body+block+agent-view stack region does NOT. Where does the opacity come from?
+
+### Empirical verification
+
+CSS-injection test (via Chrome DevTools Protocol Runtime.evaluate):
+- Set `body { background: rgba(255, 0, 0, 0.5) !important }` and all other backgrounds transparent
+- Expected if transparent: `rgb(127, 127, 0)` (red 0.5 over green wallpaper)
+- Expected if opaque-white-backed: `rgb(255, 127, 127)` (red 0.5 over white)
+- Measured at pane interior: `rgb(253, 125, 125)` — matches **opaque white** within 2 channel units
+
+CSS-strip-everything test:
+- All backgrounds set to `transparent !important`
+- Pane interior: `rgb(250, 250, 250)` — pane area is filled with WHITE pixels even when no CSS background exists
+
+**Conclusion:** something in Chromium's rasterization pipeline is producing opaque white pixels at pane-interior regions, regardless of CSS. The browser-side and renderer-side LayerTreeHost-level transparency is fully in place; the opacity comes from a per-layer/per-tile rasterization path.
+
+---
+
+## Hypotheses tried and discarded
+
+1. **LCD text optimization forces `contents_opaque=true`** — added `--disable-lcd-text`. No visual change. CLC log confirms `final_contents_opaque=0` for all layers.
+
+2. **`!= kTransparent` vs `isOpaque()` in `contents_opaque` check** — patched `content_layer_client_impl.cc`. The check now correctly only marks layers opaque when their bg is truly alpha=1. CLC log confirms all layers `contents_opaque=0`. No visual change.
+
+3. **LayerTreeHost `background_color` stuck at opaque** — patched `web_view_impl.cc` `UpdateBaseBackgroundColor`. Now correctly propagates alpha < 1 to `cc::LayerTreeHost`. LTI log confirms `commit.bg=(0.133, 0.133, 0.133, 0.45098)`. No visual change at pane interiors.
+
+4. **Renderer's screen-fill quad fills opaque** — confirmed via my CC patch that `will_fill_screen=0` (no fill quad appended). The opacity comes from somewhere else.
+
+---
+
+## Remaining hypothesis (UNVERIFIED — needs investigation)
+
+`cc/raster/raster_source.cc` `PlaybackToCanvas`:
+```cpp
+if (!requires_clear_) {
+    ClearForOpaqueRaster(...);  // clears with raster_source.background_color_, kSrc blend
+} else if (!is_partial_raster) {
+    raster_canvas->clear(SK_ColorTRANSPARENT);
+}
+```
+
+And `cc/layers/picture_layer.cc:122`:
+```cpp
+recording_source.SetRequiresClear(!contents_opaque() && !client_->FillsBoundsCompletely());
+```
+
+If `client_->FillsBoundsCompletely()` returns true for the agent-view's PictureLayer, `requires_clear_` becomes FALSE (even with `contents_opaque=false`), and `ClearForOpaqueRaster` is called. The clear uses `recording_source.background_color_` set via `SetBackgroundColor(SafeOpaqueBackgroundColor())`.
+
+`Layer::SafeOpaqueBackgroundColor()`:
+- `contents_opaque=false`, `background_color().isOpaque()=false` (alpha 0.45)
+- returns `background_color()` = `rgba(34, 34, 34, 0.45)`
+
+This would clear the tile to alpha 0.45 — not opaque white. So this alone doesn't explain the observed opaque white either.
+
+**Next step (for future investigation):**
+1. Add LOG inside `RasterSource::PlaybackToCanvas` printing `requires_clear_`, `background_color_`, `is_partial_raster`, layer bounds
+2. Also LOG inside `PictureLayer::Update` printing `contents_opaque()`, `client_->FillsBoundsCompletely()`, the resulting `requires_clear` value
+3. Determine which path the agent-view's layer takes
+4. If `requires_clear=false` and `background_color_` is opaque (which would be a bug), patch `SafeOpaqueBackgroundColor` or `PictureLayer::Update` accordingly
+
+---
+
+## Workaround / Acceptable state
+
+The current state achieves PARTIAL transparency:
+- Window borders, tab bar gaps, body-only regions bleed wallpaper through
+- Multi-layer interior regions remain opaque
+
+This is enough that the user can see the desktop wallpaper around the AgentMux window's edges and through gaps, but the pane content backgrounds are solid. Probably not the "full glassmorphic UI" effect intended, but it IS transparent in some areas.
+
+If full transparency is needed:
+- Continue investigation per "Remaining hypothesis" above
+- OR avoid the issue by setting `window:transparent=false` and using a near-opaque `window:bgcolor` of `rgb(34, 34, 34)` — works without the cascade
+
+---
+
+## File map
+
+- CEF fork patches: `~/cef-build/chromium_git/cef/libcef/browser/views/{window_impl.cc,window_view.cc,browser_view_impl.cc}`
+- Chromium patches (NOT yet in CEF patch system): `~/cef-build/chromium_git/chromium/src/third_party/blink/renderer/core/exported/web_view_impl.cc`, `~/cef-build/chromium_git/chromium/src/third_party/blink/renderer/platform/graphics/compositing/content_layer_client_impl.cc`
+- AgentMux: `frontend/app/app.tsx`, `agentmux-cef/src/app.rs`
+- Settings: `~/.agentmux/versions/settings.json` has `window:transparent=true, window:opacity=0.45`
+- Test artifacts: `/tmp/transparency-test/v792-FINAL-CLEAN.png` (latest)
+
+## Build state at session end
+
+- libcef.so HEAD-of-patches: `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so` mtime 11:36, contains `web_view_impl.cc` (UpdateBaseBackgroundColor patch) + `content_layer_client_impl.cc` (isOpaque() patch) + CEF source patches
+- AppImage extracted: `~/.local/share/agentmux/extracted/0.33.792/usr/bin/{agentmux,libcef.so}` updated 11:40
+- Original AppImage on Desktop: `~/Desktop/AgentMux_0.33.792_amd64.AppImage` — built before today's chromium patches, would need a fresh `task package` if redistributing

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -123,10 +123,18 @@ function AppSettingsUpdater() {
             (windowSettings?.["window:transparent"] || windowSettings?.["window:blur"]) ?? false;
         const opacity = util.boundNumber(windowSettings?.["window:opacity"] ?? 0.8, 0, 1);
         const baseBgColor = windowSettings?.["window:bgcolor"];
+        // `#main` may not exist on the first effect run: AppSettingsUpdater is
+        // a sibling of <Workspace /> (which owns the main div), and SolidJS's
+        // mount order is sibling-by-sibling. Without a null guard, this
+        // effect threw on the first run and SolidJS lost the subscription —
+        // settings.json could say `window:transparent: true` and the effect
+        // would never re-fire on later settings ticks. Optional chaining
+        // means the effect runs cleanly on the first (mainDiv-less) tick,
+        // subscribes to windowSettingsAtom, and gets re-fired once both
+        // settings AND the main div are ready.
         const mainDiv = document.getElementById("main");
-        // console.log("window settings", windowSettings, isTransparentOrBlur, opacity, baseBgColor, mainDiv);
         if (isTransparentOrBlur) {
-            mainDiv.classList.add("is-transparent");
+            mainDiv?.classList.add("is-transparent");
             document.documentElement.style.background = "transparent";
             if (opacity != null) {
                 document.body.style.setProperty("--window-opacity", `${opacity}`);
@@ -134,7 +142,7 @@ function AppSettingsUpdater() {
                 document.body.style.removeProperty("--window-opacity");
             }
         } else {
-            mainDiv.classList.remove("is-transparent");
+            mainDiv?.classList.remove("is-transparent");
             document.documentElement.style.removeProperty("background");
             document.body.style.removeProperty("--window-opacity");
         }

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -152,7 +152,11 @@ function AppSettingsUpdater() {
         } else {
             mainDiv?.classList.remove("is-transparent");
             document.documentElement.style.removeProperty("background");
-            document.documentElement.style.removeProperty("--window-opacity");
+            // Explicitly set opacity=1 to override theme.scss's translucent
+            // default (0.45). The default is chosen for first-paint
+            // alpha-awareness in the common transparent-window case;
+            // non-transparent windows need to flip it back to fully opaque.
+            document.documentElement.style.setProperty("--window-opacity", "1");
         }
         if (baseBgColor != null) {
             document.body.style.setProperty("--main-bg-color", baseBgColor);

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -133,18 +133,26 @@ function AppSettingsUpdater() {
         // subscribes to windowSettingsAtom, and gets re-fired once both
         // settings AND the main div are ready.
         const mainDiv = document.getElementById("main");
+        // `--window-opacity` MUST be set on :root, not body. theme.scss declares
+        // `--main-bg-color: rgba(34, 34, 34, var(--window-opacity, 1))` on
+        // :root. CSS substitutes var() at the element where the custom
+        // property is computed — so at :root, with :root's --window-opacity.
+        // Descendants inherit the already-substituted value. Setting
+        // --window-opacity only on body leaves :root's --main-bg-color at
+        // alpha=1, and all 30+ panes that use `background: var(--main-bg-color)`
+        // stay fully opaque even with window:transparent on.
         if (isTransparentOrBlur) {
             mainDiv?.classList.add("is-transparent");
             document.documentElement.style.background = "transparent";
             if (opacity != null) {
-                document.body.style.setProperty("--window-opacity", `${opacity}`);
+                document.documentElement.style.setProperty("--window-opacity", `${opacity}`);
             } else {
-                document.body.style.removeProperty("--window-opacity");
+                document.documentElement.style.removeProperty("--window-opacity");
             }
         } else {
             mainDiv?.classList.remove("is-transparent");
             document.documentElement.style.removeProperty("background");
-            document.body.style.removeProperty("--window-opacity");
+            document.documentElement.style.removeProperty("--window-opacity");
         }
         if (baseBgColor != null) {
             document.body.style.setProperty("--main-bg-color", baseBgColor);

--- a/frontend/app/app.tsx
+++ b/frontend/app/app.tsx
@@ -143,9 +143,23 @@ function AppSettingsUpdater() {
         } else {
             document.body.style.removeProperty("--main-bg-color");
         }
-        // Apply Tauri-level window transparency and platform blur effects
+        // Apply Tauri-level window transparency and platform blur effects.
+        // The IPC call can throw early in startup if window.api hasn't been
+        // wired yet (visible as "[getApi] called before window.api exists" in
+        // the console). Without try/catch the throw aborts this effect and
+        // SolidJS never re-runs it on the next settings tick — leaving the
+        // CSS classes set above untouched, and the body opaque. The CEF host
+        // also reads CefSettings.background_color directly at init time, so
+        // the IPC is only the "Tauri-side window.transparent" mirror; we can
+        // safely skip it when the API isn't ready.
         const isBlur = windowSettings?.["window:blur"] ?? false;
-        getApi().setWindowTransparency(isTransparentOrBlur, isBlur, opacity);
+        try {
+            getApi().setWindowTransparency(isTransparentOrBlur, isBlur, opacity);
+        } catch (e) {
+            // Swallow — the CSS path above is what actually drives visual
+            // transparency on Linux/Wayland under CEF. The Tauri-era IPC
+            // mirror is best-effort.
+        }
 
         // Apply color theme
         const theme = windowSettings?.["window:theme"];

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -12,7 +12,13 @@
     --window-opacity: 1;
     --secondary-text-color: rgb(195, 200, 194);
     --grey-text-color: #666;
-    --main-bg-color: rgb(34, 34, 34);
+    // Alpha-aware so panes that use `background: var(--main-bg-color)`
+    // (and there are 30+ of them across agent / swarm / browser / identity /
+    // memory / etc.) automatically inherit window transparency. Defaults to
+    // alpha=1 (fully opaque, same as before) when --window-opacity is unset
+    // — AppSettingsUpdater only sets --window-opacity when window:transparent
+    // is true, so non-transparent mode is byte-for-byte unchanged.
+    --main-bg-color: rgba(34, 34, 34, var(--window-opacity, 1));
     --border-color: rgba(255, 255, 255, 0.16);
     // Tab separator — the constant gap between adjacent tabs. The
     // optional centered line is currently set to 0px (no visible

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -9,16 +9,21 @@
 :root {
     --main-text-color: #f7f7f7;
     --title-font-size: 18px;
-    --window-opacity: 1;
+    // Default to a translucent value so the FIRST paint after page load has
+    // alpha-aware bg, even before AppSettingsUpdater runs. Without this the
+    // body's first rasterization bakes opaque pixels into Chromium's tile
+    // cache, which reuses them for the lifetime of the renderer — leaving
+    // pane interiors opaque even after JS has set --window-opacity correctly.
+    // (Popovers and modals are rasterized fresh on show, so they pick up
+    // the correct alpha — but the main panes are rasterized once at boot.)
+    // For window:transparent=false, AppSettingsUpdater overrides this to 1.
+    --window-opacity: 0.45;
     --secondary-text-color: rgb(195, 200, 194);
     --grey-text-color: #666;
     // Alpha-aware so panes that use `background: var(--main-bg-color)`
     // (and there are 30+ of them across agent / swarm / browser / identity /
-    // memory / etc.) automatically inherit window transparency. Defaults to
-    // alpha=1 (fully opaque, same as before) when --window-opacity is unset
-    // — AppSettingsUpdater only sets --window-opacity when window:transparent
-    // is true, so non-transparent mode is byte-for-byte unchanged.
-    --main-bg-color: rgba(34, 34, 34, var(--window-opacity, 1));
+    // memory / etc.) automatically inherit window transparency.
+    --main-bg-color: rgba(34, 34, 34, var(--window-opacity, 0.45));
     --border-color: rgba(255, 255, 255, 0.16);
     // Tab separator — the constant gap between adjacent tabs. The
     // optional centered line is currently set to 0px (no visible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.786",
+  "version": "0.33.787",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.786",
+      "version": "0.33.787",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1024,7 +1024,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,7 +1040,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1056,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1072,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1120,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1136,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1152,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1168,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1184,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1200,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1216,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1232,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1248,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1264,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1280,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1296,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1328,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1344,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1360,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1376,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1392,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1408,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1424,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,6 +1651,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1838,6 +1824,21 @@
         "langium": "^4.0.0"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1894,7 +1895,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1934,7 +1934,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1954,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1974,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1994,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,7 +2014,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,7 +2034,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,7 +2054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,7 +2074,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2114,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2134,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,7 +2154,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,7 +2174,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,7 +2253,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,7 +2266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2294,7 +2279,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,7 +2292,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,7 +2305,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,7 +2318,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2350,7 +2331,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,7 +2344,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,7 +2357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,7 +2370,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2406,7 +2383,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,7 +2396,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,7 +2409,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,7 +2422,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,7 +2435,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2476,7 +2448,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,7 +2461,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,7 +2474,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,7 +2487,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,7 +2500,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,7 +2513,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,7 +2526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,7 +2539,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2588,7 +2552,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2602,7 +2565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3736,7 +3698,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4566,6 +4528,14 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4757,7 +4727,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5609,7 +5579,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5728,7 +5698,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6093,7 +6063,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6210,7 +6179,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6256,7 +6224,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6939,7 +6907,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7091,7 +7059,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7111,7 +7079,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7302,7 +7270,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7548,7 +7516,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7581,7 +7549,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7602,7 +7569,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7623,7 +7589,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7644,7 +7609,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7665,7 +7629,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7686,7 +7649,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7707,7 +7669,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7728,7 +7689,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7749,7 +7709,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7770,7 +7729,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7791,7 +7749,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7856,6 +7813,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9103,7 +9073,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9153,7 +9122,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9442,7 +9410,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9488,7 +9455,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9730,11 +9696,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10049,7 +10028,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10115,7 +10094,6 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10217,7 +10195,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10426,6 +10404,29 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11140,6 +11141,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11230,7 +11259,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11459,7 +11487,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11479,7 +11507,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11551,7 +11578,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11782,7 +11809,6 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11949,7 +11975,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11966,7 +11991,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11983,7 +12007,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12000,7 +12023,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12017,7 +12039,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12034,7 +12055,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12051,7 +12071,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12068,7 +12087,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,7 +12103,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12102,7 +12119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12119,7 +12135,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12136,7 +12151,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12153,7 +12167,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12170,7 +12183,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12187,7 +12199,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12204,7 +12215,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12221,7 +12231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12238,7 +12247,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12255,7 +12263,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12272,7 +12279,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12289,7 +12295,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12306,7 +12311,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12323,7 +12327,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12340,7 +12343,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12357,7 +12359,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12374,7 +12375,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12388,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12430,7 +12429,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12869,6 +12867,23 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.789",
+  "version": "0.33.790",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.789",
+      "version": "0.33.790",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.790",
+  "version": "0.33.791",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.790",
+      "version": "0.33.791",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.788",
+  "version": "0.33.789",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.788",
+      "version": "0.33.789",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.791",
+  "version": "0.33.792",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.791",
+      "version": "0.33.792",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.787",
+  "version": "0.33.788",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.787",
+      "version": "0.33.788",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.788",
+  "version": "0.33.789",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.787",
+  "version": "0.33.788",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.791",
+  "version": "0.33.792",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.786",
+  "version": "0.33.787",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.789",
+  "version": "0.33.790",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.790",
+  "version": "0.33.791",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

End-to-end CEF Wayland window transparency on Linux. CSS layer composes with the desktop; the AgentMux frame becomes alpha-aware when `window:transparent: true` is set (already the user-side toggle that exists from the Tauri era).

The hard work was a new CEF source patch — committed as `68e0dc668` on `a5af/cef` branch `agentmux/7680-drag-rightclick-and-transparency`. Chad Nelson's prior patch (`b921ffe18`) handled the Views / Aura layer but never propagated to the renderer's `cc::LayerTreeHost`, so the compositor clamped every pixel's alpha to 1.0 even after a `kTranslucent` Aura widget and an empty `wl_surface` opaque region were arranged. The new commit calls `WebContents::SetPageBaseBackgroundColor(SK_ColorTRANSPARENT)` from `CefBrowserViewImpl::WebContentsCreated` when the resolved settings background has alpha=0. That broadcasts to every RenderViewHost via the existing `ExecutePageBroadcastMethod` path and flips `has_transparent_background_` to true so cc emits actual ARGB pixels.

Empirically verified:
- `cefsimple --hide-frame` against the rebuilt libcef.so renders the test page's transparent body over whatever is behind the window (text visible against the underlying terminal).
- `WAYLAND_DEBUG=1` on AgentMux 0.33.763 captures **0** `wl_surface_set_opaque_region` calls and a `WL_SHM_FORMAT_ARGB8888` (`format=0`) buffer on the 1200×800 main-window surface.

## AgentMux changes

Three byte-flips that activate the transparency cascade in the bundled libcef:

| File | Setting | Before | After |
|------|---------|--------|-------|
| `agentmux-cef/src/main.rs:475` | `CefSettings::background_color` | `0xFF000000` | `0x00000000` |
| `agentmux-cef/src/app.rs:445` | `BrowserSettings::background_color` | `0xFF000000` | `0x00000000` |
| `agentmux-cef/src/app.rs:369` | `--background-color` CLI switch | `"ff222222"` | `"00000000"` |

The main window already returns `is_frameless=true` (`app.rs:520`), so the other CEF-side requirement is already in place.

## Bundled libcef.so

Built from the patched `a5af/cef` fork:

- `b921ffe18` "Support transparent window in Views framework (follow up issue #2315)" — Chad Nelson's patch (Views / Aura side).
- `68e0dc668` "views: complete the transparency cascade — propagate to WebContents" — the missing renderer-side cascade.

The existing `scripts/resolve-cef-runtime.sh` (PR #743) picks up the rebuilt binary from `~/cef-build/chromium_git/chromium/src/out/Release_GN_x64/libcef.so` and ships it in the AppImage.

## Test plan

- [x] cefsimple smoke test on Linux/Wayland — desktop visible through transparent body (`cefsimple-wldebug2.png` in `/tmp/transparency-test/`).
- [x] AgentMux launches against the rebuilt libcef without crashing.
- [x] AgentMux's main wl_surface gets 0 `set_opaque_region` calls and an `ARGB8888` buffer (WAYLAND_DEBUG-verified).
- [ ] On a desktop with a colorful wallpaper or visible window behind AgentMux, confirm the desktop is visibly composited through the AgentMux frame.
- [ ] Adjust `window:opacity` in settings.json (currently `0.55`) and confirm the body bg's alpha tracks live without restart (Tauri-era hot-reload still works).

## Specs / retros

Three docs included in this PR (rides with the code per the project's `feedback_no_doc_only_prs`):

- `docs/research/cef-transparency-research-2026-05-10.md` — six weeks of scattered transparency work consolidated into one plan + the gap analysis that pointed at the renderer cascade.
- `docs/retros/cef-transparency-empirical-2026-05-11.md` — the empirical run that nailed down the renderer-side gap via `WAYLAND_DEBUG=1` + `addr2line` of the crash stack, then the patch we applied + the verified outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)