### PR TITLE
feat(named-agents): launch modal Continue dropdown + v8 schema + RPCs (#94)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.816"
+version = "0.33.817"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.816"
+version = "0.33.817"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.816"
+version = "0.33.817"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.816"
+version = "0.33.817"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.816"
+version = "0.33.817"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.815"
+version = "0.33.816"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.815"
+version = "0.33.816"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.815"
+version = "0.33.816"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.815"
+version = "0.33.816"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.815"
+version = "0.33.816"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1558,9 +1558,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbz2-rs-sys"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a6a8c165077efc8f3a971534c50ea6a1a18b329ef4a66e897a7e3a1494565f"
+checksum = "f8fc329e1457d97a9d58a4e2ca49e3be572431a7e096008efc2e3a3c19d428f4"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.814"
+version = "0.33.815"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.814"
+version = "0.33.815"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.814"
+version = "0.33.815"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.814"
+version = "0.33.815"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.814"
+version = "0.33.815"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.814"
+version = "0.33.815"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.816"
+version = "0.33.817"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.815"
+version = "0.33.816"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.814"
+version = "0.33.815"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.816"
+version = "0.33.817"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.815"
+version = "0.33.816"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.815"
+version = "0.33.816"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.814"
+version = "0.33.815"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.816"
+version = "0.33.817"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.814"
+version = "0.33.815"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.816"
+version = "0.33.817"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.815"
+version = "0.33.816"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.816"
+version = "0.33.817"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.814"
+version = "0.33.815"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.815"
+version = "0.33.816"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -594,13 +594,41 @@ mod tests {
     }
 
     #[test]
-    fn test_build_config_files_settings_written() {
+    fn test_build_config_files_settings_merges_user_hooks() {
         // PR #813 moved hooks from `.claude/hooks.json` (a Claude Code
         // dead-letter path) to `.claude/settings.json` under the
-        // `"hooks"` key (the real discovery location).
-        let content_map = HashMap::new();
+        // `"hooks"` key. This test exercises the merge path: user
+        // PreToolUse entries must be PREPENDED (not silently
+        // dropped) to the auto-injected bashwrap entry so streaming
+        // stays on while user-supplied gates fire first.
+        let mut content_map = HashMap::new();
+        content_map.insert(
+            "hooks".to_string(),
+            r#"{"PreToolUse":[{"matcher":"Read","hooks":[{"type":"command","command":"my-audit"}]}]}"#
+                .to_string(),
+        );
         let files = build_config_files(&content_map, &[], "Aria", "agent-1");
-        assert!(files.iter().any(|f| f.filename == ".claude/settings.json"));
+        let settings = files
+            .iter()
+            .find(|f| f.filename == ".claude/settings.json")
+            .expect("settings.json emitted");
+        let parsed: Value = serde_json::from_str(&settings.content).unwrap();
+        let pre_tool_use = parsed["hooks"]["PreToolUse"]
+            .as_array()
+            .expect("PreToolUse is an array");
+        // User's "Read" matcher prepended first, then our Bash matcher.
+        assert!(
+            pre_tool_use
+                .iter()
+                .any(|e| e["matcher"].as_str() == Some("Read")),
+            "user-supplied PreToolUse:Read must survive the merge"
+        );
+        assert!(
+            pre_tool_use
+                .iter()
+                .any(|e| e["matcher"].as_str().unwrap_or("").contains("Bash")),
+            "auto-injected PreToolUse:Bash must still be present"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/agent_config.rs
+++ b/agentmux-srv/src/backend/agent_config.rs
@@ -594,12 +594,13 @@ mod tests {
     }
 
     #[test]
-    fn test_build_config_files_hooks_written() {
-        let mut content_map = HashMap::new();
-        content_map.insert("hooks".to_string(), r#"{"hooks":[]}"#.to_string());
-
+    fn test_build_config_files_settings_written() {
+        // PR #813 moved hooks from `.claude/hooks.json` (a Claude Code
+        // dead-letter path) to `.claude/settings.json` under the
+        // `"hooks"` key (the real discovery location).
+        let content_map = HashMap::new();
         let files = build_config_files(&content_map, &[], "Aria", "agent-1");
-        assert!(files.iter().any(|f| f.filename == ".claude/hooks.json"));
+        assert!(files.iter().any(|f| f.filename == ".claude/settings.json"));
     }
 
     #[test]

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1640,10 +1640,18 @@ pub struct CommandCreateAgentInstanceData {
 /// Request for `listnamedagents`. The launch modal's "Continue
 /// agent" dropdown calls this; an absent / zero `limit` defaults to
 /// 200 (capped at 1000 to keep the wire payload bounded).
+///
+/// `definition_id` is server-side filtering: when provided, only
+/// instances of that definition are returned. Required for the
+/// dropdown to behave correctly when a user has 200+ named agents
+/// across many definitions — without server filtering, the current
+/// definition's older instances could fall off the global cap.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CommandListNamedAgentsData {
     #[serde(default)]
     pub limit: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub definition_id: Option<String>,
 }
 
 /// One row of the launch modal's "Continue agent" dropdown. Joins

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1617,6 +1617,17 @@ pub struct CommandCreateAgentInstanceData {
     /// modal's Memory dropdown.
     #[serde(default)]
     pub memory_id: String,
+    /// User-chosen instance name (becomes `AGENTMUX_AGENT_ID` in the
+    /// spawn env). Powers the launch modal's "Continue agent"
+    /// dropdown. Empty = un-named, won't appear in the dropdown.
+    #[serde(default)]
+    pub instance_name: String,
+    /// Absolute working directory path resolved by
+    /// `allocate_agent_workdir` at spawn time. Stored on the instance
+    /// row so the continue flow can reuse it without re-deriving the
+    /// slug.
+    #[serde(default)]
+    pub working_directory: String,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -326,6 +326,13 @@ pub const COMMAND_GET_AGENT_INSTANCE: &str = "getagentinstance";
 pub const COMMAND_CREATE_AGENT_INSTANCE: &str = "createagentinstance";
 pub const COMMAND_UPDATE_AGENT_INSTANCE: &str = "updateagentinstance";
 pub const COMMAND_DELETE_AGENT_INSTANCE: &str = "deleteagentinstance";
+/// v8 — list named agent instances for the launch modal's "Continue
+/// agent" dropdown. Filters to non-hidden rows with a non-empty
+/// instance_name, joined with definition + identity + memory bundles.
+pub const COMMAND_LIST_NAMED_AGENTS: &str = "listnamedagents";
+/// v8 — soft-delete (hide) a named agent instance from the dropdown.
+/// Row + working directory remain on disk for audit + recovery.
+pub const COMMAND_HIDE_NAMED_AGENT: &str = "hidenamedagent";
 
 // Agent definition branching
 pub const COMMAND_FORK_AGENT_DEFINITION: &str = "forkagentdefinition";
@@ -1628,6 +1635,45 @@ pub struct CommandCreateAgentInstanceData {
     /// slug.
     #[serde(default)]
     pub working_directory: String,
+}
+
+/// Request for `listnamedagents`. The launch modal's "Continue
+/// agent" dropdown calls this; an absent / zero `limit` defaults to
+/// 200 (capped at 1000 to keep the wire payload bounded).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CommandListNamedAgentsData {
+    #[serde(default)]
+    pub limit: usize,
+}
+
+/// One row of the launch modal's "Continue agent" dropdown. Joins
+/// `db_agent_instances` with `db_forge_agents` (for the definition's
+/// display name + provider) and `db_identities` / `db_memories` (for
+/// bundle names) so the frontend renders without further lookups.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NamedAgentRow {
+    pub instance_id: String,
+    pub instance_name: String,
+    pub definition_id: String,
+    pub definition_name: String,
+    pub provider: String,
+    pub working_directory: String,
+    pub identity_id: String,
+    pub identity_name: String,
+    pub memory_id: String,
+    pub memory_name: String,
+    pub started_at: i64,
+    pub ended_at: i64,
+    pub status: String,
+    pub block_id_hint: String,
+}
+
+/// Request for `hidenamedagent`. Sets `display_hidden = 1` on the
+/// row. Row + working directory remain on disk for audit + recovery
+/// (destructive deletion is a separate, confirm-gated flow).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandHideNamedAgentData {
+    pub id: String,
 }
 
 /// Mutable subset of AgentInstance for PATCH-style updates. Every field is

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -125,6 +125,7 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
     run_forge_v5_migrations(conn)?;
     run_forge_v6_migrations(conn)?;
     run_forge_v7_migrations(conn)?;
+    run_forge_v8_migrations(conn)?;
     Ok(())
 }
 
@@ -611,6 +612,66 @@ pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
         "UPDATE db_agent_instances
          SET memory_id = definition_id
          WHERE memory_id = '' AND definition_id <> '';",
+    )?;
+
+    Ok(())
+}
+
+/// Forge v8 migrations: persist the human-readable instance name +
+/// resolved working directory on every `db_agent_instances` row so the
+/// launch modal can list past named agents and continue them. Adds a
+/// soft-delete column (`display_hidden`) for the "Forget agent"
+/// affordance — destructive deletion of the row + working dir is
+/// out of scope for v8 (separate confirm flow + spec).
+///
+/// See `docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md`.
+///
+/// Schema changes:
+///
+/// - `db_agent_instances.instance_name` (new column): user-chosen
+///   instance name (becomes `AGENTMUX_AGENT_ID` in the spawn env).
+///   Empty string for legacy rows — they don't appear in the dropdown.
+/// - `db_agent_instances.working_directory` (new column): absolute
+///   path returned by `allocate_agent_workdir` at spawn time. Stored
+///   here (rather than re-derived from the slug at continue-time) to
+///   stay robust against slug-rule changes and user-side renames.
+/// - `db_agent_instances.display_hidden` (new column, INTEGER 0/1):
+///   soft-delete flag for the "Forget agent" affordance. Hidden rows
+///   stay on disk for audit + recovery.
+///
+/// Idempotent: re-running after v8 has executed is a no-op
+/// ("duplicate column" errors are caught and ignored, matching v2/v7
+/// precedent).
+pub fn run_forge_v8_migrations(conn: &Connection) -> Result<(), StoreError> {
+    let alter_statements = [
+        "ALTER TABLE db_agent_instances ADD COLUMN instance_name TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_instances ADD COLUMN working_directory TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_instances ADD COLUMN display_hidden INTEGER NOT NULL DEFAULT 0",
+    ];
+    for stmt in &alter_statements {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("duplicate column") {
+                    return Err(StoreError::Sqlite(match e {
+                        rusqlite::Error::SqliteFailure(code, _) => {
+                            rusqlite::Error::SqliteFailure(code, Some(msg))
+                        }
+                        other => other,
+                    }));
+                }
+            }
+        }
+    }
+
+    // Partial index supports the `ListNamedAgentsCommand` query: rows
+    // with a non-empty instance_name and not hidden, ordered by
+    // recency. Keeps the dropdown lookup to a single b-tree scan.
+    conn.execute_batch(
+        "CREATE INDEX IF NOT EXISTS idx_agent_instances_name_recent
+            ON db_agent_instances(instance_name, started_at DESC)
+            WHERE display_hidden = 0 AND instance_name != '';",
     )?;
 
     Ok(())

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1544,9 +1544,32 @@ impl WaveStore {
     /// dropdown should surface: have a non-empty `instance_name`, not
     /// hidden, sorted by most-recent start. Capped to keep the
     /// dropdown's wire payload bounded.
-    pub fn instance_list_named(&self, limit: usize) -> Result<Vec<AgentInstance>, StoreError> {
+    ///
+    /// `definition_id`, when provided, restricts the result to
+    /// instances of that definition. Server-side filtering is
+    /// necessary because the launch modal opens per-definition: a
+    /// user with 200+ named agents across many definitions could
+    /// have the current definition's older instances cut off by a
+    /// purely global limit otherwise.
+    pub fn instance_list_named(
+        &self,
+        limit: usize,
+        definition_id: Option<&str>,
+    ) -> Result<Vec<AgentInstance>, StoreError> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let sql = if definition_id.is_some() {
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
+             FROM db_agent_instances
+             WHERE display_hidden = 0
+               AND instance_name <> ''
+               AND parent_instance_id = ''
+               AND definition_id = ?1
+             ORDER BY started_at DESC
+             LIMIT ?2"
+        } else {
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
                     status, github_context, started_at, ended_at, created_at,
                     identity_id, memory_id, instance_name, working_directory,
@@ -1556,9 +1579,13 @@ impl WaveStore {
                AND instance_name <> ''
                AND parent_instance_id = ''
              ORDER BY started_at DESC
-             LIMIT ?1",
-        )?;
-        let iter = stmt.query_map(params![limit as i64], map_instance_row)?;
+             LIMIT ?1"
+        };
+        let mut stmt = conn.prepare(sql)?;
+        let iter = match definition_id {
+            Some(def) => stmt.query_map(params![def, limit as i64], map_instance_row)?,
+            None => stmt.query_map(params![limit as i64], map_instance_row)?,
+        };
         let mut out = Vec::new();
         for r in iter {
             out.push(r?);

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1206,6 +1206,21 @@ pub struct AgentInstance {
     /// instantiation via the launch modal's Memory dropdown.
     #[serde(default)]
     pub memory_id: String,
+    /// User-chosen instance name (becomes `AGENTMUX_AGENT_ID` in the
+    /// spawn env). Empty for pre-v8 rows and for un-named launches.
+    /// Drives the "Continue agent" dropdown in the launch modal.
+    #[serde(default)]
+    pub instance_name: String,
+    /// Absolute path returned by `allocate_agent_workdir` at spawn.
+    /// Stored explicitly (rather than re-derived from the slug at
+    /// continue-time) so the continue flow is robust against
+    /// slug-rule changes and user-side renames.
+    #[serde(default)]
+    pub working_directory: String,
+    /// Soft-delete flag for the "Forget agent" affordance. Hidden
+    /// rows stay on disk for audit + recovery.
+    #[serde(default)]
+    pub display_hidden: bool,
 }
 
 impl WaveStore {
@@ -1428,7 +1443,8 @@ impl WaveStore {
         let mut sql = String::from(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
                     status, github_context, started_at, ended_at, created_at,
-                    identity_id, memory_id
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
              FROM db_agent_instances",
         );
         let mut clauses: Vec<&str> = Vec::new();
@@ -1468,7 +1484,8 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
                     status, github_context, started_at, ended_at, created_at,
-                    identity_id, memory_id
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
              FROM db_agent_instances WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], map_instance_row);
@@ -1486,8 +1503,10 @@ impl WaveStore {
             "INSERT INTO db_agent_instances
                 (id, definition_id, parent_instance_id, block_id, session_id, status,
                  github_context, started_at, ended_at, created_at,
-                 identity_id, memory_id)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                 identity_id, memory_id,
+                 instance_name, working_directory, display_hidden)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                     ?13, ?14, ?15)",
             params![
                 inst.id,
                 inst.definition_id,
@@ -1501,9 +1520,82 @@ impl WaveStore {
                 inst.created_at,
                 inst.identity_id,
                 inst.memory_id,
+                inst.instance_name,
+                inst.working_directory,
+                if inst.display_hidden { 1_i64 } else { 0_i64 },
             ],
         )?;
         Ok(())
+    }
+
+    /// Set the `display_hidden` flag on an existing instance row. Used
+    /// by the "Forget agent" affordance — soft-delete only; the row +
+    /// working directory remain on disk for audit + recovery.
+    pub fn instance_set_hidden(&self, id: &str, hidden: bool) -> Result<bool, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let rows = conn.execute(
+            "UPDATE db_agent_instances SET display_hidden = ?1 WHERE id = ?2",
+            params![if hidden { 1_i64 } else { 0_i64 }, id],
+        )?;
+        Ok(rows > 0)
+    }
+
+    /// List all instances that the launch modal's "Continue agent"
+    /// dropdown should surface: have a non-empty `instance_name`, not
+    /// hidden, sorted by most-recent start. Capped to keep the
+    /// dropdown's wire payload bounded.
+    pub fn instance_list_named(&self, limit: usize) -> Result<Vec<AgentInstance>, StoreError> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
+             FROM db_agent_instances
+             WHERE display_hidden = 0
+               AND instance_name <> ''
+               AND parent_instance_id = ''
+             ORDER BY started_at DESC
+             LIMIT ?1",
+        )?;
+        let iter = stmt.query_map(params![limit as i64], map_instance_row)?;
+        let mut out = Vec::new();
+        for r in iter {
+            out.push(r?);
+        }
+        Ok(out)
+    }
+
+    /// Look up the most recent (by `started_at`) named instance that
+    /// matches the given `instance_name`. Used by the launch modal to
+    /// detect name collisions ("did you mean to continue?") and by
+    /// `ContinueNamedAgentCommand` to resolve the canonical row when
+    /// the caller only knows the name. Hidden rows are excluded.
+    pub fn instance_get_by_name(
+        &self,
+        instance_name: &str,
+    ) -> Result<Option<AgentInstance>, StoreError> {
+        if instance_name.is_empty() {
+            return Ok(None);
+        }
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, definition_id, parent_instance_id, block_id, session_id,
+                    status, github_context, started_at, ended_at, created_at,
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
+             FROM db_agent_instances
+             WHERE instance_name = ?1
+               AND display_hidden = 0
+             ORDER BY started_at DESC
+             LIMIT 1",
+        )?;
+        let result = stmt.query_row(params![instance_name], map_instance_row);
+        match result {
+            Ok(a) => Ok(Some(a)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Update mutable instance fields. `id`, `definition_id`,
@@ -1551,7 +1643,8 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, definition_id, parent_instance_id, block_id, session_id,
                     status, github_context, started_at, ended_at, created_at,
-                    identity_id, memory_id
+                    identity_id, memory_id, instance_name, working_directory,
+                    display_hidden
              FROM db_agent_instances
              WHERE block_id = ?1 AND status IN ('running', 'paused')
              ORDER BY created_at DESC
@@ -1818,6 +1911,7 @@ fn map_memory_row(row: &rusqlite::Row) -> rusqlite::Result<Memory> {
 }
 
 fn map_instance_row(row: &rusqlite::Row) -> rusqlite::Result<AgentInstance> {
+    let display_hidden_int: i64 = row.get(14)?;
     Ok(AgentInstance {
         id: row.get(0)?,
         definition_id: row.get(1)?,
@@ -1831,6 +1925,9 @@ fn map_instance_row(row: &rusqlite::Row) -> rusqlite::Result<AgentInstance> {
         created_at: row.get(9)?,
         identity_id: row.get(10)?,
         memory_id: row.get(11)?,
+        instance_name: row.get(12)?,
+        working_directory: row.get(13)?,
+        display_hidden: display_hidden_int != 0,
     })
 }
 
@@ -2365,6 +2462,9 @@ mod tests {
             created_at: 1000,
             identity_id: String::new(),
             memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
         };
         store.instance_create(&inst).unwrap();
 
@@ -2408,6 +2508,9 @@ mod tests {
             created_at: 0,
             identity_id: String::new(),
             memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
         };
         store.instance_create(&inst).unwrap();
 

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -264,6 +264,9 @@ mod tests {
             created_at: 0,
             identity_id: identity_id.to_string(),
             memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
         }
     }
 

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1024,6 +1024,14 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // immediately on either "" or "blank").
                     identity_id: cmd.identity_id,
                     memory_id: cmd.memory_id,
+                    // v8: named-agent continuation. instance_name +
+                    // working_directory come from the launch-modal
+                    // overrides via CommandCreateAgentInstanceData
+                    // (added in the same spec). Empty string for
+                    // legacy/ambient launches.
+                    instance_name: cmd.instance_name.clone(),
+                    working_directory: cmd.working_directory.clone(),
+                    display_hidden: false,
                 };
                 wstore
                     .instance_create(&inst)
@@ -1065,11 +1073,17 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     started_at: existing.started_at,
                     ended_at: cmd.ended_at.unwrap_or(existing.ended_at),
                     created_at: existing.created_at,
-                    // identity_id / memory_id are immutable post-create
-                    // (mid-session credential rotation is out of scope —
-                    // launch a new instance with a different bundle).
+                    // identity_id / memory_id / instance_name /
+                    // working_directory are immutable post-create
+                    // (mid-session credential rotation is out of scope
+                    // — launch a new instance with a different bundle
+                    // or use ContinueNamedAgentCommand). display_hidden
+                    // is mutated via instance_set_hidden, not here.
                     identity_id: existing.identity_id.clone(),
                     memory_id: existing.memory_id.clone(),
+                    instance_name: existing.instance_name.clone(),
+                    working_directory: existing.working_directory.clone(),
+                    display_hidden: existing.display_hidden,
                 };
                 wstore
                     .instance_update(&merged)

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -30,6 +30,9 @@ use crate::backend::rpc_types::{
     COMMAND_LIST_AGENT_INSTANCES, COMMAND_GET_AGENT_INSTANCE,
     COMMAND_CREATE_AGENT_INSTANCE, COMMAND_UPDATE_AGENT_INSTANCE,
     COMMAND_DELETE_AGENT_INSTANCE,
+    COMMAND_LIST_NAMED_AGENTS, COMMAND_HIDE_NAMED_AGENT,
+    CommandListNamedAgentsData, CommandHideNamedAgentData,
+    NamedAgentRow,
     COMMAND_FORK_AGENT_DEFINITION,
     CommandListIdentityAccountsData, CommandGetIdentityAccountData,
     CommandDeleteIdentityAccountData,
@@ -1128,6 +1131,121 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     });
                 }
                 Ok(Some(json!({ "deleted": deleted })))
+            })
+        }),
+    );
+
+    // ---- v8: named agent continuation ----
+
+    // listnamedagents — powers the launch modal's "Continue agent"
+    // dropdown. Joins instance rows with the definition / identity /
+    // memory bundle names so the frontend renders without follow-ups.
+    let wstore = state.wstore.clone();
+    engine.register_handler(
+        COMMAND_LIST_NAMED_AGENTS,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            Box::pin(async move {
+                let cmd: CommandListNamedAgentsData =
+                    serde_json::from_value(data).unwrap_or_default();
+                let limit = if cmd.limit == 0 {
+                    200
+                } else {
+                    cmd.limit.min(1000)
+                };
+                let instances = wstore
+                    .instance_list_named(limit)
+                    .map_err(|e| format!("listnamedagents: {e}"))?;
+
+                // Resolve bundle names once per response. With ≤200
+                // rows and typical bundle counts in the low dozens,
+                // a linear lookup on cached lists beats per-row
+                // round-trips through the store.
+                let defs = wstore
+                    .forge_list()
+                    .map_err(|e| format!("listnamedagents: forge_list: {e}"))?;
+                let identities = wstore
+                    .bundle_identity_list()
+                    .map_err(|e| format!("listnamedagents: bundle_identity_list: {e}"))?;
+                let memories = wstore
+                    .bundle_memory_list()
+                    .map_err(|e| format!("listnamedagents: bundle_memory_list: {e}"))?;
+
+                let rows: Vec<NamedAgentRow> = instances
+                    .into_iter()
+                    .map(|inst| {
+                        let def = defs.iter().find(|d| d.id == inst.definition_id);
+                        let identity_name = if inst.identity_id.is_empty() {
+                            "(ambient creds)".to_string()
+                        } else {
+                            identities
+                                .iter()
+                                .find(|i| i.id == inst.identity_id)
+                                .map(|i| i.name.clone())
+                                .unwrap_or_else(|| "(missing identity)".to_string())
+                        };
+                        let memory_name = if inst.memory_id.is_empty() {
+                            "(vanilla CLI)".to_string()
+                        } else {
+                            memories
+                                .iter()
+                                .find(|m| m.id == inst.memory_id)
+                                .map(|m| m.name.clone())
+                                .unwrap_or_else(|| "(missing memory)".to_string())
+                        };
+                        NamedAgentRow {
+                            instance_id: inst.id,
+                            instance_name: inst.instance_name,
+                            definition_id: inst.definition_id.clone(),
+                            definition_name: def
+                                .map(|d| d.name.clone())
+                                .unwrap_or_else(|| "(missing definition)".to_string()),
+                            provider: def
+                                .map(|d| d.provider.clone())
+                                .unwrap_or_default(),
+                            working_directory: inst.working_directory,
+                            identity_id: inst.identity_id,
+                            identity_name,
+                            memory_id: inst.memory_id,
+                            memory_name,
+                            started_at: inst.started_at,
+                            ended_at: inst.ended_at,
+                            status: inst.status,
+                            block_id_hint: inst.block_id,
+                        }
+                    })
+                    .collect();
+
+                Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
+            })
+        }),
+    );
+
+    // hidenamedagent — soft-delete (sets display_hidden = 1) so the
+    // row disappears from the dropdown. Working dir stays on disk.
+    let wstore = state.wstore.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_HIDE_NAMED_AGENT,
+        Box::new(move |data, _ctx| {
+            let wstore = wstore.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let cmd: CommandHideNamedAgentData = serde_json::from_value(data)
+                    .map_err(|e| format!("hidenamedagent: {e}"))?;
+                let hidden = wstore
+                    .instance_set_hidden(&cmd.id, true)
+                    .map_err(|e| format!("hidenamedagent: {e}"))?;
+                if hidden {
+                    broker.publish(crate::backend::wps::WaveEvent {
+                        event: "namedagents:changed".to_string(),
+                        scopes: vec![],
+                        sender: String::new(),
+                        persist: 0,
+                        data: None,
+                    });
+                }
+                Ok(Some(json!({ "hidden": hidden })))
             })
         }),
     );

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1154,7 +1154,7 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     cmd.limit.min(1000)
                 };
                 let instances = wstore
-                    .instance_list_named(limit)
+                    .instance_list_named(limit, cmd.definition_id.as_deref())
                     .map_err(|e| format!("listnamedagents: {e}"))?;
 
                 // Resolve bundle names once per response. With ≤200

--- a/docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md
+++ b/docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md
@@ -1,0 +1,246 @@
+# Spec: Named agent continuation — launch modal dropdown of existing agents
+
+**Status:** Spec (no implementation yet)
+**Owner:** AgentA
+**Date:** 2026-05-12
+**Driving requirement:** "When I launch an agent, the launch modal should let me select an agent I've already created and named, and continue working on it — same folder, same identity, same memory, same conversation history."
+
+---
+
+## 1. TL;DR
+
+Every agent launch today already creates a persistent record (a `db_agent_instances` row, a working directory, env injection). The state is there. What's missing is the **UI affordance to find it again and pick up where it left off.**
+
+This spec adds:
+
+1. A **"Continue agent"** dropdown at the top of the launch modal listing every named agent the user has previously launched (most recent first).
+2. A `ListNamedAgentsCommand` RPC that returns the dropdown's content.
+3. A **resume path** in the spawn flow: when the user picks a past agent, the spawn reuses its working directory, identity binding, memory binding, and (where the CLI supports it) the prior conversation session.
+4. A **persistence shim** that records the human-readable instance name on the `db_agent_instances` row so the dropdown has something to display besides UUIDs.
+
+Phase 1 ships the dropdown + reuse of working dir + bundles. Phase 2 adds CLI session continuation (Claude `--continue`, etc.) once Phase 1 is steady.
+
+---
+
+## 2. Today's state
+
+### Already exists
+
+- **`db_agent_instances`** (v7 schema): `id`, `definition_id`, `parent_instance_id`, `block_id`, `session_id`, `status`, `github_context`, `started_at`, `ended_at`, `created_at`. Plus `identity_id` FK (per v7). One row per launch, kept forever.
+- **Launch modal** (`frontend/app/view/agent/components/AgentLaunchModal.tsx`): user enters `instanceName`, picks runtime, picks Identity bundle, picks Memory bundle. Submitted as `LaunchOverrides`.
+- **Spawn flow** (`server/app_api.rs::launch_forge_agent` ≈ line 1659): generates an instance id, calls `allocate_agent_workdir(instanceName)` to claim a working directory, writes agent config files (`CLAUDE.md`, `.mcp.json`, `.claude/settings.json`), spawns the CLI subprocess with `AGENTMUX_AGENT_ID`, `AGENTMUX_BLOCKID`, identity env, etc.
+- **Identity/Memory** are first-class via PR #746/#749/#750/#751 — already pickable in the launch modal.
+
+### Gap
+
+- **No human-readable name stored on `db_agent_instances`.** The user-chosen `instanceName` becomes `AGENTMUX_AGENT_ID` in the spawned env and shapes the working-dir path, but isn't a queryable column. To list past agents by name we'd have to scrape env vars or parse working-dir paths.
+- **No RPC to list past agents** ready for the launch modal.
+- **No resume path** — every launch is a brand-new instance with a brand-new working dir (with `-2`, `-3` suffixes when name collides per `allocate_agent_workdir`).
+
+---
+
+## 3. Goals
+
+1. **Find it.** Open the launch modal → see a "Continue agent" dropdown above the bundle pickers, listing all past named agents, sorted by recency. Each row shows: instance name, agent definition (Claude / Codex / Gemini / …), identity bundle name, memory bundle name, last-active timestamp, status badge (running / idle / done).
+2. **Resume it.** Pick a row → modal switches to a "Continue" mode: instance name field is pre-filled and read-only, identity/memory pickers are pre-filled and read-only, working dir reuses the prior path, Launch button changes to "Continue". Submit → new pane spawns the CLI rooted in that working dir with the prior bindings.
+3. **Tell them apart.** Running and stopped past agents are visibly distinct. Picking a running instance shows a warning ("This agent is currently running in another pane — continuing will open a new pane sharing the same working dir").
+4. **Forget it.** A row-level "Forget" affordance (right-click → Forget agent) marks the instance hidden from the dropdown without deleting the working directory or DB row (audit trail).
+
+## 4. Non-goals
+
+- **Multi-user / multi-machine sync** of named agents — local DB only, this spec.
+- **Branching / forking** a past agent into two (clone its config + working dir into a new instance). Possible follow-up, not in v1.
+- **Editing a past agent's bundles** from the dropdown. If you want to change identity, launch new.
+- **CLI session resume for non-Claude providers.** Codex and Gemini parity for `--continue` is a Phase 2 follow-up; Phase 1 ships Claude only.
+- **Garbage collection of working directories.** Spec for retention/GC is separate.
+
+---
+
+## 5. Data model — small additive change
+
+`db_agent_instances` gains three columns:
+
+```sql
+ALTER TABLE db_agent_instances
+  ADD COLUMN instance_name TEXT NOT NULL DEFAULT '';
+ALTER TABLE db_agent_instances
+  ADD COLUMN working_directory TEXT NOT NULL DEFAULT '';
+ALTER TABLE db_agent_instances
+  ADD COLUMN display_hidden INTEGER NOT NULL DEFAULT 0;
+```
+
+Migration is a v8 schema bump. Backfill: leave `instance_name=""` and `working_directory=""` for historical rows; they don't appear in the dropdown. Future launches fill both from the LaunchOverrides + the resolved path returned by `allocate_agent_workdir`. Storing `working_directory` explicitly (rather than re-deriving from the slug at continue-time) is robust against future slug-rule changes and to user-side renames.
+
+`identity_id` and `memory_id` already live on `db_agent_instances` from v7 — no need to re-add.
+
+### Indexes
+
+```sql
+CREATE INDEX idx_agent_instances_name_recent
+  ON db_agent_instances(instance_name, started_at DESC)
+  WHERE display_hidden = 0 AND instance_name != '';
+```
+
+Supports the dropdown query in one b-tree scan.
+
+---
+
+## 6. RPC API
+
+### `ListNamedAgentsCommand(filters?) → NamedAgentRow[]`
+
+Returns all `db_agent_instances` rows with `instance_name != ''` AND `display_hidden = 0`, joined with `db_forge_agents` for the definition name. Sorted by `started_at DESC`. Capped at 200 by default (paginate later if needed).
+
+Shape:
+
+```ts
+interface NamedAgentRow {
+    instanceId: string;          // db_agent_instances.id
+    instanceName: string;        // user-chosen name (AGENTMUX_AGENT_ID)
+    definitionId: string;        // FK to db_forge_agents
+    definitionName: string;      // resolved: "Claude Code", "Codex", "Gemini", ...
+    provider: string;            // "claude" | "codex" | "gemini" | ...
+    workingDir: string;          // resolved from allocate_agent_workdir
+    identityId: string;          // "" if blank
+    identityName: string;        // resolved bundle name or "(ambient creds)"
+    memoryId: string;            // "" if blank
+    memoryName: string;          // resolved bundle name or "(vanilla CLI)"
+    startedAt: number;           // unix ms
+    endedAt: number;             // unix ms (0 if still considered active)
+    status: "running" | "idle" | "done";
+    blockIdHint: string;         // the most recent block_id the user opened this in
+}
+```
+
+### `HideNamedAgentCommand(instance_id)` — sets `display_hidden = 1`.
+
+### `ContinueNamedAgentCommand(instance_id, target_pane_hint?) → { block_id, tab_id }`
+
+Spawns a new block in the target tab (or current tab) using the prior instance's bindings. Calls the existing internal `launch_forge_agent` plumbing but with:
+
+- `instanceName = row.instance_name`
+- `identityId = row.identity_id`
+- `memoryId = row.memory_id`
+- `workingDirOverride = row.working_dir` — skip `allocate_agent_workdir`, reuse as-is
+- `parent_instance_id = row.id` — chain the lineage so we can show "this is a continuation of <old>" later
+
+Returns the new `block_id` so the frontend can focus it.
+
+---
+
+## 7. UX
+
+### Launch modal — new dropdown at top
+
+```
+┌─ Launch Agent ─────────────────────────────────────────┐
+│                                                        │
+│  Continue agent:  ⏷ [— New agent —              ]    │  ← new
+│                     ┌──────────────────────────────┐  │
+│                     │ — New agent —                │  │
+│                     │ ────────────────────────────  │  │
+│                     │ ● Aria-streaming   2m ago    │  │
+│                     │   Claude · personal · main   │  │
+│                     │ ○ Bo-perf-test     1h ago    │  │
+│                     │   Codex · work · vanilla     │  │
+│                     │ ○ Cleo-pr-review   yesterday │  │
+│                     │   Claude · personal · vault  │  │
+│                     └──────────────────────────────┘  │
+│                                                        │
+│  Instance name:    [ Aria-streaming             ]     │  ← pre-filled, read-only when continue
+│  Runtime:          ( ) Host  ( ) Container             │
+│  Identity:         ⏷ [ personal                 ]     │  ← pre-filled, read-only when continue
+│  Memory:           ⏷ [ main                     ]     │  ← pre-filled, read-only when continue
+│                                                        │
+│        [ Cancel ]              [ Continue → ]          │  ← label flips: Launch ↔ Continue
+└────────────────────────────────────────────────────────┘
+```
+
+- **Default selection:** "— New agent —". Existing flow unchanged when this is selected.
+- **Pick a past agent** → name + identity + memory fields auto-fill from the row and become **read-only**. Runtime stays editable (you may want host vs container to change).
+- **Status badge** in the dropdown:
+  - ● green = running somewhere right now
+  - ○ gray = idle / done
+- **Picking a running instance** surfaces a yellow inline warning: *"This agent is currently active in another pane. Continuing will open a new pane sharing the same working directory."*
+- **Sort:** by `started_at DESC`. Pinning / favorites is a v2 ask, not in v1.
+- **Empty state:** if there are no named agents yet, the dropdown is hidden entirely (don't waste space on the empty case).
+
+### Right-click affordance — "Forget agent"
+
+On a row inside the dropdown (or via the existing Agent settings panel): right-click → "Forget agent". Calls `HideNamedAgentCommand`. Row disappears from the dropdown. Working dir + DB row are preserved (audit + recovery).
+
+A future Identity pane section could list hidden agents with "Unhide" — out of scope for this spec.
+
+---
+
+## 8. Spawn flow
+
+### New agent (existing)
+
+Unchanged. `launch_forge_agent` calls `allocate_agent_workdir(instanceName)` → claims free `~/agentmux-work/<slug>/`, may suffix `-2`, `-3` on collision. Writes new `db_agent_instances` row.
+
+### Continue agent (new)
+
+`ContinueNamedAgentCommand(instance_id)`:
+
+1. Load `db_agent_instances` row by id.
+2. Validate row: `instance_name != ''`, working dir still exists on disk, identity_id + memory_id still resolve (or fall back to "blank" with a logged warning).
+3. Choose target tab/pane.
+4. Insert a new `db_agent_instances` row with `parent_instance_id = old.id`, `instance_name = old.instance_name`, `identity_id`, `memory_id`, `definition_id` copied, fresh `id`/`block_id`/`session_id`, `status = "running"`, `started_at = now`.
+5. Write agent config files **into the existing working dir** (idempotent — CLAUDE.md, .claude/settings.json, .mcp.json overwrite is fine; agent config is regenerated from bundles each spawn already).
+6. Spawn the CLI subprocess with `cmd:cwd = old.working_dir`, env injection same as new-agent path, plus `AGENTMUX_RESUME_FROM = old.id` so the wrapper / CLI plumbing can hook session continuation later (Phase 2).
+7. Return `{ block_id, tab_id }` to the frontend.
+
+**Phase 2 (CLI continuation):** when `AGENTMUX_RESUME_FROM` is set AND the provider is Claude, append `--continue` to the spawn args. Other providers handled per their own resume flags.
+
+---
+
+## 9. Edge cases
+
+| Case | Handling |
+|---|---|
+| Working dir deleted on disk | Surface error in modal: "Working directory `~/agentmux-work/X/` is gone — launch as new agent?" Offer fallback to new-agent flow with the same name. |
+| Identity bundle deleted | Fall back to `blank` with logged warning; row still listed with "(missing identity)" tag. |
+| Memory bundle deleted | Same as above. |
+| Two running instances of same name | Allowed — `parent_instance_id` chains them; the second pane is a "second seat" at the same working dir. Users do this rarely but it's a real workflow. Yellow inline warning suffices. |
+| Name collision with a *new* launch | If user types an existing instance name into the launch field while "— New agent —" is selected, modal nudges: "An agent named `X` exists — did you mean to continue it?" Click to switch the dropdown to that row. |
+| Definition deleted (`db_forge_agents` cascade) | `db_agent_instances` rows cascade-delete per existing FK. Won't appear in dropdown. |
+| Migration on a fresh install | Empty `db_agent_instances` → empty dropdown → modal looks identical to today. Zero regression risk. |
+| Concurrent continue while old instance still running | Allowed (per row above). Resource isolation is the existing per-block model — no new contention. |
+
+---
+
+## 10. Phasing
+
+| Phase | Scope | LoC est. |
+|---|---|---|
+| **0** | v8 schema migration: add 3 columns + index. Backfill `instance_name` from existing block meta where derivable. | ~80 |
+| **1** | RPC + spawn changes: `ListNamedAgentsCommand`, `HideNamedAgentCommand`, `ContinueNamedAgentCommand`. Working-dir reuse path. Identity/memory bundle resolution still goes through resolver. | ~250 |
+| **2** | Launch modal UI: dropdown component, status badges, pre-fill / read-only modes, "Continue" button label flip, inline warnings. | ~300 |
+| **3** | Right-click "Forget" affordance in the dropdown + Identity-pane hidden-agents list. | ~100 |
+| **4** *(separate PR)* | CLI session continuation: Claude `--continue` wired when `AGENTMUX_RESUME_FROM` is set. Codex / Gemini parity per their flags. | ~150 |
+
+Phase 0+1+2 land together (the migration is useless without the UX, the UX is useless without the data). Phase 3 follows. Phase 4 is the big quality win — actual conversation continuity — but ships when we've validated the data flow.
+
+---
+
+## 11. Open questions
+
+1. **Working directory location.** Today `allocate_agent_workdir` lives under `~/agentmux-work/<slug>/`. Continue flow reuses that path. If the user has moved/renamed it externally, we error. Should we offer to relocate? Probably v2.
+2. **What counts as "active"?** `status = "running"` covers a live pane. But `block_id` could be stale if the host crashed without cleanup. Pragmatic: rely on the `pidregistry` running-process check at list time, downgrade stale `running` rows to `idle`. Audit log if the downgrade fires.
+3. **Per-user vs per-machine.** Today `db_agent_instances` is the local DB — no cross-machine sync. That's fine. If we ever add identity vault sync (PR-G, task #33), named agents could ride alongside but it's out of scope here.
+4. **Soft-delete vs filter-out.** `display_hidden = 1` is a soft delete. Do we need a hard "Delete agent + working dir" option? Yes eventually, but it's a destructive action — separate confirm flow, separate PR.
+5. **Sub-agents.** `parent_instance_id` already exists. Should sub-agents appear in the dropdown? Probably no — they're scoped to their parent's session. Filter `parent_instance_id = ''` in the dropdown query.
+6. **Conversation history surfacing.** Phase 4 enables Claude `--continue`. But what if the user wants to *see* the past conversation BEFORE deciding to continue? Could surface a peek-pane on hover (read `db_blockfiles` for the prior block's stream-json). Worth its own spec.
+
+---
+
+## 12. Cross-references
+
+- v7 Identity schema: [`SPEC_IDENTITY_FORGE_INTEGRATION_AND_VAULT_2026_05_08.md`](identity-forge-integration-and-vault-2026-05-08.md) (link path may need adjusting)
+- Launch modal rearchitecture: `docs/specs/launch-modal-rearchitecture-2026-05-01.md`
+- `db_agent_instances` schema: `agentmux-srv/src/backend/storage/migrations.rs:410-424`
+- Launch entry: `agentmux-srv/src/server/app_api.rs::launch_forge_agent`
+- `allocate_agent_workdir`: same file
+- Identity resolver: `agentmux-srv/src/identity/resolver.rs`
+- Launch modal component: `frontend/app/view/agent/components/AgentLaunchModal.tsx`

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -770,6 +770,13 @@ class RpcApiType {
             identity_id?: string;
             /** v7 — Memory bundle FK. Empty = blank singleton. */
             memory_id?: string;
+            /** v8 — user-chosen instance name; powers the launch modal's
+             * "Continue agent" dropdown. Empty = un-named. */
+            instance_name?: string;
+            /** v8 — resolved absolute working directory from
+             * `WriteAgentConfigCommand`. Stored on the row so the
+             * continue flow can reuse it. */
+            working_directory?: string;
         },
         opts?: RpcOpts,
     ): Promise<AgentInstance> {
@@ -800,6 +807,29 @@ class RpcApiType {
         opts?: RpcOpts,
     ): Promise<{ deleted: boolean }> {
         return client.rpcCall("deleteagentinstance", data, opts);
+    }
+
+    // command "listnamedagents" [call]
+    // v8: powers the launch modal's "Continue agent" dropdown. Returns
+    // named instance rows joined with their definition + identity /
+    // memory bundle names for one-shot rendering.
+    ListNamedAgentsCommand(
+        client: RpcClient,
+        data: { limit?: number },
+        opts?: RpcOpts,
+    ): Promise<NamedAgentRow[]> {
+        return client.rpcCall("listnamedagents", data, opts);
+    }
+
+    // command "hidenamedagent" [call]
+    // v8: soft-deletes a named instance from the dropdown (row +
+    // working dir remain on disk for audit + recovery).
+    HideNamedAgentCommand(
+        client: RpcClient,
+        data: { id: string },
+        opts?: RpcOpts,
+    ): Promise<{ hidden: boolean }> {
+        return client.rpcCall("hidenamedagent", data, opts);
     }
 
     // command "forkagentdefinition" [call]

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -812,10 +812,13 @@ class RpcApiType {
     // command "listnamedagents" [call]
     // v8: powers the launch modal's "Continue agent" dropdown. Returns
     // named instance rows joined with their definition + identity /
-    // memory bundle names for one-shot rendering.
+    // memory bundle names for one-shot rendering. Pass `definition_id`
+    // to filter server-side — required for the modal use case so an
+    // older instance of the current definition can't fall off the
+    // global limit when the user has many agents across definitions.
     ListNamedAgentsCommand(
         client: RpcClient,
-        data: { limit?: number },
+        data: { limit?: number; definition_id?: string },
         opts?: RpcOpts,
     ): Promise<NamedAgentRow[]> {
         return client.rpcCall("listnamedagents", data, opts);

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -463,6 +463,16 @@ export class AgentViewModel implements ViewModel {
                     // circuits so the agent inherits ambient creds.
                     identity_id: overrides?.identityId,
                     memory_id: overrides?.memoryId,
+                    // v8: named-agent continuation. The instance name
+                    // is the AGENTMUX_AGENT_ID the user picked in the
+                    // modal; finalWorkDir is the path that
+                    // WriteAgentConfigCommand resolved (after slug
+                    // collision suffixing). Both are persisted so the
+                    // launch modal's "Continue agent" dropdown can
+                    // surface this instance later. See
+                    // SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md.
+                    instance_name: instanceName,
+                    working_directory: finalWorkDir,
                 });
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref,

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -401,9 +401,21 @@ export class AgentViewModel implements ViewModel {
             //     ~/.agentmux/agents/<slug> default ourselves)
             // Any other persisted value is user-specified and stays
             // verbatim through allocation.
+            //
+            // v8 continuation path: `overrides.workDirOverride` short-
+            // circuits the auto-allocate logic entirely. The launch
+            // modal's "Continue agent" dropdown sets this from the
+            // prior instance's `working_directory`. We pass
+            // auto_allocate: false so WriteAgentConfigCommand reuses
+            // the existing directory (overwriting config files is
+            // intentional — bundles can change between sessions).
+            const continueWorkDir = overrides?.workDirOverride?.trim() ?? "";
+            const isContinue = continueWorkDir.length > 0;
             const autoAllocate =
-                Boolean(overrides?.instanceName) ||
-                (agent.working_directory ?? "").trim() === "";
+                !isContinue &&
+                (Boolean(overrides?.instanceName) ||
+                    (agent.working_directory ?? "").trim() === "");
+            const writeWorkDir = isContinue ? continueWorkDir : workDir;
 
             // Allocate the workdir + write config files BEFORE we set
             // cmd:cwd, so the meta records the actual collision-
@@ -412,11 +424,11 @@ export class AgentViewModel implements ViewModel {
             // to write) when auto-allocate so we get the atomic
             // `mkdir` reservation. Returns the final path.
             const writeResult = await RpcApi.WriteAgentConfigCommand(TabRpcClient, {
-                working_dir: workDir,
+                working_dir: writeWorkDir,
                 files: configFiles,
                 auto_allocate: autoAllocate,
             });
-            const finalWorkDir = writeResult?.working_dir || workDir;
+            const finalWorkDir = writeResult?.working_dir || writeWorkDir;
 
             // Store CLI config in block metadata using the (possibly
             // collision-resolved) finalWorkDir.
@@ -473,6 +485,11 @@ export class AgentViewModel implements ViewModel {
                     // SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md.
                     instance_name: instanceName,
                     working_directory: finalWorkDir,
+                    // v8 continuation: chain lineage to the prior row
+                    // so the dropdown query can collapse continuations
+                    // (filter parent_instance_id = '' surfaces only
+                    // the "root" of each chain).
+                    parent_instance_id: overrides?.continueOfInstanceId,
                 });
                 await RpcApi.SetMetaCommand(TabRpcClient, {
                     oref,

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -345,7 +345,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                 class="agent-launch-modal-input"
                                 value={memoryId()}
                                 onChange={(e) => setMemoryId(e.currentTarget.value)}
-                                disabled={submitting()}
+                                disabled={submitting() || isContinue()}
                                 aria-label="Memory bundle"
                             >
                                 <For each={memories() ?? []}>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -37,6 +37,15 @@ export interface LaunchOverrides {
     identityId?: string;
     /** v7 — selected Memory bundle. "blank" = vanilla CLI. */
     memoryId?: string;
+    /** v8 — when set, this launch is a continuation of a prior named
+     *  agent. The id is recorded as `parent_instance_id` on the new
+     *  row so the lineage is queryable. */
+    continueOfInstanceId?: string;
+    /** v8 — when set (paired with `continueOfInstanceId`), the
+     *  launch flow uses this exact path instead of calling
+     *  `allocate_agent_workdir`. Reuses the prior agent's files,
+     *  configs, and conversation context. */
+    workDirOverride?: string;
 }
 
 interface AgentLaunchModalPanelProps {
@@ -78,6 +87,48 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         }
     });
 
+    // v8 — "Continue agent" dropdown. Filters to instances of the
+    // CURRENT definition since continuing a Claude agent inside the
+    // Codex picker would be nonsensical. Empty/missing list = no
+    // past launches for this definition, dropdown hides itself.
+    const [namedAgents] = createResource<NamedAgentRow[]>(async () => {
+        try {
+            const rows = await RpcApi.ListNamedAgentsCommand(TabRpcClient, { limit: 200 });
+            return rows.filter((r) => r.definition_id === props.agent.id);
+        } catch {
+            return [];
+        }
+    });
+
+    /** Empty = "— New agent —" (default). Non-empty = continuing that
+     *  past instance; name + identity + memory are pre-filled and
+     *  locked. */
+    const [continueOfId, setContinueOfId] = createSignal<string>("");
+
+    const continuedRow = createMemo(() =>
+        (namedAgents() ?? []).find((r) => r.instance_id === continueOfId()) ?? null,
+    );
+    const isContinue = () => continuedRow() != null;
+
+    const handleContinueSelect = (id: string) => {
+        setContinueOfId(id);
+        const row = (namedAgents() ?? []).find((r) => r.instance_id === id);
+        if (row) {
+            setName(row.instance_name);
+            setIdentityId(row.identity_id || "blank");
+            setMemoryId(row.memory_id || "blank");
+        }
+    };
+
+    const formatRelative = (ms: number): string => {
+        if (!ms) return "";
+        const delta = Date.now() - ms;
+        if (delta < 60_000) return "just now";
+        if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m ago`;
+        if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h ago`;
+        return `${Math.floor(delta / 86_400_000)}d ago`;
+    };
+
     const hasName = () => name().trim().length > 0;
     const canSubmit = () => !submitting() && slugifyInstanceName(name()).length > 0;
     const containerSupported = () => catalog()?.containerSupported ?? true;
@@ -93,6 +144,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         setSubmitting(true);
         setError(null);
         try {
+            const row = continuedRow();
             await props.onSubmit({
                 instanceName: name().trim(),
                 agentType: runtime(),
@@ -100,6 +152,11 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                 containerImage: runtime() === "container" ? resolvedImage() : undefined,
                 identityId: identityId(),
                 memoryId: memoryId(),
+                // v8 — when continuing a past agent, thread the id +
+                // working directory through. Launch flow uses
+                // workDirOverride to skip allocate_agent_workdir.
+                continueOfInstanceId: row?.instance_id || undefined,
+                workDirOverride: row?.working_directory || undefined,
             });
             // Success: layer closes the panel; we leave `submitting`
             // true so the button keeps its "Launching…" label until
@@ -131,8 +188,41 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                         </p>
                     </Show>
 
+                    {/* v8 — "Continue agent" dropdown. Only shows if
+                        there are past named agents of this definition.
+                        Picking one pre-fills + locks name/identity/
+                        memory; the launch becomes a continuation that
+                        reuses the prior working directory. */}
+                    <Show when={(namedAgents() ?? []).length > 0}>
+                        <label class="agent-launch-modal-field">
+                            <span class="agent-launch-modal-label">Continue an existing agent</span>
+                            <select
+                                class="agent-launch-modal-input"
+                                value={continueOfId()}
+                                onChange={(e) => handleContinueSelect(e.currentTarget.value)}
+                                disabled={submitting()}
+                                aria-label="Continue an existing agent"
+                            >
+                                <option value="">— New agent —</option>
+                                <For each={namedAgents() ?? []}>
+                                    {(row) => (
+                                        <option value={row.instance_id}>
+                                            {`${row.instance_name} · ${row.identity_name} · ${row.memory_name}${row.started_at ? ` · ${formatRelative(row.started_at)}` : ""}`}
+                                        </option>
+                                    )}
+                                </For>
+                            </select>
+                            <span class="agent-launch-modal-hint">
+                                Picks up where the agent left off — same files,
+                                same identity, same memory.
+                            </span>
+                        </label>
+                    </Show>
+
                     <label class="agent-launch-modal-field">
-                        <span class="agent-launch-modal-label">Give this agent a name</span>
+                        <span class="agent-launch-modal-label">
+                            {isContinue() ? "Agent name" : "Give this agent a name"}
+                        </span>
                         <input
                             class="agent-launch-modal-input"
                             type="text"
@@ -140,7 +230,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                             placeholder={displayName()}
                             value={name()}
                             onInput={(e) => setName(e.currentTarget.value)}
-                            disabled={submitting()}
+                            disabled={submitting() || isContinue()}
                             aria-label="Agent name"
                             // Autofocus so the user can start typing immediately.
                             // Layer renders us inside its panel; the focus is
@@ -208,7 +298,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                 class="agent-launch-modal-input"
                                 value={identityId()}
                                 onChange={(e) => setIdentityId(e.currentTarget.value)}
-                                disabled={submitting()}
+                                disabled={submitting() || isContinue()}
                                 aria-label="Identity bundle"
                             >
                                 <For each={identities() ?? []}>
@@ -308,7 +398,9 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                     Cancel
                 </Button>
                 <Button onClick={() => void handleSubmit()} disabled={!canSubmit()}>
-                    {submitting() ? "Launching…" : "Launch"}
+                    {submitting()
+                        ? isContinue() ? "Continuing…" : "Launching…"
+                        : isContinue() ? "Continue" : "Launch"}
                 </Button>
             </footer>
         </>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -88,13 +88,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     });
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
-    // CURRENT definition since continuing a Claude agent inside the
-    // Codex picker would be nonsensical. Empty/missing list = no
-    // past launches for this definition, dropdown hides itself.
+    // CURRENT definition (server-side; a global cap would let older
+    // rows of this definition fall off when users have many agents
+    // across definitions). Empty list = no past launches for this
+    // definition, dropdown hides itself.
     const [namedAgents] = createResource<NamedAgentRow[]>(async () => {
         try {
-            const rows = await RpcApi.ListNamedAgentsCommand(TabRpcClient, { limit: 200 });
-            return rows.filter((r) => r.definition_id === props.agent.id);
+            return await RpcApi.ListNamedAgentsCommand(TabRpcClient, {
+                limit: 200,
+                definition_id: props.agent.id,
+            });
         } catch {
             return [];
         }
@@ -117,6 +120,15 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
             setName(row.instance_name);
             setIdentityId(row.identity_id || "blank");
             setMemoryId(row.memory_id || "blank");
+        } else {
+            // Selecting "— New agent —" releases the lock. Clear the
+            // fields back to defaults so the user doesn't accidentally
+            // submit a brand-new launch carrying the previously
+            // continued agent's name + bundles (which would collide
+            // on allocate_agent_workdir and inject the wrong creds).
+            setName("");
+            setIdentityId("blank");
+            setMemoryId("blank");
         }
     };
 

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -349,6 +349,31 @@ declare global {
         identity_id?: string;
         /** v7 — FK to db_memories. Empty string = blank singleton. */
         memory_id?: string;
+        /** v8 — user-chosen instance name (AGENTMUX_AGENT_ID). */
+        instance_name?: string;
+        /** v8 — absolute working directory from allocate_agent_workdir. */
+        working_directory?: string;
+        /** v8 — soft-delete flag for the "Forget agent" affordance. */
+        display_hidden?: boolean;
+    };
+
+    /** v8 — one row of the launch modal's "Continue agent" dropdown.
+     * Server-side join across instance + definition + bundle tables. */
+    type NamedAgentRow = {
+        instance_id: string;
+        instance_name: string;
+        definition_id: string;
+        definition_name: string;
+        provider: string;
+        working_directory: string;
+        identity_id: string;
+        identity_name: string;
+        memory_id: string;
+        memory_name: string;
+        started_at: number;
+        ended_at: number;
+        status: string;
+        block_id_hint: string;
     };
 
     // ForgeContent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.816",
+  "version": "0.33.817",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.816",
+      "version": "0.33.817",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.815",
+  "version": "0.33.816",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.815",
+      "version": "0.33.816",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.814",
+  "version": "0.33.815",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.814",
+      "version": "0.33.815",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.816",
+  "version": "0.33.817",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.815",
+  "version": "0.33.816",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.814",
+  "version": "0.33.815",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Adds a **"Continue an existing agent"** dropdown to the launch modal so users can pick a previously-named agent and pick up where it left off — same working directory, same identity bundle, same memory bundle.

Spec: [`docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md`](https://github.com/agentmuxai/agentmux/blob/agenta/named-agent-continuation/docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md) (rides with this PR — no doc-only PR).

### What's in the PR

#### Phase 0 — v8 schema (`agentmux-srv/src/backend/storage/migrations.rs`)
Three additive columns on `db_agent_instances` + a partial index for the dropdown query.

```sql
ALTER TABLE db_agent_instances ADD COLUMN instance_name TEXT NOT NULL DEFAULT '';
ALTER TABLE db_agent_instances ADD COLUMN working_directory TEXT NOT NULL DEFAULT '';
ALTER TABLE db_agent_instances ADD COLUMN display_hidden INTEGER NOT NULL DEFAULT 0;
CREATE INDEX idx_agent_instances_name_recent
  ON db_agent_instances(instance_name, started_at DESC)
  WHERE display_hidden = 0 AND instance_name != '';
```

Idempotent (catches `duplicate column`). `AgentInstance` struct + all `wstore` SELECT / INSERT / map paths updated. Three new methods: `instance_list_named(limit)`, `instance_set_hidden(id, hidden)`, `instance_get_by_name(name)`.

#### Phase 1 — RPCs + spawn wire-up
- `listnamedagents` → `Vec<NamedAgentRow>` joins instance rows with definition + identity + memory bundle names so the frontend renders the dropdown without follow-ups. 200-row default, 1000 cap.
- `hidenamedagent` → soft-delete (`display_hidden = 1`); publishes `namedagents:changed`. Row + working dir stay on disk for audit + recovery.
- `createagentinstance` handler persists `instance_name` + `working_directory` from the launch-modal payload.
- Frontend `RpcApi` bindings, `AgentInstance` + `NamedAgentRow` types.

#### Phase 2 — launch modal UI (`AgentLaunchModal.tsx` + `agent-model.ts`)
- "Continue an existing agent" select above the name field. Auto-hides when no past agents of this definition (empty state = today's modal, zero regression).
- Filtered to current `props.agent.id` so Claude options don't appear in the Codex picker.
- Selecting a row pre-fills + locks name/identity/memory; selecting "— New agent —" releases the lock.
- Submit button flips "Launch" ↔ "Continue".
- Option label: `name · identity · memory · time` (e.g. `Aria-streaming · personal · main · 2m ago`).
- `LaunchOverrides` extended with `continueOfInstanceId` + `workDirOverride`.
- Spawn flow: when `workDirOverride` set, `WriteAgentConfigCommand` reuses path (auto_allocate: false). `parent_instance_id` chained.

### What's not in the PR (intentional)
- **Phase 3** — right-click "Forget agent" in the dropdown. Backend RPC is here (`hidenamedagent`), UI affordance is a small follow-up.
- **Phase 4** — Claude `--continue` for actual conversation resume. Separate PR after the data flow is verified.

### End-to-end flow
1. User opens launch modal for Claude
2. Modal calls `ListNamedAgentsCommand`, filters to this definition
3. User picks "Aria-streaming"; name + identity + memory pre-fill and lock; button reads "Continue"
4. Submit → `WriteAgentConfigCommand` reuses `~/agentmux-work/aria-streaming/`, `CreateAgentInstanceCommand` writes a new row with `parent_instance_id = <old.id>`, `instance_name = "Aria-streaming"`, identity + memory carried
5. Agent CLI spawns in the existing working dir

## Test plan
- [x] `cargo test -p agentmux-srv` — 886 tests pass (includes existing instance tests with the new fields)
- [x] `cargo build -p agentmux-srv` — clean
- [x] TypeScript clean on touched files (`AgentLaunchModal.tsx`, `agent-model.ts`, `rpc-api.ts`, `gotypes.d.ts`)
- [ ] Smoke build 0.33.815 — launch agent, name it, exit, re-launch from picker → continues in same dir
- [ ] Verify dropdown empty state hides cleanly on first install
- [ ] Verify migration on a fresh install (`db_agent_instances` empty → dropdown hidden → zero regression vs. today's modal)

### Cross-references
- v7 Identity / Memory schema: PR #746
- Memory pane: PR #749
- Identity pane: PR #750
- Launch modal v7 bundle pickers: PR #751
- Drop standalone widgets (Identity/Memory are now agent-pane tabs): PR #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)