### PR TITLE
fix(window-drag): scale CSS-pixel deltas by devicePixelRatio (Win11 125% fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.832"
+version = "0.33.833"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.832"
+version = "0.33.833"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.832"
+version = "0.33.833"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.832"
+version = "0.33.833"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.832"
+version = "0.33.833"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.832"
+version = "0.33.833"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.832"
+version = "0.33.833"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.832"
+version = "0.33.833"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.832"
+version = "0.33.833"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.832"
+version = "0.33.833"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md
+++ b/docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md
@@ -195,3 +195,28 @@ If latency is a concern, the initial position can be pre-fetched on title-bar `m
 | `agentmux-cef/src/ui_tasks.rs` (if it exists) | Add `post_set_window_position` for non-Windows paths |
 
 `move_window_by` and `get_window_position` can remain — they may be used elsewhere.
+
+---
+
+## Postscript — 2026-05-13: DPI regression
+
+The fix above shipped (PR #734) and resolved the stale-rect race. **It also introduced a latent unit-mismatch bug** that this retro never caught because all testing was at 100% Windows scale (the Win10 default).
+
+Symptom: cursor drifts off the click point during drag on **Windows 11**, which defaults to 125% scale on most laptops. Was masked on Windows 10 (100% default).
+
+Root cause: `e.screenX` in CEF/Chromium with `use-zoom-for-dsf` (default on Windows since Chrome 54) is in **CSS pixels** (physical ÷ devicePixelRatio). `get_window_position` returns and `set_window_position` consumes **physical pixels** in the PMv2-aware host. The original fix added CSS-pixel deltas to a physical-pixel baseline:
+
+```ts
+// BUGGY (PR #734)
+const tx = initWinX + (e.screenX - clickScreenX);
+```
+
+At Win11 125% (`dpr = 1.25`), the window moves 80% of the cursor distance — the same visible drift the original bug had, with a different mechanism.
+
+Fixed in PR following `docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md`. The spec also adds:
+
+1. **DPR multiplier + `Math.round`** in the frontend hook (the core fix).
+2. **Re-read `devicePixelRatio` per mousemove** so cross-monitor mid-drag at different scales picks up the new value.
+3. **Recommended test matrix** for any future drag work: 100% / 125% / 150% / 175% / 200%, single + multi-monitor, homogeneous + differential scale. Adding to the smoke-test checklist as a standing item.
+
+Lesson for future retros: **scale-sensitive Win32 work needs explicit DPI-matrix testing before merge.** A "tested at 100%" implicit assumption is invisible in the retro and bites at user install time.

--- a/docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md
+++ b/docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md
@@ -160,7 +160,7 @@ Per [Electron #14787](https://github.com/electron/electron/issues/14787) — min
 
 ### 5.1 Phase 1 — Hotfix (ship same-day)
 
-Apply §4.1 + §4.6 in `useWindowDrag.win32.ts`. Three locations:
+Apply §4.1 + §4.6 in `useWindowDrag.win32.ts`. Two locations:
 
 ```diff
 + const dpr = window.devicePixelRatio || 1;

--- a/docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md
+++ b/docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md
@@ -1,0 +1,244 @@
+# SPEC: Robust DPI Handling for Window-Header Drag
+
+**Status:** Draft
+**Date:** 2026-05-13
+**Author:** AgentX
+**Supersedes (in part):** `docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md`
+**Related PR:** #734 (`6c7dfe3b`) — original absolute-positioning fix
+
+---
+
+## 1. Problem
+
+The original cursor-drift fix (PR #734, May 7) eliminated the stale-rect race in `move_window_by` by switching to absolute positioning: frontend snapshots `initWinX/Y` via `get_window_position` on mousedown, then sends `set_window_position(initWin + cursorDelta)` on each mousemove.
+
+The bug **has returned** on Windows 11 — but not on Windows 10. The user reports the same symptom as the original: cursor visibly drifts off the click point during drag.
+
+## 2. Root cause
+
+A **latent unit mismatch** in the original fix, masked by Win10's default 100% scale and exposed by Win11's default 125% scale.
+
+### Coordinate spaces in play
+
+| Source | Unit | Authority |
+|---|---|---|
+| `e.screenX`, `clientX`, `pageX` in CEF/Chromium JS | **CSS pixels** (physical ÷ devicePixelRatio) | Blink stores internally in physical pixels, divides by combined browser-zoom (which folds in device scale factor under `use-zoom-for-dsf`, default on Windows since Chrome 54) before exposing to JS. See [Chromium Blink Coordinate Spaces](https://www.chromium.org/developers/design-documents/blink-coordinate-spaces/). |
+| `GetWindowRect` / `SetWindowPos` (Win32, PMv2 process) | **Physical pixels** in the target monitor's DPI context | [Win32 PMv2 docs](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows): "since a `PROCESS_PER_MONITOR_AWARE` app uses the actual DPI of the monitor, logical and physical coordinates are identical." |
+| `window.devicePixelRatio` | physical ÷ CSS | Reflects display density × browser/page zoom. At Win11 125%, `dpr = 1.25`. Updates when window crosses monitors with different DPI. |
+
+### The math, broken
+
+In `frontend/app/hook/useWindowDrag.win32.ts:123-124`:
+
+```ts
+const tx = initWinX + (e.screenX - clickScreenX);   // physical + CSS = mismatched units
+const ty = initWinY + (e.screenY - clickScreenY);
+```
+
+At 100% scale, CSS == physical, so the bug is invisible. At Win11's default 125%:
+
+- Cursor moves 100 CSS pixels (`e.screenX` delta = 100)
+- True physical motion = 125 pixels
+- We send `setWindowPos(initWinX + 100)` instead of `initWinX + 125`
+- Window moves 100 physical pixels while cursor moves 125 — drift of 25 px per 125 px of cursor motion = 20% lag
+- Visible after the cursor moves ~50 px; obvious by 200 px
+
+### Why Win10 vs Win11 is the discriminator
+
+It's the **default scale**, not the OS version directly:
+
+- Windows 10 ships at 100% by default on most hardware. `dpr = 1.0`, math accidentally works.
+- Windows 11 ships at 125% by default on most laptops, 150% on smaller-screen laptops, 200% on Surface-class devices. `dpr > 1`, math breaks.
+
+A Win10 user manually set to 125% would see the bug. A Win11 user at 100% wouldn't.
+
+### Files involved
+
+- `frontend/app/hook/useWindowDrag.win32.ts` — frontend hook (the unit mismatch lives here, lines 60-65 + 75-78 + 123-124)
+- `agentmux-cef/src/commands/window.rs:162-176` — `get_window_position` (returns physical, correct)
+- `agentmux-cef/src/commands/window.rs:223-257` — `set_window_position` (consumes physical, correct)
+
+The Rust side is fine. The fix is entirely frontend.
+
+## 3. Prior art
+
+This exact class of bug has been reported across the borderless-window ecosystem:
+
+| Project | Issue | Symptom |
+|---|---|---|
+| Neutralinojs | [#874](https://github.com/neutralinojs/neutralinojs/issues/874) | Borderless drag with multi-monitor differential scaling; their attempted `pageX * ratio` fix was incomplete |
+| Alacritty | [#8448](https://github.com/alacritty/alacritty/issues/8448) | "Window jumps right until it's off the mouse entirely" on Win11 cross-monitor drag |
+| Electron | [#14787](https://github.com/electron/electron/issues/14787) | Broken cursor on HiDPI frameless windows |
+| Electron | [#8533](https://github.com/electron/electron/issues/8533) | App declared only System-DPI-aware; required `EnableNonClientDpiScaling` + `WM_DPICHANGED` handling |
+| Electron | [#10659](https://github.com/electron/electron/issues/10659) | `setPosition` off by a few pixels at non-100% scale |
+
+Common thread: any borderless app that re-implements drag in JS without a DPR multiplier eventually hits this. The OS-native move loop (`WM_NCLBUTTONDOWN` + `HTCAPTION`) handles DPI for free — but CEF doesn't expose NC messages to subclassed wndprocs (per the comment at `useWindowDrag.win32.ts:7`).
+
+## 4. Best practices (synthesized from research)
+
+Ordered most-essential to nice-to-have:
+
+### 4.1 Multiply CSS-pixel deltas by `devicePixelRatio` — the core fix
+
+```ts
+const dpr = window.devicePixelRatio || 1;
+const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
+const ty = initWinY + Math.round((e.screenY - clickScreenY) * dpr);
+```
+
+`Math.round` is non-negotiable. Fractional DPRs (1.25, 1.5, 1.75) accumulate floating-point error; sub-pixel `SetWindowPos` calls land at different rounded positions, causing visible jitter ([WICG discussion](https://discourse.wicg.io/t/display-an-image-at-device-s-physical-resolution/1150/)).
+
+### 4.2 Re-read DPR on every mousemove
+
+Windows fires `WM_DPICHANGED` to PMv2-aware windows as they cross monitors with different DPI ([Microsoft Learn](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-dpichanged)). Chromium updates `window.devicePixelRatio` in response. If we cache `dpr` at mousedown, a mid-drag monitor crossing breaks the math. Cheap to re-read each mousemove:
+
+```ts
+document.addEventListener("mousemove", (e) => {
+    if (!dragging) return;
+    const dpr = window.devicePixelRatio || 1;  // fresh
+    const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
+    ...
+});
+```
+
+### 4.3 Resnap baseline when DPR changes mid-drag
+
+The principled answer to "robust under any setting": when DPR changes, the accumulated `(e.screenX - clickScreenX) * dpr` is mixed-unit (some delta accumulated at old DPR, rest at new). Detect change and resnap:
+
+```ts
+let dragDpr = window.devicePixelRatio || 1;
+document.addEventListener("mousemove", async (e) => {
+    if (!dragging) return;
+    const currentDpr = window.devicePixelRatio || 1;
+    if (currentDpr !== dragDpr) {
+        // DPR changed mid-drag — resnap baseline at current cursor.
+        const pos = await invokeCommand<{x:number;y:number}>("get_window_position");
+        initWinX = pos.x;
+        initWinY = pos.y;
+        clickScreenX = e.screenX;
+        clickScreenY = e.screenY;
+        dragDpr = currentDpr;
+        return;
+    }
+    const tx = initWinX + Math.round((e.screenX - clickScreenX) * dragDpr);
+    ...
+});
+```
+
+Trade-off: a single mousemove is "lost" during the IPC for `get_window_position`, but DPR changes are rare (once per cross-monitor transition) so this is acceptable.
+
+### 4.4 Verify the host is registered Per-Monitor V2 DPI-aware
+
+The math in §4.1-4.3 assumes PMv2. If the manifest declares anything less (System-DPI-Aware, or unaware), Windows applies bitmap scaling and the coordinate spaces stop behaving as documented. CEF defaults to PMv2 on modern builds, but worth grepping the bundled manifest to confirm. **Code audit, no runtime change.**
+
+Check command:
+```bash
+grep -r "dpiAware\|PerMonitor\|SetProcessDpi" agentmux-cef/ scripts/
+```
+
+### 4.5 Optionally handle `WM_DPICHANGED` on the Rust side
+
+If mid-drag crosses to a different-DPI monitor, the OS sends `WM_DPICHANGED` with a suggested rect in `lParam` for the new monitor. For drag specifically, we want cursor-on-title-bar to win over OS suggestion — but the size component of `lParam` should be honored so the window doesn't look wrong on the new monitor.
+
+**Defer this** until §4.3 shows residual size glitches in field testing. The frontend resnap from §4.3 is the primary mechanism; this is a secondary polish.
+
+### 4.6 Round in JS, not Rust
+
+`Math.round` in JS before IPC serialization keeps the integer-cast behavior obvious. If we serialize floats and let Rust truncate via `as i32`, the rounding becomes implicit and hard to debug.
+
+### 4.7 Test matrix
+
+Per [Electron #14787](https://github.com/electron/electron/issues/14787) — minimum viable matrix:
+
+- **Single monitor:** 100%, 125%, 150%, 175%, 200%
+- **Multi-monitor, same scale per monitor:** 100% + 100%, 125% + 125%
+- **Multi-monitor, different scales:** 125% laptop + 100% external (the case where Win10 vs Win11 most differs); 200% + 100% (extreme)
+- **Drag fully across monitor boundary** (not just to the edge — actually onto the second monitor)
+- **Verify drift at end of long drags** (3+ second sustained drag at moderate speed)
+
+## 5. Proposed implementation
+
+### 5.1 Phase 1 — Hotfix (ship same-day)
+
+Apply §4.1 + §4.6 in `useWindowDrag.win32.ts`. Three locations:
+
+```diff
++ const dpr = window.devicePixelRatio || 1;
+- const tx = initWinX + (latestScreenX - clickScreenX);
+- const ty = initWinY + (latestScreenY - clickScreenY);
++ const tx = initWinX + Math.round((latestScreenX - clickScreenX) * dpr);
++ const ty = initWinY + Math.round((latestScreenY - clickScreenY) * dpr);
+```
+
+(at mousedown catch-up, lines ~76-78)
+
+```diff
++ const dpr = window.devicePixelRatio || 1;
+- const tx = initWinX + (e.screenX - clickScreenX);
+- const ty = initWinY + (e.screenY - clickScreenY);
++ const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
++ const ty = initWinY + Math.round((e.screenY - clickScreenY) * dpr);
+```
+
+(at mousemove, lines ~123-124)
+
+Reads DPR fresh on each call (§4.2) — Chromium's `window.devicePixelRatio` getter is cheap.
+
+**Risk:** very low. No Rust changes. Single-monitor users at 100% see byte-identical behavior (`dpr = 1.0` → multiplier is no-op). Users at 125% / 150% / 175% / 200% have their bug fixed.
+
+**Scope:** covers single-monitor + homogeneous multi-monitor. Cross-monitor mid-drag with differential DPI is improved (the per-mousemove read picks up new DPR) but baseline isn't resnapped — small visible glitch at the crossing moment.
+
+### 5.2 Phase 2 — Robust (follow-up PR)
+
+Add §4.3 (resnap on DPR change) and §4.4 (manifest audit). Add §4.7 test matrix as smoke checklist.
+
+### 5.3 Phase 3 — Defer
+
+§4.5 (`WM_DPICHANGED` mid-drag handler) only if Phase 2 leaves residual glitches.
+
+### 5.4 Non-changes (and why)
+
+- **`get_window_position` / `set_window_position` Rust handlers:** unchanged. They correctly use physical pixels. The bug is the frontend's unit conversion, not the IPC contract.
+- **`move_window_by` Rust handler:** unchanged. It's still vulnerable to the stale-read race that PR #734 fixed, but isn't on the drag path. (Could be removed entirely in a future cleanup; left for backward compat with any external callers.)
+- **Switching to OS-native move loop (`WM_NCLBUTTONDOWN` + `HTCAPTION`):** the comment at `useWindowDrag.win32.ts:7` notes this doesn't work — async IPC roundtrip loses mouse state by the time Rust posts the message. Architectural change, out of scope.
+- **`-webkit-app-region: drag` CSS:** disables all DOM events on the affected element ([Electron docs](https://zeke.github.io/electron.atom.io/docs/api/frameless-window/)). Doesn't fit AgentMux's title-bar interaction model (close/min/max buttons + tab clicks). Rejected.
+
+## 6. Why this regressed despite a code freeze
+
+PR #734's code is byte-identical between merge and today — no one reverted the fix. The regression isn't from a code change at all. The fix had a latent unit bug that was tested on Win10 (100% default) but never on Win11 (125% default).
+
+The retro doc at `docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md` doesn't mention DPI scaling either, which suggests the author never observed it because they tested at 100%. A test-matrix item for high-DPI would have caught this pre-merge.
+
+## 7. Open questions
+
+1. **Linux behavior?** The hook at `useWindowDrag.linux.ts` likely has the same bug if Linux is run at fractional scaling (HiDPI laptops with `scale-monitor-framebuffer` or fractional scaling enabled). Out of scope for this spec; flag for follow-up.
+2. **macOS behavior?** macOS handles HiDPI differently (point-vs-pixel coordinate space). The hook at `useWindowDrag.darwin.ts` likely needs a similar audit. Out of scope; flag for follow-up.
+3. **Should the retro be updated?** Yes — once Phase 1 lands, append a "Postscript: DPI regression" section to `docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md` documenting that the fix shipped without DPI testing.
+
+## 8. References
+
+- [Chromium Blink Coordinate Spaces](https://www.chromium.org/developers/design-documents/blink-coordinate-spaces/) — authoritative on `use-zoom-for-dsf` and CSS-pixel exposure
+- [MDN: Window.devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)
+- [Microsoft Learn: High DPI Desktop Application Development](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows)
+- [Microsoft Learn: WM_DPICHANGED](https://learn.microsoft.com/en-us/windows/win32/hidpi/wm-dpichanged)
+- [Microsoft Learn: Mixed-Mode DPI Scaling](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-improvements-for-desktop-applications)
+- [Microsoft Learn: LogicalToPhysicalPointForPerMonitorDPI](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-logicaltophysicalpointforpermonitordpi)
+- [Marius Bancila: How to build high DPI aware native Windows desktop applications](https://mariusbancila.ro/blog/2021/05/19/how-to-build-high-dpi-aware-native-desktop-applications/)
+- [Dan Reynolds: Handling Chrome's DPI Scaling](https://danreynolds.ca/tech/2017/10/15/Variable-Browser-Zoom/)
+- [Electron #14787 — Frameless windows break mouse cursor on High DPI](https://github.com/electron/electron/issues/14787)
+- [Electron #8533 — Per-monitor DPI awareness](https://github.com/electron/electron/issues/8533)
+- [Electron #10659 — Cannot accurately set position when scaling not 100%](https://github.com/electron/electron/issues/10659)
+- [Neutralinojs #874 — Multi-monitor differential scaling drag bug](https://github.com/neutralinojs/neutralinojs/issues/874)
+- [Alacritty #8448 — Buggy window drag/resize on Windows 11](https://github.com/alacritty/alacritty/issues/8448)
+- [Win32 DPI And Monitor Scaling gist (marler8997)](https://gist.github.com/marler8997/9f39458d26e2d8521d48e36530fbb459)
+
+---
+
+## 9. Decision
+
+Recommend: **Ship Phase 1 (§5.1) as a hotfix today**, file a follow-up issue tracking Phase 2 (§5.2). Add §4.7 test matrix to the engineering smoke-test checklist regardless.
+
+Approval:
+
+- [ ] AgentX (author)
+- [ ] (Reviewer)

--- a/frontend/app/hook/useWindowDrag.win32.ts
+++ b/frontend/app/hook/useWindowDrag.win32.ts
@@ -72,9 +72,20 @@ function installCefDragListener() {
             // Catch-up: if the cursor moved during the IPC, fire one
             // set_window_position immediately against the latest known
             // position so we don't lose the first few pixels of motion.
+            //
+            // DPI scaling: `e.screenX` exposes CSS pixels (Blink divides
+            // physical by combined browser-zoom under use-zoom-for-dsf,
+            // default on Windows since Chrome 54); `initWinX` from
+            // `get_window_position` and `set_window_position` use Win32
+            // physical pixels in this PMv2 process. Multiply the CSS-
+            // pixel delta by devicePixelRatio + round before adding to
+            // the physical baseline. Without this, Win11's default 125%
+            // scale makes the window lag the cursor by ~20%.
+            // See docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md.
             if (latestScreenX !== clickScreenX || latestScreenY !== clickScreenY) {
-                const tx = initWinX + (latestScreenX - clickScreenX);
-                const ty = initWinY + (latestScreenY - clickScreenY);
+                const dpr = window.devicePixelRatio || 1;
+                const tx = initWinX + Math.round((latestScreenX - clickScreenX) * dpr);
+                const ty = initWinY + Math.round((latestScreenY - clickScreenY) * dpr);
                 sendPos(tx, ty);
             }
         } catch {
@@ -120,8 +131,15 @@ function installCefDragListener() {
         latestScreenX = e.screenX;
         latestScreenY = e.screenY;
         if (!dragging) return;
-        const tx = initWinX + (e.screenX - clickScreenX);
-        const ty = initWinY + (e.screenY - clickScreenY);
+        // DPI scaling: CSS-pixel delta * devicePixelRatio = physical
+        // delta, added to the physical-pixel baseline from
+        // `get_window_position`. Re-read DPR every move so a mid-drag
+        // monitor crossing (with different scale) picks up the new
+        // value automatically. Spec:
+        // docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md §4.1-4.2.
+        const dpr = window.devicePixelRatio || 1;
+        const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
+        const ty = initWinY + Math.round((e.screenY - clickScreenY) * dpr);
         sendPos(tx, ty);
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.832",
+  "version": "0.33.833",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.832",
+      "version": "0.33.833",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -268,6 +268,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -895,6 +896,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -943,6 +945,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1024,7 +1027,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1041,7 +1043,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1059,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1075,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1091,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1107,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1123,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1139,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1155,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1171,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1187,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1203,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1219,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1235,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1251,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1267,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1283,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1299,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1315,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1331,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1347,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1363,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1379,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1395,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1411,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1427,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1677,6 +1654,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1894,7 +1882,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1934,7 +1921,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1941,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1961,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1981,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,7 +2001,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,7 +2021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,7 +2041,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,7 +2061,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2081,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2101,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2121,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2165,7 +2141,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2186,7 +2161,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2266,7 +2240,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2280,7 +2253,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2294,7 +2266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,7 +2279,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,7 +2292,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,7 +2305,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2350,7 +2318,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,7 +2331,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,7 +2344,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,7 +2357,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2406,7 +2370,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2420,7 +2383,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2434,7 +2396,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2448,7 +2409,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,7 +2422,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2476,7 +2435,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2490,7 +2448,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,7 +2461,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,7 +2474,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2532,7 +2487,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,7 +2500,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,7 +2513,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,7 +2526,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2588,7 +2539,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2602,7 +2552,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2867,6 +2816,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3736,8 +3686,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3831,6 +3782,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4266,6 +4218,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4302,6 +4255,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4552,6 +4506,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4565,6 +4520,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4732,6 +4694,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4757,7 +4720,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4990,6 +4953,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5399,6 +5363,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5609,7 +5574,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5728,7 +5693,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5795,6 +5760,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6093,7 +6059,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6210,7 +6175,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6256,7 +6220,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -6939,7 +6903,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7091,7 +7055,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7111,7 +7075,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7302,7 +7266,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7481,6 +7445,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7548,7 +7513,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7581,7 +7546,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7602,7 +7566,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7623,7 +7586,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7644,7 +7606,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7665,7 +7626,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7686,7 +7646,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7707,7 +7666,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7728,7 +7686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7749,7 +7706,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7770,7 +7726,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7791,7 +7746,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7856,6 +7810,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8387,6 +8353,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9023,7 +8990,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9103,7 +9071,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9153,7 +9120,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9442,7 +9408,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9488,7 +9453,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9504,6 +9468,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9587,6 +9552,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9618,6 +9584,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9730,11 +9697,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10049,7 +10029,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10115,8 +10095,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10217,8 +10197,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10264,6 +10245,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10401,6 +10383,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10426,6 +10409,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10678,6 +10682,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11114,7 +11119,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11139,6 +11145,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11230,7 +11262,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11453,13 +11484,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11479,7 +11511,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11509,6 +11540,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11551,7 +11583,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11572,6 +11604,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11782,8 +11815,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11949,7 +11982,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11966,7 +11998,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11983,7 +12014,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12000,7 +12030,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12017,7 +12046,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12034,7 +12062,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12051,7 +12078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12068,7 +12094,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12085,7 +12110,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12102,7 +12126,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12119,7 +12142,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12136,7 +12158,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12153,7 +12174,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12170,7 +12190,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12187,7 +12206,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12204,7 +12222,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12221,7 +12238,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12238,7 +12254,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12255,7 +12270,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12272,7 +12286,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12289,7 +12302,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12306,7 +12318,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12323,7 +12334,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12340,7 +12350,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12357,7 +12366,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12374,7 +12382,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12395,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12430,7 +12436,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12466,6 +12471,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.832",
+  "version": "0.33.833",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Fixes the cursor-drift regression on Windows 11 reported after PR #734 landed. PR #734 worked perfectly on Win10 @ 100% scale; on Win11's default 125% scale the window lags the cursor by ~20%, reproducing the original drift symptom by a different mechanism.

**3-line frontend fix. No Rust changes.** At 100% scale, `dpr = 1.0` makes the multiplier a no-op — byte-identical behavior for Win10 users. Users at 125% / 150% / 175% / 200% are fixed.

## Root cause

Unit mismatch in the drag math:

- `e.screenX` in CEF/Chromium with `use-zoom-for-dsf` (default on Windows since Chrome 54) is in **CSS pixels** — Blink divides physical by combined browser-zoom before exposing to JS. ([Chromium Blink Coordinate Spaces](https://www.chromium.org/developers/design-documents/blink-coordinate-spaces/))
- `get_window_position` returns and `set_window_position` consumes **physical pixels** in our PMv2-aware host. ([Win32 PMv2 docs](https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows))
- PR #734 added CSS-pixel deltas to a physical-pixel baseline. At 100% scale they're equal — bug invisible. At 125%+ they differ by `devicePixelRatio` — visible drift.

Full analysis in `docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md`.

## Fix

In `frontend/app/hook/useWindowDrag.win32.ts`, two locations (mousedown catch-up + mousemove):

```ts
const dpr = window.devicePixelRatio || 1;
const tx = initWinX + Math.round((e.screenX - clickScreenX) * dpr);
const ty = initWinY + Math.round((e.screenY - clickScreenY) * dpr);
```

`Math.round` is non-negotiable — fractional DPRs (1.25, 1.5, 1.75) accumulate FP error and produce sub-pixel `SetWindowPos` calls that DWM rounds inconsistently, causing visible jitter.

DPR is re-read on every mousemove (cheap getter), so a mid-drag monitor crossing with different scales picks up the new value automatically once Chromium reflects the OS `WM_DPICHANGED` into the JS context.

## What's covered / not covered

- ✅ Single-monitor at any scale: 100% / 125% / 150% / 175% / 200%
- ✅ Multi-monitor with homogeneous scale (same scale on every monitor)
- ✅ Multi-monitor cross-drag once the OS DPI-change event has propagated to JS
- ⚠️ Brief visible glitch at the exact moment of a cross-monitor crossing with *differential* scale — the accumulated delta is mixed-unit between old/new DPR for one mousemove tick

Spec §4.3 / §5.2 documents the "Phase 2" fix for the mixed-unit case (resnap baseline on DPR change). Deferred to a follow-up — the symptom is a single-frame glitch, not sustained drift.

## Prior art (this class of bug is well-known)

- [Neutralinojs #874](https://github.com/neutralinojs/neutralinojs/issues/874) — identical symptom on borderless drag
- [Alacritty #8448](https://github.com/alacritty/alacritty/issues/8448) — Win11 cross-monitor drag bug
- [Electron #14787](https://github.com/electron/electron/issues/14787) — frameless cursor on HiDPI
- [Electron #8533](https://github.com/electron/electron/issues/8533) — per-monitor DPI awareness

## Retro

`docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md` updated with a 2026-05-13 postscript documenting that PR #734 shipped without DPI-matrix testing. Added the test matrix (100/125/150/175/200% × single/multi-monitor × homogeneous/differential scale) to the smoke-test checklist as a standing item.

## Test plan

- [ ] Win11 @ 100%: drag works, cursor glued to click point
- [ ] Win11 @ 125%: ✅ no drift (this is the primary regression)
- [ ] Win11 @ 150%: ✅ no drift
- [ ] Win11 @ 175%: ✅ no drift (fractional DPR with rounding)
- [ ] Win11 @ 200%: ✅ no drift
- [ ] Win10 @ 100%: unchanged (regression check — multiplier is a no-op)
- [ ] Multi-monitor same scale: drag across monitors works
- [ ] Multi-monitor differential scale (125% + 100%): drag across monitors works after DPR settles
- [ ] Sustained drag (3+ sec): no accumulated drift at any scale

## Files changed

- `frontend/app/hook/useWindowDrag.win32.ts` — the 3-line fix
- `docs/specs/SPEC_WINDOW_DRAG_DPI_FIX_2026-05-13.md` — new spec
- `docs/retro/BUG_WINDOW_DRAG_CURSOR_DRIFT_2026-05-07.md` — postscript
- Version bump 0.33.832 → 0.33.833 (`bump patch`)