### PR TITLE
fix(registry): migrator suppresses pre-v8 SqlInputError schema mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.827 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.826 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.824 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |
 | 0.33.823 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.827"
+version = "0.33.828"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.827"
+version = "0.33.828"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/registry/migrate.rs
+++ b/agentmux-srv/src/registry/migrate.rs
@@ -211,18 +211,22 @@ struct RowSnapshot {
 
 /// True iff the error is SQLite reporting "this column/table doesn't
 /// exist in this DB's schema." Distinguishes a pre-v8 DB (skip
-/// silently) from corruption (caller logs + continues). Matches on
-/// `SqliteFailure` with `Some(msg)` containing the canonical SQLite
-/// phrases; the underlying `ExtendedCode` for both is
-/// `SQLITE_ERROR` (1), which would also fire for plenty of other
-/// real failures, so message inspection is required.
+/// silently — those agents weren't named, so wouldn't appear in the
+/// dropdown anyway) from corruption (caller logs + continues +
+/// defers the marker).
+///
+/// rusqlite reports prepare-time schema mismatches as
+/// `Error::SqlInputError { msg, sql, offset }` and runtime errors as
+/// `Error::SqliteFailure(_, Some(msg))`. Both shapes carry the
+/// canonical SQLite phrases, but only message inspection
+/// distinguishes them from other failures with the same error code.
 fn is_missing_column_or_table(e: &rusqlite::Error) -> bool {
-    match e {
-        rusqlite::Error::SqliteFailure(_, Some(msg)) => {
-            msg.starts_with("no such column") || msg.starts_with("no such table")
-        }
-        _ => false,
-    }
+    let msg = match e {
+        rusqlite::Error::SqliteFailure(_, Some(msg)) => msg.as_str(),
+        rusqlite::Error::SqlInputError { msg, .. } => msg.as_str(),
+        _ => return false,
+    };
+    msg.starts_with("no such column") || msg.starts_with("no such table")
 }
 
 fn read_named_rows(db_path: &Path) -> Result<Vec<RowSnapshot>, rusqlite::Error> {
@@ -514,6 +518,40 @@ mod tests {
         // Tombstone must remain in retired/, NOT moved to active.
         assert!(reg.list_active().unwrap().is_empty());
         assert!(reg.root().join("retired").join("inst-1.json").exists());
+    }
+
+    #[test]
+    fn migrate_silently_skips_pre_v8_schema() {
+        // Real production case: an older SQLite (pre-v8) lacks the
+        // `instance_name` column. rusqlite reports this as
+        // `Error::SqlInputError` during prepare. The migrator must
+        // treat it as "nothing to migrate from this version" — NOT
+        // as a real DB failure that defers the marker.
+        let (home, reg) = fresh_home();
+        // Build a per-version DB with the OLD schema (no
+        // instance_name / working_directory / display_hidden cols).
+        let v_dir = home.path().join("versions").join("0.33.643");
+        let db_dir = v_dir.join("data").join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let db_path = db_dir.join("objects.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE db_agent_instances (
+                id TEXT PRIMARY KEY,
+                definition_id TEXT NOT NULL DEFAULT '',
+                parent_instance_id TEXT NOT NULL DEFAULT '',
+                started_at INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0
+            );",
+        )
+        .unwrap();
+        drop(conn);
+
+        let stats = migrate_from_sqlite_once(home.path(), &reg).unwrap();
+        assert_eq!(stats.versions_scanned, 1);
+        assert_eq!(stats.rows_seen, 0);
+        assert!(stats.complete, "pre-v8 schema must not block the marker");
+        assert!(reg.root().join(MARKER).exists());
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.827",
+  "version": "0.33.828",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.827",
+      "version": "0.33.828",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.827",
+  "version": "0.33.828",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

PR B's migrator was meant to silently skip pre-v8 per-version SQLite DBs (no \`instance_name\` column ⇒ nothing to migrate). But the suppression check only matched \`Error::SqliteFailure\`. rusqlite reports prepare-time schema mismatches as \`Error::SqlInputError\` instead, so every legacy DB fell through to "any_db_failed=true" — marker deferred, registry left empty.

End-user impact: launching a fresh portable showed an empty Continue-agent dropdown despite \`~/.agentmux/agents/\` having dozens of named agents on disk from prior versions.

## Fix

\`is_missing_column_or_table\` now matches both \`SqliteFailure\` and \`SqlInputError\` variants. Same message-prefix check ("no such column" / "no such table") so genuine corruption errors keep deferring the marker.

## Test plan

- [x] New regression test \`migrate_silently_skips_pre_v8_schema\` — creates a per-version DB with the v6 schema, verifies the migrator reports \`rows_seen=0\`, \`complete=true\`, marker written.
- [x] All 12 existing migrator tests still pass.
- [x] Discovered + verified against the host log of 0.33.827 — confirmed the exact \`"no such column: instance_name in SELECT ... at offset 11"\` error from \`SqlInputError\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)