### PR TITLE
fix(overlay): replaceChild crash on v0.33.799 — Switch instead of Show cascade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.799"
+version = "0.33.800"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.799"
+version = "0.33.800"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.799"
+version = "0.33.800"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.799"
+version = "0.33.800"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.799"
+version = "0.33.800"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.799"
+version = "0.33.800"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.799"
+version = "0.33.800"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.799"
+version = "0.33.800"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.799"
+version = "0.33.800"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.799"
+version = "0.33.800"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -15,7 +15,8 @@
  * ANSI parsing lands in Phase γ (perf + worker offload) per the spec.
  */
 
-import { For, Show, createEffect, createMemo, type JSX } from "solid-js";
+import { For, Match, Show, Switch, createEffect, createMemo, type JSX } from "solid-js";
+// `Show` retained for fallback ToolOverlayResult sub-tree.
 import type { ToolNode } from "../types";
 import { BashOutputViewer } from "./BashOutputViewer";
 import { CompactResult } from "./CompactResult";
@@ -81,26 +82,46 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
         chunks();
         if (stickToBottom && scrollRef) {
             // Wait one frame for the DOM to flush before measuring.
+            // Re-check scrollRef + isConnected because a Show-branch
+            // flip during the same RAF window can detach the element
+            // out from under us. Mutating scrollTop on a detached node
+            // raised the `replaceChild` reconciliation race that
+            // crashed v0.33.799.
             requestAnimationFrame(() => {
-                if (scrollRef) scrollRef.scrollTop = scrollRef.scrollHeight;
+                if (scrollRef && scrollRef.isConnected) {
+                    scrollRef.scrollTop = scrollRef.scrollHeight;
+                }
             });
         }
     });
 
+    /**
+     * Render decision — exhaustive, mutually exclusive branches via
+     * `<Switch>` rather than the prior 4-way `<Show>` cascade that
+     * rendered `ToolOverlayResult` from TWO different branches. SolidJS's
+     * reconciler saw the same component type in two sibling slots and
+     * (during the running → success state transition) tried to re-parent
+     * the DOM node from one Show slot to the other, calling
+     * `replaceChild` on a node that was no longer a child of the
+     * expected parent. `<Switch>` exits all other branches before
+     * rendering the matched one — no shared DOM between branches.
+     */
     return (
         <div class="agent-tool-overlay-log" ref={scrollRef} onScroll={onScroll}>
-            <Show when={isStreaming() && hasChunks()}>
-                <ChunkList chunks={chunks()} />
-            </Show>
-            <Show when={!isStreaming() && hasResult()}>
-                <ToolOverlayResult node={props.node} />
-            </Show>
-            <Show when={!isStreaming() && !hasResult() && hasChunks()}>
-                <ChunkList chunks={chunks()} />
-            </Show>
-            <Show when={!hasChunks() && !hasResult()}>
-                <ToolOverlayResult node={props.node} />
-            </Show>
+            <Switch>
+                <Match when={isStreaming() && hasChunks()}>
+                    <ChunkList chunks={chunks()} />
+                </Match>
+                <Match when={!isStreaming() && hasResult()}>
+                    <ToolOverlayResult node={props.node} />
+                </Match>
+                <Match when={!isStreaming() && !hasResult() && hasChunks()}>
+                    <ChunkList chunks={chunks()} />
+                </Match>
+                <Match when={!hasChunks() && !hasResult()}>
+                    <ToolOverlayResult node={props.node} />
+                </Match>
+            </Switch>
         </div>
     );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.799",
+  "version": "0.33.800",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.799",
+      "version": "0.33.800",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.799",
+  "version": "0.33.800",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Hotfix for the renderer crash hit on the v0.33.799 smoke build:

\`\`\`
Failed to execute 'replaceChild' on 'Node': The node to be replaced is not a child of this node.
\`\`\`

**Root cause**: \`ToolOverlayLog\` (shipped in #803) had 4 \`<Show>\` blocks as sibling slots inside the log container. Two of them rendered the same \`<ToolOverlayResult>\` from different predicate branches. SolidJS's reconciler saw the same component type in two sibling slots and during the running → success state transition tried to re-parent the DOM node from one Show slot to the other, calling \`replaceChild\` on a node that was no longer a child of the expected parent.

This is the same class of SolidJS reactive-reconciliation hazard as PR #708/#721/#722.

## Fix

- \`<Switch>\`/\`<Match>\` for the four branches. Switch is mutually exclusive by design — only one Match's children mount at a time, all others unmount before the chosen one mounts. No shared DOM nodes between branches; no re-parent attempt.
- Hardened the auto-scroll \`createEffect\`: \`scrollRef.isConnected\` check before mutating \`scrollTop\`. A Match flip during the same RAF window can detach the element; mutating a detached node was a secondary contributor.

## Test plan

- [x] \`tsc --noEmit\` — zero new errors in touched files.
- [ ] Smoke: extract a portable build, run a Bash tool to completion, hover/pin the overlay, verify no console errors during the running → success transition, verify structured result viewer (BashOutputViewer / DiffViewer / exit code) appears after completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)