### PR TITLE
feat: compositor-only DnD drop-zone animation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.837"
+version = "0.33.838"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.837"
+version = "0.33.838"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.837"
+version = "0.33.838"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.837"
+version = "0.33.838"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.837"
+version = "0.33.838"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.858"
+version = "0.33.859"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.858"
+version = "0.33.859"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.858"
+version = "0.33.859"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.858"
+version = "0.33.859"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.858"
+version = "0.33.859"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.859"
+version = "0.33.860"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.859"
+version = "0.33.860"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.859"
+version = "0.33.860"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.859"
+version = "0.33.860"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.859"
+version = "0.33.860"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.860"
+version = "0.33.861"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.860"
+version = "0.33.861"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.860"
+version = "0.33.861"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.860"
+version = "0.33.861"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.860"
+version = "0.33.861"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.861"
+version = "0.33.862"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.861"
+version = "0.33.862"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.861"
+version = "0.33.862"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.861"
+version = "0.33.862"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.861"
+version = "0.33.862"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.860"
+version = "0.33.861"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.861"
+version = "0.33.862"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.837"
+version = "0.33.838"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.858"
+version = "0.33.859"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.859"
+version = "0.33.860"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.861"
+version = "0.33.862"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.837"
+version = "0.33.838"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.859"
+version = "0.33.860"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.858"
+version = "0.33.859"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.860"
+version = "0.33.861"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.858"
+version = "0.33.859"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.860"
+version = "0.33.861"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.861"
+version = "0.33.862"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.859"
+version = "0.33.860"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.837"
+version = "0.33.838"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.837"
+version = "0.33.838"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.860"
+version = "0.33.861"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.858"
+version = "0.33.859"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.861"
+version = "0.33.862"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.859"
+version = "0.33.860"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.861"
+version = "0.33.862"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.860"
+version = "0.33.861"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.858"
+version = "0.33.859"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.859"
+version = "0.33.860"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.837"
+version = "0.33.838"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/theme.scss
+++ b/frontend/app/theme.scss
@@ -37,6 +37,7 @@
     --base-font: normal 14px / normal "Inter", sans-serif;
     --fixed-font: normal 12px / normal "Hack", monospace;
     --accent-color: rgb(65, 159, 224);
+    --accent-color-rgb: 65, 159, 224;
     --panel-bg-color: rgba(31, 33, 31, 0.5);
     --highlight-bg-color: rgba(255, 255, 255, 0.2);
     --markdown-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif,

--- a/frontend/app/themes/catppuccin.scss
+++ b/frontend/app/themes/catppuccin.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #585b70;
 
     --accent-color: #cba6f7;
+    --accent-color-rgb: 203, 166, 247;
     --link-color: #89dceb;
 
     --border-color: rgba(203, 166, 247, 0.18);

--- a/frontend/app/themes/dracula.scss
+++ b/frontend/app/themes/dracula.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #6272a4;
 
     --accent-color: #bd93f9;
+    --accent-color-rgb: 189, 147, 249;
     --link-color: #8be9fd;
 
     --border-color: rgba(189, 147, 249, 0.2);

--- a/frontend/app/themes/gruvbox.scss
+++ b/frontend/app/themes/gruvbox.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #7c6f64;
 
     --accent-color: #d79921;
+    --accent-color-rgb: 215, 153, 33;
     --link-color: #83a598;
 
     --border-color: rgba(215, 153, 33, 0.2);

--- a/frontend/app/themes/high-contrast.scss
+++ b/frontend/app/themes/high-contrast.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #a0a0a0;
 
     --accent-color: rgb(0, 220, 255);
+    --accent-color-rgb: 0, 220, 255;
     --link-color: #00dcff;
 
     --border-color: rgba(255, 255, 255, 0.4);

--- a/frontend/app/themes/midnight.scss
+++ b/frontend/app/themes/midnight.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #5a6070;
 
     --accent-color: rgb(100, 160, 255);
+    --accent-color-rgb: 100, 160, 255;
     --link-color: #7ab4ff;
 
     --border-color: rgba(100, 140, 255, 0.18);

--- a/frontend/app/themes/monokai.scss
+++ b/frontend/app/themes/monokai.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #75715e;
 
     --accent-color: #a6e22e;
+    --accent-color-rgb: 166, 226, 46;
     --link-color: #a6e22e;
 
     --border-color: rgba(255, 255, 255, 0.12);

--- a/frontend/app/themes/nord.scss
+++ b/frontend/app/themes/nord.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #616e88;
 
     --accent-color: #88c0d0;
+    --accent-color-rgb: 136, 192, 208;
     --link-color: #81a1c1;
 
     --border-color: rgba(136, 192, 208, 0.2);

--- a/frontend/app/themes/tokyo-night.scss
+++ b/frontend/app/themes/tokyo-night.scss
@@ -15,6 +15,7 @@
     --grey-text-color: #565f89;
 
     --accent-color: #7aa2f7;
+    --accent-color-rgb: 122, 162, 247;
     --link-color: #73daca;
 
     --border-color: rgba(122, 162, 247, 0.18);

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -602,14 +602,42 @@ interface PlaceholderProps {
 
 /**
  * An overlay to preview pending actions on the layout tree.
+ * Two-div split mirrors `TileLayout.win32.tsx`: outer `.placeholder-sizer`
+ * carries the inline transform (the only thing animated during drag-move,
+ * compositor-only — see `tilelayout.scss` `&.animate` selector), inner
+ * `.placeholder` carries the visual appearance + enter/exit animation.
+ * Delayed unmount holds the SolidJS `<Show>` node alive for 150ms so
+ * the CSS `.exiting` fade-out can play before the DOM node is removed.
  */
 const Placeholder = (props: PlaceholderProps) => {
     const placeholderTransform = () => props.layoutModel.placeholderTransform();
+    const [visible, setVisible] = createSignal(false);
+    const [exiting, setExiting] = createSignal(false);
+    const [lastTransform, setLastTransform] = createSignal<JSX.CSSProperties | null>(null);
+    let exitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    createEffect(() => {
+        const xf = placeholderTransform();
+        if (xf) {
+            setLastTransform(xf as JSX.CSSProperties);
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
+            setExiting(false);
+            setVisible(true);
+        } else if (visible()) {
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
+            setExiting(true);
+            exitTimer = setTimeout(() => { setVisible(false); setExiting(false); }, 150);
+        }
+    });
+
+    onCleanup(() => { if (exitTimer) clearTimeout(exitTimer); });
 
     return (
         <div class="placeholder-container" style={props.style}>
-            <Show when={placeholderTransform()}>
-                <div class="placeholder" style={placeholderTransform() as JSX.CSSProperties} />
+            <Show when={visible()}>
+                <div class="placeholder-sizer" style={lastTransform() ?? {}}>
+                    <div class={clsx("placeholder", exiting() && "exiting")} />
+                </div>
             </Show>
         </div>
     );

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -570,14 +570,42 @@ interface PlaceholderProps {
 
 /**
  * An overlay to preview pending actions on the layout tree.
+ * Two-div split mirrors `TileLayout.win32.tsx`: outer `.placeholder-sizer`
+ * carries the inline transform (the only thing animated during drag-move,
+ * compositor-only — see `tilelayout.scss` `&.animate` selector), inner
+ * `.placeholder` carries the visual appearance + enter/exit animation.
+ * Delayed unmount holds the SolidJS `<Show>` node alive for 150ms so
+ * the CSS `.exiting` fade-out can play before the DOM node is removed.
  */
 const Placeholder = (props: PlaceholderProps) => {
     const placeholderTransform = () => props.layoutModel.placeholderTransform();
+    const [visible, setVisible] = createSignal(false);
+    const [exiting, setExiting] = createSignal(false);
+    const [lastTransform, setLastTransform] = createSignal<JSX.CSSProperties | null>(null);
+    let exitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    createEffect(() => {
+        const xf = placeholderTransform();
+        if (xf) {
+            setLastTransform(xf as JSX.CSSProperties);
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
+            setExiting(false);
+            setVisible(true);
+        } else if (visible()) {
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
+            setExiting(true);
+            exitTimer = setTimeout(() => { setVisible(false); setExiting(false); }, 150);
+        }
+    });
+
+    onCleanup(() => { if (exitTimer) clearTimeout(exitTimer); });
 
     return (
         <div class="placeholder-container" style={props.style}>
-            <Show when={placeholderTransform()}>
-                <div class="placeholder" style={placeholderTransform() as JSX.CSSProperties} />
+            <Show when={visible()}>
+                <div class="placeholder-sizer" style={lastTransform() ?? {}}>
+                    <div class={clsx("placeholder", exiting() && "exiting")} />
+                </div>
             </Show>
         </div>
     );

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -659,6 +659,7 @@ const Placeholder = (props: PlaceholderProps) => {
             setExiting(false);
             setVisible(true);
         } else if (visible()) {
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
             setExiting(true);
             exitTimer = setTimeout(() => { setVisible(false); setExiting(false); }, 150);
         }

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -640,14 +640,38 @@ interface PlaceholderProps {
 
 /**
  * An overlay to preview pending actions on the layout tree.
+ * Two-div split: outer .placeholder-sizer handles position/size (transform + w/h, not animated),
+ * inner .placeholder handles appearance (opacity + scale, compositor-only).
+ * Delayed unmount gives the CSS exit transition 150 ms to play before the DOM node is removed.
  */
 const Placeholder = (props: PlaceholderProps) => {
     const placeholderTransform = () => props.layoutModel.placeholderTransform();
+    const [visible, setVisible] = createSignal(false);
+    const [exiting, setExiting] = createSignal(false);
+    const [lastTransform, setLastTransform] = createSignal<JSX.CSSProperties | null>(null);
+    let exitTimer: ReturnType<typeof setTimeout> | null = null;
+
+    createEffect(() => {
+        const xf = placeholderTransform();
+        if (xf) {
+            setLastTransform(xf as JSX.CSSProperties);
+            if (exitTimer) { clearTimeout(exitTimer); exitTimer = null; }
+            setExiting(false);
+            setVisible(true);
+        } else if (visible()) {
+            setExiting(true);
+            exitTimer = setTimeout(() => { setVisible(false); setExiting(false); }, 150);
+        }
+    });
+
+    onCleanup(() => { if (exitTimer) clearTimeout(exitTimer); });
 
     return (
         <div class="placeholder-container" style={props.style}>
-            <Show when={placeholderTransform()}>
-                <div class="placeholder" style={placeholderTransform() as JSX.CSSProperties} />
+            <Show when={visible()}>
+                <div class="placeholder-sizer" style={lastTransform() ?? {}}>
+                    <div class={clsx("placeholder", exiting() && "exiting")} />
+                </div>
             </Show>
         </div>
     );

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -153,10 +153,10 @@
 
     &.animate {
         .tile-node,
-        .placeholder {
+        .placeholder-sizer {
             transition-duration: var(--animation-time-s);
             transition-timing-function: linear;
-            transition-property: transform, width, height, background-color;
+            transition-property: transform;
         }
     }
 
@@ -166,9 +166,41 @@
         width: 100%;
     }
 
+    // Outer div: positions and sizes the drop-zone indicator.
+    // position/size come from setTransform() inline styles; only
+    // transform (translate3d) is animated — no width/height transitions.
+    .placeholder-sizer {
+        pointer-events: none;
+    }
+
+    // Inner div: purely visual — compositor-only opacity + scale animation.
     .placeholder {
-        background-color: var(--accent-color);
-        opacity: 0.5;
+        width: 100%;
+        height: 100%;
+        background-color: rgb(var(--accent-color-rgb) / 0.2);
+        border: 1px solid rgb(var(--accent-color-rgb) / 0.5);
         border-radius: calc(var(--block-border-radius) + 2px);
+        box-sizing: border-box;
+        opacity: 1;
+        transform: scale(1);
+        transition: opacity 120ms ease-out, transform 120ms ease-out;
+
+        @starting-style {
+            opacity: 0;
+            transform: scale(0.92);
+        }
+
+        &.exiting {
+            opacity: 0;
+            transform: scale(0.92);
+            transition-timing-function: ease-in;
+            transition-duration: 150ms;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .placeholder {
+            transition: none;
+        }
     }
 }

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -208,9 +208,19 @@
         // Suppress every drop-zone transition: the inner `.placeholder`
         // opacity+scale enter/exit AND the outer `.placeholder-sizer`
         // drag-move transform animation set by `&.animate` above.
-        // Reagent P2 on PR #829.
-        .placeholder,
-        .placeholder-sizer {
+        //
+        // The `&.animate` nesting on the sizer rule is deliberate —
+        // the existing `.tile-layout.animate .placeholder-sizer`
+        // selector has 0,3,0 specificity, so a plain
+        // `.tile-layout .placeholder-sizer` override (0,2,0) would
+        // not actually win. Matching the `.animate` selector inside
+        // the media query keeps specificity equal and lets source
+        // order (reduced-motion block comes later) take effect.
+        // Reagent P2 + codex P2 on PR #829.
+        .placeholder {
+            transition: none;
+        }
+        &.animate .placeholder-sizer {
             transition: none;
         }
     }

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -177,8 +177,14 @@
     .placeholder {
         width: 100%;
         height: 100%;
-        background-color: rgb(var(--accent-color-rgb) / 0.2);
-        border: 1px solid rgb(var(--accent-color-rgb) / 0.5);
+        // `--accent-color-rgb` is comma-separated (`65, 159, 224`) so
+        // it pairs with the legacy `rgba(r, g, b, a)` function rather
+        // than the modern `rgb(r g b / a)` slash-alpha form. Mixing
+        // the two (`rgb(65, 159, 224 / 0.2)`) is invalid CSS and the
+        // declaration is ignored — fill/border would render transparent.
+        // Codex P2 on PR #829.
+        background-color: rgba(var(--accent-color-rgb), 0.2);
+        border: 1px solid rgba(var(--accent-color-rgb), 0.5);
         border-radius: calc(var(--block-border-radius) + 2px);
         box-sizing: border-box;
         opacity: 1;
@@ -199,7 +205,12 @@
     }
 
     @media (prefers-reduced-motion: reduce) {
-        .placeholder {
+        // Suppress every drop-zone transition: the inner `.placeholder`
+        // opacity+scale enter/exit AND the outer `.placeholder-sizer`
+        // drag-move transform animation set by `&.animate` above.
+        // Reagent P2 on PR #829.
+        .placeholder,
+        .placeholder-sizer {
             transition: none;
         }
     }

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -152,7 +152,19 @@
     }
 
     &.animate {
-        .tile-node,
+        // `.tile-node` inline styles include width/height alongside
+        // transform — pane split/close/rebalance needs all three
+        // animated for the resize to be smooth. Codex P2 on PR #829.
+        .tile-node {
+            transition-duration: var(--animation-time-s);
+            transition-timing-function: linear;
+            transition-property: width, height, transform;
+        }
+        // `.placeholder-sizer` only changes transform during drag-move
+        // (width/height are set once per zone change and snap instantly
+        // — that's the whole point of the two-div split). Keeping the
+        // transition-property narrow to `transform` is what makes the
+        // drag-move compositor-only.
         .placeholder-sizer {
             transition-duration: var(--animation-time-s);
             transition-timing-function: linear;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.859",
+  "version": "0.33.860",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.859",
+      "version": "0.33.860",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.861",
+  "version": "0.33.862",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.861",
+      "version": "0.33.862",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.858",
+  "version": "0.33.859",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.858",
+      "version": "0.33.859",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.860",
+  "version": "0.33.861",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.860",
+      "version": "0.33.861",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.860",
+  "version": "0.33.861",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.861",
+  "version": "0.33.862",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.858",
+  "version": "0.33.859",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.837",
+  "version": "0.33.838",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.859",
+  "version": "0.33.860",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

- **Two-div split** replaces the single animated placeholder div: outer `.placeholder-sizer` handles position (`translate3d`) + size (`width`/`height` set once per zone change, not animated); inner `.placeholder` handles appearance (`opacity` + `scale`, compositor-only)
- **`@starting-style`** provides the enter animation without JS — browser transitions from `opacity:0 scale(0.92)` to `opacity:1 scale(1)` on first paint (Chrome 117+ / CEF 146+)
- **Delayed unmount** (150 ms `setTimeout`) holds the SolidJS `<Show>` node alive while the `.exiting` CSS class triggers the fade-out, then removes the DOM node cleanly
- **`--accent-color-rgb`** added to `theme.scss` and all 8 theme files, enabling `rgb(var(--accent-color-rgb) / 0.2)` fill + `/ 0.5` border syntax
- **`&.animate` cleanup** — removed `width`, `height`, `background-color` from the transition; only `transform` remains — eliminates continuous layout recalculation during drag

## Why it's smoother

Before: every drag-move updated `width`/`height` via CSS transition, forcing layout at 60 fps. After: only `transform: translate3d` changes during drag (compositor thread, zero layout/paint cost).

## Test plan

- [ ] Drag a pane — drop-zone highlight fades in with a gentle scale-up
- [ ] Move drag across zones — placeholder position transitions smoothly, size jumps instantly
- [ ] Release drag — highlight fades out and scales down before DOM removal
- [ ] All 8 themes: correct translucent accent fill and border
- [ ] `prefers-reduced-motion`: instant show/hide, no transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)