### PR TITLE
feat(live-log): Phase 3 — overlay UI (header / log / bottom action bar)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.792"
+version = "0.33.793"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.792"
+version = "0.33.793"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.792"
+version = "0.33.793"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.792"
+version = "0.33.793"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.793"
+version = "0.33.794"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.793"
+version = "0.33.794"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.793"
+version = "0.33.794"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.793"
+version = "0.33.794"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -2,7 +2,7 @@
 
 This document tracks the version history of AgentMux (forked from waveterm).
 
-## Latest Version: 0.33.792
+## Latest Version: 0.33.794
 
 **Base:** Upstream waveterm v0.12.0 + extensive custom features
 

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.792"
+version = "0.33.793"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.793"
+version = "0.33.794"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.793"
+version = "0.33.794"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.792"
+version = "0.33.793"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.793"
+version = "0.33.794"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.792"
+version = "0.33.793"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.792"
+version = "0.33.793"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.793"
+version = "0.33.794"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/NodeHoverStrip.tsx
+++ b/frontend/app/view/agent/components/NodeHoverStrip.tsx
@@ -12,6 +12,14 @@
 
 import { Show, type JSX } from "solid-js";
 
+/**
+ * Row-level strip — bookmark + expand only after Phase 3 of
+ * SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.5. Branching actions
+ * (open-in-pane, open-in-window, new-agent-here) moved into the tool
+ * overlay's bottom action bar so each row's chrome stays lean and the
+ * branching surface is contextual to the tool, not duplicated across
+ * every document row.
+ */
 interface NodeHoverStripProps {
     timestamp?: number; // Unix ms
     nodeId: string;
@@ -20,9 +28,6 @@ interface NodeHoverStripProps {
     canExpand?: boolean;
     isExpanded?: boolean;
     onExpand?: () => void;
-    onOpenInNewPane?: () => void;   // undefined → button hidden (non-tool rows)
-    onOpenInNewWindow?: () => void; // stub — logs console.warn until CEF bridge ships
-    onNewAgentFromHere?: () => void; // stub — requires backend RPC in v2
 }
 
 interface StripButtonProps {
@@ -59,10 +64,7 @@ export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
     <Show when={
         props.timestamp != null ||
         props.canExpand ||
-        props.onBookmark != null ||
-        props.onOpenInNewPane != null ||
-        props.onOpenInNewWindow != null ||
-        props.onNewAgentFromHere != null
+        props.onBookmark != null
     }>
         <div
             class="node-strip"
@@ -90,27 +92,6 @@ export const NodeHoverStrip = (props: NodeHoverStripProps): JSX.Element => (
                     label={props.isBookmarked ? "Remove bookmark" : "Bookmark"}
                     active={props.isBookmarked === true}
                     onClick={props.onBookmark}
-                />
-            </Show>
-            <Show when={props.onOpenInNewPane}>
-                <StripButton
-                    icon="⧉"
-                    label="Open in new pane"
-                    onClick={props.onOpenInNewPane}
-                />
-            </Show>
-            <Show when={props.onOpenInNewWindow}>
-                <StripButton
-                    icon="⊡"
-                    label="Open in new window"
-                    onClick={props.onOpenInNewWindow}
-                />
-            </Show>
-            <Show when={props.onNewAgentFromHere}>
-                <StripButton
-                    icon="✦"
-                    label="New agent from here"
-                    onClick={props.onNewAgentFromHere}
                 />
             </Show>
         </div>

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -38,11 +38,7 @@ import { Show, createEffect, createSignal, onCleanup, type JSX } from "solid-js"
 import { Portal } from "solid-js/web";
 import { createBlock } from "@/store/global";
 import type { ToolNode } from "../types";
-import { BashOutputViewer } from "./BashOutputViewer";
-import { CompactResult } from "./CompactResult";
-import { DiffViewer } from "./DiffViewer";
-import { HighlightedCode } from "./HighlightedCode";
-import { detectLanguage } from "./detectLanguage";
+import { ToolBlockOverlay } from "./ToolBlockOverlay";
 
 interface ToolBlockProps {
     node: ToolNode;
@@ -50,6 +46,13 @@ interface ToolBlockProps {
     pinned: boolean;
     /** Toggle the pinned state (called on click of the collapsed row). */
     onTogglePin: () => void;
+    /** Bookmark state + handler — surfaced in the overlay action bar
+     *  (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.4). Optional for
+     *  callers that don't surface bookmarking. */
+    isBookmarked?: boolean;
+    onBookmark?: () => void;
+    /** Opens the tool's overlay content in a dedicated pane. */
+    onOpenInPane?: () => void;
 }
 
 const STATUS_ICON: Record<ToolNode["status"], string> = {
@@ -168,90 +171,10 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         }
     });
 
-    // Render tool-specific content — only evaluated when expanded.
-    const renderToolContent = (): JSX.Element => {
-        const node = props.node;
-        if (node.status === "running") {
-            return (
-                <div class="agent-tool-loading">
-                    <span class="agent-tool-spinner">⏳</span> Running...
-                </div>
-            );
-        }
-
-        switch (node.tool) {
-            case "Edit":
-                return <DiffViewer params={node.params as any} result={node.result as any} />;
-
-            case "Bash":
-                return <BashOutputViewer params={node.params as any} result={node.result as any} />;
-
-            case "Read": {
-                const filePath = (node.params as any).file_path ?? "";
-                const content: string | undefined = (node.result as any)?.content;
-                return (
-                    <div class="agent-tool-read">
-                        <div class="agent-tool-file-path">{filePath}</div>
-                        <Show
-                            when={content}
-                            fallback={
-                                <Show when={node.result}>
-                                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                                </Show>
-                            }
-                        >
-                            <HighlightedCode
-                                code={content!}
-                                lang={detectLanguage(filePath, content!.split("\n")[0])}
-                                class="agent-tool-read-content"
-                            />
-                        </Show>
-                    </div>
-                );
-            }
-
-            case "Write":
-                return (
-                    <div class="agent-tool-write">
-                        <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
-                        <div class="agent-tool-write-info">
-                            {node.result && `Wrote ${(node.result as any).bytesWritten || 0} bytes`}
-                        </div>
-                    </div>
-                );
-
-            case "Grep":
-            case "Glob":
-                return (
-                    <div class="agent-tool-search">
-                        <div class="agent-tool-pattern">Pattern: {(node.params as any).pattern}</div>
-                        <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                    </div>
-                );
-
-            case "Agent":
-                return (
-                    <div class="agent-tool-agent">
-                        <Show when={(node.params as any).description}>
-                            <div class="agent-tool-agent-desc">{(node.params as any).description}</div>
-                        </Show>
-                        <Show when={node.result}>
-                            <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                        </Show>
-                    </div>
-                );
-
-            case "Task":
-                return (
-                    <div class="agent-tool-task">
-                        <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
-                    </div>
-                );
-
-            default:
-                return <CompactResult tool={node.tool} params={node.params as any} result={node.result} />;
-        }
-    };
+    // Per-tool rich result rendering moved into `ToolOverlayLog`'s
+    // fallback path (Phase 3 of SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md).
+    // The overlay is now a header / log / action-bar three-slot
+    // component — see ToolBlockOverlay.tsx.
 
     // Overlay style — only meaningful when overlayMode() is true. Computed
     // from overlayRect() which is set during measure() / handleScroll.
@@ -342,7 +265,12 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                         style={overlayStyle()}
                         onClick={(e) => e.stopPropagation()}
                     >
-                        {renderToolContent()}
+                        <ToolBlockOverlay
+                            node={props.node}
+                            isBookmarked={props.isBookmarked}
+                            onBookmark={props.onBookmark}
+                            onOpenInPane={props.onOpenInPane}
+                        />
                     </div>
                 </Portal>
             </Show>

--- a/frontend/app/view/agent/components/ToolBlockOverlay.tsx
+++ b/frontend/app/view/agent/components/ToolBlockOverlay.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ToolBlockOverlay — three-slot tool overlay
+ * (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.4):
+ *
+ *   ┌────────────────────────────────────┐
+ *   │ header   (sticky)                  │
+ *   ├────────────────────────────────────┤
+ *   │ log body (scrollable, virtualized) │
+ *   │   ...                              │
+ *   ├────────────────────────────────────┤
+ *   │ action bar (fixed)                 │
+ *   └────────────────────────────────────┘
+ *
+ * Replaces the prior inline `renderToolContent()` switch in `ToolBlock`.
+ * The log slot uses `ToolOverlayLog` which falls back to per-tool rich
+ * result content when no streaming chunks are present (graceful for the
+ * Phase 3 ship — chunks start flowing in Phase 2's backend wrap).
+ */
+
+import { Show, type JSX } from "solid-js";
+import type { ToolNode } from "../types";
+import { STATUS_ICONS } from "../types";
+import { ToolOverlayActions } from "./ToolOverlayActions";
+import { ToolOverlayLog } from "./ToolOverlayLog";
+
+export interface ToolBlockOverlayProps {
+    node: ToolNode;
+    isBookmarked?: boolean;
+    onBookmark?: () => void;
+    onOpenInPane?: () => void;
+    onOpenInWindow?: () => void;
+    onNewAgentHere?: () => void;
+}
+
+const STATUS_LABEL: Record<ToolNode["status"], string> = {
+    running: "running",
+    pending_approval: "awaiting approval",
+    success: "ok",
+    failed: "failed",
+    denied: "denied",
+};
+
+export const ToolBlockOverlay = (props: ToolBlockOverlayProps): JSX.Element => (
+    <div class="agent-tool-overlay" data-node-id={props.node.id}>
+        <div class="agent-tool-overlay-header">
+            <span class="agent-tool-overlay-status">
+                {STATUS_ICONS[props.node.status] ?? "•"}
+            </span>
+            <span class="agent-tool-overlay-tool">{props.node.tool}</span>
+            <span class="agent-tool-overlay-summary" title={props.node.summary}>
+                {props.node.summary}
+            </span>
+            <span class="agent-tool-overlay-meta">
+                <Show when={props.node.duration}>
+                    <span class="agent-tool-overlay-duration">
+                        {props.node.duration!.toFixed(1)}s
+                    </span>
+                </Show>
+                <span class="agent-tool-overlay-status-label">
+                    {STATUS_LABEL[props.node.status]}
+                </span>
+            </span>
+        </div>
+        <ToolOverlayLog node={props.node} />
+        <ToolOverlayActions
+            node={props.node}
+            isBookmarked={props.isBookmarked}
+            onBookmark={props.onBookmark}
+            onOpenInPane={props.onOpenInPane}
+            onOpenInWindow={props.onOpenInWindow}
+            onNewAgentHere={props.onNewAgentHere}
+        />
+    </div>
+);
+
+ToolBlockOverlay.displayName = "ToolBlockOverlay";

--- a/frontend/app/view/agent/components/ToolOverlayActions.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayActions.tsx
@@ -1,0 +1,104 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ToolOverlayActions — bottom action bar of the tool overlay
+ * (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.4 + §4).
+ *
+ * Hosts the branching actions that used to live in `NodeHoverStrip`:
+ * bookmark, open-in-pane, open-in-window, new-agent-here. Branching
+ * actions belong at the bottom of the log so the user sees output
+ * first, options second — matches every native log viewer (terminal,
+ * VSCode output panel, browser DevTools console).
+ *
+ * Phase 3 wires bookmark + open-in-pane to real handlers; open-in-window
+ * and new-agent-here remain stubs with explanatory tooltips until the
+ * host APIs land (open-in-window) and a backend RPC exists
+ * (new-agent-here).
+ */
+
+import { Show, type JSX } from "solid-js";
+import type { ToolNode } from "../types";
+
+interface ToolOverlayActionsProps {
+    node: ToolNode;
+    isBookmarked?: boolean;
+    onBookmark?: () => void;
+    onOpenInPane?: () => void;
+    onOpenInWindow?: () => void;
+    onNewAgentHere?: () => void;
+}
+
+interface ActionButtonProps {
+    icon: string;
+    label: string;
+    title?: string;
+    disabled?: boolean;
+    active?: boolean;
+    onClick?: () => void;
+}
+
+const ActionButton = (props: ActionButtonProps): JSX.Element => (
+    <button
+        type="button"
+        class="agent-tool-overlay-action"
+        classList={{
+            "agent-tool-overlay-action--active": props.active === true,
+            "agent-tool-overlay-action--disabled": props.disabled === true,
+        }}
+        disabled={props.disabled}
+        title={props.title ?? props.label}
+        aria-label={props.label}
+        onClick={(e) => {
+            e.stopPropagation();
+            props.onClick?.();
+        }}
+    >
+        <span class="agent-tool-overlay-action-icon">{props.icon}</span>
+        <span class="agent-tool-overlay-action-label">{props.label}</span>
+    </button>
+);
+
+export const ToolOverlayActions = (props: ToolOverlayActionsProps): JSX.Element => (
+    <div class="agent-tool-overlay-actions" data-node-id={props.node.id}>
+        <Show when={props.onBookmark}>
+            <ActionButton
+                icon="🔖"
+                label={props.isBookmarked ? "Bookmarked" : "Bookmark"}
+                active={props.isBookmarked === true}
+                onClick={props.onBookmark}
+            />
+        </Show>
+        <Show when={props.onOpenInPane}>
+            <ActionButton
+                icon="⧉"
+                label="Open in pane"
+                onClick={props.onOpenInPane}
+            />
+        </Show>
+        <ActionButton
+            icon="⊡"
+            label="Open in window"
+            title={
+                props.onOpenInWindow
+                    ? "Open in new window"
+                    : "Coming soon — host API not yet shipped"
+            }
+            disabled={props.onOpenInWindow == null}
+            onClick={props.onOpenInWindow}
+        />
+        <ActionButton
+            icon="✦"
+            label="New agent here"
+            title={
+                props.onNewAgentHere
+                    ? "Spawn a sibling agent seeded with this context"
+                    : "Coming soon — backend RPC not yet shipped"
+            }
+            disabled={props.onNewAgentHere == null}
+            onClick={props.onNewAgentHere}
+        />
+    </div>
+);
+
+ToolOverlayActions.displayName = "ToolOverlayActions";

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -38,7 +38,33 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     let scrollRef: HTMLDivElement | undefined;
 
     const chunks = createMemo(() => props.node.log?.chunks ?? []);
-    const hasLog = createMemo(() => chunks().length > 0);
+    /**
+     * Phase 3 fallback rules — refined after codex P1 on PR #803.
+     *
+     * - While the tool is still streaming (`log.open === true`):
+     *   show the live chunk feed exclusively. This is the user's
+     *   primary "what's happening" surface.
+     * - Once the tool terminates (`log.open === false`): if a
+     *   structured `result` is present (BashResult with exit code,
+     *   EditResult diff, ReadResult content), show the rich
+     *   `ToolOverlayResult`. Structured viewers carry information
+     *   the raw chunk feed can't (exit code, diff syntax highlight,
+     *   per-language code highlight).
+     * - If terminated without a structured result, keep the chunks
+     *   visible so the user can still see what happened.
+     * - If neither chunks nor result is present (running tool that
+     *   hasn't emitted yet, or a non-streaming tool with no result
+     *   yet), defer to `ToolOverlayResult` which renders the
+     *   "⏳ Running..." placeholder.
+     *
+     * The codex-reported bug was a naive `chunks.length > 0` gate
+     * that permanently suppressed the structured result viewer for
+     * every tool that streamed any output — exit codes, diffs, and
+     * highlighted Read content were silently dropped post-completion.
+     */
+    const isStreaming = createMemo(() => props.node.log?.open === true);
+    const hasChunks = createMemo(() => chunks().length > 0);
+    const hasResult = createMemo(() => props.node.result != null);
 
     // Auto-stick to bottom while the user hasn't scrolled away. The
     // threshold is forgiving — within 40px of the bottom counts as
@@ -63,20 +89,36 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
 
     return (
         <div class="agent-tool-overlay-log" ref={scrollRef} onScroll={onScroll}>
-            <Show when={hasLog()} fallback={<ToolOverlayResult node={props.node} />}>
-                <For each={chunks()}>
-                    {(chunk) => (
-                        <pre
-                            class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}
-                        >
-                            {chunk.content}
-                        </pre>
-                    )}
-                </For>
+            <Show when={isStreaming() && hasChunks()}>
+                <ChunkList chunks={chunks()} />
+            </Show>
+            <Show when={!isStreaming() && hasResult()}>
+                <ToolOverlayResult node={props.node} />
+            </Show>
+            <Show when={!isStreaming() && !hasResult() && hasChunks()}>
+                <ChunkList chunks={chunks()} />
+            </Show>
+            <Show when={!hasChunks() && !hasResult()}>
+                <ToolOverlayResult node={props.node} />
             </Show>
         </div>
     );
 };
+
+interface ChunkListProps {
+    chunks: ReadonlyArray<{ kind: string; content: string; timestamp: number }>;
+}
+function ChunkList(props: ChunkListProps): JSX.Element {
+    return (
+        <For each={props.chunks}>
+            {(chunk) => (
+                <pre class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}>
+                    {chunk.content}
+                </pre>
+            )}
+        </For>
+    );
+}
 
 ToolOverlayLog.displayName = "ToolOverlayLog";
 

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -1,0 +1,170 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * ToolOverlayLog — log body of the tool overlay (Phase 3 of
+ * SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.4).
+ *
+ * Renders `ToolNode.log.chunks` if the streaming runner has populated
+ * them. Falls back to per-tool rich result content (BashOutputViewer,
+ * DiffViewer, ...) when no chunks are present — preserves today's UX
+ * for tools that don't stream (yet) or that have already terminated
+ * before Phase 2's backend wraps the runner.
+ *
+ * No ANSI parsing in this PR (Phase 3): chunks render as plain text.
+ * ANSI parsing lands in Phase γ (perf + worker offload) per the spec.
+ */
+
+import { For, Show, createEffect, createMemo, type JSX } from "solid-js";
+import type { ToolNode } from "../types";
+import { BashOutputViewer } from "./BashOutputViewer";
+import { CompactResult } from "./CompactResult";
+import { DiffViewer } from "./DiffViewer";
+import { HighlightedCode } from "./HighlightedCode";
+import { detectLanguage } from "./detectLanguage";
+
+interface ToolOverlayLogProps {
+    node: ToolNode;
+}
+
+const KIND_CLASS: Record<string, string> = {
+    stdout: "agent-tool-log-line--stdout",
+    stderr: "agent-tool-log-line--stderr",
+    system: "agent-tool-log-line--system",
+    "diff-hunk": "agent-tool-log-line--diff",
+};
+
+export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
+    let scrollRef: HTMLDivElement | undefined;
+
+    const chunks = createMemo(() => props.node.log?.chunks ?? []);
+    const hasLog = createMemo(() => chunks().length > 0);
+
+    // Auto-stick to bottom while the user hasn't scrolled away. The
+    // threshold is forgiving — within 40px of the bottom counts as
+    // "still at bottom" so a single mousewheel tick doesn't unstick.
+    let stickToBottom = true;
+    const onScroll = () => {
+        if (!scrollRef) return;
+        const dist = scrollRef.scrollHeight - scrollRef.scrollTop - scrollRef.clientHeight;
+        stickToBottom = dist < 40;
+    };
+
+    createEffect(() => {
+        // Re-read chunks to register the dep, then schedule a scroll-down.
+        chunks();
+        if (stickToBottom && scrollRef) {
+            // Wait one frame for the DOM to flush before measuring.
+            requestAnimationFrame(() => {
+                if (scrollRef) scrollRef.scrollTop = scrollRef.scrollHeight;
+            });
+        }
+    });
+
+    return (
+        <div class="agent-tool-overlay-log" ref={scrollRef} onScroll={onScroll}>
+            <Show when={hasLog()} fallback={<ToolOverlayResult node={props.node} />}>
+                <For each={chunks()}>
+                    {(chunk) => (
+                        <pre
+                            class={`agent-tool-log-line ${KIND_CLASS[chunk.kind] ?? ""}`}
+                        >
+                            {chunk.content}
+                        </pre>
+                    )}
+                </For>
+            </Show>
+        </div>
+    );
+};
+
+ToolOverlayLog.displayName = "ToolOverlayLog";
+
+/**
+ * Per-tool rich result fallback — same content the old portal overlay
+ * rendered. Used when there are no streaming chunks yet (or the tool
+ * doesn't stream).
+ */
+function ToolOverlayResult(props: { node: ToolNode }): JSX.Element {
+    const node = props.node;
+    if (node.status === "running") {
+        return (
+            <div class="agent-tool-loading">
+                <span class="agent-tool-spinner">⏳</span> Running...
+            </div>
+        );
+    }
+
+    switch (node.tool) {
+        case "Edit":
+            return <DiffViewer params={node.params as any} result={node.result as any} />;
+
+        case "Bash":
+            return <BashOutputViewer params={node.params as any} result={node.result as any} />;
+
+        case "Read": {
+            const filePath = (node.params as any).file_path ?? "";
+            const content: string | undefined = (node.result as any)?.content;
+            return (
+                <div class="agent-tool-read">
+                    <div class="agent-tool-file-path">{filePath}</div>
+                    <Show
+                        when={content}
+                        fallback={
+                            <Show when={node.result}>
+                                <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+                            </Show>
+                        }
+                    >
+                        <HighlightedCode
+                            code={content!}
+                            lang={detectLanguage(filePath, content!.split("\n")[0])}
+                            class="agent-tool-read-content"
+                        />
+                    </Show>
+                </div>
+            );
+        }
+
+        case "Write":
+            return (
+                <div class="agent-tool-write">
+                    <div class="agent-tool-file-path">{(node.params as any).file_path}</div>
+                    <div class="agent-tool-write-info">
+                        {node.result && `Wrote ${(node.result as any).bytesWritten || 0} bytes`}
+                    </div>
+                </div>
+            );
+
+        case "Grep":
+        case "Glob":
+            return (
+                <div class="agent-tool-search">
+                    <div class="agent-tool-pattern">Pattern: {(node.params as any).pattern}</div>
+                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+                </div>
+            );
+
+        case "Agent":
+            return (
+                <div class="agent-tool-agent">
+                    <Show when={(node.params as any).description}>
+                        <div class="agent-tool-agent-desc">{(node.params as any).description}</div>
+                    </Show>
+                    <Show when={node.result}>
+                        <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+                    </Show>
+                </div>
+            );
+
+        case "Task":
+            return (
+                <div class="agent-tool-task">
+                    <CompactResult tool={node.tool} params={node.params as any} result={node.result} />
+                </div>
+            );
+
+        default:
+            return <CompactResult tool={node.tool} params={node.params as any} result={node.result} />;
+    }
+}

--- a/frontend/app/view/agent/styles/_tool-overlay-portal.scss
+++ b/frontend/app/view/agent/styles/_tool-overlay-portal.scss
@@ -16,13 +16,17 @@
     border-radius: 0 0 3px 3px;
     box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
     max-height: min(400px, 60vh);
-    overflow-y: auto;
-    padding: var(--space-1-5) 10px var(--space-2) var(--space-5);
+    // Remove outer scroll — the log slot inside owns scrolling so the
+    // bottom action bar stays fixed (SPEC_TOOL_BLOCK_LIVE_LOG §3.4).
+    overflow: hidden;
     cursor: default;
     user-select: text;
     font-family: var(--fixed-font, monospace);
     font-size: 12px;
     color: var(--main-text-color);
+    // Three-slot layout: sticky header / scrollable log / fixed action bar.
+    display: flex;
+    flex-direction: column;
 
     // Flip variant — overlay opens upward when there isn't enough room
     // below the block. Swap the border-radius so the rounded side is on
@@ -30,6 +34,105 @@
     &.overlay-up {
         border-radius: 3px 3px 0 0;
         box-shadow: 0 -6px 20px rgba(0, 0, 0, 0.35);
+    }
+}
+
+// Phase 3 three-slot overlay: header / log / action bar.
+.agent-tool-overlay {
+    display: contents;
+}
+
+.agent-tool-overlay-header {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1) var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+    font-size: 11px;
+    color: var(--secondary-text-color);
+
+    .agent-tool-overlay-tool {
+        font-weight: 600;
+        color: var(--main-text-color);
+    }
+    .agent-tool-overlay-summary {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .agent-tool-overlay-meta {
+        display: flex;
+        gap: var(--space-1);
+        flex-shrink: 0;
+    }
+    .agent-tool-overlay-status-label {
+        text-transform: lowercase;
+    }
+}
+
+.agent-tool-overlay-log {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: var(--space-1-5) 10px var(--space-1-5) var(--space-2);
+
+    .agent-tool-log-line {
+        margin: 0;
+        padding: 0;
+        font-family: var(--fixed-font, monospace);
+        font-size: 12px;
+        line-height: 1.4;
+        white-space: pre-wrap;
+        word-break: break-word;
+
+        &--stderr {
+            color: var(--error-color, #ff6b6b);
+            opacity: 0.85;
+        }
+        &--system {
+            font-style: italic;
+            opacity: 0.7;
+        }
+    }
+}
+
+.agent-tool-overlay-actions {
+    flex: 0 0 auto;
+    display: flex;
+    gap: var(--space-0-5);
+    padding: var(--space-1) var(--space-1-5);
+    border-top: 1px solid var(--border-color);
+    background: var(--main-bg-color);
+
+    .agent-tool-overlay-action {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-0-5);
+        padding: var(--space-0-5) var(--space-1);
+        border: none;
+        border-radius: 3px;
+        background: transparent;
+        color: var(--main-text-color);
+        font-size: 11px;
+        cursor: pointer;
+
+        &:hover:not(.agent-tool-overlay-action--disabled) {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.08));
+        }
+        &--active {
+            background: var(--hover-bg-color, rgba(255, 255, 255, 0.12));
+        }
+        &--disabled {
+            opacity: 0.45;
+            cursor: not-allowed;
+        }
+        .agent-tool-overlay-action-icon {
+            font-size: 12px;
+        }
     }
 }
 

--- a/frontend/app/view/agent/virtualization/DocumentRow.tsx
+++ b/frontend/app/view/agent/virtualization/DocumentRow.tsx
@@ -93,16 +93,17 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
         else props.onToggleCollapse(n.id);
     };
 
-    // Phase 6 placeholders — match existing AgentDocumentView contract.
-    const onOpenInNewPane = (): void => {
+    // Open-in-pane for tool nodes — surfaces in the overlay action bar
+    // (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §4). Stubbed in Phase 3 as
+    // a console.warn; Phase 4 wires it to createBlock({view:"tool-detail"}).
+    // The other two branching actions (open-in-window, new-agent-here)
+    // are surfaced disabled by `ToolOverlayActions` itself with their
+    // own coming-soon tooltips.
+    const onOpenInPane = (): void => {
         if (props.node().type === "tool") {
-            console.warn("[hover-strip] open in new pane — not yet implemented");
+            console.warn("[tool-overlay] open in pane — not yet implemented");
         }
     };
-    const onOpenInNewWindow = (): void =>
-        console.warn("[hover-strip] open in new window — not yet implemented");
-    const onNewAgentFromHere = (): void =>
-        console.warn("[hover-strip] new agent from here — not yet implemented");
 
     const handleRowKey = (e: KeyboardEvent): void => {
         if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -113,15 +114,6 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 break;
             case "b":
                 if (props.onBookmark != null) { props.onBookmark(n); e.preventDefault(); }
-                break;
-            case "p":
-                if (n.type === "tool") { onOpenInNewPane(); e.preventDefault(); }
-                break;
-            case "w":
-                onOpenInNewWindow(); e.preventDefault();
-                break;
-            case "n":
-                onNewAgentFromHere(); e.preventDefault();
                 break;
             case "escape":
                 (e.currentTarget as HTMLElement).blur();
@@ -167,6 +159,9 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
             <DocumentNodeBody
                 node={props.node}
                 documentState={props.documentState}
+                isBookmarked={isBookmarked()}
+                onBookmark={props.onBookmark != null ? () => props.onBookmark!(props.node()) : undefined}
+                onOpenInPane={onOpenInPane}
                 onToggleCollapse={props.onToggleCollapse}
                 onTogglePin={props.onTogglePin}
                 onSubagentClick={props.onSubagentClick}
@@ -179,9 +174,6 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
                 canExpand={canExpand()}
                 isExpanded={isExpanded()}
                 onExpand={onExpand}
-                onOpenInNewPane={props.node().type === "tool" ? onOpenInNewPane : undefined}
-                onOpenInNewWindow={onOpenInNewWindow}
-                onNewAgentFromHere={onNewAgentFromHere}
             />
         </div>
     );
@@ -190,6 +182,14 @@ export function DocumentRow(props: DocumentRowProps): JSX.Element {
 interface DocumentNodeBodyProps {
     node: Accessor<DocumentNode>;
     documentState: Accessor<DocumentState>;
+    /** Bookmark state + handler — surfaced inside the tool overlay's
+     *  bottom action bar (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md §3.5).
+     *  The row-level NodeHoverStrip also surfaces bookmark — same handler
+     *  threaded through both. */
+    isBookmarked?: boolean;
+    onBookmark?: () => void;
+    /** Open-in-pane handler for tool nodes (overlay action bar). */
+    onOpenInPane?: () => void;
     onToggleCollapse: (id: string) => void;
     onTogglePin: (id: string) => void;
     onSubagentClick?: (node: SubagentLinkNode) => void;
@@ -234,6 +234,9 @@ function DocumentNodeBody(props: DocumentNodeBodyProps): JSX.Element {
                     node={props.node() as Extract<DocumentNode, { type: "tool" }>}
                     pinned={props.documentState().pinnedNodes.has(props.node().id)}
                     onTogglePin={() => props.onTogglePin(props.node().id)}
+                    isBookmarked={props.isBookmarked}
+                    onBookmark={props.onBookmark}
+                    onOpenInPane={props.onOpenInPane}
                 />
             </Show>
             <Show when={props.node() && props.node().type === "agent_message"}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.793",
+  "version": "0.33.794",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.793",
+      "version": "0.33.794",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.792",
+  "version": "0.33.793",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.792",
+      "version": "0.33.793",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -1024,6 +1024,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,6 +1041,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1056,6 +1058,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,6 +1075,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,6 +1092,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,6 +1109,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,6 +1126,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1136,6 +1143,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,6 +1160,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1168,6 +1177,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,6 +1194,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1200,6 +1211,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,6 +1228,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1232,6 +1245,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1248,6 +1262,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1264,6 +1279,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,6 +1296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,6 +1313,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1312,6 +1330,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,6 +1347,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,6 +1364,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1360,6 +1381,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1376,6 +1398,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,6 +1415,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1408,6 +1432,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1424,6 +1449,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1651,18 +1677,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1824,21 +1838,6 @@
         "langium": "^4.0.0"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1895,6 +1894,7 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1934,6 +1934,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1954,6 +1955,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1974,6 +1976,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1994,6 +1997,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,6 +2018,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2034,6 +2039,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2054,6 +2060,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2074,6 +2081,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2094,6 +2102,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2114,6 +2123,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2134,6 +2144,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2154,6 +2165,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2174,6 +2186,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2253,6 +2266,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,6 +2280,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2279,6 +2294,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2292,6 +2308,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2305,6 +2322,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2318,6 +2336,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2331,6 +2350,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2344,6 +2364,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2357,6 +2378,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,6 +2392,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2383,6 +2406,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2396,6 +2420,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,6 +2434,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2422,6 +2448,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2435,6 +2462,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,6 +2476,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2461,6 +2490,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2474,6 +2504,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2487,6 +2518,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,6 +2532,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,6 +2546,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,6 +2560,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2539,6 +2574,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2552,6 +2588,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2565,6 +2602,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3698,7 +3736,7 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4528,14 +4566,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -4727,7 +4757,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5579,7 +5609,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5698,7 +5728,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6063,6 +6093,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6179,6 +6210,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6224,7 +6256,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6907,7 +6939,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7059,7 +7091,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7079,7 +7111,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7270,7 +7302,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7516,7 +7548,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7549,6 +7581,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7569,6 +7602,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7589,6 +7623,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7609,6 +7644,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7629,6 +7665,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7649,6 +7686,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7669,6 +7707,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7689,6 +7728,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7709,6 +7749,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7729,6 +7770,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7749,6 +7791,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7813,19 +7856,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -9073,6 +9103,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9122,6 +9153,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9410,6 +9442,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9455,6 +9488,7 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9696,24 +9730,11 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
-    "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10028,7 +10049,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10094,6 +10115,7 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10195,7 +10217,7 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.0",
@@ -10404,29 +10426,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11141,34 +11140,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser": {
-      "version": "5.47.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/test-exclude": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
@@ -11259,6 +11230,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11487,7 +11459,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11507,6 +11479,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11578,7 +11551,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11809,6 +11782,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -11975,6 +11949,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11991,6 +11966,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12007,6 +11983,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12023,6 +12000,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12039,6 +12017,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12055,6 +12034,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12071,6 +12051,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12087,6 +12068,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12103,6 +12085,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12119,6 +12102,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12135,6 +12119,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12151,6 +12136,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12167,6 +12153,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12183,6 +12170,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12199,6 +12187,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12215,6 +12204,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12231,6 +12221,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12247,6 +12238,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12263,6 +12255,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12279,6 +12272,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12295,6 +12289,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12311,6 +12306,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12327,6 +12323,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12343,6 +12340,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12359,6 +12357,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12375,6 +12374,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,6 +12388,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12429,6 +12430,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12867,23 +12869,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.792",
+  "version": "0.33.793",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.793",
+  "version": "0.33.794",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 3 of [SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md) §3.4 + §3.5. Replaces \`ToolBlock\`'s inline \`renderToolContent()\` switch with a three-slot \`ToolBlockOverlay\` (sticky header, scrollable log body, fixed bottom action bar). Branching actions move out of \`NodeHoverStrip\` into the overlay action bar.

**Stacked on #800** (Phase 1: types + reducer + tests). Will rebase to \`main\` after #800 merges.

## What's new

- \`ToolBlockOverlay.tsx\` — three-slot wrapper (header / log / actions)
- \`ToolOverlayLog.tsx\` — renders \`node.log.chunks\` when present (live log), falls back to existing per-tool result viewers (\`BashOutputViewer\`, \`DiffViewer\`, ...) when not. Auto-scroll-to-bottom with 40px stick threshold.
- \`ToolOverlayActions.tsx\` — bottom action bar: bookmark, open-in-pane, open-in-window (disabled w/ tooltip), new-agent-here (disabled w/ tooltip)
- \`_tool-overlay-portal.scss\` — three-slot flex layout, per-kind log-line styling (stdout / stderr / system)

## What's removed from \`NodeHoverStrip\` (§3.5)

The three branching button slots — \`onOpenInNewPane\` / \`onOpenInNewWindow\` / \`onNewAgentFromHere\` — are deleted from the strip. They surface in the overlay's bottom action bar instead. Strip now carries timestamp + expand + bookmark only.

\`DocumentRow\` drops the keyboard shortcuts (\`p\` / \`w\` / \`n\`) that were tied to the removed buttons; \`e\` (expand) and \`b\` (bookmark) stay.

## Behavior today (chunks not flowing yet)

Phase 3 ships pure UI restructuring. The Phase 2 backend wrapper (\`SPEC_STREAMING_BASH_RUNNER_2026_05_11.md\`) isn't merged yet, so \`log.chunks\` stays empty for now. The fallback path renders the same content as before — \`BashOutputViewer\`, \`DiffViewer\`, etc. — so nothing visibly regresses. The overlay structure (header + action bar) is visible immediately and is the entry point for Phase 2's streaming chunks.

## Test plan

- [x] \`tsc --noEmit\` — zero new errors in touched files.
- [x] Existing reducer + parser tests: 63/63 pass.
- [ ] Smoke: extract a portable build, run a Bash tool, hover/pin to verify the overlay opens with header + body + action bar in the expected positions; verify the action bar's stub buttons show correct tooltips; verify NodeHoverStrip on a tool row now shows only bookmark + expand.

## Phasing

- **#800 (parent)** — Phase 1: types + reducer + tests.
- **This PR (α)** — Phase 3: overlay UI.
- **Next (β)** — Phase 2: streaming bash runner ([SPEC_STREAMING_BASH_RUNNER_2026_05_11.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md)). Chunks start flowing.
- **Then (γ)** — RAF coalescing + perf.
- **Then (δ)** — Codex / Gemini parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)