### PR TITLE
feat(agent-pane): hover-expand tool blocks + show bash output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -87,7 +87,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.827"
+version = "0.33.828"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.827"
+version = "0.33.828"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.827"
+version = "0.33.828"
 description = "AgentMux Launcher — tiny exe that sets DLL path then spawns the CEF host"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.827"
+version = "0.33.828"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/components/BashOutputViewer.tsx
+++ b/frontend/app/view/agent/components/BashOutputViewer.tsx
@@ -16,8 +16,21 @@ interface BashOutputViewerProps {
 }
 
 export const BashOutputViewer = ({ params, result }: BashOutputViewerProps): JSX.Element => {
-    const hasOutput = result && (result.stdout || result.stderr);
-    const hasError = result && result.exitCode !== 0;
+    // Tool result may come back as either the structured BashResult
+    // shape (Claude Code's tool_use_result: stdout/stderr/exitCode)
+    // or as the loose `{ content: "<string>" }` fallback when the
+    // translator can't find a structured field. Treat both — the
+    // user just wants to see the output.
+    const looseResult = result as Record<string, unknown> | undefined;
+    const stdout =
+        (looseResult?.stdout as string | undefined) ??
+        (looseResult?.content as string | undefined) ??
+        "";
+    const stderr = (looseResult?.stderr as string | undefined) ?? "";
+    const exitCode = looseResult?.exitCode as number | undefined;
+
+    const hasOutput = stdout.length > 0 || stderr.length > 0;
+    const hasError = exitCode !== undefined && exitCode !== 0;
 
     return (
         <div class="agent-bash">
@@ -31,20 +44,20 @@ export const BashOutputViewer = ({ params, result }: BashOutputViewerProps): JSX
             </div>
             <Show when={hasOutput}>
                 <pre class={clsx("agent-bash-output", { "has-error": hasError })}>
-                    {result.stdout}
-                    <Show when={result.stderr}>
-                        <span class="agent-bash-stderr">{result.stderr}</span>
+                    {stdout}
+                    <Show when={stderr}>
+                        <span class="agent-bash-stderr">{stderr}</span>
                     </Show>
                 </pre>
             </Show>
-            <Show when={result}>
+            <Show when={exitCode !== undefined}>
                 <div
                     class={clsx("agent-bash-exit", {
-                        "exit-success": result.exitCode === 0,
-                        "exit-error": result.exitCode !== 0,
+                        "exit-success": exitCode === 0,
+                        "exit-error": exitCode !== 0,
                     })}
                 >
-                    Exit code: {result.exitCode}
+                    Exit code: {exitCode}
                 </div>
             </Show>
         </div>

--- a/frontend/app/view/agent/components/BashOutputViewer.tsx
+++ b/frontend/app/view/agent/components/BashOutputViewer.tsx
@@ -15,19 +15,45 @@ interface BashOutputViewerProps {
     result?: BashResult;
 }
 
+// `agentmux-bashwrap` prepends every captured bash run with a single
+// line like `<exited 0 in 0.60s>` (or `<exited 1 in 1.23s>` on
+// failure). It's the only durable carrier of the exit code through
+// Claude's tool_use_result, which doesn't include an `exitCode`
+// field. We strip the prefix when rendering stdout and use it as
+// the fallback exit-code source when the result didn't carry one
+// natively.
+const EXIT_PREFIX_RE = /^<exited (-?\d+) in [\d.]+s>\n?/;
+
+function parseExitPrefix(s: string | undefined): {
+    exit: number | undefined;
+    body: string;
+} {
+    if (!s) return { exit: undefined, body: "" };
+    const m = s.match(EXIT_PREFIX_RE);
+    if (!m) return { exit: undefined, body: s };
+    return { exit: parseInt(m[1], 10), body: s.slice(m[0].length) };
+}
+
 export const BashOutputViewer = ({ params, result }: BashOutputViewerProps): JSX.Element => {
     // Tool result may come back as either the structured BashResult
-    // shape (Claude Code's tool_use_result: stdout/stderr/exitCode)
+    // shape (Claude Code's tool_use_result: stdout/stderr/interrupted)
     // or as the loose `{ content: "<string>" }` fallback when the
     // translator can't find a structured field. Treat both — the
     // user just wants to see the output.
     const looseResult = result as Record<string, unknown> | undefined;
-    const stdout =
+    const rawStdout =
         (looseResult?.stdout as string | undefined) ??
         (looseResult?.content as string | undefined) ??
         "";
     const stderr = (looseResult?.stderr as string | undefined) ?? "";
-    const exitCode = looseResult?.exitCode as number | undefined;
+    const nativeExit = looseResult?.exitCode as number | undefined;
+
+    // Recover the exit code from the `<exited N in Ts>` prefix that
+    // bashwrap injects, when the result lacks a native exitCode field.
+    // Strip the prefix from stdout regardless — the user shouldn't
+    // see the marker.
+    const { exit: parsedExit, body: stdout } = parseExitPrefix(rawStdout);
+    const exitCode = nativeExit ?? parsedExit;
 
     const hasOutput = stdout.length > 0 || stderr.length > 0;
     const hasError = exitCode !== undefined && exitCode !== 0;

--- a/frontend/app/view/agent/components/ToolBlock.tsx
+++ b/frontend/app/view/agent/components/ToolBlock.tsx
@@ -96,6 +96,12 @@ function findScrollParent(el: HTMLElement): HTMLElement | null {
 // upward instead of downward.
 const OVERLAY_MAX_HEIGHT_PX = 400;
 
+// Hover-expand delays — match docs/specs/tool-collapse.md §"Expanded State (on Hover)".
+// 150ms enter avoids flicker on scroll-through; 300ms leave lets the user move the
+// cursor down into the expanded overlay without it collapsing first.
+const HOVER_ENTER_DELAY_MS = 150;
+const HOVER_LEAVE_DELAY_MS = 300;
+
 export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     // Position of the collapsed row in viewport coordinates, recomputed when
     // pinned flips true. The overlay is rendered via a <Portal> to document.body
@@ -112,8 +118,41 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
 
     let blockRef: HTMLDivElement | undefined;
 
-    const expanded = () => props.pinned;
-    const overlayMode = () => props.pinned;
+    // Hover-expand state. Click pins (props.pinned); mouse hover
+    // expands transiently. The overlay portal uses overlayMode for
+    // styling — same for both hover and pin.
+    const [hovering, setHovering] = createSignal(false);
+    let enterTimer: ReturnType<typeof setTimeout> | undefined;
+    let leaveTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearTimers = () => {
+        if (enterTimer !== undefined) { clearTimeout(enterTimer); enterTimer = undefined; }
+        if (leaveTimer !== undefined) { clearTimeout(leaveTimer); leaveTimer = undefined; }
+    };
+
+    const handleMouseEnter = () => {
+        if (props.pinned) return;
+        if (leaveTimer !== undefined) { clearTimeout(leaveTimer); leaveTimer = undefined; }
+        if (hovering()) return;
+        enterTimer = setTimeout(() => {
+            setHovering(true);
+            enterTimer = undefined;
+        }, HOVER_ENTER_DELAY_MS);
+    };
+
+    const handleMouseLeave = () => {
+        if (enterTimer !== undefined) { clearTimeout(enterTimer); enterTimer = undefined; }
+        if (!hovering()) return;
+        leaveTimer = setTimeout(() => {
+            setHovering(false);
+            leaveTimer = undefined;
+        }, HOVER_LEAVE_DELAY_MS);
+    };
+
+    onCleanup(clearTimers);
+
+    const expanded = () => props.pinned || hovering();
+    const overlayMode = () => expanded();
 
     const statusIcon = (): string => STATUS_ICON[props.node.status] || "•";
 
@@ -135,9 +174,11 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
         });
     };
 
-    // Measure position when pin flips true so the portal has coordinates on first render.
+    // Measure position when overlay flips visible so the portal has
+    // coordinates on first render. Fires for both pin (click) and
+    // hover paths via the unified `overlayMode()` getter.
     createEffect(() => {
-        if (props.pinned && blockRef) {
+        if (overlayMode() && blockRef) {
             measure();
         }
     });
@@ -216,6 +257,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
     return (
         <div
             ref={blockRef}
+            onMouseEnter={handleMouseEnter}
+            onMouseLeave={handleMouseLeave}
             class={clsx("agent-tool-block", {
                 collapsed: !expanded(),
                 expanded: expanded(),
@@ -264,6 +307,8 @@ export const ToolBlock = (props: ToolBlockProps): JSX.Element => {
                         })}
                         style={overlayStyle()}
                         onClick={(e) => e.stopPropagation()}
+                        onMouseEnter={handleMouseEnter}
+                        onMouseLeave={handleMouseLeave}
                     >
                         <ToolBlockOverlay
                             node={props.node}

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -241,7 +241,25 @@ export class ClaudeTranslator implements OutputTranslator {
         // Check for tool_result blocks in user messages
         if (message.role === "user" && Array.isArray(message.content)) {
             const results: StreamEvent[] = [];
+            // `tool_use_result` is a sibling of `message` on the event,
+            // not embedded per-block — it carries structured stdout/
+            // stderr/exitCode for the tool that just ran. With a SINGLE
+            // tool_result block in the message we can confidently apply
+            // it; with multiple blocks (parallel tool use) the structured
+            // result is unattributable (Claude doesn't include a
+            // tool_use_id inside `tool_use_result`), so every block
+            // falls back to the per-block string form. The dropped
+            // structured shape just means BashOutputViewer renders
+            // from `result.content` instead — same visible output,
+            // missing the exitCode field.
             const structuredResult = event.tool_use_result;
+            const toolResultBlocks = message.content.filter(
+                (b: any) => b && b.type === "tool_result",
+            );
+            const canApplyStructured =
+                toolResultBlocks.length === 1
+                && structuredResult
+                && typeof structuredResult === "object";
             for (const block of message.content) {
                 if (block.type === "tool_result") {
                     const isError = block.is_error === true;
@@ -254,9 +272,7 @@ export class ClaudeTranslator implements OutputTranslator {
                         tool: block.tool_name || this.toolNameById.get(toolId) || "Unknown",
                         id: toolId,
                         status: isError ? "failed" : "success",
-                        result: structuredResult && typeof structuredResult === "object"
-                            ? structuredResult
-                            : fallback,
+                        result: canApplyStructured ? structuredResult : fallback,
                     });
                 }
             }

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -220,7 +220,19 @@ export class ClaudeTranslator implements OutputTranslator {
 
     /**
      * message_start may contain tool_result blocks when role is "user"
-     * (these are the results of tool calls being fed back to Claude)
+     * (these are the results of tool calls being fed back to Claude).
+     *
+     * Claude Code emits TWO views of the result:
+     *   - `message.content[N].content` — human-readable string the model
+     *     sees (concatenated stdout/stderr/exit prefix).
+     *   - `event.tool_use_result` — sibling structured object with
+     *     `stdout`, `stderr`, and optional `interrupted`.
+     *
+     * The structured shape is what BashOutputViewer (and other
+     * per-tool viewers) expect — `result.stdout` / `result.stderr`.
+     * Prefer it; fall back to the string-wrapped form when the
+     * provider didn't emit a structured shape (e.g. non-bash tools,
+     * older Claude Code).
      */
     private handleMessageStart(event: any): StreamEvent[] {
         const message = event.message;
@@ -229,18 +241,22 @@ export class ClaudeTranslator implements OutputTranslator {
         // Check for tool_result blocks in user messages
         if (message.role === "user" && Array.isArray(message.content)) {
             const results: StreamEvent[] = [];
+            const structuredResult = event.tool_use_result;
             for (const block of message.content) {
                 if (block.type === "tool_result") {
                     const isError = block.is_error === true;
                     const toolId = block.tool_use_id || `tool_${Date.now()}`;
+                    const fallback = typeof block.content === "string"
+                        ? { content: block.content }
+                        : block.content;
                     results.push({
                         type: "tool_result",
                         tool: block.tool_name || this.toolNameById.get(toolId) || "Unknown",
                         id: toolId,
                         status: isError ? "failed" : "success",
-                        result: typeof block.content === "string"
-                            ? { content: block.content }
-                            : block.content,
+                        result: structuredResult && typeof structuredResult === "object"
+                            ? structuredResult
+                            : fallback,
                     });
                 }
             }

--- a/frontend/app/view/agent/providers/claude-translator.ts
+++ b/frontend/app/view/agent/providers/claude-translator.ts
@@ -51,9 +51,10 @@ export class ClaudeTranslator implements OutputTranslator {
             return this.handleAssistantMessage(rawEvent.message);
         }
 
-        // Case 4: Top-level "user" event (tool results)
+        // Case 4: Top-level "user" event (tool results). Pass the full
+        // event so `tool_use_result` (sibling of `message`) is reachable.
         if (rawEvent.type === "user" && rawEvent.message) {
-            return this.handleUserMessage(rawEvent.message);
+            return this.handleUserMessage(rawEvent.message, rawEvent.tool_use_result);
         }
 
         // Case 5a: Top-level "result" event — session complete with stats
@@ -183,9 +184,13 @@ export class ClaudeTranslator implements OutputTranslator {
     }
 
     /**
-     * Top-level "user" event contains tool_result blocks.
+     * Top-level "user" event contains tool_result blocks. The caller
+     * forwards `event.tool_use_result` here so the structured shape
+     * (`stdout/stderr/interrupted`) reaches `buildToolResults` —
+     * keeps this path symmetric with the `message_start` user-role
+     * path.
      */
-    private handleUserMessage(message: any): StreamEvent[] {
+    private handleUserMessage(message: any, structuredResult?: any): StreamEvent[] {
         const content = message.content;
         if (!content) return [];
 
@@ -196,22 +201,7 @@ export class ClaudeTranslator implements OutputTranslator {
 
         // Handle array content with tool_result blocks
         if (Array.isArray(content)) {
-            const results: StreamEvent[] = [];
-            for (const block of content) {
-                if (block.type === "tool_result") {
-                    const isError = block.is_error === true;
-                    const toolId = block.tool_use_id || `tool_${Date.now()}`;
-                    results.push({
-                        type: "tool_result",
-                        tool: block.tool_name || this.toolNameById.get(toolId) || "Unknown",
-                        id: toolId,
-                        status: isError ? "failed" : "success",
-                        result: typeof block.content === "string"
-                            ? { content: block.content }
-                            : block.content,
-                    });
-                }
-            }
+            const results = this.buildToolResults(content, structuredResult);
             return results;
         }
 
@@ -240,46 +230,56 @@ export class ClaudeTranslator implements OutputTranslator {
 
         // Check for tool_result blocks in user messages
         if (message.role === "user" && Array.isArray(message.content)) {
-            const results: StreamEvent[] = [];
-            // `tool_use_result` is a sibling of `message` on the event,
-            // not embedded per-block — it carries structured stdout/
-            // stderr/exitCode for the tool that just ran. With a SINGLE
-            // tool_result block in the message we can confidently apply
-            // it; with multiple blocks (parallel tool use) the structured
-            // result is unattributable (Claude doesn't include a
-            // tool_use_id inside `tool_use_result`), so every block
-            // falls back to the per-block string form. The dropped
-            // structured shape just means BashOutputViewer renders
-            // from `result.content` instead — same visible output,
-            // missing the exitCode field.
-            const structuredResult = event.tool_use_result;
-            const toolResultBlocks = message.content.filter(
-                (b: any) => b && b.type === "tool_result",
-            );
-            const canApplyStructured =
-                toolResultBlocks.length === 1
-                && structuredResult
-                && typeof structuredResult === "object";
-            for (const block of message.content) {
-                if (block.type === "tool_result") {
-                    const isError = block.is_error === true;
-                    const toolId = block.tool_use_id || `tool_${Date.now()}`;
-                    const fallback = typeof block.content === "string"
-                        ? { content: block.content }
-                        : block.content;
-                    results.push({
-                        type: "tool_result",
-                        tool: block.tool_name || this.toolNameById.get(toolId) || "Unknown",
-                        id: toolId,
-                        status: isError ? "failed" : "success",
-                        result: canApplyStructured ? structuredResult : fallback,
-                    });
-                }
-            }
-            return results;
+            return this.buildToolResults(message.content, event.tool_use_result);
         }
 
         return [];
+    }
+
+    /**
+     * Shared tool_result builder used by both entry points
+     * (`message_start` with role:user, and top-level `user` events).
+     *
+     * `tool_use_result` is a sibling of `message` on the event — it
+     * carries structured `{ stdout, stderr, interrupted }` for the
+     * tool that just ran. With a SINGLE tool_result block in the
+     * message we can confidently apply it; with multiple blocks
+     * (parallel tool use) the structured result is unattributable
+     * (Claude doesn't include a `tool_use_id` inside it), so every
+     * block falls back to the per-block string form.
+     *
+     * Note: Claude's `tool_use_result` carries no `exitCode` — only
+     * stdout/stderr/interrupted. The wrapper encodes the exit code
+     * as an `<exited N in Ts>` prefix in stdout; BashOutputViewer
+     * parses it back out at render time so failed bash commands stay
+     * visible even when stderr is empty.
+     */
+    private buildToolResults(content: any[], structuredResult: any): StreamEvent[] {
+        const results: StreamEvent[] = [];
+        const toolResultBlocks = content.filter(
+            (b: any) => b && b.type === "tool_result",
+        );
+        const canApplyStructured =
+            toolResultBlocks.length === 1
+            && structuredResult
+            && typeof structuredResult === "object";
+        for (const block of content) {
+            if (block.type === "tool_result") {
+                const isError = block.is_error === true;
+                const toolId = block.tool_use_id || `tool_${Date.now()}`;
+                const fallback = typeof block.content === "string"
+                    ? { content: block.content }
+                    : block.content;
+                results.push({
+                    type: "tool_result",
+                    tool: block.tool_name || this.toolNameById.get(toolId) || "Unknown",
+                    id: toolId,
+                    status: isError ? "failed" : "success",
+                    result: canApplyStructured ? structuredResult : fallback,
+                });
+            }
+        }
+        return results;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.827",
+  "version": "0.33.828",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.827",
+      "version": "0.33.828",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.827",
+  "version": "0.33.828",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Three connected fixes to the agent pane's tool-block UX. Live-log streaming was already shipped end-to-end (PR #800+, broker side proven), but the rendering layer had two gaps that hid the output, plus the spec'd hover-expand was never wired.

### 1. \`ToolBlock\` — hover-expand wiring

\`docs/specs/tool-collapse.md\` calls for hover-to-expand with 150ms enter / 300ms leave delays. The code only implemented click-to-pin (\`expanded = () => props.pinned\`). Hovering did nothing.

Now \`onMouseEnter\` on the collapsed row triggers the overlay after 150ms; \`onMouseLeave\` cancels (or schedules collapse if expanded). Hover handlers on the portal overlay too so moving the cursor into the expanded content extends the dwell. Click-to-pin still works and persists across mouse-out.

### 2. \`claude-translator\` — prefer structured \`tool_use_result\`

Claude Code's tool_result event emits both:
- \`message.content[N].content\` — a human-readable string blob (\`<exited 0 in 0.60s>\n...\`)
- \`event.tool_use_result\` — sibling \`{ stdout, stderr, interrupted, ... }\` structured object

Translator only read the string, so \`node.result\` became \`{ content: "..." }\`. \`BashOutputViewer\`'s \`result.stdout\` check was always falsy → the output was never rendered, only the command. Now we prefer \`event.tool_use_result\` when present; fall back to the string-wrapped form for non-bash tools or older CLIs that don't emit the structured shape.

### 3. \`BashOutputViewer\` — fall back to \`result.content\`

Defense in depth: even if a result lands without \`stdout\` set, fall back to \`result.content\`. Also handle missing \`exitCode\` gracefully — the section doesn't render rather than showing "Exit code: undefined".

## Test plan

- [x] Hover over a fresh bash tool block → overlay pops up after 150ms, shows command + output
- [x] Click the tool row → overlay pins; click again → collapses
- [x] Mouse into the overlay → it stays open; mouse out → collapses after 300ms
- [x] All existing tool block unit tests still pass
- [x] \`cargo check --workspace\` green (no backend changes)

## Related

- Live-log streaming end-to-end: #800, #803, #804, #815 (already merged)
- Tool-collapse spec: \`docs/specs/tool-collapse.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)