### PR TITLE
feat(registry): cut-over reads + one-shot migration (PR B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.824"
+version = "0.33.825"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.824"
+version = "0.33.825"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.824"
+version = "0.33.825"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.824"
+version = "0.33.825"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.824"
+version = "0.33.825"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.825"
+version = "0.33.826"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.825"
+version = "0.33.826"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.825"
+version = "0.33.826"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.825"
+version = "0.33.826"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.825"
+version = "0.33.826"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.826 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.824 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.823 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.822 | 2026-05-12 | 164.1 MiB | 343.9 MiB | |

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.824"
+version = "0.33.825"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.825"
+version = "0.33.826"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.825"
+version = "0.33.826"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.824"
+version = "0.33.825"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.824"
+version = "0.33.825"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.825"
+version = "0.33.826"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.824"
+version = "0.33.825"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.825"
+version = "0.33.826"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.824"
+version = "0.33.825"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.825"
+version = "0.33.826"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1657,6 +1657,12 @@ impl WaveStore {
     /// Set the `display_hidden` flag on an existing instance row. Used
     /// by the "Forget agent" affordance — soft-delete only; the row +
     /// working directory remain on disk for audit + recovery.
+    ///
+    /// Cross-version case: an agent migrated into the registry from
+    /// another version's SQLite won't have a row in the current
+    /// version's SQLite. The UPDATE returns 0 rows, but the registry
+    /// still needs to flip — otherwise "Forget agent" silently no-ops
+    /// on cross-version entries. Returns `true` if either side acted.
     pub fn instance_set_hidden(&self, id: &str, hidden: bool) -> Result<bool, StoreError> {
         let rows = {
             let conn = self.conn.lock().unwrap();
@@ -1665,24 +1671,29 @@ impl WaveStore {
                 params![if hidden { 1_i64 } else { 0_i64 }, id],
             )?
         };
-        if rows > 0 {
-            if let Some(reg) = self.registry() {
+        let mut registry_acted = false;
+        if let Some(reg) = self.registry() {
+            // Only act on the registry side if a record exists there
+            // (in either active or retired). Avoids logging spurious
+            // "failed to retire" warnings on a no-op for unrelated ids.
+            if reg.exists_anywhere(id) {
                 let res = if hidden {
                     reg.retire(id)
                 } else {
                     reg.unretire(id)
                 };
-                if let Err(e) = res {
-                    tracing::warn!(
+                match res {
+                    Ok(()) => registry_acted = true,
+                    Err(e) => tracing::warn!(
                         instance_id = %id,
                         hidden,
                         error = %e,
                         "registry: failed to mirror instance_set_hidden"
-                    );
+                    ),
                 }
             }
         }
-        Ok(rows > 0)
+        Ok(rows > 0 || registry_acted)
     }
 
     /// List all instances that the launch modal's "Continue agent"
@@ -3218,6 +3229,45 @@ mod tests {
         assert_eq!(reg.list_active().unwrap().len(), 1);
         assert!(!reg.root().join("retired").join("inst-toggle.json").exists(),
             "no orphan retired file alongside active");
+    }
+
+    #[test]
+    fn instance_set_hidden_acts_on_registry_only_row() {
+        // Cross-version case: a registry record exists (e.g. migrated
+        // from another version's SQLite) but the current version's
+        // SQLite has no matching row. `instance_set_hidden` must still
+        // flip the registry file and report success.
+        let (tmp, store, reg) = store_with_registry();
+        // Seed a registry record directly — no SQLite row.
+        let agents_root = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("cross-ver");
+        std::fs::create_dir_all(&wd).unwrap();
+        reg.upsert(&crate::registry::NamedAgentRecord {
+            schema_version: crate::registry::MAX_SUPPORTED_SCHEMA,
+            data: crate::registry::NamedAgentRecordV1 {
+                instance_id: "inst-crossver".to_string(),
+                instance_name: "crossver".to_string(),
+                definition_id: "claude-code".to_string(),
+                identity_id: None,
+                memory_id: None,
+                working_dir: "cross-ver".to_string(),
+                created_at_ms: 100,
+                last_launched_at_ms: 100,
+                created_by_version: "0.33.821".to_string(),
+                last_launched_by_version: "0.33.821".to_string(),
+            },
+        })
+        .unwrap();
+        assert_eq!(reg.list_active().unwrap().len(), 1);
+        assert!(store.instance_get("inst-crossver").unwrap().is_none(),
+            "precondition: no SQLite row for cross-version agent");
+
+        let result = store.instance_set_hidden("inst-crossver", true).unwrap();
+        assert!(result, "must report success even when only registry was affected");
+        assert!(reg.list_active().unwrap().is_empty(),
+            "registry record must be retired");
+        assert!(reg.root().join("retired").join("inst-crossver.json").exists());
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -86,6 +86,14 @@ impl WaveStore {
             .clone()
     }
 
+    /// Public accessor for the cross-version named-agent registry.
+    /// Returns `None` when the registry couldn't be resolved at
+    /// startup (CI / unusual envs); callers must handle the absent
+    /// case by falling back to SQLite.
+    pub fn shared_agent_registry(&self) -> Option<Arc<Registry>> {
+        self.registry()
+    }
+
     /// Table name for a WaveObj type: `db_<otype>`.
     fn table_name<T: WaveObj>() -> String {
         format!("db_{}", T::get_otype())

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -330,8 +330,8 @@ async fn main() {
                     .parent()
                     .and_then(|p| p.parent())
                     .map(|p| p.to_path_buf());
-                if let Some(home) = shared_home {
-                    match registry::migrate_from_sqlite_once(&home, &reg) {
+                match shared_home {
+                    Some(home) => match registry::migrate_from_sqlite_once(&home, &reg) {
                         Ok(stats) if stats.versions_scanned > 0 || stats.records_written > 0 => {
                             tracing::info!(
                                 versions_scanned = stats.versions_scanned,
@@ -347,7 +347,11 @@ async fn main() {
                             error = %e,
                             "registry: SQLite migration errored — continuing with empty registry; SQLite remains authoritative"
                         ),
-                    }
+                    },
+                    None => tracing::warn!(
+                        root = %root.display(),
+                        "registry: cannot resolve shared home (root has fewer than 2 ancestors) — skipping one-shot SQLite migration"
+                    ),
                 }
                 wstore_raw.set_registry(Arc::new(reg));
             }

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -346,10 +346,16 @@ async fn main() {
                                     records_written = stats.records_written,
                                     records_skipped_existing = stats.records_skipped_existing,
                                     records_skipped_unmappable = stats.records_skipped_unmappable,
-                                    "registry: one-shot SQLite migration complete"
+                                    complete = stats.complete,
+                                    "registry: one-shot SQLite migration finished"
                                 );
                             }
-                            true
+                            // Gate attach on `complete` — partial
+                            // migration leaves the registry detached
+                            // so the read path serves SQLite (full,
+                            // current-version-only view) rather than
+                            // a half-populated registry.
+                            stats.complete
                         }
                         Err(e) => {
                             tracing::warn!(

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -322,38 +322,55 @@ async fn main() {
     if let Some(root) = registry::resolve_shared_registry_dir() {
         match registry::Registry::open(root.clone()) {
             Ok(reg) => {
-                tracing::info!(root = %root.display(), "registry: shared agent registry attached");
                 // PR B — one-shot backfill from every per-version
                 // objects.db into the registry. Idempotent via marker
                 // file in the registry root. Read-only on SQLite.
+                //
+                // Gating: the registry is only attached to wstore if
+                // migration completes (Ok) — that way the read path
+                // never serves a partial view. On Err, mirror writes
+                // are also disabled (registry stays detached); SQLite
+                // remains authoritative and the next launch retries
+                // the migration via the same marker logic.
                 let shared_home = root
                     .parent()
                     .and_then(|p| p.parent())
                     .map(|p| p.to_path_buf());
-                match shared_home {
+                let migration_ok = match shared_home {
                     Some(home) => match registry::migrate_from_sqlite_once(&home, &reg) {
-                        Ok(stats) if stats.versions_scanned > 0 || stats.records_written > 0 => {
-                            tracing::info!(
-                                versions_scanned = stats.versions_scanned,
-                                rows_seen = stats.rows_seen,
-                                records_written = stats.records_written,
-                                records_skipped_existing = stats.records_skipped_existing,
-                                records_skipped_unmappable = stats.records_skipped_unmappable,
-                                "registry: one-shot SQLite migration complete"
-                            );
+                        Ok(stats) => {
+                            if stats.versions_scanned > 0 || stats.records_written > 0 {
+                                tracing::info!(
+                                    versions_scanned = stats.versions_scanned,
+                                    rows_seen = stats.rows_seen,
+                                    records_written = stats.records_written,
+                                    records_skipped_existing = stats.records_skipped_existing,
+                                    records_skipped_unmappable = stats.records_skipped_unmappable,
+                                    "registry: one-shot SQLite migration complete"
+                                );
+                            }
+                            true
                         }
-                        Ok(_) => {} // marker already existed; no-op
-                        Err(e) => tracing::warn!(
-                            error = %e,
-                            "registry: SQLite migration errored — continuing with empty registry; SQLite remains authoritative"
-                        ),
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "registry: SQLite migration errored — leaving registry detached; SQLite stays authoritative, next launch retries"
+                            );
+                            false
+                        }
                     },
-                    None => tracing::warn!(
-                        root = %root.display(),
-                        "registry: cannot resolve shared home (root has fewer than 2 ancestors) — skipping one-shot SQLite migration"
-                    ),
+                    None => {
+                        tracing::warn!(
+                            root = %root.display(),
+                            "registry: cannot resolve shared home (root has fewer than 2 ancestors) — leaving registry detached"
+                        );
+                        false
+                    }
+                };
+                if migration_ok {
+                    tracing::info!(root = %root.display(), "registry: shared agent registry attached");
+                    wstore_raw.set_registry(Arc::new(reg));
                 }
-                wstore_raw.set_registry(Arc::new(reg));
             }
             Err(e) => tracing::warn!(
                 root = %root.display(),

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -323,6 +323,32 @@ async fn main() {
         match registry::Registry::open(root.clone()) {
             Ok(reg) => {
                 tracing::info!(root = %root.display(), "registry: shared agent registry attached");
+                // PR B — one-shot backfill from every per-version
+                // objects.db into the registry. Idempotent via marker
+                // file in the registry root. Read-only on SQLite.
+                let shared_home = root
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .map(|p| p.to_path_buf());
+                if let Some(home) = shared_home {
+                    match registry::migrate_from_sqlite_once(&home, &reg) {
+                        Ok(stats) if stats.versions_scanned > 0 || stats.records_written > 0 => {
+                            tracing::info!(
+                                versions_scanned = stats.versions_scanned,
+                                rows_seen = stats.rows_seen,
+                                records_written = stats.records_written,
+                                records_skipped_existing = stats.records_skipped_existing,
+                                records_skipped_unmappable = stats.records_skipped_unmappable,
+                                "registry: one-shot SQLite migration complete"
+                            );
+                        }
+                        Ok(_) => {} // marker already existed; no-op
+                        Err(e) => tracing::warn!(
+                            error = %e,
+                            "registry: SQLite migration errored — continuing with empty registry; SQLite remains authoritative"
+                        ),
+                    }
+                }
                 wstore_raw.set_registry(Arc::new(reg));
             }
             Err(e) => tracing::warn!(

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -96,7 +96,11 @@ pub fn migrate_from_sqlite_once(
     }
 
     for (id, row) in latest_by_id {
-        if registry.exists(&id) {
+        // Check active AND retired — a record retired by a newer
+        // version's "Forget agent" must NOT be resurrected just
+        // because an older version's SQLite still lists it as
+        // visible.
+        if registry.exists_anywhere(&id) {
             stats.records_skipped_existing += 1;
             continue;
         }
@@ -149,15 +153,31 @@ struct RowSnapshot {
     created_at: i64,
 }
 
+/// True iff the error is SQLite reporting "this column/table doesn't
+/// exist in this DB's schema." Distinguishes a pre-v8 DB (skip
+/// silently) from corruption (caller logs + continues). Matches on
+/// `SqliteFailure` with `Some(msg)` containing the canonical SQLite
+/// phrases; the underlying `ExtendedCode` for both is
+/// `SQLITE_ERROR` (1), which would also fire for plenty of other
+/// real failures, so message inspection is required.
+fn is_missing_column_or_table(e: &rusqlite::Error) -> bool {
+    match e {
+        rusqlite::Error::SqliteFailure(_, Some(msg)) => {
+            msg.starts_with("no such column") || msg.starts_with("no such table")
+        }
+        _ => false,
+    }
+}
+
 fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> {
     let conn = Connection::open_with_flags(
         db_path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )?;
     // Older schemas (pre-v8) lack `instance_name` / `working_directory`
-    // columns. Treat a prepare failure as "nothing to migrate from this
-    // version" — those agents weren't named, so wouldn't surface in the
-    // dropdown anyway.
+    // columns. Suppress ONLY the specific "no such column/table"
+    // errors — broader SqliteFailures (corruption, locked, etc.) must
+    // surface so the caller can log + continue with the next DB.
     let mut stmt = match conn.prepare(
         "SELECT id, instance_name, definition_id, identity_id, memory_id,
                 working_directory, started_at, created_at
@@ -167,9 +187,7 @@ fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> 
            AND display_hidden = 0",
     ) {
         Ok(s) => s,
-        Err(rusqlite::Error::SqliteFailure(_, _)) | Err(rusqlite::Error::InvalidColumnName(_)) => {
-            return Ok(Vec::new());
-        }
+        Err(e) if is_missing_column_or_table(&e) => return Ok(Vec::new()),
         Err(e) => return Err(e),
     };
     let iter = stmt.query_map([], |row| {
@@ -382,6 +400,51 @@ mod tests {
         let recs = reg.list_active().unwrap();
         assert_eq!(recs.len(), 1);
         assert_eq!(recs[0].data.instance_name, "preexisting");
+    }
+
+    #[test]
+    fn migrate_skips_when_record_is_retired() {
+        // A user "Forgot" an agent (its registry file is in retired/).
+        // Another version's SQLite still has display_hidden=0 for that
+        // id. Migration must NOT resurrect the row into active/.
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("demo");
+        std::fs::create_dir_all(&wd).unwrap();
+
+        // Pre-tombstone a retired record.
+        let retired_record = NamedAgentRecord {
+            schema_version: MAX_SUPPORTED_SCHEMA,
+            data: NamedAgentRecordV1 {
+                instance_id: "inst-1".to_string(),
+                instance_name: "demo".to_string(),
+                definition_id: "claude-code".to_string(),
+                identity_id: None,
+                memory_id: None,
+                working_dir: "demo".to_string(),
+                created_at_ms: 50,
+                last_launched_at_ms: 50,
+                created_by_version: "0.33.823".to_string(),
+                last_launched_by_version: "0.33.823".to_string(),
+            },
+        };
+        reg.upsert(&retired_record).unwrap();
+        reg.retire("inst-1").unwrap();
+        assert!(reg.list_active().unwrap().is_empty());
+        assert!(reg.exists_anywhere("inst-1"));
+
+        // Legacy SQLite still has display_hidden=0 for the same id.
+        let v_dir = home.path().join("versions").join("0.33.821");
+        make_version_db(&v_dir, &[("inst-1", "demo", 100, &wd.to_string_lossy())]);
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.rows_seen, 1);
+        assert_eq!(stats.records_skipped_existing, 1);
+        assert_eq!(stats.records_written, 0);
+        // Tombstone must remain in retired/, NOT moved to active.
+        assert!(reg.list_active().unwrap().is_empty());
+        assert!(reg.root().join("retired").join("inst-1.json").exists());
     }
 
     #[test]

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -21,6 +21,11 @@ pub struct MigrateStats {
     pub records_written: usize,
     pub records_skipped_existing: usize,
     pub records_skipped_unmappable: usize,
+    /// True iff every per-version DB read cleanly. Callers gate
+    /// registry attachment on this — partial migrations leave the
+    /// registry detached so reads keep falling back to SQLite, and
+    /// the next launch retries (no marker written when `false`).
+    pub complete: bool,
 }
 
 /// Marker filename. Lives in the registry root so the registry's
@@ -42,7 +47,12 @@ pub fn migrate_from_sqlite_once(
 ) -> Result<MigrateStats, RegistryError> {
     let marker_path = registry.root().join(MARKER);
     if marker_path.exists() {
-        return Ok(MigrateStats::default());
+        // Marker present ⇒ a prior run completed; treat as complete
+        // so callers attach the registry.
+        return Ok(MigrateStats {
+            complete: true,
+            ..MigrateStats::default()
+        });
     }
 
     let mut stats = MigrateStats::default();
@@ -55,6 +65,7 @@ pub fn migrate_from_sqlite_once(
 
     let versions_root = shared_home.join("versions");
     if !versions_root.is_dir() {
+        stats.complete = true;
         write_marker(&marker_path, &stats)?;
         return Ok(stats);
     }
@@ -154,9 +165,11 @@ pub fn migrate_from_sqlite_once(
 
     // Only finalize the migration when every DB we encountered was
     // readable. On any per-DB error, defer the marker so a future
-    // launch retries the migration. The already-written rows are
-    // idempotency-skipped on retry via `exists_anywhere`.
-    if !any_db_failed {
+    // launch retries the migration AND signal `complete = false` so
+    // main.rs leaves the registry detached for this session (reads
+    // fall back to SQLite — preferred over serving a partial view).
+    stats.complete = !any_db_failed;
+    if stats.complete {
         write_marker(&marker_path, &stats)?;
     } else {
         tracing::info!(
@@ -584,12 +597,13 @@ mod tests {
 
         // Next launch retries the migration; the good rows are
         // idempotency-skipped (exists_anywhere), and the bad DB now
-        // works (simulate by replacing with a valid file).
+        // works (simulate by replacing with a valid file pointing at
+        // the same `wd` so we don't need a second working-dir
+        // fixture).
         std::fs::remove_file(bad_db_dir.join("objects.db")).unwrap();
-        make_version_db(&bad_v, &[("inst-other", "demo2", 50, &wd.to_string_lossy())]);
-        std::fs::create_dir_all(agents_root.join("demo2")).unwrap();
-        // ^ wait — demo2 wd: rebuild
+        make_version_db(&bad_v, &[("inst-other", "demo", 50, &wd.to_string_lossy())]);
         let stats2 = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert!(stats2.complete, "complete flag set on clean retry");
         assert!(
             reg.root().join(MARKER).exists(),
             "marker written on the retry once all DBs read successfully"

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -1,0 +1,419 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! One-shot SQLite → file-registry migration. Runs at most once per
+//! `<root>/.migrated_from_sqlite` marker; idempotent and read-only on
+//! every SQLite it touches. See SPEC §8.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use rusqlite::{Connection, OpenFlags};
+
+use super::schema::{NamedAgentRecord, NamedAgentRecordV1, MAX_SUPPORTED_SCHEMA};
+use super::store::{Registry, RegistryError};
+
+/// Outcome stats — surfaced in the marker file + the srv log.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MigrateStats {
+    pub versions_scanned: usize,
+    pub rows_seen: usize,
+    pub records_written: usize,
+    pub records_skipped_existing: usize,
+    pub records_skipped_unmappable: usize,
+}
+
+/// Marker filename. Lives in the registry root so the registry's
+/// existence implies the migration question has been asked at least
+/// once.
+const MARKER: &str = ".migrated_from_sqlite";
+
+/// Scan every per-version `data/db/objects.db` and populate the
+/// shared registry. Skipped if the marker file exists. Never
+/// overwrites an existing registry record (idempotency + respect
+/// for newer-written data). The SQLite files are opened **read-only**
+/// — never modified.
+///
+/// On dedup conflicts (same `instance_id` in multiple versions), the
+/// row with the latest `started_at` wins.
+pub fn migrate_from_sqlite_once(
+    shared_home: &Path,
+    registry: &Registry,
+) -> Result<MigrateStats, RegistryError> {
+    let marker_path = registry.root().join(MARKER);
+    if marker_path.exists() {
+        return Ok(MigrateStats::default());
+    }
+
+    let mut stats = MigrateStats::default();
+    let agents_root = registry.agents_root().ok_or_else(|| {
+        RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "registry root has no parent",
+        ))
+    })?;
+
+    let versions_root = shared_home.join("versions");
+    if !versions_root.is_dir() {
+        write_marker(&marker_path, &stats)?;
+        return Ok(stats);
+    }
+
+    let mut latest_by_id: HashMap<String, RowSnapshot> = HashMap::new();
+
+    for entry in std::fs::read_dir(&versions_root)? {
+        let v_dir = entry?.path();
+        if !v_dir.is_dir() {
+            continue;
+        }
+        let db_path = v_dir.join("data").join("db").join("objects.db");
+        if !db_path.is_file() {
+            continue;
+        }
+        stats.versions_scanned += 1;
+
+        match read_named_rows(&db_path) {
+            Ok(rows) => {
+                for row in rows {
+                    stats.rows_seen += 1;
+                    let key = row.id.clone();
+                    match latest_by_id.get(&key) {
+                        Some(existing) if existing.started_at >= row.started_at => {}
+                        _ => {
+                            latest_by_id.insert(key, row);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    db = %db_path.display(),
+                    error = %e,
+                    "registry-migrate: skipping unreadable per-version DB"
+                );
+            }
+        }
+    }
+
+    for (id, row) in latest_by_id {
+        if registry.exists(&id) {
+            stats.records_skipped_existing += 1;
+            continue;
+        }
+        let Some(rec) = row_to_record(&row, agents_root) else {
+            stats.records_skipped_unmappable += 1;
+            continue;
+        };
+        if let Err(e) = registry.upsert(&rec) {
+            tracing::warn!(
+                instance_id = %id,
+                error = %e,
+                "registry-migrate: upsert failed"
+            );
+            stats.records_skipped_unmappable += 1;
+            continue;
+        }
+        stats.records_written += 1;
+    }
+
+    write_marker(&marker_path, &stats)?;
+    Ok(stats)
+}
+
+fn write_marker(path: &Path, stats: &MigrateStats) -> std::io::Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let body = format!(
+        "migrated_at: {now}\n\
+         versions_scanned: {}\n\
+         rows_seen: {}\n\
+         records_written: {}\n\
+         records_skipped_existing: {}\n\
+         records_skipped_unmappable: {}\n",
+        stats.versions_scanned,
+        stats.rows_seen,
+        stats.records_written,
+        stats.records_skipped_existing,
+        stats.records_skipped_unmappable,
+    );
+    std::fs::write(path, body)
+}
+
+struct RowSnapshot {
+    id: String,
+    instance_name: String,
+    definition_id: String,
+    identity_id: String,
+    memory_id: String,
+    working_directory: String,
+    started_at: i64,
+    created_at: i64,
+}
+
+fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )?;
+    // Older schemas (pre-v8) lack `instance_name` / `working_directory`
+    // columns. Treat a prepare failure as "nothing to migrate from this
+    // version" — those agents weren't named, so wouldn't surface in the
+    // dropdown anyway.
+    let mut stmt = match conn.prepare(
+        "SELECT id, instance_name, definition_id, identity_id, memory_id,
+                working_directory, started_at, created_at
+         FROM db_agent_instances
+         WHERE instance_name <> ''
+           AND parent_instance_id = ''
+           AND display_hidden = 0",
+    ) {
+        Ok(s) => s,
+        Err(rusqlite::Error::SqliteFailure(_, _)) | Err(rusqlite::Error::InvalidColumnName(_)) => {
+            return Ok(Vec::new());
+        }
+        Err(e) => return Err(e),
+    };
+    let iter = stmt.query_map([], |row| {
+        Ok(RowSnapshot {
+            id: row.get(0)?,
+            instance_name: row.get(1)?,
+            definition_id: row.get(2)?,
+            identity_id: row.get(3)?,
+            memory_id: row.get(4)?,
+            working_directory: row.get(5)?,
+            started_at: row.get(6)?,
+            created_at: row.get(7)?,
+        })
+    })?;
+    iter.collect()
+}
+
+fn row_to_record(row: &RowSnapshot, agents_root: &Path) -> Option<NamedAgentRecord> {
+    let abs = std::path::Path::new(&row.working_directory);
+    let rel = abs.strip_prefix(agents_root).ok()?;
+    let rel_str = rel.to_string_lossy().to_string();
+    if rel_str.is_empty() || rel_str == "." {
+        return None;
+    }
+    Some(NamedAgentRecord {
+        schema_version: MAX_SUPPORTED_SCHEMA,
+        data: NamedAgentRecordV1 {
+            instance_id: row.id.clone(),
+            instance_name: row.instance_name.clone(),
+            definition_id: row.definition_id.clone(),
+            identity_id: empty_to_none(&row.identity_id),
+            memory_id: empty_to_none(&row.memory_id),
+            working_dir: rel_str,
+            created_at_ms: row.created_at,
+            last_launched_at_ms: row.started_at,
+            // We don't know what version originally inserted these rows.
+            // Tag them so post-migration audits can tell. PR C will
+            // never overwrite a record so these stay forever.
+            created_by_version: "(legacy)".to_string(),
+            last_launched_by_version: "(legacy)".to_string(),
+        },
+    })
+}
+
+fn empty_to_none(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+
+    /// Build a per-version SQLite at `<version_dir>/data/db/objects.db`
+    /// with a minimal `db_agent_instances` schema and the given rows.
+    fn make_version_db(version_dir: &Path, rows: &[(&str, &str, i64, &str)]) {
+        let db_path = version_dir.join("data").join("db");
+        std::fs::create_dir_all(&db_path).unwrap();
+        let db_path = db_path.join("objects.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE db_agent_instances (
+                id TEXT PRIMARY KEY,
+                definition_id TEXT NOT NULL DEFAULT '',
+                parent_instance_id TEXT NOT NULL DEFAULT '',
+                block_id TEXT NOT NULL DEFAULT '',
+                session_id TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'running',
+                github_context TEXT NOT NULL DEFAULT '',
+                started_at INTEGER NOT NULL DEFAULT 0,
+                ended_at INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0,
+                identity_id TEXT NOT NULL DEFAULT '',
+                memory_id TEXT NOT NULL DEFAULT '',
+                instance_name TEXT NOT NULL DEFAULT '',
+                working_directory TEXT NOT NULL DEFAULT '',
+                display_hidden INTEGER NOT NULL DEFAULT 0
+            );",
+        )
+        .unwrap();
+        for (id, name, started_at, working_directory) in rows {
+            conn.execute(
+                "INSERT INTO db_agent_instances
+                    (id, definition_id, instance_name, working_directory, started_at, created_at)
+                 VALUES (?1, 'claude-code', ?2, ?3, ?4, ?4)",
+                params![id, name, working_directory, started_at],
+            )
+            .unwrap();
+        }
+    }
+
+    fn fresh_home() -> (tempfile::TempDir, Registry) {
+        let home = tempfile::tempdir().unwrap();
+        let reg = Registry::open(home.path().join("agents").join("registry")).unwrap();
+        (home, reg)
+    }
+
+    #[test]
+    fn migrate_with_no_versions_dir_writes_marker_and_no_rows() {
+        let (home, reg) = fresh_home();
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.versions_scanned, 0);
+        assert_eq!(stats.records_written, 0);
+        assert!(reg.root().join(MARKER).exists());
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let (home, reg) = fresh_home();
+        // Empty home — marker gets written on first call.
+        migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        // Add a version DB AFTER the marker — second run must NOT pick it up.
+        let agents_root = home.path().join("agents");
+        let v_dir = home.path().join("versions").join("0.33.821");
+        let wd = agents_root.join("demo-1");
+        std::fs::create_dir_all(&wd).unwrap();
+        make_version_db(
+            &v_dir,
+            &[("inst-1", "demo", 100, &wd.to_string_lossy())],
+        );
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(
+            stats.records_written, 0,
+            "marker must short-circuit subsequent runs"
+        );
+        assert!(reg.list_active().unwrap().is_empty());
+    }
+
+    #[test]
+    fn migrate_writes_one_record_per_unique_id() {
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd_a = agents_root.join("demo-a");
+        let wd_b = agents_root.join("demo-b");
+        std::fs::create_dir_all(&wd_a).unwrap();
+        std::fs::create_dir_all(&wd_b).unwrap();
+        let v_dir = home.path().join("versions").join("0.33.821");
+        make_version_db(
+            &v_dir,
+            &[
+                ("inst-a", "demoA", 100, &wd_a.to_string_lossy()),
+                ("inst-b", "demoB", 200, &wd_b.to_string_lossy()),
+            ],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.rows_seen, 2);
+        assert_eq!(stats.records_written, 2);
+        assert_eq!(reg.list_active().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn migrate_picks_latest_started_at_on_dedup() {
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("demo");
+        std::fs::create_dir_all(&wd).unwrap();
+        // Same instance_id in two versions, different started_at.
+        let v1 = home.path().join("versions").join("0.33.800");
+        let v2 = home.path().join("versions").join("0.33.821");
+        make_version_db(&v1, &[("inst-1", "demo", 100, &wd.to_string_lossy())]);
+        make_version_db(&v2, &[("inst-1", "demo", 200, &wd.to_string_lossy())]);
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.rows_seen, 2);
+        assert_eq!(stats.records_written, 1);
+        let recs = reg.list_active().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].data.last_launched_at_ms, 200);
+    }
+
+    #[test]
+    fn migrate_skips_when_registry_already_has_record() {
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("demo");
+        std::fs::create_dir_all(&wd).unwrap();
+        // Pre-existing registry record (e.g. PR A already wrote it).
+        reg.upsert(&NamedAgentRecord {
+            schema_version: MAX_SUPPORTED_SCHEMA,
+            data: NamedAgentRecordV1 {
+                instance_id: "inst-1".to_string(),
+                instance_name: "preexisting".to_string(),
+                definition_id: "claude-code".to_string(),
+                identity_id: None,
+                memory_id: None,
+                working_dir: "demo".to_string(),
+                created_at_ms: 50,
+                last_launched_at_ms: 500,
+                created_by_version: "0.33.823".to_string(),
+                last_launched_by_version: "0.33.823".to_string(),
+            },
+        })
+        .unwrap();
+        // Legacy SQLite row with the SAME instance_id but older data.
+        let v_dir = home.path().join("versions").join("0.33.821");
+        make_version_db(&v_dir, &[("inst-1", "legacyname", 100, &wd.to_string_lossy())]);
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.records_skipped_existing, 1);
+        assert_eq!(stats.records_written, 0);
+        // Pre-existing record stays — name is "preexisting", not "legacyname".
+        let recs = reg.list_active().unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0].data.instance_name, "preexisting");
+    }
+
+    #[test]
+    fn migrate_skips_unmappable_working_dirs() {
+        let (home, reg) = fresh_home();
+        // Working dir is OUTSIDE the agents root — unmappable.
+        let v_dir = home.path().join("versions").join("0.33.821");
+        let outside = home.path().join("not_under_agents").join("foo");
+        make_version_db(&v_dir, &[("inst-x", "demo", 100, &outside.to_string_lossy())]);
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.rows_seen, 1);
+        assert_eq!(stats.records_skipped_unmappable, 1);
+        assert_eq!(stats.records_written, 0);
+    }
+
+    #[test]
+    fn migrate_tolerates_missing_or_corrupt_dbs() {
+        let (home, reg) = fresh_home();
+        // Version dir with no DB file.
+        std::fs::create_dir_all(home.path().join("versions").join("0.33.700")).unwrap();
+        // Version dir with corrupt DB.
+        let bad_v = home.path().join("versions").join("0.33.701");
+        let db_dir = bad_v.join("data").join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        std::fs::write(db_dir.join("objects.db"), b"not a sqlite file").unwrap();
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        // Both version dirs scanned; only one had a *file*, and it
+        // failed to read — no panic, no rows migrated.
+        assert_eq!(stats.versions_scanned, 1);
+        assert_eq!(stats.records_written, 0);
+        assert!(reg.root().join(MARKER).exists());
+    }
+}

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -60,6 +60,11 @@ pub fn migrate_from_sqlite_once(
     }
 
     let mut latest_by_id: HashMap<String, RowSnapshot> = HashMap::new();
+    // True iff any per-version DB threw a non-transient-looking error.
+    // We use this to skip writing the marker so the next launch
+    // retries — otherwise a brief filesystem hiccup permanently
+    // omits those rows from the registry-backed dropdown.
+    let mut any_db_failed = false;
 
     for entry in std::fs::read_dir(&versions_root)? {
         let v_dir = entry?.path();
@@ -77,9 +82,21 @@ pub fn migrate_from_sqlite_once(
                 for row in rows {
                     stats.rows_seen += 1;
                     let key = row.id.clone();
-                    match latest_by_id.get(&key) {
-                        Some(existing) if existing.started_at >= row.started_at => {}
-                        _ => {
+                    match latest_by_id.get_mut(&key) {
+                        Some(existing) if existing.started_at >= row.started_at => {
+                            // Existing snapshot wins on started_at, but
+                            // OR the hidden flag — any version expressing
+                            // "forget" intent is preserved as a tombstone.
+                            existing.display_hidden =
+                                existing.display_hidden || row.display_hidden;
+                        }
+                        Some(existing) => {
+                            let merged_hidden =
+                                existing.display_hidden || row.display_hidden;
+                            *existing = row;
+                            existing.display_hidden = merged_hidden;
+                        }
+                        None => {
                             latest_by_id.insert(key, row);
                         }
                     }
@@ -89,8 +106,9 @@ pub fn migrate_from_sqlite_once(
                 tracing::warn!(
                     db = %db_path.display(),
                     error = %e,
-                    "registry-migrate: skipping unreadable per-version DB"
+                    "registry-migrate: per-version DB unreadable — will retry on next launch"
                 );
+                any_db_failed = true;
             }
         }
     }
@@ -104,6 +122,7 @@ pub fn migrate_from_sqlite_once(
             stats.records_skipped_existing += 1;
             continue;
         }
+        let display_hidden = row.display_hidden;
         let Some(rec) = row_to_record(&row, agents_root) else {
             stats.records_skipped_unmappable += 1;
             continue;
@@ -117,10 +136,33 @@ pub fn migrate_from_sqlite_once(
             stats.records_skipped_unmappable += 1;
             continue;
         }
+        // Preserve pre-registry "forget" intent: if any version's
+        // SQLite had this row hidden, move the freshly-written
+        // registry file to retired/ so the dropdown stays consistent
+        // with the user's prior soft-delete.
+        if display_hidden {
+            if let Err(e) = registry.retire(&id) {
+                tracing::warn!(
+                    instance_id = %id,
+                    error = %e,
+                    "registry-migrate: failed to retire migrated tombstone — record may surface as active"
+                );
+            }
+        }
         stats.records_written += 1;
     }
 
-    write_marker(&marker_path, &stats)?;
+    // Only finalize the migration when every DB we encountered was
+    // readable. On any per-DB error, defer the marker so a future
+    // launch retries the migration. The already-written rows are
+    // idempotency-skipped on retry via `exists_anywhere`.
+    if !any_db_failed {
+        write_marker(&marker_path, &stats)?;
+    } else {
+        tracing::info!(
+            "registry-migrate: deferring marker write; one or more per-version DBs were unreadable and will be retried next launch"
+        );
+    }
     Ok(stats)
 }
 
@@ -151,6 +193,7 @@ struct RowSnapshot {
     working_directory: String,
     started_at: i64,
     created_at: i64,
+    display_hidden: bool,
 }
 
 /// True iff the error is SQLite reporting "this column/table doesn't
@@ -178,13 +221,15 @@ fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> 
     // columns. Suppress ONLY the specific "no such column/table"
     // errors — broader SqliteFailures (corruption, locked, etc.) must
     // surface so the caller can log + continue with the next DB.
+    // Include hidden rows — the caller turns them into retired/
+    // tombstones so a pre-registry "Forget agent" intent survives
+    // migration even if another version still has the row visible.
     let mut stmt = match conn.prepare(
         "SELECT id, instance_name, definition_id, identity_id, memory_id,
-                working_directory, started_at, created_at
+                working_directory, started_at, created_at, display_hidden
          FROM db_agent_instances
          WHERE instance_name <> ''
-           AND parent_instance_id = ''
-           AND display_hidden = 0",
+           AND parent_instance_id = ''",
     ) {
         Ok(s) => s,
         Err(e) if is_missing_column_or_table(&e) => return Ok(Vec::new()),
@@ -200,6 +245,7 @@ fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> 
             working_directory: row.get(5)?,
             started_at: row.get(6)?,
             created_at: row.get(7)?,
+            display_hidden: row.get::<_, i64>(8)? != 0,
         })
     })?;
     iter.collect()
@@ -248,6 +294,16 @@ mod tests {
     /// Build a per-version SQLite at `<version_dir>/data/db/objects.db`
     /// with a minimal `db_agent_instances` schema and the given rows.
     fn make_version_db(version_dir: &Path, rows: &[(&str, &str, i64, &str)]) {
+        let rows: Vec<_> = rows.iter().map(|(a, b, c, d)| (*a, *b, *c, *d, false)).collect();
+        make_version_db_with_hidden(version_dir, &rows);
+    }
+
+    /// Variant that lets each row carry an explicit `display_hidden`
+    /// flag. Used by tests that exercise tombstone propagation.
+    fn make_version_db_with_hidden(
+        version_dir: &Path,
+        rows: &[(&str, &str, i64, &str, bool)],
+    ) {
         let db_path = version_dir.join("data").join("db");
         std::fs::create_dir_all(&db_path).unwrap();
         let db_path = db_path.join("objects.db");
@@ -272,12 +328,12 @@ mod tests {
             );",
         )
         .unwrap();
-        for (id, name, started_at, working_directory) in rows {
+        for (id, name, started_at, working_directory, hidden) in rows {
             conn.execute(
                 "INSERT INTO db_agent_instances
-                    (id, definition_id, instance_name, working_directory, started_at, created_at)
-                 VALUES (?1, 'claude-code', ?2, ?3, ?4, ?4)",
-                params![id, name, working_directory, started_at],
+                    (id, definition_id, instance_name, working_directory, started_at, created_at, display_hidden)
+                 VALUES (?1, 'claude-code', ?2, ?3, ?4, ?4, ?5)",
+                params![id, name, working_directory, started_at, if *hidden { 1_i64 } else { 0_i64 }],
             )
             .unwrap();
         }
@@ -448,6 +504,102 @@ mod tests {
     }
 
     #[test]
+    fn migrate_writes_legacy_hidden_row_as_tombstone() {
+        // Pre-registry "Forget agent" intent must survive migration:
+        // a single-version row with display_hidden=1 should land in
+        // retired/, not active/.
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("forgotten");
+        std::fs::create_dir_all(&wd).unwrap();
+        let v_dir = home.path().join("versions").join("0.33.821");
+        make_version_db_with_hidden(
+            &v_dir,
+            &[("inst-1", "forgotten", 100, &wd.to_string_lossy(), true)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.records_written, 1);
+        assert!(reg.list_active().unwrap().is_empty(),
+            "hidden legacy row must NOT appear active");
+        assert!(reg.root().join("retired").join("inst-1.json").exists(),
+            "hidden legacy row must be migrated as retired tombstone");
+    }
+
+    #[test]
+    fn migrate_preserves_forget_intent_across_versions() {
+        // Same id in two versions: one hides it (Forget), the other
+        // still has it visible. The "forget" must win — registry
+        // tombstone, not active record.
+        let (home, reg) = fresh_home();
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("toggled");
+        std::fs::create_dir_all(&wd).unwrap();
+        let v1 = home.path().join("versions").join("0.33.800");
+        let v2 = home.path().join("versions").join("0.33.821");
+        // v1 has it visible; v2 has it hidden (user later Forgot it).
+        make_version_db_with_hidden(
+            &v1,
+            &[("inst-1", "toggled", 100, &wd.to_string_lossy(), false)],
+        );
+        make_version_db_with_hidden(
+            &v2,
+            &[("inst-1", "toggled", 200, &wd.to_string_lossy(), true)],
+        );
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.records_written, 1);
+        assert!(reg.list_active().unwrap().is_empty(),
+            "hidden intent in any version must propagate to registry tombstone");
+        assert!(reg.root().join("retired").join("inst-1.json").exists());
+    }
+
+    #[test]
+    fn migrate_defers_marker_on_unreadable_db() {
+        // A briefly-unreadable per-version DB during startup must NOT
+        // bake "permanently skip" into the marker. Marker is only
+        // written when every DB read succeeded.
+        let (home, reg) = fresh_home();
+        // Good DB.
+        let agents_root = home.path().join("agents");
+        std::fs::create_dir_all(&agents_root).unwrap();
+        let wd = agents_root.join("demo");
+        std::fs::create_dir_all(&wd).unwrap();
+        let good_v = home.path().join("versions").join("0.33.821");
+        make_version_db(&good_v, &[("inst-good", "demo", 100, &wd.to_string_lossy())]);
+        // Bad DB — looks like a SQLite file but is corrupt.
+        let bad_v = home.path().join("versions").join("0.33.800");
+        let bad_db_dir = bad_v.join("data").join("db");
+        std::fs::create_dir_all(&bad_db_dir).unwrap();
+        std::fs::write(bad_db_dir.join("objects.db"), b"not actually sqlite").unwrap();
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.records_written, 1, "good DB still migrated");
+        assert!(
+            !reg.root().join(MARKER).exists(),
+            "marker MUST NOT be written when any DB was unreadable"
+        );
+
+        // Next launch retries the migration; the good rows are
+        // idempotency-skipped (exists_anywhere), and the bad DB now
+        // works (simulate by replacing with a valid file).
+        std::fs::remove_file(bad_db_dir.join("objects.db")).unwrap();
+        make_version_db(&bad_v, &[("inst-other", "demo2", 50, &wd.to_string_lossy())]);
+        std::fs::create_dir_all(agents_root.join("demo2")).unwrap();
+        // ^ wait — demo2 wd: rebuild
+        let stats2 = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert!(
+            reg.root().join(MARKER).exists(),
+            "marker written on the retry once all DBs read successfully"
+        );
+        // Retry: 2 rows seen, 1 new written (inst-other), 1 skipped existing (inst-good).
+        assert_eq!(stats2.records_skipped_existing, 1);
+        assert_eq!(stats2.records_written, 1);
+    }
+
+    #[test]
     fn migrate_skips_unmappable_working_dirs() {
         let (home, reg) = fresh_home();
         // Working dir is OUTSIDE the agents root — unmappable.
@@ -474,9 +626,14 @@ mod tests {
 
         let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
         // Both version dirs scanned; only one had a *file*, and it
-        // failed to read — no panic, no rows migrated.
+        // failed to read — no panic, no rows migrated. Marker is
+        // deferred so the next launch retries; see the dedicated
+        // `migrate_defers_marker_on_unreadable_db` test.
         assert_eq!(stats.versions_scanned, 1);
         assert_eq!(stats.records_written, 0);
-        assert!(reg.root().join(MARKER).exists());
+        assert!(
+            !reg.root().join(MARKER).exists(),
+            "marker deferred on unreadable DB"
+        );
     }
 }

--- a/agentmux-srv/src/registry/mod.rs
+++ b/agentmux-srv/src/registry/mod.rs
@@ -18,6 +18,7 @@
 #![allow(dead_code, unused_imports)]
 
 mod atomic;
+mod migrate;
 mod paths;
 mod schema;
 mod store;
@@ -25,6 +26,7 @@ mod store;
 #[cfg(test)]
 mod tests;
 
+pub use migrate::{migrate_from_sqlite_once, MigrateStats};
 pub use paths::resolve_shared_registry_dir;
 pub use schema::{
     NamedAgentRecord, NamedAgentRecordV1, ValidationError, MAX_SUPPORTED_SCHEMA,

--- a/agentmux-srv/src/registry/store.rs
+++ b/agentmux-srv/src/registry/store.rs
@@ -129,9 +129,19 @@ impl Registry {
     }
 
     /// Whether an active record exists for `instance_id`. Doesn't
-    /// validate — useful for migration idempotency checks.
+    /// validate — useful for migration idempotency checks. Use
+    /// [`Self::exists_anywhere`] when retired records should also
+    /// count (e.g. so migration doesn't resurrect a hidden agent).
     pub fn exists(&self, instance_id: &str) -> bool {
         self.active_path(instance_id).exists()
+    }
+
+    /// Whether a record exists in either active or retired. Used by
+    /// migration to skip already-tombstoned records (avoid
+    /// resurrecting a user's deliberate "Forget agent" via a
+    /// per-version SQLite row that still has `display_hidden = 0`).
+    pub fn exists_anywhere(&self, instance_id: &str) -> bool {
+        self.active_path(instance_id).exists() || self.retired_path(instance_id).exists()
     }
 
     /// Read every valid active record. Invalid files are skipped +

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1221,6 +1221,20 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                         .to_string(),
                                     None => d.working_dir.clone(),
                                 };
+                                // Same-version enrichment: if this id
+                                // also exists in current SQLite, the
+                                // row carries runtime state (block_id
+                                // for focus-existing-pane, status,
+                                // ended_at) that the registry
+                                // intentionally doesn't track.
+                                // Cross-version rows fall through with
+                                // sentinel "available" status and
+                                // empty block_id_hint.
+                                let sqlite_view = wstore.instance_get(&d.instance_id).ok().flatten();
+                                let (block_id_hint, status, ended_at) = match sqlite_view {
+                                    Some(inst) => (inst.block_id, inst.status, inst.ended_at),
+                                    None => (String::new(), "available".to_string(), 0),
+                                };
                                 NamedAgentRow {
                                     instance_id: d.instance_id,
                                     instance_name: d.instance_name,
@@ -1237,9 +1251,9 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                     memory_id: memory_id_str,
                                     memory_name,
                                     started_at: d.last_launched_at_ms,
-                                    ended_at: 0,
-                                    status: "available".to_string(),
-                                    block_id_hint: String::new(),
+                                    ended_at,
+                                    status,
+                                    block_id_hint,
                                 }
                             })
                             .collect()

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1188,6 +1188,15 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 .cmp(&a.data.last_launched_at_ms)
                         });
                         records.truncate(limit);
+                        // Pre-fetch all candidate same-version rows
+                        // ONCE so enrichment doesn't issue N+1 queries.
+                        // Indexed by instance_id; rows that aren't in
+                        // current SQLite fall through to sentinels.
+                        let sqlite_rows: Vec<AgentInstance> = wstore
+                            .instance_list_named(records.len().max(1), cmd.definition_id.as_deref())
+                            .unwrap_or_default();
+                        let sqlite_by_id: std::collections::HashMap<&str, &AgentInstance> =
+                            sqlite_rows.iter().map(|i| (i.id.as_str(), i)).collect();
                         records
                             .into_iter()
                             .map(|rec| {
@@ -1230,11 +1239,15 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                                 // Cross-version rows fall through with
                                 // sentinel "available" status and
                                 // empty block_id_hint.
-                                let sqlite_view = wstore.instance_get(&d.instance_id).ok().flatten();
-                                let (block_id_hint, status, ended_at) = match sqlite_view {
-                                    Some(inst) => (inst.block_id, inst.status, inst.ended_at),
-                                    None => (String::new(), "available".to_string(), 0),
-                                };
+                                let (block_id_hint, status, ended_at) =
+                                    match sqlite_by_id.get(d.instance_id.as_str()) {
+                                        Some(inst) => (
+                                            inst.block_id.clone(),
+                                            inst.status.clone(),
+                                            inst.ended_at,
+                                        ),
+                                        None => (String::new(), "available".to_string(), 0),
+                                    };
                                 NamedAgentRow {
                                     instance_id: d.instance_id,
                                     instance_name: d.instance_name,

--- a/agentmux-srv/src/server/forge_handlers.rs
+++ b/agentmux-srv/src/server/forge_handlers.rs
@@ -1153,10 +1153,6 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 } else {
                     cmd.limit.min(1000)
                 };
-                let instances = wstore
-                    .instance_list_named(limit, cmd.definition_id.as_deref())
-                    .map_err(|e| format!("listnamedagents: {e}"))?;
-
                 // Resolve bundle names once per response. With ≤200
                 // rows and typical bundle counts in the low dozens,
                 // a linear lookup on cached lists beats per-row
@@ -1171,50 +1167,133 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     .bundle_memory_list()
                     .map_err(|e| format!("listnamedagents: bundle_memory_list: {e}"))?;
 
-                let rows: Vec<NamedAgentRow> = instances
-                    .into_iter()
-                    .map(|inst| {
-                        let def = defs.iter().find(|d| d.id == inst.definition_id);
-                        let identity_name = if inst.identity_id.is_empty() {
-                            "(ambient creds)".to_string()
-                        } else {
-                            identities
-                                .iter()
-                                .find(|i| i.id == inst.identity_id)
-                                .map(|i| i.name.clone())
-                                .unwrap_or_else(|| "(missing identity)".to_string())
-                        };
-                        let memory_name = if inst.memory_id.is_empty() {
-                            "(vanilla CLI)".to_string()
-                        } else {
-                            memories
-                                .iter()
-                                .find(|m| m.id == inst.memory_id)
-                                .map(|m| m.name.clone())
-                                .unwrap_or_else(|| "(missing memory)".to_string())
-                        };
-                        NamedAgentRow {
-                            instance_id: inst.id,
-                            instance_name: inst.instance_name,
-                            definition_id: inst.definition_id.clone(),
-                            definition_name: def
-                                .map(|d| d.name.clone())
-                                .unwrap_or_else(|| "(missing definition)".to_string()),
-                            provider: def
-                                .map(|d| d.provider.clone())
-                                .unwrap_or_default(),
-                            working_directory: inst.working_directory,
-                            identity_id: inst.identity_id,
-                            identity_name,
-                            memory_id: inst.memory_id,
-                            memory_name,
-                            started_at: inst.started_at,
-                            ended_at: inst.ended_at,
-                            status: inst.status,
-                            block_id_hint: inst.block_id,
+                // PR B — read from the cross-version registry when
+                // it's available. Falls back to SQLite when the
+                // registry couldn't be resolved at startup (CI / odd
+                // environments). SQLite remains authoritative for
+                // PR B (parallel-write is still active); the choice
+                // here just affects which surface gets surfaced.
+                let rows: Vec<NamedAgentRow> = match wstore.shared_agent_registry() {
+                    Some(reg) => {
+                        let agents_root = reg.agents_root().map(|p| p.to_path_buf());
+                        let mut records = reg
+                            .list_active()
+                            .map_err(|e| format!("listnamedagents: registry: {e}"))?;
+                        if let Some(def_filter) = cmd.definition_id.as_deref() {
+                            records.retain(|r| r.data.definition_id == def_filter);
                         }
-                    })
-                    .collect();
+                        records.sort_by(|a, b| {
+                            b.data
+                                .last_launched_at_ms
+                                .cmp(&a.data.last_launched_at_ms)
+                        });
+                        records.truncate(limit);
+                        records
+                            .into_iter()
+                            .map(|rec| {
+                                let d = rec.data;
+                                let def = defs.iter().find(|x| x.id == d.definition_id);
+                                let identity_id_str =
+                                    d.identity_id.clone().unwrap_or_default();
+                                let memory_id_str = d.memory_id.clone().unwrap_or_default();
+                                let identity_name = if identity_id_str.is_empty() {
+                                    "(ambient creds)".to_string()
+                                } else {
+                                    identities
+                                        .iter()
+                                        .find(|i| i.id == identity_id_str)
+                                        .map(|i| i.name.clone())
+                                        .unwrap_or_else(|| "(missing identity)".to_string())
+                                };
+                                let memory_name = if memory_id_str.is_empty() {
+                                    "(vanilla CLI)".to_string()
+                                } else {
+                                    memories
+                                        .iter()
+                                        .find(|m| m.id == memory_id_str)
+                                        .map(|m| m.name.clone())
+                                        .unwrap_or_else(|| "(missing memory)".to_string())
+                                };
+                                let working_directory = match agents_root.as_ref() {
+                                    Some(root) => root
+                                        .join(&d.working_dir)
+                                        .to_string_lossy()
+                                        .to_string(),
+                                    None => d.working_dir.clone(),
+                                };
+                                NamedAgentRow {
+                                    instance_id: d.instance_id,
+                                    instance_name: d.instance_name,
+                                    definition_id: d.definition_id.clone(),
+                                    definition_name: def
+                                        .map(|x| x.name.clone())
+                                        .unwrap_or_else(|| "(missing definition)".to_string()),
+                                    provider: def
+                                        .map(|x| x.provider.clone())
+                                        .unwrap_or_default(),
+                                    working_directory,
+                                    identity_id: identity_id_str,
+                                    identity_name,
+                                    memory_id: memory_id_str,
+                                    memory_name,
+                                    started_at: d.last_launched_at_ms,
+                                    ended_at: 0,
+                                    status: "available".to_string(),
+                                    block_id_hint: String::new(),
+                                }
+                            })
+                            .collect()
+                    }
+                    None => {
+                        let instances = wstore
+                            .instance_list_named(limit, cmd.definition_id.as_deref())
+                            .map_err(|e| format!("listnamedagents: {e}"))?;
+                        instances
+                            .into_iter()
+                            .map(|inst| {
+                                let def = defs.iter().find(|d| d.id == inst.definition_id);
+                                let identity_name = if inst.identity_id.is_empty() {
+                                    "(ambient creds)".to_string()
+                                } else {
+                                    identities
+                                        .iter()
+                                        .find(|i| i.id == inst.identity_id)
+                                        .map(|i| i.name.clone())
+                                        .unwrap_or_else(|| "(missing identity)".to_string())
+                                };
+                                let memory_name = if inst.memory_id.is_empty() {
+                                    "(vanilla CLI)".to_string()
+                                } else {
+                                    memories
+                                        .iter()
+                                        .find(|m| m.id == inst.memory_id)
+                                        .map(|m| m.name.clone())
+                                        .unwrap_or_else(|| "(missing memory)".to_string())
+                                };
+                                NamedAgentRow {
+                                    instance_id: inst.id,
+                                    instance_name: inst.instance_name,
+                                    definition_id: inst.definition_id.clone(),
+                                    definition_name: def
+                                        .map(|d| d.name.clone())
+                                        .unwrap_or_else(|| "(missing definition)".to_string()),
+                                    provider: def
+                                        .map(|d| d.provider.clone())
+                                        .unwrap_or_default(),
+                                    working_directory: inst.working_directory,
+                                    identity_id: inst.identity_id,
+                                    identity_name,
+                                    memory_id: inst.memory_id,
+                                    memory_name,
+                                    started_at: inst.started_at,
+                                    ended_at: inst.ended_at,
+                                    status: inst.status,
+                                    block_id_hint: inst.block_id,
+                                }
+                            })
+                            .collect()
+                    }
+                };
 
                 Ok(Some(serde_json::to_value(&rows).unwrap_or_default()))
             })

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -62,6 +62,15 @@
         opacity: 0.5;
         cursor: not-allowed;
     }
+
+    // <select> dropdown options render in Chromium's native picker —
+    // it doesn't reliably inherit the parent's color, so options
+    // appear with system white-on-white when the OS theme is light.
+    // Pin readable colors against the app's panel background.
+    & > option {
+        color: var(--main-text-color);
+        background-color: var(--main-bg-color);
+    }
 }
 
 .agent-launch-modal-hint {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.824",
+  "version": "0.33.825",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.824",
+      "version": "0.33.825",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.825",
+  "version": "0.33.826",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.825",
+      "version": "0.33.826",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.824",
+  "version": "0.33.825",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.825",
+  "version": "0.33.826",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Follow-up to #818. Activates the cross-version Continue-agent dropdown:

- **Read-path swap** — \`ListNamedAgentsCommand\` sources from \`Registry::list_active\` instead of \`db_agent_instances\`. Falls back to SQLite only when the registry can't be resolved (CI / odd envs); SQLite remains the parallel-write authority so this PR is reversible.
- **One-shot SQLite migration** — on first launch, srv scans every \`~/.agentmux/versions/*/data/db/objects.db\` read-only and writes any named instances not yet in the registry. Dedupes by \`instance_id\` (latest \`started_at\` wins). Marker file at \`<registry>/.migrated_from_sqlite\` ensures the migration runs exactly once; re-running is harmless.

After PR B ships, an agent named in 0.33.821 appears in the Continue dropdown of any future portable on the same machine — exactly what triggered the spec.

Spec: \`docs/specs/SPEC_SHARED_AGENT_REGISTRY_2026_05_12.md\` §8 (migration), §7 (RPC surface).

## Test plan

- [x] **Migrator** — 7 new unit tests in \`registry::migrate::tests\`:
  - Empty home → marker written, no rows
  - Idempotent (marker short-circuits second run)
  - One record per unique \`instance_id\` across multiple versions
  - Dedup picks latest \`started_at\` on conflict
  - Skips when registry already has the record (don't clobber PR A's writes)
  - Skips unmappable working dirs (paths not under shared agents root)
  - Tolerates missing / corrupt per-version DBs (warns + continues)
- [x] **Read swap** — reads via registry path when available; SQLite fallback still tested via existing \`test_instance_create_update_filter\`.
- [x] All PR A tests still pass (34 registry + 11 mirror + 1 cascade).
- [x] \`cargo build --workspace\` green.

## Rollback

Revert this PR → reads go back to SQLite, the registry files stay on disk (harmless — PR A still writes them), and the migration marker remains. Re-applying re-uses the existing marker, so no double-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)