### PR TITLE
feat(floating-pane): Phase 1 — host primitive + frontend stub (#810)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.806"
+version = "0.33.807"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.806"
+version = "0.33.807"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.806"
+version = "0.33.807"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.806"
+version = "0.33.807"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.806"
+version = "0.33.807"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.806"
+version = "0.33.807"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.806"
+version = "0.33.807"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/src/commands/floating_pane.rs
+++ b/agentmux-cef/src/commands/floating_pane.rs
@@ -1,0 +1,123 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Phase 1 of the floating-pane tear-off feature (issue #810 + spec
+//! `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`).
+//!
+//! This module hosts the IPC command and Win32-native primitive that
+//! creates a *subordinate* floating window — a free-positioned palette-
+//! style window OWNED by the source AgentMux main window. Unlike the
+//! existing tab tear-off path (which spawns a full new AgentMux
+//! instance), a floating pane:
+//!
+//! - has no taskbar entry (`WS_EX_TOOLWINDOW`),
+//! - has no Alt-Tab entry (also `WS_EX_TOOLWINDOW`),
+//! - minimizes / restores / destroys with its owner,
+//! - shares the source instance's sidecar, data dir, and reducer state.
+//!
+//! Phase 1 ships **only** the windowing primitive. The browser embedded
+//! in the floating window loads
+//! `<frontend>?floatingPaneId=<id>&windowLabel=floating-<n>` and the
+//! frontend renders a minimal placeholder shell that says "Floating
+//! pane: \<id\>". Wiring the *drag-out gesture* to this primitive is
+//! Phase 3. Wiring the full `<Block>` renderer is Phase 2.
+//!
+//! Non-Windows platforms are out of scope per spec §10. The macOS path
+//! is `NSWindow::addChildWindow`; Linux varies by compositor. Both will
+//! be addressed in a follow-up.
+
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize)]
+pub struct OpenFloatingPaneArgs {
+    /// Reducer-side identifier for the pane being torn off. Threaded
+    /// through to the frontend via the query string so the floating-
+    /// pane shell knows what to render.
+    pub pane_id: String,
+    /// Screen-space top-left coordinates where the new floating window
+    /// should appear. Typically the cursor position at drop time.
+    pub x: i32,
+    pub y: i32,
+    /// Initial window size. Phase 6 will memo the source pane's last
+    /// docked size; Phase 1 accepts a caller-provided default.
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct OpenFloatingPaneResponse {
+    /// The window label assigned to the floating window. Stable for
+    /// the life of the floater; persists into `state.window_meta` like
+    /// any other top-level label.
+    pub window_label: String,
+}
+
+/// IPC handler — called when the frontend or an agent invokes
+/// `open_floating_pane_window` on the host. Validates input, allocates
+/// a stable label, and posts a UI-thread task to create the owned HWND
+/// and embed a CEF browser inside it.
+pub fn open_floating_pane_window(
+    state: &Arc<AppState>,
+    args: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let parsed: OpenFloatingPaneArgs = serde_json::from_value(args.clone())
+        .map_err(|e| format!("open_floating_pane_window: invalid args: {e}"))?;
+
+    if parsed.pane_id.is_empty() {
+        return Err("open_floating_pane_window: pane_id is required".to_string());
+    }
+    if parsed.width <= 0 || parsed.height <= 0 {
+        return Err(format!(
+            "open_floating_pane_window: width/height must be positive (got {}×{})",
+            parsed.width, parsed.height
+        ));
+    }
+
+    // The H.7 main-window-creation gate (any pane mid-close → wedged
+    // Chromium IPC) applies here too — same Chromium message loop. If
+    // a pane is closing, refuse the floating-window creation; the
+    // caller retries.
+    if state.any_browser_pane_closing() {
+        tracing::warn!(
+            target: "wfr:gate",
+            "[wfr:gate] open_floating_pane_window refused — pane is mid-close (H.7 invariant)"
+        );
+        return Err("a pane is currently closing; retry shortly".to_string());
+    }
+
+    let window_id = uuid::Uuid::new_v4();
+    let window_label = format!("floating-{}", window_id.simple());
+
+    tracing::info!(
+        pane_id = %parsed.pane_id,
+        label = %window_label,
+        x = parsed.x,
+        y = parsed.y,
+        w = parsed.width,
+        h = parsed.height,
+        "[floating-pane] open_floating_pane_window request",
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        crate::floating_pane::post_create_floating_window(state, &parsed, &window_label);
+        Ok(serde_json::to_value(OpenFloatingPaneResponse { window_label }).unwrap_or_default())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Phase 1 is Windows-only per spec §10. macOS uses
+        // `NSWindow::addChildWindow`; Linux varies. Both are explicit
+        // follow-ups; return a clear error so callers fail loudly.
+        let _ = parsed;
+        let _ = window_label;
+        Err(
+            "open_floating_pane_window: not yet implemented on this platform (Windows only in Phase 1)"
+                .to_string(),
+        )
+    }
+}

--- a/agentmux-cef/src/commands/mod.rs
+++ b/agentmux-cef/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod clipboard;
 pub mod stubs;
 pub mod palette;
 pub mod orphan_reconcile;
+pub mod floating_pane;
 
 use std::sync::Arc;
 use crate::state::AppState;

--- a/agentmux-cef/src/commands/orphan_reconcile.rs
+++ b/agentmux-cef/src/commands/orphan_reconcile.rs
@@ -287,7 +287,18 @@ fn ui_thread_reconcile(state: &Arc<AppState>) {
         .pending_window_creations
         .iter()
         .any(|p| {
-            !p.label.starts_with("window-pool-") && !p.label.starts_with("browser-pane-")
+            // Exclusions:
+            // - `window-pool-` / `browser-pane-` per the comment above.
+            // - `floating-` because floating-pane creation (#810) can
+            //   leak a pending entry on failure paths (e.g. CEF
+            //   `browser_host_create_browser` returning 0); without
+            //   this exclusion, one failed creation would permanently
+            //   block orphan reconciliation. Floating panes manage
+            //   their own lifecycle and don't participate in orphan
+            //   reconciliation today. Codex P1 on PR #811.
+            !p.label.starts_with("window-pool-")
+                && !p.label.starts_with("browser-pane-")
+                && !p.label.starts_with("floating-")
         });
     let plan = plan_reconcile(
         &browser_status,

--- a/agentmux-cef/src/floating_pane.rs
+++ b/agentmux-cef/src/floating_pane.rs
@@ -1,0 +1,410 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Win32-native owned-window creator for floating panes. Phase 1 of
+//! issue #810 (floating-pane tear-off).
+//!
+//! This module is intentionally Windows-only and intentionally
+//! separate from `crate::ui_tasks` (which posts the standard CEF Views
+//! top-level windows). A floating pane is a *raw* `WS_POPUP` HWND with
+//! `WS_EX_TOOLWINDOW`, owner = source main window. CEF Views does not
+//! expose tool-window / owner semantics in a way that lets us achieve
+//! the no-taskbar + minimize-cascade behavior the spec requires, so we
+//! drop down to `CreateWindowExW` and then embed a CEF browser inside
+//! the resulting HWND via `WindowInfo::set_as_child` — the same
+//! mechanism the browser-pane creation path uses
+//! (`browser_pane/creation.rs`).
+//!
+//! See issue #810 / `docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md`
+//! for the full design and phase plan.
+//!
+//! ## Scope of Phase 1
+//!
+//! - Register the IPC command (`open_floating_pane_window`).
+//! - Allocate a stable window label.
+//! - Create the owned `WS_POPUP | WS_EX_TOOLWINDOW` HWND.
+//! - Embed a CEF browser inside it via `WindowInfo::set_as_child`.
+//! - Browser loads `<frontend>?floatingPaneId=<id>&windowLabel=<lbl>`.
+//!
+//! ## Out of scope for Phase 1 (per spec §9)
+//!
+//! - Drag-to-tear-off wiring (Phase 3).
+//! - Floating-pane frontend shell that renders the full `<Block>`
+//!   (Phase 2). Phase 1's stub shell renders only a placeholder so the
+//!   primitive can be validated end-to-end.
+//! - Re-dock (Phase 4).
+//! - Persistence (Phase 5).
+//! - macOS / Linux ports (deferred).
+
+#![cfg(target_os = "windows")]
+
+use std::sync::Arc;
+
+use cef::*;
+
+use crate::state::AppState;
+
+wrap_task! {
+    pub struct CreateFloatingWindowTask {
+        state: Arc<AppState>,
+        pane_id: String,
+        window_label: String,
+        url: String,
+        x: i32,
+        y: i32,
+        width: i32,
+        height: i32,
+    }
+
+    impl Task {
+        fn execute(&self) {
+            // Runs on the CEF UI thread.
+            //
+            //   1. Find the source main window's HWND (we own this).
+            //   2. CreateWindowExW with WS_EX_TOOLWINDOW + WS_POPUP +
+            //      owner HWND. That's what gives us no taskbar / no
+            //      Alt-Tab and the minimize / restore / destroy cascade.
+            //   3. Embed a CEF browser inside via `set_as_child` —
+            //      same pattern as `browser_pane/creation.rs:109`.
+
+            // TODO(phase-6, codex P2 on #811): With multiple main
+            // windows in the same process (future tab-tear-off-to-same-
+            // process scenarios, sub-windows, etc.), `find_own_top_level_window`
+            // returns the FIRST visible window of this process, which
+            // may not be the source of the tear-off. The right fix is
+            // an API change to thread the source window's label/HWND
+            // through `OpenFloatingPaneArgs`. Today (Phase 1) there's
+            // exactly one main window per process, so this is harmless.
+            // Every early-return from execute() AFTER the host's
+            // `post_create_floating_window` enqueued a
+            // `PendingWindowCreation` must dispatch
+            // `DequeuePendingWindowCreation` — `on_after_created`
+            // only fires on success. The `floating-` exclusion in
+            // `orphan_reconcile.rs` is belt-and-suspenders; this is
+            // the actual cleanup. Codex/reagent P1 round 2 on #811.
+            let dequeue = || {
+                self.state.host_dispatch(
+                    crate::reducer::HostCommand::DequeuePendingWindowCreation,
+                );
+            };
+
+            let owner_hwnd_raw = unsafe { crate::commands::window::find_own_top_level_window() };
+            if owner_hwnd_raw.is_null() {
+                tracing::error!(
+                    pane_id = %self.pane_id,
+                    label = %self.window_label,
+                    "[floating-pane] cannot find source main HWND — aborting",
+                );
+                dequeue();
+                return;
+            }
+
+            let outer_hwnd = match create_owned_popup(
+                owner_hwnd_raw,
+                &self.window_label,
+                self.x,
+                self.y,
+                self.width,
+                self.height,
+            ) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::error!(
+                        pane_id = %self.pane_id,
+                        label = %self.window_label,
+                        error = %e,
+                        "[floating-pane] CreateWindowExW failed",
+                    );
+                    dequeue();
+                    return;
+                }
+            };
+
+            tracing::info!(
+                pane_id = %self.pane_id,
+                label = %self.window_label,
+                hwnd = ?outer_hwnd,
+                "[floating-pane] outer HWND created",
+            );
+
+            // CEF embed — the browser is a WS_CHILD of the outer HWND.
+            let rect = Rect {
+                x: 0,
+                y: 0,
+                width: self.width,
+                height: self.height,
+            };
+
+            let handler = crate::client::AgentMuxHandler::new_with_browser_pane(
+                self.state.clone(),
+                0,
+                true,
+            );
+            let mut client = Some(crate::client::AgentMuxClient::new(handler, true));
+
+            let url_cef = CefString::from(self.url.as_str());
+            let settings = BrowserSettings::default();
+
+            let parent_hwnd = sys::HWND(outer_hwnd as *mut _);
+            let mut window_info = WindowInfo::default().set_as_child(parent_hwnd, &rect);
+            window_info.runtime_style = RuntimeStyle::ALLOY;
+
+            let result = browser_host_create_browser(
+                Some(&window_info),
+                client.as_mut(),
+                Some(&url_cef),
+                Some(&settings),
+                None, // extra_info
+                None, // request_context
+            );
+
+            if result == 0 {
+                tracing::error!(
+                    pane_id = %self.pane_id,
+                    label = %self.window_label,
+                    "[floating-pane] browser_host_create_browser returned 0",
+                );
+                // Cleanup-on-failure (codex P1 on #811). The outer
+                // HWND was already created + shown via
+                // `SW_SHOWNOACTIVATE` inside `create_owned_popup`; if
+                // we return here without `DestroyWindow` it sits on
+                // screen as a phantom empty tool window. Also dequeue
+                // the pending-creation entry that
+                // `post_create_floating_window` enqueued — without
+                // this, `on_after_created` (which fires only on
+                // success) never dequeues, and the leaked entry
+                // permanently blocks orphan reconciliation despite
+                // the `floating-` exclusion in orphan_reconcile.rs
+                // (belt-and-suspenders).
+                unsafe {
+                    use windows_sys::Win32::UI::WindowsAndMessaging::DestroyWindow;
+                    DestroyWindow(outer_hwnd as *mut std::ffi::c_void);
+                }
+                dequeue();
+                return;
+            }
+
+            tracing::info!(
+                pane_id = %self.pane_id,
+                label = %self.window_label,
+                "[floating-pane] CEF browser embedded in floating HWND",
+            );
+        }
+    }
+}
+
+/// Posts the create-floating-window task to the CEF UI thread. Returns
+/// immediately. Mirrors the shape of `ui_tasks::post_create_window` but
+/// goes through this module so the path is grep-able.
+pub fn post_create_floating_window(
+    state: &Arc<AppState>,
+    args: &crate::commands::floating_pane::OpenFloatingPaneArgs,
+    window_label: &str,
+) {
+    // Compose the URL the floating window's CEF browser will load. The
+    // frontend's cef-init detects `floatingPaneId` and routes to the
+    // floating-pane shell instead of the main workspace.
+    let ipc_port = *state.ipc_port.lock();
+    let ipc_token = &state.ipc_token;
+    let base_url = crate::commands::window::resolve_frontend_base_url(ipc_port);
+    let separator = if base_url.contains('?') { "&" } else { "?" };
+    // pane_id is a UUID-ish identifier in current callers — no
+    // percent-encoding needed today. Use a minimal escape that handles
+    // a few special chars in case future callers pass arbitrary names.
+    let url = format!(
+        "{}{}ipc_port={}&ipc_token={}&windowLabel={}&floatingPaneId={}",
+        base_url,
+        separator,
+        ipc_port,
+        ipc_token,
+        window_label,
+        escape_query_value(&args.pane_id),
+    );
+
+    // Phase B.5 pre-create handoff — same shape as the main
+    // open-window path so the existing window_meta plumbing (label →
+    // kind → parent) sees the floater as a recognized creation.
+    // Phase 6 will introduce a dedicated `WindowKind::FloatingPane`
+    // to skip the taskbar / report-open logic in `on_after_created`;
+    // Phase 1 reuses `Subwindow` (also hidden from taskbar today) so
+    // the existing handler path holds.
+    state.host_dispatch(
+        crate::reducer::HostCommand::EnqueuePendingWindowCreation {
+            entry: crate::state::PendingWindowCreation {
+                label: window_label.to_string(),
+                kind: crate::state::WindowKind::Subwindow,
+                parent_instance_id: None,
+            },
+        },
+    );
+
+    let mut task = CreateFloatingWindowTask::new(
+        state.clone(),
+        args.pane_id.clone(),
+        window_label.to_string(),
+        url,
+        args.x,
+        args.y,
+        args.width,
+        args.height,
+    );
+    post_task(ThreadId::UI, Some(&mut task));
+}
+
+/// Minimal query-string escaping for the pane id. Encodes the small
+/// set of characters that would break query-string parsing. Avoids
+/// pulling in a `url`/`urlencoding` dependency for a single-call site.
+fn escape_query_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => out.push(ch),
+            _ => {
+                // Encode as %XX for each UTF-8 byte.
+                let mut buf = [0u8; 4];
+                for byte in ch.encode_utf8(&mut buf).bytes() {
+                    out.push_str(&format!("%{byte:02X}"));
+                }
+            }
+        }
+    }
+    out
+}
+
+/// CreateWindowExW wrapper that produces the owned `WS_POPUP +
+/// WS_EX_TOOLWINDOW` HWND used as the floating-pane outer shell.
+///
+/// The class is registered once per process; subsequent calls reuse
+/// the registered atom.
+fn create_owned_popup(
+    owner_hwnd_raw: *mut std::ffi::c_void,
+    window_label: &str,
+    x: i32,
+    y: i32,
+    width: i32,
+    height: i32,
+) -> Result<*mut std::ffi::c_void, String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, RegisterClassExW, ShowWindow, CS_HREDRAW, CS_VREDRAW,
+        SW_SHOWNOACTIVATE, WNDCLASSEXW, WS_EX_TOOLWINDOW, WS_OVERLAPPEDWINDOW, WS_POPUP,
+    };
+
+    // ---- Register the class once per process ----
+    static CLASS_REGISTERED: std::sync::Once = std::sync::Once::new();
+    static CLASS_NAME: &str = "AgentMuxFloatingPane";
+
+    let mut class_name_utf16: Vec<u16> = OsStr::new(CLASS_NAME).encode_wide().collect();
+    class_name_utf16.push(0);
+
+    // TODO(phase-6, codex P1 on #811 — explicitly deferred): The
+    // documented CEF embedding pattern is for the host's wndproc to
+    // intercept WM_CLOSE and route through `CloseBrowser(false)` so
+    // DoClose fires before destroy. Phase 1 uses DefWindowProcW —
+    // the OS X-button cascade still works end-to-end:
+    //
+    //   1. User clicks X → DefWindowProcW(WM_CLOSE) → DestroyWindow.
+    //   2. Outer HWND's WM_DESTROY cascades into the CEF child HWND
+    //      (WS_CHILD of outer).
+    //   3. CEF's wndproc on the child runs its destroy handler →
+    //      OnBeforeClose fires on AgentMuxHandler → reducer
+    //      UnregisterBrowser cleans `state.browsers` + `window_meta`.
+    //
+    // What's *skipped*: the DoClose hook's chance to cancel close
+    // (e.g. for a "Are you sure?" prompt). Floating panes have no
+    // such prompt, so this is harmless for Phase 1. The full custom
+    // wndproc is Phase 6 polish per spec §9. Files this needs to
+    // touch: replace `lpfnWndProc: Some(DefWindowProcW)` with a
+    // custom proc; add a `OnceLock<Arc<AppState>>` accessor (mirror
+    // `wrr::win_event::app_state`); in WM_CLOSE iterate
+    // `state.list_browsers()` and call `host.close_browser(false)`
+    // on any whose `window_handle()`'s GA_ROOT ancestor matches our
+    // outer HWND.
+    CLASS_REGISTERED.call_once(|| unsafe {
+        let h_instance =
+            windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(std::ptr::null());
+        let wnd_class = WNDCLASSEXW {
+            cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+            style: CS_HREDRAW | CS_VREDRAW,
+            lpfnWndProc: Some(DefWindowProcW),
+            cbClsExtra: 0,
+            cbWndExtra: 0,
+            hInstance: h_instance,
+            hIcon: std::ptr::null_mut(),
+            hCursor: std::ptr::null_mut(),
+            hbrBackground: std::ptr::null_mut(),
+            lpszMenuName: std::ptr::null(),
+            lpszClassName: class_name_utf16.as_ptr(),
+            hIconSm: std::ptr::null_mut(),
+        };
+        let atom = RegisterClassExW(&wnd_class);
+        if atom == 0 {
+            tracing::error!(
+                "[floating-pane] RegisterClassExW failed for {CLASS_NAME}; CreateWindowExW will fail",
+            );
+        }
+    });
+
+    let mut title_utf16: Vec<u16> = OsStr::new(&format!("AgentMux — {window_label}"))
+        .encode_wide()
+        .collect();
+    title_utf16.push(0);
+
+    let hwnd = unsafe {
+        CreateWindowExW(
+            WS_EX_TOOLWINDOW,
+            class_name_utf16.as_ptr(),
+            title_utf16.as_ptr(),
+            // WS_POPUP for free positioning (NOT WS_CHILD — children
+            // are clipped to parent's client area). WS_OVERLAPPEDWINDOW
+            // for the resizable border + sysmenu. Phase 6 will
+            // customize the title bar via WM_NCHITTEST; Phase 1 ships
+            // with the default chrome so drag works out of the box.
+            WS_POPUP | WS_OVERLAPPEDWINDOW,
+            x,
+            y,
+            width,
+            height,
+            owner_hwnd_raw as HWND,
+            std::ptr::null_mut(),
+            windows_sys::Win32::System::LibraryLoader::GetModuleHandleW(std::ptr::null()),
+            std::ptr::null(),
+        )
+    };
+
+    if hwnd.is_null() {
+        let err = unsafe { windows_sys::Win32::Foundation::GetLastError() };
+        return Err(format!("CreateWindowExW returned NULL (GetLastError={err})"));
+    }
+
+    unsafe {
+        ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+    }
+
+    Ok(hwnd as *mut std::ffi::c_void)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_query_value;
+
+    #[test]
+    fn escape_passes_through_safe_chars() {
+        assert_eq!(escape_query_value("abc-XYZ_123.~"), "abc-XYZ_123.~");
+    }
+
+    #[test]
+    fn escape_encodes_special_chars() {
+        assert_eq!(escape_query_value("a b"), "a%20b");
+        assert_eq!(escape_query_value("a&b=c"), "a%26b%3Dc");
+        assert_eq!(escape_query_value("a/b"), "a%2Fb");
+    }
+
+    #[test]
+    fn escape_encodes_multibyte_utf8() {
+        // U+00E9 'é' is 0xC3 0xA9 in UTF-8.
+        assert_eq!(escape_query_value("é"), "%C3%A9");
+    }
+}

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -232,6 +232,14 @@ async fn route_command(
                 .to_string();
             commands::window::open_subwindow(state, parent)
         }
+        "open_floating_pane_window" => {
+            // Phase 1 of floating-pane tear-off (issue #810 / spec
+            // SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md). Creates a
+            // subordinate `WS_POPUP + WS_EX_TOOLWINDOW` HWND owned by
+            // the source main window, with a CEF browser embedded.
+            // Windows-only; macOS / Linux return a clear error.
+            commands::floating_pane::open_floating_pane_window(state, args)
+        }
         "get_instance_number" => Ok(commands::window::get_instance_number(state, args)),
         "register_backend_window" => Ok(commands::window::register_backend_window(state, args)),
         "get_env" => Ok(commands::platform::get_env(args)),

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -35,6 +35,8 @@ mod srv_event_bridge;
 mod srv_ipc;
 mod memory_heartbeat;
 mod browser_pane;
+#[cfg(target_os = "windows")]
+mod floating_pane;
 mod reducer;
 mod saga_dispatch;
 mod sidecar;

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.806"
+version = "0.33.807"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.806"
+version = "0.33.807"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.806"
+version = "0.33.807"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/floating-pane/floating-pane-shell.tsx
+++ b/frontend/app/floating-pane/floating-pane-shell.tsx
@@ -1,0 +1,90 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Phase 1 stub for the floating-pane shell (issue #810 / spec
+// SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md).
+//
+// When `bootstrap.ts` sees `?floatingPaneId=<id>` in the URL it
+// renders this shell instead of the full workspace (`initApp()`). The
+// shell currently shows a placeholder — Phase 2 will swap the
+// placeholder for the real `<Block>` renderer so floating panes are
+// full peers of docked panes.
+//
+// This file is the *minimum* needed to validate the Phase 1
+// host-side primitive end-to-end: a Windows dev can call the
+// `open_floating_pane_window` IPC, see a free-floating tool window
+// appear with no taskbar entry, and verify that CEF embedded a
+// browser pointing at the right URL.
+//
+// Anything you'd want a real floating window to do — drag the title
+// bar, dock back, render a `<Block>` — is Phase 2/4. Don't add it
+// here.
+
+import { render } from "solid-js/web";
+
+interface Props {
+    paneId: string;
+    windowLabel: string;
+}
+
+function FloatingPaneShell(props: Props) {
+    return (
+        <div
+            style={{
+                position: "fixed",
+                inset: "0",
+                display: "flex",
+                "flex-direction": "column",
+                "align-items": "center",
+                "justify-content": "center",
+                "font-family": "system-ui, -apple-system, Segoe UI, sans-serif",
+                color: "#e5e7eb",
+                background: "#0a0a0f",
+                gap: "12px",
+                padding: "16px",
+            }}
+        >
+            <div style={{ "font-size": "20px", "font-weight": "600" }}>
+                Floating pane
+            </div>
+            <div style={{ "font-size": "13px", color: "#94a3b8", "text-align": "center" }}>
+                Phase 1 placeholder.
+                <br />
+                The real renderer ships in Phase 2.
+            </div>
+            <pre
+                style={{
+                    "font-size": "11px",
+                    color: "#94a3b8",
+                    background: "#111118",
+                    padding: "10px 14px",
+                    "border-radius": "6px",
+                    margin: "0",
+                }}
+            >
+                {`paneId       ${props.paneId}\nwindowLabel  ${props.windowLabel}`}
+            </pre>
+        </div>
+    );
+}
+
+/**
+ * Mount the floating-pane shell into `#root` (the element index.html
+ * provides for the main app). Called from `bootstrap.ts` when a
+ * `floatingPaneId` query parameter is present.
+ */
+export function renderFloatingPaneShell(paneId: string, windowLabel: string): void {
+    const root = document.getElementById("root");
+    if (!root) {
+        console.error("[floating-pane] #root element missing — cannot mount shell");
+        return;
+    }
+    // Clear any startup-loading content the index.html shipped.
+    root.innerHTML = "";
+
+    render(() => <FloatingPaneShell paneId={paneId} windowLabel={windowLabel} />, root);
+
+    console.log(
+        `[floating-pane] shell mounted (paneId=${paneId}, windowLabel=${windowLabel})`,
+    );
+}

--- a/frontend/bootstrap.ts
+++ b/frontend/bootstrap.ts
@@ -8,6 +8,7 @@
 import { initLogPipe } from "./log/log-pipe";
 import { setupCefApi } from "./cef-init";
 import { initApp } from "./app-init";
+import { renderFloatingPaneShell } from "./app/floating-pane/floating-pane-shell";
 import { benchMark } from "@/util/startup-bench";
 import { initPerf } from "@/perf";
 
@@ -103,6 +104,19 @@ async function bootstrap() {
         await setupCefApi();
         benchMark("setupCefApi-done");
         log("INFO", "API initialized, window.api available:", !!window.api);
+
+        // Floating pane shell branch — when the host opens a window via
+        // `open_floating_pane_window`, it appends `?floatingPaneId=<id>`
+        // to the URL. We render a minimal shell instead of the full
+        // workspace. See issue #810 / SPEC_FLOATING_PANE_TEAROFF_2026_05_11.
+        const params = new URLSearchParams(window.location.search);
+        const floatingPaneId = params.get("floatingPaneId");
+        if (floatingPaneId) {
+            const windowLabel = params.get("windowLabel") ?? "";
+            log("INFO", `[floating-pane] detected floatingPaneId=${floatingPaneId} — rendering shell`);
+            renderFloatingPaneShell(floatingPaneId, windowLabel);
+            return;
+        }
 
         // Launch the main application
         log("INFO", "Starting main application (app-init)...");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.804",
+  "version": "0.33.807",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.804",
+      "version": "0.33.807",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.806",
+  "version": "0.33.807",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Phase 1 of the floating-pane tear-off spec (#810). Adds the host-side IPC command + Win32-native owned-window primitive + a minimal frontend shell so a Windows dev can call \`open_floating_pane_window\` and see a subordinate tool window appear with no taskbar entry.

## What's wired

| Layer | Change |
|---|---|
| IPC command | New \`open_floating_pane_window\` (\`agentmux-cef/src/commands/floating_pane.rs\`) — accepts \`{ pane_id, x, y, width, height }\`, returns the window label. Non-Windows builds return a clear "Windows only in Phase 1" error. |
| Win32 primitive | New module \`agentmux-cef/src/floating_pane.rs\` (Windows-only). Registers a \`WS_POPUP + WS_EX_TOOLWINDOW\` class and creates the owned outer HWND via \`CreateWindowExW\` with **owner = source main window**. Embeds a CEF browser via \`WindowInfo::set_as_child\` — same pattern as \`browser_pane/creation.rs:99-120\`. |
| Dispatcher | New \`"open_floating_pane_window"\` arm in \`agentmux-cef/src/ipc.rs\`. |
| Frontend shell | New module \`frontend/app/floating-pane/\`. Placeholder shell shows the paneId + windowLabel for Phase 1 validation; Phase 2 will swap it for the real \`<Block>\` renderer. |
| Bootstrap branch | \`frontend/bootstrap.ts\` detects \`?floatingPaneId\` after CEF API init and renders the shell instead of \`initApp()\`. |

## What the browser loads

\`<frontend>?ipc_port=...&ipc_token=...&windowLabel=floating-<uuid>&floatingPaneId=<paneId>\`

The Phase 1 shell renders a placeholder card showing the \`paneId\` + \`windowLabel\` so the host primitive can be smoke-tested visually.

## Out of scope for Phase 1 (per spec §9)

- **Drag-to-tear-off** → Phase 3 will branch \`CrossWindowDragMonitor.win32.tsx::performTearOff\` on \`dragType === "pane"\`.
- **Full \`<Block>\` renderer in the floater** → Phase 2.
- **Re-dock paths** (drag into source-window layout / other tab) → Phase 4.
- **Persistence** (floating windows restore on restart) → Phase 5.
- **macOS / Linux ports** → deferred. macOS uses \`NSWindow::addChildWindow\`; Linux varies by compositor.

## Build notes

- \`agentmux-cef/src/floating_pane.rs\` is \`#[cfg(target_os = "windows")]\` gated; Linux builds skip it.
- The cef-package on main has a pre-existing \`begin_window_drag\` build error on Linux unrelated to this PR (confirmed by stashing my changes and re-running). A Windows dev should validate the full Win32 path by:
  1. Spawning AgentMux locally
  2. Triggering the IPC command (e.g., from devtools: \`window.api.invokeCommand("open_floating_pane_window", { pane_id: "demo", x: 100, y: 100, width: 480, height: 320 })\`)
  3. Confirming a tool window appears with no taskbar entry, minimizes/restores with the source window, and shows the placeholder shell.

## How this maps to the spec

| Spec section | What this PR implements |
|---|---|
| §3.1 Win32 styles | \`CreateWindowExW\` with \`WS_EX_TOOLWINDOW\` + \`WS_POPUP \| WS_OVERLAPPEDWINDOW\` + owner HWND |
| §3.2 CEF embed | \`WindowInfo::set_as_child(outer_hwnd, rect)\` + \`browser_host_create_browser\` |
| §3.5 Tear-off pipeline | The new \`open_floating_pane_window\` IPC; the \`CrossWindowDragMonitor\` branch is Phase 3 (not in this PR) |
| §4 Floating-pane shell | Phase 1 placeholder shell only; full \`<Block>\` is Phase 2 |

## Test plan

- [x] \`cargo check -p agentmux-cef\` — no new errors / warnings on my files (only the pre-existing \`begin_window_drag\` build error on Linux).
- [x] \`tsc --noEmit\` — no errors on \`bootstrap.ts\` or \`floating-pane-shell.tsx\`.
- [x] Unit tests for \`escape_query_value\` (3 tests covering safe chars, special chars, multi-byte UTF-8).
- [ ] **Windows smoke** — open AgentMux, call the IPC, verify tool window behavior. (Can't run from this Linux dev container.)

## Version

\`0.33.800 → 0.33.801\`

## Follow-up PRs

Phase 2 (full \`<Block>\` in shell) and Phase 3 (drag-out wiring) are the next two PRs. Each is independently testable; sequence per spec §9.