### PR TITLE
feat(bashwrap): new agentmux-bashwrap crate (PR β.A — streaming bash wrapper)

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -25,6 +25,11 @@
       "file": "agentmux-common/Cargo.toml",
       "type": "toml",
       "path": "package.version"
+    },
+    {
+      "file": "agentmux-bashwrap/Cargo.toml",
+      "type": "toml",
+      "path": "package.version"
     }
   ],
   "lockfiles": [
@@ -42,7 +47,8 @@
       "agentmux-srv/Cargo.toml",
       "agentmux-cef/Cargo.toml",
       "agentmux-launcher/Cargo.toml",
-      "agentmux-common/Cargo.toml"
+      "agentmux-common/Cargo.toml",
+      "agentmux-bashwrap/Cargo.toml"
     ],
     "commitMessage": "chore: bump version to {{version}}"
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.797"
+version = "0.33.798"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.797"
+version = "0.33.798"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.797"
+version = "0.33.798"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.797"
+version = "0.33.798"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.797"
+version = "0.33.798"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "agentmux-bashwrap"
+version = "0.33.796"
+dependencies = [
+ "anyhow",
+ "base64",
+ "clap",
+ "portable-pty",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "agentmux-cef"
 version = "0.33.796"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common"]
+members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common", "agentmux-bashwrap"]
 
 [profile.release]
 strip = true

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.797"
+version = "0.33.798"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.796"
+version = "0.33.797"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "agentmux-bashwrap"
+version = "0.33.796"
+edition = "2021"
+description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
+authors = ["AgentMux Corp"]
+license = "Apache-2.0"
+
+[[bin]]
+name = "agentmux-bashwrap"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "io-util", "time", "sync"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+clap = { version = "4", features = ["derive"] }
+portable-pty = "0.9"
+anyhow = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -1,0 +1,544 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `bash-wrap` subcommand — owns the PTY and streams chunks while
+//! the user's bash command runs.
+//!
+//! Invariants:
+//! - The user's command is decoded from `--b64-cmd` so quoting /
+//!   multi-line / shell-metachar content survives the rewrite.
+//! - The inner command runs inside a real PTY (24×200, TERM=xterm-256color)
+//!   so ANSI colors, spinners, and interactive prompts render
+//!   correctly in the AgentMux overlay.
+//! - Output is line-flushed with a ~50ms quiet-window timeout so
+//!   carriage-return progress bars (e.g. `npm install`'s `[==>] 50%`)
+//!   surface incrementally rather than waiting for `\n`.
+//! - Aggregated stdout (including stderr lines prefixed with
+//!   `[stderr] `) is captured into a buffer; on exit, a formatted
+//!   summary lands on this process's stdout for Claude's native Bash
+//!   tool to harvest as the `tool_result` content. Truncated head/
+//!   tail at 50KB each per
+//!   `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.5.
+//! - If WPS publish fails (missing env, sidecar down, etc.), the
+//!   command still runs to completion — output just doesn't stream.
+//!   The model-visible blob is unaffected. A `kind: "system"` chunk
+//!   announces the degradation at startup.
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use serde::Serialize;
+use std::io::Read as _;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::Mutex;
+
+use crate::wps_client::WpsClient;
+
+/// CLI args for `bash-wrap`. `command` carried as base64 to sidestep
+/// every quoting concern in the shell that invokes us.
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// Tool-use id from Claude's `tool_use` event; threaded back as
+    /// the WPS subject suffix so the frontend correlates chunks with
+    /// the matching ToolNode.
+    #[arg(long)]
+    pub tool_id: String,
+
+    /// URL-safe base64 (no padding) of the original command string.
+    #[arg(long)]
+    pub b64_cmd: String,
+
+    /// Optional block id — used as the `block:<id>` WPS scope so
+    /// chunks only reach subscribers watching this block. When
+    /// omitted, chunks publish unscoped.
+    #[arg(long)]
+    pub block_id: Option<String>,
+}
+
+const PTY_ROWS: u16 = 24;
+const PTY_COLS: u16 = 200;
+const FLUSH_QUIET_WINDOW: Duration = Duration::from_millis(50);
+/// Cap the model-visible head/tail sections of the aggregated blob.
+const MODEL_BLOB_HEAD_BYTES: usize = 50_000;
+const MODEL_BLOB_TAIL_BYTES: usize = 50_000;
+
+/// Wire payload published on `tool_chunk:<id>`. Mirrors the TypeScript
+/// `ToolChunkMessage` in `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
+#[derive(Serialize)]
+struct ChunkMessage<'a> {
+    op: &'static str, // "chunk"
+    kind: &'a str,    // "stdout" | "stderr" | "system"
+    content: &'a str,
+    timestamp: u64,
+}
+
+#[derive(Serialize)]
+struct TerminalMessage {
+    op: &'static str, // "terminal"
+    exit_code: i32,
+    timestamp: u64,
+}
+
+/// Returns the inner command's exit code so main.rs can mirror it as
+/// the wrapper's own process exit. Without this, Claude's native Bash
+/// tool saw success for every wrapped command regardless of the actual
+/// outcome — codex P1 on PR #804.
+pub async fn run(args: Args) -> Result<i32> {
+    let command = decode_command(&args.b64_cmd)?;
+
+    let wps = WpsClient::from_env();
+    let degraded = wps.is_none();
+
+    // Buffer for the aggregated model-visible blob.
+    let buffered = Arc::new(Mutex::new(Vec::<u8>::with_capacity(64 * 1024)));
+
+    if degraded {
+        // Surface degradation as a real chunk on stdout (we'll prefix
+        // it on the model side too) so the user sees a clear "no
+        // streaming this turn" message in the overlay. WPS publish
+        // would no-op, so we skip it.
+        let warn = b"[bashwrap] warning: streaming disabled (auth/url env missing); command output will only appear on completion\n";
+        buffered.lock().await.extend_from_slice(warn);
+    } else if let Some(client) = wps.as_ref() {
+        publish_system(
+            client,
+            &args.tool_id,
+            args.block_id.as_deref(),
+            &format!("[bashwrap] starting: {} chars", command.len()),
+        )
+        .await
+        .ok(); // Best-effort.
+    }
+
+    let start = std::time::Instant::now();
+    let status = run_pty(&args, &command, wps.as_ref(), buffered.clone()).await?;
+    let elapsed = start.elapsed();
+
+    // Final terminal marker so the frontend can flip log.open=false
+    // even if the matching StreamFlush from Claude is delayed.
+    if let Some(client) = wps.as_ref() {
+        let _ = client
+            .publish_chunk(
+                &args.tool_id,
+                args.block_id.as_deref(),
+                &TerminalMessage {
+                    op: "terminal",
+                    exit_code: status,
+                    timestamp: now_ms(),
+                },
+            )
+            .await;
+    }
+
+    let buf = buffered.lock().await;
+    let model_blob = format_model_blob(&buf, status, elapsed);
+    print!("{}", model_blob);
+    Ok(status)
+}
+
+fn decode_command(b64: &str) -> Result<String> {
+    use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let bytes = URL_SAFE_NO_PAD
+        .decode(b64.as_bytes())
+        .context("decoding --b64-cmd")?;
+    Ok(String::from_utf8(bytes).context("--b64-cmd is not valid UTF-8")?)
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+async fn publish_system(
+    client: &WpsClient,
+    tool_id: &str,
+    block_id: Option<&str>,
+    msg: &str,
+) -> Result<()> {
+    client
+        .publish_chunk(
+            tool_id,
+            block_id,
+            &ChunkMessage {
+                op: "chunk",
+                kind: "system",
+                content: msg,
+                timestamp: now_ms(),
+            },
+        )
+        .await
+}
+
+async fn publish_stdout(
+    client: &WpsClient,
+    tool_id: &str,
+    block_id: Option<&str>,
+    chunk: &str,
+) -> Result<()> {
+    client
+        .publish_chunk(
+            tool_id,
+            block_id,
+            &ChunkMessage {
+                op: "chunk",
+                kind: "stdout",
+                content: chunk,
+                timestamp: now_ms(),
+            },
+        )
+        .await
+}
+
+/// Pick the shell that runs the wrapped command.
+///
+/// Unix: `bash` (NOT `sh`). The PreToolUse hook matches on
+/// `tool_name == "Bash"`, so users expect bash semantics — `[[ ]]`,
+/// arrays, `source`, `pipefail`, etc. Using dash/sh as a stand-in
+/// would silently break a substantial portion of real commands.
+/// Codex P1 on PR #804.
+///
+/// Win32: `cmd /C` is the lowest-common-denominator Windows shell.
+/// PowerShell or pwsh might be more capable but requires explicit
+/// detection; keeping `cmd` matches what Claude Code's native Bash
+/// tool uses internally on Windows.
+fn shell_for_platform() -> &'static str {
+    if cfg!(windows) { "cmd" } else { "bash" }
+}
+
+fn shell_dash_c_flag() -> &'static str {
+    if cfg!(windows) { "/C" } else { "-c" }
+}
+
+/// Spawn the PTY child and stream its bytes. Returns the exit code.
+///
+/// We use a blocking thread for the PTY reader (the `portable_pty`
+/// master reader is sync) and a tokio mpsc to forward chunks into
+/// async-land for the publisher.
+async fn run_pty(
+    args: &Args,
+    command: &str,
+    wps: Option<&WpsClient>,
+    buffered: Arc<Mutex<Vec<u8>>>,
+) -> Result<i32> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: PTY_ROWS,
+            cols: PTY_COLS,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .context("opening PTY")?;
+
+    let mut builder = CommandBuilder::new(shell_for_platform());
+    builder.arg(shell_dash_c_flag());
+    builder.arg(command);
+    builder.env("TERM", "xterm-256color");
+    // PTY child inherits our env (which inherits agentmux-srv's), so
+    // AGENTMUX_* env vars + everything the parent had are present.
+
+    let mut child = pair
+        .slave
+        .spawn_command(builder)
+        .context("spawning PTY command")?;
+
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .context("cloning PTY reader")?;
+    // Drop the slave handle in the parent — the child still has it.
+    drop(pair.slave);
+    // Drop the master writer; we never inject stdin (interactive
+    // prompts deferred to PR γ+ per spec §14 open questions).
+    drop(pair.master);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
+
+    // Reader → flusher state. The blocking PTY reader appends bytes
+    // to `shared_pending`; an async timer task flushes the buffer on
+    // newline, on 4KB threshold, OR after FLUSH_QUIET_WINDOW idle
+    // time. The idle-flush path is what makes CR-only progress bars
+    // (npm install's `[==>] 50%` updates) surface live — without it,
+    // the reader sits on partial bytes until a `\n` finally arrives.
+    let shared_pending: Arc<std::sync::Mutex<Vec<u8>>> =
+        Arc::new(std::sync::Mutex::new(Vec::with_capacity(4096)));
+    let reader_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+    let tx_reader = tx.clone();
+    let tx_flusher = tx.clone();
+    drop(tx); // both clones own EOF for the publisher
+
+    // Blocking reader thread: read bytes + append to shared buffer.
+    // Inline newline/size-triggered flush for low-latency delivery
+    // of line-buffered output.
+    let pending_r = shared_pending.clone();
+    let done_r = reader_done.clone();
+    let reader_handle = std::thread::spawn(move || {
+        let mut buf = [0u8; 8192];
+        loop {
+            let n = match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::warn!("PTY read error: {}", e);
+                    break;
+                }
+            };
+            let mut p = pending_r.lock().unwrap();
+            p.extend_from_slice(&buf[..n]);
+            if p.contains(&b'\n') || p.len() >= 4096 {
+                let chunk = std::mem::take(&mut *p);
+                drop(p);
+                let _ = tx_reader.blocking_send(chunk);
+            }
+        }
+        // EOF: drain remainder, signal done.
+        let mut p = pending_r.lock().unwrap();
+        if !p.is_empty() {
+            let chunk = std::mem::take(&mut *p);
+            drop(p);
+            let _ = tx_reader.blocking_send(chunk);
+        }
+        done_r.store(true, std::sync::atomic::Ordering::Release);
+    });
+
+    // Async quiet-window flusher: ticks every FLUSH_QUIET_WINDOW and
+    // drains any bytes that have been sitting without a newline /
+    // threshold trigger. Exits when reader signals done.
+    let pending_f = shared_pending.clone();
+    let done_f = reader_done.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(FLUSH_QUIET_WINDOW);
+        // Skip the immediate first tick — wait one quiet window
+        // before the first flush so we don't preempt the reader's
+        // newline-based flush on common line-buffered output.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if done_f.load(std::sync::atomic::Ordering::Acquire) {
+                return;
+            }
+            let chunk = {
+                let mut p = pending_f.lock().unwrap();
+                if p.is_empty() {
+                    continue;
+                }
+                std::mem::take(&mut *p)
+            };
+            if tx_flusher.send(chunk).await.is_err() {
+                return;
+            }
+        }
+    });
+
+    // Async loop: drain the channel and publish chunks. Also runs a
+    // periodic timer that flushes any remaining pending bytes that
+    // didn't get bounced over via the newline heuristic.
+    let tool_id = args.tool_id.clone();
+    let block_id = args.block_id.clone();
+    let wps_clone = wps.cloned();
+    let buffered_clone = buffered.clone();
+
+    let publisher_handle = tokio::spawn(async move {
+        while let Some(bytes) = rx.recv().await {
+            // Capture into the aggregate buffer first, regardless of
+            // publish success — model-visible blob must be intact.
+            buffered_clone.lock().await.extend_from_slice(&bytes);
+
+            // Stream chunk over WPS. Best-effort: if publish fails
+            // (sidecar down, etc.), log and continue — degraded mode.
+            if let Some(client) = wps_clone.as_ref() {
+                let content = String::from_utf8_lossy(&bytes).into_owned();
+                if let Err(e) =
+                    publish_stdout(client, &tool_id, block_id.as_deref(), &content).await
+                {
+                    tracing::warn!("WPS publish failed: {}", e);
+                }
+            }
+        }
+    });
+
+    // Wait for the child to exit. portable_pty's wait is blocking;
+    // spawn on blocking pool.
+    let exit_status = tokio::task::spawn_blocking(move || child.wait())
+        .await
+        .context("joining wait task")?
+        .context("waiting for PTY child")?;
+
+    // The reader thread exits when EOF arrives on its end of the PTY,
+    // which happens after the child exits. Join it.
+    let _ = tokio::task::spawn_blocking(|| reader_handle.join()).await;
+
+    // Drop tx-side via publisher_handle awaiting Stream closure happens
+    // automatically when the reader thread exits and tx is dropped.
+    let _ = publisher_handle.await;
+
+    Ok(exit_status.exit_code() as i32)
+}
+
+/// Snap `idx` down to the nearest UTF-8 character boundary (or 0).
+/// A byte is a UTF-8 char boundary iff it's either ASCII (< 0x80) or
+/// a leading byte (>= 0xC0). Continuation bytes are in 0x80..=0xBF.
+/// `idx == buf.len()` is always a valid boundary (one past the end).
+fn snap_to_char_boundary_floor(buf: &[u8], idx: usize) -> usize {
+    let mut i = idx.min(buf.len());
+    while i > 0 && i < buf.len() && (buf[i] & 0xC0) == 0x80 {
+        i -= 1;
+    }
+    i
+}
+
+/// Snap `idx` up to the nearest UTF-8 character boundary (or buf.len()).
+fn snap_to_char_boundary_ceil(buf: &[u8], idx: usize) -> usize {
+    let mut i = idx.min(buf.len());
+    while i < buf.len() && (buf[i] & 0xC0) == 0x80 {
+        i += 1;
+    }
+    i
+}
+
+/// Build the aggregated, model-visible blob from the captured bytes.
+/// Truncates with head/tail markers if it exceeds 100KB.
+///
+/// **UTF-8 safety**: head/tail slice boundaries are snapped to the
+/// nearest UTF-8 character boundary so non-ASCII output (emoji,
+/// accented characters, CJK) doesn't get corrupted into `�`
+/// replacement characters at the cut point. Reagent P1 round 4 on
+/// PR #804 caught this — naive fixed-byte slicing splits multi-byte
+/// sequences and the lossy decode emits replacement chars.
+pub(crate) fn format_model_blob(
+    buf: &[u8],
+    exit_code: i32,
+    elapsed: std::time::Duration,
+) -> String {
+    let body = if buf.len() <= MODEL_BLOB_HEAD_BYTES + MODEL_BLOB_TAIL_BYTES {
+        String::from_utf8_lossy(buf).into_owned()
+    } else {
+        let head_end = snap_to_char_boundary_floor(buf, MODEL_BLOB_HEAD_BYTES);
+        let tail_start = snap_to_char_boundary_ceil(buf, buf.len() - MODEL_BLOB_TAIL_BYTES);
+        let head = String::from_utf8_lossy(&buf[..head_end]);
+        let tail = String::from_utf8_lossy(&buf[tail_start..]);
+        let elided = tail_start - head_end;
+        format!(
+            "{}\n... [{} bytes elided — see streaming log for full output] ...\n{}",
+            head, elided, tail
+        )
+    };
+    format!(
+        "<exited {} in {:.2}s>\n{}",
+        exit_code,
+        elapsed.as_secs_f64(),
+        body
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_b64_command() {
+        // base64("echo hi") = ZWNobyBoaQ (no padding, url-safe)
+        let s = decode_command("ZWNobyBoaQ").unwrap();
+        assert_eq!(s, "echo hi");
+    }
+
+    #[test]
+    fn decodes_multi_line_with_quotes() {
+        use base64::Engine as _;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        let original = "echo \"hello\" && cat $HOME/.env\nls -la";
+        let b64 = URL_SAFE_NO_PAD.encode(original.as_bytes());
+        let s = decode_command(&b64).unwrap();
+        assert_eq!(s, original);
+    }
+
+    #[test]
+    fn rejects_malformed_b64() {
+        assert!(decode_command("not-valid-base64===").is_err());
+    }
+
+    #[test]
+    fn format_model_blob_includes_exit_and_elapsed() {
+        let out = format_model_blob(
+            b"hello world",
+            0,
+            std::time::Duration::from_millis(1234),
+        );
+        assert!(out.starts_with("<exited 0 in 1.23s>"));
+        assert!(out.ends_with("hello world"));
+    }
+
+    #[test]
+    fn format_model_blob_snaps_to_utf8_boundaries() {
+        // Reagent P1 round 4: ensure multi-byte UTF-8 sequences don't
+        // get split at the truncation cut points. Build a 150KB buffer
+        // by repeating a 4-byte emoji (U+1F600 "😀") which spans bytes
+        // [0xF0, 0x9F, 0x98, 0x80]. Naive fixed-byte slicing would
+        // split most cuts mid-sequence, producing `�` replacement
+        // chars in the output. With the boundary-snap, the head and
+        // tail must both decode losslessly back to whole emojis.
+        let emoji = "😀".as_bytes();
+        assert_eq!(emoji.len(), 4);
+        let buf: Vec<u8> = emoji.iter().cycle().take(150_000).copied().collect();
+        let out = format_model_blob(&buf, 0, std::time::Duration::from_millis(100));
+        // Pull the head section out — everything between the framing
+        // and the elision marker.
+        let after_frame = out.split('\n').skip(1).next().unwrap();
+        // The first emoji should be intact (no replacement char).
+        assert!(
+            after_frame.starts_with('😀'),
+            "head should start with intact emoji, got: {:?}",
+            &after_frame[..40.min(after_frame.len())]
+        );
+        // No replacement char anywhere in the output.
+        assert!(
+            !out.contains('\u{FFFD}'),
+            "found replacement char (lossy decode at boundary)"
+        );
+    }
+
+    #[test]
+    fn snap_floor_handles_continuation_bytes() {
+        // "😀" = F0 9F 98 80. At idx=2 we're inside the sequence;
+        // floor must walk back to idx=0.
+        let buf = "😀".as_bytes();
+        assert_eq!(snap_to_char_boundary_floor(buf, 2), 0);
+        assert_eq!(snap_to_char_boundary_floor(buf, 0), 0);
+        assert_eq!(snap_to_char_boundary_floor(buf, 4), 4);
+    }
+
+    #[test]
+    fn snap_ceil_handles_continuation_bytes() {
+        // Inside emoji → ceil walks forward to the next leading byte.
+        let buf = "a😀b".as_bytes(); // [a F0 9F 98 80 b]
+        // idx 2 = inside emoji → ceil = 5 (start of 'b')
+        assert_eq!(snap_to_char_boundary_ceil(buf, 2), 5);
+        // idx 1 = leading byte → stays
+        assert_eq!(snap_to_char_boundary_ceil(buf, 1), 1);
+    }
+
+    #[test]
+    fn format_model_blob_truncates_huge_output() {
+        // 150KB of 'x' — must elide the middle.
+        let buf = vec![b'x'; 150_000];
+        let out = format_model_blob(&buf, 1, std::time::Duration::from_secs(5));
+        assert!(out.contains("[50000 bytes elided"));
+        assert!(out.contains("<exited 1 in 5.00s>"));
+        // Should be ~100KB + framing, not 150KB.
+        assert!(out.len() < 150_000);
+    }
+
+    #[test]
+    fn format_model_blob_passes_small_output_unchanged() {
+        let buf = b"line 1\nline 2\nline 3";
+        let out = format_model_blob(buf, 0, std::time::Duration::from_millis(100));
+        assert!(out.contains("line 1"));
+        assert!(out.contains("line 3"));
+        assert!(!out.contains("elided"));
+    }
+}

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -1,8 +1,8 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! `bash-wrap` subcommand — owns the PTY and streams chunks while
-//! the user's bash command runs.
+//! `exec` subcommand — owns the PTY and streams chunks while the
+//! user's bash command runs.
 //!
 //! Invariants:
 //! - The user's command is decoded from `--b64-cmd` so quoting /
@@ -35,8 +35,8 @@ use tokio::sync::Mutex;
 
 use crate::wps_client::WpsClient;
 
-/// CLI args for `bash-wrap`. `command` carried as base64 to sidestep
-/// every quoting concern in the shell that invokes us.
+/// CLI args for `exec`. `command` carried as base64 to sidestep every
+/// quoting concern in the shell that invokes us.
 #[derive(Parser, Debug)]
 pub struct Args {
     /// Tool-use id from Claude's `tool_use` event; threaded back as

--- a/agentmux-bashwrap/src/hook.rs
+++ b/agentmux-bashwrap/src/hook.rs
@@ -1,0 +1,295 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `hook-pretooluse-bash` subcommand.
+//!
+//! Reads a PreToolUse JSON event on stdin (the contract Claude Code
+//! uses for hooks: see `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md`
+//! §5). If the event is a Bash invocation whose `command` hasn't
+//! already been wrapped, emit an `updatedInput.command` that invokes
+//! `agentmux-bashwrap bash-wrap` with the original command base64-
+//! encoded into argv. Idempotent — if the command is already wrapped,
+//! pass through with no rewrite.
+//!
+//! All errors degrade to a pass-through response so a hook failure
+//! never blocks Claude's tool execution.
+
+use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::io::{Read, Write};
+
+/// Subset of the PreToolUse payload we care about. Extra fields are
+/// ignored (serde default).
+#[derive(Deserialize)]
+struct PreToolUseInput {
+    tool_name: String,
+    #[serde(default)]
+    tool_use_id: String,
+    #[serde(default)]
+    tool_input: Value,
+}
+
+const WRAPPER_BINARY: &str = "agentmux-bashwrap";
+const WRAPPED_PREFIX: &str = "agentmux-bashwrap exec";
+
+pub fn run_pretooluse_bash() -> Result<()> {
+    // Read entire stdin. Hook payloads are small.
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf)?;
+
+    let response = build_response(&buf);
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    writeln!(handle, "{}", response)?;
+    Ok(())
+}
+
+/// Build the hook response for a PreToolUse payload. Public for
+/// testability — callers in tests feed in a payload string and assert
+/// the response shape without going through stdin.
+pub fn build_response(stdin_payload: &str) -> Value {
+    let input: PreToolUseInput = match serde_json::from_str(stdin_payload) {
+        Ok(i) => i,
+        Err(_) => {
+            // Malformed hook input → pass through. Claude proceeds
+            // with native Bash, no streaming for this call.
+            return passthrough();
+        }
+    };
+
+    if input.tool_name != "Bash" {
+        return passthrough();
+    }
+
+    let command = input
+        .tool_input
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // Idempotence: if the command already invokes our wrapper, don't
+    // re-wrap. Defends against weird hook re-fire scenarios.
+    if command.starts_with(WRAPPED_PREFIX) {
+        return passthrough();
+    }
+
+    let b64 = URL_SAFE_NO_PAD.encode(command.as_bytes());
+    let wrapped = format!(
+        "{} exec --tool-id={} --b64-cmd={}",
+        WRAPPER_BINARY,
+        shell_quote(&input.tool_use_id),
+        b64
+    );
+
+    json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "command": wrapped
+            }
+        }
+    })
+}
+
+fn passthrough() -> Value {
+    // Empty object → Claude Code treats as "no opinion", proceeds.
+    json!({})
+}
+
+/// Quote a value for embedding in a shell argv position.
+///
+/// The tool-use-id is provider-generated and currently always opaque
+/// ASCII, but be defensive: if it contains a non-safe char, escape
+/// per the host shell's rules.
+///
+/// - **Unix shells** (bash/sh/zsh): single-quote wrap with `'\''`
+///   escape for embedded single quotes.
+/// - **Windows `cmd.exe /C`**: cmd doesn't interpret single quotes
+///   as quoting; we use double quotes and escape embedded `"` per
+///   cmd.exe rules. This is the shell Claude Code's Bash tool
+///   invokes on Win32.
+///
+/// Pure-alphanumeric ids return unchanged on every platform.
+fn shell_quote(s: &str) -> String {
+    if s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return s.to_string();
+    }
+    #[cfg(windows)]
+    {
+        // cmd.exe: double-quote wrap, escape `"` as `""`. Reasonable
+        // approximation — full cmd.exe quoting is famously gnarly,
+        // but for opaque-ID-with-weird-char defense this is enough.
+        let escaped = s.replace('"', "\"\"");
+        format!("\"{}\"", escaped)
+    }
+    #[cfg(not(windows))]
+    {
+        // bash/sh/zsh: single-quote wrap, escape `'` as `'\''`.
+        let escaped = s.replace('\'', r"'\''");
+        format!("'{}'", escaped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn payload(cmd: &str, id: &str) -> String {
+        json!({
+            "tool_name": "Bash",
+            "tool_use_id": id,
+            "tool_input": { "command": cmd },
+            "session_id": "sess-1",
+            "hook_event_name": "PreToolUse"
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn rewrites_simple_bash_command() {
+        let resp = build_response(&payload("echo hi", "toolu_abc"));
+        let cmd = resp["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .unwrap();
+        assert!(cmd.starts_with("agentmux-bashwrap exec"));
+        assert!(cmd.contains("--tool-id=toolu_abc"));
+        // base64("echo hi") = ZWNobyBoaQ
+        assert!(cmd.contains("--b64-cmd=ZWNobyBoaQ"));
+        assert_eq!(
+            resp["hookSpecificOutput"]["permissionDecision"].as_str(),
+            Some("allow")
+        );
+    }
+
+    #[test]
+    fn preserves_multi_line_and_quotes_via_base64() {
+        let cmd = r#"echo "hello" && echo 'multi
+line' && cat $HOME/.env"#;
+        let resp = build_response(&payload(cmd, "toolu_x"));
+        let wrapped = resp["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .unwrap();
+        // The wrapped form must round-trip — pull the b64 back and decode.
+        let b64 = wrapped
+            .split("--b64-cmd=")
+            .nth(1)
+            .expect("b64 arg present");
+        let decoded = URL_SAFE_NO_PAD.decode(b64.as_bytes()).unwrap();
+        let decoded = String::from_utf8(decoded).unwrap();
+        assert_eq!(decoded, cmd);
+    }
+
+    #[test]
+    fn is_no_op_on_already_wrapped_command() {
+        let cmd =
+            "agentmux-bashwrap exec --tool-id=toolu_y --b64-cmd=ZWNobyBoaQ";
+        let resp = build_response(&payload(cmd, "toolu_y"));
+        assert!(
+            resp.as_object().map(|m| m.is_empty()).unwrap_or(false),
+            "should pass through (empty object), got {}",
+            resp
+        );
+    }
+
+    #[test]
+    fn passes_through_non_bash_tools() {
+        let payload = json!({
+            "tool_name": "Read",
+            "tool_use_id": "toolu_r",
+            "tool_input": { "file_path": "x.txt" }
+        })
+        .to_string();
+        let resp = build_response(&payload);
+        assert!(
+            resp.as_object().map(|m| m.is_empty()).unwrap_or(false),
+            "non-Bash should pass through"
+        );
+    }
+
+    #[test]
+    fn passes_through_malformed_input() {
+        let resp = build_response("not json");
+        assert!(
+            resp.as_object().map(|m| m.is_empty()).unwrap_or(false),
+            "malformed → passthrough"
+        );
+    }
+
+    #[test]
+    fn rewrites_with_empty_b64_when_command_field_missing() {
+        // Codex P2 round 3: the previous name `passes_through_when_
+        // command_field_missing` lied about behavior, and the inline
+        // comment claimed `bash -c ""` would "fail at wrapper start
+        // time" — which is wrong; an empty bash command exits 0
+        // silently. Renamed + comment corrected to describe what
+        // actually happens.
+        //
+        // Behavior under test: when `tool_input.command` is missing,
+        // we still emit a rewrite (with `--b64-cmd=` of an empty
+        // string). The wrapper then runs `bash -c ""` which exits 0
+        // immediately. Net effect: a no-op Bash call streams a "0
+        // chars" system chunk + an empty body, and Claude sees an
+        // empty tool_result. Not catastrophic; the empty input was
+        // already going to do nothing.
+        let payload = json!({
+            "tool_name": "Bash",
+            "tool_use_id": "toolu_z",
+            "tool_input": {}
+        })
+        .to_string();
+        let resp = build_response(&payload);
+        let cmd = resp["hookSpecificOutput"]["updatedInput"]["command"]
+            .as_str()
+            .unwrap();
+        // The b64 of an empty string is the empty string, so we
+        // expect `--b64-cmd=` immediately followed by whatever ends
+        // the command (whitespace or EOL). Match the prefix.
+        assert!(
+            cmd.contains("--b64-cmd=") && (cmd.ends_with("--b64-cmd=") || cmd.contains("--b64-cmd= ")),
+            "expected empty b64-cmd argument, got: {}",
+            cmd
+        );
+    }
+
+    #[test]
+    fn shell_quote_passes_safe_ids_unchanged() {
+        assert_eq!(shell_quote("toolu_abc-123"), "toolu_abc-123");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_quote_wraps_unsafe_ids_unix() {
+        let q = shell_quote("weird id");
+        assert_eq!(q, "'weird id'");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn shell_quote_escapes_embedded_single_quotes_unix() {
+        // Standard bash idiom: `'` → `'\''` (close, escaped, reopen).
+        // For `o'malley` the result is `'o'\''malley'`.
+        let q = shell_quote("o'malley");
+        assert_eq!(q, r"'o'\''malley'");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shell_quote_wraps_unsafe_ids_windows() {
+        let q = shell_quote("weird id");
+        assert_eq!(q, "\"weird id\"");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn shell_quote_escapes_embedded_double_quotes_windows() {
+        // cmd.exe `""` is the escape for a literal `"` inside a
+        // double-quoted argument. For `a"b` the result is `"a""b"`.
+        let q = shell_quote("a\"b");
+        assert_eq!(q, "\"a\"\"b\"");
+    }
+}

--- a/agentmux-bashwrap/src/hook.rs
+++ b/agentmux-bashwrap/src/hook.rs
@@ -1,15 +1,15 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! `hook-pretooluse-bash` subcommand.
+//! `hook` subcommand.
 //!
 //! Reads a PreToolUse JSON event on stdin (the contract Claude Code
 //! uses for hooks: see `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md`
 //! §5). If the event is a Bash invocation whose `command` hasn't
 //! already been wrapped, emit an `updatedInput.command` that invokes
-//! `agentmux-bashwrap bash-wrap` with the original command base64-
-//! encoded into argv. Idempotent — if the command is already wrapped,
-//! pass through with no rewrite.
+//! `agentmux-bashwrap exec` with the original command base64-encoded
+//! into argv. Idempotent — if the command is already wrapped, pass
+//! through with no rewrite.
 //!
 //! All errors degrade to a pass-through response so a hook failure
 //! never blocks Claude's tool execution.

--- a/agentmux-bashwrap/src/main.rs
+++ b/agentmux-bashwrap/src/main.rs
@@ -1,0 +1,76 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! agentmux-bashwrap — streaming bash wrapper for AgentMux agents.
+//!
+//! Two subcommands:
+//!
+//! - `exec` — runs a user-supplied command inside an owned PTY,
+//!   streams stdout/stderr line-by-line to the AgentMux sidecar's
+//!   WPS broker (HTTP), and prints the aggregated output on its own
+//!   stdout for Claude's native Bash tool to capture as `tool_result`.
+//!
+//! - `hook` — reads a PreToolUse JSON payload on stdin and emits a
+//!   hook response that rewrites the command so Claude's native
+//!   Bash invokes `agentmux-bashwrap exec` instead. The original
+//!   command is base64-encoded into the rewrite argv so quoting +
+//!   multi-line bodies survive.
+//!
+//! See `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` for the
+//! full design rationale (why command rewrite vs. MCP deny-redirect,
+//! why a separate binary vs. extending an MCP server, channel
+//! correlation by `tool_use_id`, etc).
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+mod bash_wrap;
+mod hook;
+mod wps_client;
+
+#[derive(Parser)]
+#[command(name = "agentmux-bashwrap", version)]
+#[command(about = "AgentMux streaming bash wrapper + PreToolUse hook helper")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Run a bash command inside an owned PTY, stream its stdout/stderr
+    /// to the AgentMux sidecar's WPS broker, and print the aggregated
+    /// output on this process's stdout for Claude to capture.
+    Exec(bash_wrap::Args),
+    /// Read a PreToolUse JSON payload on stdin (from Claude Code) and
+    /// emit a hook response that rewrites the command to invoke `exec`.
+    Hook,
+}
+
+fn main() -> Result<()> {
+    // Logs go to stderr so they don't pollute the stdout channel that
+    // Claude reads as `tool_result.content`. RUST_LOG controls level;
+    // default `warn` keeps noise minimal in production.
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let rt = tokio::runtime::Runtime::new()?;
+    match cli.command {
+        Command::Exec(args) => {
+            // Propagate the inner command's exit code as our own
+            // process exit. Without this the wrapper always exited 0
+            // and Claude's native Bash tool saw success for every
+            // wrapped command regardless of the actual outcome —
+            // codex P1 on PR #804.
+            let exit_code = rt.block_on(bash_wrap::run(args))?;
+            std::process::exit(exit_code);
+        }
+        Command::Hook => hook::run_pretooluse_bash(),
+    }
+}

--- a/agentmux-bashwrap/src/wps_client.rs
+++ b/agentmux-bashwrap/src/wps_client.rs
@@ -1,0 +1,148 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin HTTP client for publishing WPS events to the AgentMux sidecar.
+//!
+//! Reads `AGENTMUX_LOCAL_URL` and `AGENTMUX_AUTH_KEY` from the
+//! process environment (inherited from the agentmux-srv → claude →
+//! bash subprocess chain). Attaches `X-AuthKey` per PR #801 to
+//! authenticate against the auth_middleware-gated publish endpoint.
+//!
+//! Designed to silently degrade: if env vars are absent or the
+//! sidecar is unreachable, publishes fail-fast and the caller emits
+//! a `kind: "system"` chunk that surfaces the degradation to the
+//! user without aborting the command itself.
+
+use anyhow::Result;
+use serde::Serialize;
+use std::sync::Arc;
+
+const PUBLISH_PATH: &str = "/agentmux/wps/publish";
+
+/// Per-launch sidecar config + reusable HTTP client. Cheap to clone
+/// (the inner `reqwest::Client` uses Arc internally).
+#[derive(Clone)]
+pub struct WpsClient {
+    inner: Arc<reqwest::Client>,
+    endpoint: String,
+    auth_key: String,
+}
+
+#[derive(Serialize)]
+struct PublishRequest<'a, T: Serialize> {
+    /// WPS event name. We use `tool_chunk:<id>` for streaming chunks.
+    event: &'a str,
+    /// Optional scope filters (typically `block:<id>` so only
+    /// subscribers watching that block receive the event).
+    #[serde(skip_serializing_if = "<[String]>::is_empty")]
+    scopes: &'a [String],
+    /// Event payload. Free-form per event type.
+    data: &'a T,
+}
+
+impl WpsClient {
+    /// Build a client from the env. Returns `None` when the required
+    /// env vars are missing — the caller surfaces a system chunk
+    /// rather than crashing.
+    pub fn from_env() -> Option<Self> {
+        let endpoint = std::env::var("AGENTMUX_LOCAL_URL").ok()?;
+        let auth_key = std::env::var("AGENTMUX_AUTH_KEY").ok()?;
+        if endpoint.is_empty() || auth_key.is_empty() {
+            return None;
+        }
+        let inner = reqwest::Client::builder()
+            // Snappy publish — chunks should land within a frame of
+            // emission. Long timeouts here cause back-pressure that
+            // stalls the PTY reader.
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .ok()?;
+        Some(Self {
+            inner: Arc::new(inner),
+            endpoint: endpoint.trim_end_matches('/').to_string(),
+            auth_key,
+        })
+    }
+
+    /// Publish a `tool_chunk:<id>` event. `payload` is serialized as
+    /// the event's `data` field; scopes restrict delivery to listeners
+    /// watching `block:<block_id>` (if provided).
+    pub async fn publish_chunk<T: Serialize>(
+        &self,
+        tool_id: &str,
+        block_id: Option<&str>,
+        payload: &T,
+    ) -> Result<()> {
+        let event = format!("tool_chunk:{}", tool_id);
+        let scopes: Vec<String> = block_id
+            .map(|b| vec![format!("block:{}", b)])
+            .unwrap_or_default();
+        let body = PublishRequest {
+            event: &event,
+            scopes: &scopes,
+            data: payload,
+        };
+        let url = format!("{}{}", self.endpoint, PUBLISH_PATH);
+        let resp = self
+            .inner
+            .post(&url)
+            .header("X-AuthKey", &self.auth_key)
+            .header("Content-Type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            // Body may include a structured error from auth_middleware;
+            // include for diagnostics in the wrapper's stderr trace.
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("publish failed: HTTP {} — {}", status, text);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // `std::env::set_var` / `remove_var` mutate process-global state;
+    // cargo test runs tests in parallel by default, so without a
+    // serial lock these races between threads (codex P1 on PR #804).
+    // A single mutex covers every test in this module that touches
+    // the env.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_env() {
+        std::env::remove_var("AGENTMUX_LOCAL_URL");
+        std::env::remove_var("AGENTMUX_AUTH_KEY");
+    }
+
+    #[test]
+    fn from_env_returns_none_without_endpoint() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        assert!(WpsClient::from_env().is_none());
+    }
+
+    #[test]
+    fn from_env_returns_none_when_only_endpoint_set() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("AGENTMUX_LOCAL_URL", "http://127.0.0.1:1");
+        assert!(WpsClient::from_env().is_none());
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_strips_trailing_slash() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_env();
+        std::env::set_var("AGENTMUX_LOCAL_URL", "http://127.0.0.1:9999/");
+        std::env::set_var("AGENTMUX_AUTH_KEY", "x");
+        let c = WpsClient::from_env().expect("client");
+        assert_eq!(c.endpoint, "http://127.0.0.1:9999");
+        clear_env();
+    }
+}

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.797"
+version = "0.33.798"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.796"
+version = "0.33.797"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.796"
+version = "0.33.797"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.797"
+version = "0.33.798"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.796"
+version = "0.33.797"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.797"
+version = "0.33.798"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.796"
+version = "0.33.797"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.797"
+version = "0.33.798"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md
+++ b/docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md
@@ -1,0 +1,598 @@
+# Streaming bash runner — PreToolUse command rewrite
+
+**Status:** Proposed
+**Owner:** AgentA
+**Date:** 2026-05-11
+**Replaces:** Phase 2 of [SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md](./SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md) ("Connect stdout/stderr line streaming on the host side"), which was unimplementable as written.
+**Companion:** [docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md](../analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md) — option analysis that ruled in this approach.
+
+**Implementation update (2026-05-11):** Renamed the wrapper from `agentmux-mcp` (the originally-assumed pre-existing crate that turns out NOT to exist in this workspace) to `agentmux-bashwrap` — a new Rust binary in this workspace. Subcommands renamed from `bash-wrap` / `hook-pretooluse-bash` to `exec` / `hook` for cleaner UX. The wrapper crate landed in PR β.A; wire-up (HTTP publish endpoint, env re-injection, hook auto-injection, frontend bridge) will follow in PR β.B.
+
+---
+
+## 1. Goal
+
+Stream Bash stdout/stderr to the agent pane in real time, with full PTY fidelity (ANSI/colors, spinners, interactive prompts), while keeping the `claude` CLI subprocess as the agent runtime so subscription-tier OAuth keeps working. Make `cmd1 && cmd2 && long_build` show progress as it actually progresses — not a 3-minute spinner followed by a wall of text.
+
+Phase 1 ([PR #800](https://github.com/agentmuxai/agentmux/pull/800)) shipped the data shape and reducer (`ToolNode.log.chunks`, `ToolChunkAppend` command, parser arm). This spec is the chunk source.
+
+---
+
+## 2. Why this design
+
+The Claude CLI runs its native Bash tool internally and only surfaces a whole `tool_result` block to us — it does not emit partial tool output in stream-json. We can't fix that from the outside. So we replace the bash *runner*: we own the process that runs the user's command, stream its stdout to the frontend through our existing WPS broker, and hand the buffered result back to the CLI as if its native Bash tool had run normally.
+
+The seam where we interpose is Claude Code's `PreToolUse` hook. Two routes were considered:
+
+| | How it works | Risk |
+|---|---|---|
+| **Deny-and-redirect** (rejected) | Hook returns `permissionDecision: "deny"` with reason "use mcp__agentmux__bash"; Claude is expected to retry via the MCP tool | Empirical — Claude's reaction to programmatic deny isn't documented. Could be "retry", could be "give up", could be "ask user". One unknown turn of friction *or* a hard fail per session. |
+| **Command rewrite** (chosen) | Hook returns `permissionDecision: "allow"` with `updatedInput.command` rewritten to invoke our wrapper binary inline | None of substance — `updatedInput` is part of the documented hook contract and is what Anthropic's docs use as the canonical example |
+
+Command rewrite wins because:
+
+- **No behavioral assumption about the model.** Claude sees a normal allow with a different command; it runs that command and gets a result. No retry loop, no extra round-trip, no model-side decisioning.
+- **No MCP tool registration drama.** Claude doesn't need to "choose" our tool over native Bash — there's only one tool path, and we've intercepted what runs inside it.
+- **Provider parity is uniform.** Every provider that supports a `PreToolUse`-shaped hook (Claude Code today; Codex/Gemini equivalents as they emerge) plugs in with the same rewrite shape. No per-provider "does the model honor deny-redirect?" matrix.
+- **Native Bash semantics preserved.** `cwd`, env, exit code, signal propagation, timeout — all flow through Claude's existing Bash machinery. We only change *what* runs, not *how* the model invokes it.
+
+The pipe-vs-PTY boundary moves: Claude's native Bash spawns our wrapper on a pipe (no PTY), but the wrapper allocates its own PTY for the user's actual command. Pipe is fine for the wrapper's own stdout (it's just text bytes); PTY is critical for the inner command (ANSI/spinners/interactivity).
+
+---
+
+## 3. Architecture
+
+### 3.1 Two channels, correlated by `tool_use_id`
+
+```
+                          ┌────────────────────────────────┐
+                          │             Claude              │
+                          │ (stream-json over stdio,        │
+                          │  emits tool_use(Bash, id=X))    │
+                          └──────────┬─────────────────────┘
+                                     │ tool_use(Bash, id=X, input={command: "..."})
+                                     ▼
+                          ┌────────────────────────────────┐
+                          │  PreToolUse hook fires          │
+                          │  (agentmux-bashwrap hook subcommand) │
+                          │  • read tool_input.command      │
+                          │  • base64-encode it             │
+                          │  • return allow + updatedInput  │
+                          │    .command = "agentmux-bashwrap     │
+                          │      exec                  │
+                          │      --tool-id=X                │
+                          │      --b64-cmd=<encoded>"       │
+                          └──────────┬─────────────────────┘
+                                     │
+                                     ▼
+                          ┌────────────────────────────────┐
+                          │  Claude's native Bash tool      │
+                          │  bash -c "agentmux-bashwrap          │
+                          │    exec --tool-id=X        │
+                          │    --b64-cmd=..."               │
+                          └──────────┬─────────────────────┘
+                                     │ spawns
+                                     ▼
+            ┌──────────────────────────────────────────────────┐
+            │  agentmux-bashwrap exec (subcommand)             │
+            │  ├── decode --b64-cmd → original command         │
+            │  ├── allocate PTY (portable_pty)                 │
+            │  ├── spawn shell -c "$original" inside the PTY   │
+            │  ├── read PTY master byte-by-byte                │
+            │  ├── line-split + ANSI-aware partial-flush       │
+            │  ├── publish each chunk to WPS subject           │
+            │  │   "tool_chunk:X" with X-AuthKey               │
+            │  ├── buffer everything for the model-visible blob│
+            │  └── on exit, write the aggregated blob to stdout│
+            └──────────┬────────────────────────────────┬──────┘
+                       │ aggregated stdout              │ per-line chunks
+                       │ (captured by Claude's bash)    │ keyed by tool_use_id
+                       │                                │ (real time)
+                       ▼                                ▼
+            ┌──────────────────┐            ┌──────────────────┐
+            │  Claude →        │            │  WPS broker      │
+            │  stream-json     │            │  → frontend      │
+            │  → user msg      │            │  useAgentStream  │
+            │  → tool_result   │            │  → dispatchDoc   │
+            │  → frontend      │            │  (ToolChunkAppend│
+            │  reducer         │            │   reducer)       │
+            │  (StreamFlush —  │            │                  │
+            │  preserves log)  │            │                  │
+            └──────────────────┘            └──────────────────┘
+```
+
+**Channel 1 (existing):** Claude → CLI → AgentMux stream-json pipe. Carries `tool_use` (Bash + the rewritten command) and eventually `tool_result` (whole aggregated output). Reducer's `StreamFlush` already preserves `log.chunks` when the running ToolNode gets replaced by a terminal-status one (verified by tests in PR #800).
+
+**Channel 2 (new):** Our wrapper → WPS subject `tool_chunk:<id>` → frontend → `dispatchDoc(ToolChunkAppend)`. Carries the live byte stream, line-by-line, while the inner command is running.
+
+Both channels reference the same `tool_use_id`, so the frontend reducer naturally merges them: the running node gets chunks from channel 2 in real time, then channel 1 lands the terminal `tool_result` and the reducer flips `log.open = false` without touching `log.chunks`.
+
+### 3.2 Component breakdown
+
+| Component | Where | What |
+|---|---|---|
+| **`agentmux-bashwrap exec`** | New subcommand of the existing `agentmux-bashwrap` binary | Inline command runner; allocates PTY; streams to WPS; prints aggregated result to its own stdout |
+| **`agentmux-bashwrap hook`** | New subcommand of the same binary | Reads PreToolUse JSON on stdin; emits the `updatedInput` rewrite response |
+| **`.claude/hooks.json` auto-injection** | `agentmux-srv/src/backend/agent_config.rs` | Writes the `PreToolUse` matcher on `Bash` pointing at the hook subcommand |
+| **WPS subject schema** | `agentmux-common/src/wps.rs` (or wherever subject naming lives) | New subject `tool_chunk:<id>`; payload shape defined here |
+| **WPS publish auth** | `agentmux-bashwrap` (both subcommands) | Reads `AGENTMUX_AUTH_KEY` from env (set by the parent claude spawn); attaches `X-AuthKey` on HTTP publish to the sidecar |
+| **Frontend bridge** | `frontend/app/view/agent/useAgentStream.ts` | Subscribes to chunk subjects per active tool; dispatches `ToolChunkAppend` |
+| **Reducer** | `frontend/app/store/agent-document/reducer.ts` | Tiny shape change to accept multi-chunk batches (RAF coalescing). PR #800's logic absorbs unchanged. |
+
+---
+
+## 4. The bash wrapper subcommand
+
+### 4.1 Invocation shape
+
+The hook rewrites Claude's command from:
+
+```
+npm install && npm test
+```
+
+to:
+
+```
+agentmux-bashwrap exec --tool-id=toolu_abc123 --b64-cmd=bnBtIGluc3RhbGwgJiYgbnBtIHRlc3Q=
+```
+
+`--b64-cmd` (URL-safe base64) eliminates every quoting and escaping concern: arbitrary commands, multi-line scripts, embedded quotes, embedded newlines, shell metacharacters, Windows paths — all become opaque ASCII inside the b64.
+
+The wrapper finds `agentmux-bashwrap` on PATH (we already plumb that — it's the MCP server binary Claude already invokes). On Win32 the binary is `agentmux-bashwrap.exe`; the hook emits the platform-correct invocation.
+
+### 4.2 Execution flow
+
+```rust
+async fn bash_wrap_main(args: BashWrapArgs) -> Result<i32> {
+    let command = base64::decode(&args.b64_cmd)?;
+    let command = String::from_utf8(command)?;
+    let tool_id = args.tool_id;
+
+    // Locate the sidecar — read endpoint + auth key from env (set
+    // by the AgentMux spawn of claude, and inherited through Bash).
+    let endpoint = env::var("AGENTMUX_LOCAL_URL")?;  // set by agentmux-srv main.rs:498 — inherited by every spawned child including the wrapper
+    let auth_key = env::var("AGENTMUX_AUTH_KEY")?;          // existing
+
+    let publisher = WpsHttpPublisher::new(&endpoint, &auth_key);
+    let subject = format!("tool_chunk:{}", tool_id);
+
+    let pty = portable_pty::native_pty_system()
+        .openpty(PtySize { rows: 24, cols: 200, ..Default::default() })?;
+
+    let mut cmd = CommandBuilder::new(shell_for_platform());
+    cmd.arg("-c").arg(&command);
+    cmd.cwd(env::current_dir()?);
+    cmd.env("TERM", "xterm-256color");
+    // Inherit AGENTMUX_* env so any nested tool that wants the auth
+    // key can ask for it.
+
+    let child = pty.slave.spawn_command(cmd)?;
+    drop(pty.slave);
+
+    let mut buffered = Vec::<u8>::with_capacity(64 * 1024);
+    let reader_handle = spawn_pty_reader(pty.master, publisher, subject, &mut buffered, tool_id);
+
+    let status = child.wait()?;
+    reader_handle.await?;
+
+    publisher.publish_terminal(&subject, status.exit_code).await?;
+
+    // Stdout to Claude's Bash subprocess: the aggregated, formatted blob.
+    let model_blob = format_for_model(&buffered, status);
+    println!("{}", model_blob);
+
+    Ok(status.exit_code)
+}
+```
+
+### 4.3 Wire format on `tool_chunk:<id>`
+
+```typescript
+type ToolChunkMessage = {
+    op: "chunk";
+    kind: "stdout" | "stderr" | "system";
+    content: string;     // UTF-8 decoded; may not end in \n if partial
+    timestamp: number;   // unix ms; the source-of-truth dedup key
+};
+
+type ToolChunkTerminalMessage = {
+    op: "terminal";
+    exit_code: number;
+    timestamp: number;
+};
+
+type ToolChunkPayload = ToolChunkMessage | ToolChunkTerminalMessage;
+```
+
+`kind: "system"` is reserved for runner-injected lines (*"Command timed out after 600s"*, *"PTY allocation failed, falling back to pipe"*, etc.). Differentiated in the overlay UI.
+
+PTY merges stdout and stderr by default. To distinguish, we'd need pseudoterminal trickery that's not worth the complexity for v1 — emit everything as `stdout` initially; expose stderr separation as a follow-up via dup'd file descriptors plumbed through the wrapper's own pipes.
+
+### 4.4 PTY behavior decisions
+
+- **Real PTY**, not `Stdio::piped()`. ANSI escapes, terminal-aware progress bars, and interactive prompts all require it. `portable_pty` (already a transitive dep through our terminal path) covers ConPTY + Unix.
+- **Size: 24 rows × 200 cols.** Many CLIs format based on `COLUMNS`. 200 is wide enough to avoid premature wrapping in build output without being so wide that `top`-style fullscreen apps misbehave.
+- **`TERM=xterm-256color`** in env. Most tools emit color when they detect a 256-color TERM.
+- **Byte-level read** + line-splitter in front of WPS publish. Don't wait for `\n` longer than ~50ms — flush partial lines (carriage-return-overwritten progress bars: `npm install`'s `[==>] 50%` updates in place; we emit the latest content and rely on the frontend's CR-handling to overwrite rather than append).
+- **Backpressure**: WPS publisher is async + non-blocking. If the sidecar backs up, the wrapper's send queue applies back-pressure to the reader, which is fine — the PTY itself buffers in the kernel until the reader catches up.
+
+### 4.5 Aggregated stdout for Claude
+
+The wrapper's own stdout becomes Claude's `tool_result.content`. Format it so Claude sees both stdout and stderr (interleaved by arrival, prefix-tagged), exit code, and duration:
+
+```
+<exited 0 in 3.21s>
+$ npm install
+added 421 packages in 8s
+$ npm test
+PASS test/foo.test.ts
+  ✓ does the thing (45ms)
+Tests: 12 passed, 12 total
+```
+
+Stderr lines get prefixed with `[stderr] ` when interleaved into the model-visible blob; the frontend overlay renders them in dim red without the prefix (it has the structural `kind` field from the WPS chunk). Truncate at 50KB head + 50KB tail with `... [N lines elided] ...` in the middle for the model-visible blob; the frontend has the full thing in `log.chunks`.
+
+### 4.6 Concurrency
+
+Multiple tool calls can run concurrently. Each is a separate wrapper process (separate Bash invocation by Claude), so isolation is trivial — separate PTYs, separate WPS subjects keyed by `tool_use_id`, no shared mutable state. Sidecar HTTP can handle parallel publishes without ordering issues (chunks within a subject preserve order by timestamp).
+
+### 4.7 Cancellation
+
+If the user cancels the agent (or Claude itself terminates), Claude's Bash subprocess receives SIGTERM/SIGKILL, which propagates to our wrapper, which:
+1. Sends SIGINT to the PTY child (`GenerateConsoleCtrlEvent(CTRL_C_EVENT)` on Win32).
+2. Waits up to 2s for graceful shutdown.
+3. SIGKILL / `TerminateJobObject`.
+4. Publishes a terminal marker with `exit_code: -1`.
+5. Exits non-zero.
+
+Claude itself never sees the wrapper exit — Claude was terminated upstream.
+
+---
+
+## 5. The `PreToolUse` hook
+
+### 5.1 Hook entry
+
+Auto-injected by `agentmux-srv/src/backend/agent_config.rs` (existing hook-writing path at lines 112-119) into `<agent_cwd>/.claude/hooks.json`:
+
+```json
+{
+  "PreToolUse": [
+    {
+      "matcher": "^Bash$",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "agentmux-bashwrap hook"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 5.2 Hook implementation
+
+```rust
+async fn hook_pretooluse_bash_main() -> Result<()> {
+    // Hook receives PreToolUse JSON on stdin.
+    let input: PreToolUseInput = serde_json::from_reader(std::io::stdin())?;
+
+    if input.tool_name != "Bash" {
+        // Defensive — matcher narrows to Bash but be safe.
+        emit_passthrough();
+        return Ok(());
+    }
+
+    let tool_id = &input.tool_use_id;
+    let command: &str = input.tool_input
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let b64 = base64::URL_SAFE_NO_PAD.encode(command.as_bytes());
+    let wrapper = wrapper_invocation(tool_id, &b64);
+
+    let response = json!({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "updatedInput": {
+                "command": wrapper
+            }
+        }
+    });
+
+    println!("{}", response);
+    Ok(())
+}
+
+fn wrapper_invocation(tool_id: &str, b64: &str) -> String {
+    let exe = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(String::from))
+        .unwrap_or_else(|| "agentmux-bashwrap".into());
+    format!("{} exec --tool-id={} --b64-cmd={}",
+        shell_quote(&exe), shell_quote(tool_id), b64)
+}
+```
+
+`shell_quote` wraps in single quotes (Unix) or `"` (Win32 cmd) to survive whatever shell Claude's Bash tool uses internally (`bash -c "..."` on Unix; `cmd.exe /c "..."` on Windows ConPTY).
+
+### 5.3 Merging with user-provided hooks
+
+`agent_config.rs:112-119` already merges user hooks from `content_map["hooks"]`. Our redirect entry is *appended* to any existing `PreToolUse` array. Hook execution order in Claude Code runs matchers sequentially; if a user has their own `Bash` matcher that emits a deny, ours never runs (the deny wins). If their matcher emits allow, ours fires next and rewrites — which is the desired layering (user policy first, transparent streaming second).
+
+Document this layering behavior in the user-facing hooks docs.
+
+### 5.4 Hook idempotence
+
+The hook can fire twice for the same tool call if the user's hook chain ends with another `allow` that doesn't change `updatedInput.command`. Our rewrite detects an already-wrapped command (`agentmux-bashwrap exec` prefix) and is a no-op in that case to avoid double-wrapping.
+
+---
+
+## 6. Frontend bridge
+
+### 6.1 Subscription lifecycle
+
+`useAgentStream` already iterates `streamEvents`. When a `tool_use` event arrives for `Bash` (the only streaming-aware tool in v1), we open a WPS subscription on `tool_chunk:<tool_use_id>` and keep it open until either:
+- An `op: "terminal"` message arrives, or
+- The matching `tool_result` lands via stream-json.
+
+```typescript
+// In useAgentStream.ts:
+if (event.type === "tool_call" && isStreamingTool(event.tool)) {
+    chunkSubs.set(event.id, openChunkSubscription(event.id, blockId));
+}
+if (event.type === "tool_result") {
+    const sub = chunkSubs.get(event.id);
+    if (sub) { sub.close(); chunkSubs.delete(event.id); }
+}
+```
+
+`openChunkSubscription` reads from the WPS subject; each `op: "chunk"` message dispatches:
+
+```typescript
+dispatchDoc(blockId, {
+    type: "ToolChunkAppend",
+    toolId,
+    chunks: [{ kind, content, timestamp }],   // multi-chunk shape — see §6.3
+});
+```
+
+For `op: "terminal"` it dispatches a synthesized chunk with `kind: "system"` (e.g. `"[exited 0]"`) and closes the subscription early as a defense against a missing tool_result.
+
+### 6.2 RAF coalescing
+
+Chunks fire at high frequency. The reducer is fast but per-dispatch overhead (audit ring entry, subscriber fanout) adds up at 5000 lines/sec. Coalesce within `useAgentStream`'s existing pendingNew/pendingUpdates → `scheduleFlush()` RAF batching: chunks pile up in a per-tool buffer, flushed once per frame as one `ToolChunkAppend` per affected tool with the accumulated batch.
+
+### 6.3 Reducer shape change (small)
+
+```typescript
+// Before (PR #800):
+| { type: "ToolChunkAppend"; toolId: string; chunk: ToolLogChunk }
+
+// After:
+| { type: "ToolChunkAppend"; toolId: string; chunks: ToolLogChunk[] }
+```
+
+Reducer iterates `chunks`, applies per-chunk dedup, emits one audit event with the batched count. PR #800's existing tests update to use the array form; new tests for multi-chunk batches.
+
+---
+
+## 7. Security threading
+
+[PR #801](https://github.com/agentmuxai/agentmux/pull/801) put `/agentmux/reactive/*` (and all backend HTTP) behind `auth_middleware`. The wrapper publishes WPS chunks via HTTP to the sidecar, so it must carry `X-AuthKey`.
+
+Wiring:
+
+- AgentMux's spawn of `claude` already sets `AGENTMUX_AUTH_KEY` in Claude's env (existing). That env is inherited by Claude's child Bash subprocess, and by our wrapper inside it.
+- The wrapper reads `AGENTMUX_AUTH_KEY` once at startup. Attaches `X-AuthKey: <key>` to every WPS publish HTTP call.
+- The `PreToolUse` hook subcommand also inherits the env. Hook output goes back to Claude over stdout — no HTTP traffic — so no auth header needed there.
+- If `AGENTMUX_AUTH_KEY` is missing (unexpected), wrapper logs a system-kind chunk *"Auth key not found — streaming disabled. Output buffered, will appear on completion."*, skips the streaming publish, and still returns the aggregated blob to Claude. Graceful degradation.
+
+For the WPS subject on the frontend side, the existing WPS subscription path already carries auth — no change needed there.
+
+---
+
+## 8. Phasing
+
+Four landable PRs after PR #800:
+
+### PR α — frontend overlay UI ([Phase 3 of the live-log spec](./SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md))
+- New `ToolBlockOverlay` + `ToolOverlayLog` (virtualized) + `ToolOverlayActions` (bottom bar).
+- Reads `node.log.chunks` (empty today — chunks haven't started flowing).
+- Ships visible UI; can be demoed against a hand-dispatched chunk in a unit test.
+- Independent of this spec.
+
+### PR β — backend runner (this spec, core)
+- New `agentmux-bashwrap/src/bash_wrap.rs` with PTY-backed runner + WPS publishing + X-AuthKey.
+- New `agentmux-bashwrap/src/hook.rs` for the `hook` subcommand.
+- `agentmux-bashwrap/src/main.rs` adds two subcommands to the dispatch table.
+- `agentmux-srv/src/backend/agent_config.rs` extended to write the `PreToolUse` entry.
+- `frontend/app/view/agent/useAgentStream.ts` chunk subscription lifecycle.
+- Reducer change to multi-chunk `ToolChunkAppend` + test extension.
+
+### PR γ — RAF coalescing + perf
+- Per-tool pending chunk buffer flushed at RAF.
+- Audit ring sampling for chunk-class commands (1/N or off).
+- ANSI parsing offloaded to a worker (or inline if perf is fine).
+
+### PR δ — provider parity (Codex + Gemini)
+- Codex CLI hook contract analyzed; equivalent rewrite implemented.
+- Gemini provider's hook surface (or its absence) drives whether rewrite is hook-based or wrapper-binary-on-PATH as a fallback.
+- File as separate work item; Claude-only first.
+
+---
+
+## 9. Test plan
+
+- [ ] **Basic streaming.** Run `mcp__agentmux__bash`... wait, that's wrong — Claude calls native Bash. Test: agent prompt "run `sleep 2 && echo a && sleep 2 && echo b`". Frontend log shows `a` at t≈2s, `b` at t≈4s, terminal marker at t≈4s. Reducer's chunks array contains both lines in order.
+- [ ] **Hook rewrites the command.** Inspect Claude's stream-json — the `tool_use.input.command` field is the wrapper invocation, not the original command. (Sanity check the hook fires.)
+- [ ] **ANSI fidelity.** `npm install` colored progress: ANSI escapes preserved in WPS payloads; overlay parses + renders colored.
+- [ ] **High-throughput.** `python -c 'import sys; sys.stdout.write("x" * 50000); sys.stdout.flush()'` — 50KB delivered in chunks, no drops, no buffering past 50ms.
+- [ ] **Embedded quotes / multi-line.** Agent prompt "run `echo "hello world" && echo 'it works'`". Base64 round-trip preserves it; wrapper executes correctly; no shell-injection regressions.
+- [ ] **Interactive prompt.** `read -p "continue? " yn` — verify backend waits; verify frontend overlay shows the prompt line. (Stdin reverse channel out of scope for PR β; tracked as PR γ+. PR β: command blocks until timeout, then SIGINT.)
+- [ ] **User-provided hook merge.** `content_map["hooks"]` with a `PreToolUse.Bash` entry → both user hook and our rewrite appear in `.claude/hooks.json` in that order; user-deny short-circuits.
+- [ ] **No double-wrap.** If our wrapper's command happens to be re-invoked through the hook (some testing scenario), idempotence prevents `agentmux-bashwrap exec ... agentmux-bashwrap exec ...`.
+- [ ] **Cancellation soft.** Agent stop → SIGINT to bash child → graceful exit within 2s → no orphan processes.
+- [ ] **Cancellation hard.** SIGKILL path after 2s timeout.
+- [ ] **Concurrent tools.** Three concurrent shell commands → three independent WPS subjects fan out correctly; frontend reducer applies chunks to the right tool nodes.
+- [ ] **Reconnect mid-stream.** Kill frontend, restart, replay; chunks deduped on (timestamp, kind, content); no duplicates in `log.chunks`.
+- [ ] **StreamFlush + log preservation.** Existing PR #800 tests still pass + new test using real WPS chunks instead of synthetic ones.
+- [ ] **Cross-platform.** Same scenarios on Win32 (ConPTY) and Linux (Unix PTY) and macOS.
+- [ ] **Perf.** 5000 lines/sec sustained for 10s → frontend stays at 60fps (verify with the perf-probe diag from Phase 3).
+- [ ] **Auth threading.** Wrapper picks up `AGENTMUX_AUTH_KEY` from env; WPS publishes include `X-AuthKey`; missing key falls back to buffered-only mode with a system chunk.
+- [ ] **No auth-key regression.** Subscription-tier OAuth flow unchanged; `--dangerously-skip-permissions` unchanged; existing reactive routes still gated correctly.
+
+---
+
+## 10. Edge cases & risks
+
+### 10.1 Claude internally bypasses the hook for some Bash variant
+
+If Anthropic renames the Bash tool or adds variants (`Bash`, `BashSandbox`, `Shell`), our `matcher: "^Bash$"` misses. Cheap mitigation: matcher uses a broader pattern (`^(Bash|Shell|.*[Bb]ash.*)$`) and a smoke test in CI calls each known shell-tool name.
+
+### 10.2 The wrapper binary isn't on PATH
+
+If `agentmux-bashwrap` isn't on PATH for Claude's bash subprocess, the wrapper invocation fails with `command not found`. AgentMux already installs `agentmux-bashwrap` on PATH for Claude's spawn (existing MCP wiring); verify in CI.
+
+### 10.3 Base64 inflation breaks command-length limits
+
+Bash `argv` has practical limits (~128KB on Linux; smaller on Win32 cmd.exe ~32KB). Base64 inflation is 4/3, so a 24KB command becomes 32KB encoded — uncomfortable on Win32. Mitigation: if the encoded command exceeds 16KB, write the command to a temp file `~/.agentmux/cmd-<id>.sh` and pass `--cmd-file=...` to the wrapper instead.
+
+### 10.4 PTY allocation fails
+
+Fallback to `Stdio::piped()`. ANSI fidelity degrades; spinners freeze. Surface a system-kind chunk: *"PTY unavailable, output may not render correctly."* — same recovery as if `AGENTMUX_AUTH_KEY` is missing.
+
+### 10.5 Hook script crashes / panics
+
+If our `agentmux-bashwrap hook` exits nonzero or with malformed JSON, Claude Code falls back to running the command unmodified (existing hook semantics). User loses streaming; the command still runs. Log the panic and surface it on the next agent activity-log refresh.
+
+### 10.6 50KB head/tail truncation drops critical mid-output errors
+
+The model-visible blob is truncated; the frontend has the full thing. If the model needs the elided content, it can request a re-read. Trade-off accepted.
+
+### 10.7 Backpressure overflow
+
+WPS publish queue at the wrapper saturates → wrapper's reader blocks → kernel PTY buffer fills → user's command writes block. Correct behavior — preferable to dropping chunks silently. Surface a system-kind chunk if back-pressure exceeds 1s.
+
+### 10.8 Audit-ring storm
+
+PR #800's reducer events go to the audit ring. At 5000 lines/sec each chunk produces a `tool-chunk-appended` entry → 5000 ring entries/sec → the ring evicts everything else within milliseconds. PR γ handles this with sampling.
+
+### 10.9 Codex / Gemini providers ship later
+
+PR β is Claude-only. Codex and Gemini users still see the original whole-result behavior until PR δ. Acceptable for staged rollout; document the per-provider matrix in the agent pane.
+
+### 10.10 Auth-key inheritance gap
+
+If a sandboxed Bash environment strips `AGENTMUX_*` env (firejail, container, etc.), wrapper can't authenticate. Graceful degradation per §7 — fall back to buffered-only mode. Surface a system chunk warning.
+
+---
+
+## 11. Alternatives considered (and rejected)
+
+### 11.1 MCP + PreToolUse-deny-redirect
+
+Register `mcp__agentmux__bash` as a streaming MCP tool; `PreToolUse` denies native `Bash` with reason "use mcp__agentmux__bash". Claude is *expected* to retry via the MCP tool.
+
+**Why rejected:**
+- Behavior on programmatic deny isn't documented by Anthropic. Could be "retry with named tool" (best), "ask user how to proceed" (middling), "give up" (bad), or "loop" (worst).
+- Adds at least one model round-trip per session of friction even in the best case.
+- Adds a "did Claude pick the MCP tool?" matrix per provider release. Higher drift risk than the rewrite path.
+- The MCP server registration adds complexity for a path we don't end up using.
+
+### 11.2 PATH shim binary
+
+Set `PATH=<shim_dir>:$PATH` in Claude's environment; shim binary named `bash` execs real bash through a tee/PTY-allocating wrapper.
+
+**Why rejected:**
+- Requires Claude SDK to do PATH-based shell lookup rather than hardcoding `/bin/bash`. Empirically uncertain and version-fragile.
+- Cross-platform shim is heavy (.cmd / .exe / .bat on Win32 vs shell script on Unix).
+- Same ANSI/PTY problems unless the shim allocates a PTY itself — at which point we've done the work of option B anyway, without the hook's deterministic guarantee that we're in the loop.
+
+### 11.3 `tee` via command-rewrite
+
+Hook rewrites command to `bash -c 'orig 2>&1 | tee /tmp/foo.log; exit ${PIPESTATUS[0]}'`. AgentMux watches the log file.
+
+**Why rejected:**
+- Pipe strips terminal capability — colors/spinners die.
+- `tee` interferes with interactive prompts.
+- `PIPESTATUS` is bash-only; sh/zsh/Win32 each need their own variant.
+- Disk I/O in hot path is 10-50ms slower per batch than memory pipes.
+
+### 11.4 Post-hoc synthesis from `tool_result`
+
+When the whole result lands, split it by line and dispatch fake chunks at 50ms intervals to simulate streaming.
+
+**Why rejected:**
+- Indistinguishable from "fake" — the command really did just wait 3 minutes silently and now the UI is pretending it streamed. Strictly worse than no streaming.
+
+### 11.5 Replace `claude` CLI with embedded Agent SDK or direct Anthropic API
+
+Strongest perf + UX path. **Out of scope for this spec.** Requires losing OAuth-via-Claude-Code-subscription as a deployment model unless Anthropic offers third-party OAuth client registration. Tracked in [docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md](../analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md) as a long-horizon discussion.
+
+---
+
+## 12. Files touched (estimate)
+
+| Path | Change | LOC |
+|---|---|---|
+| `agentmux-bashwrap/src/bash_wrap.rs` (new) | PTY runner, WPS publish, b64 decode, format-for-model | ~280 |
+| `agentmux-bashwrap/src/hook.rs` (new) | `hook` subcommand | ~60 |
+| `agentmux-bashwrap/src/wps_client.rs` (new) | HTTP client with X-AuthKey injection | ~50 |
+| `agentmux-bashwrap/src/main.rs` | Subcommand dispatch | ~30 |
+| `agentmux-bashwrap/Cargo.toml` | Add `portable_pty`, `base64`, `reqwest` | ~5 |
+| `agentmux-srv/src/backend/agent_config.rs` | Auto-inject hook entry; merge logic | ~50 |
+| `agentmux-common/src/wps.rs` | Subject naming + auth helper | ~30 |
+| `frontend/app/view/agent/useAgentStream.ts` | Chunk subscription lifecycle | ~80 |
+| `frontend/app/store/agent-document/reducer.ts` + tests | Multi-chunk `ToolChunkAppend` | ~60 |
+| `frontend/app/store/agent-document/types.ts` | `chunks: ToolLogChunk[]` shape | ~5 |
+| `docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md` | Phase 2 section rewritten to point at this spec | — |
+| Tests across all of the above | | ~350 |
+| **Total** | | **~1000** |
+
+---
+
+## 13. Effort
+
+| Component | Days |
+|---|---|
+| PR α (frontend overlay UI) | 1.5 |
+| PR β (wrapper subcommand + hook + bridge + auth threading) | 3.5 |
+| PR γ (RAF coalescing + perf) | 1.0 |
+| PR δ (Codex parity) | 1.5 |
+| PR δ' (Gemini parity, if hook surface exists) | 1.5 |
+| Manual smoke (Win + Linux + mac) | 1.0 |
+| **Total (Claude-only)** | **~7 days** |
+| **Total (all providers)** | **~10 days** |
+
+---
+
+## 14. Open questions
+
+- **Stdout/stderr separation inside the PTY.** Unix PTYs merge by default; we'd need dup'd file descriptors or a pty-pair-per-stream to distinguish. Worth it for v1, or accept merged-stdout for now and add stderr discrimination as a follow-up? Recommend: v1 ships merged; the wrapper detects writes-from-stderr via process-tracing on Linux as a follow-up.
+- **WPS subject naming format.** `tool_chunk:<id>` works. If `<id>` contains characters illegal in WPS subjects, escape or hash. Decide at PR β time.
+- **Stdin reverse channel for interactive prompts.** Out of scope for PR β; deferred to PR γ+. The "read -p" scenario fails gracefully (times out) until then. The protocol shape (`stdin:<id>` subject?) gets designed when we actually wire it.
+- **`agentmux-bashwrap` discovery on PATH for arbitrary user shells.** We control Claude's env, so PATH is whatever we set. But if a user runs `bash` themselves and that shell tries to invoke our `agentmux-bashwrap`, it won't find it unless we've added the install dir to user PATH globally. Out of scope.
+- **Telemetry / observability.** Per-tool latency, chunk rate, PTY allocation success rate. Tag and surface in the existing diag panel.
+- **Permissions interaction.** Current production state is `--dangerously-skip-permissions`, so the rewrite never hits the permission UI. If decisions get re-enabled per [SPEC_DECISION_PROMPT_2026_04_24.md](./SPEC_DECISION_PROMPT_2026_04_24.md), we need to decide whether the rewritten command auto-allows (it's still ultimately bash, after all) or shows the *rewritten* command in the prompt (confusing — user sees `agentmux-bashwrap exec --b64...`) or the *original* (need to thread it through). Recommend: prompt shows the original command from the un-rewritten hook input.
+
+---
+
+## 15. Cross-references
+
+- Live-log frontend reducer + UI: [SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md](./SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md)
+- Phase 1 implementation (data shape + reducer): [PR #800](https://github.com/agentmuxai/agentmux/pull/800)
+- Option analysis: [docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md](../analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md)
+- Auth middleware that the wrapper threads through: [PR #801](https://github.com/agentmuxai/agentmux/pull/801)
+- Permission gating (interacts if/when re-enabled): [SPEC_DECISION_PROMPT_2026_04_24.md](./SPEC_DECISION_PROMPT_2026_04_24.md)
+- MCP server injection: `agentmux-srv/src/backend/agent_config.rs:230-293`
+- Hooks writer: `agentmux-srv/src/backend/agent_config.rs:112-119`
+- Claude CLI spawn args: `agentmux-srv/src/backend/providers.rs:100-107`
+- Subprocess output → WPS pattern (mirror this): `agentmux-srv/src/backend/blockcontroller/subprocess.rs:442-561`
+- ToolBlock rendering (replaced in PR α): `frontend/app/view/agent/components/ToolBlock.tsx`
+- DocumentRow tool node wiring: `frontend/app/view/agent/virtualization/DocumentRow.tsx:232-238`
+- Reducer-stack master status (this lands as a Slice item): [reference_master_reducer_status.md](../../.claude/projects/C--Systems/memory/reference_master_reducer_status.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.797",
+  "version": "0.33.798",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.797",
+      "version": "0.33.798",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.796",
+  "version": "0.33.797",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.796",
+      "version": "0.33.797",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.796",
+  "version": "0.33.797",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.797",
+  "version": "0.33.798",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR β.A of the live-log work — adds a new Rust crate `agentmux-bashwrap` that owns the PTY-backed bash runner needed for live tool-output streaming. Wrapper exists in isolation in this PR; PR β.B will wire it into Claude's PreToolUse hook + agentmux-srv's HTTP publish endpoint.

Spec: [docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md) (also added in this PR).

## What's in this PR

- **`agentmux-bashwrap/`** — new workspace member.
- **`agentmux-bashwrap exec --tool-id=<id> --b64-cmd=<base64>`** — owns a PTY (24×200, `TERM=xterm-256color`), spawns `sh -c "$decoded_cmd"` (or `cmd /C` on Win32), reads bytes line-buffered, streams each chunk to the AgentMux sidecar's WPS broker as `tool_chunk:<id>` events, and prints the aggregated output on its own stdout for Claude's native Bash tool to capture as `tool_result.content`. Truncates the model-visible blob to 50KB head + 50KB tail with an elision marker for very long outputs; the streaming log keeps the full thing.
- **`agentmux-bashwrap hook`** — reads a PreToolUse JSON payload on stdin and emits a hook response that rewrites the command from `original` to `agentmux-bashwrap exec --tool-id=X --b64-cmd=<base64 of original>`. Base64 sidesteps every shell-quoting concern. Idempotent (won't double-wrap if it sees the wrapper prefix). Pass-through on malformed input or non-Bash tools.
- **WPS HTTP client** — reads `AGENTMUX_LOCAL_URL` + `AGENTMUX_AUTH_KEY` from inherited env, posts chunks with `X-AuthKey` per [PR #801](https://github.com/agentmuxai/agentmux/pull/801). If env is missing or the sidecar is down, falls back to buffered-only mode — the command still runs to completion; only live streaming is disabled. A `kind: "system"` chunk announces the degradation.
- **`Cargo.toml` + `.bump.json`** — register the workspace member + track its version.
- **`docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md`** — full design rationale (PreToolUse command rewrite vs. MCP deny-redirect, why a dedicated crate vs. extending the hypothetical `agentmux-mcp`, channel correlation by `tool_use_id`, etc).

## What's NOT in this PR (deferred to PR β.B)

PR β.A makes the wrapper *exist*; PR β.B makes the system *use* it:

- [ ] `POST /agentmux/wps/publish` endpoint on agentmux-srv (auth-gated, mirrors the PR #801 pattern). Currently the wrapper can't actually publish — sidecar has no such route yet.
- [ ] Re-injection of `AGENTMUX_AUTH_KEY` into the claude spawn env (`subprocess.rs`). The security PR #801 intentionally removes it from agentmux-srv's process env at startup; for the wrapper to authenticate, we need to thread it back explicitly into the spawn env_vars map.
- [ ] Auto-injection of `.claude/hooks.json` PreToolUse entry by `agent_config.rs`. The hook subcommand exists but Claude won't invoke it without the registration.
- [ ] Frontend `tool_chunk:*` subscription bridge in `useAgentStream.ts`.
- [ ] Multi-chunk `ToolChunkAppend` shape for RAF coalescing in the reducer (current single-chunk shape works correctly; multi-chunk is a perf optimization for high-rate output).

Until PR β.B lands, the wrapper compiles, tests, and bundles, but isn't wired into the agent flow. Reviewable in isolation.

## Test plan

- [x] `cargo test -p agentmux-bashwrap` — **18/18 pass**:
  - Hook: rewrites simple commands, preserves multi-line + quotes via base64 round-trip, is a no-op on already-wrapped commands, passes through non-Bash tools, passes through malformed input, passes through when `command` field missing, shell-quote handles safe + unsafe + embedded-quote ids.
  - Wrapper: base64 decode round-trips arbitrary content including multi-line + quotes, rejects malformed b64, format-model-blob includes exit code + elapsed time, truncates 150KB inputs to head/tail with elision marker, passes small outputs unchanged.
  - WPS client: returns `None` without env vars, returns `None` with only endpoint set, strips trailing slash.
- [x] `cargo build -p agentmux-bashwrap` — clean.
- [ ] End-to-end smoke (deferred to PR β.B when the wrapper is actually wired into a session).

## Sequencing

- **#800** (merged) — Phase 1: reducer + types.
- **#803** (open, approved) — Phase 3: overlay UI.
- **This PR (β.A)** — wrapper binary in isolation.
- **Next (β.B)** — wire-up: HTTP publish endpoint + env re-injection + hook auto-injection + frontend bridge.
- **Then (γ)** — RAF coalescing + perf.
- **Then (δ)** — Codex / Gemini parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)