### PR TITLE
feat(live-log): β.B wire-up — env, HTTP publish, hooks.json injection, frontend bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.800"
+version = "0.33.801"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.800"
+version = "0.33.801"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.800"
+version = "0.33.801"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.800"
+version = "0.33.801"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.800"
+version = "0.33.801"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.801"
+version = "0.33.802"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.801"
+version = "0.33.802"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.801"
+version = "0.33.802"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.801"
+version = "0.33.802"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.801"
+version = "0.33.802"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.802"
+version = "0.33.803"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.802"
+version = "0.33.803"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.802"
+version = "0.33.803"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.802"
+version = "0.33.803"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.802"
+version = "0.33.803"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.799 | 2026-05-11 | 162.4 MiB | 340.2 MiB | |
 | 0.33.789 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |
 | 0.33.788 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |
 | 0.33.787 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.800"
+version = "0.33.801"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.801"
+version = "0.33.802"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.802"
+version = "0.33.803"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.801"
+version = "0.33.802"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.802"
+version = "0.33.803"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.800"
+version = "0.33.801"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.801"
+version = "0.33.802"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.802"
+version = "0.33.803"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.800"
+version = "0.33.801"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.801"
+version = "0.33.802"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.802"
+version = "0.33.803"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.800"
+version = "0.33.801"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.802"
+version = "0.33.803"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.800"
+version = "0.33.801"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.801"
+version = "0.33.802"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -323,17 +323,38 @@ pub fn build_hooks_config(user_hooks_content: Option<&str>) -> Option<String> {
     let mut hooks_obj = serde_json::Map::new();
     let mut pretooluse_entries: Vec<Value> = Vec::new();
 
-    // Start with user hooks if present + parseable.
+    // Start with user hooks if present + parseable. Parse failures or
+    // non-Object top-levels are logged at WARN so the diagnostic trail
+    // surfaces — silent swallowing made user hooks disappear with no
+    // signal (reagent P2 on PR #809).
     if let Some(raw) = user_hooks_content {
-        if let Ok(Value::Object(user_obj)) = serde_json::from_str::<Value>(raw) {
-            for (k, v) in user_obj {
-                if k == "PreToolUse" {
-                    if let Value::Array(arr) = v {
-                        pretooluse_entries.extend(arr);
+        match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(user_obj)) => {
+                for (k, v) in user_obj {
+                    if k == "PreToolUse" {
+                        if let Value::Array(arr) = v {
+                            pretooluse_entries.extend(arr);
+                        } else {
+                            tracing::warn!(
+                                "agent_config: user hooks.PreToolUse is not an array; dropped"
+                            );
+                        }
+                    } else {
+                        hooks_obj.insert(k, v);
                     }
-                } else {
-                    hooks_obj.insert(k, v);
                 }
+            }
+            Ok(other) => {
+                tracing::warn!(
+                    kind = ?other,
+                    "agent_config: user hooks top-level value is not an object; dropped"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "agent_config: failed to parse user hooks JSON; dropped"
+                );
             }
         }
     }

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -109,12 +109,20 @@ pub fn build_config_files(
     }
 
     // ----------------------------------------------------------------
-    // Write .claude/hooks.json if hooks content is present
+    // Write .claude/hooks.json — always includes a PreToolUse:Bash
+    // entry pointing at `agentmux-bashwrap hook` so the streaming
+    // wrapper is invoked for every Bash tool call. User-provided
+    // hooks (from content_map["hooks"]) are merged on top, with the
+    // user's entries winning on key collisions, EXCEPT that our
+    // PreToolUse entries are always appended to any user
+    // PreToolUse array so streaming stays on regardless. See
+    // docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §5.
     // ----------------------------------------------------------------
-    if let Some(hooks) = content_map.get("hooks") {
+    let user_hooks = content_map.get("hooks").map(|s| s.as_str());
+    if let Some(hooks_json) = build_hooks_config(user_hooks) {
         files.push(AgentConfigFile {
             filename: ".claude/hooks.json".to_string(),
-            content: hooks.clone(),
+            content: hooks_json,
         });
     }
 
@@ -287,6 +295,57 @@ pub fn build_mcp_config(
         Ok(s) => Some(s),
         Err(e) => {
             tracing::error!("agent_config: failed to serialize MCP config: {e}");
+            None
+        }
+    }
+}
+
+/// Build `.claude/hooks.json` content with the auto-injected PreToolUse
+/// Bash hook that redirects Bash invocations into the streaming
+/// wrapper (`agentmux-bashwrap exec`). User-supplied hooks (from the
+/// agent's `content_map["hooks"]`) are merged in: their keys win on
+/// collision for non-PreToolUse events, and for PreToolUse the user's
+/// matchers are appended *before* ours so user policy can short-circuit
+/// (e.g. deny a dangerous command) before our rewrite fires.
+///
+/// See `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §5.
+pub fn build_hooks_config(user_hooks_content: Option<&str>) -> Option<String> {
+    use serde_json::Value;
+    let agentmux_pretooluse = json!({
+        "matcher": "^(Bash|.*[Bb]ash.*)$",
+        "hooks": [
+            {
+                "type": "command",
+                "command": "agentmux-bashwrap hook"
+            }
+        ]
+    });
+    let mut hooks_obj = serde_json::Map::new();
+    let mut pretooluse_entries: Vec<Value> = Vec::new();
+
+    // Start with user hooks if present + parseable.
+    if let Some(raw) = user_hooks_content {
+        if let Ok(Value::Object(user_obj)) = serde_json::from_str::<Value>(raw) {
+            for (k, v) in user_obj {
+                if k == "PreToolUse" {
+                    if let Value::Array(arr) = v {
+                        pretooluse_entries.extend(arr);
+                    }
+                } else {
+                    hooks_obj.insert(k, v);
+                }
+            }
+        }
+    }
+    // Append our entry last so user matchers (deny rules etc.) get a chance to
+    // short-circuit before our rewrite.
+    pretooluse_entries.push(agentmux_pretooluse);
+    hooks_obj.insert("PreToolUse".to_string(), Value::Array(pretooluse_entries));
+
+    match serde_json::to_string_pretty(&Value::Object(hooks_obj)) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::error!("agent_config: failed to serialize hooks config: {e}");
             None
         }
     }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -183,6 +183,12 @@ pub fn build_router(state: AppState) -> Router {
         .route("/schema/*path", get(files::handle_schema))
         .route("/api/lan-instances", get(handle_lan_instances))
         .route("/agentmux/diag/sagas", get(handle_diag_sagas))
+        // Streaming-bash wrapper publish endpoint
+        // (SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §4.3). agentmux-bashwrap
+        // POSTs `{event, scopes, data}` here while a PreToolUse-rewritten
+        // Bash command is running; we forward to the in-process WPS broker.
+        // Auth-gated like the other reactive routes (PR #801 pattern).
+        .route("/agentmux/wps/publish", post(handle_wps_publish))
         .merge(bus_routes)
         .merge(reactive_routes)
         .route_layer(middleware::from_fn_with_state(
@@ -281,6 +287,43 @@ async fn stub_501() -> impl IntoResponse {
         StatusCode::NOT_IMPLEMENTED,
         Json(json!({"error": "not implemented"})),
     )
+}
+
+/// Wire shape for `POST /agentmux/wps/publish`. Mirrors `WaveEvent`
+/// but keeps the field set narrow for what `agentmux-bashwrap`
+/// actually needs (no `sender`, no `persist`).
+#[derive(serde::Deserialize)]
+struct WpsPublishRequest {
+    /// WPS event name. We use `tool_chunk:<tool_use_id>` for
+    /// streaming chunks, but the handler is general-purpose.
+    event: String,
+    /// Optional scope filters (e.g. `["block:<id>"]`) so only
+    /// subscribers watching that block receive the event.
+    #[serde(default)]
+    scopes: Vec<String>,
+    /// Free-form payload. For tool_chunk events this is the
+    /// `{op, kind, content, timestamp}` shape from
+    /// `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
+    data: serde_json::Value,
+}
+
+/// Auth-gated WPS publish endpoint
+/// (SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §3.2). `agentmux-bashwrap`
+/// POSTs here while running a Bash command; we forward to the
+/// in-process WPS broker so subscribed frontends receive the event.
+async fn handle_wps_publish(
+    State(state): State<AppState>,
+    Json(req): Json<WpsPublishRequest>,
+) -> impl IntoResponse {
+    let event = crate::backend::wps::WaveEvent {
+        event: req.event,
+        scopes: req.scopes,
+        sender: String::new(),
+        persist: 0,
+        data: Some(req.data),
+    };
+    state.broker.publish(event);
+    (StatusCode::OK, Json(json!({"ok": true})))
 }
 
 // ---- Auth Middleware ----

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -780,10 +780,15 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
 
     // agentinput → send message to agent (persistent or per-turn subprocess)
     let wstore_ai = state.wstore.clone();
+    // Streaming-bash wrapper auth — clone the per-launch auth_key into the
+    // handler's closure so each spawn can inject it into Claude's env.
+    // See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §7.
+    let auth_key_ai = state.auth_key.clone();
     engine.register_handler(
         COMMAND_AGENT_INPUT,
         Box::new(move |data, _ctx| {
             let wstore = wstore_ai.clone();
+            let auth_key = auth_key_ai.clone();
             Box::pin(async move {
                 let cmd: CommandAgentInputData = serde_json::from_value(data)
                     .map_err(|e| format!("agentinput: {e}"))?;
@@ -835,6 +840,32 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                     &cmd.blockid,
                     &mut env_vars,
                 );
+                // Streaming-bash wrapper auth + discovery
+                // (SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §7).
+                //
+                // 1. AGENTMUX_AUTH_KEY — config.rs:42 removed it from
+                //    the process env at startup (security PR #801).
+                //    Re-inject for this spawn so the wrapper (running
+                //    inside Claude's bash subprocess tree) can
+                //    authenticate against the auth_middleware-gated
+                //    /agentmux/wps/publish endpoint via X-AuthKey.
+                // 2. PATH — prepend the bundled tools/bin dir so
+                //    `agentmux-bashwrap.exe` resolves when the
+                //    PreToolUse hook (auto-injected by agent_config.rs)
+                //    rewrites the command to invoke it. AGENTMUX_LOCAL_URL
+                //    is already in the inherited process env (main.rs:498).
+                env_vars.insert("AGENTMUX_AUTH_KEY".to_string(), auth_key.clone());
+                if let Some(tools_dir) = crate::backend::tool_store::bundled_tools_dir() {
+                    let existing = env_vars
+                        .get("PATH")
+                        .cloned()
+                        .or_else(|| std::env::var("PATH").ok())
+                        .unwrap_or_default();
+                    let sep = if cfg!(windows) { ";" } else { ":" };
+                    let new_path = format!("{}{}{}", tools_dir.display(), sep, existing);
+                    env_vars.insert("PATH".to_string(), new_path);
+                }
+
                 let session_id_field = crate::backend::obj::meta_get_string(
                     &block.meta, "agent:session_id_field", "session_id",
                 );

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -602,9 +602,16 @@ function buildConfigFiles(
         }
     }
 
-    // Write hooks.json if hooks content exists
-    if (contentMap["hooks"]) {
-        files.push({ path: ".claude/hooks.json", content: contentMap["hooks"] });
+    // Always write .claude/hooks.json with the auto-injected PreToolUse:Bash
+    // hook (agentmux-bashwrap) so live streaming engages on every
+    // session. User-supplied hooks merge in. Codex P1 on PR #809:
+    // the prior conditional silently disabled live streaming for the
+    // primary UI launch path (any agent without pre-existing user
+    // hooks). Mirror of agentmux-srv/src/backend/agent_config.rs
+    // build_hooks_config — keep the two paths in sync.
+    const hooksJson = buildHooksConfig(contentMap["hooks"]);
+    if (hooksJson) {
+        files.push({ path: ".claude/hooks.json", content: hooksJson });
     }
 
     // Build .mcp.json: auto-inject AgentMux MCP + merge user-provided config
@@ -623,6 +630,62 @@ function expandTemplate(content: string, vars: Record<string, string>): string {
     return content.replace(/\{\{(\w+)\}\}/g, (match, key) => {
         return vars[key] ?? match;
     });
+}
+
+/**
+ * Build .claude/hooks.json content with the auto-injected PreToolUse:Bash
+ * entry pointing at `agentmux-bashwrap hook`. User-supplied hooks merge
+ * in: non-PreToolUse keys win on collision; user PreToolUse matchers
+ * are appended BEFORE ours so a user deny-rule can short-circuit before
+ * our rewrite fires.
+ *
+ * Mirror of `build_hooks_config` in
+ * `agentmux-srv/src/backend/agent_config.rs`. The two paths must stay
+ * in sync — keep changes aligned across both files. See
+ * docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §5.
+ */
+function buildHooksConfig(userHooksContent: string | undefined): string | null {
+    const agentmuxPretooluse = {
+        matcher: "^(Bash|.*[Bb]ash.*)$",
+        hooks: [
+            { type: "command", command: "agentmux-bashwrap hook" },
+        ],
+    };
+    const hooksObj: Record<string, unknown> = {};
+    const pretooluseEntries: unknown[] = [];
+
+    if (userHooksContent) {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(userHooksContent);
+        } catch (e) {
+            console.warn("agent-model: failed to parse user hooks JSON; dropping", e);
+            parsed = null;
+        }
+        if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+                if (k === "PreToolUse") {
+                    if (Array.isArray(v)) {
+                        pretooluseEntries.push(...v);
+                    } else {
+                        console.warn("agent-model: user hooks.PreToolUse is not an array; dropping");
+                    }
+                } else {
+                    hooksObj[k] = v;
+                }
+            }
+        } else if (parsed != null) {
+            console.warn("agent-model: user hooks top-level is not an object; dropping");
+        }
+    }
+    pretooluseEntries.push(agentmuxPretooluse);
+    hooksObj["PreToolUse"] = pretooluseEntries;
+    try {
+        return JSON.stringify(hooksObj, null, 2);
+    } catch (e) {
+        console.error("agent-model: failed to serialize hooks config", e);
+        return null;
+    }
 }
 
 /**

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -101,6 +101,61 @@ export function useAgentStream({
     let pendingUpdates: DocumentNode[] = [];
     let flushRafId: number | null = null;
 
+    // Per-tool WPS subscriptions for `tool_chunk:<tool_use_id>` events.
+    // `agentmux-bashwrap exec` (invoked via the PreToolUse hook) publishes
+    // each stdout/stderr line to its own subject; we open a subscription
+    // when `tool_call` lands, dispatch the chunks into the reducer's
+    // `ToolChunkAppend` command, and tear it down on `tool_result` (or on
+    // unmount). See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §6.
+    const chunkSubs: Map<string, () => void> = new Map();
+
+    function openChunkSub(toolId: string) {
+        if (chunkSubs.has(toolId)) return;
+        const unsub = waveEventSubscribe({
+            eventType: `tool_chunk:${toolId}`,
+            scope: "",
+            handler: (event: any) => {
+                const data = event?.data;
+                if (!data || typeof data !== "object") return;
+                if (data.op === "terminal") {
+                    // Synthesize a system chunk and close the subscription
+                    // — defense in depth if the matching tool_result is
+                    // delayed by network or backend.
+                    dispatchDoc(blockId, {
+                        type: "ToolChunkAppend",
+                        toolId,
+                        chunk: {
+                            kind: "system",
+                            content: `[exited ${data.exit_code ?? "?"}]`,
+                            timestamp: data.timestamp ?? Date.now(),
+                        },
+                    });
+                    closeChunkSub(toolId);
+                    return;
+                }
+                if (data.op !== "chunk") return;
+                dispatchDoc(blockId, {
+                    type: "ToolChunkAppend",
+                    toolId,
+                    chunk: {
+                        kind: data.kind ?? "stdout",
+                        content: data.content ?? "",
+                        timestamp: data.timestamp ?? Date.now(),
+                    },
+                });
+            },
+        });
+        chunkSubs.set(toolId, unsub);
+    }
+
+    function closeChunkSub(toolId: string) {
+        const unsub = chunkSubs.get(toolId);
+        if (unsub) {
+            try { unsub(); } catch { /* ignore */ }
+            chunkSubs.delete(toolId);
+        }
+    }
+
     function flushPendingNodes() {
         flushRafId = null;
         if (pendingNew.length === 0 && pendingUpdates.length === 0) return;
@@ -428,8 +483,17 @@ export function useAgentStream({
                         } else {
                             dispatchPane(blockId, { type: "ToolEnd" });
                         }
+                        // Open per-tool WPS subscription for live chunks
+                        // (β.B wire-up). Only Bash currently streams, but
+                        // the subscription is cheap and provider-agnostic —
+                        // if the wrapper publishes for this tool_id, we
+                        // receive; if not, the subject stays silent and
+                        // the existing tool_result path lands the whole
+                        // result as before.
+                        if (event.id) openChunkSub(event.id);
                     } else if (event.type === "tool_result") {
                         dispatchPane(blockId, { type: "ToolEnd" });
+                        if (event.id) closeChunkSub(event.id);
                     } else if (event.type === "tool_chunk") {
                         // Live-log streaming (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md):
                         // route chunks through their own reducer command
@@ -469,6 +533,11 @@ export function useAgentStream({
         onCleanup(() => {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
+            // Tear down all live tool_chunk subscriptions opened during
+            // this session (β.B wire-up). A pin/unpin race that left a
+            // chunk subscription open would otherwise leak into the next
+            // session.
+            for (const [id] of chunkSubs) closeChunkSub(id);
             // StreamUnsubscribe also force-clears turnActive (so a crash
             // or exit without session_end doesn't leave "Working…" stuck).
             const at = Date.now();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.800",
+  "version": "0.33.801",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.800",
+      "version": "0.33.801",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.802",
+  "version": "0.33.803",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.802",
+      "version": "0.33.803",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.801",
+  "version": "0.33.802",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.801",
+      "version": "0.33.802",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.800",
+  "version": "0.33.801",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.801",
+  "version": "0.33.802",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.802",
+  "version": "0.33.803",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/scripts/package-portable.sh
+++ b/scripts/package-portable.sh
@@ -20,7 +20,7 @@ ZIPPATH="$OUTDIR/agentmux-$VERSION-x64-portable.zip"
 echo "Packaging AgentMux v$VERSION Portable..."
 
 # Verify required files
-for f in target/release/agentmux-cef.exe dist/cef/libcef.dll dist/bin/agentmux-srv-$VERSION-windows.x64.exe dist/frontend/index.html target/release/agentmux-launcher.exe; do
+for f in target/release/agentmux-cef.exe dist/cef/libcef.dll dist/bin/agentmux-srv-$VERSION-windows.x64.exe dist/frontend/index.html target/release/agentmux-launcher.exe target/release/agentmux-bashwrap.exe; do
     if [ ! -f "$f" ]; then
         echo "ERROR: $f not found — build first" >&2
         exit 1
@@ -79,6 +79,13 @@ DATAEOF
 # Runtime binaries — versioned filenames so WER dumps & Event Viewer show versions
 cp target/release/agentmux-cef.exe "$PORTABLE/runtime/agentmux-$VERSION.exe"
 cp dist/bin/agentmux-srv-$VERSION-windows.x64.exe "$PORTABLE/runtime/"
+
+# Streaming bash wrapper — invoked by Claude's Bash subprocess via the
+# PreToolUse hook (agent_config.rs auto-injects .claude/hooks.json
+# pointing at "agentmux-bashwrap hook"). agentmux-srv adds tools/bin
+# to PATH for Claude's env, so the wrapper must land in tools/bin.
+# See docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md.
+cp target/release/agentmux-bashwrap.exe "$PORTABLE/runtime/tools/bin/"
 
 # wsh has been retired — see specs/SPEC_RETIRE_WSH_2026_04_12.md. No binary
 # to ship anymore; AGENTMUX env var is now a plain "1" sentinel.


### PR DESCRIPTION
## Summary

PR β.B of the streaming-bash-runner work — makes the wrapper from PR #804 actually flow chunks end-to-end. Five surfaces:

1. **AUTH_KEY + URL env re-injection** (`agentmux-srv/src/server/websocket.rs` agentinput handler). \`AGENTMUX_AUTH_KEY\` was removed from agentmux-srv's process env at startup (config.rs:42, security PR #801) so child processes lose it. Now cloned from \`state.auth_key\` into the spawn \`env_vars\` so Claude's bash subprocess inherits it and the wrapper picks it up. \`AGENTMUX_LOCAL_URL\` was already in the inherited process env (main.rs:498).

2. **PATH augmentation** — prepend the bundled \`tools/bin\` dir to \`PATH\` so the PreToolUse-rewritten command finds \`agentmux-bashwrap.exe\`. Uses the existing \`tool_store::bundled_tools_dir()\` helper.

3. **\`POST /agentmux/wps/publish\` endpoint** (\`server/mod.rs\`). Auth-gated under the same \`auth_middleware\` as reactive routes (PR #801 pattern). Accepts \`{event, scopes, data}\`, forwards to the in-process WPS broker. The wrapper POSTs here with \`X-AuthKey\` while running.

4. **\`.claude/hooks.json\` auto-injection** (\`agent_config.rs\`). New \`build_hooks_config()\` always emits a \`PreToolUse:Bash\` entry pointing at \`agentmux-bashwrap hook\`. User-supplied hooks merge in: their non-PreToolUse keys win on collision, and their PreToolUse matchers go FIRST so a user deny-rule short-circuits before our rewrite fires.

5. **Frontend WPS subscription bridge** (\`useAgentStream.ts\`). \`chunkSubs\` map of \`tool_use_id\` → unsubscribe. On \`tool_call\`: open subscription for \`tool_chunk:<id>\` that dispatches each chunk to \`ToolChunkAppend\`. On \`tool_result\` OR terminal marker from the wrapper: close subscription. \`onCleanup\` tears down all live subscriptions to prevent leaks across sessions.

Plus **packaging**: bundle \`target/release/agentmux-bashwrap.exe\` into \`runtime/tools/bin/\` in the portable.

## Test plan

- [x] \`cargo check -p agentmux-srv\` — clean (37 pre-existing warnings, none new).
- [x] \`tsc --noEmit\` — zero new errors in touched files.
- [x] \`vitest run reducer.test.ts stream-parser.test.ts\` — 63/63 pass.
- [ ] Manual smoke: extract portable build, run an agent, fire \`sleep 2 && echo a && sleep 2 && echo b\`. Expect: \`a\` appears in overlay at t≈2s, \`b\` at t≈4s (live streaming). Verify exit code lands as \`tool_result\` post-completion.
- [ ] Verify \`.claude/hooks.json\` written with PreToolUse entry at agent boot.
- [ ] Verify wrapper auth: \`X-AuthKey\` propagates; no 401s in srv logs while bash command runs.

## Sequencing

- **#800** ✅ — Phase 1: types + reducer.
- **#803** ✅ — Phase 3: overlay UI.
- **#804** ✅ — β.A: bashwrap binary.
- **#808** ✅ — replaceChild hotfix.
- **This PR (β.B)** — wire-up. Live streaming actually flows.
- **Next (γ)** — RAF coalescing + perf (multi-chunk reducer shape, audit-ring sampling, ANSI worker).
- **Then (δ)** — Codex / Gemini provider parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)