### PR TITLE
refactor(settings): rename telemetry:* → sysinfo:*; add drift keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "dirs",
  "serde",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.796"
+version = "0.33.797"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.796"
+version = "0.33.797"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.796"
+version = "0.33.797"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.796"
+version = "0.33.797"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.796"
+version = "0.33.797"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/sysinfo.rs
+++ b/agentmux-srv/src/backend/sysinfo.rs
@@ -3,7 +3,7 @@
 
 //! Sysinfo data collection loop: collects CPU, memory, and network metrics
 //! and publishes them via the WPS broker. Sampling interval is configurable
-//! via the `telemetry:interval` setting (0.1s–2.0s, default 1.0s).
+//! via the `sysinfo:interval` setting (0.1s–2.0s, default 1.0s).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -114,9 +114,9 @@ fn get_disk_data(disks: &Disks, elapsed_secs: f64, values: &mut HashMap<String, 
     values.insert("disk:total".to_string(), read_rate + write_rate);
 }
 
-/// Read the telemetry interval from config, clamped to [MIN, MAX].
+/// Read the sysinfo polling interval from config, clamped to [MIN, MAX].
 fn get_interval_secs(config_watcher: &ConfigWatcher) -> f64 {
-    let val = config_watcher.get_settings().telemetry_interval;
+    let val = config_watcher.get_settings().sysinfo_interval;
     if val <= 0.0 {
         return DEFAULT_INTERVAL_SECS;
     }

--- a/agentmux-srv/src/backend/wconfig/mod.rs
+++ b/agentmux-srv/src/backend/wconfig/mod.rs
@@ -81,7 +81,7 @@ mod tests {
             "term:scrollback": 5000,
             "window:transparent": true,
             "window:opacity": 0.85,
-            "telemetry:interval": 1.5
+            "sysinfo:interval": 1.5
         }"#;
         let s: SettingsType = serde_json::from_str(json_str).unwrap();
         assert_eq!(s.term_font_size, 13.0);
@@ -89,7 +89,7 @@ mod tests {
         assert_eq!(s.term_scrollback, Some(5000));
         assert!(s.window_transparent);
         assert_eq!(s.window_opacity, Some(0.85));
-        assert_eq!(s.telemetry_interval, 1.5);
+        assert_eq!(s.sysinfo_interval, 1.5);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -144,18 +144,17 @@ pub struct SettingsType {
     #[serde(rename = "window:magnifiedblockblursecondarypx", default, skip_serializing_if = "Option::is_none")]
     pub window_magnified_block_blur_secondary_px: Option<i64>,
 
-    // -- Telemetry settings --
-    // NOTE: telemetry:interval/numpoints actually drive the sysinfo widget
-    // polling rate (local-only, no transmission). Renamed to sysinfo:* in
-    // a follow-up PR. telemetry:enabled was dead and was removed.
-    #[serde(rename = "telemetry:*", default, skip_serializing_if = "is_false")]
-    pub telemetry_clear: bool,
+    // -- Sysinfo widget polling --
+    // Drives the local sysinfo widget polling rate. No data transmission.
+    // (Previously named telemetry:* — renamed for honesty.)
+    #[serde(rename = "sysinfo:*", default, skip_serializing_if = "is_false")]
+    pub sysinfo_clear: bool,
 
-    #[serde(rename = "telemetry:interval", default, skip_serializing_if = "is_zero_f64")]
-    pub telemetry_interval: f64,
+    #[serde(rename = "sysinfo:interval", default, skip_serializing_if = "is_zero_f64")]
+    pub sysinfo_interval: f64,
 
-    #[serde(rename = "telemetry:numpoints", default, skip_serializing_if = "Option::is_none")]
-    pub telemetry_numpoints: Option<i64>,
+    #[serde(rename = "sysinfo:numpoints", default, skip_serializing_if = "Option::is_none")]
+    pub sysinfo_numpoints: Option<i64>,
 
     // -- Connection settings --
     #[serde(rename = "conn:*", default, skip_serializing_if = "is_false")]

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -399,7 +399,7 @@ async fn main() {
     let bridge = backend::eventbus::EventBusBridge::new(event_bus.clone());
     broker.set_client(Box::new(bridge));
 
-    // Config watcher (created before sysinfo loop so it can read telemetry:interval)
+    // Config watcher (created before sysinfo loop so it can read sysinfo:interval)
     let config_watcher = Arc::new(wconfig::ConfigWatcher::with_config(wconfig::build_default_config()));
 
     // Load user's settings.json from disk (merges with defaults)
@@ -411,7 +411,7 @@ async fn main() {
         event_bus.clone(),
     );
 
-    // Start sysinfo collection loop (interval configurable via telemetry:interval)
+    // Start sysinfo collection loop (interval configurable via sysinfo:interval)
     let sysinfo_broker = broker.clone();
     let sysinfo_config = config_watcher.clone();
     tokio::spawn(async move {

--- a/frontend/app/view/sysinfo/sysinfo-model.ts
+++ b/frontend/app/view/sysinfo/sysinfo-model.ts
@@ -101,7 +101,7 @@ class SysinfoViewModel implements ViewModel {
 
         this.numPoints = createMemo(() => {
             const fullConfig = atoms.fullConfigAtom();
-            const settingsNumPoints = fullConfig?.settings?.["telemetry:numpoints"];
+            const settingsNumPoints = fullConfig?.settings?.["sysinfo:numpoints"];
             if (settingsNumPoints != null && settingsNumPoints > 0) {
                 return Math.max(30, Math.min(1024, settingsNumPoints));
             }
@@ -152,7 +152,7 @@ class SysinfoViewModel implements ViewModel {
 
         this.intervalSecsAtom = createMemo(() => {
             const fullConfig = atoms.fullConfigAtom();
-            const val = fullConfig?.settings?.["telemetry:interval"];
+            const val = fullConfig?.settings?.["sysinfo:interval"];
             if (val == null || val <= 0) return 1.0;
             return val as number;
         });

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1121,6 +1121,8 @@ declare global {
         "term:transparency"?: number;
         "term:allowbracketedpaste"?: boolean;
         "term:shiftenternewline"?: boolean;
+        "term:agentmaxruntimehours"?: number;
+        "term:agentidletimeoutmins"?: number;
         "cmd:env"?: {[key: string]: string};
         "blockheader:*"?: boolean;
         "blockheader:showblockids"?: boolean;
@@ -1139,9 +1141,9 @@ declare global {
         "window:magnifiedblockblurprimarypx"?: number;
         "window:magnifiedblockblursecondarypx"?: number;
         "window:theme"?: string;
-        "telemetry:*"?: boolean;
-        "telemetry:interval"?: number;
-        "telemetry:numpoints"?: number;
+        "sysinfo:*"?: boolean;
+        "sysinfo:interval"?: number;
+        "sysinfo:numpoints"?: number;
         "conn:*"?: boolean;
         "network:lan_discovery"?: boolean;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.796",
+  "version": "0.33.797",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.796",
+      "version": "0.33.797",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.796",
+  "version": "0.33.797",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/schema/settings.json
+++ b/schema/settings.json
@@ -53,6 +53,16 @@
         "term:shiftenternewline": {
           "type": "boolean"
         },
+        "term:agentmaxruntimehours": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum runtime in hours before the agent watchdog kills an agent pane. 0 disables the limit."
+        },
+        "term:agentidletimeoutmins": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Minutes of PTY silence before the agent watchdog kills an idle agent pane. 0 disables the limit."
+        },
         "cmd:env": {
           "additionalProperties": {
             "type": "string"
@@ -109,13 +119,13 @@
           "enum": ["default", "midnight", "high-contrast", "monokai", "nord", "dracula", "catppuccin", "tokyo-night", "gruvbox"],
           "description": "UI color theme. Options: default (dark grey + blue), midnight (deep navy), high-contrast (black + cyan), monokai (warm dark + green), nord (arctic blue-grey), dracula (purple dark), catppuccin (pastel dark + mauve), tokyo-night (blue-purple), gruvbox (retro warm + yellow)"
         },
-        "telemetry:*": {
+        "sysinfo:*": {
           "type": "boolean"
         },
-        "telemetry:interval": {
+        "sysinfo:interval": {
           "type": "number"
         },
-        "telemetry:numpoints": {
+        "sysinfo:numpoints": {
           "type": "integer",
           "minimum": 30,
           "maximum": 1024,

--- a/settings-template.jsonc
+++ b/settings-template.jsonc
@@ -4,6 +4,19 @@
 //
 // Docs: https://docs.agentmux.ai/settings
 {
+    // -- Appearance --
+    // "window:theme":             "default",
+    // "window:transparent":       false,
+    // "window:blur":              false,
+    // "window:opacity":           1.0,
+    // "window:bgcolor":           "",
+    // "window:tilegapsize":       3,
+    // "window:reducedmotion":     false,
+    // "window:magnifiedblockopacity":       0.6,
+    // "window:magnifiedblocksize":          0.9,
+    // "window:magnifiedblockblurprimarypx":   0,
+    // "window:magnifiedblockblursecondarypx": 0,
+
     // -- Terminal --
     // "term:fontsize":            12,
     // "term:fontfamily":          "JetBrains Mono",
@@ -17,31 +30,25 @@
     // "term:allowbracketedpaste": true,
     // "term:shiftenternewline":   false,
 
-    // -- Window --
-    // "window:transparent":       false,
-    // "window:blur":              false,
-    // "window:opacity":           1.0,
-    // "window:bgcolor":           "",
-    // "window:tilegapsize":       3,
-    // "window:reducedmotion":     false,
-    // "window:magnifiedblockopacity": 0.6,
-    // "window:magnifiedblocksize":    0.9,
+    // -- Agent Watchdog --
+    // 0 disables the limit.
+    // "term:agentmaxruntimehours": 0,
+    // "term:agentidletimeoutmins": 0,
 
     // -- App --
     // "app:defaultnewblock":      "",
     // "app:showoverlayblocknums": false,
+    // "widget:icononly":          false,
+    // "blockheader:showblockids": false,
 
     // -- Shell Environment --
     // "cmd:env":                  {},
 
-    // -- Telemetry --
-    // telemetry:interval/numpoints actually drive the local sysinfo widget
-    // polling rate (no data transmission). These keys will be renamed to
-    // sysinfo:* in a follow-up release.
-    // "telemetry:interval":       1.0,
-    // "telemetry:numpoints":      120,
+    // -- Sysinfo Widget --
+    // Local sysinfo widget polling rate (CPU/memory/network chart).
+    // "sysinfo:interval":         1.0,
+    // "sysinfo:numpoints":        120,
 
-    // -- Other --
-    // "widget:icononly":          false,
-    // "blockheader:showblockids": false
+    // -- Networking --
+    // "network:lan_discovery":    false
 }


### PR DESCRIPTION
## Summary

Third and final settings-cleanup PR. Stacked on #806 (which is stacked on #805).

Two changes:

1. **Rename `telemetry:*` → `sysinfo:*`** — the keys named \`telemetry:interval\` and \`telemetry:numpoints\` have always driven the local sysinfo widget polling rate. No data leaves the machine. The name was a waveterm-era misnomer. Renamed for honesty.

2. **Add 5 drift keys to the template** — already wired in code, missing from \`settings-template.jsonc\` so users couldn't discover them.

> **Base branch:** \`agent2/settings-cleanup-dead-keys\` (stacked). Merge #805 → #806 → this.

## Renamed

| Before | After |
|---|---|
| \`telemetry:interval\` | \`sysinfo:interval\` |
| \`telemetry:numpoints\` | \`sysinfo:numpoints\` |
| \`telemetry:*\` (wildcard) | \`sysinfo:*\` |

Renamed across:
- \`agentmux-srv/src/backend/wconfig/types.rs\` (struct fields + serde renames)
- \`agentmux-srv/src/backend/sysinfo.rs\` (one field access + doc comment)
- \`agentmux-srv/src/main.rs\` (two comments)
- \`agentmux-srv/src/backend/wconfig/mod.rs\` (test fixtures)
- \`schema/settings.json\`
- \`frontend/types/gotypes.d.ts\`
- \`frontend/app/view/sysinfo/sysinfo-model.ts\` (the only frontend consumer)
- \`settings-template.jsonc\`

(The \`TelemetryUpdate\` RPC stub and \`sendtelemetry\` call in \`rpc-api.ts\` are *unrelated* — they're already \"accept but ignore\" stubs for legacy waveterm telemetry events. Cleaning those up belongs to a different PR.)

## Added to template (drift fixed)

| Key | Status |
|---|---|
| \`window:theme\` | Already in schema/gotypes; already written by the tab-bar UI via \`SetConfigCommand\` |
| \`term:agentmaxruntimehours\` | New in schema/gotypes (was Rust-only); agent watchdog hard limit |
| \`term:agentidletimeoutmins\` | New in schema/gotypes (was Rust-only); agent watchdog idle limit |
| \`window:magnifiedblockblurprimarypx\` | Already in schema/gotypes |
| \`window:magnifiedblockblursecondarypx\` | Already in schema/gotypes |

## Template reorganized

Sections regrouped to align with the planned settings modal: Appearance, Terminal, Agent Watchdog, App, Shell Environment, Sysinfo Widget, Networking.

## Breaking change

Users who previously set \`telemetry:interval\` or \`telemetry:numpoints\` in their \`settings.json\` will see those keys ignored. They'll flow through \`SettingsType.extra\` (the serde \`flatten\` catch-all) without errors.

**No deprecation shim.** The only consumer was the sysinfo widget, the defaults are sensible (1.0s / 120 points), and the population that tuned these is tiny. If someone hits it, the fix is a one-line edit.

## Test plan

- [ ] \`task build:backend\` + \`cargo test -p agentmux-srv backend::wconfig\`
- [ ] \`task build:frontend\`
- [ ] **Manual:** open sysinfo widget — confirm it still polls at default 1.0s rate
- [ ] **Manual:** set \`sysinfo:interval\` to 0.5 in \`settings.json\` — confirm widget updates faster
- [ ] **Manual:** existing user \`settings.json\` with legacy \`telemetry:interval\` — confirm it loads cleanly (warning-free; value just ignored)

## Combined result of PRs 805 + 806 + this

\`SettingsType\`: **54 → 25 truly-wired keys**. Template: **54 → 26 visible keys**, all of which do something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)