### PR TITLE
feat: live-log streaming + session-replay framework + reducer audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.818"
+version = "0.33.819"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.818"
+version = "0.33.819"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.818"
+version = "0.33.819"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.818"
+version = "0.33.819"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.818"
+version = "0.33.819"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.817"
+version = "0.33.818"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.817"
+version = "0.33.818"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.817"
+version = "0.33.818"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.817"
+version = "0.33.818"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.817"
+version = "0.33.818"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.819"
+version = "0.33.820"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.819"
+version = "0.33.820"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.819"
+version = "0.33.820"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.819"
+version = "0.33.820"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.819"
+version = "0.33.820"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.818"
+version = "0.33.819"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.819"
+version = "0.33.820"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.817"
+version = "0.33.818"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -78,19 +78,23 @@ const FLUSH_BYTES: usize = 4096;
 /// natural flush.
 const FLUSH_QUIET_WINDOW: Duration = Duration::from_millis(50);
 
-/// Wire payload published on `tool_chunk:<id>`. Mirrors the TypeScript
-/// `ToolChunkMessage` in `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
+/// Wire payload published on the `tool_chunk` event. The tool_use_id
+/// rides in the payload (not the event name) so the frontend opens
+/// a single per-block subscription on mount and routes by `tool_id`
+/// rather than per-tool subscriptions racing the tool's execution.
 #[derive(Serialize)]
 struct ChunkMessage<'a> {
     op: &'static str, // "chunk"
+    tool_id: &'a str,
     kind: &'a str,    // "stdout" | "stderr" | "system"
     content: &'a str,
     timestamp: u64,
 }
 
 #[derive(Serialize)]
-struct TerminalMessage {
+struct TerminalMessage<'a> {
     op: &'static str, // "terminal"
+    tool_id: &'a str,
     exit_code: i32,
     timestamp: u64,
 }
@@ -112,9 +116,22 @@ struct LineEvent {
 /// the wrapper's own process exit. Without this, Claude's native Bash
 /// tool would see success for every wrapped command regardless of the
 /// actual outcome.
-pub async fn run(args: Args) -> Result<i32> {
+pub async fn run(mut args: Args) -> Result<i32> {
     log_relevant_env();
     let command = decode_command(&args.b64_cmd)?;
+
+    // `block_id` controls the WPS publish scope. Prefer the explicit
+    // CLI arg, but fall back to AGENTMUX_BLOCKID env (set by
+    // agentmux-srv when spawning Claude) so the hook doesn't have to
+    // pass it explicitly. Without a scope, the frontend's per-block
+    // subscription won't receive the events.
+    if args.block_id.as_deref().filter(|s| !s.is_empty()).is_none() {
+        if let Ok(v) = std::env::var("AGENTMUX_BLOCKID") {
+            if !v.is_empty() {
+                args.block_id = Some(v);
+            }
+        }
+    }
 
     let wps = WpsClient::from_env();
     let degraded = wps.is_none();
@@ -124,6 +141,7 @@ pub async fn run(args: Args) -> Result<i32> {
     tracing::info!(
         target: "bashwrap",
         tool_id = %args.tool_id,
+        block_id = %args.block_id.as_deref().unwrap_or(""),
         degraded,
         command_len = command.len(),
         "exec start"
@@ -161,6 +179,7 @@ pub async fn run(args: Args) -> Result<i32> {
                 args.block_id.as_deref(),
                 &TerminalMessage {
                     op: "terminal",
+                    tool_id: &args.tool_id,
                     exit_code: status,
                     timestamp: now_ms(),
                 },
@@ -221,6 +240,7 @@ async fn publish_system(
             block_id,
             &ChunkMessage {
                 op: "chunk",
+                tool_id,
                 kind: "system",
                 content: msg,
                 timestamp: now_ms(),
@@ -242,6 +262,7 @@ async fn publish_line(
             block_id,
             &ChunkMessage {
                 op: "chunk",
+                tool_id,
                 kind,
                 content: line,
                 timestamp: now_ms(),

--- a/agentmux-bashwrap/src/bash_wrap.rs
+++ b/agentmux-bashwrap/src/bash_wrap.rs
@@ -175,7 +175,6 @@ pub async fn run(mut args: Args) -> Result<i32> {
     if let Some(client) = wps.as_ref() {
         let _ = client
             .publish_chunk(
-                &args.tool_id,
                 args.block_id.as_deref(),
                 &TerminalMessage {
                     op: "terminal",
@@ -236,7 +235,6 @@ async fn publish_system(
 ) -> Result<()> {
     client
         .publish_chunk(
-            tool_id,
             block_id,
             &ChunkMessage {
                 op: "chunk",
@@ -258,7 +256,6 @@ async fn publish_line(
 ) -> Result<()> {
     client
         .publish_chunk(
-            tool_id,
             block_id,
             &ChunkMessage {
                 op: "chunk",

--- a/agentmux-bashwrap/src/wps_client.rs
+++ b/agentmux-bashwrap/src/wps_client.rs
@@ -30,15 +30,38 @@ pub struct WpsClient {
 
 #[derive(Serialize)]
 struct PublishRequest<'a, T: Serialize> {
-    /// WPS event name. We use `tool_chunk:<id>` for streaming chunks.
+    /// WPS event name. Fixed `tool_chunk` for every streaming chunk —
+    /// the tool_use_id lives in the payload, not in the event name.
+    /// Lets the frontend open a single per-block subscription on mount
+    /// instead of per-tool subscriptions racing the tool's execution.
     event: &'a str,
-    /// Optional scope filters (typically `block:<id>` so only
-    /// subscribers watching that block receive the event).
+    /// Scope filters. Always `["block:<id>"]` for tool_chunk so the
+    /// broker delivers only to the relevant pane.
     #[serde(skip_serializing_if = "<[String]>::is_empty")]
     scopes: &'a [String],
+    /// Per-event persistence count (kept by the broker for
+    /// replay-on-subscribe). Captures the wrapper's full output for
+    /// late subscribers when Claude buffers the tool_use stream until
+    /// after the tool runs.
+    #[serde(skip_serializing_if = "is_zero_usize")]
+    persist: usize,
     /// Event payload. Free-form per event type.
     data: &'a T,
 }
+
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
+}
+
+/// How many `tool_chunk` events the broker keeps per `block:<id>`
+/// scope. Sized for npm-install class output (~1000 lines is typical;
+/// 1024 covers all but heavy CI builds). Each event is ~200–500 bytes,
+/// so the steady-state ceiling is ~512 KB per actively-streaming block.
+const TOOL_CHUNK_PERSIST: usize = 1024;
+
+/// Event name for streaming bash chunks. Held constant across every
+/// publish so the frontend can subscribe once per block on mount.
+const TOOL_CHUNK_EVENT: &str = "tool_chunk";
 
 impl WpsClient {
     /// Build a client from the env. Returns `None` when the required
@@ -64,22 +87,25 @@ impl WpsClient {
         })
     }
 
-    /// Publish a `tool_chunk:<id>` event. `payload` is serialized as
-    /// the event's `data` field; scopes restrict delivery to listeners
-    /// watching `block:<block_id>` (if provided).
+    /// Publish a `tool_chunk` event. `tool_id` goes into the payload
+    /// rather than the event name so a single per-block subscription
+    /// receives chunks for every tool in that block. Persists with
+    /// `TOOL_CHUNK_PERSIST` so late subscribers (the frontend, which
+    /// learns about the tool_use only after Claude buffers the stream)
+    /// get the full history on subscribe.
     pub async fn publish_chunk<T: Serialize>(
         &self,
-        tool_id: &str,
+        _tool_id: &str,
         block_id: Option<&str>,
         payload: &T,
     ) -> Result<()> {
-        let event = format!("tool_chunk:{}", tool_id);
         let scopes: Vec<String> = block_id
             .map(|b| vec![format!("block:{}", b)])
             .unwrap_or_default();
         let body = PublishRequest {
-            event: &event,
+            event: TOOL_CHUNK_EVENT,
             scopes: &scopes,
+            persist: TOOL_CHUNK_PERSIST,
             data: payload,
         };
         let url = format!("{}{}", self.endpoint, PUBLISH_PATH);
@@ -93,8 +119,6 @@ impl WpsClient {
             .await?;
         if !resp.status().is_success() {
             let status = resp.status();
-            // Body may include a structured error from auth_middleware;
-            // include for diagnostics in the wrapper's stderr trace.
             let text = resp.text().await.unwrap_or_default();
             anyhow::bail!("publish failed: HTTP {} — {}", status, text);
         }

--- a/agentmux-bashwrap/src/wps_client.rs
+++ b/agentmux-bashwrap/src/wps_client.rs
@@ -87,15 +87,14 @@ impl WpsClient {
         })
     }
 
-    /// Publish a `tool_chunk` event. `tool_id` goes into the payload
-    /// rather than the event name so a single per-block subscription
-    /// receives chunks for every tool in that block. Persists with
-    /// `TOOL_CHUNK_PERSIST` so late subscribers (the frontend, which
-    /// learns about the tool_use only after Claude buffers the stream)
-    /// get the full history on subscribe.
+    /// Publish a `tool_chunk` event. The tool_use_id lives in the
+    /// payload (not on this method's signature) so a single per-block
+    /// subscription receives chunks for every tool in that block.
+    /// Persists with `TOOL_CHUNK_PERSIST` so late subscribers (the
+    /// frontend, which learns about the tool_use only after Claude
+    /// buffers the stream) get the full history on subscribe.
     pub async fn publish_chunk<T: Serialize>(
         &self,
-        _tool_id: &str,
         block_id: Option<&str>,
         payload: &T,
     ) -> Result<()> {

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.817"
+version = "0.33.818"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.818"
+version = "0.33.819"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.819"
+version = "0.33.820"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.817"
+version = "0.33.818"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.818"
+version = "0.33.819"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.819"
+version = "0.33.820"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.818"
+version = "0.33.819"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.817"
+version = "0.33.818"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.819"
+version = "0.33.820"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.818"
+version = "0.33.819"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.817"
+version = "0.33.818"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.819"
+version = "0.33.820"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -11,7 +11,7 @@
 //! - Star-scope subscriptions (e.g., "block:*")
 //! - Event persistence (history/replay)
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 
 use serde::{Deserialize, Serialize};
@@ -141,10 +141,19 @@ pub struct Broker {
     inner: Mutex<BrokerInner>,
 }
 
+/// Tracks `(route_id, event_name, scope)` tuples whose persisted
+/// history has already been replayed to a given route. Skipping
+/// replay on resubscribe prevents the frontend's `eventsub`
+/// flushes (sent on every listener add/remove against the shared
+/// `ws-main` route) from re-emitting completed bash logs on every
+/// pane mount or tab switch. Codex P2 on PR #817.
+type ReplayKey = (String, String, String);
+
 struct BrokerInner {
     client: Option<Box<dyn WpsClient>>,
     sub_map: HashMap<String, BrokerSubscription>,
     persist_map: HashMap<PersistKey, PersistEventWrap>,
+    replayed: HashSet<ReplayKey>,
 }
 
 impl Broker {
@@ -154,6 +163,7 @@ impl Broker {
                 client: None,
                 sub_map: HashMap::new(),
                 persist_map: HashMap::new(),
+                replayed: HashSet::new(),
             }),
         }
     }
@@ -196,41 +206,67 @@ impl Broker {
             }
         }
 
-        Self::replay_to_route(&inner, route_id, &sub);
+        Self::replay_to_route(&mut inner, route_id, &sub);
     }
 
     /// Deliver any persisted events matching `sub` to `route_id`.
-    /// Called inside `subscribe` so replay happens atomically under the
-    /// broker lock — no live event published mid-replay can interleave.
+    /// Called inside `subscribe` so replay happens atomically under
+    /// the broker lock — no live event published mid-replay can
+    /// interleave.
+    ///
+    /// **Once-per-(route, event, scope).** The frontend
+    /// (`frontend/app/store/wps.ts`) flushes `eventsub` for the
+    /// shared `ws-main` route on every listener add/remove. Replaying
+    /// persisted history on each of those flushes would re-emit
+    /// completed bash logs every pane mount / tab switch / sibling
+    /// subscription. The `replayed` set tracks tuples that already
+    /// received their backfill and short-circuits subsequent
+    /// resubscribes. Cleared per-route in `unsubscribe_all` so a true
+    /// reconnect (route dropped + re-registered) gets a fresh replay.
+    ///
     /// Star-scope replay is intentionally not implemented (rare,
     /// requires scanning every persist key; can add later if needed).
-    fn replay_to_route(inner: &BrokerInner, route_id: &str, sub: &SubscriptionRequest) {
+    fn replay_to_route(
+        inner: &mut BrokerInner,
+        route_id: &str,
+        sub: &SubscriptionRequest,
+    ) {
         let client = match &inner.client {
             Some(c) => c,
             None => return,
         };
 
-        let deliver = |scope: &str| {
-            let key = PersistKey {
-                event: sub.event.clone(),
-                scope: scope.to_string(),
-            };
-            if let Some(pe) = inner.persist_map.get(&key) {
-                for event in &pe.events {
-                    client.send_event(route_id, event.clone());
-                }
-            }
-        };
-
+        let mut scopes_to_deliver: Vec<String> = Vec::new();
         if sub.allscopes {
             // "" key holds the global history per persist_event's scope_set.
-            deliver("");
+            scopes_to_deliver.push(String::new());
         } else {
             for scope in &sub.scopes {
                 if !scope_has_star(scope) {
-                    deliver(scope);
+                    scopes_to_deliver.push(scope.clone());
                 }
             }
+        }
+
+        let mut to_send: Vec<WaveEvent> = Vec::new();
+        for scope in scopes_to_deliver {
+            let key = (route_id.to_string(), sub.event.clone(), scope.clone());
+            if inner.replayed.contains(&key) {
+                continue;
+            }
+            let pkey = PersistKey {
+                event: sub.event.clone(),
+                scope: scope.clone(),
+            };
+            if let Some(pe) = inner.persist_map.get(&pkey) {
+                for event in &pe.events {
+                    to_send.push(event.clone());
+                }
+            }
+            inner.replayed.insert(key);
+        }
+        for event in to_send {
+            client.send_event(route_id, event);
         }
     }
 
@@ -241,12 +277,18 @@ impl Broker {
     }
 
     /// Unsubscribe a route from all events.
+    ///
+    /// Also clears the `replayed` tracker for this route so a future
+    /// reconnect (route registers again from scratch) gets a fresh
+    /// replay of persisted history. Without this, a transient
+    /// WebSocket drop would silently lose all subsequent replay.
     pub fn unsubscribe_all(&self, route_id: &str) {
         let mut inner = self.inner.lock().unwrap();
         let events: Vec<String> = inner.sub_map.keys().cloned().collect();
         for event in events {
             Self::unsubscribe_nolock(&mut inner, route_id, &event);
         }
+        inner.replayed.retain(|(r, _, _)| r != route_id);
     }
 
     fn unsubscribe_nolock(inner: &mut BrokerInner, route_id: &str, event_name: &str) {
@@ -698,6 +740,74 @@ mod tests {
         assert_eq!(events.len(), 5, "all 5 persisted events replayed");
         assert_eq!(events[0].1.data, Some(serde_json::json!({"tool_id": "t1", "n": 0})));
         assert_eq!(events[4].1.data, Some(serde_json::json!({"tool_id": "t1", "n": 4})));
+    }
+
+    /// Regression: re-subscribing the SAME route to the SAME
+    /// (event, scope) does NOT replay again. The frontend's
+    /// `eventsub` flushes happen on every listener add/remove, so
+    /// the broker has to be idempotent across resubscribe calls.
+    /// Codex P2 on PR #817.
+    #[test]
+    fn test_replay_on_resubscribe_is_idempotent() {
+        let broker = Broker::new();
+        let client = Arc::new(TestClient::new());
+        broker.set_client(Box::new(Arc::clone(&client)));
+
+        for i in 0..3 {
+            broker.publish(WaveEvent {
+                event: "tool_chunk".to_string(),
+                scopes: vec!["block:abc".to_string()],
+                sender: String::new(),
+                persist: 10,
+                data: Some(serde_json::json!({"n": i})),
+            });
+        }
+
+        let sub = SubscriptionRequest {
+            event: "tool_chunk".to_string(),
+            scopes: vec!["block:abc".to_string()],
+            allscopes: false,
+        };
+
+        broker.subscribe("route-1", sub.clone());
+        assert_eq!(
+            client.received_events().len(),
+            3,
+            "first subscribe replays all 3 persisted events"
+        );
+
+        // Re-subscribe (same route, same event+scope) — must not
+        // replay a second time.
+        broker.subscribe("route-1", sub.clone());
+        assert_eq!(
+            client.received_events().len(),
+            3,
+            "re-subscribe is a no-op for replay; received count stays at 3"
+        );
+
+        // Live publish after re-subscribe still delivers.
+        broker.publish(WaveEvent {
+            event: "tool_chunk".to_string(),
+            scopes: vec!["block:abc".to_string()],
+            sender: String::new(),
+            persist: 10,
+            data: Some(serde_json::json!({"n": "live"})),
+        });
+        assert_eq!(
+            client.received_events().len(),
+            4,
+            "live publish after resubscribe is delivered exactly once"
+        );
+
+        // Disconnect (unsubscribe_all) + reconnect — fresh replay.
+        broker.unsubscribe_all("route-1");
+        broker.subscribe("route-1", sub.clone());
+        assert_eq!(
+            client.received_events().len(),
+            8,
+            "reconnect after unsubscribe_all clears the replayed tracker; \
+             gets all 4 persisted events again"
+        );
     }
 
     /// Regression: replay does NOT cross-pollute scopes. Subscriber to

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -164,6 +164,13 @@ impl Broker {
     }
 
     /// Subscribe a route to an event, optionally scoped.
+    ///
+    /// **Replay-on-subscribe**: after registering the route, immediately
+    /// deliver any persisted events that match the subscription. Lets
+    /// late subscribers catch up on the most recent state without
+    /// waiting for the next publish — closes the race for live-log
+    /// streaming where the frontend learns the tool_use_id only after
+    /// the wrapper has already finished publishing.
     pub fn subscribe(&self, route_id: &str, sub: SubscriptionRequest) {
         if sub.event.is_empty() {
             return;
@@ -179,13 +186,50 @@ impl Broker {
 
         if sub.allscopes {
             add_unique(&mut bs.all_subs, route_id);
-            return;
+        } else {
+            for scope in &sub.scopes {
+                if scope_has_star(scope) {
+                    add_to_scope_map(&mut bs.star_subs, scope, route_id);
+                } else {
+                    add_to_scope_map(&mut bs.scope_subs, scope, route_id);
+                }
+            }
         }
-        for scope in &sub.scopes {
-            if scope_has_star(scope) {
-                add_to_scope_map(&mut bs.star_subs, scope, route_id);
-            } else {
-                add_to_scope_map(&mut bs.scope_subs, scope, route_id);
+
+        Self::replay_to_route(&inner, route_id, &sub);
+    }
+
+    /// Deliver any persisted events matching `sub` to `route_id`.
+    /// Called inside `subscribe` so replay happens atomically under the
+    /// broker lock — no live event published mid-replay can interleave.
+    /// Star-scope replay is intentionally not implemented (rare,
+    /// requires scanning every persist key; can add later if needed).
+    fn replay_to_route(inner: &BrokerInner, route_id: &str, sub: &SubscriptionRequest) {
+        let client = match &inner.client {
+            Some(c) => c,
+            None => return,
+        };
+
+        let deliver = |scope: &str| {
+            let key = PersistKey {
+                event: sub.event.clone(),
+                scope: scope.to_string(),
+            };
+            if let Some(pe) = inner.persist_map.get(&key) {
+                for event in &pe.events {
+                    client.send_event(route_id, event.clone());
+                }
+            }
+        };
+
+        if sub.allscopes {
+            // "" key holds the global history per persist_event's scope_set.
+            deliver("");
+        } else {
+            for scope in &sub.scopes {
+                if !scope_has_star(scope) {
+                    deliver(scope);
+                }
             }
         }
     }
@@ -614,6 +658,75 @@ mod tests {
         });
 
         assert!(client.received_events().is_empty());
+    }
+
+    /// Regression: replay-on-subscribe delivers persisted events that
+    /// were published BEFORE the route subscribed. This closes the
+    /// late-subscribe race for tool_chunk streaming.
+    #[test]
+    fn test_replay_on_subscribe_exact_scope() {
+        let broker = Broker::new();
+        let client = Arc::new(TestClient::new());
+        broker.set_client(Box::new(Arc::clone(&client)));
+
+        // Publish 5 persisted events BEFORE any subscriber exists.
+        for i in 0..5 {
+            broker.publish(WaveEvent {
+                event: "tool_chunk".to_string(),
+                scopes: vec!["block:abc".to_string()],
+                sender: String::new(),
+                persist: 10,
+                data: Some(serde_json::json!({"tool_id": "t1", "n": i})),
+            });
+        }
+        assert!(
+            client.received_events().is_empty(),
+            "no subscriber yet, no delivery"
+        );
+
+        // Subscribe to the matching scope — replay should fire.
+        broker.subscribe(
+            "route-1",
+            SubscriptionRequest {
+                event: "tool_chunk".to_string(),
+                scopes: vec!["block:abc".to_string()],
+                allscopes: false,
+            },
+        );
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 5, "all 5 persisted events replayed");
+        assert_eq!(events[0].1.data, Some(serde_json::json!({"tool_id": "t1", "n": 0})));
+        assert_eq!(events[4].1.data, Some(serde_json::json!({"tool_id": "t1", "n": 4})));
+    }
+
+    /// Regression: replay does NOT cross-pollute scopes. Subscriber to
+    /// `block:abc` must not receive events persisted for `block:xyz`.
+    #[test]
+    fn test_replay_on_subscribe_scope_isolation() {
+        let broker = Broker::new();
+        let client = Arc::new(TestClient::new());
+        broker.set_client(Box::new(Arc::clone(&client)));
+
+        broker.publish(WaveEvent {
+            event: "tool_chunk".to_string(),
+            scopes: vec!["block:xyz".to_string()],
+            sender: String::new(),
+            persist: 10,
+            data: Some(serde_json::json!({"tool_id": "other"})),
+        });
+
+        broker.subscribe(
+            "route-1",
+            SubscriptionRequest {
+                event: "tool_chunk".to_string(),
+                scopes: vec!["block:abc".to_string()],
+                allscopes: false,
+            },
+        );
+
+        let events = client.received_events();
+        assert_eq!(events.len(), 0, "scope:abc must not get block:xyz events");
     }
 
     #[test]

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -860,15 +860,34 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 // a scope and the frontend's per-block subscription
                 // doesn't receive them.
                 env_vars.insert("AGENTMUX_BLOCKID".to_string(), cmd.blockid.clone());
-                if let Some(tools_dir) = crate::backend::tool_store::bundled_tools_dir() {
+                // PATH includes BOTH bundled tools dir (portable
+                // builds, runtime/tools/bin/) AND user tools dir
+                // (~/.agentmux/tools/bin/). bundled is None in dev
+                // mode (target/debug exclusion in tool_store), so
+                // without user_tools_dir the wrapper wouldn't be on
+                // the agent's PATH during `task dev`.
+                {
                     let existing = env_vars
                         .get("PATH")
                         .cloned()
                         .or_else(|| std::env::var("PATH").ok())
                         .unwrap_or_default();
                     let sep = if cfg!(windows) { ";" } else { ":" };
-                    let new_path = format!("{}{}{}", tools_dir.display(), sep, existing);
-                    env_vars.insert("PATH".to_string(), new_path);
+                    let mut extras: Vec<String> = Vec::new();
+                    if let Some(d) = crate::backend::tool_store::bundled_tools_dir() {
+                        if d.exists() {
+                            extras.push(d.to_string_lossy().into_owned());
+                        }
+                    }
+                    if let Some(d) = crate::backend::tool_store::user_tools_dir() {
+                        if d.exists() {
+                            extras.push(d.to_string_lossy().into_owned());
+                        }
+                    }
+                    if !extras.is_empty() {
+                        let new_path = format!("{}{}{}", extras.join(sep), sep, existing);
+                        env_vars.insert("PATH".to_string(), new_path);
+                    }
                 }
 
                 let session_id_field = crate::backend::obj::meta_get_string(

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -855,6 +855,11 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
                 //    rewrites the command to invoke it. AGENTMUX_LOCAL_URL
                 //    is already in the inherited process env (main.rs:498).
                 env_vars.insert("AGENTMUX_AUTH_KEY".to_string(), auth_key.clone());
+                // Block id so the wrapper can scope its WPS publishes
+                // to `block:<id>`. Without this, chunks publish without
+                // a scope and the frontend's per-block subscription
+                // doesn't receive them.
+                env_vars.insert("AGENTMUX_BLOCKID".to_string(), cmd.blockid.clone());
                 if let Some(tools_dir) = crate::backend::tool_store::bundled_tools_dir() {
                     let existing = env_vars
                         .get("PATH")

--- a/docs/analysis/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md
+++ b/docs/analysis/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md
@@ -1,0 +1,179 @@
+# Agent pane reducer-coverage audit
+
+**Date:** 2026-05-12
+**Owner:** AgentA
+**Driving question:** *"Should we first migrate the agent pane to 100% reducer before building the session-replay framework?"*
+
+---
+
+## 1. TL;DR
+
+**No migration needed. The agent pane is already 100% reducer-routed for every state cell that affects rendered output.**
+
+The audit reveals an architecture that wasn't obvious from the surface:
+
+- `state.ts` looks like local SolidJS signal state, but its setters are passed to `registerAgentPaneStatePane` — they're slot-store-writable signals.
+- `useAgentStream.ts` explicitly documents the contract: *"Read-side accessors only — all writes route through dispatchPane"* (line 87).
+- The reducer dispatches (`dispatchPane`, `dispatchDoc`) are the only write path; signals are the *reactive projection layer*, not independent state.
+
+The previous reading ("11 signals not in reducer, need to migrate") was wrong. Those 11 signals are **outputs** of the reducer, not parallel state.
+
+**The session-replay framework spec (`SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`) can proceed as written.** The single `recordDispatch` tap captures every rendering-relevant state change.
+
+---
+
+## 2. Architecture (as-built)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Write path (single)                                        │
+│                                                             │
+│  useAgentStream / commands / hooks                          │
+│              ↓                                              │
+│        dispatchPane / dispatchDoc                           │
+│              ↓                                              │
+│        slot store reducer                                   │
+│              ↓                                              │
+│        (recordDispatch audit ring)  ← REPLAY TAP            │
+│              ↓                                              │
+│        signal setter                                        │
+│                                                             │
+│  Read path (reactive)                                       │
+│                                                             │
+│        signal accessor → component → DOM                    │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+`state.ts` produces a struct of `[Accessor, Setter]` pairs. The setters are handed to `registerAgentPaneStatePane` on mount (`agent-view.tsx:119-128`). From that point forward, the slot-store reducer owns when setters fire. Components consume the accessors, never the setters.
+
+This is the **store-of-truth + reactive projection** pattern — clean and what we want.
+
+---
+
+## 3. Signal-by-signal audit
+
+### `frontend/app/view/agent/state.ts` (11 cells)
+
+| Cell | Reducer-routed? | Notes |
+|---|---|---|
+| `documentAtom: DocumentNode[]` | ✅ via agent-document slot store | `dispatchDoc` commands: `SessionStart`, `NodesAppended`, `NodesUpdated`, `HistoryLoaded`, `ToolChunkAppend`, etc. |
+| `documentStateAtom: DocumentState` | ✅ same slot store | collapsed/pinned/scroll/filter — local UI prefs via reducer |
+| `streamingStateAtom: StreamingState` | ✅ via agent-pane-state | `StreamSubscribe` / `StreamUnsubscribe` |
+| `sessionStatsAtom: SessionStats \| null` | ✅ same | `TurnEnd` (merges stats) |
+| `currentToolAtom: string \| null` | ✅ same | `ToolStart` / `ToolEnd` |
+| `turnTokensAtom: TurnTokens \| null` | ✅ same | `TokensIn` / `TokensOut` |
+| `turnActiveAtom: boolean` | ✅ same | `TurnStart` / `TurnEnd` / `TurnReset` |
+| `stoppingAtom: boolean` | ✅ same | cascades from `TurnEnd` |
+| `pendingMessagesAtom: PendingMessage[]` | ✅ same | `MessageQueued` / `MessageAccepted` |
+| `initPhaseAtom: InitPhase` | ✅ same | `InitReady` / `InitFailed` |
+
+**Verdict:** 100% reducer-routed. The presence of `setters` in `state.ts` is misleading at first glance — they're consumed by the slot store, not called from elsewhere.
+
+**Sanity check** (`grep` from this audit):
+- `setTurnActive`, `setCurrentTool`, `setStopping`, `setSessionStats`, `setInitPhase`, `setStreaming`, `setPending` — called only in `state.test.ts`.
+- `useAgentStream.ts` has zero direct setter calls; 20+ `dispatchPane` / `dispatchDoc` calls.
+
+### `frontend/app/view/agent/hooks/useAgentControllerStatus.ts` (6 cells)
+
+| Cell | Reducer-routed? | Why it's OK |
+|---|---|---|
+| `authUrl: string \| null` | ❌ local signal | OAuth URL during login. Transient — clears on flow end. |
+| `canRetry: boolean` | ❌ local signal | "Retry login" button affordance. Local to retry UI. |
+| `flowRunning: boolean` | ❌ local signal | Guards re-entry into `startLaunchFlow`. Lifecycle-local. |
+| `agentReady: boolean` | ❌ local signal | Spinner gate. Set once on launch success. |
+| `loginWaiting: boolean` | ❌ local signal | OAuth polling phase. Resets per flow. |
+| `loginCancelled: bool` (let var) | ❌ local mutable | Cancellation flag. Read in poll loop. |
+
+**Verdict:** Launch / OAuth lifecycle state. **Separate concern from the conversation transcript** — these don't appear in the rendered agent document. They drive the launch spinner and the OAuth modal.
+
+**Recommendation:** *do not migrate.* Reasoning:
+1. These cells reset every launch — they're transient by design.
+2. They have no cross-cell invariants (each is independent).
+3. For session-replay, **launch is out of fixture scope** (replays start *after* the agent is ready; the auth flow is mocked / pre-seeded via OAuth credentials).
+4. Migrating them into a reducer would add ceremony without unlocking anything (no time-travel benefit, no replay value, no audit benefit).
+
+If we later want to test the launch flow itself (e.g., "OAuth timeout → retry button appears"), that's a separate fixture domain — not the same `.session.ndjson` as conversation replay.
+
+### Other component-local signals (sampled)
+
+| File | Count | Affects replay? |
+|---|---|---|
+| `AgentLaunchModal.tsx` | 10 | No — modal form state (instance name, runtime radio, identity/memory dropdowns). Modal isn't part of the running pane. |
+| `AgentPicker.tsx` | 7 | No — picker UI (search filter, selected card). Pre-launch. |
+| `AgentDecisionPanel.tsx` | 7 | No — permission-decision flow. UI-ephemeral. The DECISIONS themselves are dispatched. |
+| `AgentFooter.tsx` | 6 | No — footer toggle states. |
+| `AgentControlBar.tsx` | 5 | No — control-bar UI. |
+| `useSessionDigest.ts` | 5 | Borderline — session summary view. Likely derives from the document store; needs verification only if we want digest-replay tests. |
+
+**Verdict:** UI-ephemeral. Not in fixture scope. Don't migrate.
+
+---
+
+## 4. Why this confused the initial read
+
+The grep for `createSignal` returns 60+ hits across the agent pane, which *looks* like a lot of non-reducer state. But:
+
+- The 11 signals in `state.ts` are slot-store outputs (setters consumed by the store).
+- The signals in `useAgentControllerStatus` are launch lifecycle, not session state.
+- The signals in modal/picker/footer/etc. are local UI state.
+
+**`createSignal` is the SolidJS primitive — its presence doesn't imply "non-reducer state".** It implies "reactive projection". The actual question is *who writes to the setter*. The audit answer: the slot store writes to `state.ts` setters; nothing else does.
+
+---
+
+## 5. Recommendations
+
+### Do
+
+1. **Proceed with the session-replay framework as spec'd.** The single `recordDispatch` tap is sufficient for capturing every rendering-relevant state change.
+
+2. **Document the bridge architecture.** Add a doc comment at the top of `state.ts` that says: *"This file is the reactive projection layer of `agent-pane-state` + `agent-document` slot stores. Setters are consumed by `registerAgentPaneStatePane` / `registerAgentDocPane`; nothing else may call them. Accessors are the read API for components."* Prevents the same confusion next time.
+
+3. **Add a lint rule** (or grep CI guard) that flags any direct setter call on `state.ts` atoms outside the registration sites. Today the only violator would be `state.test.ts`, which is allowed.
+
+### Don't
+
+1. **Don't migrate `useAgentControllerStatus`.** Launch state is transient and out of replay scope.
+2. **Don't migrate modal/picker/footer signals.** UI-ephemeral, not in scope.
+3. **Don't add reducer ceremony "for completeness".** The current line is principled: state that affects the rendered conversation tree is reducer-routed; UI affordances around it are local.
+
+### Defer
+
+1. **Launch-flow replay.** Future work if we want to test the OAuth + agent-ready transitions. Would need a parallel `.launch.ndjson` fixture domain. Out of scope for v1 session replay.
+2. **Sub-agent recursion replay.** Per session-replay spec §9. v2.
+
+---
+
+## 6. Action items (small, scoped)
+
+| Item | LoC | PR fit |
+|---|---|---|
+| Add architecture comment to `state.ts` | ~15 | Rides with session-replay implementation PR |
+| Add architecture comment to `useAgentStream.ts:87` (expand the existing one) | ~5 | Same PR |
+| Optional: lint rule / CI grep for setter-misuse | ~30 | Separate small PR |
+
+Total: < 1 hour of work. Not a "migration phase" — just architecture documentation that prevents future people (and future-us) from re-doing this audit.
+
+---
+
+## 7. Conclusion
+
+The previous answer ("focused migration of `state.ts` + `useAgentControllerStatus` to reducer first") was based on a surface read of `createSignal` counts. The audit shows:
+
+- `state.ts` is **not parallel state** — it's the reactive output of the slot stores.
+- `useAgentControllerStatus` is **out of replay scope** — launch lifecycle, not session state.
+
+The agent pane is, by the criterion that matters (every rendering-state write goes through a reducer dispatch), already 100% reducer-routed. We can proceed straight to the session-replay framework with no migration in front of it.
+
+---
+
+## 8. Cross-references
+
+- Session-replay spec: [`docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`](../specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md)
+- Slot store + `recordDispatch` audit: PR #764
+- agent-pane-state reducer: `frontend/app/store/agent-pane-state/reducer.ts`
+- agent-document reducer: `frontend/app/store/agent-document/`
+- Phase-1 agent state machine refinements: PR #752
+- State module: `frontend/app/view/agent/state.ts` (read/render projection)
+- Stream consumer: `frontend/app/view/agent/useAgentStream.ts:87` (dispatch-only contract)

--- a/docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md
+++ b/docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md
@@ -1,0 +1,228 @@
+# Spec: Agent pane session-replay framework
+
+**Status:** Spec (no implementation yet)
+**Owner:** AgentA
+**Date:** 2026-05-12
+**Driving requirement:** *"Build a framework that makes it easy to simulate agent pane conversations — record one real session, reuse it as a deterministic fixture in tests, smoke runs, and bug repros. We don't want to run through a whole conversation manually."*
+
+---
+
+## 1. TL;DR
+
+The agent pane has three input channels: **Claude stream-json** (subprocess stdout), **WPS broker events** (live `tool_chunk`, controller status, etc.), and **reducer dispatches** (initiated by the frontend itself). Today, exercising any non-trivial code path requires launching a real Claude agent end-to-end — OAuth, CLI spawn, API tokens, network — which is slow, costly, and non-deterministic.
+
+This spec proposes:
+
+1. A single **`.session.ndjson`** fixture format that captures all three channels with relative timestamps + stable sequence numbers.
+2. A **record harness** that wraps `useAgentStream` + the WPS broker + the dispatch transport, taps each event, and emits the fixture to disk.
+3. A **replay harness** that drives the SolidJS agent pane through the same three injection points in record-order, with configurable speed (1×, instant, single-step).
+4. A **test surface** in three tiers — Vitest unit replay for reducer + parser, Storybook stories for visual snapshots, Playwright integration replay for full-pane DOM assertions.
+5. **Redaction + normalization at record time** so fixtures are safe to commit: OAuth tokens, working-dir paths, `session_id`s, `tool_use_id`s, timestamps all scrubbed.
+
+Closest prior art: **OpenHands** (event-sourced state + `mock_llm_server.py` + `pytest-textual-snapshot`). We adopt their dual-track strategy (mocked unit / scheduled real integration) and their tagged-NDJSON event log shape.
+
+---
+
+## 2. Today's pain
+
+- **OAuth in every test run.** First Claude launch on a fresh data dir triggers the auth flow; no auth = no test. We hit this twice in the last session alone.
+- **Non-deterministic CLI output.** Same prompt → different `session_id`, `tool_use_id`, timestamps. Snapshot tests break on every run.
+- **End-to-end is slow.** 4 minutes from `task dev` cold start to a usable agent pane. Iteration loop on rendering bugs is brutal.
+- **Live-log streaming bugs are race-sensitive.** The fix we just merged (broker replay-on-subscribe) only became reproducible after instrumented logs. Without a deterministic replay, we burned ~6 cycles narrowing the race.
+- **No regression catch.** Past visual regressions (replaceChild crash from `<Show>` cascade — PR #808) shipped to portable before we noticed. Storybook + visual diffs would have caught it on the PR.
+
+---
+
+## 3. Goals
+
+1. **One-line replay.** `vitest run agent-pane.replay.test.ts` loads a fixture and drives the pane through to assertion in under 2 seconds.
+2. **One-line record.** `agentmux dev --record-session=path.ndjson` wraps a real live session and writes the fixture.
+3. **Composable fixtures.** Three "verbs" — `agent-message`, `tool-call+result`, `tool-chunk-burst` — can be mixed by hand to build edge-case scenarios without running a real agent.
+4. **Visual smoke without OAuth.** Storybook story per fixture renders the final document tree; Playwright takes a screenshot. CI runs both on every PR.
+5. **Deterministic.** Same fixture + same code = same DOM. Timestamps in the rendered output are the *fixture's* relative times, not wall-clock.
+6. **Honest scope coverage.** Reducer, parser, render, AND the WPS broker dispatch + subscribe path are all exercised — not just unit-level reducer tests.
+
+## 4. Non-goals
+
+- **Replaying the live Claude API** with real tokens (that's promptfoo's job, separate concern).
+- **Recording sub-agent (`Task` tool) recursion** in v1 — flatten as opaque blocks for now; structured sub-agent replay is v2.
+- **Cross-version replay** (a fixture recorded on schema v7 should not be expected to play cleanly on schema v9). Fixtures are pinned to a schema version and migration is opt-in.
+- **Replaying the agent's bash side effects.** The wrapper's PTY child does not actually run during replay — we replay the *recorded* stdout, no real bash spawn.
+
+---
+
+## 5. Fixture format — `.session.ndjson`
+
+One file per recorded session. Each line is a JSON object tagged by source. Lines are ordered by `seq` (insertion order); `t_ms` is the relative offset from session start (replay scheduler honors it for live-feel pacing or ignores it for instant replay).
+
+```jsonc
+// Header (line 1): metadata + schema version
+{
+  "kind": "header",
+  "version": 1,
+  "agentmux_version": "0.33.817",
+  "schema_version": 8,
+  "recorded_at": "2026-05-12T15:30:00Z",
+  "provider": "claude",
+  "block_id": "<placeholder-uuid-1>",
+  "instance_name": "test-fixture",
+  "redactions": ["session_id", "tool_use_id", "cwd"]
+}
+
+// Each subsequent line is one event
+{ "seq": 1, "t_ms": 0,     "src": "stream-json", "line": "{\"type\":\"message_start\",...}" }
+{ "seq": 2, "t_ms": 14,    "src": "stream-json", "line": "{\"type\":\"content_block_start\",...}" }
+{ "seq": 3, "t_ms": 152,   "src": "wps",         "event": "tool_chunk", "scopes": ["block:<placeholder-uuid-1>"], "data": { "op": "chunk", "tool_id": "<placeholder-tool-1>", "kind": "stdout", "content": "fixture line 1", "timestamp": 152 } }
+{ "seq": 4, "t_ms": 197,   "src": "wps",         "event": "tool_chunk", "scopes": ["block:<placeholder-uuid-1>"], "data": { "op": "chunk", "tool_id": "<placeholder-tool-1>", "kind": "stdout", "content": "fixture line 2", "timestamp": 197 } }
+{ "seq": 5, "t_ms": 1340,  "src": "dispatch",    "blockId": "<placeholder-uuid-1>", "action": { "type": "PaneClicked", ... } }
+{ "seq": 6, "t_ms": 1880,  "src": "stream-json", "line": "{\"type\":\"content_block_start\",\"content_block\":{\"type\":\"tool_use\",\"id\":\"<placeholder-tool-1>\",...}}" }
+{ "seq": 7, "t_ms": 4500,  "src": "stream-json", "line": "{\"type\":\"user\",\"message\":{\"content\":[{\"tool_use_id\":\"<placeholder-tool-1>\",\"type\":\"tool_result\",...}]}}" }
+// ... etc
+
+// Optional trailer (last line): final document state + assertion targets
+{ "kind": "trailer", "final_doc_node_count": 23, "final_status": "complete", "wall_time_ms": 4870 }
+```
+
+### Why NDJSON, not JSON
+
+- **Append-friendly recording** — record harness writes line-by-line, doesn't need to hold the session in memory.
+- **Streamable replay** — replay reads lines, schedules them, no parse-the-world.
+- **Diff-friendly** — git diffs and PR reviews stay readable.
+
+### Why three tags
+
+- `stream-json`: opaque pass-through of Claude CLI output. Goes through the real `stream-parser.ts`. Tests every text/thinking/tool_use/tool_result path.
+- `wps`: events from the broker. Goes through the real `waveEventSubscribe` handler. Tests the broker bridge.
+- `dispatch`: reducer commands originating in the frontend (clicks, scroll, command-K, etc.). Captured from `recordDispatch` audit (already exists — PR #764). Tests the slot store + audit ring + downstream cells.
+
+### Redactions
+
+Done at **record time**, not replay time. A redactor function takes each line and replaces:
+
+| Field | Replacement |
+|---|---|
+| `session_id` (UUID, Claude's) | `<placeholder-session>` |
+| `tool_use_id` (`toolu_*`) | `<placeholder-tool-N>` (stable across session) |
+| `block_id` (UUID, AgentMux's) | `<placeholder-uuid-1>` (one per recorded pane) |
+| `cwd` | `<placeholder-cwd>` |
+| OAuth tokens, API keys | `<redacted>` |
+| `accessToken` / `refreshToken` | `<redacted>` |
+| `timestamp` (ISO 8601) | `<placeholder-time-N>` or normalized to `t_ms`-derived synthetic |
+| Anthropic `id` fields | `<placeholder-id-N>` |
+
+Replay can opt-out of de-placeholdering (default: replay reinflates with real-looking UUIDs/timestamps for the duration of the test run).
+
+---
+
+## 6. Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Record mode                                                 │
+│                                                              │
+│  Real agent → stream-parser → reducer → SolidJS render       │
+│             ↘ (tap)                                          │
+│  WPS broker → useAgentStream → reducer                       │
+│             ↘ (tap)                                          │
+│  Frontend → recordDispatch → reducer                         │
+│             ↘ (tap)                                          │
+│                                                              │
+│  All three taps → redactor → ndjson writer → fixture.ndjson  │
+└──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  Replay mode                                                 │
+│                                                              │
+│  fixture.ndjson → scheduler → demux by src                   │
+│                                                              │
+│      stream-json lines  → fake subprocess emit              │
+│      wps events         → broker.publish (or direct sub)    │
+│      dispatch actions   → dispatchPane / dispatchDoc         │
+│                                                              │
+│  Same parser + reducer + renderer as production.             │
+│  Test asserts on the rendered DOM / store state.             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Three injection points (same in record + replay)
+
+| Layer | Record tap | Replay inject |
+|---|---|---|
+| **Subprocess** | wrap stdout stream | feed bytes into the real stream-parser |
+| **WPS broker** | broker middleware on `publish` | call `broker.publish(event)` |
+| **Reducer** | `recordDispatch` audit hook (already present) | call `dispatchPane` / `dispatchDoc` directly |
+
+### Scheduler modes
+
+- `instant` — fire every event in `seq` order with zero delay (default for unit tests). Sync.
+- `realtime` — respect `t_ms` deltas. Async. For visual smoke + perf measurements.
+- `step` — manual `.next()` calls. For debugger walkthroughs.
+
+---
+
+## 7. Implementation phases
+
+| Phase | Scope | LoC est. |
+|---|---|---|
+| **0** | Spec + fixture-format definition + JSON schema for `.session.ndjson`. | ~50 |
+| **1** | Record harness: `--record-session=path.ndjson` CLI flag on `task dev`. Taps the three channels in a running srv + frontend. Writes redacted NDJSON. | ~400 |
+| **2** | Replay harness: a TS library `frontend/test/replay/agent-session.ts` exposing `playFixture(path, mode)` that demuxes by `src` and drives the pane. | ~250 |
+| **3** | Reducer + parser unit tests (`*.replay.test.ts`) under Vitest. One per fixture, asserting final node count + selected cell values. | ~150 + 5 fixtures |
+| **4** | Storybook stories: one per fixture, mode=`instant`, renders the final tree. | ~100 |
+| **5** | Playwright visual snapshot CI step (mode=`realtime`, screenshot at end). Compare against committed PNG. | ~150 |
+| **6** | Synthetic fixture authoring: a tiny TS DSL (`fixture.bash("echo hi").assistant("here it is")`) for composing edge cases without recording. | ~200 |
+
+Phase 0 ships first as this spec.
+Phase 1 + 2 + 3 land as one PR (a minimal end-to-end demo: record a real session, replay it in a Vitest test, assert document state).
+Phase 4 + 5 are visual + CI infra.
+Phase 6 is the productivity power-up for authoring edge cases.
+
+---
+
+## 8. Best-practice references (annotated)
+
+| Source | What we borrow |
+|---|---|
+| **OpenHands** ([SDK paper](https://arxiv.org/html/2511.03690v1), [AGENTS.md](https://github.com/OpenHands/OpenHands-CLI/blob/main/AGENTS.md)) | Event-sourced state + tagged-NDJSON event log + dual-track (mocked unit / scheduled real-LLM integration) + `pytest-textual-snapshot` for visual. Closest peer. |
+| **Temporal replay-testing** ([Bitovi write-up](https://www.bitovi.com/blog/replay-testing-to-avoid-non-determinism-in-temporal-workflows)) | Replay history against current reducer code; throw on non-determinism. Right correctness model for a reducer-backed pane. |
+| **VCR.py / vcrpy** ([docs](https://vcrpy.readthedocs.io/en/latest/advanced.html), [pytest-recording](https://github.com/kiwicom/pytest-recording)) | Redact at record time via `before_record_response`; order-based matching for streaming chunks. |
+| **PollyJS** ([config](https://github.com/Netflix/pollyjs/blob/master/docs/configuration.md)) | HAR-compliant JSON for browser-side. Lesson: don't reinvent the format — JSON Schema'd ours so editors lint it. |
+| **MSW v2** ([SSE docs](https://mswjs.io/docs/sse/), [streaming](https://mswjs.io/docs/http/mocking-responses/streaming/)) | First-class SSE + streaming-body APIs. We'll use MSW to mock the `/agentmux/wps/publish` endpoint in browser-only tests. |
+| **Playwright** ([HAR mock](https://playwright.dev/docs/mock), [HAR-with-dynamic-params](https://medium.com/@sdgroup/harmageddon-is-cancelled-how-we-taught-playwright-to-replay-har-with-dynamic-parameters-efc4cc24894e)) | `routeFromHAR()` and `routeWebSocket()` for visual smoke. HAR-normalization pattern (replace dynamic tokens *in the HAR* before replay) — we do the same in our redactor. |
+| **LangChain `FakeStreamingListLLM`** ([api ref](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.fake.FakeStreamingListLLM.html)) | Confirmed: list-replay with optional inter-chunk sleep. We generalize the same pattern to three event sources. |
+| **promptfoo caching** ([Semgrep blog](https://semgrep.dev/blog/2024/does-your-llm-thing-work-how-we-use-promptfoo/)) | "Snapshot all template variables to JSON" → reproducible. Equivalent rule for us: every fixture commits with its full input set. |
+| **Claude Code CLI** ([reference](https://code.claude.com/docs/en/cli-reference), [Khan/format-claude-stream](https://github.com/Khan/format-claude-stream)) | `claude -p --output-format stream-json --include-partial-messages` → NDJSON. Community pattern: `tee fixture.ndjson` to record, `cat \| replayer` to replay. We adopt this as our `src: "stream-json"` line format directly. |
+| **Spatie event-sourcing** ([replaying-events](https://spatie.be/docs/laravel-event-sourcing/v7/advanced-usage/replaying-events)) | Timestamp normalization at replay time vs record time. We pick record-time (simpler; replay is deterministic). |
+
+---
+
+## 9. Open questions
+
+1. **Where does the record harness live?** Probably a small wrapper around `useAgentStream` initialized when `AGENTMUX_RECORD_SESSION=path` env var is set. Frontend-side, since that's where all three channels converge. Alternative: a srv-side recorder that taps the subprocess + broker, but it'd miss `dispatch` events.
+
+2. **Fixture identity / pinning.** Do we commit fixtures alongside the test that uses them, or in a central `frontend/test/fixtures/agent-sessions/`? Central wins for discovery + dedup; local wins for refactor-safety.
+
+3. **Should `dispatch` events replay the action, or assert that the action *would have been* dispatched?** Replay is simpler. Assert mode catches divergence (current code dispatches X, fixture has Y) — that's Temporal's non-determinism check. Default to replay; add assert mode in v2.
+
+4. **Visual diff tolerance.** Pixel-perfect Playwright screenshots break on font kerning. Tolerance threshold or SVG snapshot? OpenHands uses SVG (textual-snapshot) which is more forgiving. For our DOM-rendered pane, a `toMatchSnapshot()` against HTML markup (not pixels) is probably what we want.
+
+5. **Recording while live UI is being driven.** Concurrent user clicks during recording: do we capture them as `dispatch` events (yes), or skip them (cleaner fixtures)? Capture; have a `--filter-input` flag to strip user-input dispatches on demand.
+
+6. **Sub-agent (`Task` tool) recursion.** A spawn of a sub-agent creates a new agent pane with its own stream. v1: flatten the sub-agent's output as opaque `text_delta` lines tagged `sub_agent_id`. v2: structured replay where each sub-agent gets its own nested fixture.
+
+7. **Wrapper publishes outside the pane.** The bash wrapper publishes from a separate process, outside frontend taps. We catch them at the broker (`src: "wps"`). But if someone runs the agent on a different machine and the broker is remote, the recorder needs to pick them up via the WebSocket subscribe channel. Out of scope for v1 (single-machine).
+
+8. **API drift.** When `stream-parser.ts` adds support for a new Claude event type, old fixtures stay valid (opaque pass-through). When the reducer adds a new command, old fixtures need replay-time tolerance. Plan: replay tolerates unknown commands by warning; new fixtures opt in to the new behavior.
+
+---
+
+## 10. Cross-references
+
+- Live-log streaming spec: `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md`
+- Named-agent continuation: `docs/specs/SPEC_NAMED_AGENT_CONTINUATION_2026_05_12.md`
+- Live-log retro (motivates this work): `docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md`
+- `useAgentStream`: `frontend/app/view/agent/useAgentStream.ts`
+- Stream parser: `frontend/app/view/agent/stream-parser.ts`
+- Reducer slot store + audit: `frontend/app/store/agent-document/` (PR #764)
+- `recordDispatch` audit: same module
+- WPS broker: `agentmux-srv/src/backend/wps.rs`

--- a/frontend/app/view/agent/state.ts
+++ b/frontend/app/view/agent/state.ts
@@ -2,10 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * State management for agent widget using SolidJS signals
+ * State management for agent widget using SolidJS signals.
  *
- * IMPORTANT: All signals are instance-scoped (created per ViewModel instance)
- * to prevent state bleeding between multiple agent widgets.
+ * IMPORTANT: All signals are instance-scoped (created per ViewModel
+ * instance) to prevent state bleeding between multiple agent widgets.
+ *
+ * **Architecture: this file is the read/render projection layer, not
+ * a parallel state store.** The setters returned here are consumed by
+ * `registerAgentPaneStatePane` and `registerAgentDocPane` on mount; the
+ * slot-store reducers are the *only* callers of those setters. The
+ * components in this directory read via the accessors and never touch
+ * the setters directly. Every write to these signals therefore flows
+ * through `dispatchPane` / `dispatchDoc` and is captured by the
+ * `recordDispatch` audit ring.
+ *
+ * Anti-pattern to flag in review: a `set*` call from a component or
+ * hook outside `state.test.ts`. That bypass would break replay (see
+ * `docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`) and the
+ * audit confirmation in `docs/analysis/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md`.
  */
 
 import { createSignal, type Accessor, type Setter } from "solid-js";

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -101,60 +101,47 @@ export function useAgentStream({
     let pendingUpdates: DocumentNode[] = [];
     let flushRafId: number | null = null;
 
-    // Per-tool WPS subscriptions for `tool_chunk:<tool_use_id>` events.
-    // `agentmux-bashwrap exec` (invoked via the PreToolUse hook) publishes
-    // each stdout/stderr line to its own subject; we open a subscription
-    // when `tool_call` lands, dispatch the chunks into the reducer's
-    // `ToolChunkAppend` command, and tear it down on `tool_result` (or on
-    // unmount). See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §6.
-    const chunkSubs: Map<string, () => void> = new Map();
-
-    function openChunkSub(toolId: string) {
-        if (chunkSubs.has(toolId)) return;
-        const unsub = waveEventSubscribe({
-            eventType: `tool_chunk:${toolId}`,
-            scope: "",
-            handler: (event: any) => {
-                const data = event?.data;
-                if (!data || typeof data !== "object") return;
-                if (data.op === "terminal") {
-                    // Synthesize a system chunk and close the subscription
-                    // — defense in depth if the matching tool_result is
-                    // delayed by network or backend.
-                    dispatchDoc(blockId, {
-                        type: "ToolChunkAppend",
-                        toolId,
-                        chunk: {
-                            kind: "system",
-                            content: `[exited ${data.exit_code ?? "?"}]`,
-                            timestamp: data.timestamp ?? Date.now(),
-                        },
-                    });
-                    closeChunkSub(toolId);
-                    return;
-                }
-                if (data.op !== "chunk") return;
+    // Single per-block WPS subscription for `tool_chunk` events.
+    // `agentmux-bashwrap exec` publishes every stdout/stderr line to a
+    // fixed event name with `scopes: ["block:<id>"]` and the tool_use_id
+    // in the payload. The broker persists ~1024 events per scope, so
+    // the subscription installed on mount picks up any chunks that
+    // landed before Claude's stream-json caught up enough for the
+    // frontend to learn the tool_use_id — closes the late-subscribe
+    // race that the previous per-tool subscription model could not.
+    // See `docs/specs/SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §6.
+    const blockChunkUnsub = waveEventSubscribe({
+        eventType: "tool_chunk",
+        scope: `block:${blockId}`,
+        handler: (event: any) => {
+            const data = event?.data;
+            if (!data || typeof data !== "object") return;
+            const toolId = typeof data.tool_id === "string" ? data.tool_id : "";
+            if (!toolId) return;
+            if (data.op === "terminal") {
                 dispatchDoc(blockId, {
                     type: "ToolChunkAppend",
                     toolId,
                     chunk: {
-                        kind: data.kind ?? "stdout",
-                        content: data.content ?? "",
+                        kind: "system",
+                        content: `[exited ${data.exit_code ?? "?"}]`,
                         timestamp: data.timestamp ?? Date.now(),
                     },
                 });
-            },
-        });
-        chunkSubs.set(toolId, unsub);
-    }
-
-    function closeChunkSub(toolId: string) {
-        const unsub = chunkSubs.get(toolId);
-        if (unsub) {
-            try { unsub(); } catch { /* ignore */ }
-            chunkSubs.delete(toolId);
-        }
-    }
+                return;
+            }
+            if (data.op !== "chunk") return;
+            dispatchDoc(blockId, {
+                type: "ToolChunkAppend",
+                toolId,
+                chunk: {
+                    kind: data.kind ?? "stdout",
+                    content: data.content ?? "",
+                    timestamp: data.timestamp ?? Date.now(),
+                },
+            });
+        },
+    });
 
     function flushPendingNodes() {
         flushRafId = null;
@@ -472,28 +459,21 @@ export function useAgentStream({
                         finalizeTurn(event.stats ?? null);
                         continue;
                     }
-                    // Track the currently-running tool for the status line
+                    // Track the currently-running tool for the status line.
+                    // Per-tool subscription open/close was removed — a single
+                    // per-block subscription installed on mount above handles
+                    // every tool's chunks (the wrapper publishes on a fixed
+                    // event name with the tool_use_id in the payload), and
+                    // the broker's replay-on-subscribe covers the late-
+                    // subscribe race that the per-tool model lost.
                     if (event.type === "tool_call") {
-                        // Preserve prior semantic: missing tool name means
-                        // "no tool" (currentTool=null), NOT "tool with empty
-                        // name". Pre-reducer code did setCurrentTool(event.tool ?? null);
-                        // route through ToolEnd in the missing-name case.
                         if (event.tool) {
                             dispatchPane(blockId, { type: "ToolStart", name: event.tool });
                         } else {
                             dispatchPane(blockId, { type: "ToolEnd" });
                         }
-                        // Open per-tool WPS subscription for live chunks
-                        // (β.B wire-up). Only Bash currently streams, but
-                        // the subscription is cheap and provider-agnostic —
-                        // if the wrapper publishes for this tool_id, we
-                        // receive; if not, the subject stays silent and
-                        // the existing tool_result path lands the whole
-                        // result as before.
-                        if (event.id) openChunkSub(event.id);
                     } else if (event.type === "tool_result") {
                         dispatchPane(blockId, { type: "ToolEnd" });
-                        if (event.id) closeChunkSub(event.id);
                     } else if (event.type === "tool_chunk") {
                         // Live-log streaming (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md):
                         // route chunks through their own reducer command
@@ -533,11 +513,8 @@ export function useAgentStream({
         onCleanup(() => {
             if (flushRafId != null) { cancelAnimationFrame(flushRafId); flushRafId = null; }
             subscription.unsubscribe();
-            // Tear down all live tool_chunk subscriptions opened during
-            // this session (β.B wire-up). A pin/unpin race that left a
-            // chunk subscription open would otherwise leak into the next
-            // session.
-            for (const [id] of chunkSubs) closeChunkSub(id);
+            // Tear down the per-block tool_chunk subscription.
+            try { blockChunkUnsub(); } catch { /* ignore */ }
             // StreamUnsubscribe also force-clears turnActive (so a crash
             // or exit without session_end doesn't leave "Working…" stuck).
             const at = Date.now();

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -85,6 +85,10 @@ export function useAgentStream({
     provider,
 }: UseAgentStreamOpts): void {
     // Read-side accessors only — all writes route through dispatchPane.
+    // Maintaining this contract is how the agent pane stays 100%
+    // reducer-routed and why `recordDispatch` is a sufficient tap for
+    // session-replay fixtures. See docs/analysis/AGENT_PANE_REDUCER_
+    // AUDIT_2026_05_12.md.
     const [getTurnTokens] = turnTokensAtom;
     const getStopping = stoppingAtom?.[0];
 

--- a/frontend/test/fixtures/agent-sessions/bash-with-live-log.session.ndjson
+++ b/frontend/test/fixtures/agent-sessions/bash-with-live-log.session.ndjson
@@ -1,0 +1,9 @@
+{"kind":"header","version":1,"agentmux_version":"0.33.817","schema_version":8,"recorded_at":"2026-05-12T15:00:00Z","provider":"claude","block_id":"<placeholder-uuid-1>","instance_name":"livelog-fixture","redactions":["session_id","tool_use_id","cwd","timestamp"]}
+{"seq":1,"t_ms":0,"src":"stream-json","line":"{\"type\":\"text\",\"content\":\"I'll run a bash command.\"}"}
+{"seq":2,"t_ms":150,"src":"stream-json","line":"{\"type\":\"tool_call\",\"tool\":\"Bash\",\"id\":\"<placeholder-tool-1>\",\"params\":{\"command\":\"ls /tmp\"}}"}
+{"seq":3,"t_ms":200,"src":"wps","event":"tool_chunk","scopes":["block:<placeholder-uuid-1>"],"data":{"op":"chunk","tool_id":"<placeholder-tool-1>","kind":"stdout","content":"file1.txt","timestamp":200}}
+{"seq":4,"t_ms":240,"src":"wps","event":"tool_chunk","scopes":["block:<placeholder-uuid-1>"],"data":{"op":"chunk","tool_id":"<placeholder-tool-1>","kind":"stdout","content":"file2.txt","timestamp":240}}
+{"seq":5,"t_ms":280,"src":"wps","event":"tool_chunk","scopes":["block:<placeholder-uuid-1>"],"data":{"op":"chunk","tool_id":"<placeholder-tool-1>","kind":"stdout","content":"file3.txt","timestamp":280}}
+{"seq":6,"t_ms":320,"src":"wps","event":"tool_chunk","scopes":["block:<placeholder-uuid-1>"],"data":{"op":"terminal","tool_id":"<placeholder-tool-1>","exit_code":0,"timestamp":320}}
+{"seq":7,"t_ms":380,"src":"stream-json","line":"{\"type\":\"tool_result\",\"tool\":\"Bash\",\"id\":\"<placeholder-tool-1>\",\"result\":\"file1.txt\\nfile2.txt\\nfile3.txt\",\"isError\":false}"}
+{"kind":"trailer","wall_time_ms":380,"expect":{"tool_chunks_applied":4,"warnings_count":0,"tool_id":"<placeholder-tool-1>","final_kind_breakdown":{"stdout":3,"system":1}}}

--- a/frontend/test/replay/bash-with-live-log.replay.test.ts
+++ b/frontend/test/replay/bash-with-live-log.replay.test.ts
@@ -1,0 +1,125 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end replay test against a synthetic Bash + live-log fixture.
+ *
+ * What this proves:
+ *   - The session-replay framework loads + validates an NDJSON fixture.
+ *   - The replay driver demuxes stream-json + wps + dispatch events to
+ *     the right reducer commands.
+ *   - The agent-document reducer accumulates ToolChunkAppend events on
+ *     the matching ToolNode (a smoke test for the live-log feature's
+ *     state path; PR #800 / #815).
+ *
+ * Adding more fixtures here is the v1 expansion path — every recorded
+ * bug repro becomes its own `*.replay.test.ts` with one assert per
+ * regression we don't want to ship again. Spec:
+ * `docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`.
+ */
+
+import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadFixture } from "./loader";
+import { replayInstant } from "./replay";
+import type { ToolNode } from "@/app/view/agent/types";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.resolve(
+    __dirname,
+    "../fixtures/agent-sessions/bash-with-live-log.session.ndjson",
+);
+
+describe("agent-pane session replay: bash-with-live-log", () => {
+    it("loads + parses the fixture", () => {
+        const fixture = loadFixture(FIXTURE);
+        expect(fixture.header.version).toBe(1);
+        expect(fixture.header.provider).toBe("claude");
+        expect(fixture.events.length).toBeGreaterThan(0);
+        // Trailer has expectations the replay must satisfy.
+        expect(fixture.trailer?.expect).toBeDefined();
+    });
+
+    it("applies stream-json + wps events through the real reducers", () => {
+        const fixture = loadFixture(FIXTURE);
+        const result = replayInstant(fixture);
+
+        const expected = fixture.trailer!.expect as {
+            tool_chunks_applied: number;
+            warnings_count: number;
+            tool_id: string;
+            final_kind_breakdown: Record<string, number>;
+        };
+
+        // Tool chunks were dispatched (3 stdout + 1 terminal=>system).
+        expect(result.stats.toolChunksApplied).toBe(expected.tool_chunks_applied);
+
+        // No warnings — the chunks landed on a known tool, nothing dropped.
+        expect(result.warnings).toEqual([]);
+        expect(result.stats.eventsDropped).toBe(0);
+        // (cross-check via fixture expectation too)
+        expect(result.warnings.length).toBe(expected.warnings_count);
+
+        // The ToolNode should have the live-log chunks attached.
+        const toolNode = result.docState.nodes.find(
+            (n): n is ToolNode => n.type === "tool" && n.id === expected.tool_id,
+        );
+        expect(toolNode).toBeDefined();
+        const chunks = toolNode!.log?.chunks ?? [];
+        expect(chunks.length).toBe(expected.tool_chunks_applied);
+
+        // Kinds match the breakdown the fixture predicts.
+        const breakdown: Record<string, number> = {};
+        for (const c of chunks) breakdown[c.kind] = (breakdown[c.kind] ?? 0) + 1;
+        expect(breakdown).toEqual(expected.final_kind_breakdown);
+
+        // Content sanity — stdout chunks should appear in input order.
+        const stdoutContents = chunks
+            .filter((c) => c.kind === "stdout")
+            .map((c) => c.content);
+        expect(stdoutContents).toEqual(["file1.txt", "file2.txt", "file3.txt"]);
+    });
+
+    it("rejects fixtures with non-monotonic seq", () => {
+        // Negative test for the loader's strict-shape guarantees.
+        // Inline a small bad fixture to a temp file and assert throw.
+        // Using a literal string avoids file I/O in the test happy path.
+        const bad = [
+            JSON.stringify({
+                kind: "header",
+                version: 1,
+                agentmux_version: "0.33.817",
+                schema_version: 8,
+                recorded_at: "2026-05-12T15:00:00Z",
+                provider: "claude",
+                block_id: "x",
+                instance_name: "x",
+                redactions: [],
+            }),
+            JSON.stringify({
+                seq: 5,
+                t_ms: 0,
+                src: "stream-json",
+                line: "{}",
+            }),
+            // seq goes backwards — must throw.
+            JSON.stringify({
+                seq: 3,
+                t_ms: 1,
+                src: "stream-json",
+                line: "{}",
+            }),
+        ].join("\n");
+
+        const fs = require("node:fs") as typeof import("node:fs");
+        const tmp = path.join(__dirname, `.tmp-bad-${Date.now()}.ndjson`);
+        fs.writeFileSync(tmp, bad, "utf8");
+        try {
+            expect(() => loadFixture(tmp)).toThrow(/seq must be strictly increasing/);
+        } finally {
+            fs.unlinkSync(tmp);
+        }
+    });
+});

--- a/frontend/test/replay/loader.ts
+++ b/frontend/test/replay/loader.ts
@@ -1,0 +1,97 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NDJSON fixture loader for agent-pane session replay.
+ *
+ * Strict shape validation: a fixture must start with a `header`, end
+ * optionally with a `trailer`, and have monotonically-increasing
+ * `seq` numbers in between. Validation errors throw so the test
+ * driver surfaces them as test failures rather than mysterious
+ * downstream replay errors.
+ */
+
+import { readFileSync } from "node:fs";
+import type {
+    Fixture,
+    FixtureEvent,
+    FixtureHeader,
+    FixtureLine,
+    FixtureTrailer,
+} from "./types";
+
+export function loadFixture(absPath: string): Fixture {
+    const raw = readFileSync(absPath, "utf8");
+    const lines = raw.split(/\r?\n/).filter((l) => l.trim().length > 0);
+    if (lines.length === 0) {
+        throw new Error(`fixture is empty: ${absPath}`);
+    }
+
+    const parsed: FixtureLine[] = lines.map((line, i) => {
+        try {
+            return JSON.parse(line) as FixtureLine;
+        } catch (e) {
+            throw new Error(
+                `fixture ${absPath} line ${i + 1}: invalid JSON — ${(e as Error).message}\n  line: ${line.slice(0, 200)}`,
+            );
+        }
+    });
+
+    // First line must be header.
+    const first = parsed[0];
+    if (!isHeader(first)) {
+        throw new Error(`fixture ${absPath} line 1: must be a header (kind: "header")`);
+    }
+    if (first.version !== 1) {
+        throw new Error(
+            `fixture ${absPath}: unsupported version ${first.version} (expected 1)`,
+        );
+    }
+
+    // Last line may be trailer.
+    const last = parsed[parsed.length - 1];
+    const trailer = isTrailer(last) ? last : null;
+    const eventLines = trailer ? parsed.slice(1, -1) : parsed.slice(1);
+
+    const events: FixtureEvent[] = [];
+    let prevSeq = 0;
+    for (let i = 0; i < eventLines.length; i++) {
+        const ev = eventLines[i];
+        if (isHeader(ev) || isTrailer(ev)) {
+            throw new Error(
+                `fixture ${absPath} line ${i + 2}: extra header/trailer not allowed`,
+            );
+        }
+        const fev = ev as FixtureEvent;
+        if (typeof fev.seq !== "number" || fev.seq <= prevSeq) {
+            throw new Error(
+                `fixture ${absPath} line ${i + 2}: seq must be strictly increasing (got ${fev.seq}, prev ${prevSeq})`,
+            );
+        }
+        prevSeq = fev.seq;
+        if (fev.src !== "stream-json" && fev.src !== "wps" && fev.src !== "dispatch") {
+            throw new Error(
+                `fixture ${absPath} line ${i + 2}: invalid src "${fev.src}" (expected stream-json / wps / dispatch)`,
+            );
+        }
+        events.push(fev);
+    }
+
+    return { header: first, events, trailer };
+}
+
+function isHeader(line: unknown): line is FixtureHeader {
+    return (
+        typeof line === "object" &&
+        line !== null &&
+        (line as { kind?: unknown }).kind === "header"
+    );
+}
+
+function isTrailer(line: unknown): line is FixtureTrailer {
+    return (
+        typeof line === "object" &&
+        line !== null &&
+        (line as { kind?: unknown }).kind === "trailer"
+    );
+}

--- a/frontend/test/replay/replay.ts
+++ b/frontend/test/replay/replay.ts
@@ -158,7 +158,18 @@ function handleStreamLine(
 ): void {
     stats.streamLinesParsed += 1;
     const node = parser.parseLine(ev.line);
-    if (!node) return; // partial / init / no-op-yielding line
+    if (!node) {
+        // Parser returned null. Expected for line types the parser
+        // intentionally ignores (e.g. `tool_chunk` lines handled
+        // out-of-band, message_start/_stop). Surface it as a
+        // soft warning so authors of new fixtures notice when a
+        // line they expected to yield a node silently doesn't.
+        warnings.push(
+            `stream-json line at seq ${ev.seq} produced no node ` +
+                `(line starts with: ${ev.line.slice(0, 80)})`,
+        );
+        return;
+    }
     const isUpdate = seenIds.has(node.id);
     if (isUpdate) {
         applyDoc({ type: "StreamFlush", newNodes: [], updatedNodes: [node] });
@@ -166,7 +177,6 @@ function handleStreamLine(
         applyDoc({ type: "StreamFlush", newNodes: [node], updatedNodes: [] });
         stats.nodesAppended += 1;
     }
-    void warnings;
 }
 
 function handleWpsEvent(

--- a/frontend/test/replay/replay.ts
+++ b/frontend/test/replay/replay.ts
@@ -1,0 +1,253 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Replay driver for agent-pane session fixtures.
+ *
+ * The single public entry point — `replayInstant(fixture)` — applies
+ * every event in `seq` order using the real reducers + the real
+ * stream-parser. No SolidJS rendering, no slot-store registration,
+ * no async waits. Returns the final document + pane state for the
+ * test to assert against.
+ *
+ * Three event sources, three demuxer arms:
+ *
+ * 1. `stream-json` — feed the raw line to `ClaudeCodeStreamParser`.
+ *    Each line that yields a `DocumentNode` becomes a `StreamFlush`
+ *    command (new vs update routed by id-presence). Lines that yield
+ *    `null` (partial, init, session-end-only) are skipped.
+ *
+ * 2. `wps` — match `event` + `data.op` to the right reducer command:
+ *      - `tool_chunk` + `op: "chunk"` → `dispatchDoc(ToolChunkAppend)`
+ *      - `tool_chunk` + `op: "terminal"` → synthesize a system chunk
+ *        (the frontend's chunk handler does the same — see
+ *        `useAgentStream.ts` `blockChunkUnsub` handler).
+ *      - Other broker events are recorded into `warnings` and skipped
+ *        (extend as needed).
+ *
+ * 3. `dispatch` — direct command application. `store` discriminates
+ *    between doc and pane.
+ *
+ * Higher-fidelity modes (`realtime`, `step`) come in a follow-up —
+ * `instant` is enough for unit-level reducer + parser regression
+ * coverage, which is Phase 3 of the spec.
+ */
+
+import { ClaudeCodeStreamParser } from "@/app/view/agent/stream-parser";
+import type { ProviderDefinition } from "@/app/view/agent/providers";
+import { update as updateDoc } from "@/app/store/agent-document/reducer";
+import {
+    initialState as initialDocState,
+    type AgentDocumentState,
+    type AgentDocumentCommand,
+} from "@/app/store/agent-document/types";
+import { update as updatePane } from "@/app/store/agent-pane-state/reducer";
+import {
+    initialState as initialPaneState,
+    type AgentPaneState,
+    type AgentPaneCommand,
+} from "@/app/store/agent-pane-state/types";
+
+import type {
+    Fixture,
+    FixtureWpsEvent,
+    FixtureStreamEvent,
+    FixtureDispatchEvent,
+} from "./types";
+
+export interface ReplayResult {
+    docState: AgentDocumentState;
+    paneState: AgentPaneState;
+    /** Non-fatal anomalies the driver noticed (unknown event types,
+     *  dropped chunks, parser nulls, etc). Tests can assert on
+     *  `warnings.length === 0` for the strict path. */
+    warnings: string[];
+    /** Stats — handy for diagnostic asserts. */
+    stats: {
+        streamLinesParsed: number;
+        nodesAppended: number;
+        wpsEvents: number;
+        toolChunksApplied: number;
+        dispatchEvents: number;
+        eventsDropped: number;
+    };
+}
+
+export interface ReplayOptions {
+    /** Frozen wall clock for deterministic `nowMs` injection.
+     *  Defaults to the fixture's header time. */
+    nowMs?: number;
+    /** Provider for the parser. Defaults to a minimal stub —
+     *  override when testing provider-specific paths. */
+    provider?: ProviderDefinition;
+}
+
+/**
+ * Apply every event in fixture order. Synchronous.
+ */
+export function replayInstant(
+    fixture: Fixture,
+    options: ReplayOptions = {},
+): ReplayResult {
+    const nowMs = options.nowMs ?? (Date.parse(fixture.header.recorded_at) || 0);
+    const provider = options.provider ?? minimalProvider(fixture.header.provider);
+
+    const blockId = fixture.header.block_id;
+    const agentId = `replay-${blockId}`;
+
+    let docState = initialDocState();
+    let paneState = initialPaneState(agentId);
+    const warnings: string[] = [];
+    const stats = {
+        streamLinesParsed: 0,
+        nodesAppended: 0,
+        wpsEvents: 0,
+        toolChunksApplied: 0,
+        dispatchEvents: 0,
+        eventsDropped: 0,
+    };
+
+    const parser = new ClaudeCodeStreamParser(provider);
+    const nodeIds = new Set<string>();
+
+    const applyDoc = (cmd: AgentDocumentCommand): void => {
+        const result = updateDoc(docState, cmd, nowMs);
+        docState = result.state;
+        if (cmd.type === "StreamFlush") {
+            for (const n of cmd.newNodes) nodeIds.add(n.id);
+        } else if (cmd.type === "HistoryLoaded") {
+            for (const n of cmd.nodes) nodeIds.add(n.id);
+        }
+        // Surface tool-chunk-dropped events as warnings — they're the
+        // late-subscribe race signal we care about diagnosing.
+        for (const ev of result.events) {
+            if (ev.type === "tool-chunk-dropped") {
+                warnings.push(
+                    `dropped tool_chunk for ${ev.toolId} — reason: ${ev.reason}`,
+                );
+                stats.eventsDropped += 1;
+            }
+        }
+    };
+
+    const applyPane = (cmd: AgentPaneCommand): void => {
+        const result = updatePane(paneState, cmd, nowMs);
+        paneState = result.state;
+    };
+
+    for (const ev of fixture.events) {
+        if (ev.src === "stream-json") {
+            handleStreamLine(ev, parser, nodeIds, applyDoc, stats, warnings);
+        } else if (ev.src === "wps") {
+            handleWpsEvent(ev, applyDoc, stats, warnings);
+        } else if (ev.src === "dispatch") {
+            handleDispatch(ev, applyDoc, applyPane, stats, warnings);
+        }
+    }
+
+    return { docState, paneState, warnings, stats };
+}
+
+function handleStreamLine(
+    ev: FixtureStreamEvent,
+    parser: ClaudeCodeStreamParser,
+    seenIds: Set<string>,
+    applyDoc: (cmd: AgentDocumentCommand) => void,
+    stats: ReplayResult["stats"],
+    warnings: string[],
+): void {
+    stats.streamLinesParsed += 1;
+    const node = parser.parseLine(ev.line);
+    if (!node) return; // partial / init / no-op-yielding line
+    const isUpdate = seenIds.has(node.id);
+    if (isUpdate) {
+        applyDoc({ type: "StreamFlush", newNodes: [], updatedNodes: [node] });
+    } else {
+        applyDoc({ type: "StreamFlush", newNodes: [node], updatedNodes: [] });
+        stats.nodesAppended += 1;
+    }
+    void warnings;
+}
+
+function handleWpsEvent(
+    ev: FixtureWpsEvent,
+    applyDoc: (cmd: AgentDocumentCommand) => void,
+    stats: ReplayResult["stats"],
+    warnings: string[],
+): void {
+    stats.wpsEvents += 1;
+    if (ev.event !== "tool_chunk") {
+        // Recognized but unhandled — extend the demuxer when a test
+        // needs controller-status / blockfile replay.
+        warnings.push(
+            `wps event "${ev.event}" not handled by replay driver (seq ${ev.seq})`,
+        );
+        return;
+    }
+    const data = ev.data as {
+        op?: string;
+        tool_id?: string;
+        kind?: string;
+        content?: string;
+        timestamp?: number;
+        exit_code?: number;
+    } | null;
+    if (!data || typeof data !== "object") return;
+    const toolId = typeof data.tool_id === "string" ? data.tool_id : "";
+    if (!toolId) return;
+
+    if (data.op === "chunk") {
+        applyDoc({
+            type: "ToolChunkAppend",
+            toolId,
+            chunk: {
+                kind: (data.kind as never) ?? "stdout",
+                content: data.content ?? "",
+                timestamp: data.timestamp ?? ev.t_ms,
+            },
+        });
+        stats.toolChunksApplied += 1;
+    } else if (data.op === "terminal") {
+        // Mirrors useAgentStream's handler: synthesize a system chunk.
+        applyDoc({
+            type: "ToolChunkAppend",
+            toolId,
+            chunk: {
+                kind: "system",
+                content: `[exited ${data.exit_code ?? "?"}]`,
+                timestamp: data.timestamp ?? ev.t_ms,
+            },
+        });
+        stats.toolChunksApplied += 1;
+    }
+}
+
+function handleDispatch(
+    ev: FixtureDispatchEvent,
+    applyDoc: (cmd: AgentDocumentCommand) => void,
+    applyPane: (cmd: AgentPaneCommand) => void,
+    stats: ReplayResult["stats"],
+    warnings: string[],
+): void {
+    stats.dispatchEvents += 1;
+    if (ev.store === "doc") {
+        applyDoc(ev.action as AgentDocumentCommand);
+    } else if (ev.store === "pane") {
+        applyPane(ev.action as AgentPaneCommand);
+    } else {
+        warnings.push(`dispatch event seq ${ev.seq}: unknown store "${ev.store}"`);
+    }
+}
+
+/** Lightweight stub provider — enough for the parser to emit basic
+ *  nodes. Replace via `options.provider` for provider-specific tests. */
+function minimalProvider(name: string): ProviderDefinition {
+    return {
+        id: name,
+        displayName: name,
+        styledOutputFormat: "stream-json",
+        sessionIdField: "session_id",
+        resumeFlag: "",
+        controllerType: "subprocess",
+    } as unknown as ProviderDefinition;
+}

--- a/frontend/test/replay/types.ts
+++ b/frontend/test/replay/types.ts
@@ -65,7 +65,7 @@ export interface FixtureDispatchEvent {
     src: "dispatch";
     blockId: string;
     /** Either an agent-document or an agent-pane-state command. */
-    action: AgentDocumentCommand | AgentPaneStateCommand;
+    action: AgentDocumentCommand | AgentPaneCommand;
     /** Which slot store the action targets. */
     store: "doc" | "pane";
 }

--- a/frontend/test/replay/types.ts
+++ b/frontend/test/replay/types.ts
@@ -1,0 +1,95 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent pane session-replay fixture types.
+ *
+ * Shape and rationale: `docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`.
+ *
+ * One `.session.ndjson` file per recorded session. Each line is a
+ * single JSON object — header first, then events tagged by `src`,
+ * optional trailer last. Events carry a relative `t_ms` and a stable
+ * `seq` so replay schedulers can honor (or ignore) timing.
+ */
+
+import type { AgentDocumentCommand } from "@/app/store/agent-document/types";
+import type { AgentPaneCommand } from "@/app/store/agent-pane-state/types";
+
+/** Fixture metadata. Line 1 of every `.session.ndjson`. */
+export interface FixtureHeader {
+    kind: "header";
+    /** Bump on incompatible format changes. */
+    version: 1;
+    /** AgentMux version the session was recorded against. */
+    agentmux_version: string;
+    /** v8 schema or whatever's active at record time. */
+    schema_version: number;
+    recorded_at: string;
+    provider: "claude" | "codex" | "gemini" | string;
+    block_id: string;
+    instance_name: string;
+    /** Which fields were redacted to placeholders at record time. */
+    redactions: string[];
+}
+
+/** A single Claude Code stream-json line, opaque to the replay
+ *  driver — handed verbatim to the real parser. */
+export interface FixtureStreamEvent {
+    seq: number;
+    t_ms: number;
+    src: "stream-json";
+    /** Raw JSON text of one stream-json line. */
+    line: string;
+}
+
+/** A WPS broker event. The replay driver matches `event` + `data.op`
+ *  to translate into the right reducer command. */
+export interface FixtureWpsEvent {
+    seq: number;
+    t_ms: number;
+    src: "wps";
+    /** Broker event name, e.g. `"tool_chunk"`, `"controllerstatus"`. */
+    event: string;
+    /** Scope filters (`["block:<id>"]`). */
+    scopes: string[];
+    /** Free-form payload. Shape depends on `event`. */
+    data: unknown;
+}
+
+/** A reducer command dispatched by the frontend (not derived from
+ *  the upstream channels). Captures user input + frontend-local
+ *  state transitions during recording. */
+export interface FixtureDispatchEvent {
+    seq: number;
+    t_ms: number;
+    src: "dispatch";
+    blockId: string;
+    /** Either an agent-document or an agent-pane-state command. */
+    action: AgentDocumentCommand | AgentPaneStateCommand;
+    /** Which slot store the action targets. */
+    store: "doc" | "pane";
+}
+
+/** Final-state assertions + recording stats. Optional last line. */
+export interface FixtureTrailer {
+    kind: "trailer";
+    final_doc_node_count?: number;
+    final_status?: string;
+    wall_time_ms?: number;
+    /** Free-form expectations for replay tests to assert. */
+    expect?: Record<string, unknown>;
+}
+
+export type FixtureEvent =
+    | FixtureStreamEvent
+    | FixtureWpsEvent
+    | FixtureDispatchEvent;
+
+export type FixtureLine = FixtureHeader | FixtureEvent | FixtureTrailer;
+
+/** Parsed fixture file. */
+export interface Fixture {
+    header: FixtureHeader;
+    events: FixtureEvent[];
+    trailer: FixtureTrailer | null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.819",
+  "version": "0.33.820",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.819",
+      "version": "0.33.820",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.817",
+  "version": "0.33.818",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.817",
+      "version": "0.33.818",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.818",
+  "version": "0.33.819",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.818",
+      "version": "0.33.819",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.818",
+  "version": "0.33.819",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.817",
+  "version": "0.33.818",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.819",
+  "version": "0.33.820",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Three related pieces of work landing together because they're causally chained: the live-log streaming fix was painful to debug → motivated a replay framework → audit showed the framework can ship without prerequisite migration.

### 1. Live-log streaming — broker replay + frontend single-subscription
Fixes the late-subscribe race that prevented chunks from reaching the frontend on 0.33.814 (smoke-tested + diagnosed in [`docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md)).

- **Wrapper** (`agentmux-bashwrap/src/wps_client.rs`, `bash_wrap.rs`) — publishes to fixed `tool_chunk` event name + `scopes: ["block:<id>"]` with `tool_id` in payload + `persist: 1024`. Falls back to `$AGENTMUX_BLOCKID` env when `--block-id` CLI arg is absent.
- **Broker** (`agentmux-srv/src/backend/wps.rs`) — `subscribe()` now replays persisted events matching the new sub's scope **atomically under the broker mutex**. Star-scope replay deliberately deferred. +2 regression tests (`test_replay_on_subscribe_exact_scope`, `test_replay_on_subscribe_scope_isolation`).
- **srv websocket** — injects `AGENTMUX_BLOCKID` into Claude spawn env_vars; adds both `bundled_tools_dir()` (portable) and `user_tools_dir()` (dev) to PATH so the wrapper is discoverable in `task dev` mode too.
- **Frontend** (`useAgentStream.ts`) — replaces per-tool `openChunkSub`/`closeChunkSub` with **one** per-block subscription installed on mount. Removes the timing dependency on `tool_call` events entirely.
- Cleans up the `.claude/hooks.json` → `.claude/settings.json` orphan test left over from PR #813.

### 2. Session-replay framework (Phase 1+2+3)
Spec: [`SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md`](https://github.com/agentmuxai/agentmux/blob/agenta/live-log-scope-replay/docs/specs/SPEC_AGENT_PANE_SESSION_REPLAY_2026_05_12.md). NDJSON tagged-event fixtures driven through the real reducers — no OAuth, no API calls, no UI render. **2ms** per replay test.

- `frontend/test/replay/types.ts` — header / event-by-source / trailer line shapes.
- `frontend/test/replay/loader.ts` — strict NDJSON parser with monotonic-seq + shape validation.
- `frontend/test/replay/replay.ts` — `replayInstant(fixture)` demuxes `stream-json` / `wps` / `dispatch` to the real parser + reducers; returns final state + warnings + stats.
- `frontend/test/fixtures/agent-sessions/bash-with-live-log.session.ndjson` — first synthetic fixture (tool_call + 3 chunks + terminal + tool_result).
- `frontend/test/replay/bash-with-live-log.replay.test.ts` — 3 Vitest cases, all pass.

Phases 4 (Storybook), 5 (Playwright visual), 6 (DSL) and the record harness (Phase 1 of the original 6-phase plan) are intentional follow-ups.

### 3. Reducer-coverage audit
[`AGENT_PANE_REDUCER_AUDIT_2026_05_12.md`](https://github.com/agentmuxai/agentmux/blob/agenta/live-log-scope-replay/docs/analysis/AGENT_PANE_REDUCER_AUDIT_2026_05_12.md). The agent pane is **already 100% reducer-routed** for every rendering-state cell. `state.ts` is the reactive projection layer; slot stores own writes; `useAgentStream.ts:87` documents the dispatch-only contract. Adds architecture comments to both files to prevent the next reader from re-doing the audit.

## Test plan
- [x] `cargo test -p agentmux-srv` — 888 tests pass (includes 2 new broker replay-on-subscribe regressions)
- [x] `cargo test -p agentmux-bashwrap` — 20 tests pass
- [x] `npx vitest run frontend/test/replay/ frontend/app/store/agent-document/ frontend/app/view/agent/state.test.ts` — 46 tests pass
- [x] Standalone smoke of the wrapper (echo / binary / slow-trickle / 10KB newline-free) — all pass
- [ ] End-to-end UI verification of live-log streaming in `task dev` — deferred to the next pickup (this is the actual goal of the replay framework: make this no longer require manual UI testing)

## Notes for review
- This PR is ~1k lines of code spread across Rust + TypeScript + docs + tests + one new NDJSON fixture. The pieces are small individually; the breadth is from spanning three areas. The retro and audit docs are the orienting reads.
- The live-log change is functionally equivalent to PR #815 (wrapper rewrite) + the broker replay-on-subscribe fix; the latter is the new bit on top of main.
- No version-pin shenanigans — bumped to 0.33.818 fresh after rebase onto main (which is at 0.33.817 from PR #816).

🤖 Generated with [Claude Code](https://claude.com/claude-code)