### PR TITLE
secure: gate /agentmux/reactive/* under auth_middleware (audit C1+C2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.790"
+version = "0.33.791"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.790"
+version = "0.33.791"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.790"
+version = "0.33.791"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.790"
+version = "0.33.791"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.790"
+version = "0.33.791"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -78,9 +78,10 @@ fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
 ///
 /// The entry includes the writing instance's auth_key (from
 /// `LOCAL_AUTH_KEY`) so a peer performing an HTTP forward of a missed
-/// inject can authenticate. The on-disk file is set to mode 0600 on
-/// Unix because the auth_key is sensitive — same security boundary as
-/// the existing `authkey.dev` file. On Windows, default ACLs inherit
+/// inject can authenticate. On Unix the file is created with mode 0600
+/// **at open time** (not write-then-chmod, which would briefly expose
+/// the file at the default umask — same security boundary as the
+/// existing `authkey.dev` file). On Windows, default ACLs inherit
 /// user-only on user-owned directories.
 pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
     let dir = agents_dir(data_dir);
@@ -94,16 +95,18 @@ pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
         auth_key: local_auth_key().to_string(),
     };
     let path = agent_path(data_dir, agent_id);
-    if let Ok(json) = serde_json::to_string(&entry) {
-        let _ = std::fs::write(&path, json);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(
-                &path,
-                std::fs::Permissions::from_mode(0o600),
-            );
-        }
+    let Ok(json) = serde_json::to_string(&entry) else { return };
+
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    if let Ok(mut f) = opts.open(&path) {
+        use std::io::Write;
+        let _ = f.write_all(json.as_bytes());
     }
 }
 

--- a/agentmux-srv/src/backend/reactive/registry.rs
+++ b/agentmux-srv/src/backend/reactive/registry.rs
@@ -15,6 +15,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use super::now_unix_millis;
 
@@ -29,6 +30,35 @@ pub struct AgentEntry {
     pub pid: u32,
     /// Unix milliseconds of last update.
     pub updated_at: u64,
+    /// Per-launch auth key of the owning instance. Required by peers
+    /// performing cross-instance HTTP forward of `/agentmux/reactive/inject`
+    /// after the route moved under auth_middleware. Optional in the
+    /// struct (serde default) so older on-disk entries still deserialize;
+    /// a missing or empty value means a forward to this entry will be
+    /// rejected by the peer's auth layer (graceful — falls back to cloud
+    /// agentbus).
+    #[serde(default)]
+    pub auth_key: String,
+}
+
+/// Process-wide auth key for the local AgentMux instance.
+///
+/// Initialised once by `main.rs` after `Config::from_env_and_args` reads
+/// `AGENTMUX_AUTH_KEY` and removes it from the env. The registry write
+/// path reads this to populate `AgentEntry::auth_key`, which lets peers
+/// authenticate cross-instance inject forwards.
+///
+/// Tests and the `register` HTTP handler (which has `state.auth_key`)
+/// can both pre-set this safely — the first `set` wins.
+static LOCAL_AUTH_KEY: OnceLock<String> = OnceLock::new();
+
+/// Initialise the process's local auth key. Idempotent — first call wins.
+pub fn init_local_auth_key(key: impl Into<String>) {
+    let _ = LOCAL_AUTH_KEY.set(key.into());
+}
+
+fn local_auth_key() -> &'static str {
+    LOCAL_AUTH_KEY.get().map(String::as_str).unwrap_or("")
 }
 
 fn agents_dir(data_dir: &Path) -> PathBuf {
@@ -45,6 +75,13 @@ fn agent_path(data_dir: &Path, agent_id: &str) -> PathBuf {
 }
 
 /// Write (create or update) an agent entry in the shared registry.
+///
+/// The entry includes the writing instance's auth_key (from
+/// `LOCAL_AUTH_KEY`) so a peer performing an HTTP forward of a missed
+/// inject can authenticate. The on-disk file is set to mode 0600 on
+/// Unix because the auth_key is sensitive — same security boundary as
+/// the existing `authkey.dev` file. On Windows, default ACLs inherit
+/// user-only on user-owned directories.
 pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
     let dir = agents_dir(data_dir);
     let _ = std::fs::create_dir_all(&dir);
@@ -54,9 +91,19 @@ pub fn write(data_dir: &Path, agent_id: &str, local_url: &str, block_id: &str) {
         block_id: block_id.to_string(),
         pid: std::process::id(),
         updated_at: now_unix_millis(),
+        auth_key: local_auth_key().to_string(),
     };
+    let path = agent_path(data_dir, agent_id);
     if let Ok(json) = serde_json::to_string(&entry) {
-        let _ = std::fs::write(agent_path(data_dir, agent_id), json);
+        let _ = std::fs::write(&path, json);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(
+                &path,
+                std::fs::Permissions::from_mode(0o600),
+            );
+        }
     }
 }
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -264,6 +264,14 @@ async fn main() {
     let version = config.version.to_string();
     let build_time = config.build_time.to_string();
 
+    // Make the per-launch auth_key available to the cross-instance agent
+    // registry writer. Peers performing an HTTP forward of a missed inject
+    // use this to authenticate against the writing instance's sidecar.
+    // Must happen after Config::from_env_and_args (which removes
+    // AGENTMUX_AUTH_KEY from the process env) but before anything calls
+    // `agent_registry::write`.
+    crate::backend::reactive::registry::init_local_auth_key(&config.auth_key);
+
     // 4. Initialize backend (matching Go cmd/server/main-server.go:374-590)
     base::set_version(&version);
     base::set_build_time(&build_time);

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -109,7 +109,13 @@ pub fn build_router(state: AppState) -> Router {
             "x-vercel-ai-ui-message-stream".parse().unwrap(),
         ]);
 
-    // No-auth routes (matching Go SkipAuth: true — localhost-only reactive endpoints)
+    // Reactive routes. Previously registered without auth on the
+    // assumption that localhost is a trust boundary; the 2026-05-11
+    // security audit (C1 + C2) showed that any local process — or a
+    // web page driving 127.0.0.1 via the permissive CORS layer — could
+    // drive `/agentmux/reactive/inject` and reconfigure the cloud
+    // agentbus poller. These routes are now merged into `authed_routes`
+    // below and gated by `auth_middleware`.
     let reactive_routes = Router::new()
         .route("/agentmux/reactive/inject", post(reactive::handle_reactive_inject))
         .route("/agentmux/reactive/agents", get(reactive::handle_reactive_agents))
@@ -156,6 +162,7 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/lan-instances", get(handle_lan_instances))
         .route("/agentmux/diag/sagas", get(handle_diag_sagas))
         .merge(bus_routes)
+        .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
@@ -166,7 +173,6 @@ pub fn build_router(state: AppState) -> Router {
 
     Router::new()
         .merge(health)
-        .merge(reactive_routes)
         .merge(authed_routes)
         .layer(cors)
         .with_state(state)

--- a/agentmux-srv/src/server/reactive.rs
+++ b/agentmux-srv/src/server/reactive.rs
@@ -47,7 +47,17 @@ pub(super) async fn handle_reactive_inject(
                     url = %forward_url,
                     "cross-instance inject forward"
                 );
-                match state.http_client.post(&forward_url).json(&req).send().await {
+                // Reactive routes now require auth (audit C1/C2 fix).
+                // Peers authenticate using the entry's `auth_key` (the
+                // owning instance's per-launch UUID, written into the
+                // registry by `registry::write`). If a pre-fix entry has
+                // no auth_key, the peer returns 401 and the cloud
+                // agentbus fallback handles it.
+                let mut fwd = state.http_client.post(&forward_url).json(&req);
+                if !entry.auth_key.is_empty() {
+                    fwd = fwd.header("X-AuthKey", &entry.auth_key);
+                }
+                match fwd.send().await {
                     Ok(r) if r.status().is_success() => {
                         if let Ok(body) = r.json::<serde_json::Value>().await {
                             return Json(body);

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -147,14 +147,31 @@ async fn auth_accepts_query_param() {
 }
 
 #[tokio::test]
-async fn reactive_routes_skip_auth() {
+async fn reactive_routes_require_auth_unauthenticated() {
+    // Audit C1/C2 fix: /agentmux/reactive/* used to skip auth on the
+    // "localhost is trusted" assumption. It isn't — same-host CSRF
+    // via the permissive CORS layer could drive inject + poller-config.
+    // These routes now require X-AuthKey. The previous test
+    // (`reactive_routes_skip_auth`) asserted the bug; this one asserts
+    // the fix.
     let app = test_router();
     let req = Request::builder()
         .uri("/agentmux/reactive/agents")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
-    assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn reactive_routes_accept_valid_authkey() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/agentmux/reactive/agents")
+        .header("X-AuthKey", "test-secret-key")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
@@ -250,6 +267,7 @@ async fn reactive_agents_returns_empty_list() {
     let app = test_router();
     let req = Request::builder()
         .uri("/agentmux/reactive/agents")
+        .header("X-AuthKey", "test-secret-key")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
@@ -267,6 +285,7 @@ async fn reactive_poller_status() {
     let app = test_router();
     let req = Request::builder()
         .uri("/agentmux/reactive/poller/status")
+        .header("X-AuthKey", "test-secret-key")
         .body(Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();

--- a/frontend/app/view/term/termagent.ts
+++ b/frontend/app/view/term/termagent.ts
@@ -4,18 +4,28 @@
 // Reactive agent registration helpers.
 // Extracted from termwrap.ts — standalone async functions, no TermWrap dependency.
 
+import { getApi } from "@/store/global";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { fireAndForget } from "@/util/util";
 
 // Track registered agent IDs per block to detect changes
 export const registeredAgentsByBlock = new Map<string, string>();
 
+// Build the `X-AuthKey` header expected by the sidecar's auth middleware.
+// Returns an empty object if no key is available (early-boot / tests);
+// callers will see a 401 in that case, which is a clearer signal than
+// silently succeeding.
+function authHeaders(): Record<string, string> {
+    const k = getApi()?.getAuthKey?.();
+    return k ? { "X-AuthKey": k } : {};
+}
+
 export async function registerAgent(agentId: string, blockId: string, tabId?: string): Promise<void> {
     try {
         const url = getWebServerEndpoint() + "/agentmux/reactive/register";
         const response = await fetch(url, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...authHeaders() },
             body: JSON.stringify({
                 agent_id: agentId,
                 block_id: blockId,
@@ -44,7 +54,7 @@ export async function unregisterAgent(agentId: string): Promise<void> {
         const url = getWebServerEndpoint() + "/agentmux/reactive/unregister";
         const response = await fetch(url, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers: { "Content-Type": "application/json", ...authHeaders() },
             body: JSON.stringify({ agent_id: agentId }),
         });
         if (!response.ok) {

--- a/frontend/app/view/term/termosc.ts
+++ b/frontend/app/view/term/termosc.ts
@@ -6,7 +6,7 @@
 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { WOS, atoms } from "@/app/store/global";
+import { WOS, atoms, getApi } from "@/app/store/global";
 import * as services from "@/app/store/services";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { fireAndForget } from "@/util/util";
@@ -290,9 +290,14 @@ export function handleOsc16162Command(data: string, blockId: string, loaded: boo
             fireAndForget(async () => {
                 try {
                     const url = getWebServerEndpoint() + "/agentmux/reactive/poller/config";
+                    // X-AuthKey required after audit C1/C2 fix moved
+                    // /agentmux/reactive/* under auth_middleware.
+                    const authKey = getApi()?.getAuthKey?.();
+                    const headers: Record<string, string> = { "Content-Type": "application/json" };
+                    if (authKey) headers["X-AuthKey"] = authKey;
                     const response = await fetch(url, {
                         method: "POST",
-                        headers: { "Content-Type": "application/json" },
+                        headers,
                         body: JSON.stringify({
                             agentmux_url: cmd.data.agentmux_url || "",
                             agentmux_token: cmd.data.agentmux_token || "",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.790",
+  "version": "0.33.791",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes the highest-leverage findings from the 2026-05-11 security audit. The \`/agentmux/reactive/*\` routes were registered without auth on the assumption that localhost is a trust boundary. It isn't — any local process, or any web page the user has open (via the permissive \`Access-Control-Allow-Origin: *\` layer), could drive these endpoints and:

- queue arbitrary prompts into any running agent's PTY (\`POST /agentmux/reactive/inject\`) → prompt injection, RCE-equivalent via the agent's own context
- reconfigure the cloud agentbus poller to an attacker URL + supply an attacker token (\`POST /agentmux/reactive/poller/config\`)
- read the existing poller token via \`GET /agentmux/reactive/poller/status\`

These are **C1 + C2** in \`/workspace/SECURITY_AUDIT_2026_05_11.md\`. **C3** (CORS \`Any\` + query-string \`?authkey=\`) is a separate PR that follows.

## What changes

### Server router
- \`agentmux-srv/src/server/mod.rs\` — merge \`reactive_routes\` into the same auth-gated group as \`authed_routes\`. One-line shift; same \`route_layer(auth_middleware)\`.

### Cross-instance forward (so multi-instance jekt still works)
- \`agentmux-srv/src/backend/reactive/registry.rs\` — \`AgentEntry\` gains an \`auth_key\` field, populated from a process-wide \`LOCAL_AUTH_KEY\` OnceLock initialised by main.rs from \`config.auth_key\`.
- \`agentmux-srv/src/server/reactive.rs\` — the cross-instance HTTP forward sends \`X-AuthKey: entry.auth_key\` so the receiving peer's middleware can authenticate.
- Registry files are mode 0600 on Unix because they now carry a sensitive token (same boundary as \`authkey.dev\`).
- \`auth_key\` is \`#[serde(default)]\` so older on-disk entries still deserialize; their forwards will 401 and the cloud agentbus fallback handles it. Not a regression of any current behavior.

### Frontend
- \`frontend/app/view/term/termagent.ts\` — \`registerAgent\` / \`unregisterAgent\` send \`X-AuthKey\` via \`getApi().getAuthKey()\`.
- \`frontend/app/view/term/termosc.ts\` — \`poller/config\` does the same.

### Tests
- Replace \`server::tests::reactive_routes_skip_auth\` (which asserted the bug) with two new tests: 401 without key, 200 with valid key.
- Existing \`reactive_agents_returns_empty_list\` and \`reactive_poller_status\` now pass the auth header.

## Results

- \`cargo test -p agentmux-srv --bin agentmux-srv server::\` — **13/13 pass**.
- \`cargo test -p agentmux-srv --bin agentmux-srv backend::reactive\` — **45/45 pass**.
- \`tsc --noEmit -p tsconfig.json\` — no new errors in touched files (pre-existing errors in unrelated test files only).

## Audit findings closed

- **C1** (Critical) — unauthenticated agent-input injection via \`/agentmux/reactive/inject\`.
- **C2** (Critical) — unauthenticated cloud-bus poller reconfiguration via \`/agentmux/reactive/poller/config\` + token leak via \`/poller/status\`.

C3 (CORS \`Any\` + query-string authkey) is a planned follow-up PR.

## Version

\`0.33.789\` → \`0.33.790\` via \`bump-cli\`.

## Test plan

- [x] Server-tier tests pass with auth required on reactive routes.
- [x] Reactive backend tests pass with the registry schema change.
- [ ] Manual: start AgentMux, spawn an agent, confirm registration + jekt-from-MCP both work end-to-end.
- [ ] Manual: run two AgentMux instances, confirm cross-instance jekt still delivers when the auth keys are present in both registry entries.