### PR TITLE
fix(streaming-bash): hooks at .claude/settings.json — NOT .claude/hooks.json (live-log critical)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ nul
 
 # AppImage build artifacts (assembled in build/AgentMux.AppDir/ before being bundled by appimagetool)
 /build/AgentMux.AppDir/
+
+# Claude Code agent session state — worktrees, logs, todos, etc.
+.claude/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.808"
+version = "0.33.809"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.808"
+version = "0.33.809"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.808"
+version = "0.33.809"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.808"
+version = "0.33.809"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.808"
+version = "0.33.809"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.807"
+version = "0.33.808"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.807"
+version = "0.33.808"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.807"
+version = "0.33.808"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.807"
+version = "0.33.808"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.807"
+version = "0.33.808"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.804 | 2026-05-11 | 164.1 MiB | 343.8 MiB | |
 | 0.33.799 | 2026-05-11 | 162.4 MiB | 340.2 MiB | |
 | 0.33.789 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |
 | 0.33.788 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.808"
+version = "0.33.809"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.807"
+version = "0.33.808"
 edition = "2021"
 description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.807"
+version = "0.33.808"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.808"
+version = "0.33.809"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.807"
+version = "0.33.808"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.808"
+version = "0.33.809"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.807"
+version = "0.33.808"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.808"
+version = "0.33.809"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.808"
+version = "0.33.809"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.807"
+version = "0.33.808"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -400,14 +400,31 @@ pub fn build_settings_with_hooks(
         }
     }
     // Merge: any existing hooks key from user settings is merged with our
-    // additions (ours wins on collision for PreToolUse since we already
-    // collected user PreToolUse entries above via content_map["hooks"]).
+    // additions. For PreToolUse specifically, user matchers from
+    // settings.json are PREPENDED (not dropped) so they short-circuit
+    // before our auto-injected agentmux-bashwrap entry — same ordering
+    // rule we apply to legacy content_map["hooks"] PreToolUse entries.
+    // For other event types (PostToolUse, Stop, etc.) we keep user's
+    // entries verbatim. Reagent P1 on PR #813 (the `continue` was a
+    // silent drop — caught a real merge bug).
     if let Some(Value::Object(existing_hooks)) = settings_obj.get("hooks").cloned() {
         for (k, v) in existing_hooks {
             if k == "PreToolUse" {
-                // User PreToolUse in settings.json already merged above
-                // (if also provided via legacy content_map["hooks"]).
-                // Leave hooks_obj's PreToolUse intact.
+                if let Value::Array(user_pretooluse) = v {
+                    // Prepend user PreToolUse so their matchers run
+                    // first; our auto-injected entry stays last.
+                    if let Some(Value::Array(ours)) = hooks_obj.remove("PreToolUse") {
+                        let mut merged = user_pretooluse;
+                        merged.extend(ours);
+                        hooks_obj.insert("PreToolUse".to_string(), Value::Array(merged));
+                    } else {
+                        hooks_obj.insert("PreToolUse".to_string(), Value::Array(user_pretooluse));
+                    }
+                } else {
+                    tracing::warn!(
+                        "agent_config: user settings.hooks.PreToolUse is not an array; dropped"
+                    );
+                }
                 continue;
             }
             hooks_obj.entry(k).or_insert(v);

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -119,10 +119,11 @@ pub fn build_config_files(
     // docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §5.
     // ----------------------------------------------------------------
     let user_hooks = content_map.get("hooks").map(|s| s.as_str());
-    if let Some(hooks_json) = build_hooks_config(user_hooks) {
+    let user_settings = content_map.get("settings").map(|s| s.as_str());
+    if let Some(settings_json) = build_settings_with_hooks(user_settings, user_hooks) {
         files.push(AgentConfigFile {
-            filename: ".claude/hooks.json".to_string(),
-            content: hooks_json,
+            filename: ".claude/settings.json".to_string(),
+            content: settings_json,
         });
     }
 
@@ -300,16 +301,27 @@ pub fn build_mcp_config(
     }
 }
 
-/// Build `.claude/hooks.json` content with the auto-injected PreToolUse
-/// Bash hook that redirects Bash invocations into the streaming
-/// wrapper (`agentmux-bashwrap exec`). User-supplied hooks (from the
-/// agent's `content_map["hooks"]`) are merged in: their keys win on
-/// collision for non-PreToolUse events, and for PreToolUse the user's
-/// matchers are appended *before* ours so user policy can short-circuit
-/// (e.g. deny a dangerous command) before our rewrite fires.
+/// Build `.claude/settings.json` content with the auto-injected
+/// PreToolUse Bash hook (under the `"hooks"` key) that redirects
+/// Bash invocations into the streaming wrapper
+/// (`agentmux-bashwrap exec`). User-supplied settings.json (from
+/// the agent's `content_map["settings"]`) is parsed and merged at
+/// the top level; user-supplied legacy hooks content (from
+/// `content_map["hooks"]`) is merged into `settings.hooks`.
 ///
-/// See `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §5.
-pub fn build_hooks_config(user_hooks_content: Option<&str>) -> Option<String> {
+/// **File location matters.** Claude Code reads project hooks from
+/// `<project>/.claude/settings.json` under the `"hooks"` key.
+/// A standalone `.claude/hooks.json` is NOT a Claude Code
+/// discovery location — that was the v0.33.804 streaming-bug root
+/// cause: the file was written but Claude never read it, so the
+/// PreToolUse hook never fired and live streaming silently failed.
+///
+/// See `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §5
+/// and Claude Code docs: https://code.claude.com/docs/en/hooks.md
+pub fn build_settings_with_hooks(
+    user_settings_content: Option<&str>,
+    user_hooks_content: Option<&str>,
+) -> Option<String> {
     use serde_json::Value;
     let agentmux_pretooluse = json!({
         "matcher": "^(Bash|.*[Bb]ash.*)$",
@@ -363,10 +375,50 @@ pub fn build_hooks_config(user_hooks_content: Option<&str>) -> Option<String> {
     pretooluse_entries.push(agentmux_pretooluse);
     hooks_obj.insert("PreToolUse".to_string(), Value::Array(pretooluse_entries));
 
-    match serde_json::to_string_pretty(&Value::Object(hooks_obj)) {
+    // Build the settings.json object: start from user-supplied settings.json
+    // (if any), then overlay our hooks key. User keys other than `hooks`
+    // pass through unchanged.
+    let mut settings_obj = serde_json::Map::new();
+    if let Some(raw) = user_settings_content {
+        match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(user_obj)) => {
+                for (k, v) in user_obj {
+                    settings_obj.insert(k, v);
+                }
+            }
+            Ok(_other) => {
+                tracing::warn!(
+                    "agent_config: user settings.json top-level is not an object; dropped"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "agent_config: failed to parse user settings.json; dropped"
+                );
+            }
+        }
+    }
+    // Merge: any existing hooks key from user settings is merged with our
+    // additions (ours wins on collision for PreToolUse since we already
+    // collected user PreToolUse entries above via content_map["hooks"]).
+    if let Some(Value::Object(existing_hooks)) = settings_obj.get("hooks").cloned() {
+        for (k, v) in existing_hooks {
+            if k == "PreToolUse" {
+                // User PreToolUse in settings.json already merged above
+                // (if also provided via legacy content_map["hooks"]).
+                // Leave hooks_obj's PreToolUse intact.
+                continue;
+            }
+            hooks_obj.entry(k).or_insert(v);
+        }
+    }
+    settings_obj.insert("hooks".to_string(), Value::Object(hooks_obj));
+
+    match serde_json::to_string_pretty(&Value::Object(settings_obj)) {
         Ok(s) => Some(s),
         Err(e) => {
-            tracing::error!("agent_config: failed to serialize hooks config: {e}");
+            tracing::error!("agent_config: failed to serialize settings.json: {e}");
             None
         }
     }

--- a/docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md
+++ b/docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md
@@ -1,0 +1,229 @@
+# Tool output streaming — analysis and solution options
+
+**Status:** Analysis (decision pending)
+**Owner:** AgentA
+**Date:** 2026-05-11
+**Driving question:** Why doesn't `tool_chunk` "just work" if we wire it in the backend, and what does it actually take to ship live bash output in the agent pane?
+
+---
+
+## 1. TL;DR
+
+The Phase 2 task in [SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md](../specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md) — *"Connect stdout/stderr line streaming on the host side to emit `tool_chunk` events"* — is **not implementable as written**. It assumes Claude Code CLI exposes partial tool output through its `stream-json` protocol. It does not, and the Anthropic Messages API has no public roadmap entry that changes that. Every comparable product (Cursor, Cline, OpenHands, Continue, Zed) ships its **own** command runner outside the model's tool model and streams that runner's stdout to the UI through a side channel.
+
+For AgentMux this is a small architectural shift, not a one-PR feature. The recommended path is an **MCP-mediated runner with an out-of-band stream channel** that reuses our existing WPS broker. Three options are evaluated in §5; the recommendation is option **B+** with an option-A intermediate ship for screenshot value.
+
+---
+
+## 2. What we confirmed, with receipts
+
+### 2.1 Claude Code stream-json does not carry partial tool output
+
+Events present in `--output-format stream-json --include-partial-messages`:
+
+| Event | Payload | Streams partially? |
+|---|---|---|
+| `content_block_delta` / `text_delta` | assistant prose | Yes |
+| `content_block_delta` / `thinking_delta` | reasoning | Yes |
+| `content_block_delta` / `input_json_delta` | tool **input** JSON | Yes (fine-grained tool streaming) |
+| `tool_use` block (in assistant message) | tool call site | Whole |
+| `tool_result` block (in user message) | tool output | **Whole — buffered until command exits** |
+
+No `tool_output_delta` event exists. Fine-grained tool streaming (`eager_input_streaming: true`) streams *inputs*, never outputs. Anthropic's public docs surface this as a design choice, not a roadmap item.
+
+> Sources: `platform.claude.com/docs/.../tool-use/fine-grained-tool-streaming`, `platform.claude.com/docs/.../streaming`.
+
+### 2.2 Hooks cannot synthesize stream events
+
+`PreToolUse` and `PostToolUse` are the only points where AgentMux can interpose. Their JSON contract:
+
+- `PreToolUse` returns `permissionDecision: "allow" | "deny"` and optionally `updatedInput` (rewrites the bash command).
+- `PostToolUse` returns optionally `updatedToolOutput` (rewrites the final result before Claude sees it).
+- **Neither hook can emit `content_block_delta` events into the stream-json output**. Hook return values flow back to Claude on the *next turn*, not into the live stream.
+
+Practical consequence: a `PreToolUse` hook can route Bash through our own runner, but the result still arrives at AgentMux as one whole `tool_result` block.
+
+### 2.3 The CLI does not expose `--allowed-tools` / `--disallowed-tools`
+
+We currently spawn:
+
+```
+claude -p --output-format stream-json --verbose --include-partial-messages --dangerously-skip-permissions
+```
+
+(`agentmux-srv/src/backend/providers.rs:100-107` + `subprocess.rs:250-281`.) No tool-allowlist switch is documented in the CLI today. An MCP-registered `bash` tool will sit *alongside* the native Bash tool; Claude picks one per call based on its own tool-selection heuristics and the tool description we register. We **cannot** force Claude to use our MCP bash by config flag alone — we have to make ours look better (description + system prompt nudge), or block the native one via a `PreToolUse` hook.
+
+### 2.4 AgentMux already injects an MCP server
+
+`agentmux-srv/src/backend/agent_config.rs:230-293` auto-writes an `agentmux` MCP server entry into the agent's working-dir `.mcp.json` with stdio transport. This is the natural place to add a streaming `bash` tool — no new server scaffolding needed.
+
+### 2.5 Every peer product uses host-side interception
+
+| Product | Bash runner | Streaming channel |
+|---|---|---|
+| **Cline** | VSCode shell-integration API (`terminal.shellIntegration.executeCommand`) | Async for-await over `execution.read()` |
+| **Cursor** | Own terminal | SSE / proprietary stream |
+| **OpenHands** | `od-runtime-client` inside Docker, `pexpect` on /bin/bash | EventStream → `CommandOutputObservation` events; agent loop replays them on next turn as concatenated tool_result |
+| **Continue.dev** | VSCode terminal | Same shell-integration pattern as Cline |
+| **Zed** | ACP adapter intercepts before native bash runs | ACP stream events |
+| **Codex CLI** | Native tool | Whole result today; PR #13640 (in flight) adds long-lived PTY exec |
+
+Zero of them rely on Anthropic delivering partial tool output. The MCP ecosystem has shell servers (`ripple`, `mcp-shell`, `tumf/mcp-shell-server`, `g0t4/mcp-server-commands`, `stdout-mcp-server`) — only **ripple** streams (named pipes + OSC 633 markers). MCP's request/response model itself doesn't carry partial tool results, which is why competitors stream through their own channels rather than through the protocol.
+
+---
+
+## 3. The real shape of "streaming bash output"
+
+There are two channels in play; conflating them is the source of the Phase 2 confusion in the original spec.
+
+```
+                                  ┌─────────────────────────────────┐
+                                  │             Claude              │
+                                  │  (decides to call bash, waits   │
+                                  │   for whole tool_result block)  │
+                                  └────────────┬────────────────────┘
+                                               │ MCP stdio
+                                               │ tool_use → wait → tool_result
+                                               ▼
+┌──────────────┐     stdout       ┌──────────────────────────────┐
+│ The bash     │ ───── line ────► │ AgentMux MCP `bash` runner   │
+│ command      │                  │ (lives in agentmux-srv or    │
+│ (pty/sh -c)  │                  │  the agentmux-mcp binary)    │
+└──────────────┘                  └────┬──────────────────┬──────┘
+                                       │                  │
+              concatenated final stdout│                  │ per-line WPS
+              ← back into Claude as    │                  │ events on a new
+                tool_result block      ▼                  ▼ "tool_chunk" subject
+                                ┌────────────┐    ┌──────────────────┐
+                                │ stream-json│    │ AgentMux         │
+                                │  pipe to   │    │ frontend         │
+                                │  frontend  │────┤ correlates by    │
+                                └────────────┘    │ tool_use_id      │
+                                                  └──────────────────┘
+```
+
+**Channel 1 (existing):** Claude → AgentMux frontend via stream-json. Carries `tool_call` (with id) and eventually `tool_result` (whole). Frontend already parses both.
+
+**Channel 2 (new):** Our runner → AgentMux frontend via the existing WPS broker. Carries `tool_chunk` events keyed by the same id, line by line, in real time.
+
+The frontend reducer plumbed by [PR #800](https://github.com/agentmuxai/agentmux/pull/800) is already shaped for this: `ToolChunkAppend` takes a `toolId` and a chunk; `StreamFlush` preserves `log.chunks` across the running→terminal transition. The data shape is right; the source of the chunks just isn't Claude's stream-json — it's our runner.
+
+---
+
+## 4. Constraints and non-goals
+
+- **No protocol-level streaming changes.** Anthropic Messages API spec is fixed for our timeline. We don't wait on `tool_output_delta`.
+- **No replacement of Claude Code CLI** with Agent SDK embedding. That's a separate, much larger architectural call (touches auth, session resume, partial messages, all provider integrations). Keep it on the "future" list.
+- **Provider parity.** Codex and Gemini providers face the same gap. Whatever pattern we pick should generalize — they each get their own runner injection.
+- **No regression on `--dangerously-skip-permissions`.** We currently rely on it. If the chosen path forces us off it, that's a separate scope (and intersects [SPEC_DECISION_PROMPT_2026_04_24.md](../specs/SPEC_DECISION_PROMPT_2026_04_24.md)).
+- **Frontend reducer is settled.** Anything that ships partial output goes through `ToolChunkAppend` — no parallel state store.
+
+---
+
+## 5. Solution options
+
+Three real options, ordered by cost.
+
+### Option A — Post-hoc synthesis from `tool_result`
+
+When `tool_result` arrives whole, the translator splits the content by newline and dispatches one `ToolChunkAppend` per line. The UI then virtualizes the buffer and renders an action bar at the bottom — same overlay design, same data shape, but the "streaming" is a render trick: every line arrives in the same RAF.
+
+- **Cost:** ~120 LOC in `claude-translator.ts` + per-provider parity (Codex/Gemini translators each get the same arm).
+- **Value:** Zero live feedback during the actual run; the user still stares at a spinner for 3-minute commands. Visible "streaming" only happens after the command finishes — anti-feature for `npm install && npm test`.
+- **Verdict:** Worth shipping only as a stepping stone to validate the overlay UI (Phase 3) without blocking on the real runner. Otherwise misleading.
+
+### Option B — MCP bash runner with WPS side-channel **(recommended)**
+
+Extend the existing `agentmux-mcp` server with a `bash` (and `shell`) tool whose execution path:
+
+1. Generates / receives a `tool_use_id` (from the MCP request — Claude provides it).
+2. Spawns a PTY-backed `bash -c "$command"` (or `sh` / `pwsh` per platform).
+3. Streams stdout + stderr line-by-line to a new WPS subject keyed by `tool_use_id`. Each line publishes one `{ kind, content, timestamp }` payload.
+4. Buffers the full output internally.
+5. Returns the buffered output to Claude as the MCP `tool_result` when the command exits.
+
+Frontend side, the new WPS subject is bridged into `useAgentStream` as synthetic `tool_chunk` events (already plumbed). Dedup is timestamp + last-content based; reducer is unchanged.
+
+To get Claude to actually call our MCP bash instead of native Bash, two paths:
+
+- **(B-soft)** Tool description nudging + system prompt. Our `mcp__agentmux__bash` advertises "live-streaming output, preferred for long-running commands." Claude picks it most of the time — but not always.
+- **(B-hard)** A `PreToolUse` hook on native `Bash` that returns `permissionDecision: "deny"` with `permissionDecisionReason: "Use mcp__agentmux__bash instead — streams output to the UI"`. Claude retries via the MCP tool. Deterministic but does add a turn-of-friction on first invocation.
+
+Recommend **B-hard** for the deterministic path: zero non-streaming bash invocations possible.
+
+- **Cost:** ~400-600 LOC across `agentmux-mcp/src/bash.rs` (new), `agentmux-srv` WPS subject wiring, frontend bridge from new WPS subject → `dispatchDoc(ToolChunkAppend)`, `.claude/hooks.json` auto-injection in `agent_config.rs`, plus tests.
+- **Value:** Real live streaming. Matches every peer product's pattern. Re-uses our existing infra (WPS broker, MCP injector).
+- **Risks:**
+  - **Tool-selection drift.** If Claude's tool-selection heuristic flips, B-soft fails silently. B-hard's `PreToolUse` deny safeguards this. Test matrix needs an explicit "Claude picks mcp__agentmux__bash" assertion per provider release.
+  - **PTY portability.** `portable_pty` crate works on Win32 ConPTY + Unix; we already depend on it elsewhere. No new dep.
+  - **Permission flow.** B-hard's hook interacts with the per-tool permission decision panel ([SPEC_DECISION_PROMPT_2026_04_24.md](../specs/SPEC_DECISION_PROMPT_2026_04_24.md)). Need a sequencing decision: deny native → mcp call gets a fresh permission prompt, or auto-allow on the redirect.
+  - **stderr stays out of the model's view if we don't include it.** Concatenated tool_result should include stderr (interleaved with stdout, prefixed) so Claude reasons about errors correctly. Different from frontend rendering, which interleaves by arrival time.
+  - **Multi-line dedup.** If a chunk re-arrives during replay (history), reducer dedups against the last chunk only. Long-running tools with hours of output could trip dedup false-positives. Keep the bounded ring (50k lines per [SPEC_TOOL_BLOCK_LIVE_LOG §5](../specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md)).
+- **Verdict:** This is the path. Closes the gap fully, generalizes to other providers, and is the smallest delta that actually delivers live streaming.
+
+### Option C — Replace Claude Code CLI with Agent SDK embedding
+
+Drop the CLI subprocess and embed Anthropic's Agent SDK directly in `agentmux-srv`. Implement Bash as a host-side tool with our own streaming. Use the SDK's `permission_callback` for the decision flow.
+
+- **Cost:** Easily 4-6 weeks. Replaces every CLI-mediated codepath: auth, session resume, partial messages, slash commands, all providers' equivalent. Codex/Gemini have no equivalent SDK; we'd be heterogeneous.
+- **Value:** Cleanest interception model, full control. Long-term right answer if we go all-in on Anthropic.
+- **Verdict:** Out of scope for live-log work. Park as a long-horizon discussion.
+
+---
+
+## 6. Recommendation
+
+**Ship in two PRs:**
+
+1. **PR α (the screenshot):** Phase 3 UI (overlay with header / virtualized log / bottom action bar) wired to whatever `ToolNode.log.chunks` happens to contain, plus option **A** in the Claude translator so we have visible content while option B lands. The render-trick streaming is wrong, but the overlay is right, and we want it in users' hands.
+2. **PR β (the real thing):** Option **B-hard**. Adds the streaming MCP bash tool, the WPS bridge, the `PreToolUse` deny hook, and per-provider parity stubs. PR α's translator synthesis gets removed in the same PR — single source of truth for chunks is the runner.
+
+This lets us land the UI value in days, defer the runner work to the right scope, and avoid carrying the post-hoc synthesizer as permanent code.
+
+Provider parity for Codex / Gemini in PR β is bandwidth-bounded — start with Claude, file follow-ups for the others. The MCP bash tool is provider-agnostic on the server side; the only per-provider work is the `PreToolUse`-equivalent in their respective hook systems (or alternate nudge if absent).
+
+---
+
+## 7. Open questions to resolve before PR β
+
+- **PTY vs `Stdio::piped()`?** Real PTYs surface progress bars and ANSI redraws correctly (think `npm install`'s spinner); pipes flatten them. Recommend PTY via `portable_pty`.
+- **Output size cap?** Long builds produce 100k+ lines. Frontend caps at 50k per spec; should the MCP runner also truncate what it returns to Claude, or send the whole thing? Truncating in the runner risks the model losing critical end-of-output errors. Probably: full output to Claude (with a head/tail compression for >1MB), capped view to the frontend log.
+- **What happens to direct `task dev` / inline terminal Bash calls** that don't route through the agent at all? Out of scope — they live in the terminal pane, separate code path.
+- **Per-OS shell selection.** Bash on Linux/macOS; pwsh-then-cmd on Windows (we already detect this in `agentmux-srv/.../shell.rs`). Reuse that path.
+- **Hook injection mechanics.** We already write `.claude/hooks.json` from `agent_config.rs:112-119`; the `PreToolUse` redirect entry is one new JSON object. No new infra.
+- **Permission flow interaction.** With `--dangerously-skip-permissions` set, the `PreToolUse` deny still fires and re-routes — but if we ever turn permissions back on, the redirect must auto-allow the MCP follow-up. Decision needed alongside [SPEC_DECISION_PROMPT_2026_04_24.md](../specs/SPEC_DECISION_PROMPT_2026_04_24.md).
+
+---
+
+## 8. Cross-references
+
+- Live-log data shape + reducer (PR #800): [SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md](../specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md)
+- Permission gating: [SPEC_DECISION_PROMPT_2026_04_24.md](../specs/SPEC_DECISION_PROMPT_2026_04_24.md)
+- Existing MCP server injection: `agentmux-srv/src/backend/agent_config.rs:230-293`
+- Claude CLI spawn: `agentmux-srv/src/backend/providers.rs:100-107`, `agentmux-srv/src/backend/blockcontroller/subprocess.rs:250-281`
+- Subprocess output → WPS: `agentmux-srv/src/backend/blockcontroller/subprocess.rs:442-561` (stdout) + `563-586` (stderr — currently logged only)
+- ToolBlock rendering: `frontend/app/view/agent/components/ToolBlock.tsx`
+- DocumentRow: `frontend/app/view/agent/virtualization/DocumentRow.tsx:232-238`
+
+## 9. Sources
+
+**Anthropic primary docs:**
+- Fine-grained tool streaming — `platform.claude.com/docs/.../fine-grained-tool-streaming`
+- Streaming messages — `platform.claude.com/docs/.../streaming`
+- Claude Code hooks — `code.claude.com/docs/.../hooks`
+- Agent SDK hooks — `code.claude.com/docs/.../agent-sdk/hooks`
+- MCP — `code.claude.com/docs/.../mcp`
+
+**Competitive landscape:**
+- Cursor terminal — `cursor.com/docs/agent/tools/terminal`
+- Cline repo + issue #6708 + #10524 — `github.com/cline/cline`
+- OpenHands deep-dive + issue #2404 — `github.com/OpenHands/OpenHands`
+- Zed ACP + Claude Code via ACP — `zed.dev/acp`, `zed.dev/blog/claude-code-via-acp`
+- Codex issue #4751 + PR #13640 — `github.com/openai/codex`
+
+**MCP shell server prior art:**
+- `github.com/yotsuda/ripple` (streaming via named pipes + OSC 633)
+- `github.com/amitdeshmukh/stdout-mcp-server`
+- `github.com/sonirico/mcp-shell`
+- `github.com/tumf/mcp-shell-server`
+- `github.com/g0t4/mcp-server-commands`

--- a/docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md
+++ b/docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md
@@ -151,7 +151,7 @@ To get Claude to actually call our MCP bash instead of native Bash, two paths:
 
 Recommend **B-hard** for the deterministic path: zero non-streaming bash invocations possible.
 
-- **Cost:** ~400-600 LOC across `agentmux-mcp/src/bash.rs` (new), `agentmux-srv` WPS subject wiring, frontend bridge from new WPS subject → `dispatchDoc(ToolChunkAppend)`, `.claude/hooks.json` auto-injection in `agent_config.rs`, plus tests.
+- **Cost:** ~400-600 LOC across `agentmux-mcp/src/bash.rs` (new), `agentmux-srv` WPS subject wiring, frontend bridge from new WPS subject → `dispatchDoc(ToolChunkAppend)`, `.claude/settings.json` (under `"hooks"` key — the real Claude Code discovery location; `.claude/hooks.json` is not read) auto-injection in `agent_config.rs`, plus tests.
 - **Value:** Real live streaming. Matches every peer product's pattern. Re-uses our existing infra (WPS broker, MCP injector).
 - **Risks:**
   - **Tool-selection drift.** If Claude's tool-selection heuristic flips, B-soft fails silently. B-hard's `PreToolUse` deny safeguards this. Test matrix needs an explicit "Claude picks mcp__agentmux__bash" assertion per provider release.
@@ -190,7 +190,7 @@ Provider parity for Codex / Gemini in PR β is bandwidth-bounded — start with 
 - **Output size cap?** Long builds produce 100k+ lines. Frontend caps at 50k per spec; should the MCP runner also truncate what it returns to Claude, or send the whole thing? Truncating in the runner risks the model losing critical end-of-output errors. Probably: full output to Claude (with a head/tail compression for >1MB), capped view to the frontend log.
 - **What happens to direct `task dev` / inline terminal Bash calls** that don't route through the agent at all? Out of scope — they live in the terminal pane, separate code path.
 - **Per-OS shell selection.** Bash on Linux/macOS; pwsh-then-cmd on Windows (we already detect this in `agentmux-srv/.../shell.rs`). Reuse that path.
-- **Hook injection mechanics.** We already write `.claude/hooks.json` from `agent_config.rs:112-119`; the `PreToolUse` redirect entry is one new JSON object. No new infra.
+- **Hook injection mechanics.** We write `.claude/settings.json` (under the `"hooks"` key — the real Claude Code discovery location) from `agent_config.rs`; the `PreToolUse` redirect entry is one new JSON object. No new infra.
 - **Permission flow interaction.** With `--dangerously-skip-permissions` set, the `PreToolUse` deny still fires and re-routes — but if we ever turn permissions back on, the redirect must auto-allow the MCP follow-up. Decision needed alongside [SPEC_DECISION_PROMPT_2026_04_24.md](../specs/SPEC_DECISION_PROMPT_2026_04_24.md).
 
 ---

--- a/docs/analysis/data-dir-status-2026-05-09.md
+++ b/docs/analysis/data-dir-status-2026-05-09.md
@@ -1,0 +1,86 @@
+# Data directory status — where AgentMux writes things, 2026-05-09
+
+**Question:** "why are we maintaining things outside of `~/.agentmux/`? I see `ai.agentmux.cef`?"
+
+**Short answer:** We're not — anymore. The data-dir unification (`SPEC_DATA_DIR_UNIFICATION_2026-05-05.md`, implemented in PR #695) shipped. Everything AgentMux writes today is under `~/.agentmux/`. The `ai.agentmux.cef.*` references the user is seeing are **dead paths** in test harness code that I touched yesterday (the auth-file lookup in `tools/tests/authfile.ps1`). Those references are residue from the pre-unification harness and should be removed.
+
+---
+
+## What actually lives where, today
+
+### `~/.agentmux/` — the only root
+
+```
+~/.agentmux/
+├── versions/<version>/                ← installed + portable per-version state
+│   ├── data/                          ← srv DB (objects.db, sagas.db, …)
+│   ├── config/                        ← settings.json, providers.json
+│   ├── logs/                          ← agentmux-host-vX.Y.Z.log.<date>
+│   ├── cef-cache/                     ← Chromium per-version cache
+│   ├── agents/                        ← agent working dirs
+│   └── runtime/                       ← per-instance runtime files
+├── dev/<branch>/                      ← task dev per-branch state (mirrors versions/)
+│   ├── data/                          ← authkey.dev lives here
+│   ├── config/, logs/, cef-cache/, agents/, runtime/
+├── shared/                            ← account-wide, version-independent
+│   ├── chromium-cookies/, credentials/, agent-cache/
+├── agents/, shell/, tool-build-cache/ ← legacy account-wide locations
+└── 0.33.6XX/                          ← LEGACY per-version dirs (cli configs);
+                                        pre-unification leftovers, safe to delete
+```
+
+Path resolution lives in **one place**: `agentmux-common/src/data_paths.rs::DataPaths::resolve` (`agentmux-launcher/src/data_dir.rs` is a compat shim that just calls into it). The launcher exports `AGENTMUX_DATA_DIR` / `AGENTMUX_CEF_CACHE_DIR` / etc. as env vars; host + srv read those rather than re-resolving. **There is one path-resolution truth source, not three.**
+
+### What's NOT there anymore
+
+- **`%APPDATA%\ai.agentmux.cef.*`** — confirmed empty on this machine; the historical Tauri-era + early-CEF-era home for installed-mode config/data. Migrated to `~/.agentmux/versions/<v>/config/`.
+- **`%LOCALAPPDATA%\ai.agentmux.cef.*`** — confirmed empty. Was the Chromium cache. Now `~/.agentmux/versions/<v>/cef-cache/`.
+- **`%LOCALAPPDATA%\ai.agentmux.app.*`** — Tauri-era leftovers, dead. Spec called these out for cleanup.
+- **`<portable-extract>/data/`** — portable builds used to bundle data inside the extract folder, defeating the "share account-wide caches across versions" goal. Now portable instances also write to `~/.agentmux/versions/<v>/`.
+
+---
+
+## What I touched this session — and what's stale
+
+In yesterday's auth-path fix (PR #766), I added `%APPDATA%\ai.agentmux.cef.*` to the search list of `Get-AgentMuxAuthFile`. That's **literally hunting an empty directory** — those paths haven't been written by AgentMux since PR #695 shipped weeks ago. The search keeps it for theoretical "stale-machine compatibility" but in practice it never fires. **Should be removed** in a follow-up cleanup.
+
+Same goes for the README + spec / analysis files that mention `ai.agentmux.cef.*` paths; they document the pre-unification state. Most are clearly dated (e.g. `pane-tearoff-bug-status-2026-04-07.md`) so the staleness is obvious. Worth a `grep -l ai.agentmux.cef docs/ tools/` sweep to flag anything that should be updated to reference the new layout, but it's a docs-cleanup task, not a code question.
+
+---
+
+## Why the spec was important
+
+`SPEC_DATA_DIR_UNIFICATION_2026-05-05.md` cataloged four problems that were real:
+
+1. **Three independent dev-mode detections** in launcher / cef / sidecar with subtle disagreements.
+2. **Empty-string `AGENTMUX_DEV` propagation** misclassified release builds as dev when terminals inherited it.
+3. **Portable bundles bloated** with Chromium cache and dead state.
+4. **No version key in dev mode** — every dev branch shared `ai.agentmux.cef.dev`.
+
+PR #695 fixed all four by:
+- Centralizing path resolution in `agentmux_common::DataPaths`.
+- Replacing `AGENTMUX_DEV` heuristics with explicit `AGENTMUX_RUNTIME_MODE=dev:<branch>` (or `installed` / `portable`).
+- Moving portable cache out of the extract folder into `~/.agentmux/versions/<v>/cef-cache/`.
+- Per-branch dev paths (`~/.agentmux/dev/<branch>/`) instead of single shared `ai.agentmux.cef.dev`.
+
+The on-disk view confirms the spec landed: `~/.agentmux/dev/agenta-perf-baseline-retro/data/authkey.dev` is the path my latest task dev wrote. No `%APPDATA%` writes happened.
+
+---
+
+## Recommended follow-ups (small, isolated)
+
+1. **Remove dead `%APPDATA%\ai.agentmux.cef.*` from the auth-file lookup.** The harness should only search `~/.agentmux/dev/<branch>/data/` and `~/.agentmux/versions/<v>/data/`. ~5 LOC. Rides with the next test-harness PR.
+2. **Sweep doc references.** `grep -l ai.agentmux.cef docs/` shows ~25 files; most are dated reports that are accurate-as-of-then. The current ones (`SPEC_TEST_API_ACCESS.md`, `LOG_RESOLUTION_SPEC.md`, `portable-data-dir.md`) deserve a freshness pass. Doc-only PR ride-along.
+3. **Delete the legacy per-version dirs at `~/.agentmux/0.33.6XX/`**. These are cli configs from before the `versions/<v>/` migration. The `wipe-old-data-dirs.sh` script exists for this; not run on this machine. Manual one-time op.
+
+---
+
+## Cross-references
+
+- `docs/specs/SPEC_DATA_DIR_UNIFICATION_2026-05-05.md` — the original plan.
+- `agentmux-common/src/data_paths.rs` — the unified resolver.
+- `agentmux-launcher/src/data_dir.rs` — compat shim.
+- `agentmux-common/src/runtime_mode.rs` — the `AGENTMUX_RUNTIME_MODE` enum.
+- `scripts/wipe-old-data-dirs.sh` — cleanup script for pre-unification leftovers.
+- PR #695 — implementation.
+- Memory `reference_data_dir_unification_plan.md` — pointer.

--- a/docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md
+++ b/docs/specs/SPEC_FLOATING_PANE_TEAROFF_2026_05_11.md
@@ -1,0 +1,270 @@
+# Floating pane tear-off (subordinate window, owned by mother instance)
+
+**Status:** Proposed
+**Owner:** AgentA
+**Date:** 2026-05-11
+**Driving observation:** *"When tearing off panes, we don't create a new instance (no new taskbar icon). Instead it's a floating window owned by the mother instance. Panes currently tear off and create a new instance; instead they would tear to subpanels."*
+
+Today, tearing a tab off creates a new full AgentMux instance — own backend sidecar, own data dir, own taskbar entry. That's the right model for tabs (workspace-level isolation). For **panes** within a tab, the new ask is different: tear into a **floating subordinate window** owned by the source instance, like Photoshop's palettes or VSCode's "Move Editor into New Window".
+
+This spec covers panes specifically. Tab tear-off behavior is unchanged.
+
+---
+
+## 1. Target behavior
+
+When the user drags a pane out of its tile layout and drops it outside the source window:
+
+- A floating window opens at the cursor.
+- The floating window has **no taskbar entry**, **no Alt-Tab entry**.
+- The floating window **minimizes/restores with the source window** automatically.
+- Closing the source window **destroys all its floating panes**.
+- The floating pane shares **the source instance's backend sidecar, data dir, reducer state**. There is no new sidecar process, no new data dir, no new browser-pane HWND pool.
+- The pane can be dragged from its titlebar to any position on any monitor (not clipped to the source window's bounds).
+- A "dock back" affordance: drag the floater into the source window's layout, or use a button on its title bar.
+
+The user gets a free-floating pane that's a full peer of the docked panes (same state, same broadcasts, same drag-drop into other tiles).
+
+---
+
+## 2. Why owned, not standalone
+
+The current "new instance" path is overkill for panes:
+
+| Cost | New full instance (today) | Owned floating (proposed) |
+|---|---|---|
+| Backend sidecar | Spawns a new one (~150-300 ms cold start) | Reuses the parent's |
+| Data directory | New `~/.agentmux/versions/<v>/` dir | Shares parent's |
+| Taskbar entry | One per torn-off pane | None |
+| Cross-pane state | Requires inter-instance IPC | Shared in-process |
+| Persistence | Per-instance layout file | Single layout file with `isFloating` flag |
+| Resource overhead | ×N sidecars, ×N data dirs, ×N CEF process pools | One of each |
+| Crash blast radius | Per-instance isolation | Floaters die with parent (acceptable for palettes) |
+
+Photoshop, Figma, After Effects, VSCode "Move Editor", Chrome PiP — every modern UI that supports detached panels uses the owned-floating pattern. The full-instance model is reserved for genuinely independent workspaces.
+
+---
+
+## 3. Architecture
+
+### 3.1 Win32 window styles
+
+The floating window's HWND is created with:
+
+```c++
+CreateWindowEx(
+    WS_EX_TOOLWINDOW,                       // no taskbar, no Alt-Tab
+    "AgentMuxFloatingPane",
+    "AgentMux — <pane title>",
+    WS_OVERLAPPEDWINDOW | WS_POPUP,         // resizable, frameless-or-not, free-positioned
+    x, y, w, h,
+    sourceMainWindowHwnd,                   // OWNER (not parent — Win32 names it confusingly)
+    NULL, hInstance, NULL
+);
+```
+
+Critical bits:
+
+| Flag / arg | Effect |
+|---|---|
+| `WS_EX_TOOLWINDOW` | Removes from taskbar AND Alt-Tab |
+| `WS_POPUP` (not `WS_CHILD`) | Free positioning, not clipped to source window bounds |
+| Owner HWND in arg 8 | OS auto-handles minimize/restore cascade and destroy cascade |
+
+`WS_CHILD` is **wrong** — children are clipped to parent's client area. Owned `WS_POPUP` is the right pattern.
+
+### 3.2 CEF browser hosting
+
+The floating window's outer HWND is created by us; the Chromium browser inside is a `WS_CHILD` of that outer HWND, via standard CEF embed:
+
+```c++
+CefWindowInfo info;
+info.SetAsChild(outerHwnd, CefRect{0, 0, w, h});
+CefBrowserHost::CreateBrowser(info, clientHandler, frontendUrl, browserSettings, ...);
+```
+
+**Don't** use `SetAsPopup` — that's for `window.open()`-style CEF-managed popups and bypasses our owner relationship.
+
+Known CEF + owner-window pitfalls (from existing literature):
+
+- Focus chain: CEF needs explicit `OnFocus`/`SetFocus` plumbing. An owned window doesn't auto-forward focus to its embedded browser. We already have this plumbing for the main window's webview (`agentmux-cef/src/browser_pane/hwnd.rs::install_focus_redirect_wndproc`); the floating-pane HWND needs the same treatment.
+- Drag-from-titlebar with a frameless window: implement `WM_NCHITTEST` returning `HTCAPTION` over the draggable region. We already do this for the main window; mirror the pattern.
+- DPI: handle `WM_DPICHANGED` on the floating HWND separately from the parent. CEF won't auto-rescale; we already handle this for the main window.
+- `GWLP_HWNDPARENT` mutation must happen before `ShowWindow` for clean taskbar behavior. Set the owner at create time, not later.
+
+### 3.3 Reducer & state
+
+The floating pane is a **view of the same workspace** the parent window owns:
+
+- The pane's block stays in the same workspace's `blockids` (no `TearOffBlock` mutation that moves the block to a new workspace).
+- A new layout field `floating: { paneId → { monitor, x, y, w, h, isFloating: true } }` records float state.
+- The layout reducer reads `isFloating` to decide whether to render the pane in the tile layout (omits it) or in a separate floating overlay (renders it).
+- Re-dock: drag the floater into the tile layout, or click a "dock" button. Reducer command `RedockFloatingPane(paneId, dropTargetNodeId)`. Layout returns to standard tile flow.
+
+### 3.4 The frontend Pane component is unchanged
+
+The pane's component (`<Block>` in `frontend/app/block/block.tsx`) is identical whether it renders inside a `<TileLayout>` or inside a floating window. Same RPC, same atoms, same focus handling. The DIFFERENCE is who owns the surrounding HWND:
+
+- Docked: source window's main HWND, positioned via TileLayout's flex math.
+- Floating: a separate HWND owned by the source window, positioned via window manager.
+
+This means the existing browser-pane / agent-pane / terminal renderers Just Work in floating mode — no per-pane work.
+
+### 3.5 What changes in the tear-off pipeline
+
+Today (cf. `frontend/app/drag/CrossWindowDragMonitor.win32.tsx::performTearOff` + `agentmux-cef/src/commands/drag.rs::open_window_at_position`):
+
+1. User drops a pane outside the window
+2. Frontend calls `WorkspaceService.TearOffBlock` → moves block to new workspace
+3. Frontend calls `openTearOffWindow` → host creates a new top-level AgentMux instance pointing at the new workspace
+4. SC_MOVE handshake transfers cursor capture
+
+For panes after this spec ships, branch on `dragType === "pane"`:
+
+1. User drops pane outside the window
+2. Frontend calls **`openFloatingPaneWindow(paneId, x, y, w, h)`** — new host command
+3. Host creates an OWNED HWND with `WS_EX_TOOLWINDOW` (per §3.1)
+4. CEF browser embedded into the owned HWND, navigated to the frontend's same URL with `?floatingPaneId=<id>&windowLabel=floating-<n>`
+5. Frontend in the floating window:
+   - Detects the `floatingPaneId` query param
+   - Boots into a minimal `<FloatingPaneShell>` that renders only the one Block
+   - Connects to the parent instance's backend via the shared sidecar IPC
+6. Reducer dispatch: `MarkPaneFloating(paneId, {monitor, x, y, w, h})`. The tile layout drops the pane from its leaf order; floating overlay picks it up.
+7. SC_MOVE handshake still applies (same cursor-grab anchor math), so the floating window opens with its title bar under the cursor.
+
+Tab tear-off path remains unchanged.
+
+---
+
+## 4. Floating-pane shell
+
+A new frontend entry point: `frontend/app/floating-pane/`:
+
+- `floating-pane-shell.tsx` — minimal layout: a small title bar with pane title + dock button + close button, then the `<Block>` filling the rest.
+- The title bar uses `-webkit-app-region: drag` plus our `WM_NCHITTEST` shim (§3.2) so dragging anywhere in the title bar moves the HWND.
+- The shell shares the global Solid store with the main instance via... wait, no — these are separate CEF browser instances in DIFFERENT processes. They share the BACKEND (one sidecar), not the frontend store.
+- So the shell connects to the sidecar via the same RPC client (`TabRpcClient`) — same authKey, same IPC port. The reducer state in the floating window's frontend syncs to the same backend objects.
+- A WebSocket subscription on the floating window listens for `block:update` events for its pane and re-renders.
+
+This is the same pattern modal-v2 / DevTools secondary window already uses for cross-window state sync.
+
+---
+
+## 5. Re-docking
+
+User can:
+
+1. **Drag the floater's title bar back into the source window's current tile layout.** Drop on any leaf or split target. Layout reducer dispatches `RedockFloatingPane(paneId, dropTargetTabId, dropTargetNodeId)`. The floating HWND is destroyed; the pane re-renders inside the target tab's TileLayout.
+2. **Drag the floater's title bar into a different tab on the source window's tab bar.** Same instance, different tab. Reducer command moves the block from its current `tabId` to the dropped-on `tabId`, updates the target tab's `blockids` array, and destroys the floating HWND. Free given the same plumbing as #1 — the drop target just resolves to the tab's root layout node rather than a leaf.
+3. **Drag the floater's title bar into another AgentMux instance.** Cross-process — uses the existing cross-window-drag IPC (`startCrossDrag`/`updateCrossDrag`/`completeCrossDrag`) that today supports tab cross-drop. Source instance serializes the block's persistent state (meta, view-specific data); destination instance deserializes into its sidecar, inserts into the target tab/workspace, and the source floating HWND is destroyed. Deferred to Phase 7 — the same-instance flows (1, 2) cover most cases without cross-process serialization.
+4. **Click the "dock" button** on the floater's title bar. Pane re-docks into the source window at its last docked position (saved on tear-off).
+5. **Close the floater.** Same as closing a docked pane — destroys the block.
+
+---
+
+## 6. Persistence
+
+The source window's layout file gains a `floating` map:
+
+```ts
+{
+    layout: { rootNode, leaforder, focusednodeid },
+    floating: {
+        [paneId: string]: {
+            monitor: number;      // monitor index for restore
+            x: number; y: number; // screen coords
+            w: number; h: number;
+            isFloating: true;
+        };
+    };
+}
+```
+
+On instance restart:
+- Layout reducer reads `floating` map.
+- For each entry, host creates an owned floating window at the saved geometry.
+- If the saved monitor is no longer present (laptop unplugged from dock), clamp to primary monitor's working area.
+
+---
+
+## 7. Multi-monitor & DPI
+
+- Floating HWND can sit on any monitor — Win32 owned `WS_POPUP` supports this natively.
+- DPI: each floating window receives its own `WM_DPICHANGED` when moved across DPI boundaries. We forward this to the CEF browser (existing `WM_DPICHANGED` handler in `agentmux-cef/src/client/wndproc.rs`) and re-render with the new device pixel ratio.
+- When parent moves across monitors, owned floaters stay on their CURRENT monitor (they don't follow). This is the OS-standard behavior; documented for the user.
+
+---
+
+## 8. Edge cases
+
+- **Source window closes while floaters are open:** OS cascade destroys all owned windows. Reducer command `WindowClosed` clears the `floating` map. No orphan windows.
+- **Source window crashes:** WER kills the process; OS cascade still cleans up owned windows. Acceptable failure mode.
+- **User drags floater onto another AgentMux instance's tile layout:** out of scope. Re-docking only into the source window. To move a pane between instances, the user must close the floater and re-open in the target instance (or drag the underlying block via a future cross-instance handle).
+- **User puts floater on a virtual desktop different from source:** owned windows follow the owner across virtual desktops (Win+Ctrl+arrow). User can't "split" the owner and a floater onto different virtual desktops. This is OS behavior; document it.
+- **Source window minimized:** floaters auto-hide. On restore, they reappear at their previous positions.
+- **Source window full-screen:** floater still shows ABOVE its owner (owned-window behavior). If user wants floaters hidden during full-screen, that's a future preference.
+- **Floater positioned mostly off-screen at restart:** clamp to the working area of the closest visible monitor.
+
+---
+
+## 9. Implementation phases
+
+| Phase | Scope | LOC est. | Risk | Ship as |
+|---|---|---|---|---|
+| **1 — Host API + owned HWND** | `openFloatingPaneWindow(paneId, x, y, w, h)` CEF command. Creates owned `WS_POPUP \| WS_EX_TOOLWINDOW` HWND. CEF browser embedded. Loads `?floatingPaneId=…`. Minimal shell renders "hello". | ~400 | Medium (new Win32 path) | Standalone PR for the windowing primitive. |
+| **2 — Floating-pane shell** | New `frontend/app/floating-pane/` shell renders `<Block>` for the requested paneId. Sidecar IPC via existing TabRpcClient. Title bar + dock + close buttons. WM_NCHITTEST drag region. | ~300 | Low | Bundle with Phase 1 if small enough; otherwise separate. |
+| **3 — Tear-off routing** | `CrossWindowDragMonitor.win32.tsx::performTearOff` branches on `dragType`. `pane` → call `openFloatingPaneWindow`. `tab` → unchanged. Add `MarkPaneFloating` reducer command. | ~200 | Medium | Separate PR. |
+| **4 — Re-dock (same-window, same-tab + cross-tab)** | Drag floater onto tile layout in current tab → re-dock as normal pane. Drag onto another tab in the same source window's tab bar → move block to that tab and destroy floater. Drop targets accept floating-pane payloads. `RedockFloatingPane(paneId, tabId, nodeId?)` reducer command. | ~300 | Medium | Separate PR. |
+| **5 — Persistence** | `floating` map in layout file. Restore floaters on startup. Monitor-clamp logic for missing monitors. | ~150 | Low | Bundle with Phase 4. |
+| **6 — Polish** | Per-pane title in floater title bar, last-docked-position memory, escape-key behavior, keyboard shortcuts. | ~150 | Low | Standalone polish PR. |
+| **7 — Cross-instance floater drop (optional)** | Drag floater into a different AgentMux instance's tab bar or tile layout. Uses existing `startCrossDrag`/`updateCrossDrag`/`completeCrossDrag` IPC. Source serializes the block's state (meta, view-specific persistence); destination deserializes into its sidecar. | ~400 | High (cross-process serialization correctness) | Follow-up; not required for MVP. |
+
+Phases 1-3 give a working tear-off-to-float MVP. Phases 4-5 round out the same-instance experience (drag floater between tabs of the source window included). Phase 6 polishes. Phase 7 extends to cross-instance, which mirrors what tab tear-off already does.
+
+---
+
+## 10. Out of scope
+
+- **Tab tear-off behavior.** Tabs continue to spawn new full instances. Only panes change.
+- **Floater-to-floater drag.** Can't drag a pane from one floating window into another. Only floater ↔ source-window-tile-layout-or-tab.
+- **Floater on macOS / Linux.** This spec is Windows-only initially. macOS has its own owned-window model (`NSWindow.addChildWindow`); Linux compositors vary. Cross-platform is a follow-up.
+- **Pinning a floater always-on-top globally.** `WS_EX_TOPMOST` is intentionally NOT used — global topmost windows are user-irritating. A "pin" toggle that adds `WS_EX_TOPMOST` could be a future preference but defaults off.
+
+(Note: floater → another tab in the source window, and floater → another AgentMux instance, are both in scope — Phases 4 and 7 respectively.)
+
+---
+
+## 11. Test plan
+
+- [ ] Tear a pane off → floating window appears at cursor, no taskbar entry, no Alt-Tab entry
+- [ ] Minimize source window → all floaters disappear
+- [ ] Restore source window → all floaters reappear at their previous positions
+- [ ] Close source window → all floaters destroyed (no orphans in Task Manager)
+- [ ] Move floater to second monitor → DPI scales correctly
+- [ ] Drag floater's title bar into source window's tile layout (current tab) → re-docks as normal pane
+- [ ] Drag floater's title bar into a different tab on the source window's tab bar → block moves to that tab, floater destroyed
+- [ ] (Phase 7) Drag floater into another AgentMux instance → block transfers cross-process, floater destroyed
+- [ ] Click floater's dock button → re-docks at last docked position
+- [ ] Restart AgentMux → floating panes restore at their saved positions
+- [ ] Floater can render every pane type: browser, agent, terminal, sysinfo, swarm, etc. (no per-type work needed — same `<Block>` renderer)
+- [ ] Existing tab tear-off behavior unchanged: spawns new full instance with its own taskbar entry
+
+---
+
+## 12. Cross-references
+
+- Current tear-off: `frontend/app/drag/CrossWindowDragMonitor.win32.tsx`, `frontend/app/tab/tabbar.tsx::requestTearOff`
+- Host create-window: `agentmux-cef/src/commands/window.rs::open_window_at_position`, `agentmux-cef/src/commands/window_pool.rs::promote_pool_window`
+- Focus chain plumbing: `agentmux-cef/src/browser_pane/hwnd.rs`
+- Block renderer: `frontend/app/block/block.tsx`
+- Existing similar pattern (cross-window state sync): modal-v2, DevTools secondary window
+- Win32 owned-window docs: [MSDN — Window Features](https://learn.microsoft.com/windows/win32/winmsg/window-features)
+- VSCode auxiliary windows precedent: [microsoft/vscode#10121](https://github.com/Microsoft/vscode/issues/10121)
+- CEF embed pattern: `CefWindowInfo::SetAsChild` (NOT `SetAsPopup`)
+- Tab tear-off behavior (unchanged): `docs/specs/SPEC_TAB_TEAROFF_POSITION_AND_PAINT_2026-05-07.md`
+
+---
+
+## 13. Driving observation (verbatim)
+
+> "lets also smoke test tab tear … when tearing off panes, we don't create a new instance (no new taskbar icon) instead its a floating window owned by the mother instance. panes currently tear off and create a new instance, instead they would tear to subpanels. lets do best practice research, write spec to file"

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -602,16 +602,21 @@ function buildConfigFiles(
         }
     }
 
-    // Always write .claude/hooks.json with the auto-injected PreToolUse:Bash
-    // hook (agentmux-bashwrap) so live streaming engages on every
-    // session. User-supplied hooks merge in. Codex P1 on PR #809:
-    // the prior conditional silently disabled live streaming for the
-    // primary UI launch path (any agent without pre-existing user
-    // hooks). Mirror of agentmux-srv/src/backend/agent_config.rs
-    // build_hooks_config — keep the two paths in sync.
-    const hooksJson = buildHooksConfig(contentMap["hooks"]);
-    if (hooksJson) {
-        files.push({ path: ".claude/hooks.json", content: hooksJson });
+    // Always write .claude/settings.json with the auto-injected
+    // PreToolUse:Bash hook (under the `hooks` key) so live streaming
+    // engages on every session. User-supplied legacy hooks content
+    // and user settings.json content both merge in. Mirror of
+    // agentmux-srv/src/backend/agent_config.rs build_settings_with_hooks —
+    // keep the two paths in sync.
+    //
+    // FILE LOCATION (v0.33.805+): Claude Code reads project hooks from
+    // .claude/settings.json under the "hooks" key. A standalone
+    // .claude/hooks.json is NOT a discovery location — that was the
+    // v0.33.804 root cause: file was written but Claude never read it.
+    // See https://code.claude.com/docs/en/hooks.md.
+    const settingsJson = buildSettingsWithHooks(contentMap["settings"], contentMap["hooks"]);
+    if (settingsJson) {
+        files.push({ path: ".claude/settings.json", content: settingsJson });
     }
 
     // Build .mcp.json: auto-inject AgentMux MCP + merge user-provided config
@@ -644,7 +649,10 @@ function expandTemplate(content: string, vars: Record<string, string>): string {
  * in sync — keep changes aligned across both files. See
  * docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §5.
  */
-function buildHooksConfig(userHooksContent: string | undefined): string | null {
+function buildSettingsWithHooks(
+    userSettingsContent: string | undefined,
+    userHooksContent: string | undefined,
+): string | null {
     const agentmuxPretooluse = {
         matcher: "^(Bash|.*[Bb]ash.*)$",
         hooks: [
@@ -680,10 +688,39 @@ function buildHooksConfig(userHooksContent: string | undefined): string | null {
     }
     pretooluseEntries.push(agentmuxPretooluse);
     hooksObj["PreToolUse"] = pretooluseEntries;
+
+    // Wrap into settings.json shape, merging any user-supplied settings.
+    const settingsObj: Record<string, unknown> = {};
+    if (userSettingsContent) {
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(userSettingsContent);
+        } catch (e) {
+            console.warn("agent-model: failed to parse user settings JSON; dropping", e);
+            parsed = null;
+        }
+        if (parsed != null && typeof parsed === "object" && !Array.isArray(parsed)) {
+            Object.assign(settingsObj, parsed as Record<string, unknown>);
+        } else if (parsed != null) {
+            console.warn("agent-model: user settings top-level is not an object; dropping");
+        }
+    }
+    // Merge existing user settings.hooks (non-PreToolUse keys) into ours;
+    // ours wins on PreToolUse since user-PreToolUse from content_map["hooks"]
+    // is already in pretooluseEntries.
+    const existingHooks = settingsObj["hooks"];
+    if (existingHooks != null && typeof existingHooks === "object" && !Array.isArray(existingHooks)) {
+        for (const [k, v] of Object.entries(existingHooks as Record<string, unknown>)) {
+            if (k === "PreToolUse") continue;
+            if (!(k in hooksObj)) hooksObj[k] = v;
+        }
+    }
+    settingsObj["hooks"] = hooksObj;
+
     try {
-        return JSON.stringify(hooksObj, null, 2);
+        return JSON.stringify(settingsObj, null, 2);
     } catch (e) {
-        console.error("agent-model: failed to serialize hooks config", e);
+        console.error("agent-model: failed to serialize settings.json", e);
         return null;
     }
 }

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -705,13 +705,23 @@ function buildSettingsWithHooks(
             console.warn("agent-model: user settings top-level is not an object; dropping");
         }
     }
-    // Merge existing user settings.hooks (non-PreToolUse keys) into ours;
-    // ours wins on PreToolUse since user-PreToolUse from content_map["hooks"]
-    // is already in pretooluseEntries.
+    // Merge existing user settings.hooks. For PreToolUse, user matchers are
+    // PREPENDED so they short-circuit before our auto-injected entry. Other
+    // event types (PostToolUse, Stop, etc.) pass through. Reagent P1 on
+    // #813 caught the previous `continue` as a silent drop of user
+    // PreToolUse from settings.json.
     const existingHooks = settingsObj["hooks"];
     if (existingHooks != null && typeof existingHooks === "object" && !Array.isArray(existingHooks)) {
         for (const [k, v] of Object.entries(existingHooks as Record<string, unknown>)) {
-            if (k === "PreToolUse") continue;
+            if (k === "PreToolUse") {
+                if (Array.isArray(v)) {
+                    const ours = Array.isArray(hooksObj["PreToolUse"]) ? hooksObj["PreToolUse"] as unknown[] : [];
+                    hooksObj["PreToolUse"] = [...v, ...ours];
+                } else {
+                    console.warn("agent-model: user settings.hooks.PreToolUse is not an array; dropped");
+                }
+                continue;
+            }
             if (!(k in hooksObj)) hooksObj[k] = v;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.807",
+  "version": "0.33.808",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.807",
+      "version": "0.33.808",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.808",
+  "version": "0.33.809",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.808",
+      "version": "0.33.809",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.807",
+  "version": "0.33.808",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.808",
+  "version": "0.33.809",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

**CRITICAL HOTFIX for live-log streaming.** β.B (#809) wrote PreToolUse hooks to \`.claude/hooks.json\`. Claude Code does NOT read that file — per the docs (https://code.claude.com/docs/en/hooks.md), project hooks live in **\`.claude/settings.json\`** under the \`"hooks"\` key.

**Result on 0.33.804:** \`agentmux-bashwrap hook\` never fired. Every Bash tool ran natively, no command rewrite, no live streaming. Smoke-build confirmed: 410 \`tool_use\` events in the sidecar log, **0 mentions** of \`bashwrap\` / \`PreToolUse\` / \`tool_chunk\` / \`/wps/publish\`.

## Fix

Both paths kept in sync:

- **Rust (\`agentmux-srv/src/backend/agent_config.rs\`)**: \`build_hooks_config\` → \`build_settings_with_hooks\`. Writes \`.claude/settings.json\`, wraps hooks under \`"hooks"\` key, merges with user-supplied \`content_map["settings"]\` AND legacy \`content_map["hooks"]\`.
- **TypeScript (\`frontend/app/view/agent/agent-model.ts\`)**: same shape via \`buildSettingsWithHooks\`.

## Migration

Existing agents from prior sessions have a stale \`.claude/hooks.json\` lingering. Fresh agent sessions get the correct \`.claude/settings.json\` written. Users can safely delete the now-unread \`.claude/hooks.json\` (Claude ignores it).

## Test plan

- [x] \`cargo check -p agentmux-srv\` — clean.
- [x] \`tsc --noEmit\` — zero new errors.
- [ ] Smoke: extract 0.33.808 portable, spawn a fresh agent, ask it to run \`sleep 2 && echo a && sleep 2 && echo b\`. Expect \`a\` at t≈2s, \`b\` at t≈4s in the overlay (live streaming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)