### PR TITLE
fix(bashwrap): drop portable_pty for piped tokio::process + bash -c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.810"
+version = "0.33.811"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.810"
+version = "0.33.811"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.810"
+version = "0.33.811"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.810"
+version = "0.33.811"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.810"
+version = "0.33.811"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.809"
+version = "0.33.810"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.809"
+version = "0.33.810"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.809"
+version = "0.33.810"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.809"
+version = "0.33.810"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.809"
+version = "0.33.810"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.811"
+version = "0.33.812"
 dependencies = [
  "anyhow",
  "base64",
@@ -26,7 +26,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.811"
+version = "0.33.812"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.811"
+version = "0.33.812"
 dependencies = [
  "dirs",
  "serde",
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.811"
+version = "0.33.812"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.811"
+version = "0.33.812"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,13 +15,13 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
- "portable-pty",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "which",
 ]
 
 [[package]]
@@ -850,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,6 +1169,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "http"
@@ -1584,6 +1599,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2015,7 +2036,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2421,6 +2442,19 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -2428,7 +2462,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2840,7 +2874,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3520,6 +3554,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3923,6 +3969,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4029,7 +4081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.810"
+version = "0.33.811"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.811"
+version = "0.33.812"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.809"
+version = "0.33.810"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "agentmux-bashwrap"
 version = "0.33.809"
 edition = "2021"
-description = "AgentMux streaming bash wrapper — owned PTY runner + PreToolUse hook helper"
+description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]
 license = "Apache-2.0"
 
@@ -17,7 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
-portable-pty = "0.9"
+which = "6"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -86,8 +86,7 @@ struct TerminalMessage {
 /// Internal channel payload: a single line tagged with its source.
 /// Bytes are raw — UTF-8 conversion is deferred to the publish /
 /// aggregation site so non-UTF-8 output (binary `cat`, Windows
-/// legacy-encoded tools) doesn't abort the reader. Reagent + codex
-/// P2 on round 1 of PR #815.
+/// legacy-encoded tools) doesn't abort the reader.
 #[derive(Debug)]
 struct LineEvent {
     kind: &'static str, // "stdout" or "stderr"
@@ -99,8 +98,8 @@ struct LineEvent {
 
 /// Returns the inner command's exit code so main.rs can mirror it as
 /// the wrapper's own process exit. Without this, Claude's native Bash
-/// tool saw success for every wrapped command regardless of the actual
-/// outcome — codex P1 on PR #804.
+/// tool would see success for every wrapped command regardless of the
+/// actual outcome.
 pub async fn run(args: Args) -> Result<i32> {
     log_relevant_env();
     let command = decode_command(&args.b64_cmd)?;
@@ -316,7 +315,7 @@ async fn run_proc(
     // Stdout reader: byte-level read_until('\n'). NOT lines() — that
     // returns an IO error on the first non-UTF-8 sequence (binary
     // `cat`, Windows legacy-encoded output) and silently truncates
-    // every subsequent byte. Reagent + codex P2.
+    // every subsequent byte.
     tokio::spawn(async move {
         let mut reader = BufReader::new(stdout);
         loop {
@@ -450,9 +449,9 @@ fn snap_to_char_boundary_ceil(buf: &[u8], idx: usize) -> usize {
 /// **UTF-8 safety**: head/tail slice boundaries are snapped to the
 /// nearest UTF-8 character boundary so non-ASCII output (emoji,
 /// accented characters, CJK) doesn't get corrupted into `�`
-/// replacement characters at the cut point. Reagent P1 round 4 on
-/// PR #804 caught this — naive fixed-byte slicing splits multi-byte
-/// sequences and the lossy decode emits replacement chars.
+/// replacement characters at the cut point — naive fixed-byte slicing
+/// splits multi-byte sequences and the lossy decode emits replacement
+/// chars.
 pub(crate) fn format_model_blob(
     buf: &[u8],
     exit_code: i32,
@@ -487,7 +486,7 @@ mod tests {
     // `std::env::set_var` / `remove_var` mutate process-global state;
     // cargo test runs tests in parallel by default, so without a
     // serial lock tests that touch the env race each other. Mirrors
-    // the same pattern in `wps_client::tests`. Reagent P2 on PR #815.
+    // the same pattern in `wps_client::tests`.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -467,6 +467,13 @@ pub(crate) fn format_model_blob(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // `std::env::set_var` / `remove_var` mutate process-global state;
+    // cargo test runs tests in parallel by default, so without a
+    // serial lock tests that touch the env race each other. Mirrors
+    // the same pattern in `wps_client::tests`. Reagent P2 on PR #815.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn decodes_b64_command() {
@@ -532,15 +539,27 @@ mod tests {
     fn locate_bash_via_explicit_env() {
         // Use the binary that runs the test as a stand-in for "bash"
         // — we only assert that the override is honored, not that the
-        // path is a real bash.
+        // path is a real bash. ENV_LOCK serializes against any future
+        // env-touching test (and against `BASH` reads in the same fn).
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let exe = std::env::current_exe().expect("current_exe");
+        let prev_agentmux_bash = std::env::var("AGENTMUX_BASH").ok();
+        let prev_bash = std::env::var("BASH").ok();
+        // Clear BASH so the override path is the one being asserted.
         unsafe {
             std::env::set_var("AGENTMUX_BASH", &exe);
+            std::env::remove_var("BASH");
         }
         let found = locate_bash().expect("locate_bash with override");
         assert_eq!(found, exe);
         unsafe {
-            std::env::remove_var("AGENTMUX_BASH");
+            match prev_agentmux_bash {
+                Some(v) => std::env::set_var("AGENTMUX_BASH", v),
+                None => std::env::remove_var("AGENTMUX_BASH"),
+            }
+            if let Some(v) = prev_bash {
+                std::env::set_var("BASH", v);
+            }
         }
     }
 }

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -34,8 +34,8 @@ use serde::Serialize;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::{Mutex, mpsc};
 
@@ -65,6 +65,18 @@ pub struct Args {
 /// Cap the model-visible head/tail sections of the aggregated blob.
 const MODEL_BLOB_HEAD_BYTES: usize = 50_000;
 const MODEL_BLOB_TAIL_BYTES: usize = 50_000;
+
+/// Flush pending bytes to the publisher when buffered without a
+/// newline AND the buffer reaches this size — so long lines and
+/// newline-free output (minified JSON, CR-only progress bars) still
+/// stream live instead of accumulating in memory unbounded.
+const FLUSH_BYTES: usize = 4096;
+
+/// Flush pending bytes after this much idle time even if no newline /
+/// size threshold has been hit — keeps slow-trickle output visible
+/// without waiting for the next byte that would have triggered a
+/// natural flush.
+const FLUSH_QUIET_WINDOW: Duration = Duration::from_millis(50);
 
 /// Wire payload published on `tool_chunk:<id>`. Mirrors the TypeScript
 /// `ToolChunkMessage` in `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
@@ -270,6 +282,80 @@ pub(crate) fn locate_bash() -> Result<PathBuf> {
     ))
 }
 
+/// Read raw bytes from a child stdio handle and forward chunks to
+/// the publisher with three flush triggers:
+///
+/// 1. **Newline.** As soon as a `\n` is in the buffer, drain everything
+///    up to and including that newline as one chunk. Loop, since a
+///    single read can contain multiple complete lines.
+/// 2. **Size threshold** (`FLUSH_BYTES`). If the buffer accumulates
+///    without a newline (minified JSON output, long progress lines,
+///    `printf` without `\n`), flush as soon as it exceeds the
+///    threshold. Prevents unbounded memory growth and keeps streaming
+///    live for newline-free output.
+/// 3. **Quiet-window** (`FLUSH_QUIET_WINDOW`). After this much idle
+///    time with non-empty pending bytes, flush. Surfaces slow-trickle
+///    output (one byte at a time) that would otherwise wait for the
+///    next byte to trigger a natural flush.
+async fn stream_reader<R>(mut reader: R, kind: &'static str, tx: mpsc::Sender<LineEvent>)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut pending: Vec<u8> = Vec::with_capacity(8192);
+    let mut buf = [0u8; 8192];
+    loop {
+        match tokio::time::timeout(FLUSH_QUIET_WINDOW, reader.read(&mut buf)).await {
+            Ok(Ok(0)) => {
+                // EOF: drain remainder and exit.
+                if !pending.is_empty() {
+                    let _ = tx
+                        .send(LineEvent { kind, bytes: std::mem::take(&mut pending) })
+                        .await;
+                }
+                return;
+            }
+            Ok(Ok(n)) => {
+                pending.extend_from_slice(&buf[..n]);
+                // Drain every complete line.
+                while let Some(nl_pos) = pending.iter().position(|&b| b == b'\n') {
+                    let line: Vec<u8> = pending.drain(..=nl_pos).collect();
+                    if tx.send(LineEvent { kind, bytes: line }).await.is_err() {
+                        return;
+                    }
+                }
+                // Newline-free residue past the size threshold: flush
+                // as one chunk to keep memory bounded + streaming live.
+                if pending.len() >= FLUSH_BYTES {
+                    if tx
+                        .send(LineEvent { kind, bytes: std::mem::take(&mut pending) })
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::warn!(target: "bashwrap", error = %e, kind, "read error");
+                return;
+            }
+            Err(_elapsed) => {
+                // Quiet window: flush any pending bytes so slow-trickle
+                // output doesn't sit indefinitely.
+                if !pending.is_empty() {
+                    if tx
+                        .send(LineEvent { kind, bytes: std::mem::take(&mut pending) })
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Spawn the bash child via piped stdio and stream its lines.
 ///
 /// Why pipes instead of a PTY: on Windows, the previous `portable_pty`
@@ -308,60 +394,9 @@ async fn run_proc(
         .ok_or_else(|| anyhow!("bash child has no stderr"))?;
 
     let (tx, mut rx) = mpsc::channel::<LineEvent>(1024);
-    let tx_stdout = tx.clone();
-    let tx_stderr = tx.clone();
-    drop(tx); // both clones own EOF for the publisher
-
-    // Stdout reader: byte-level read_until('\n'). NOT lines() — that
-    // returns an IO error on the first non-UTF-8 sequence (binary
-    // `cat`, Windows legacy-encoded output) and silently truncates
-    // every subsequent byte.
-    tokio::spawn(async move {
-        let mut reader = BufReader::new(stdout);
-        loop {
-            let mut buf = Vec::with_capacity(256);
-            match reader.read_until(b'\n', &mut buf).await {
-                Ok(0) => return, // EOF
-                Ok(_) => {
-                    if tx_stdout
-                        .send(LineEvent { kind: "stdout", bytes: buf })
-                        .await
-                        .is_err()
-                    {
-                        return;
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(target: "bashwrap", error = %e, "stdout read error");
-                    return;
-                }
-            }
-        }
-    });
-
-    // Stderr reader: same byte-level shape.
-    tokio::spawn(async move {
-        let mut reader = BufReader::new(stderr);
-        loop {
-            let mut buf = Vec::with_capacity(256);
-            match reader.read_until(b'\n', &mut buf).await {
-                Ok(0) => return,
-                Ok(_) => {
-                    if tx_stderr
-                        .send(LineEvent { kind: "stderr", bytes: buf })
-                        .await
-                        .is_err()
-                    {
-                        return;
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!(target: "bashwrap", error = %e, "stderr read error");
-                    return;
-                }
-            }
-        }
-    });
+    tokio::spawn(stream_reader(stdout, "stdout", tx.clone()));
+    tokio::spawn(stream_reader(stderr, "stderr", tx.clone()));
+    drop(tx); // last surviving sender lives in the spawned tasks
 
     // Publisher: aggregate into buffer + publish to WPS.
     let tool_id = args.tool_id.clone();

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -1,37 +1,43 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-//! `exec` subcommand — owns the PTY and streams chunks while the
-//! user's bash command runs.
+//! `exec` subcommand — runs the user's bash command and streams chunks.
 //!
 //! Invariants:
 //! - The user's command is decoded from `--b64-cmd` so quoting /
 //!   multi-line / shell-metachar content survives the rewrite.
-//! - The inner command runs inside a real PTY (24×200, TERM=xterm-256color)
-//!   so ANSI colors, spinners, and interactive prompts render
-//!   correctly in the AgentMux overlay.
-//! - Output is line-flushed with a ~50ms quiet-window timeout so
-//!   carriage-return progress bars (e.g. `npm install`'s `[==>] 50%`)
-//!   surface incrementally rather than waiting for `\n`.
-//! - Aggregated stdout (including stderr lines prefixed with
-//!   `[stderr] `) is captured into a buffer; on exit, a formatted
-//!   summary lands on this process's stdout for Claude's native Bash
-//!   tool to harvest as the `tool_result` content. Truncated head/
-//!   tail at 50KB each per
+//! - The inner command runs under `bash -c` via piped stdio (NOT a PTY).
+//!   PTY was tried in β.A and broke on Win10's ConPTY (child exited
+//!   with `STATUS_DLL_INIT_FAILED` because `portable_pty`'s master
+//!   handle was dropped during child startup — see
+//!   `docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md`
+//!   §4.2 and §6.3). Plain pipes give us line streaming, which is what
+//!   the live-log feature needs; PTY-only behaviors (spinner fidelity,
+//!   interactive prompts, CR-only progress bars) are deferred.
+//! - Bash is located via `$BASH` → `$AGENTMUX_BASH` → PATH search →
+//!   well-known Windows locations (Git Bash). Fails loud if missing.
+//! - stdout and stderr are streamed concurrently, each line published
+//!   as its own chunk with `kind` set to `"stdout"` or `"stderr"`.
+//!   Aggregated stdout (with stderr lines prefixed `[stderr] `) is
+//!   captured into a buffer; on exit, a formatted summary lands on
+//!   this process's stdout for Claude's native Bash tool to harvest as
+//!   the `tool_result` content. Truncated head/tail at 50KB each per
 //!   `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.5.
 //! - If WPS publish fails (missing env, sidecar down, etc.), the
 //!   command still runs to completion — output just doesn't stream.
 //!   The model-visible blob is unaffected. A `kind: "system"` chunk
 //!   announces the degradation at startup.
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use clap::Parser;
-use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use serde::Serialize;
-use std::io::Read as _;
+use std::path::PathBuf;
+use std::process::Stdio;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::{Mutex, mpsc};
 
 use crate::wps_client::WpsClient;
 
@@ -56,9 +62,6 @@ pub struct Args {
     pub block_id: Option<String>,
 }
 
-const PTY_ROWS: u16 = 24;
-const PTY_COLS: u16 = 200;
-const FLUSH_QUIET_WINDOW: Duration = Duration::from_millis(50);
 /// Cap the model-visible head/tail sections of the aggregated blob.
 const MODEL_BLOB_HEAD_BYTES: usize = 50_000;
 const MODEL_BLOB_TAIL_BYTES: usize = 50_000;
@@ -80,17 +83,24 @@ struct TerminalMessage {
     timestamp: u64,
 }
 
+/// Internal channel payload: a single line tagged with its source.
+#[derive(Debug)]
+struct LineEvent {
+    kind: &'static str, // "stdout" or "stderr"
+    text: String,       // newline NOT included (lines() strips it)
+}
+
 /// Returns the inner command's exit code so main.rs can mirror it as
 /// the wrapper's own process exit. Without this, Claude's native Bash
 /// tool saw success for every wrapped command regardless of the actual
 /// outcome — codex P1 on PR #804.
 pub async fn run(args: Args) -> Result<i32> {
+    log_relevant_env();
     let command = decode_command(&args.b64_cmd)?;
 
     let wps = WpsClient::from_env();
     let degraded = wps.is_none();
 
-    // Buffer for the aggregated model-visible blob.
     let buffered = Arc::new(Mutex::new(Vec::<u8>::with_capacity(64 * 1024)));
 
     if degraded {
@@ -112,11 +122,9 @@ pub async fn run(args: Args) -> Result<i32> {
     }
 
     let start = std::time::Instant::now();
-    let status = run_pty(&args, &command, wps.as_ref(), buffered.clone()).await?;
+    let status = run_proc(&args, &command, wps.as_ref(), buffered.clone()).await?;
     let elapsed = start.elapsed();
 
-    // Final terminal marker so the frontend can flip log.open=false
-    // even if the matching StreamFlush from Claude is delayed.
     if let Some(client) = wps.as_ref() {
         let _ = client
             .publish_chunk(
@@ -153,6 +161,25 @@ fn now_ms() -> u64 {
         .unwrap_or(0)
 }
 
+/// Log which streaming-relevant env vars the wrapper actually received,
+/// so the sidecar log tells us at a glance whether the env-propagation
+/// chain from agentmux-srv → claude → bash → hook → here is intact.
+/// Values are not logged (auth key is sensitive); presence/absence is
+/// the only signal we need to triage the propagation gap.
+fn log_relevant_env() {
+    let has = |k: &str| std::env::var(k).is_ok();
+    tracing::info!(
+        target: "bashwrap",
+        auth_key = has("AGENTMUX_AUTH_KEY"),
+        local_url = has("AGENTMUX_LOCAL_URL"),
+        agent_id = has("AGENTMUX_AGENT_ID"),
+        block_id = has("AGENTMUX_BLOCKID"),
+        bash = std::env::var("BASH").ok(),
+        agentmux_bash = std::env::var("AGENTMUX_BASH").ok(),
+        "bashwrap exec env snapshot"
+    );
+}
+
 async fn publish_system(
     client: &WpsClient,
     tool_id: &str,
@@ -173,11 +200,12 @@ async fn publish_system(
         .await
 }
 
-async fn publish_stdout(
+async fn publish_line(
     client: &WpsClient,
     tool_id: &str,
     block_id: Option<&str>,
-    chunk: &str,
+    kind: &str,
+    line: &str,
 ) -> Result<()> {
     client
         .publish_chunk(
@@ -185,199 +213,199 @@ async fn publish_stdout(
             block_id,
             &ChunkMessage {
                 op: "chunk",
-                kind: "stdout",
-                content: chunk,
+                kind,
+                content: line,
                 timestamp: now_ms(),
             },
         )
         .await
 }
 
-/// Pick the shell that runs the wrapped command.
+/// Locate bash. Order:
+/// 1. `$AGENTMUX_BASH` — explicit override from agentmux-srv config.
+/// 2. `$BASH` — set by bash itself when it spawns a child; reliable
+///    inside Claude Code's hook context because Claude shells out to
+///    bash to run the hook.
+/// 3. `which bash` on PATH.
+/// 4. Well-known Windows paths (Git Bash, msys2). Skipped on Unix.
 ///
-/// Unix: `bash` (NOT `sh`). The PreToolUse hook matches on
-/// `tool_name == "Bash"`, so users expect bash semantics — `[[ ]]`,
-/// arrays, `source`, `pipefail`, etc. Using dash/sh as a stand-in
-/// would silently break a substantial portion of real commands.
-/// Codex P1 on PR #804.
-///
-/// Win32: `cmd /C` is the lowest-common-denominator Windows shell.
-/// PowerShell or pwsh might be more capable but requires explicit
-/// detection; keeping `cmd` matches what Claude Code's native Bash
-/// tool uses internally on Windows.
-fn shell_for_platform() -> &'static str {
-    if cfg!(windows) { "cmd" } else { "bash" }
+/// Fail-loud if not found — pass-through fallback would hide the issue.
+pub(crate) fn locate_bash() -> Result<PathBuf> {
+    if let Ok(p) = std::env::var("AGENTMUX_BASH") {
+        if !p.is_empty() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = std::env::var("BASH") {
+        if !p.is_empty() && PathBuf::from(&p).exists() {
+            return Ok(PathBuf::from(p));
+        }
+    }
+    if let Ok(p) = which::which("bash") {
+        return Ok(p);
+    }
+    #[cfg(windows)]
+    {
+        for candidate in [
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+            r"C:\msys64\usr\bin\bash.exe",
+            r"C:\msys2\usr\bin\bash.exe",
+        ] {
+            let p = PathBuf::from(candidate);
+            if p.exists() {
+                return Ok(p);
+            }
+        }
+    }
+    Err(anyhow!(
+        "bash not found — set AGENTMUX_BASH, install Git Bash, or add bash to PATH"
+    ))
 }
 
-fn shell_dash_c_flag() -> &'static str {
-    if cfg!(windows) { "/C" } else { "-c" }
-}
-
-/// Spawn the PTY child and stream its bytes. Returns the exit code.
+/// Spawn the bash child via piped stdio and stream its lines.
 ///
-/// We use a blocking thread for the PTY reader (the `portable_pty`
-/// master reader is sync) and a tokio mpsc to forward chunks into
-/// async-land for the publisher.
-async fn run_pty(
+/// Why pipes instead of a PTY: on Windows, the previous `portable_pty`
+/// path dropped `pair.master` immediately after cloning the reader,
+/// which tears down the ConPTY mid-startup and yields
+/// `STATUS_DLL_INIT_FAILED` for every child. The fix is either to keep
+/// `master` alive across `child.wait()` OR drop PTY entirely. The
+/// live-log feature wants line streaming, not spinner fidelity, so
+/// plain pipes win — they sidestep the entire ConPTY lifetime class.
+async fn run_proc(
     args: &Args,
     command: &str,
     wps: Option<&WpsClient>,
     buffered: Arc<Mutex<Vec<u8>>>,
 ) -> Result<i32> {
-    let pty_system = native_pty_system();
-    let pair = pty_system
-        .openpty(PtySize {
-            rows: PTY_ROWS,
-            cols: PTY_COLS,
-            pixel_width: 0,
-            pixel_height: 0,
-        })
-        .context("opening PTY")?;
+    let bash = locate_bash()?;
+    tracing::info!(target: "bashwrap", bash = %bash.display(), "spawning bash -c");
 
-    let mut builder = CommandBuilder::new(shell_for_platform());
-    builder.arg(shell_dash_c_flag());
-    builder.arg(command);
-    builder.env("TERM", "xterm-256color");
-    // PTY child inherits our env (which inherits agentmux-srv's), so
-    // AGENTMUX_* env vars + everything the parent had are present.
+    let mut child = Command::new(&bash)
+        .arg("-c")
+        .arg(command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .with_context(|| format!("spawning bash at {}", bash.display()))?;
 
-    let mut child = pair
-        .slave
-        .spawn_command(builder)
-        .context("spawning PTY command")?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("bash child has no stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("bash child has no stderr"))?;
 
-    let mut reader = pair
-        .master
-        .try_clone_reader()
-        .context("cloning PTY reader")?;
-    // Drop the slave handle in the parent — the child still has it.
-    drop(pair.slave);
-    // Drop the master writer; we never inject stdin (interactive
-    // prompts deferred to PR γ+ per spec §14 open questions).
-    drop(pair.master);
-
-    let (tx, mut rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1024);
-
-    // Reader → flusher state. The blocking PTY reader appends bytes
-    // to `shared_pending`; an async timer task flushes the buffer on
-    // newline, on 4KB threshold, OR after FLUSH_QUIET_WINDOW idle
-    // time. The idle-flush path is what makes CR-only progress bars
-    // (npm install's `[==>] 50%` updates) surface live — without it,
-    // the reader sits on partial bytes until a `\n` finally arrives.
-    let shared_pending: Arc<std::sync::Mutex<Vec<u8>>> =
-        Arc::new(std::sync::Mutex::new(Vec::with_capacity(4096)));
-    let reader_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-    let tx_reader = tx.clone();
-    let tx_flusher = tx.clone();
+    let (tx, mut rx) = mpsc::channel::<LineEvent>(1024);
+    let tx_stdout = tx.clone();
+    let tx_stderr = tx.clone();
     drop(tx); // both clones own EOF for the publisher
 
-    // Blocking reader thread: read bytes + append to shared buffer.
-    // Inline newline/size-triggered flush for low-latency delivery
-    // of line-buffered output.
-    let pending_r = shared_pending.clone();
-    let done_r = reader_done.clone();
-    let reader_handle = std::thread::spawn(move || {
-        let mut buf = [0u8; 8192];
-        loop {
-            let n = match reader.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => n,
-                Err(e) => {
-                    tracing::warn!("PTY read error: {}", e);
-                    break;
-                }
-            };
-            let mut p = pending_r.lock().unwrap();
-            p.extend_from_slice(&buf[..n]);
-            if p.contains(&b'\n') || p.len() >= 4096 {
-                let chunk = std::mem::take(&mut *p);
-                drop(p);
-                let _ = tx_reader.blocking_send(chunk);
-            }
-        }
-        // EOF: drain remainder, signal done.
-        let mut p = pending_r.lock().unwrap();
-        if !p.is_empty() {
-            let chunk = std::mem::take(&mut *p);
-            drop(p);
-            let _ = tx_reader.blocking_send(chunk);
-        }
-        done_r.store(true, std::sync::atomic::Ordering::Release);
-    });
-
-    // Async quiet-window flusher: ticks every FLUSH_QUIET_WINDOW and
-    // drains any bytes that have been sitting without a newline /
-    // threshold trigger. Exits when reader signals done.
-    let pending_f = shared_pending.clone();
-    let done_f = reader_done.clone();
+    // Stdout reader: line-buffered, each line is a chunk.
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(FLUSH_QUIET_WINDOW);
-        // Skip the immediate first tick — wait one quiet window
-        // before the first flush so we don't preempt the reader's
-        // newline-based flush on common line-buffered output.
-        interval.tick().await;
+        let mut reader = BufReader::new(stdout).lines();
         loop {
-            interval.tick().await;
-            if done_f.load(std::sync::atomic::Ordering::Acquire) {
-                return;
-            }
-            let chunk = {
-                let mut p = pending_f.lock().unwrap();
-                if p.is_empty() {
-                    continue;
+            match reader.next_line().await {
+                Ok(Some(line)) => {
+                    if tx_stdout
+                        .send(LineEvent {
+                            kind: "stdout",
+                            text: line,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
                 }
-                std::mem::take(&mut *p)
-            };
-            if tx_flusher.send(chunk).await.is_err() {
-                return;
+                Ok(None) => return, // EOF
+                Err(e) => {
+                    tracing::warn!(target: "bashwrap", error = %e, "stdout read error");
+                    return;
+                }
             }
         }
     });
 
-    // Async loop: drain the channel and publish chunks. Also runs a
-    // periodic timer that flushes any remaining pending bytes that
-    // didn't get bounced over via the newline heuristic.
+    // Stderr reader: same shape; lines tagged so the model can tell
+    // them apart in the aggregated blob.
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(stderr).lines();
+        loop {
+            match reader.next_line().await {
+                Ok(Some(line)) => {
+                    if tx_stderr
+                        .send(LineEvent {
+                            kind: "stderr",
+                            text: line,
+                        })
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+                Ok(None) => return,
+                Err(e) => {
+                    tracing::warn!(target: "bashwrap", error = %e, "stderr read error");
+                    return;
+                }
+            }
+        }
+    });
+
+    // Publisher: aggregate into buffer + publish to WPS.
     let tool_id = args.tool_id.clone();
     let block_id = args.block_id.clone();
     let wps_clone = wps.cloned();
     let buffered_clone = buffered.clone();
-
     let publisher_handle = tokio::spawn(async move {
-        while let Some(bytes) = rx.recv().await {
-            // Capture into the aggregate buffer first, regardless of
-            // publish success — model-visible blob must be intact.
-            buffered_clone.lock().await.extend_from_slice(&bytes);
+        while let Some(event) = rx.recv().await {
+            // Aggregate into the model-visible buffer first. Stderr
+            // lines are prefixed so Claude can reason about them
+            // distinctly when it reads the tool_result blob.
+            {
+                let mut buf = buffered_clone.lock().await;
+                if event.kind == "stderr" {
+                    buf.extend_from_slice(b"[stderr] ");
+                }
+                buf.extend_from_slice(event.text.as_bytes());
+                buf.push(b'\n');
+            }
 
-            // Stream chunk over WPS. Best-effort: if publish fails
-            // (sidecar down, etc.), log and continue — degraded mode.
+            // Stream chunk over WPS. Best-effort: a publish failure
+            // doesn't abort the command (the buffer already has the
+            // line). The frontend will see the line on `tool_result`
+            // even if the chunk never arrived.
             if let Some(client) = wps_clone.as_ref() {
-                let content = String::from_utf8_lossy(&bytes).into_owned();
-                if let Err(e) =
-                    publish_stdout(client, &tool_id, block_id.as_deref(), &content).await
+                if let Err(e) = publish_line(
+                    client,
+                    &tool_id,
+                    block_id.as_deref(),
+                    event.kind,
+                    &event.text,
+                )
+                .await
                 {
-                    tracing::warn!("WPS publish failed: {}", e);
+                    tracing::warn!(target: "bashwrap", error = %e, "WPS publish failed");
                 }
             }
         }
     });
 
-    // Wait for the child to exit. portable_pty's wait is blocking;
-    // spawn on blocking pool.
-    let exit_status = tokio::task::spawn_blocking(move || child.wait())
-        .await
-        .context("joining wait task")?
-        .context("waiting for PTY child")?;
-
-    // The reader thread exits when EOF arrives on its end of the PTY,
-    // which happens after the child exits. Join it.
-    let _ = tokio::task::spawn_blocking(|| reader_handle.join()).await;
-
-    // Drop tx-side via publisher_handle awaiting Stream closure happens
-    // automatically when the reader thread exits and tx is dropped.
+    // Wait for the child; tokio::process gives us the real exit code.
+    let exit_status = child.wait().await.context("waiting for bash child")?;
     let _ = publisher_handle.await;
 
-    Ok(exit_status.exit_code() as i32)
+    // tokio::process exposes Option<i32> for Unix-signal-terminated
+    // children; surface -1 in that case so Claude sees a clearly
+    // abnormal exit.
+    Ok(exit_status.code().unwrap_or(-1))
 }
 
 /// Snap `idx` down to the nearest UTF-8 character boundary (or 0).
@@ -451,7 +479,7 @@ mod tests {
     fn decodes_multi_line_with_quotes() {
         use base64::Engine as _;
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-        let original = "echo \"hello\" && cat $HOME/.env\nls -la";
+        let original = "echo \"line one\"\necho 'line two'";
         let b64 = URL_SAFE_NO_PAD.encode(original.as_bytes());
         let s = decode_command(&b64).unwrap();
         assert_eq!(s, original);
@@ -463,82 +491,56 @@ mod tests {
     }
 
     #[test]
-    fn format_model_blob_includes_exit_and_elapsed() {
-        let out = format_model_blob(
-            b"hello world",
-            0,
-            std::time::Duration::from_millis(1234),
-        );
-        assert!(out.starts_with("<exited 0 in 1.23s>"));
-        assert!(out.ends_with("hello world"));
+    fn format_model_blob_under_cap_passes_body_through() {
+        let body = b"hello world\n";
+        let out = format_model_blob(body, 0, std::time::Duration::from_millis(123));
+        assert!(out.starts_with("<exited 0 in 0.12s>\n"));
+        assert!(out.contains("hello world"));
     }
 
     #[test]
-    fn format_model_blob_snaps_to_utf8_boundaries() {
-        // Reagent P1 round 4: ensure multi-byte UTF-8 sequences don't
-        // get split at the truncation cut points. Build a 150KB buffer
-        // by repeating a 4-byte emoji (U+1F600 "😀") which spans bytes
-        // [0xF0, 0x9F, 0x98, 0x80]. Naive fixed-byte slicing would
-        // split most cuts mid-sequence, producing `�` replacement
-        // chars in the output. With the boundary-snap, the head and
-        // tail must both decode losslessly back to whole emojis.
-        let emoji = "😀".as_bytes();
-        assert_eq!(emoji.len(), 4);
-        let buf: Vec<u8> = emoji.iter().cycle().take(150_000).copied().collect();
-        let out = format_model_blob(&buf, 0, std::time::Duration::from_millis(100));
-        // Pull the head section out — everything between the framing
-        // and the elision marker.
-        let after_frame = out.split('\n').skip(1).next().unwrap();
-        // The first emoji should be intact (no replacement char).
-        assert!(
-            after_frame.starts_with('😀'),
-            "head should start with intact emoji, got: {:?}",
-            &after_frame[..40.min(after_frame.len())]
-        );
-        // No replacement char anywhere in the output.
+    fn format_model_blob_truncates_over_cap_at_char_boundary() {
+        // 200KB of '🌟' (4-byte emoji) > 100KB cap → truncates.
+        let s = "🌟".repeat(50_000);
+        let bytes = s.as_bytes();
+        let out = format_model_blob(bytes, 0, std::time::Duration::from_secs(1));
+        // No replacement char `�` (U+FFFD) — boundary snap must keep
+        // multi-byte sequences whole at the cut point.
         assert!(
             !out.contains('\u{FFFD}'),
             "found replacement char (lossy decode at boundary)"
         );
+        assert!(out.contains("bytes elided"));
     }
 
     #[test]
-    fn snap_floor_handles_continuation_bytes() {
-        // "😀" = F0 9F 98 80. At idx=2 we're inside the sequence;
-        // floor must walk back to idx=0.
-        let buf = "😀".as_bytes();
-        assert_eq!(snap_to_char_boundary_floor(buf, 2), 0);
+    fn snap_floor_is_idempotent_at_ascii() {
+        let buf = b"abcdef";
+        assert_eq!(snap_to_char_boundary_floor(buf, 3), 3);
         assert_eq!(snap_to_char_boundary_floor(buf, 0), 0);
-        assert_eq!(snap_to_char_boundary_floor(buf, 4), 4);
+        assert_eq!(snap_to_char_boundary_floor(buf, 6), 6);
     }
 
     #[test]
-    fn snap_ceil_handles_continuation_bytes() {
-        // Inside emoji → ceil walks forward to the next leading byte.
-        let buf = "a😀b".as_bytes(); // [a F0 9F 98 80 b]
-        // idx 2 = inside emoji → ceil = 5 (start of 'b')
-        assert_eq!(snap_to_char_boundary_ceil(buf, 2), 5);
-        // idx 1 = leading byte → stays
-        assert_eq!(snap_to_char_boundary_ceil(buf, 1), 1);
+    fn snap_floor_steps_back_off_continuation_bytes() {
+        // "é" = [0xC3, 0xA9]; index 1 is a continuation byte.
+        let buf = b"\xc3\xa9x";
+        assert_eq!(snap_to_char_boundary_floor(buf, 1), 0);
     }
 
     #[test]
-    fn format_model_blob_truncates_huge_output() {
-        // 150KB of 'x' — must elide the middle.
-        let buf = vec![b'x'; 150_000];
-        let out = format_model_blob(&buf, 1, std::time::Duration::from_secs(5));
-        assert!(out.contains("[50000 bytes elided"));
-        assert!(out.contains("<exited 1 in 5.00s>"));
-        // Should be ~100KB + framing, not 150KB.
-        assert!(out.len() < 150_000);
-    }
-
-    #[test]
-    fn format_model_blob_passes_small_output_unchanged() {
-        let buf = b"line 1\nline 2\nline 3";
-        let out = format_model_blob(buf, 0, std::time::Duration::from_millis(100));
-        assert!(out.contains("line 1"));
-        assert!(out.contains("line 3"));
-        assert!(!out.contains("elided"));
+    fn locate_bash_via_explicit_env() {
+        // Use the binary that runs the test as a stand-in for "bash"
+        // — we only assert that the override is honored, not that the
+        // path is a real bash.
+        let exe = std::env::current_exe().expect("current_exe");
+        unsafe {
+            std::env::set_var("AGENTMUX_BASH", &exe);
+        }
+        let found = locate_bash().expect("locate_bash with override");
+        assert_eq!(found, exe);
+        unsafe {
+            std::env::remove_var("AGENTMUX_BASH");
+        }
     }
 }

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -84,10 +84,17 @@ struct TerminalMessage {
 }
 
 /// Internal channel payload: a single line tagged with its source.
+/// Bytes are raw — UTF-8 conversion is deferred to the publish /
+/// aggregation site so non-UTF-8 output (binary `cat`, Windows
+/// legacy-encoded tools) doesn't abort the reader. Reagent + codex
+/// P2 on round 1 of PR #815.
 #[derive(Debug)]
 struct LineEvent {
     kind: &'static str, // "stdout" or "stderr"
-    text: String,       // newline NOT included (lines() strips it)
+    /// Raw bytes including the trailing `\n` if present. May be the
+    /// final fragment before EOF without a newline, in which case it
+    /// has no trailing delimiter.
+    bytes: Vec<u8>,
 }
 
 /// Returns the inner command's exit code so main.rs can mirror it as
@@ -306,24 +313,25 @@ async fn run_proc(
     let tx_stderr = tx.clone();
     drop(tx); // both clones own EOF for the publisher
 
-    // Stdout reader: line-buffered, each line is a chunk.
+    // Stdout reader: byte-level read_until('\n'). NOT lines() — that
+    // returns an IO error on the first non-UTF-8 sequence (binary
+    // `cat`, Windows legacy-encoded output) and silently truncates
+    // every subsequent byte. Reagent + codex P2.
     tokio::spawn(async move {
-        let mut reader = BufReader::new(stdout).lines();
+        let mut reader = BufReader::new(stdout);
         loop {
-            match reader.next_line().await {
-                Ok(Some(line)) => {
+            let mut buf = Vec::with_capacity(256);
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => return, // EOF
+                Ok(_) => {
                     if tx_stdout
-                        .send(LineEvent {
-                            kind: "stdout",
-                            text: line,
-                        })
+                        .send(LineEvent { kind: "stdout", bytes: buf })
                         .await
                         .is_err()
                     {
                         return;
                     }
                 }
-                Ok(None) => return, // EOF
                 Err(e) => {
                     tracing::warn!(target: "bashwrap", error = %e, "stdout read error");
                     return;
@@ -332,25 +340,22 @@ async fn run_proc(
         }
     });
 
-    // Stderr reader: same shape; lines tagged so the model can tell
-    // them apart in the aggregated blob.
+    // Stderr reader: same byte-level shape.
     tokio::spawn(async move {
-        let mut reader = BufReader::new(stderr).lines();
+        let mut reader = BufReader::new(stderr);
         loop {
-            match reader.next_line().await {
-                Ok(Some(line)) => {
+            let mut buf = Vec::with_capacity(256);
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) => return,
+                Ok(_) => {
                     if tx_stderr
-                        .send(LineEvent {
-                            kind: "stderr",
-                            text: line,
-                        })
+                        .send(LineEvent { kind: "stderr", bytes: buf })
                         .await
                         .is_err()
                     {
                         return;
                     }
                 }
-                Ok(None) => return,
                 Err(e) => {
                     tracing::warn!(target: "bashwrap", error = %e, "stderr read error");
                     return;
@@ -366,29 +371,39 @@ async fn run_proc(
     let buffered_clone = buffered.clone();
     let publisher_handle = tokio::spawn(async move {
         while let Some(event) = rx.recv().await {
-            // Aggregate into the model-visible buffer first. Stderr
-            // lines are prefixed so Claude can reason about them
-            // distinctly when it reads the tool_result blob.
+            // Aggregate raw bytes into the model-visible buffer
+            // FIRST, before any UTF-8 conversion — preserves binary
+            // output fidelity. Stderr lines are prefixed so Claude
+            // can reason about them distinctly in the tool_result.
+            // `event.bytes` already includes the trailing `\n` from
+            // read_until (or omits it on the final EOF fragment).
             {
                 let mut buf = buffered_clone.lock().await;
                 if event.kind == "stderr" {
                     buf.extend_from_slice(b"[stderr] ");
                 }
-                buf.extend_from_slice(event.text.as_bytes());
-                buf.push(b'\n');
+                buf.extend_from_slice(&event.bytes);
             }
 
-            // Stream chunk over WPS. Best-effort: a publish failure
-            // doesn't abort the command (the buffer already has the
-            // line). The frontend will see the line on `tool_result`
-            // even if the chunk never arrived.
+            // For the WPS chunk, the wire format is JSON so we must
+            // produce a String. `from_utf8_lossy` replaces invalid
+            // sequences with U+FFFD rather than aborting, preserving
+            // the model-visible blob's fidelity (kept above) while
+            // still publishing a readable line for the overlay.
+            // Strip the trailing `\n` from the chunk content so the
+            // frontend renderer doesn't add a stray blank line.
             if let Some(client) = wps_clone.as_ref() {
+                let mut line_bytes: &[u8] = &event.bytes;
+                if line_bytes.last() == Some(&b'\n') {
+                    line_bytes = &line_bytes[..line_bytes.len() - 1];
+                }
+                let line_str = String::from_utf8_lossy(line_bytes);
                 if let Err(e) = publish_line(
                     client,
                     &tool_id,
                     block_id.as_deref(),
                     event.kind,
-                    &event.text,
+                    &line_str,
                 )
                 .await
                 {

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.810"
+version = "0.33.811"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.809"
+version = "0.33.810"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.811"
+version = "0.33.812"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.810"
+version = "0.33.811"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.811"
+version = "0.33.812"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.809"
+version = "0.33.810"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.810"
+version = "0.33.811"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.811"
+version = "0.33.812"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.809"
+version = "0.33.810"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.809"
+version = "0.33.810"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.811"
+version = "0.33.812"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.810"
+version = "0.33.811"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md
+++ b/docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md
@@ -1,0 +1,283 @@
+# Retro — live-log streaming, the wrapper that didn't work
+
+**Date:** 2026-05-11
+**Owner:** AgentA
+**Surface area:** `agentmux-bashwrap`, `agentmux-srv` (websocket + agent_config), `frontend/app/view/agent` log overlay
+**PR sequence:** #800 → #803 → #804 → #808 (replaceChild hotfix) → #813 (settings.json hotfix) → **next** (wrapper rewrite)
+**Status:** Streaming still doesn't work end-to-end at 0.33.808. This retro is being written while the wrapper rewrite (PR γ) is being planned.
+
+---
+
+## 0. TL;DR
+
+We designed a sound architecture (analysis doc → spec → 3 PRs) but the implementation deviated from the design in two ways that we didn't flag at the time, and the wrapper binary that resulted has three independent bugs:
+
+1. **Wrong hook discovery file.** β.B wrote `.claude/hooks.json`; Claude Code only reads `.claude/settings.json` under a `"hooks"` key. Fixed in PR #813.
+2. **Wrapper's spawned child dies before producing output.** `portable_pty::CommandBuilder("cmd").args(["/C", cmd])` returns child exit code `-1073741502` (`0xC0000142`, `STATUS_DLL_INIT_FAILED`) on Win10 19045 for *every* command, including `echo hello`. **Root cause confirmed via research:** the wrapper drops `pair.master` immediately after cloning the reader; per the portable-pty maintainer, ConPTY can't tolerate that — dropping the master mid-startup is the canonical anti-pattern that produces exactly this error code. The same `CommandBuilder` pattern works in `agentmux-srv/.../shell.rs` because there `master` is moved into a long-lived task.
+3. **Env vars don't propagate.** The wrapper logs `streaming disabled (auth/url env missing)` when invoked inside Claude — meaning `AGENTMUX_AUTH_KEY` and `AGENTMUX_LOCAL_URL` aren't reaching it even when websocket.rs's `agent_input` handler explicitly injects them for the Claude spawn. Unverified which of the five spawn hops drops them; instrumentation in the rewrite will tell us.
+
+The new theory: drop `portable_pty` and `cmd /C` entirely from the wrapper; use `tokio::process::Command` with `Stdio::piped()` running `bash -c`. Plain pipes give us line streaming, which is all the live-log feature actually needs, and they sidestep the ConPTY lifetime footgun entirely. We could alternatively keep PTY and fix only the `master`-drop bug (one-line diff), but the costs of carrying portable_pty in a binary that doesn't need TTY semantics aren't worth the spinner fidelity. **Online research validates this direction:** the wezterm maintainer's recommendation for stream-capture use cases is explicitly "use plain `std::process::Command` + `Stdio::piped()`," and the Anthropic Agent SDK provides no help here either ([open issue #213](https://github.com/anthropics/claude-agent-sdk-typescript/issues/213)).
+
+---
+
+## 1. Timeline
+
+| Day | What happened |
+|---|---|
+| 2026-05-11 morning | TOOL_OUTPUT_STREAMING analysis doc written. Conclusion: option B-hard (MCP bash + PreToolUse deny). |
+| 2026-05-11 mid-day | SPEC_STREAMING_BASH_RUNNER detailed: tool_chunk wire format, WPS subject naming, head/tail truncation. |
+| 2026-05-11 PRs landed | #800 (reducer + types) → #803 (overlay UI) → #804 (β.A: `agentmux-bashwrap` crate). |
+| 2026-05-11 evening | β.B (#809-equivalent) wired bashwrap into agentmux-srv: HTTP publish endpoint, env injection, hook auto-injection, frontend WPS subscription. Build 0.33.804 packaged for smoke test. |
+| 2026-05-11 late | Smoke test fails — overlay shows time hover but no streaming text. Diagnosis: sidecar log has zero `bashwrap` / `PreToolUse` mentions. Root cause: hook auto-injected at `.claude/hooks.json` which Claude Code does not read. |
+| 2026-05-11 night | PR #813 force-pushed to write `.claude/settings.json` under `"hooks"` key, with user-PreToolUse prepended. Reagent approved on round 2; codex re-review pending. Smoke build 0.33.808 ships. |
+| 2026-05-11 night (this retro) | User runs 0.33.808 — `.claude/settings.json` IS written now, hook IS firing, **but every bash command fails**. Sidecar log shows `task_started → task_notification status=failed` within ms. Standalone wrapper test reveals child exits with `STATUS_DLL_INIT_FAILED` *before* producing any output. Hook discovery is fixed; spawn is broken. |
+
+---
+
+## 2. The first solution — what was designed and why
+
+The analysis doc landed on **Option B-hard**:
+
+> Extend the existing `agentmux-mcp` server with a `bash` tool whose execution path: (1) generates / receives a `tool_use_id`, (2) spawns a PTY-backed `bash -c "$command"`, (3) streams stdout+stderr to a new WPS subject keyed by `tool_use_id`, (4) buffers full output, (5) returns buffered output to Claude as the MCP `tool_result`. To guarantee Claude routes through it, add a `PreToolUse` hook on native `Bash` that returns `permissionDecision: "deny"` with reason "Use `mcp__agentmux__bash` instead."
+
+Why this and not the alternatives:
+
+- **Option A (post-hoc synthesis from `tool_result`)** — rejected as an anti-feature: rendering a 3-minute command's output all at once at the end of the run feels worse than the existing spinner because the user is conditioned to expect live streams. We did briefly consider shipping A as a stepping stone for the overlay UI; in the end the overlay was small enough to ship without it.
+- **Option C (replace Claude CLI with Agent SDK)** — 4-6 week scope, touches auth, session resume, slash commands, partial-message handling, and breaks Codex/Gemini parity since they have no equivalent SDK. Out of scope for live-log work.
+
+**Implicit assumptions baked into B-hard that turned out to be wrong:**
+
+1. **"`agentmux-mcp` server already exists."** It doesn't — and never did. The analysis doc said *"AgentMux already injects an MCP server (`agentmux-srv/src/backend/agent_config.rs:230-293`)"* and we read that as "the server's a binary we can extend." It's not — it's just a `.mcp.json` config entry that points at a binary we never actually built. (Memory record: `reference_agentmux_mcp_nonexistent.md`.)
+2. **"`PreToolUse` can do deterministic routing via `permissionDecision: deny` with a redirect-reason."** Claude Code's hook contract does support deny + reason, but routing the model from "native Bash denied" → "mcp__agentmux__bash retry" depends on the model interpreting the reason text. It's not a hard guarantee — and given assumption #1 collapsed, we couldn't even test it.
+3. **"`.claude/hooks.json` is where project hooks live."** Wrong — `.claude/settings.json` under a `"hooks"` key is the real path. The analysis doc actually had this right in §5 and §7 ("`.claude/settings.json` (under `\"hooks\"` key — the real Claude Code discovery location)"), but the code in `agent_config.rs` predated the spec and was writing `.claude/hooks.json`. The spec text and the code never reconciled.
+4. **"PTY is the right transport because spinners."** True for `npm install` aesthetics, false for the actual live-log use case. The feature is *"see the log lines as they happen"* not *"see the spinner spin."* PTY is a hedge against a problem we don't have, and it locks us into platform-specific PTY shenanigans (ConPTY on Windows, openpty on macOS/Linux).
+
+---
+
+## 3. What we actually shipped — the deviation
+
+Because `agentmux-mcp` didn't exist, β.A took a different shape: a standalone binary `agentmux-bashwrap` with two subcommands:
+
+- `agentmux-bashwrap hook` — reads a PreToolUse JSON event on stdin, emits `updatedInput.command` that rewrites the bash command to invoke `agentmux-bashwrap exec` with the original command base64-encoded into argv.
+- `agentmux-bashwrap exec --tool-id=… --b64-cmd=…` — spawns `cmd /C <decoded>` (Windows) or `bash -c <decoded>` (Unix) via `portable_pty`, streams output to WPS via HTTP POST, and prints the aggregated output on stdout for Claude to capture as the `tool_result`.
+
+This is a **PreToolUse command rewrite** approach, *not* the MCP-tool-with-deny-hook approach the spec called for. The two are similar in effect but very different in failure modes:
+
+| | MCP tool + deny hook (spec) | Command-rewrite hook (shipped) |
+|---|---|---|
+| **Tool surface to Claude** | New tool `mcp__agentmux__bash` | Same `Bash` tool, rewritten command |
+| **Permission flow** | Native Bash denied, MCP tool may need its own allow | Same as native Bash |
+| **Routing reliability** | Depends on model picking up "use mcp__agentmux__bash instead" reason | Deterministic — the hook rewrites unconditionally |
+| **Hook lives at** | `.claude/settings.json` `"hooks"` key | `.claude/settings.json` `"hooks"` key |
+| **Wrapper invocation** | Via MCP stdio JSON-RPC | Via shell `agentmux-bashwrap exec …` |
+| **Output → Claude** | MCP `tool_result` (text content) | Wrapper prints to stdout, Claude reads as Bash `tool_result` |
+| **Wrapper crash mode** | MCP server stops responding → Claude shows error | Shell command exits non-zero → Claude shows `task_notification status=failed` |
+| **Provider parity** | Generalizes to Codex/Gemini if they support MCP | Generalizes to any provider with a "rewrite command" hook |
+
+The shipped form is **more deterministic** than the spec form (no model-reasoning dependency for routing) but **more fragile** at the shell layer — every command goes through a tiny binary whose own correctness is now load-bearing for *all* bash invocations the agent makes. Which brings us to:
+
+---
+
+## 4. The three failure modes
+
+### 4.1 Wrong hook discovery path (`hooks.json` vs `settings.json`)
+
+**Symptom:** sidecar log at 0.33.804 has zero mentions of `bashwrap`, `PreToolUse`, or `tool_chunk` even though tool_use events fire normally.
+
+**Diagnosis:** `agent_config.rs:223` (legacy path) wrote `.claude/hooks.json` from a `content_map["hooks"]` field that no agent had ever populated, so the wrong-file bug was dormant until β.B started writing the auto-injected PreToolUse there.
+
+**Fix (PR #813):** rename `build_hooks_config` → `build_settings_with_hooks`, write `.claude/settings.json` with the auto-injected `PreToolUse:Bash` entry under the top-level `"hooks"` key. User-supplied settings.json `PreToolUse` entries are *prepended* (round 2 of the fix, after codex P2) so they short-circuit ours.
+
+**Why we missed it in design:** the analysis doc had the right answer (§5 + §7 both mention `.claude/settings.json`), but the existing legacy code wrote `.claude/hooks.json`, and during implementation we extended the existing code path without re-reading the spec. **The spec was right, the code was wrong, and the reconciliation never happened.**
+
+Memory record: `reference_claude_code_hooks_location.md`.
+
+### 4.2 Wrapper child crashes with STATUS_DLL_INIT_FAILED
+
+**Symptom:** at 0.33.808, hook fires correctly — sidecar log shows `agentmux-bashwrap exec --tool-id=… --b64-cmd=…` for every bash call — but `task_started` is immediately followed by `task_notification status=failed`. Standalone reproduction:
+
+```
+$ agentmux-bashwrap exec --tool-id=t --b64-cmd=ZWNobyBoZWxsbw
+<exited -1073741502 in 0.07s>
+[bashwrap] warning: streaming disabled (auth/url env missing); command output will only appear on completion
+```
+
+`-1073741502` = `0xC0000142` = `STATUS_DLL_INIT_FAILED`. The wrapper itself ran (otherwise no `<exited …>` line), but the PTY child (`cmd.exe`) died 70ms after launch without producing any output, and the wrapper faithfully reported the exit code back.
+
+**Root cause (identified via research — wezterm discussion [#4674](https://github.com/wezterm/wezterm/discussions/4674)):** the wrapper drops `pair.master` immediately after cloning the reader:
+
+```rust
+// agentmux-bashwrap/src/bash_wrap.rs:253-257
+let mut reader = pair.master.try_clone_reader()?;
+drop(pair.slave);   // ← OK
+drop(pair.master);  // ← THIS is the anti-pattern
+```
+
+Per the wezterm maintainer (who maintains `portable-pty`), **ConPTY does not tolerate handle closure during child startup.** Dropping `pair.master` before the child has finished initializing causes the spawned process to fail with `STATUS_DLL_INIT_FAILED` — exactly our symptom. The comment in the wrapper code (*"Drop the master writer; we never inject stdin (interactive prompts deferred to PR γ+ per spec §14 open questions)"*) reflects a misunderstanding: on Windows, the master handle isn't just a writer to stdin — it's the *pseudoconsole anchor* for the child, and dropping it tears down ConPTY mid-startup.
+
+Why `agentmux-srv/.../shell.rs:450` works with the same `CommandBuilder` pattern: it stores `pair.master` in a long-lived task (line 788: `let master = pair.master; tokio::spawn(async move { ... });`) so the master outlives the child. The wrapper code took a shortcut for the "no stdin injection" case and broke ConPTY in the process.
+
+**Two fix paths:**
+
+1. **Minimal-diff fix: keep `pair.master` alive.** Don't drop it until after `child.wait()` returns. ~5 lines changed. Preserves PTY semantics (spinners, ANSI redraws).
+2. **Larger refactor: drop `portable_pty` entirely, use `tokio::process::Command` + `Stdio::piped()`.** Loses PTY semantics but is simpler code, fewer Windows footguns, and cross-platform consistent.
+
+Given the live-log feature wants *line streaming* (not spinner fidelity), and the codebase already has another consumer of `portable_pty` working correctly, **path 2 is the recommended choice for v1 of the wrapper.** PTY can come back as a follow-up if/when we actually want progress-bar fidelity, and at that point we'll know exactly which anti-pattern to avoid.
+
+**New theory (the fix in flight):** stop using `portable_pty` + `cmd /C` entirely. The live-log feature wants line-streaming, not PTY fidelity. Switch to `tokio::process::Command` with `Stdio::piped()` running `bash -c <command>`. Three reasons:
+
+1. **Sidesteps ConPTY init.** Plain pipe spawning on Windows uses the same CreateProcessW path Node.js, Go, Rust std, and every other language uses successfully. No pseudoconsole attach, no STATUS_DLL_INIT_FAILED risk.
+2. **Bash, not cmd.** Claude sends bash syntax (`2>&1`, `[[ -f x ]]`, `pipefail`). `cmd /C` of a bash command works for the simple cases by accident and breaks for the real cases silently. Using `bash` matches what Claude's native Bash tool does internally.
+3. **Cross-platform parity.** Same code path on Win + Linux + macOS. Locate bash via `$BASH` env → `which bash` PATH search → well-known Windows paths (`C:\Program Files\Git\bin\bash.exe`, etc.).
+
+The tradeoff we lose: `npm install`'s `[==>] 50%` progress bar won't animate live, because `npm` checks `isatty(stdout)` and emits flat text when piped. For the *log* feature that's fine — the spinner/progress aesthetic is nice-to-have, line-streaming is the actual ask.
+
+### 4.3 Env propagation drops `AGENTMUX_AUTH_KEY` / `AGENTMUX_LOCAL_URL`
+
+**Symptom:** every wrapper invocation prints `[bashwrap] warning: streaming disabled (auth/url env missing)` — even though `agentmux-srv/src/server/websocket.rs:857` explicitly injects `AGENTMUX_AUTH_KEY` into `env_vars` for the Claude spawn, and `agentmux-srv/src/main.rs:498` sets `AGENTMUX_LOCAL_URL` in the parent process env (which should inherit).
+
+**Chain:** agentmux-srv → portable_pty spawn of `claude` → claude reads env → claude spawns `bash` (for tool) inheriting env → bash spawns `agentmux-bashwrap hook` (via PreToolUse) inheriting env → bash spawns `agentmux-bashwrap exec` (after hook rewrites command) inheriting env. Five hops.
+
+**Status:** unverified — we never instrumented the wrapper to log which env vars it actually receives. Right now we can't tell which of the five hops is dropping the vars. Adding `tracing::info!` in `WpsClient::from_env` to log the keys it sees is a one-line fix that should land in the same PR as the spawn rewrite, so we get diagnostic visibility on the next smoke test.
+
+---
+
+## 5. The new theory — pipe-based, bash-based, observable
+
+```
+                                  hook subcommand
+                                  (unchanged: rewrite cmd → b64)
+                                            │
+                                            ▼
+                                  agentmux-bashwrap exec --tool-id=… --b64-cmd=…
+                                            │
+                                            ▼
+                                  tokio::process::Command::new(locate_bash())
+                                       .arg("-c").arg(decoded_command)
+                                       .stdin(Stdio::null())
+                                       .stdout(Stdio::piped())
+                                       .stderr(Stdio::piped())
+                                       .spawn()
+                                            │
+                          ┌─────────────────┼──────────────────┐
+                          ▼                 ▼                  ▼
+                  read stdout lines   read stderr lines    wait for exit
+                          │                 │                  │
+                          └──────┬──────────┘                  │
+                                 ▼                             ▼
+                         publish to WPS                   forward exit code
+                         (HTTP POST chunk:<id>)           to wrapper exit
+                                 │
+                                 ▼
+                         frontend WPS sub
+                         → dispatchDoc(ToolChunkAppend)
+```
+
+Key properties:
+
+- **No PTY.** No ConPTY init, no STATUS_DLL_INIT_FAILED.
+- **Bash on Windows.** Found at runtime via `$BASH`, `$AGENTMUX_BASH`, `which bash`, then fallback to `C:\Program Files\Git\bin\bash.exe`. Fail-loud (not pass-through) if not found.
+- **Diagnostic env logging.** First thing the `exec` subcommand does is `tracing::info!(target: "bashwrap", env_keys = ?relevant_env_keys())` so the sidecar log tells us if `AGENTMUX_AUTH_KEY` / `AGENTMUX_LOCAL_URL` arrived.
+- **Single dependency drop.** `portable_pty` removed from `agentmux-bashwrap/Cargo.toml`. The crate stays small.
+- **Same public contract.** Hook subcommand unchanged. `exec` argv unchanged. WPS publish payload unchanged. No frontend changes.
+
+---
+
+## 6. Online research findings
+
+### 6.1 Claude Code hooks — the canonical contract
+
+- **File on disk:** project hooks live at `.claude/settings.json` (committable). User-level at `~/.claude/settings.json`. Gitignored overrides at `.claude/settings.local.json`. `.claude/hooks.json` is **not** a discovery location.
+- **URL gotcha:** `docs.claude.com/en/docs/claude-code/hooks` now 301-redirects to `code.claude.com/docs/en/hooks` (verified 2026-05-11). Same content; the old URL just isn't canonical.
+- **Two `hooks` keys.** The wire shape is `{ "hooks": { "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "..." }] }] } }`. Outer object key + inner array key — frequent config-bug source. Our `build_settings_with_hooks` emits the correct nesting.
+- **`permissionDecision` enum:** `"allow" | "deny" | "ask" | "defer"`. Our hook emits `"allow"` with `updatedInput.command` set, which is the documented pattern for command rewriting.
+- **Hook stdin/stdout contract:**
+  - stdin: `{session_id, transcript_path, cwd, hook_event_name: "PreToolUse", tool_name, tool_input: {command, description, timeout, run_in_background}, tool_use_id}`
+  - stdout (on exit 0): `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "...", "permissionDecisionReason": "...", "updatedInput": {"command": "..."}, "additionalContext": "..."}}`
+  - exit codes: `0` = parse stdout JSON; `2` = blocking error (stderr surfaced to Claude); other non-zero = non-blocking (stderr to transcript).
+- **Chained-command matcher caveat:** the `if` Bash matcher strips leading `VAR=value` and matches each subcommand of `&&`/`||`/`;` chains independently. Our matcher `"^(Bash|.*[Bb]ash.*)$"` doesn't use the `if` form — it's a plain `matcher` regex on `tool_name` — so this doesn't affect us, but it's worth knowing if we ever want to selectively wrap (e.g. only `npm` / `gh` commands).
+
+### 6.2 Agent SDK doesn't help (yet)
+
+- `includePartialMessages: true` yields `stream_event` envelopes around the raw Anthropic API events: `message_start`, `content_block_start`, `content_block_delta` (text or `input_json_delta`), `content_block_stop`, `message_delta`, `message_stop`. Same shape as `claude --output-format stream-json` — the SDK is a thin wrapper.
+- **The gap:** streaming covers the model's response generation only. Once `tool_use` finishes, execution happens silently; Claude only emits the next `message_start` after `tool_result` is appended. **No `tool_execution_output` event exists.**
+- Open feature request: [anthropics/claude-agent-sdk-typescript#213](https://github.com/anthropics/claude-agent-sdk-typescript/issues/213) (opened 2026-03-05, still open, no Anthropic comment as of 2026-05-11) requests exactly `tool_execution_start/output/end` events. **Not implemented.**
+- `canUseTool` callback intercepts before execution (permission decision + `updatedInput`) but gives no handle to the running process. No documented in-progress subscription.
+
+**Implication for AgentMux:** the spec-doc conclusion ("don't wait on `tool_output_delta`") still holds. Host-side interception via hook + wrapper remains the right path until/unless Anthropic ships #213.
+
+### 6.3 `portable-pty` Windows ConPTY — known root cause
+
+Per [wezterm discussion #4674](https://github.com/wezterm/wezterm/discussions/4674) (wez, the maintainer) and [issue #4206](https://github.com/wezterm/wezterm/issues/4206):
+
+- **Primary root cause of `0xC0000142`:** dropping the `PtyPair` / `master` / reader / writer too early. ConPTY cannot tolerate handle closure during child startup — the child returns immediately with `STATUS_DLL_INIT_FAILED`.
+- **Canonical anti-pattern:** returning `Box<dyn Child + Send + Sync>` from a function while `pair` falls out of scope in the caller. Same shape as our wrapper's eager `drop(pair.master)`.
+- **Fix recipe (per wez):**
+  1. Keep `pair.master` alive in the same scope as the I/O copy loop. Don't drop until after `child.wait()` returns.
+  2. Run `child.wait()` on a dedicated thread, separate from the read/write loops.
+  3. Don't `env_clear()` without seeding `SystemRoot` and `PATH` — `cmd.exe` needs these DLLs to init.
+  4. Make sure `cwd` points at a real existing directory.
+  5. **If you only need stream capture (no TTY semantics), use plain `std::process::Command` + `Stdio::piped()`.** Far fewer Windows footguns.
+
+The match between this list and our wrapper's bug list is near-perfect — we hit #1 head-on. Path 5 (plain pipes) is what the new theory adopts; it sidesteps the entire class of issues.
+
+### 6.4 Survey of approaches to wrap a sub-agent's bash
+
+| Approach | Fidelity | Robustness | Complexity |
+|---|---|---|---|
+| **(a) PreToolUse hook command rewriting** *(our approach)* | High — raw bytes, ANSI preserved, real-time | Medium — depends on `updatedInput` semantics holding stable; shell-quoting edge cases; chained commands need care | Low–Medium — config + tiny wrapper binary |
+| **(b) MCP server providing custom Bash tool** | High — full control + can stream via MCP notifications | High — official extension point; survives SDK upgrades | Medium-High — reimplement Bash semantics (cwd persistence, timeouts, background, env); must denylist built-in Bash via `disallowedTools` |
+| **(c) Agent SDK + intercept `tool_use_id` chunks** | Low for execution — input deltas only, no execution output (issue #213). Still needs (a) or (b) underneath. | High at the SDK layer | High and **doesn't solve the problem** until #213 lands |
+
+**Verdict for an IDE wrapper today:** (a) is the right pragmatic choice — minimal surface area, fidelity to actual stdout/stderr bytes, no need to reimplement Bash semantics. (b) becomes attractive if/when we want sandboxing/policy/multi-tenant isolation (since the MCP server then owns the process tree). (c) is a non-starter on its own.
+
+### 6.5 Sources
+
+- [Claude Code Hooks](https://code.claude.com/docs/en/hooks) — canonical; docs.claude.com redirects here.
+- [Agent SDK streaming output](https://code.claude.com/docs/en/agent-sdk/streaming-output)
+- [claude-agent-sdk-typescript#213](https://github.com/anthropics/claude-agent-sdk-typescript/issues/213) — open feature request for tool-execution streaming events
+- [wezterm discussion #4674](https://github.com/wezterm/wezterm/discussions/4674) — `STATUS_DLL_INIT_FAILED` root cause analysis from the portable-pty maintainer
+- [wezterm issue #4206](https://github.com/wezterm/wezterm/issues/4206) — portable-pty Windows write failures
+- [portable-pty `CommandBuilder` rustdoc](https://docs.rs/portable-pty/latest/portable_pty/cmdbuilder/struct.CommandBuilder.html)
+- [Bringing Claude Code Sub-agents to Any MCP-Compatible Tool](https://dev.to/shinpr/bringing-claude-codes-sub-agents-to-any-mcp-compatible-tool-1hb9) — survey post
+- [MCP — Claude API Docs](https://platform.claude.com/docs/en/agent-sdk/mcp)
+
+---
+
+## 7. Lessons
+
+1. **When the spec and the existing code disagree, reconcile in a separate commit before building on top.** The `.claude/hooks.json` path was wrong in the legacy code; the spec said `.claude/settings.json`. We extended the legacy path. **One sentence of "wait, the spec says the other file — let me fix the legacy first" would have saved a smoke build.**
+
+2. **Don't assume a binary exists from a config-file reference.** `agentmux-mcp` appeared in `.mcp.json` injection logic; we assumed it was a real binary we could extend. It wasn't. **Grep for the binary name in the build system before scoping work that depends on it.**
+
+3. **Reuse working code instead of reinventing.** `agentmux-srv/.../shell.rs` spawns processes via `portable_pty` + ConPTY successfully every day. The wrapper's spawn code was written from scratch and ran into a problem the working code had already solved. **If a pattern works elsewhere in the codebase, start from a copy of it.**
+
+4. **PTY is a hedge, not a default.** "We might want spinner fidelity later" cost us a wedged feature. The right move was plain pipes + `bash -c` for v1, PTY in a follow-up if/when we actually want progress bars.
+
+5. **Instrument before you ship the feature.** The "env vars not arriving" bug would have been one log line away from diagnosis if the wrapper logged its env on every invocation. We're adding that in the rewrite — should have been there in β.A.
+
+6. **Smoke test the seam, not just the unit.** β.A had unit tests for hook JSON parsing, base64 round-tripping, and head/tail truncation. None of them spawned a real child. The first time `cmd /C echo` ran inside the wrapper was on the user's machine.
+
+7. **Read the platform-specific lifetime contracts before writing platform code.** The `drop(pair.master)` that broke us was added with a comment explaining *why* we were dropping it (no stdin injection needed). That's a great answer to the Unix question (master holds the writer; drop frees it) and the wrong answer to the Windows question (master is the pseudoconsole anchor; dropping it kills the child). A 30-second skim of the portable-pty docs or the wezterm issue tracker would have caught this. **When using a cross-platform abstraction, the Windows lifetime contract is usually the strictest — start there.**
+
+---
+
+## 8. Forward plan
+
+1. **(in flight)** PR #813 — `.claude/settings.json` hook discovery fix. Reagent approved; codex re-review pending after force-push to f311f0f0. Merge once codex green.
+2. **(next)** PR γ — wrapper rewrite. Drop `portable_pty`, use `tokio::process` with piped stdout/stderr, run via `bash -c`. Add env-trace logging. Bump 0.33.810. Smoke test inside Claude pane.
+3. **(after γ smoke)** Investigate env propagation: if `bashwrap` logs show `AGENTMUX_AUTH_KEY` / `AGENTMUX_LOCAL_URL` missing, walk the spawn chain from agentmux-srv outward to find which hop drops them.
+4. **(post-streaming)** Decide whether PTY is worth a follow-up — the plain-pipes path may be good enough that the spinner-fidelity work never lands.
+
+---
+
+## 9. Cross-references
+
+- Original analysis: [`docs/analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md`](../analysis/TOOL_OUTPUT_STREAMING_2026_05_11.md)
+- Detailed spec: [`docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md`](../specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md)
+- Live-log data shape: [`docs/specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md`](../specs/SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md)
+- Wrapper source: `agentmux-bashwrap/src/{main,hook,bash_wrap,wps_client}.rs`
+- Hook auto-injection: `agentmux-srv/src/backend/agent_config.rs:111-128` (post-PR #813)
+- Env injection at Claude spawn: `agentmux-srv/src/server/websocket.rs:843-867`
+- WPS publish endpoint: `agentmux-srv/src/server/mod.rs` `handle_wps_publish`
+- Frontend WPS subscription: `frontend/app/view/agent/useAgentStream.ts` chunkSubs map

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.809",
+  "version": "0.33.810",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.809",
+      "version": "0.33.810",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.810",
+  "version": "0.33.811",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.810",
+      "version": "0.33.811",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.811",
+  "version": "0.33.812",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.811",
+      "version": "0.33.812",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.811",
+  "version": "0.33.812",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.809",
+  "version": "0.33.810",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.810",
+  "version": "0.33.811",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

The wrapper crashed every Bash tool call inside Claude on Windows. Standalone repro showed the spawned `cmd /C` child exiting with `STATUS_DLL_INIT_FAILED` (0xC0000142) in ~70ms, before producing a single byte. Root cause: the wrapper drops `pair.master` immediately after cloning the reader, which per the portable-pty maintainer tears down ConPTY mid-startup ([wezterm discussion #4674](https://github.com/wezterm/wezterm/discussions/4674)). The same `CommandBuilder` pattern works in `agentmux-srv/.../shell.rs` only because there `pair.master` is moved into a long-lived `tokio::spawn` task.

Two fix paths existed:

1. **Minimal**: keep `pair.master` alive across `child.wait()` — preserves PTY (~5 lines).
2. **Larger**: drop `portable_pty` entirely for `tokio::process::Command` + `Stdio::piped()`.

This PR picks (2). The live-log feature wants line streaming, not spinner fidelity, and plain pipes sidestep the entire ConPTY lifetime class. Tradeoff acknowledged: `npm install`'s CR-only progress bars won't animate live (npm checks `isatty` before emitting them). The "log" feature is about lines anyway; PTY-only behaviors are a follow-up if/when we want them back, and we now know exactly which contract to honor.

### What changed
- `tokio::process::Command` with `Stdio::piped()` for stdout + stderr — read concurrently via `BufReader::lines()`.
- `bash -c <command>` instead of `cmd /C` — matches what Claude's native Bash tool uses, and what Claude actually sends syntactically (`[[ ]]`, `pipefail`, `2>&1`, …).
- Bash located via `$AGENTMUX_BASH` > `$BASH` > `which bash` > well-known Windows paths (Git Bash / msys2). Fail-loud if not found.
- Each stdout / stderr line published as its own `tool_chunk` with `kind` set to `"stdout"` or `"stderr"`. Stderr lines also prefixed `[stderr] ` in the aggregated `tool_result` blob.
- `tracing::info!` of streaming-relevant env vars on entry — presence-only, auth key value never logged — so the next smoke test diagnoses the `AGENTMUX_AUTH_KEY` / `AGENTMUX_LOCAL_URL` propagation gap from a single sidecar log line.
- Drops `portable-pty` dep; adds `which`.

### Retro
Full retrospective at `docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md` — covers original design vs. shipped form, all three failure modes (hook discovery, ConPTY child crash, env propagation), online research findings, and 7 lessons.

## Test plan
- [x] `cargo test -p agentmux-bashwrap` — 20 tests pass
- [x] Standalone: `agentmux-bashwrap exec --tool-id=t --b64-cmd=ZWNobyBoZWxsbw` → exit 0, prints "hello"
- [x] Standalone: `agentmux-bashwrap exec --tool-id=t --b64-cmd=Z2ggYXV0aCBzdGF0dXMgMj4mMQ` → exit 0, prints real `gh auth status` output
- [ ] Smoke build 0.33.809 inside Claude pane — verify live streaming in the overlay + env presence in sidecar log
- [ ] If env vars still missing in sidecar log, walk the spawn chain (agentmux-srv → claude → bash → hook → wrapper) — follow-up PR

## Sequencing
Depends on #813 (`.claude/settings.json` hook discovery fix) landing first — without it the hook never fires regardless of wrapper correctness. This PR is the second half of the live-log streaming fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)