### PR TITLE
fix(empty-tab): re-show brain logo when all panes are closed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.789"
+version = "0.33.790"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.789"
+version = "0.33.790"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.789"
+version = "0.33.790"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.789"
+version = "0.33.790"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.789"
+version = "0.33.790"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/tab/tabcontent.tsx
+++ b/frontend/app/tab/tabcontent.tsx
@@ -106,16 +106,23 @@ function TabContent(props: { tabId: string }): JSX.Element {
                 when={tabData() != null}
                 fallback={<CenteredDiv>Tab Not Found</CenteredDiv>}
             >
-                <Show when={isEmpty()}>
+                <Show
+                    when={isEmpty()}
+                    fallback={
+                        <TabModalLayer>
+                            <TileLayout
+                                contents={tileLayoutContents()}
+                                tabAtom={tabAtom()}
+                                getCursorPoint={getApi().getCursorPoint}
+                            />
+                        </TabModalLayer>
+                    }
+                >
                     <img
                         src={logoUrl}
                         alt="AgentMux"
                         class="empty-tab-logo"
                         style={{
-                            position: "absolute",
-                            top: "50%",
-                            left: "50%",
-                            transform: "translate(-50%, -50%)",
                             "max-width": "160px",
                             "max-height": "160px",
                             opacity: "0.4",
@@ -124,13 +131,6 @@ function TabContent(props: { tabId: string }): JSX.Element {
                         }}
                     />
                 </Show>
-                <TabModalLayer>
-                    <TileLayout
-                        contents={tileLayoutContents()}
-                        tabAtom={tabAtom()}
-                        getCursorPoint={getApi().getCursorPoint}
-                    />
-                </TabModalLayer>
             </Show>
         </div>
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.789",
+  "version": "0.33.790",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.789",
+      "version": "0.33.790",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.789",
+  "version": "0.33.790",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Previously the brain logo appeared on a fresh empty tab but did NOT reappear after the user closed the last remaining pane in a tab.

**Root cause**: both the logo and `TileLayout` were rendering as siblings in the same flex container; `TileLayout`'s leftover `rootnode` paint sat over the logo's absolute-positioned `<img>`.

**Fix**: switch to mutually-exclusive rendering via `<Show>` + `fallback`: empty tab → logo only; non-empty → `TileLayout` only. Solid unmounts/remounts the appropriate branch on `isEmpty()` toggle. Dropped the absolute-positioning hack — parent flex's `items-center justify-center` centers the img naturally.

## Test plan

- [x] Open new tab — logo appears centered
- [x] Add a pane — logo disappears, TileLayout renders
- [x] Close the last pane — logo re-appears (the bug)
- [x] Right-click on empty area still shows widget menu through the logo (pointer-events: none preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)