### PR TITLE
feat(registry): parallel-write shared agent registry (PR A)

### DIFF
--- a/.release-notes-0.33.814.md
+++ b/.release-notes-0.33.814.md
@@ -1,0 +1,81 @@
+## Pre-release snapshot
+
+This is a **pre-release** snapshot — published so the artifact has a downloadable URL, but the live-log streaming work is still under active diagnosis. Use this for testing, not for general distribution.
+
+112 commits since v0.33.669 (May 6, 2026). Headline themes below; full commit log via `git log v0.33.669..v0.33.814`.
+
+## What's new
+
+### Live-log streaming for the agent pane (preview)
+Streaming bash output line-by-line into the agent pane overlay during long-running commands.
+- **Phase 1** ([#800](https://github.com/agentmuxai/agentmux/pull/800)) — `tool_chunk` reducer, types, and tests.
+- **Phase 3** ([#803](https://github.com/agentmuxai/agentmux/pull/803)) — overlay UI (header / virtualized log / bottom action bar).
+- **β.A** ([#804](https://github.com/agentmuxai/agentmux/pull/804)) — new `agentmux-bashwrap` crate: PreToolUse hook helper + bash runner that publishes chunks to WPS.
+- **β.B** ([#809](https://github.com/agentmuxai/agentmux/pull/809)) — wiring: HTTP publish endpoint, env injection at Claude spawn, frontend WPS bridge.
+- **Hotfix** ([#808](https://github.com/agentmuxai/agentmux/pull/808)) — fix `replaceChild` crash from `<Show>` cascade on overlay transitions.
+- **Hook discovery fix** ([#813](https://github.com/agentmuxai/agentmux/pull/813)) — write `.claude/settings.json` under the `"hooks"` key (Claude Code's real discovery location), not the dead-letter `.claude/hooks.json`.
+- **Wrapper rewrite** ([#815](https://github.com/agentmuxai/agentmux/pull/815)) — drop `portable_pty` + `cmd /C` (was hitting `STATUS_DLL_INIT_FAILED` on every command), switch to `tokio::process` + `bash -c` pipes. Byte-level reads with lossy UTF-8, 4KB/50ms quiet-window flushing. Full retrospective at `docs/retros/2026-05-11-live-log-streaming-wrapper-failures.md`.
+- **Diagnostic logging** (0.33.814) — wrapper now writes its tracing to `~/.agentmux/logs/bashwrap-debug.log` so we can pinpoint where end-to-end streaming is still breaking.
+
+**Known issue:** the wrapper runs to completion and bash output appears in the model's `tool_result`, but the live overlay log stays empty — WPS publishes aren't reaching the frontend reliably. The diagnostic log in 0.33.814 is the next step toward resolution.
+
+### Floating panes (tear-off, Phase 1)
+- **Phase 1** ([#810](https://github.com/agentmuxai/agentmux/pull/810) / [#811](https://github.com/agentmuxai/agentmux/pull/811)) — Win32 owned-window primitive (`WS_POPUP + WS_EX_TOOLWINDOW`) + frontend stub. Sets the foundation for full tab/pane tear-off in upcoming phases.
+
+### Reducer-stack Slice #9 (browser pane → host reducer)
+Migrates every browser-pane state cell from atom-direct to reducer-routed dispatches, with audit + diagnostic panel for the reducer ring buffer.
+- Phases 3a-3e — closed/loading/error/canGoBack/canGoForward/title/faviconUrl/url cells through the reducer ([#756](https://github.com/agentmuxai/agentmux/pull/756), [#757](https://github.com/agentmuxai/agentmux/pull/757), [#758](https://github.com/agentmuxai/agentmux/pull/758), [#761](https://github.com/agentmuxai/agentmux/pull/761), [#763](https://github.com/agentmuxai/agentmux/pull/763)).
+- **Phase 4** ([#764](https://github.com/agentmuxai/agentmux/pull/764)) — slot store + `recordDispatch` audit + PaneClicked through reducer.
+- **Phase 5** ([#765](https://github.com/agentmuxai/agentmux/pull/765)) — diag panel UI for the audit ring.
+
+### Performance instrumentation
+- **Phase 0** ([#762](https://github.com/agentmuxai/agentmux/pull/762)) — marks + observers + IPC clock + dev HUD.
+- **Phase 0.5** ([#766](https://github.com/agentmuxai/agentmux/pull/766)) — reactive tab-switch mark + auth-path lookup unified.
+- **Hotfix** ([#767](https://github.com/agentmuxai/agentmux/pull/767)) — exclude log-pipe IPCs from perf measurement (was creating a feedback storm).
+- **Paint-aligned tab-switch marks** ([#772](https://github.com/agentmuxai/agentmux/pull/772)).
+
+### Agent-pane virtualization
+- **Phase 1** ([#783](https://github.com/agentmuxai/agentmux/pull/783)) — store, anchor, partition, registry.
+- **Phase 2** ([#784](https://github.com/agentmuxai/agentmux/pull/784)) — virtualization layer + streaming buffer via `@tanstack/solid-virtual`.
+- **Phase 3** ([#787](https://github.com/agentmuxai/agentmux/pull/787)) — intelligent perf probing.
+- **Polish** ([#790](https://github.com/agentmuxai/agentmux/pull/790)) — dynamic ellipsis truncation + agent-pane layout/spacing fixes.
+
+### Identity + Memory panes
+- **v7 schema** ([#746](https://github.com/agentmuxai/agentmux/pull/746)) — Identity bundles + Memory + agent_instance FKs.
+- **Memory pane** ([#749](https://github.com/agentmuxai/agentmux/pull/749)) — first-class management of Memory bundles.
+- **Identity pane** ([#750](https://github.com/agentmuxai/agentmux/pull/750)) — first-class management of Identity bundles.
+- **Launch modal** ([#751](https://github.com/agentmuxai/agentmux/pull/751)) — bundle pickers + spawn-time env injection.
+
+### Menu / overlay / theme polish
+- **Menu chrome unification** ([#796](https://github.com/agentmuxai/agentmux/pull/796)) — single menu surface for hamburger, right-click, and tab popover.
+- **Declarative `data-pane-overlay` auto-clip** ([#793](https://github.com/agentmuxai/agentmux/pull/793)) — closes the menu/popover/tooltip airspace bug class.
+- **Instant submenu open** ([#792](https://github.com/agentmuxai/agentmux/pull/792)).
+- **Theme picker + midnight pure-black agent pane** ([#791](https://github.com/agentmuxai/agentmux/pull/791)).
+- **Tear-off polish** ([#798](https://github.com/agentmuxai/agentmux/pull/798)) — preserve grab offset across `dragend`, brain-logo center on empty tabs.
+
+### Security
+- **Strict CORS + drop `?authkey=` on non-`/ws` routes** ([#802](https://github.com/agentmuxai/agentmux/pull/802)) — audit C3.
+- **Gate `/agentmux/reactive/*` under auth_middleware** ([#801](https://github.com/agentmuxai/agentmux/pull/801)) — audit C1+C2.
+
+### Crash + correctness fixes
+- **Renderer storm crash** ([#724](https://github.com/agentmuxai/agentmux/pull/724)) — root cause of repeated `Crashpad_NotConnectedToHandler` crashes: SolidJS reactive-dep leak via `recordDispatch`. Wrapped in `untrack()`.
+- **Tear-off drift storm** ([#721](https://github.com/agentmuxai/agentmux/pull/721), [#722](https://github.com/agentmuxai/agentmux/pull/722)) — cap `HiddenSinceOpen` events at one per window + host-bridge dedup.
+- **Browser-pane focus** ([#739](https://github.com/agentmuxai/agentmux/pull/739), [#760](https://github.com/agentmuxai/agentmux/pull/760)) — multi-window focus bounce + address-bar/page-DOM focus routing on first click.
+- **Linux pane crash** ([#788](https://github.com/agentmuxai/agentmux/pull/788)).
+- **Launcher placement** ([#725](https://github.com/agentmuxai/agentmux/pull/725), [#726](https://github.com/agentmuxai/agentmux/pull/726)) — grace for HiddenSinceOpen + suppress drift on routine Repaired.
+
+### Build / infra
+- **`pwsh` instead of `powershell` in Taskfile** ([#812](https://github.com/agentmuxai/agentmux/pull/812)) — UTF-8 parsing reliability.
+
+## Install
+
+Extract `agentmux-0.33.814-x64-portable.zip`, run `agentmux.exe`. Concurrent with any existing AgentMux instance — version-isolated data dir.
+
+Per-version data: `%USERPROFILE%\.agentmux\versions\0.33.814\`
+
+## Diagnostics
+
+If you're testing the live-log streaming work:
+- Wrapper debug log: `%USERPROFILE%\.agentmux\logs\bashwrap-debug.log`
+- Sidecar log: `%USERPROFILE%\.agentmux\logs\agentmuxsrv-v0.33.814.log.*`
+- Tail both while running a bash command in an agent pane.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.822"
+version = "0.33.823"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.822"
+version = "0.33.823"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.822"
+version = "0.33.823"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.822"
+version = "0.33.823"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.822"
+version = "0.33.823"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.823"
+version = "0.33.824"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.823"
+version = "0.33.824"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.823"
+version = "0.33.824"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.823"
+version = "0.33.824"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.823"
+version = "0.33.824"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.821"
+version = "0.33.822"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.821"
+version = "0.33.822"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.821"
+version = "0.33.822"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.821"
+version = "0.33.822"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.821"
+version = "0.33.822"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.823 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.822 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.821 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.814 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.822 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.821 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.814 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.813 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,9 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.821 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
+| 0.33.814 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
+| 0.33.813 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.804 | 2026-05-11 | 164.1 MiB | 343.8 MiB | |
 | 0.33.799 | 2026-05-11 | 162.4 MiB | 340.2 MiB | |
 | 0.33.789 | 2026-05-11 | 162.4 MiB | 340.4 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.824 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.823 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.822 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |
 | 0.33.821 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.822"
+version = "0.33.823"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.821"
+version = "0.33.822"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.823"
+version = "0.33.824"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.823"
+version = "0.33.824"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.821"
+version = "0.33.822"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.822"
+version = "0.33.823"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.822"
+version = "0.33.823"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.821"
+version = "0.33.822"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.823"
+version = "0.33.824"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.823"
+version = "0.33.824"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.821"
+version = "0.33.822"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.822"
+version = "0.33.823"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.821"
+version = "0.33.822"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.823"
+version = "0.33.824"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -43,6 +43,7 @@ sha2 = "0.10"
 hex = "0.4"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 tar = "0.4"
+tempfile = "3"
 
 [target.'cfg(windows)'.dependencies]
 # Out-of-process crash dump capture via VEH + named-pipe IPC.
@@ -68,7 +69,6 @@ winres = "0.1"
 tower = { version = "0.5", features = ["util"] }
 serde_json = "1"
 libc = "0.2"
-tempfile = "3"
 # Phase E.7 — property-based testing for reducer arm invariants.
 # `default-features = false` to avoid the timeout-fork machinery
 # that doesn't play nicely with our existing test runner; we only

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.822"
+version = "0.33.823"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -709,23 +709,25 @@ impl WaveStore {
 
     /// Delete a forge agent by id. Returns true if a row was deleted.
     pub fn forge_delete(&self, id: &str) -> Result<bool, StoreError> {
-        // Pre-fetch the instance ids that the FK cascade will delete.
-        // The cascade fires inside SQLite without invoking
-        // `instance_delete`, so without this snapshot the registry
-        // mirror would leak orphan JSON files for the cascaded rows.
-        let cascaded_instance_ids: Vec<String> = {
+        // Snapshot cascaded instance ids AND issue the parent DELETE
+        // under one lock acquisition so no thread can `instance_create`
+        // a new row for this definition between the two steps. The
+        // SQL DELETE's FK cascade fires inside SQLite while we hold
+        // the mutex, so the snapshot exactly matches the rows that
+        // got removed by the cascade.
+        let (cascaded_instance_ids, rows) = {
             let conn = self.conn.lock().unwrap();
-            let mut stmt = conn
-                .prepare("SELECT id FROM db_agent_instances WHERE definition_id = ?1")?;
-            let iter = stmt.query_map(params![id], |row| row.get::<_, String>(0))?;
-            iter.collect::<Result<Vec<_>, _>>()?
-        };
-        let rows = {
-            let conn = self.conn.lock().unwrap();
-            conn.execute(
+            let cascaded_instance_ids: Vec<String> = {
+                let mut stmt = conn
+                    .prepare("SELECT id FROM db_agent_instances WHERE definition_id = ?1")?;
+                let iter = stmt.query_map(params![id], |row| row.get::<_, String>(0))?;
+                iter.collect::<Result<Vec<_>, _>>()?
+            };
+            let rows = conn.execute(
                 "DELETE FROM db_forge_agents WHERE id=?1",
                 params![id],
-            )?
+            )?;
+            (cascaded_instance_ids, rows)
         };
         if rows > 0 {
             if let Some(reg) = self.registry() {

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -709,11 +709,38 @@ impl WaveStore {
 
     /// Delete a forge agent by id. Returns true if a row was deleted.
     pub fn forge_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "DELETE FROM db_forge_agents WHERE id=?1",
-            params![id],
-        )?;
+        // Pre-fetch the instance ids that the FK cascade will delete.
+        // The cascade fires inside SQLite without invoking
+        // `instance_delete`, so without this snapshot the registry
+        // mirror would leak orphan JSON files for the cascaded rows.
+        let cascaded_instance_ids: Vec<String> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn
+                .prepare("SELECT id FROM db_agent_instances WHERE definition_id = ?1")?;
+            let iter = stmt.query_map(params![id], |row| row.get::<_, String>(0))?;
+            iter.collect::<Result<Vec<_>, _>>()?
+        };
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "DELETE FROM db_forge_agents WHERE id=?1",
+                params![id],
+            )?
+        };
+        if rows > 0 {
+            if let Some(reg) = self.registry() {
+                for instance_id in &cascaded_instance_ids {
+                    if let Err(e) = reg.hard_delete(instance_id) {
+                        tracing::warn!(
+                            instance_id = %instance_id,
+                            forge_id = %id,
+                            error = %e,
+                            "registry: failed to mirror forge_delete cascade"
+                        );
+                    }
+                }
+            }
+        }
         Ok(rows > 0)
     }
 
@@ -1246,17 +1273,25 @@ pub struct AgentInstance {
     pub display_hidden: bool,
 }
 
-/// Build a registry record from an `AgentInstance`. Returns an error if
-/// the working directory can't be expressed as a path relative to the
-/// shared agents root (e.g. user pointed an agent at `~/projects/foo`).
-/// Caller is expected to log + skip in that case — the agent stays in
-/// SQLite, just not in the cross-version dropdown.
+/// Build a registry record from an `AgentInstance`. Returns an error
+/// if the working directory can't be expressed as a path relative to
+/// the canonical shared agents root (e.g. user pointed an agent at
+/// `~/projects/foo`, which would also fail a naive `"agents"`
+/// segment-scan that happened to match `~/projects/agents/foo`).
+/// Caller logs + skips — agent stays in SQLite, just not in the
+/// cross-version dropdown.
 fn agent_instance_to_record(
     inst: &AgentInstance,
+    agents_root: &Path,
 ) -> Result<crate::registry::NamedAgentRecord, String> {
     use crate::registry::{NamedAgentRecord, NamedAgentRecordV1, MAX_SUPPORTED_SCHEMA};
-    let rel = relative_workdir(&inst.working_directory)
-        .ok_or_else(|| format!("working_directory {:?} is not under agents/", inst.working_directory))?;
+    let rel = relative_workdir(&inst.working_directory, agents_root).ok_or_else(|| {
+        format!(
+            "working_directory {:?} is not under {:?}",
+            inst.working_directory,
+            agents_root.display()
+        )
+    })?;
     let version = env!("CARGO_PKG_VERSION").to_string();
     Ok(NamedAgentRecord {
         schema_version: MAX_SUPPORTED_SCHEMA,
@@ -1279,34 +1314,26 @@ fn empty_to_none(s: &str) -> Option<String> {
     if s.is_empty() { None } else { Some(s.to_string()) }
 }
 
-/// Strip the `<shared_home>/agents/` prefix from an absolute working
-/// directory. Returns the relative segment (e.g. `livelog-821-0512a`),
-/// or `None` if the path isn't under agents/. Agents living outside
-/// the shared tree (user-specified paths) skip the registry mirror;
-/// they're not surfaced in the cross-version dropdown by design.
-fn relative_workdir(abs: &str) -> Option<String> {
+/// Express `abs` as a path relative to `agents_root`. Returns `None`
+/// when `abs` is empty, not under `agents_root`, or after stripping
+/// resolves to an empty path. Anchors against the **resolved** shared
+/// root (passed in by the caller) — never scans for a path segment
+/// named "agents", which would match unrelated user directories like
+/// `/home/me/projects/agents/foo`.
+fn relative_workdir(abs: &str, agents_root: &Path) -> Option<String> {
     if abs.is_empty() {
         return None;
     }
     let p = std::path::Path::new(abs);
-    let comps: Vec<_> = p.components().collect();
-    // Find the last "agents" segment; the registry-eligible workdir
-    // sits one level beneath it. We scan from the right so a user
-    // home like `/home/agents-user/.agentmux/agents/foo` finds the
-    // right anchor.
-    for i in (0..comps.len()).rev() {
-        if let std::path::Component::Normal(seg) = comps[i] {
-            if seg == "agents" && i + 1 < comps.len() {
-                let rel: std::path::PathBuf = comps[i + 1..].iter().collect();
-                let s = rel.to_string_lossy().to_string();
-                if s.is_empty() {
-                    return None;
-                }
-                return Some(s);
-            }
-        }
+    let rel = p.strip_prefix(agents_root).ok()?;
+    // Reject empties + traversals (defense in depth — strip_prefix
+    // already rules out `..` escapes, but the registry's own validator
+    // re-checks).
+    let s = rel.to_string_lossy().to_string();
+    if s.is_empty() || s == "." {
+        return None;
     }
-    None
+    Some(s)
 }
 
 impl WaveStore {
@@ -1797,7 +1824,11 @@ impl WaveStore {
             return;
         }
         let Some(reg) = self.registry() else { return };
-        let rec = match agent_instance_to_record(inst) {
+        let Some(agents_root) = reg.agents_root() else {
+            tracing::warn!("registry: agents_root has no parent — skipping mirror");
+            return;
+        };
+        let rec = match agent_instance_to_record(inst, agents_root) {
             Ok(rec) => rec,
             Err(e) => {
                 tracing::warn!(
@@ -3034,5 +3065,40 @@ mod tests {
         // SQL row was written, but mirror is skipped because the working
         // dir can't be expressed as a relative subpath under agents/.
         assert!(reg.list_active().unwrap().is_empty());
+    }
+
+    #[test]
+    fn instance_create_user_path_with_agents_segment_is_skipped() {
+        // Anchored-prefix check: a user-owned workspace at
+        // `/home/user/code/agents/myproject` must NOT be mirrored. The
+        // pre-fix scan-for-segment logic matched the inner "agents",
+        // producing `working_dir = "myproject"` that would resolve to
+        // `<shared>/agents/myproject` (wrong) when PR B reads the row.
+        let (tmp, store, reg) = store_with_registry();
+        // tmp is NOT under the registry's agents root, so this is a
+        // user path that happens to include an "agents" component.
+        let outside = tmp.path().join("code").join("agents").join("myproject");
+        let mut inst = make_named_inst("inst-pathconfuse", "confuse", tmp.path());
+        inst.working_directory = outside.to_string_lossy().to_string();
+        store.instance_create(&inst).unwrap();
+        assert!(reg.list_active().unwrap().is_empty(),
+            "user path with inner 'agents' segment must not be mirrored");
+    }
+
+    #[test]
+    fn forge_delete_cascade_removes_registry_files() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst_a = make_named_inst("inst-cascade-a", "demoA", &agents_root);
+        let inst_b = make_named_inst("inst-cascade-b", "demoB", &agents_root);
+        store.instance_create(&inst_a).unwrap();
+        store.instance_create(&inst_b).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 2);
+
+        // Delete the forge agent — SQLite FK cascades both instance
+        // rows; the mirror must also drop both registry files.
+        store.forge_delete("def-mirror").unwrap();
+        assert!(reg.list_active().unwrap().is_empty(),
+            "forge_delete cascade must remove all child instance registry files");
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -9,12 +9,13 @@
 
 
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use rusqlite::{params, Connection};
 use serde::{Deserialize, Serialize};
 
 use crate::backend::obj::{wave_obj_from_json, wave_obj_to_json, WaveObj};
+use crate::registry::Registry;
 
 use super::error::StoreError;
 use super::migrations::{run_forge_migrations, run_wstore_migrations};
@@ -22,6 +23,11 @@ use super::migrations::{run_forge_migrations, run_wstore_migrations};
 /// SQLite-backed object store for WaveObj types.
 pub struct WaveStore {
     conn: Mutex<Connection>,
+    /// Cross-version named-agent registry. `None` for in-memory test
+    /// stores; `Some` for production srv. Mutations to
+    /// `db_agent_instances` parallel-write to this registry when set.
+    /// See `docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md`.
+    registry: Mutex<Option<Arc<Registry>>>,
 }
 
 impl WaveStore {
@@ -60,7 +66,24 @@ impl WaveStore {
         run_forge_migrations(&conn)?;
         Ok(Self {
             conn: Mutex::new(conn),
+            registry: Mutex::new(None),
         })
+    }
+
+    /// Attach a shared cross-version agent registry. Called once on
+    /// srv startup after `WaveStore::open` and before the store is
+    /// wrapped in `Arc`. Mutations to `db_agent_instances` will then
+    /// parallel-write to the registry; the SQLite table remains the
+    /// authoritative read path for PR A.
+    pub fn set_registry(&self, registry: Arc<Registry>) {
+        *self.registry.lock().unwrap_or_else(|e| e.into_inner()) = Some(registry);
+    }
+
+    fn registry(&self) -> Option<Arc<Registry>> {
+        self.registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
     }
 
     /// Table name for a WaveObj type: `db_<otype>`.
@@ -1223,6 +1246,69 @@ pub struct AgentInstance {
     pub display_hidden: bool,
 }
 
+/// Build a registry record from an `AgentInstance`. Returns an error if
+/// the working directory can't be expressed as a path relative to the
+/// shared agents root (e.g. user pointed an agent at `~/projects/foo`).
+/// Caller is expected to log + skip in that case — the agent stays in
+/// SQLite, just not in the cross-version dropdown.
+fn agent_instance_to_record(
+    inst: &AgentInstance,
+) -> Result<crate::registry::NamedAgentRecord, String> {
+    use crate::registry::{NamedAgentRecord, NamedAgentRecordV1, MAX_SUPPORTED_SCHEMA};
+    let rel = relative_workdir(&inst.working_directory)
+        .ok_or_else(|| format!("working_directory {:?} is not under agents/", inst.working_directory))?;
+    let version = env!("CARGO_PKG_VERSION").to_string();
+    Ok(NamedAgentRecord {
+        schema_version: MAX_SUPPORTED_SCHEMA,
+        data: NamedAgentRecordV1 {
+            instance_id: inst.id.clone(),
+            instance_name: inst.instance_name.clone(),
+            definition_id: inst.definition_id.clone(),
+            identity_id: empty_to_none(&inst.identity_id),
+            memory_id: empty_to_none(&inst.memory_id),
+            working_dir: rel,
+            created_at_ms: inst.created_at,
+            last_launched_at_ms: inst.started_at,
+            created_by_version: version.clone(),
+            last_launched_by_version: version,
+        },
+    })
+}
+
+fn empty_to_none(s: &str) -> Option<String> {
+    if s.is_empty() { None } else { Some(s.to_string()) }
+}
+
+/// Strip the `<shared_home>/agents/` prefix from an absolute working
+/// directory. Returns the relative segment (e.g. `livelog-821-0512a`),
+/// or `None` if the path isn't under agents/. Agents living outside
+/// the shared tree (user-specified paths) skip the registry mirror;
+/// they're not surfaced in the cross-version dropdown by design.
+fn relative_workdir(abs: &str) -> Option<String> {
+    if abs.is_empty() {
+        return None;
+    }
+    let p = std::path::Path::new(abs);
+    let comps: Vec<_> = p.components().collect();
+    // Find the last "agents" segment; the registry-eligible workdir
+    // sits one level beneath it. We scan from the right so a user
+    // home like `/home/agents-user/.agentmux/agents/foo` finds the
+    // right anchor.
+    for i in (0..comps.len()).rev() {
+        if let std::path::Component::Normal(seg) = comps[i] {
+            if seg == "agents" && i + 1 < comps.len() {
+                let rel: std::path::PathBuf = comps[i + 1..].iter().collect();
+                let s = rel.to_string_lossy().to_string();
+                if s.is_empty() {
+                    return None;
+                }
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
 impl WaveStore {
     // ---- Identity account CRUD ----
 
@@ -1498,33 +1584,36 @@ impl WaveStore {
 
     /// Insert a new instance row. Caller is responsible for the id (UUID).
     pub fn instance_create(&self, inst: &AgentInstance) -> Result<(), StoreError> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO db_agent_instances
-                (id, definition_id, parent_instance_id, block_id, session_id, status,
-                 github_context, started_at, ended_at, created_at,
-                 identity_id, memory_id,
-                 instance_name, working_directory, display_hidden)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                     ?13, ?14, ?15)",
-            params![
-                inst.id,
-                inst.definition_id,
-                inst.parent_instance_id,
-                inst.block_id,
-                inst.session_id,
-                inst.status,
-                inst.github_context,
-                inst.started_at,
-                inst.ended_at,
-                inst.created_at,
-                inst.identity_id,
-                inst.memory_id,
-                inst.instance_name,
-                inst.working_directory,
-                if inst.display_hidden { 1_i64 } else { 0_i64 },
-            ],
-        )?;
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO db_agent_instances
+                    (id, definition_id, parent_instance_id, block_id, session_id, status,
+                     github_context, started_at, ended_at, created_at,
+                     identity_id, memory_id,
+                     instance_name, working_directory, display_hidden)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
+                         ?13, ?14, ?15)",
+                params![
+                    inst.id,
+                    inst.definition_id,
+                    inst.parent_instance_id,
+                    inst.block_id,
+                    inst.session_id,
+                    inst.status,
+                    inst.github_context,
+                    inst.started_at,
+                    inst.ended_at,
+                    inst.created_at,
+                    inst.identity_id,
+                    inst.memory_id,
+                    inst.instance_name,
+                    inst.working_directory,
+                    if inst.display_hidden { 1_i64 } else { 0_i64 },
+                ],
+            )?;
+        }
+        self.registry_upsert_if_named(inst);
         Ok(())
     }
 
@@ -1532,11 +1621,30 @@ impl WaveStore {
     /// by the "Forget agent" affordance — soft-delete only; the row +
     /// working directory remain on disk for audit + recovery.
     pub fn instance_set_hidden(&self, id: &str, hidden: bool) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "UPDATE db_agent_instances SET display_hidden = ?1 WHERE id = ?2",
-            params![if hidden { 1_i64 } else { 0_i64 }, id],
-        )?;
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE db_agent_instances SET display_hidden = ?1 WHERE id = ?2",
+                params![if hidden { 1_i64 } else { 0_i64 }, id],
+            )?
+        };
+        if rows > 0 {
+            if let Some(reg) = self.registry() {
+                let res = if hidden {
+                    reg.retire(id)
+                } else {
+                    reg.unretire(id)
+                };
+                if let Err(e) = res {
+                    tracing::warn!(
+                        instance_id = %id,
+                        hidden,
+                        error = %e,
+                        "registry: failed to mirror instance_set_hidden"
+                    );
+                }
+            }
+        }
         Ok(rows > 0)
     }
 
@@ -1629,31 +1737,84 @@ impl WaveStore {
     /// `parent_instance_id`, `started_at`, `created_at` are immutable
     /// after insert (they describe provenance, not state).
     pub fn instance_update(&self, inst: &AgentInstance) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute(
-            "UPDATE db_agent_instances SET
-                block_id = ?1,
-                session_id = ?2,
-                status = ?3,
-                github_context = ?4,
-                ended_at = ?5
-             WHERE id = ?6",
-            params![
-                inst.block_id,
-                inst.session_id,
-                inst.status,
-                inst.github_context,
-                inst.ended_at,
-                inst.id,
-            ],
-        )?;
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE db_agent_instances SET
+                    block_id = ?1,
+                    session_id = ?2,
+                    status = ?3,
+                    github_context = ?4,
+                    ended_at = ?5
+                 WHERE id = ?6",
+                params![
+                    inst.block_id,
+                    inst.session_id,
+                    inst.status,
+                    inst.github_context,
+                    inst.ended_at,
+                    inst.id,
+                ],
+            )?
+        };
+        if rows > 0 {
+            // Refresh the registry from the post-update authoritative row.
+            // `inst` is the caller's pre-update view; SQL UPDATE only
+            // touches a subset of fields, so we reload to keep registry
+            // mirror exact.
+            if let Ok(Some(fresh)) = self.instance_get(&inst.id) {
+                self.registry_upsert_if_named(&fresh);
+            }
+        }
         Ok(rows > 0)
     }
 
     pub fn instance_delete(&self, id: &str) -> Result<bool, StoreError> {
-        let conn = self.conn.lock().unwrap();
-        let rows = conn.execute("DELETE FROM db_agent_instances WHERE id = ?1", params![id])?;
+        let rows = {
+            let conn = self.conn.lock().unwrap();
+            conn.execute("DELETE FROM db_agent_instances WHERE id = ?1", params![id])?
+        };
+        if rows > 0 {
+            if let Some(reg) = self.registry() {
+                if let Err(e) = reg.hard_delete(id) {
+                    tracing::warn!(
+                        instance_id = %id,
+                        error = %e,
+                        "registry: failed to mirror instance_delete"
+                    );
+                }
+            }
+        }
         Ok(rows > 0)
+    }
+
+    /// Mirror a `db_agent_instances` mutation into the cross-version
+    /// registry — but only for **named** rows (the dropdown ignores
+    /// nameless instances). Failures are logged, never propagated:
+    /// SQLite remains authoritative in PR A.
+    fn registry_upsert_if_named(&self, inst: &AgentInstance) {
+        if inst.instance_name.is_empty() {
+            return;
+        }
+        let Some(reg) = self.registry() else { return };
+        let rec = match agent_instance_to_record(inst) {
+            Ok(rec) => rec,
+            Err(e) => {
+                tracing::warn!(
+                    instance_id = %inst.id,
+                    error = %e,
+                    "registry: instance not representable as record, skipping mirror"
+                );
+                return;
+            }
+        };
+        if let Err(e) = reg.upsert(&rec) {
+            tracing::warn!(
+                instance_id = %inst.id,
+                error = %e,
+                "registry: failed to mirror instance_create/update"
+            );
+        }
     }
 
     /// Look up the most-recently-created **active** instance for a
@@ -2757,5 +2918,121 @@ mod tests {
         // Delete the user memory.
         assert!(store.bundle_memory_delete("mem-coder").unwrap());
         assert_eq!(store.bundle_memory_list().unwrap().len(), 1);
+    }
+
+    // ---- Registry parallel-write mirror (PR A) ----
+
+    fn make_named_inst(id: &str, name: &str, agents_root: &Path) -> AgentInstance {
+        // working_directory must sit under <agents_root>/<slug> so the
+        // relative-path resolver picks it up.
+        let wd = agents_root.join(format!("{name}-fixture")).to_string_lossy().to_string();
+        AgentInstance {
+            id: id.to_string(),
+            definition_id: "def-mirror".to_string(),
+            parent_instance_id: String::new(),
+            block_id: String::new(),
+            session_id: String::new(),
+            status: "running".to_string(),
+            github_context: String::new(),
+            started_at: 1_000,
+            ended_at: 0,
+            created_at: 900,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: name.to_string(),
+            working_directory: wd,
+            display_hidden: false,
+        }
+    }
+
+    fn store_with_registry() -> (tempfile::TempDir, WaveStore, Arc<crate::registry::Registry>) {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents_root = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let reg_root = agents_root.join("registry");
+        let reg = Arc::new(crate::registry::Registry::open(reg_root).unwrap());
+        let store = WaveStore::open_in_memory().unwrap();
+        store.set_registry(reg.clone());
+        // Satisfy the FK from db_agent_instances.definition_id.
+        let mut agent = sample_agent("def-mirror", "mirror");
+        store.forge_insert(&mut agent).unwrap();
+        (tmp, store, reg)
+    }
+
+    #[test]
+    fn instance_create_named_writes_registry_file() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-1", "demo", &agents_root);
+        store.instance_create(&inst).unwrap();
+        let records = reg.list_active().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].data.instance_id, "inst-1");
+        assert_eq!(records[0].data.instance_name, "demo");
+        assert_eq!(records[0].data.identity_id, None);
+        assert_eq!(records[0].data.memory_id, None);
+        assert_eq!(records[0].data.working_dir, "demo-fixture");
+    }
+
+    #[test]
+    fn instance_create_unnamed_does_not_mirror() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let mut inst = make_named_inst("inst-2", "demo2", &agents_root);
+        inst.instance_name = String::new(); // unnamed
+        store.instance_create(&inst).unwrap();
+        assert!(reg.list_active().unwrap().is_empty());
+    }
+
+    #[test]
+    fn instance_set_hidden_retires_then_unretires() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-3", "demo3", &agents_root);
+        store.instance_create(&inst).unwrap();
+        store.instance_set_hidden("inst-3", true).unwrap();
+        assert!(reg.list_active().unwrap().is_empty());
+        store.instance_set_hidden("inst-3", false).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn instance_update_refreshes_registry_record() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-4", "demo4", &agents_root);
+        store.instance_create(&inst).unwrap();
+        let mut updated = inst.clone();
+        updated.status = "paused".to_string();
+        updated.session_id = "sess-xyz".to_string();
+        store.instance_update(&updated).unwrap();
+        // instance_update doesn't bump last_launched_at_ms (started_at is
+        // immutable in the SQL update), so we just verify the record
+        // still exists and is reachable.
+        let records = reg.list_active().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].data.instance_id, "inst-4");
+    }
+
+    #[test]
+    fn instance_delete_removes_registry_file() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-5", "demo5", &agents_root);
+        store.instance_create(&inst).unwrap();
+        store.instance_delete("inst-5").unwrap();
+        assert!(reg.list_active().unwrap().is_empty());
+    }
+
+    #[test]
+    fn instance_create_outside_agents_dir_skips_mirror() {
+        let (tmp, store, reg) = store_with_registry();
+        let mut inst = make_named_inst("inst-6", "demo6", tmp.path());
+        // Override working_dir to live outside any "agents/" segment.
+        inst.working_directory = tmp.path().join("projects").join("myrepo").to_string_lossy().to_string();
+        store.instance_create(&inst).unwrap();
+        // SQL row was written, but mirror is skipped because the working
+        // dir can't be expressed as a relative subpath under agents/.
+        assert!(reg.list_active().unwrap().is_empty());
     }
 }

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1816,9 +1816,21 @@ impl WaveStore {
     }
 
     /// Mirror a `db_agent_instances` mutation into the cross-version
-    /// registry — but only for **named** rows (the dropdown ignores
-    /// nameless instances). Failures are logged, never propagated:
-    /// SQLite remains authoritative in PR A.
+    /// registry. Only fires for **named** rows. Routes by
+    /// `display_hidden` so the registry file ends up in the tree
+    /// matching SQLite's dropdown filter:
+    ///
+    /// - hidden = true  → upsert (atomic write to active/) then
+    ///   retire (atomic rename to retired/). Net: file lives in
+    ///   `retired/<id>.json` with the freshest content. Prevents
+    ///   `instance_update` on a previously-hidden row from
+    ///   resurrecting an active registry file, AND keeps the
+    ///   retired tombstone's content current.
+    /// - hidden = false → unretire (no-op if not retired) then
+    ///   upsert. Net: file in `active/<id>.json`, no orphan retired.
+    ///
+    /// Failures are logged, never propagated: SQLite remains
+    /// authoritative.
     fn registry_upsert_if_named(&self, inst: &AgentInstance) {
         if inst.instance_name.is_empty() {
             return;
@@ -1839,12 +1851,39 @@ impl WaveStore {
                 return;
             }
         };
+
+        // If the row was previously hidden, the file lives in
+        // `retired/`. Move it back to active before upserting so
+        // upsert's merge-preserves-unknown-fields path operates on
+        // the right file (and we never leave dangling retired files).
+        if let Err(e) = reg.unretire(&inst.id) {
+            tracing::warn!(
+                instance_id = %inst.id,
+                error = %e,
+                "registry: failed to unretire row before upsert"
+            );
+        }
+
         if let Err(e) = reg.upsert(&rec) {
             tracing::warn!(
                 instance_id = %inst.id,
                 error = %e,
                 "registry: failed to mirror instance_create/update"
             );
+            return;
+        }
+
+        // After the upsert, move into retired/ if the row is hidden.
+        // Combined: hidden row's tombstone always has up-to-date
+        // content, and active/ never carries a hidden row.
+        if inst.display_hidden {
+            if let Err(e) = reg.retire(&inst.id) {
+                tracing::warn!(
+                    instance_id = %inst.id,
+                    error = %e,
+                    "registry: failed to retire hidden row post-upsert"
+                );
+            }
         }
     }
 
@@ -3083,6 +3122,65 @@ mod tests {
         store.instance_create(&inst).unwrap();
         assert!(reg.list_active().unwrap().is_empty(),
             "user path with inner 'agents' segment must not be mirrored");
+    }
+
+    #[test]
+    fn instance_update_does_not_resurrect_hidden_row() {
+        // Sequence: create (active) → set_hidden(true) → update.
+        // The update must NOT move the file from retired/ back to active.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-resurrect", "demoR", &agents_root);
+        store.instance_create(&inst).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+
+        store.instance_set_hidden("inst-resurrect", true).unwrap();
+        assert!(reg.list_active().unwrap().is_empty(),
+            "after set_hidden(true), record must be in retired/");
+        assert!(reg.root().join("retired").join("inst-resurrect.json").exists());
+
+        // SQLite still has the row (display_hidden=1). instance_update
+        // would refresh it — the mirror must NOT re-add to active.
+        let mut updated = inst.clone();
+        updated.status = "stopped".to_string();
+        updated.ended_at = 9999;
+        store.instance_update(&updated).unwrap();
+
+        assert!(reg.list_active().unwrap().is_empty(),
+            "instance_update on a hidden row must NOT resurrect it");
+        assert!(reg.root().join("retired").join("inst-resurrect.json").exists());
+    }
+
+    #[test]
+    fn instance_create_with_display_hidden_writes_retired() {
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let mut inst = make_named_inst("inst-bornhidden", "demoH", &agents_root);
+        inst.display_hidden = true;
+        store.instance_create(&inst).unwrap();
+        assert!(reg.list_active().unwrap().is_empty());
+        assert!(reg.root().join("retired").join("inst-bornhidden.json").exists());
+    }
+
+    #[test]
+    fn instance_update_toggling_hidden_off_unretires() {
+        // Sequence: create → set_hidden(true) → set_hidden(false) →
+        // update. After the toggle off, the file should be in active.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let inst = make_named_inst("inst-toggle", "demoT", &agents_root);
+        store.instance_create(&inst).unwrap();
+        store.instance_set_hidden("inst-toggle", true).unwrap();
+        store.instance_set_hidden("inst-toggle", false).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+
+        // A subsequent update should preserve active state.
+        let mut updated = inst.clone();
+        updated.status = "paused".to_string();
+        store.instance_update(&updated).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+        assert!(!reg.root().join("retired").join("inst-toggle.json").exists(),
+            "no orphan retired file alongside active");
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1832,7 +1832,14 @@ impl WaveStore {
     /// Failures are logged, never propagated: SQLite remains
     /// authoritative.
     fn registry_upsert_if_named(&self, inst: &AgentInstance) {
-        if inst.instance_name.is_empty() {
+        // Mirror filter must match SQLite's dropdown filter
+        // (instance_list_named): non-empty instance_name AND
+        // parent_instance_id == ''. Continuation rows (created when
+        // the user resumes an existing named agent) carry the prior
+        // row in parent_instance_id and would otherwise produce a
+        // duplicate registry entry that the registry-sourced read
+        // path would surface as a separate dropdown row.
+        if inst.instance_name.is_empty() || !inst.parent_instance_id.is_empty() {
             return;
         }
         let Some(reg) = self.registry() else { return };
@@ -3122,6 +3129,26 @@ mod tests {
         store.instance_create(&inst).unwrap();
         assert!(reg.list_active().unwrap().is_empty(),
             "user path with inner 'agents' segment must not be mirrored");
+    }
+
+    #[test]
+    fn instance_create_continuation_row_does_not_mirror() {
+        // SQLite's dropdown filter excludes rows where
+        // parent_instance_id != ''. The mirror must agree, otherwise
+        // continuation rows duplicate their parent in the registry.
+        let (tmp, store, reg) = store_with_registry();
+        let agents_root = tmp.path().join("agents");
+        let parent = make_named_inst("inst-parent", "demoP", &agents_root);
+        store.instance_create(&parent).unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+
+        let mut child = make_named_inst("inst-child", "demoP", &agents_root);
+        child.parent_instance_id = "inst-parent".to_string();
+        store.instance_create(&child).unwrap();
+        // Still only one record — the continuation row is NOT mirrored.
+        let recs = reg.list_active().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].data.instance_id, "inst-parent");
     }
 
     #[test]

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -5,6 +5,7 @@ mod identity;
 mod persist;
 mod persist_subscriber;
 mod reducer;
+mod registry;
 mod sagas;
 mod server;
 mod srv_ipc;
@@ -310,10 +311,30 @@ async fn main() {
 
     // Open databases
     let db_dir = base::get_wave_db_dir();
-    let wstore = Arc::new(WaveStore::open(&db_dir.join("objects.db")).unwrap_or_else(|e| {
+    let wstore_raw = WaveStore::open(&db_dir.join("objects.db")).unwrap_or_else(|e| {
         tracing::error!("Failed to open object store: {}", e);
         std::process::exit(1);
-    }));
+    });
+    // Attach the cross-version named-agent registry. Falls back to a
+    // disabled registry when the shared home can't be resolved (CI,
+    // unusual envs); mutations still hit SQLite, just don't mirror.
+    // See docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md.
+    if let Some(root) = registry::resolve_shared_registry_dir() {
+        match registry::Registry::open(root.clone()) {
+            Ok(reg) => {
+                tracing::info!(root = %root.display(), "registry: shared agent registry attached");
+                wstore_raw.set_registry(Arc::new(reg));
+            }
+            Err(e) => tracing::warn!(
+                root = %root.display(),
+                error = %e,
+                "registry: failed to open shared agent registry — SQLite remains authoritative"
+            ),
+        }
+    } else {
+        tracing::warn!("registry: could not resolve shared registry dir — mirror disabled");
+    }
+    let wstore = Arc::new(wstore_raw);
     let filestore = Arc::new(FileStore::open(&db_dir.join("filestore.db")).unwrap_or_else(|e| {
         tracing::error!("Failed to open file store: {}", e);
         std::process::exit(1);

--- a/agentmux-srv/src/registry/atomic.rs
+++ b/agentmux-srv/src/registry/atomic.rs
@@ -1,0 +1,80 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Atomic file write + rename helpers. All registry mutations route
+//! through these so readers never observe a half-written file.
+
+use std::io::Write;
+use std::path::Path;
+
+/// Write `bytes` to `path` atomically: sibling temp file → fsync →
+/// rename over the target. Rename is atomic on every supported
+/// filesystem when source and destination live on the same volume,
+/// which is guaranteed here (sibling temp).
+pub fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "write_atomic: path has no parent",
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".registry-tmp-")
+        .suffix(".json")
+        .tempfile_in(parent)?;
+    tmp.as_file_mut().write_all(bytes)?;
+    tmp.as_file_mut().sync_all()?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Atomic rename. Used for retire/unretire (same-directory tree).
+pub fn rename_atomic(from: &Path, to: &Path) -> std::io::Result<()> {
+    if let Some(parent) = to.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::rename(from, to)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_atomic_creates_parent_and_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("nested").join("file.json");
+        write_atomic(&target, b"hello").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn write_atomic_overwrites() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("a.json");
+        write_atomic(&target, b"v1").unwrap();
+        write_atomic(&target, b"v2-longer").unwrap();
+        assert_eq!(std::fs::read(&target).unwrap(), b"v2-longer");
+    }
+
+    #[test]
+    fn rename_atomic_moves_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("from.json");
+        let to = tmp.path().join("retired").join("from.json");
+        std::fs::write(&from, b"x").unwrap();
+        rename_atomic(&from, &to).unwrap();
+        assert!(!from.exists());
+        assert_eq!(std::fs::read(&to).unwrap(), b"x");
+    }
+
+    #[test]
+    fn rename_atomic_does_not_create_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let from = tmp.path().join("missing.json");
+        let to = tmp.path().join("retired.json");
+        let err = rename_atomic(&from, &to).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+}

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared, cross-version named-agent registry. File-per-agent JSON
+//! tree at `<shared_home>/agents/registry/`. See
+//! `docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md`.
+//!
+//! PR A — Parallel-write only. The `WaveStore` `instance_*` mutators
+//! call `Registry::{upsert,retire,unretire,hard_delete}` after their
+//! SQL execute() succeeds. Frontend RPCs still source rows from
+//! SQLite; the registry files are populated but not yet read.
+//!
+//! `MIN_SUPPORTED_SCHEMA`, `ValidationError`, `RegistryError`, and
+//! `Registry::list_active` are part of the registry's stable surface
+//! but are only consumed by tests + by PR B's read-path swap. The
+//! `allow(dead_code)` on the re-exports keeps that intent explicit.
+
+#![allow(dead_code, unused_imports)]
+
+mod atomic;
+mod paths;
+mod schema;
+mod store;
+
+#[cfg(test)]
+mod tests;
+
+pub use paths::resolve_shared_registry_dir;
+pub use schema::{
+    NamedAgentRecord, NamedAgentRecordV1, ValidationError, MAX_SUPPORTED_SCHEMA,
+    MIN_SUPPORTED_SCHEMA,
+};
+pub use store::{Registry, RegistryError};

--- a/agentmux-srv/src/registry/paths.rs
+++ b/agentmux-srv/src/registry/paths.rs
@@ -1,0 +1,91 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolve the shared registry directory (`<shared_home>/agents/registry/`).
+
+use std::path::PathBuf;
+
+/// Resolve `<shared_home>/agents/registry/`.
+///
+/// The registry is shared across every portable/installed version on
+/// the same machine — it must NOT use the per-version data dir.
+///
+/// Resolution order:
+/// 1. `AGENTMUX_HOME_OVERRIDE` — test-only escape hatch, matching
+///    `agentmux-common::data_paths` convention.
+/// 2. Walk up from `AGENTMUX_DATA_DIR` (per-version data dir set by
+///    the launcher) by three levels: `data → versions/<v> → versions
+///    → <shared_home>`. Robust against the launcher running without
+///    a real home dir (CI).
+/// 3. Fall back to `~/.agentmux/`.
+///
+/// Returns `None` only if every source fails — caller treats this as
+/// "registry disabled," no write attempts.
+pub fn resolve_shared_registry_dir() -> Option<PathBuf> {
+    resolve_shared_home().map(|h| h.join("agents").join("registry"))
+}
+
+fn resolve_shared_home() -> Option<PathBuf> {
+    if let Ok(s) = std::env::var("AGENTMUX_HOME_OVERRIDE") {
+        if !s.is_empty() {
+            return Some(PathBuf::from(s));
+        }
+    }
+    if let Ok(s) = std::env::var("AGENTMUX_DATA_DIR") {
+        if !s.is_empty() {
+            let p = PathBuf::from(s);
+            // .../versions/<v>/data → ancestors()[3] = .../
+            if let Some(root) = p.ancestors().nth(3) {
+                if !root.as_os_str().is_empty() {
+                    return Some(root.to_path_buf());
+                }
+            }
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".agentmux"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Process-global env access — serialize so parallel tests don't race.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear() {
+        std::env::remove_var("AGENTMUX_HOME_OVERRIDE");
+        std::env::remove_var("AGENTMUX_DATA_DIR");
+    }
+
+    #[test]
+    fn override_wins() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var("AGENTMUX_HOME_OVERRIDE", "/tmp/test-home");
+        let r = resolve_shared_registry_dir().unwrap();
+        assert_eq!(r, PathBuf::from("/tmp/test-home/agents/registry"));
+        clear();
+    }
+
+    #[test]
+    fn walks_up_from_data_dir() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        std::env::set_var(
+            "AGENTMUX_DATA_DIR",
+            "/home/user/.agentmux/versions/0.33.822/data",
+        );
+        let r = resolve_shared_registry_dir().unwrap();
+        assert_eq!(r, PathBuf::from("/home/user/.agentmux/agents/registry"));
+        clear();
+    }
+
+    #[test]
+    fn falls_back_to_home() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear();
+        // No env set — uses dirs::home_dir(). Just assert non-None.
+        assert!(resolve_shared_registry_dir().is_some());
+    }
+}

--- a/agentmux-srv/src/registry/schema.rs
+++ b/agentmux-srv/src/registry/schema.rs
@@ -1,0 +1,201 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Registry file format + per-row validation.
+//!
+//! Bumping `MAX_SUPPORTED_SCHEMA` is the additive-evolution path:
+//! readers of the previous bound still skip-and-log new files; old
+//! disk files keep validating because the v1 reader stays intact.
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Lowest envelope schema this binary will load. Bumped only with a
+/// deprecation cycle (see SPEC §6).
+pub const MIN_SUPPORTED_SCHEMA: u32 = 1;
+/// Highest envelope schema this binary will write or read. Bumped
+/// per release that adds fields.
+pub const MAX_SUPPORTED_SCHEMA: u32 = 1;
+
+/// On-disk envelope. The `data` field's shape is gated by
+/// `schema_version`; readers should match on the version before
+/// projecting.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NamedAgentRecord {
+    pub schema_version: u32,
+    pub data: NamedAgentRecordV1,
+}
+
+/// v1 payload. Add new optional fields here under `#[serde(default)]`
+/// and bump `MAX_SUPPORTED_SCHEMA` — old readers will skip the new
+/// version, new readers fill defaults for old files.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct NamedAgentRecordV1 {
+    pub instance_id: String,
+    pub instance_name: String,
+    pub definition_id: String,
+    /// FK to `db_identities.id`. None = unbound (= ambient creds).
+    pub identity_id: Option<String>,
+    /// FK to `db_memories.id`. None = unbound (= vanilla CLI).
+    pub memory_id: Option<String>,
+    /// Path **relative to `<shared_home>/agents/`** — never absolute.
+    /// Keeps the record portable across machines where the home dir
+    /// differs.
+    pub working_dir: String,
+    pub created_at_ms: i64,
+    pub last_launched_at_ms: i64,
+    pub created_by_version: String,
+    pub last_launched_by_version: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error("schema_version {version} outside supported [{min}, {max}]")]
+    UnsupportedSchema {
+        version: u32,
+        min: u32,
+        max: u32,
+    },
+    #[error("filename UUID {filename:?} does not match data.instance_id {instance_id:?}")]
+    IdMismatch {
+        filename: String,
+        instance_id: String,
+    },
+    #[error("working_dir {0:?} is not a safe relative subpath of agents/")]
+    UnsafeWorkingDir(String),
+    #[error("required field missing: {0}")]
+    MissingField(&'static str),
+}
+
+/// Per-row validation. Fails fast on anything that would let a
+/// malformed file be returned to the launch modal. Validation
+/// failures are skipped (not auto-fixed), logged, and the file stays
+/// on disk for ops triage.
+pub fn validate(filename_stem: &str, rec: &NamedAgentRecord) -> Result<(), ValidationError> {
+    if rec.schema_version < MIN_SUPPORTED_SCHEMA || rec.schema_version > MAX_SUPPORTED_SCHEMA {
+        return Err(ValidationError::UnsupportedSchema {
+            version: rec.schema_version,
+            min: MIN_SUPPORTED_SCHEMA,
+            max: MAX_SUPPORTED_SCHEMA,
+        });
+    }
+    let d = &rec.data;
+    if d.instance_id.is_empty() {
+        return Err(ValidationError::MissingField("instance_id"));
+    }
+    if d.instance_id != filename_stem {
+        return Err(ValidationError::IdMismatch {
+            filename: filename_stem.to_string(),
+            instance_id: d.instance_id.clone(),
+        });
+    }
+    if d.instance_name.is_empty() {
+        return Err(ValidationError::MissingField("instance_name"));
+    }
+    if d.definition_id.is_empty() {
+        return Err(ValidationError::MissingField("definition_id"));
+    }
+    if d.working_dir.is_empty() {
+        return Err(ValidationError::MissingField("working_dir"));
+    }
+    if !is_safe_relative_subpath(&d.working_dir) {
+        return Err(ValidationError::UnsafeWorkingDir(d.working_dir.clone()));
+    }
+    Ok(())
+}
+
+fn is_safe_relative_subpath(s: &str) -> bool {
+    let p = std::path::Path::new(s);
+    if p.is_absolute() {
+        return false;
+    }
+    for comp in p.components() {
+        match comp {
+            std::path::Component::ParentDir
+            | std::path::Component::RootDir
+            | std::path::Component::Prefix(_) => return false,
+            _ => {}
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v1_record(id: &str) -> NamedAgentRecord {
+        NamedAgentRecord {
+            schema_version: 1,
+            data: NamedAgentRecordV1 {
+                instance_id: id.to_string(),
+                instance_name: "demo".to_string(),
+                definition_id: "claude-code".to_string(),
+                identity_id: None,
+                memory_id: None,
+                working_dir: "demo-0512a".to_string(),
+                created_at_ms: 1,
+                last_launched_at_ms: 1,
+                created_by_version: "0.33.822".to_string(),
+                last_launched_by_version: "0.33.822".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn happy_path() {
+        let r = v1_record("abc");
+        validate("abc", &r).unwrap();
+    }
+
+    #[test]
+    fn unsupported_schema_is_rejected() {
+        let mut r = v1_record("abc");
+        r.schema_version = 999;
+        let err = validate("abc", &r).unwrap_err();
+        assert!(matches!(err, ValidationError::UnsupportedSchema { .. }));
+    }
+
+    #[test]
+    fn filename_mismatch_is_rejected() {
+        let r = v1_record("abc");
+        assert!(matches!(
+            validate("xyz", &r).unwrap_err(),
+            ValidationError::IdMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn absolute_workdir_is_rejected() {
+        let mut r = v1_record("abc");
+        r.data.working_dir = if cfg!(windows) {
+            "C:\\tmp\\evil".to_string()
+        } else {
+            "/tmp/evil".to_string()
+        };
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            ValidationError::UnsafeWorkingDir(_)
+        ));
+    }
+
+    #[test]
+    fn dotdot_workdir_is_rejected() {
+        let mut r = v1_record("abc");
+        r.data.working_dir = "..\\..\\sneaky".to_string();
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            ValidationError::UnsafeWorkingDir(_)
+        ));
+    }
+
+    #[test]
+    fn missing_required_field_is_rejected() {
+        let mut r = v1_record("abc");
+        r.data.instance_name = String::new();
+        assert!(matches!(
+            validate("abc", &r).unwrap_err(),
+            ValidationError::MissingField("instance_name")
+        ));
+    }
+}

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -49,6 +49,16 @@ impl Registry {
         &self.root
     }
 
+    /// Resolved `<shared_home>/agents/` — one level above `root`.
+    /// Used by callers that need to express working-directory paths
+    /// as relative subpaths under the shared agents tree. Returns
+    /// `None` if the registry root has no parent (only happens in
+    /// pathological filesystem-root setups; production always nests
+    /// under `~/.agentmux/agents/registry`).
+    pub fn agents_root(&self) -> Option<&Path> {
+        self.root.parent()
+    }
+
     fn active_path(&self, instance_id: &str) -> PathBuf {
         self.root.join(format!("{instance_id}.json"))
     }

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -1,0 +1,194 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `Registry` — file-per-agent CRUD on `<root>/<uuid>.json` with
+//! a sibling `retired/<uuid>.json` tombstone tree.
+//!
+//! Concurrency: cross-process safety comes from filesystem atomic
+//! rename. The internal `Mutex` only serializes partial-merge writes
+//! from threads inside the same `srv` so a v1 binary touching
+//! `last_launched_at_ms` doesn't race itself.
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde_json::Value;
+use thiserror::Error;
+
+use super::atomic::{rename_atomic, write_atomic};
+use super::schema::{validate, NamedAgentRecord, ValidationError};
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("validation: {0}")]
+    Validation(#[from] ValidationError),
+}
+
+pub struct Registry {
+    root: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl Registry {
+    /// Open or create the registry rooted at `root`. Ensures the
+    /// active dir and `retired/` subdir both exist.
+    pub fn open(root: PathBuf) -> Result<Self, RegistryError> {
+        std::fs::create_dir_all(&root)?;
+        std::fs::create_dir_all(root.join("retired"))?;
+        Ok(Self {
+            root,
+            write_lock: Mutex::new(()),
+        })
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn active_path(&self, instance_id: &str) -> PathBuf {
+        self.root.join(format!("{instance_id}.json"))
+    }
+
+    fn retired_path(&self, instance_id: &str) -> PathBuf {
+        self.root.join("retired").join(format!("{instance_id}.json"))
+    }
+
+    /// Insert or update a record. If the file already exists, unknown
+    /// top-level + `data` fields are preserved (forward-compat with
+    /// future schemas that add columns this binary doesn't know).
+    pub fn upsert(&self, rec: &NamedAgentRecord) -> Result<(), RegistryError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let path = self.active_path(&rec.data.instance_id);
+        let bytes = match std::fs::read(&path) {
+            Ok(existing) => merge_for_write(&existing, rec)?,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => to_pretty(rec)?,
+            Err(e) => return Err(e.into()),
+        };
+        write_atomic(&path, &bytes)?;
+        Ok(())
+    }
+
+    /// Move record into `retired/` (soft delete — keeps the working
+    /// dir intact, drops it from the launch-modal dropdown). Idempotent.
+    pub fn retire(&self, instance_id: &str) -> Result<(), RegistryError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let from = self.active_path(instance_id);
+        if !from.exists() {
+            return Ok(());
+        }
+        rename_atomic(&from, &self.retired_path(instance_id))?;
+        Ok(())
+    }
+
+    /// Move record back from `retired/` to active. Idempotent.
+    pub fn unretire(&self, instance_id: &str) -> Result<(), RegistryError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let from = self.retired_path(instance_id);
+        if !from.exists() {
+            return Ok(());
+        }
+        rename_atomic(&from, &self.active_path(instance_id))?;
+        Ok(())
+    }
+
+    /// Hard-delete (drops both active and retired files). Mirrors
+    /// SQLite `instance_delete`.
+    pub fn hard_delete(&self, instance_id: &str) -> Result<(), RegistryError> {
+        let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+        for p in [self.active_path(instance_id), self.retired_path(instance_id)] {
+            match std::fs::remove_file(&p) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        Ok(())
+    }
+
+    /// Whether an active record exists for `instance_id`. Doesn't
+    /// validate — useful for migration idempotency checks.
+    pub fn exists(&self, instance_id: &str) -> bool {
+        self.active_path(instance_id).exists()
+    }
+
+    /// Read every valid active record. Invalid files are skipped +
+    /// logged. PR A doesn't wire this into the RPC path; included so
+    /// PR B can swap reads over without further restructuring.
+    pub fn list_active(&self) -> Result<Vec<NamedAgentRecord>, RegistryError> {
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            match read_and_validate(&path, stem) {
+                Ok(rec) => out.push(rec),
+                Err(e) => {
+                    tracing::warn!(
+                        file = %path.display(),
+                        error = %e,
+                        "registry: skipping invalid record"
+                    );
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+fn read_and_validate(path: &Path, stem: &str) -> Result<NamedAgentRecord, RegistryError> {
+    let bytes = std::fs::read(path)?;
+    let rec: NamedAgentRecord = serde_json::from_slice(&bytes)?;
+    validate(stem, &rec)?;
+    Ok(rec)
+}
+
+fn to_pretty(rec: &NamedAgentRecord) -> Result<Vec<u8>, serde_json::Error> {
+    let mut bytes = serde_json::to_vec_pretty(rec)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Merge an in-memory record into an on-disk file's raw JSON,
+/// preserving fields beyond this binary's struct shape. Falls back
+/// to the in-memory record verbatim if the on-disk file is corrupt.
+fn merge_for_write(existing: &[u8], rec: &NamedAgentRecord) -> Result<Vec<u8>, RegistryError> {
+    let Ok(mut on_disk) = serde_json::from_slice::<Value>(existing) else {
+        return Ok(to_pretty(rec)?);
+    };
+    let updates = serde_json::to_value(rec)?;
+    merge_known(&mut on_disk, &updates);
+    let mut bytes = serde_json::to_vec_pretty(&on_disk)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+/// Overwrite `target`'s top-level keys with `updates`' keys. Keys in
+/// `target` that aren't in `updates` are preserved. Recurses into
+/// the `data` sub-object so future fields inside `data` also survive.
+fn merge_known(target: &mut Value, updates: &Value) {
+    let (Some(t), Some(u)) = (target.as_object_mut(), updates.as_object()) else {
+        *target = updates.clone();
+        return;
+    };
+    for (k, v) in u {
+        if k == "data" {
+            if let Some(t_data) = t.get_mut("data") {
+                merge_known(t_data, v);
+                continue;
+            }
+        }
+        t.insert(k.clone(), v.clone());
+    }
+}

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -16,7 +16,7 @@ use serde_json::Value;
 use thiserror::Error;
 
 use super::atomic::{rename_atomic, write_atomic};
-use super::schema::{validate, NamedAgentRecord, ValidationError};
+use super::schema::{validate, NamedAgentRecord, ValidationError, MAX_SUPPORTED_SCHEMA};
 
 #[derive(Debug, Error)]
 pub enum RegistryError {
@@ -60,11 +60,20 @@ impl Registry {
     /// Insert or update a record. If the file already exists, unknown
     /// top-level + `data` fields are preserved (forward-compat with
     /// future schemas that add columns this binary doesn't know).
+    ///
+    /// Forward-compat invariant (spec §6): never write a higher-schema
+    /// row into a lower schema, never overwrite a corrupt/unparseable
+    /// file. Both cases skip the mirror with a warning — the on-disk
+    /// file stays intact for the binary that authored it (or for ops
+    /// triage). Skipping is `Ok(())`: SQLite remains authoritative.
     pub fn upsert(&self, rec: &NamedAgentRecord) -> Result<(), RegistryError> {
         let _g = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
         let path = self.active_path(&rec.data.instance_id);
         let bytes = match std::fs::read(&path) {
-            Ok(existing) => merge_for_write(&existing, rec)?,
+            Ok(existing) => match merge_for_write(&existing, rec)? {
+                Some(b) => b,
+                None => return Ok(()),
+            },
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => to_pretty(rec)?,
             Err(e) => return Err(e.into()),
         };
@@ -161,17 +170,53 @@ fn to_pretty(rec: &NamedAgentRecord) -> Result<Vec<u8>, serde_json::Error> {
 }
 
 /// Merge an in-memory record into an on-disk file's raw JSON,
-/// preserving fields beyond this binary's struct shape. Falls back
-/// to the in-memory record verbatim if the on-disk file is corrupt.
-fn merge_for_write(existing: &[u8], rec: &NamedAgentRecord) -> Result<Vec<u8>, RegistryError> {
-    let Ok(mut on_disk) = serde_json::from_slice::<Value>(existing) else {
-        return Ok(to_pretty(rec)?);
+/// preserving fields beyond this binary's struct shape.
+///
+/// Returns `Ok(None)` when the writer must refuse the merge (corrupt
+/// JSON, missing `schema_version`, or `schema_version` above
+/// `MAX_SUPPORTED_SCHEMA`). The caller treats `None` as a skip and
+/// leaves the on-disk file intact.
+fn merge_for_write(
+    existing: &[u8],
+    rec: &NamedAgentRecord,
+) -> Result<Option<Vec<u8>>, RegistryError> {
+    let on_disk: Value = match serde_json::from_slice(existing) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "registry: existing file is unparseable JSON — refusing to overwrite (may be a newer schema)"
+            );
+            return Ok(None);
+        }
     };
+    let on_disk_version = on_disk
+        .get("schema_version")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+    match on_disk_version {
+        Some(v) if v > MAX_SUPPORTED_SCHEMA => {
+            tracing::warn!(
+                on_disk = v,
+                writer_max = MAX_SUPPORTED_SCHEMA,
+                "registry: on-disk schema_version > writer max — refusing downgrade"
+            );
+            return Ok(None);
+        }
+        Some(_) => {}
+        None => {
+            tracing::warn!(
+                "registry: existing file lacks schema_version — refusing to overwrite"
+            );
+            return Ok(None);
+        }
+    }
+    let mut merged = on_disk;
     let updates = serde_json::to_value(rec)?;
-    merge_known(&mut on_disk, &updates);
-    let mut bytes = serde_json::to_vec_pretty(&on_disk)?;
+    merge_known(&mut merged, &updates);
+    let mut bytes = serde_json::to_vec_pretty(&merged)?;
     bytes.push(b'\n');
-    Ok(bytes)
+    Ok(Some(bytes))
 }
 
 /// Overwrite `target`'s top-level keys with `updates`' keys. Keys in

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -200,10 +200,14 @@ fn merge_for_write(
             return Ok(None);
         }
     };
+    // Use `try_from` so any number above `u32::MAX` is treated as
+    // unparseable rather than wrapping into the supported range. A
+    // wrap would let an oversized envelope downgrade-bypass the
+    // forward-compat guard below.
     let on_disk_version = on_disk
         .get("schema_version")
         .and_then(|v| v.as_u64())
-        .map(|v| v as u32);
+        .and_then(|v| u32::try_from(v).ok());
     match on_disk_version {
         Some(v) if v > MAX_SUPPORTED_SCHEMA => {
             tracing::warn!(

--- a/agentmux-srv/src/registry/tests.rs
+++ b/agentmux-srv/src/registry/tests.rs
@@ -180,6 +180,32 @@ fn upsert_refuses_to_downgrade_schema_version() {
 }
 
 #[test]
+fn upsert_refuses_when_schema_version_overflows_u32() {
+    // A future binary writing `schema_version: u32::MAX + 1` would
+    // wrap to 1 under an unchecked `as u32` cast and bypass the
+    // downgrade guard. With `u32::try_from`, the cast fails and we
+    // treat it the same as a missing/unparseable version — refuse.
+    let (_t, reg) = fresh();
+    let path = reg.root().join("aaa.json");
+    let oversized: u64 = u32::MAX as u64 + 1;
+    let raw = serde_json::json!({
+        "schema_version": oversized,
+        "data": { "instance_id": "aaa", "future_field": "x" }
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+
+    reg.upsert(&record("aaa", "demo", 200)).unwrap();
+
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(
+        after.pointer("/schema_version"),
+        Some(&serde_json::json!(oversized)),
+        "schema_version above u32::MAX must not be downgraded via wraparound"
+    );
+}
+
+#[test]
 fn upsert_refuses_when_schema_version_missing() {
     let (_t, reg) = fresh();
     let path = reg.root().join("aaa.json");

--- a/agentmux-srv/src/registry/tests.rs
+++ b/agentmux-srv/src/registry/tests.rs
@@ -1,0 +1,187 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module-level integration tests for the registry. Per-file unit
+//! tests live alongside each submodule.
+
+use super::*;
+
+fn fresh() -> (tempfile::TempDir, Registry) {
+    let tmp = tempfile::tempdir().unwrap();
+    let reg = Registry::open(tmp.path().to_path_buf()).unwrap();
+    (tmp, reg)
+}
+
+fn record(id: &str, name: &str, ts: i64) -> NamedAgentRecord {
+    NamedAgentRecord {
+        schema_version: 1,
+        data: NamedAgentRecordV1 {
+            instance_id: id.to_string(),
+            instance_name: name.to_string(),
+            definition_id: "claude-code".to_string(),
+            identity_id: Some("agenta".to_string()),
+            memory_id: Some("default".to_string()),
+            working_dir: format!("{name}-0512a"),
+            created_at_ms: ts,
+            last_launched_at_ms: ts,
+            created_by_version: "0.33.822".to_string(),
+            last_launched_by_version: "0.33.822".to_string(),
+        },
+    }
+}
+
+#[test]
+fn upsert_create_then_list() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    let listed = reg.list_active().unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].data.instance_name, "demo");
+}
+
+#[test]
+fn upsert_update_replaces_known_fields() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    reg.upsert(&record("aaa", "demo", 200)).unwrap();
+    let listed = reg.list_active().unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].data.last_launched_at_ms, 200);
+}
+
+#[test]
+fn retire_then_unretire_round_trips() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    reg.retire("aaa").unwrap();
+    assert!(reg.list_active().unwrap().is_empty());
+    assert!(reg.root().join("retired").join("aaa.json").exists());
+
+    reg.unretire("aaa").unwrap();
+    assert_eq!(reg.list_active().unwrap().len(), 1);
+}
+
+#[test]
+fn retire_is_idempotent_when_absent() {
+    let (_t, reg) = fresh();
+    reg.retire("never-existed").unwrap();
+}
+
+#[test]
+fn hard_delete_removes_both_paths() {
+    let (_t, reg) = fresh();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    reg.retire("aaa").unwrap();
+    reg.upsert(&record("bbb", "demo2", 100)).unwrap();
+
+    reg.hard_delete("aaa").unwrap();
+    reg.hard_delete("bbb").unwrap();
+    assert!(reg.list_active().unwrap().is_empty());
+    assert!(!reg.root().join("retired").join("aaa.json").exists());
+}
+
+#[test]
+fn unknown_envelope_schema_is_skipped() {
+    let (_t, reg) = fresh();
+    // Forge a future-schema file directly on disk.
+    let path = reg.root().join("future.json");
+    let raw = serde_json::json!({
+        "schema_version": 999,
+        "data": { "instance_id": "future", "anything": "goes" }
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+    let listed = reg.list_active().unwrap();
+    assert!(listed.is_empty(), "v999 row must be skipped");
+    assert!(path.exists(), "skipped file stays on disk");
+}
+
+#[test]
+fn unknown_fields_in_data_survive_round_trip() {
+    let (_t, reg) = fresh();
+    // Write a record with a future field directly.
+    let path = reg.root().join("aaa.json");
+    let raw = serde_json::json!({
+        "schema_version": 1,
+        "data": {
+            "instance_id": "aaa",
+            "instance_name": "demo",
+            "definition_id": "claude-code",
+            "identity_id": null,
+            "memory_id": null,
+            "working_dir": "demo-0512a",
+            "created_at_ms": 100,
+            "last_launched_at_ms": 100,
+            "created_by_version": "0.33.999",
+            "last_launched_by_version": "0.33.999",
+            "tags": ["important", "long-running"]
+        }
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+
+    // An older binary touches last_launched_at_ms.
+    reg.upsert(&record("aaa", "demo", 200)).unwrap();
+
+    // The unknown `tags` field must still be on disk.
+    let on_disk: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    let tags = on_disk
+        .pointer("/data/tags")
+        .expect("tags field preserved across older-writer update");
+    assert_eq!(tags, &serde_json::json!(["important", "long-running"]));
+    // And the known field did get updated.
+    assert_eq!(
+        on_disk.pointer("/data/last_launched_at_ms"),
+        Some(&serde_json::json!(200))
+    );
+}
+
+#[test]
+fn corrupt_file_is_overwritten_on_upsert() {
+    let (_t, reg) = fresh();
+    let path = reg.root().join("aaa.json");
+    std::fs::write(&path, b"{ not json").unwrap();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    let listed = reg.list_active().unwrap();
+    assert_eq!(listed.len(), 1);
+}
+
+#[test]
+fn filename_id_mismatch_is_skipped() {
+    let (_t, reg) = fresh();
+    let path = reg.root().join("wrongname.json");
+    let mut rec = record("realid", "demo", 100);
+    rec.data.instance_id = "realid".to_string();
+    std::fs::write(&path, serde_json::to_vec_pretty(&rec).unwrap()).unwrap();
+    assert!(reg.list_active().unwrap().is_empty());
+}
+
+#[test]
+fn list_ignores_non_json_files() {
+    let (_t, reg) = fresh();
+    std::fs::write(reg.root().join("readme.txt"), b"hi").unwrap();
+    reg.upsert(&record("aaa", "demo", 100)).unwrap();
+    assert_eq!(reg.list_active().unwrap().len(), 1);
+}
+
+#[test]
+fn concurrent_upserts_same_id_dont_corrupt() {
+    use std::sync::Arc;
+    use std::thread;
+
+    let (_t, reg) = fresh();
+    let reg = Arc::new(reg);
+    let mut handles = Vec::new();
+    for i in 0..16 {
+        let reg = reg.clone();
+        handles.push(thread::spawn(move || {
+            reg.upsert(&record("aaa", "demo", i)).unwrap();
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+    let listed = reg.list_active().unwrap();
+    assert_eq!(listed.len(), 1);
+    // ts is whichever thread wrote last — we just care it's a valid value.
+    assert!((0..16).contains(&listed[0].data.last_launched_at_ms));
+}

--- a/agentmux-srv/src/registry/tests.rs
+++ b/agentmux-srv/src/registry/tests.rs
@@ -136,13 +136,64 @@ fn unknown_fields_in_data_survive_round_trip() {
 }
 
 #[test]
-fn corrupt_file_is_overwritten_on_upsert() {
+fn corrupt_file_is_preserved_not_overwritten() {
+    // A corrupt-on-disk file might be a newer-schema file with a
+    // syntax error this binary doesn't understand. Refuse to clobber
+    // it; SQLite remains authoritative for the row.
     let (_t, reg) = fresh();
     let path = reg.root().join("aaa.json");
     std::fs::write(&path, b"{ not json").unwrap();
     reg.upsert(&record("aaa", "demo", 100)).unwrap();
-    let listed = reg.list_active().unwrap();
-    assert_eq!(listed.len(), 1);
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        b"{ not json",
+        "corrupt on-disk file must not be overwritten"
+    );
+}
+
+#[test]
+fn upsert_refuses_to_downgrade_schema_version() {
+    let (_t, reg) = fresh();
+    let path = reg.root().join("aaa.json");
+    // Future v999 envelope already on disk.
+    let v999 = serde_json::json!({
+        "schema_version": 999,
+        "data": { "instance_id": "aaa", "future_only": "field" }
+    });
+    std::fs::write(&path, serde_json::to_vec_pretty(&v999).unwrap()).unwrap();
+
+    // v1 binary calls upsert — must not clobber.
+    reg.upsert(&record("aaa", "demo", 200)).unwrap();
+
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert_eq!(
+        after.pointer("/schema_version"),
+        Some(&serde_json::json!(999)),
+        "schema_version must not be downgraded"
+    );
+    assert_eq!(
+        after.pointer("/data/future_only"),
+        Some(&serde_json::json!("field")),
+        "future_only field must be preserved"
+    );
+}
+
+#[test]
+fn upsert_refuses_when_schema_version_missing() {
+    let (_t, reg) = fresh();
+    let path = reg.root().join("aaa.json");
+    // Envelope with no schema_version at all (some future format we
+    // can't reason about).
+    let raw = serde_json::json!({ "data": { "instance_id": "aaa", "foo": 1 } });
+    std::fs::write(&path, serde_json::to_vec_pretty(&raw).unwrap()).unwrap();
+
+    reg.upsert(&record("aaa", "demo", 200)).unwrap();
+
+    let after: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    assert!(after.get("schema_version").is_none());
+    assert_eq!(after.pointer("/data/foo"), Some(&serde_json::json!(1)));
 }
 
 #[test]

--- a/docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md
+++ b/docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md
@@ -1,6 +1,6 @@
 # Spec: Shared agent registry — cross-version "Continue agent" dropdown
 
-**Status:** Spec (no implementation yet)
+**Status:** PR A landed (parallel-write registry); PR B pending (cut-over reads + migration)
 **Owner:** AgentA
 **Date:** 2026-05-12
 **Driving requirement:** "Agents are shared across versions. The Continue dropdown should show every agent I've ever named, no matter which agentmux version I launched it from. And if a future agentmux version doesn't understand an older agent's schema, it should fail soft — not erase or crash."

--- a/docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md
+++ b/docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md
@@ -1,0 +1,497 @@
+# Spec: Shared agent registry — cross-version "Continue agent" dropdown
+
+**Status:** Spec (no implementation yet)
+**Owner:** AgentA
+**Date:** 2026-05-12
+**Driving requirement:** "Agents are shared across versions. The Continue dropdown should show every agent I've ever named, no matter which agentmux version I launched it from. And if a future agentmux version doesn't understand an older agent's schema, it should fail soft — not erase or crash."
+
+---
+
+## 1. TL;DR
+
+Today every portable/installed agentmux instance writes the `db_named_agents` table into its **per-version** SQLite database (`~/.agentmux/versions/<v>/data/db/objects.db`). Working directories at `~/.agentmux/agents/<name>-<suffix>/` are already shared across versions, but the metadata row that powers the launch-modal dropdown is not. Result: smoke-build a new version, launch the modal, dropdown is empty even though you have ten named agents on disk.
+
+This spec carves out a **shared, file-per-agent registry** at `~/.agentmux/agents/registry/<instance_id>.json`, with a row-level schema version so:
+
+- **Bulk per-version state** (tabs, blocks, layouts, identities, memories, sagas, filestore) stays in per-version SQLite. No bulk migration headache.
+- **Cross-version state** (the "named agents" index — name, definition, working_dir, identity_id, memory_id, timestamps) lives in shared, version-tagged JSON files.
+- **Forward compat**: a future agentmux that adds fields the current one doesn't understand stays readable. Unknown rows are skipped + logged, never deleted.
+- **Backward compat**: an old agentmux that wrote a schema_version=1 row stays readable forever; we promise never to remove the v1 reader.
+
+The launch modal's `ListNamedAgentsCommand` RPC keeps the same shape — it just sources rows from the file registry instead of the SQLite table. Working-dir reuse, identity/memory binding, and the Phase 4 `--continue` resume hook all stay intact.
+
+Two PRs:
+
+- **PR A — Parallel-write registry.** Add the registry resolver + writer; every `db_named_agents` insert/update/delete also writes/touches/deletes a registry file. RPC reads from SQLite still (no behavior change). Safe to roll back.
+- **PR B — Cut over.** RPC reads from registry. One-shot migration on first launch copies every `db_named_agents` row from every version's SQLite into the shared registry. SQLite table is read-only legacy after this.
+
+A future PR C (out of scope for this spec) drops the SQLite table after a release or two of dual-write.
+
+---
+
+## 2. Today's state
+
+### What's per-version
+
+`~/.agentmux/versions/<version>/data/db/`:
+
+- `objects.db` — `db_named_agents`, `db_identities`, `db_memories`, `db_agent_instances`, `db_tabs`, `db_blocks`, …
+- `filestore.db` — per-block file dataset
+- `sagas.db` — saga state
+
+Schema gated by `agentmux-srv/src/storage/schema.rs` migrations. Every version may add migrations; rolling back forward isn't supported.
+
+### What's already shared
+
+`~/.agentmux/agents/<name>-<suffix>/`:
+
+- Working directory (one per named agent).
+- Contains the CLI's project state: `.claude/`, repo checkouts, conversation transcripts, etc.
+- Created by `allocate_agent_workdir` (`agentmux-srv/src/spawn/workdir.rs`).
+- Filename collisions resolved by `-2`, `-3` suffixes; the registered name is the slugified user-typed name.
+
+### The gap
+
+Two pieces of state for the same logical "named agent" live in different places with different lifetimes:
+
+| Piece | Where | Lifetime |
+|---|---|---|
+| Working directory | `~/.agentmux/agents/<slug>/` | Shared across versions, persists forever |
+| Registry row | `~/.agentmux/versions/<v>/data/db/objects.db :: db_named_agents` | Per-version, dies when the user moves to a new version |
+
+When the user upgrades from 0.33.821 → 0.33.822, the working directories are still there, but the modal can't find them.
+
+---
+
+## 3. Goals
+
+1. **One source of truth for "named agents" across versions.** The launch modal's dropdown lists every agent the user has ever named, regardless of which version created it.
+2. **Per-version SQLite stays intact.** No risky bulk migration of objects.db. Versions still own their tabs/blocks/identities/memories independently.
+3. **Forward-compatible.** A 0.33.999 file can sit next to a 0.33.822 file. Old version reads what it understands, skips what it doesn't, logs the skip. **No row is ever silently dropped or destructively migrated.**
+4. **Concurrency-safe.** Two portables (e.g. 0.33.821 + 0.33.822) can run side-by-side. Both can list, both can append, neither corrupts the other.
+5. **Tolerant of partial writes.** If a registry file is corrupt, malformed, or half-written (crash mid-rename), the reader skips it + logs, and the next valid write self-heals.
+6. **Migration is one-shot and idempotent.** First launch after PR B reads every per-version `db_named_agents` table, writes registry files, and never re-runs.
+
+### Non-goals
+
+- Sharing identities/memories across versions. Out of scope; separate PR with its own data-shape questions.
+- Sharing tabs/blocks/sagas. Per-version stays per-version; that's an explicit design choice.
+- Cross-machine sync. Local single-host only.
+- Schema evolution beyond additive fields in this spec. Renames/removals get a deprecation-window plan in a follow-up.
+
+---
+
+## 4. Storage layout
+
+### Directory
+
+```
+~/.agentmux/
+├── agents/                              # already shared, untouched
+│   ├── livelog-821-0512a/                # working dirs (existing)
+│   ├── moams-05059/
+│   ├── ...
+│   └── registry/                         # NEW: shared agent registry
+│       ├── 7c8e4f12-….json              # one file per named agent
+│       ├── 1a9b2d8a-….json
+│       ├── ...
+│       └── retired/                      # NEW: tombstones
+│           └── 3d2e1f4a-….json
+```
+
+**Why `agents/registry/` and not `~/.agentmux/registry/` directly:** colocation with working dirs. A backup script that snapshots `~/.agentmux/agents/` captures both halves of "the agent." Easier mental model.
+
+### One file per agent
+
+Path: `~/.agentmux/agents/registry/<instance_id>.json`
+Encoding: UTF-8 JSON, 2-space indent (so `git diff` is readable when users version-control their `~/.agentmux/agents`).
+Filename is the agent's UUID — globally unique, no slug collision possible.
+
+### Tombstones (soft-delete)
+
+Path: `~/.agentmux/agents/registry/retired/<instance_id>.json`
+
+Retiring an agent moves the file from `registry/` → `registry/retired/` atomically. Keeps a forensic trail without cluttering the dropdown. The "Forget agent" right-click in Phase 3 of the named-agent spec maps to this move.
+
+### Concurrency model
+
+- **Create / update** = atomic write to a temp file in the same dir, then `rename()`. Filesystem guarantees on Windows + macOS + Linux: `rename` over an existing file is atomic. No reader ever sees a partial file.
+- **Retire** = atomic `rename(registry/<id>.json, retired/<id>.json)`.
+- **Hard delete** = `unlink(retired/<id>.json)`. Out of normal flow; only invoked by an explicit "purge" admin path (not exposed in UI initially).
+- **Lock-free list**: readers `readdir + read each file`. A file that disappears mid-list (race with retire) just isn't in the result. A file that's mid-rename either has the old contents or the new contents, never half of either.
+- **Two writers, same id**: last write wins. This is acceptable because the only multi-writer scenario is "two portables both update `last_launched_at_ms` for the same instance," and either timestamp is correct enough.
+
+### Why not SQLite at the shared location
+
+Considered. Rejected because:
+
+- SQLite locks are per-database. A shared `registry.db` accessed by multiple portables fights over WAL/SHM files. We'd need careful timeouts + retry logic.
+- Schema migrations on a shared DB mean *the newest version writes a schema older versions might not be able to read.* Whoever writes the migration breaks everyone else.
+- File-per-agent gives us free per-row schema versioning — exactly what we need for the forward/backward compat story.
+- No noticeable perf hit at the relevant scale (hundreds of agents, not millions).
+
+---
+
+## 5. File format
+
+### v1 envelope
+
+```json
+{
+  "schema_version": 1,
+  "data": {
+    "instance_id": "7c8e4f12-9a3b-4cba-bd60-1a9e8f7c0001",
+    "instance_name": "livelog-821",
+    "definition_id": "claude-code",
+    "identity_id": "agenta",
+    "memory_id": "default",
+    "working_dir": "livelog-821-0512a",
+    "created_at_ms": 1747049400000,
+    "last_launched_at_ms": 1747061640000,
+    "created_by_version": "0.33.821",
+    "last_launched_by_version": "0.33.821"
+  }
+}
+```
+
+**Field rules:**
+
+| Field | Type | Required (v1) | Notes |
+|---|---|---|---|
+| `schema_version` | u32 | yes | Envelope-level. Reader's first decision point. |
+| `data.instance_id` | UUID string | yes | Must match filename. Mismatch = skip + log. |
+| `data.instance_name` | string | yes | User-typed name, not slugified. |
+| `data.definition_id` | string | yes | `"claude-code"`, `"gemini"`, … from widgets.json definitions. |
+| `data.identity_id` | string \| null | yes | Null = no identity bound. |
+| `data.memory_id` | string \| null | yes | Null = no memory bound. |
+| `data.working_dir` | string | yes | **Relative** path inside `~/.agentmux/agents/`. Never an absolute path (portable home moves). |
+| `data.created_at_ms` | i64 | yes | Unix epoch ms. |
+| `data.last_launched_at_ms` | i64 | yes | Updated every launch. Used for dropdown sort order. |
+| `data.created_by_version` | string | yes | Diagnostics only. |
+| `data.last_launched_by_version` | string | yes | Diagnostics only. |
+
+### Validation contract
+
+A row that fails any of these is **skipped, not destroyed, not migrated, not auto-fixed**:
+
+1. Top-level `schema_version` outside `[MIN_SUPPORTED, MAX_SUPPORTED]`.
+2. Filename UUID ≠ `data.instance_id`.
+3. Missing required field for the row's declared `schema_version`.
+4. `data.working_dir` is absolute, contains `..`, or escapes the agents dir.
+5. JSON parse error.
+
+Skip logs the cause and emits a `skipped_registry_file` event into the broker for ops visibility (frontend can surface a one-line "1 agent record could not be loaded" in the Identity/Memory diagnostics pane).
+
+---
+
+## 6. Versioning contract
+
+### Reader
+
+A single resolver in `agentmux-srv/src/registry/schema.rs` declares:
+
+```rust
+pub const MIN_SUPPORTED_SCHEMA: u32 = 1;
+pub const MAX_SUPPORTED_SCHEMA: u32 = 1;
+```
+
+Bumped per release:
+
+- **Add an optional field** (e.g. v2 adds `tags: Vec<String>`): bump `MAX_SUPPORTED_SCHEMA` to 2. Writers populate. Readers default-fill if absent. Old version on the same machine still reads v2 files: parses the envelope, sees `schema_version=2 > MAX_SUPPORTED=1`, skips + logs. The user's dropdown is shorter on the old portable; nothing is lost.
+- **Add a required field**: bump major-ish. Writers write v(N+1). Readers of v(N+1) require the field. Old readers skip. Migration of pre-existing v(N) files to v(N+1) is done in the first launch of the new release.
+- **Remove or rename a field**: never in v1. If we ever need to, the policy is:
+  - One full release cycle of dual-write: writers emit *both* old and new fields.
+  - Bump `MIN_SUPPORTED_SCHEMA` in the release after that.
+  - Old portables on disk that only understood the pre-change schema continue to find readable rows during the deprecation window.
+
+### Writer
+
+Always writes the latest schema known to this binary. Never writes a partial row "matching" an older schema. Never rewrites an existing higher-schema row into a lower schema.
+
+### "Unknown field tolerance"
+
+Inside `data`, **unknown JSON keys are preserved on round-trip when possible, ignored otherwise**:
+
+- Read: `serde(deny_unknown_fields)` is OFF. Unknown keys are dropped from the deserialized struct.
+- Write: writer always writes from its known struct shape. **An old reader doing a round-trip strips unknown fields**. To prevent this, the writer never re-writes a row it didn't conceptually mutate. `touch_last_launched` and similar update paths use **partial JSON merge** (read raw `serde_json::Value`, update only known fields, write back) so unknown fields from newer schemas survive an update by an older binary.
+
+This is the most subtle part of the design and the most important for forward-compat. It's small enough to put in a helper:
+
+```rust
+fn merge_known_fields(
+    existing: &mut serde_json::Value,
+    updates: &serde_json::Value,
+) {
+    // existing = on-disk JSON parsed as Value (preserves unknown fields)
+    // updates = serde_json::to_value(known_struct) where known_struct is
+    //           a snapshot the caller built using only the fields it knows
+    // result: existing has updates' top-level keys overwritten, all other
+    //         keys (potentially from newer schemas) preserved.
+    if let (Some(e), Some(u)) = (existing.as_object_mut(), updates.as_object()) {
+        for (k, v) in u {
+            e.insert(k.clone(), v.clone());
+        }
+    }
+}
+```
+
+### Forward compat self-test
+
+Every release adds one test fixture in `agentmux-srv/tests/registry-fixtures/`:
+
+- `v1_minimal.json` — only required v1 fields. Must load.
+- `v1_with_future_fields.json` — v1 envelope, but `data` includes a `tags: []` array we haven't shipped. Must load *and* survive round-trip (unknown field preserved).
+- `v999_unknown_envelope.json` — `schema_version: 999`. Must be skipped + logged + not deleted.
+
+These run on every PR. Catches the "we accidentally regressed forward-compat" class of bug.
+
+---
+
+## 7. RPC surface
+
+No new RPCs vs the named-agent continuation spec. Internals change:
+
+### `ListNamedAgentsCommand`
+
+```ts
+// Frontend signature unchanged from PR #816.
+RpcApi.ListNamedAgentsCommand(TabRpcClient, {
+  definition_id: "claude-code",
+}): Promise<NamedAgentRow[]>
+```
+
+Backend (`agentmux-srv/src/server/rpc/named_agents.rs`):
+
+```rust
+pub fn list_named_agents(definition_id: &str) -> Vec<NamedAgentRow> {
+    let registry = Registry::open(data_paths().home_dir.join("agents/registry"))?;
+    let mut rows = registry
+        .iter_active()                      // skips retired/, skips invalid
+        .filter(|r| r.definition_id == definition_id)
+        .collect::<Vec<_>>();
+    rows.sort_by(|a, b| b.last_launched_at_ms.cmp(&a.last_launched_at_ms));
+    rows
+}
+```
+
+### `LaunchAgentCommand`
+
+When `overrides.continue_of_instance_id` is set:
+1. Read the registry row.
+2. Resolve `working_dir` to absolute (`agents_root.join(row.working_dir)`).
+3. Reuse identity / memory bindings.
+4. After successful spawn, update `last_launched_at_ms` + `last_launched_by_version` via `Registry::touch(instance_id, now)`.
+
+Failure handling:
+- Registry file disappears between list and launch → return "Agent no longer exists" + log.
+- Working dir disappears → return "Working directory missing" + offer to recreate (out of scope here, separate UX).
+
+### `RetireNamedAgentCommand` (new, for Phase 3 right-click "Forget")
+
+```ts
+RpcApi.RetireNamedAgentCommand(TabRpcClient, {
+  instance_id: string;
+}): Promise<void>
+```
+
+Moves `<id>.json` → `retired/<id>.json` atomically. Working directory untouched (deliberate; user keeps the on-disk transcript).
+
+### `ListRetiredNamedAgentsCommand` (out of scope for first cut)
+
+For a future "Trash" view. Spec'd here for completeness, not implemented now.
+
+---
+
+## 8. Migration
+
+### First launch after PR B ships
+
+`agentmux-srv` startup invokes `registry::migrate_from_sqlite_once()`:
+
+```rust
+pub fn migrate_from_sqlite_once(data_paths: &DataPaths) -> Result<()> {
+    let marker = data_paths.home_dir.join("agents/registry/.migrated_from_sqlite");
+    if marker.exists() { return Ok(()); }
+
+    let home = &data_paths.home_dir;
+    let versions_root = home.join("versions");
+    if !versions_root.is_dir() {
+        std::fs::write(&marker, "no versions dir found\n")?;
+        return Ok(());
+    }
+
+    let mut latest_by_id: HashMap<String, (i64, NamedAgentRow)> = HashMap::new();
+    for v_entry in std::fs::read_dir(&versions_root)? {
+        let v_dir = v_entry?.path();
+        let db_path = v_dir.join("data/db/objects.db");
+        if !db_path.exists() { continue; }
+        for row in read_named_agents_readonly(&db_path)? {
+            let key = row.instance_id.clone();
+            let ts = row.last_launched_at_ms;
+            match latest_by_id.entry(key) {
+                Entry::Occupied(mut e) if e.get().0 < ts => { e.insert((ts, row)); }
+                Entry::Vacant(e) => { e.insert((ts, row)); }
+                _ => {}
+            }
+        }
+    }
+
+    let registry = Registry::open(home.join("agents/registry"))?;
+    for (_, row) in latest_by_id.into_values() {
+        if registry.exists(&row.instance_id)? {
+            // A user who already ran a newer build has a registry row.
+            // Don't clobber it.
+            continue;
+        }
+        registry.create_if_missing(&row)?;
+    }
+    std::fs::write(&marker, chrono::Utc::now().to_rfc3339())?;
+    Ok(())
+}
+```
+
+**Properties:**
+- **Idempotent.** Marker file ensures we run once. Manual delete = re-run.
+- **Read-only on SQLite.** Migration never modifies `objects.db`. Old portables keep working unchanged.
+- **Conflict resolution:** if the same `instance_id` exists in multiple per-version DBs (because the user launched it under two versions before this migration), the one with the latest `last_launched_at_ms` wins.
+- **Don't overwrite a registry file that already exists.** Lets users who upgrade through multiple versions in sequence avoid clobbering newer state.
+- **Marker file isn't authoritative**; deleting it just re-runs the merge, which is safe.
+
+### What about the SQLite table after migration?
+
+Stays. PR B keeps `db_named_agents` populated as a parallel write (so a rollback to a pre-registry release still finds rows it wrote itself). PR C, a release or two later, removes the parallel write. Schema migration removes the table.
+
+### Rollback
+
+- Roll back PR B alone → reverts the RPC source. Registry files stay on disk (harmless, ignored by older binary). SQLite table still authoritative.
+- Roll back PR A alone → drops the parallel-write code. Registry files stop being updated but don't get deleted. Roll-forward simply re-syncs via the migrator.
+
+---
+
+## 9. Frontend
+
+Zero changes to `AgentLaunchModal.tsx` from PR #816. Same `ListNamedAgentsCommand` shape, same dropdown gating, same `handleContinueSelect` flow. The backend is the only thing that changes shape.
+
+The "1 agent record could not be loaded" footer in the modal (when the broker has emitted `skipped_registry_file` events since the modal opened) is **optional, Phase 2**. First cut is silent skip + log.
+
+---
+
+## 10. Code layout
+
+```
+agentmux-srv/src/registry/
+├── mod.rs                 // pub use of below
+├── schema.rs              // schema_version constants, NamedAgentRow struct, validate()
+├── store.rs               // Registry struct: open/create/touch/retire/iter_active
+├── atomic.rs              // write_atomic(path, bytes), rename_atomic(from, to)
+├── migrate.rs             // migrate_from_sqlite_once + per-version DB readers
+└── tests/
+    ├── store_tests.rs
+    ├── schema_tests.rs    // forward-compat fixtures live here
+    └── migrate_tests.rs
+```
+
+`server/rpc/named_agents.rs` becomes a thin shim over `registry::store::Registry`.
+
+`storage/named_agents.rs` (the existing SQLite layer) stays as-is in PR A, gets demoted to "writeback to legacy table" in PR B, gets removed in PR C.
+
+---
+
+## 11. Diagnostics
+
+Add three things, all behind the existing diag/perf machinery so they cost nothing in production:
+
+1. **Broker event `named_agent_registry_loaded`** on first list: `{ active_count, retired_count, skipped_count, slowest_file_ms }`. The launch modal listens to it for the optional "could not load N records" footer.
+2. **Broker event `named_agent_registry_skipped`** per skip: `{ filename, reason }`. Surface in a diag panel; never in the modal directly (don't blame the user for a forward-compat skip).
+3. **`muxlog srv` line per registry write**: `INFO registry: wrote 7c8e…json schema_version=1 fields=10 elapsed_ms=2`. Useful when triaging "why isn't my agent showing up."
+
+No new perf probes — file IO at this scale is negligible compared to broker pub/sub overhead we already instrument.
+
+---
+
+## 12. Test plan
+
+### Unit (Rust)
+
+- **Atomic write**: `write_atomic` followed by a kill -9 emulation (temp file with no rename) leaves the original intact.
+- **Forward-compat fixtures**: schema_version=999 fixture is skipped + reported, not deleted.
+- **Round-trip preserves unknown fields**: simulate v2 input → v1 binary touches `last_launched_at_ms` → re-read with a v2-aware deserializer → `tags` field still present.
+- **Filename / instance_id mismatch**: detected, skipped, logged.
+- **Concurrent touch**: two threads update `last_launched_at_ms` for the same id; final value is one of the two timestamps (no merge nonsense).
+- **Migration idempotency**: run `migrate_from_sqlite_once` twice. Second call no-ops.
+
+### Integration (Rust + the srv test harness)
+
+- **PR A**: insert a row via the legacy SQLite path; verify a registry file appears with matching contents.
+- **PR A**: insert a row via the legacy path while a portable is mid-shutdown (simulate by dropping the connection); registry file is consistent (no half-written).
+- **PR B**: cold-launch portable with two simulated per-version DBs (one with 3 rows from version A, one with 2 rows + 1 overlap from version B). Registry has the union with the overlap's newer timestamp winning.
+
+### Replay (frontend)
+
+- New fixture in `frontend/test/fixtures/agent-sessions/`: a launch-modal-open event sequence with the dropdown populated from the broker's `named_agent_registry_loaded` event.
+- Replay verifies the dropdown order matches the sort contract.
+
+### Manual smoke
+
+- Build 0.33.823 (PR B). Verify dropdown shows `livelog-821` (created on 0.33.821) without further action.
+- Launch from dropdown. Verify working dir is reused, identity/memory pre-locked.
+- Switch to portable 0.33.821, launch a *new* agent there. Switch back to 0.33.823. Reopen modal. New agent appears (because the parallel write path during PR A is still live until PR C).
+
+---
+
+## 13. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Two concurrent portables both `touch` the same row — clobbering a field a newer version wrote. | Partial-merge writer (§6) preserves unknown fields. For known fields, last-write-wins on a single `last_launched_at_ms` is fine. |
+| A registry file gets corrupted (disk error, antivirus quarantine, user edit). | Skip + log + emit broker event. Don't delete. User can edit JSON by hand to repair. |
+| Migration runs on a system with 30+ versions and stalls startup. | Migration is read-only + bounded by total agent count, not version count. ~1ms per row in practice. Worst-case 100 agents × 30 versions = ~3s, behind a marker file so it runs once. |
+| User deletes `~/.agentmux/agents/registry/.migrated_from_sqlite` thinking it's junk. | Migration is idempotent; re-runs are harmless (won't overwrite existing registry files). |
+| A future agentmux ships a v2 schema and an old portable on the same machine loses access to v2-only rows. | By design. The old portable still launches those agents *if it learns their id from somewhere else*, but the dropdown is shorter. We accept this. The alternative — auto-downgrading v2 → v1 — destroys data. |
+| Working-dir collision: two registry rows point to the same `working_dir`. | Detected on launch; latest-modified registry row wins; the other is logged as a stale duplicate. Should never happen in normal flow (UUID-keyed rows). |
+| Path traversal in `working_dir`. | Validated on read (§5) — must be relative, no `..`, must resolve inside agents root. |
+
+---
+
+## 14. Out of scope
+
+- Sharing identities or memories across versions. Tracked under data-dir unification (see `reference_data_dir_unification_plan.md`); decided independently.
+- Cloud sync of the registry.
+- A trash/restore UI for retired agents.
+- A registry-level audit log (`who last touched this row when from which version`). The per-row `last_launched_by_version` is enough for v1.
+
+---
+
+## 15. PR sequence
+
+### PR A — Parallel-write registry (no behavior change)
+
+- New `agentmux-srv/src/registry/` module per §10.
+- Every existing `db_named_agents` insert/update/delete call site also writes the registry file.
+- RPC reads still come from SQLite.
+- Migration code added but **not invoked** yet.
+- Bump patch. Smoke: confirm registry dir fills up as the user launches agents. Confirm SQLite still authoritative.
+- Tests: unit + integration per §12.
+
+### PR B — Cut over reads, run one-shot migration
+
+- `list_named_agents` / `launch_named_agent_continue` / `retire_named_agent` switch source to `Registry`.
+- `migrate_from_sqlite_once` runs on srv startup behind the marker file.
+- Parallel write to SQLite is **kept** (for one-version rollback safety).
+- Add forward-compat test fixtures (§6).
+- Bump patch. Smoke: 0.33.821-created agents appear in 0.33.823's dropdown.
+
+### PR C (future, not this spec) — Retire the SQLite table
+
+- Drop parallel write.
+- Add a schema migration that deletes `db_named_agents` from objects.db.
+- Bump patch. Smoke: existing registry state intact, SQLite clean.
+
+---
+
+## 16. Open questions for review
+
+1. **Encoding choice**: pretty-printed JSON (this spec's choice) vs `bincode` / `cbor` for smaller files? Pretty JSON wins on debuggability and `git diff`-ability; size at this scale (≤1KB per file) is irrelevant.
+2. **Filename = UUID vs filename = slug**: UUID guarantees uniqueness but is unreadable. Slug is readable but collides. UUID + `instance_name` inside the file is the safe combo.
+3. **Should retire be reversible from the UI** in v1? Currently no — the retired/ subdir exists but no "restore" affordance. Likely OK to defer until users actually ask.
+4. **Should the migration also pull from old `~/.waveterm` directories**? Tracked under the AGENTMUX rebrand migration in `CLAUDE.md`; we said no there, and this spec inherits that decision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.823",
+  "version": "0.33.824",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.823",
+      "version": "0.33.824",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.821",
+  "version": "0.33.822",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.821",
+      "version": "0.33.822",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.822",
+  "version": "0.33.823",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.822",
+      "version": "0.33.823",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.821",
+  "version": "0.33.822",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.823",
+  "version": "0.33.824",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.822",
+  "version": "0.33.823",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

First of two PRs that move named-agent metadata out of per-version SQLite into a shared, forward-compatible file registry so the launch-modal "Continue agent" dropdown works across portable versions.

**This PR is no-behavior-change for users.** RPC reads still come from SQLite. Mutations are parallel-written to the new registry; PR B will cut the read path over and run a one-shot migration.

- New module \`agentmux-srv/src/registry/\` (atomic write, paths resolver, schema envelope, file-per-agent store)
- \`WaveStore::set_registry()\` attaches the shared registry at srv startup
- \`instance_{create,update,set_hidden,delete}\` mirror to the registry after their SQL succeeds (named rows only)
- Mirror failures are logged + swallowed — SQLite remains authoritative, rollback is harmless
- Forward-compat: row-level \`schema_version\` + MIN/MAX bounds; unknown fields inside \`data\` survive round-trip via JSON merge so old binaries don't strip future fields

Spec: \`docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md\`

## Test plan

- [x] 24 registry unit + integration tests (atomic, paths, schema, store)
  - Round-trips, retire/unretire, idempotency
  - **Forward-compat fixture**: \`schema_version=999\` envelope is skipped + logged, not deleted
  - **Unknown-field preservation**: a future \`tags\` field inside \`data\` survives an older binary's update of \`last_launched_at_ms\`
  - Concurrent upserts of the same id don't corrupt
  - Corrupt-file recovery on upsert
- [x] 6 WaveStore → Registry mirror tests covering all four mutation paths + named/unnamed filter + outside-agents-dir skip
- [x] 3 pre-existing \`test_instance_*\` tests still pass (no regression)
- [x] \`cargo build --workspace\` green
- [x] Built locally — registry directory creates correctly on startup

## Rollback

Reverting this PR leaves any registry JSON files on disk (harmless, ignored by older binaries) and reinstates pure-SQLite behavior. No schema migration runs in PR A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)