### PR TITLE
feat(agents): unified agent types + runner skeleton (Workflows Phase 1.5 PR 0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.850"
+version = "0.33.851"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.850"
+version = "0.33.851"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.850"
+version = "0.33.851"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.850"
+version = "0.33.851"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.850"
+version = "0.33.851"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.849"
+version = "0.33.850"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.849"
+version = "0.33.850"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.849"
+version = "0.33.850"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.849"
+version = "0.33.850"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.849"
+version = "0.33.850"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.845"
+version = "0.33.846"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.845"
+version = "0.33.846"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.845"
+version = "0.33.846"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.845"
+version = "0.33.846"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.845"
+version = "0.33.846"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.851"
+version = "0.33.852"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.851"
+version = "0.33.852"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.851"
+version = "0.33.852"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.851"
+version = "0.33.852"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.851"
+version = "0.33.852"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.847"
+version = "0.33.848"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.847"
+version = "0.33.848"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.847"
+version = "0.33.848"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.847"
+version = "0.33.848"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.847"
+version = "0.33.848"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.848"
+version = "0.33.849"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.848"
+version = "0.33.849"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.848"
+version = "0.33.849"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.848"
+version = "0.33.849"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.848"
+version = "0.33.849"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.846"
+version = "0.33.847"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.846"
+version = "0.33.847"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.846"
+version = "0.33.847"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.846"
+version = "0.33.847"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.846"
+version = "0.33.847"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.850"
+version = "0.33.851"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.847"
+version = "0.33.848"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.849"
+version = "0.33.850"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.845"
+version = "0.33.846"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.851"
+version = "0.33.852"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.846"
+version = "0.33.847"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.848"
+version = "0.33.849"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.847"
+version = "0.33.848"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.849"
+version = "0.33.850"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.848"
+version = "0.33.849"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.851"
+version = "0.33.852"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.845"
+version = "0.33.846"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.850"
+version = "0.33.851"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.846"
+version = "0.33.847"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.849"
+version = "0.33.850"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.847"
+version = "0.33.848"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.850"
+version = "0.33.851"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.845"
+version = "0.33.846"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.848"
+version = "0.33.849"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.846"
+version = "0.33.847"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.851"
+version = "0.33.852"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.846"
+version = "0.33.847"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.845"
+version = "0.33.846"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.848"
+version = "0.33.849"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.849"
+version = "0.33.850"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.847"
+version = "0.33.848"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.851"
+version = "0.33.852"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.850"
+version = "0.33.851"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.851"
+version = "0.33.852"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.850"
+version = "0.33.851"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.845"
+version = "0.33.846"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.847"
+version = "0.33.848"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.849"
+version = "0.33.850"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.848"
+version = "0.33.849"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.846"
+version = "0.33.847"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/agents/mod.rs
+++ b/agentmux-srv/src/agents/mod.rs
@@ -1,0 +1,19 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unified agent runner — single entry point for spawning Claude
+//! Code (or any future provider) used by BOTH the interactive agent
+//! pane and the headless workflow Agent block.
+//!
+//! See `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` for the
+//! full design + 5-PR migration plan.
+//!
+//! This is Phase 1.5 PR 0: types + skeleton. PR 1 wires the agent
+//! pane through this module; PR 2 wires the workflow Agent block.
+
+pub mod runner;
+pub mod translator;
+pub mod types;
+
+pub use runner::{run_agent, AgentError, AgentRunHandle};
+pub use types::{AgentEvent, AgentRef, AgentRunResult, AgentTask, TokenCounts, Turn};

--- a/agentmux-srv/src/agents/mod.rs
+++ b/agentmux-srv/src/agents/mod.rs
@@ -16,4 +16,4 @@ pub mod translator;
 pub mod types;
 
 pub use runner::{run_agent, AgentError, AgentRunHandle};
-pub use types::{AgentEvent, AgentRef, AgentRunResult, AgentTask, TokenCounts, Turn};
+pub use types::{AgentEvent, AgentRef, AgentRunResult, AgentTask, TokenCounts, AgentTurn};

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -17,13 +17,16 @@ use tokio::sync::{mpsc, oneshot};
 
 use super::types::{AgentEvent, AgentRef, AgentRunResult, AgentTask};
 
-/// Handle returned by `run_agent`. Callers drain `events` for the
-/// streaming side (UI render or per-event broker publish) and await
-/// `final_result` for the structured terminal value (workflow Agent
-/// block's downstream output).
+/// Handle returned by `run_agent`. The caller already holds the
+/// `mpsc::UnboundedReceiver<AgentEvent>` they paired with the `tx`
+/// passed into `run_agent`; this handle adds the structured terminal
+/// value via `final_result` (workflow Agent block's downstream
+/// output) and the `instance_id` of the backing `db_agent_instances`
+/// row.
 ///
-/// Closing the `events` receiver implicitly cancels the run only if
-/// the runner observes it — Phase 2 adds an explicit AbortHandle.
+/// Dropping the caller's receiver implicitly cancels the run only if
+/// the runner observes the send error — Phase 2 adds an explicit
+/// `AbortHandle`.
 pub struct AgentRunHandle {
     /// `db_agent_instances.id` of the row backing this run. Empty
     /// string until the runner allocates one (PR 1).

--- a/agentmux-srv/src/agents/runner.rs
+++ b/agentmux-srv/src/agents/runner.rs
@@ -1,0 +1,86 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unified agent runner. Phase 1.5 PR 0 ships the SKELETON only:
+//! types are wired, the `run_agent` entry point exists, and a
+//! handle type is defined — but the actual spawn / drain pipeline
+//! lands in PR 1 (refactor of `blockcontroller/shell.rs`) and PR 2
+//! (workflow Agent block wiring).
+//!
+//! Until then, `run_agent` returns a `NotImplemented` error so any
+//! premature caller fails loudly rather than silently producing
+//! empty output.
+//!
+//! See `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` §4.2.
+
+use tokio::sync::{mpsc, oneshot};
+
+use super::types::{AgentEvent, AgentRef, AgentRunResult, AgentTask};
+
+/// Handle returned by `run_agent`. Callers drain `events` for the
+/// streaming side (UI render or per-event broker publish) and await
+/// `final_result` for the structured terminal value (workflow Agent
+/// block's downstream output).
+///
+/// Closing the `events` receiver implicitly cancels the run only if
+/// the runner observes it — Phase 2 adds an explicit AbortHandle.
+pub struct AgentRunHandle {
+    /// `db_agent_instances.id` of the row backing this run. Empty
+    /// string until the runner allocates one (PR 1).
+    pub instance_id: String,
+    pub final_result: oneshot::Receiver<Result<AgentRunResult, String>>,
+}
+
+/// Error returned by the runner.
+#[derive(Debug, thiserror::Error)]
+pub enum AgentError {
+    #[error("agent runner: not yet implemented — Phase 1.5 PR 1 wires the spawn pipeline")]
+    NotImplemented,
+    #[error("agent runner: invalid AgentRef: {0}")]
+    InvalidRef(String),
+    #[error("agent runner: spawn failed: {0}")]
+    Spawn(String),
+}
+
+/// Spawn an agent subprocess per the `agent_ref`, drain its output,
+/// translate frames into `AgentEvent`s, broadcast each on `tx`, and
+/// (when the run terminates) resolve the returned handle's
+/// `final_result` with an `AgentRunResult`.
+///
+/// PR 0 returns `NotImplemented` — wiring lands in PR 1 (agent
+/// pane refactor) and PR 2 (workflow Agent block).
+pub async fn run_agent(
+    _agent_ref: AgentRef,
+    _task: AgentTask,
+    _tx: mpsc::UnboundedSender<AgentEvent>,
+) -> Result<AgentRunHandle, AgentError> {
+    Err(AgentError::NotImplemented)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_agent_returns_not_implemented_in_pr_0() {
+        // Regression guard — PR 1 replaces this with a real spawn.
+        // Until then, any caller (including the workflow Agent block
+        // stub) should get a clear error instead of silent empty
+        // output.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let result = run_agent(AgentRef::default(), simple_task(), tx).await;
+        match result {
+            Err(AgentError::NotImplemented) => {}
+            Err(other) => panic!("expected NotImplemented, got: {other}"),
+            Ok(_) => panic!("expected NotImplemented error, got Ok(handle)"),
+        }
+    }
+
+    fn simple_task() -> AgentTask {
+        AgentTask {
+            prompt: "hi".to_string(),
+            context: serde_json::Map::new(),
+            max_turns: None,
+        }
+    }
+}

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -1,0 +1,67 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Claude Code stream-json → `AgentEvent` translator.
+//!
+//! Claude Code emits one JSON object per line. Top-level shape:
+//!
+//!   ```json
+//!   {"type":"stream_event","event":{...}}
+//!   {"type":"message_start","message":{...}}
+//!   {"type":"result","cost_usd":0.001,"usage":{...}}
+//!   ```
+//!
+//! The frontend has the reference implementation at
+//! `frontend/app/view/agent/providers/claude-translator.ts`. This
+//! module mirrors its logic on the backend so the workflow Agent
+//! block can consume the same stream without round-tripping through
+//! the frontend.
+//!
+//! PR 0 ships the SKELETON only — `translate()` accepts a frame but
+//! returns an empty `Vec`. PR 1 fills in the logic and replaces
+//! `agentmux-srv/src/backend/history/claude_adapter.rs` (which
+//! currently has the only backend-side parsing).
+
+use serde_json::Value;
+
+use super::super::types::AgentEvent;
+use super::Translator;
+
+#[derive(Debug, Default)]
+pub struct ClaudeTranslator {
+    /// Running buffer for partial events that span multiple frames.
+    /// Reserved for PR 1 wiring; not used in PR 0.
+    _buffer: Vec<u8>,
+}
+
+impl ClaudeTranslator {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Translator for ClaudeTranslator {
+    type Frame = Value;
+
+    fn translate(&mut self, _frame: Value) -> Vec<AgentEvent> {
+        // PR 1 lands the translation logic. The skeleton keeps the
+        // surface area visible so PR 1 is a focused fill-in.
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn skeleton_returns_empty_for_any_frame() {
+        // Regression guard — PR 1 replaces this with shape-specific
+        // tests. Until then, any caller of `translate` gets an empty
+        // event list, signalling "skeleton — needs implementation".
+        let mut t = ClaudeTranslator::new();
+        assert!(t.translate(json!({})).is_empty());
+        assert!(t.translate(json!({ "type": "stream_event" })).is_empty());
+    }
+}

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -41,8 +41,6 @@ impl ClaudeTranslator {
 }
 
 impl Translator for ClaudeTranslator {
-    type Frame = Value;
-
     fn translate(&mut self, _frame: Value) -> Vec<AgentEvent> {
         // PR 1 lands the translation logic. The skeleton keeps the
         // surface area visible so PR 1 is a focused fill-in.

--- a/agentmux-srv/src/agents/translator/mod.rs
+++ b/agentmux-srv/src/agents/translator/mod.rs
@@ -8,26 +8,30 @@
 //! `AgentEvent`s. The runner is provider-agnostic; only this layer
 //! knows the wire format.
 
+use serde_json::Value;
+
 use super::types::AgentEvent;
 
 pub mod claude;
 
-/// A streaming translator: feeds raw provider frames (bytes,
-/// JSON values, line strings — whatever the provider speaks) and
-/// emits zero-or-more `AgentEvent`s per frame.
+/// A streaming translator: feeds raw provider frames as parsed JSON
+/// values and emits zero-or-more `AgentEvent`s per frame.
+///
+/// Using a concrete `serde_json::Value` frame type (rather than an
+/// associated type) keeps the trait `dyn`-dispatchable so the
+/// runner can hold `Box<dyn Translator>` and switch providers at
+/// run time. All currently-planned providers (Claude Code
+/// stream-json, ACP, future Aider/Codex/Gemini) speak JSON over
+/// stdout, so the lowest-common-denominator frame fits them.
+/// Providers with binary framing would wrap their parser to emit
+/// `Value` envelopes before this layer.
 ///
 /// PR 0 ships only the trait + Claude skeleton. PR 1 fills in the
-/// translation logic and adds the ACP translator (mirror of the
-/// frontend `acp-translator.ts`).
+/// translation logic.
 pub trait Translator: Send {
-    /// Frame type the provider speaks. For Claude Code stream-json
-    /// this is `serde_json::Value` (one parsed line per call). For
-    /// ACP it's the parsed frame struct.
-    type Frame;
-
     /// Translate a single frame into zero-or-more events. Returning
     /// `Vec` (not `Option`) because some provider frames produce
     /// multiple events (e.g. a `message_start` with embedded
     /// `tool_use` blocks).
-    fn translate(&mut self, frame: Self::Frame) -> Vec<AgentEvent>;
+    fn translate(&mut self, frame: Value) -> Vec<AgentEvent>;
 }

--- a/agentmux-srv/src/agents/translator/mod.rs
+++ b/agentmux-srv/src/agents/translator/mod.rs
@@ -1,0 +1,33 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provider frame → unified `AgentEvent` translation.
+//!
+//! Each provider (Claude Code stream-json, ACP, future Aider /
+//! Codex / Gemini) implements `Translator` to produce a stream of
+//! `AgentEvent`s. The runner is provider-agnostic; only this layer
+//! knows the wire format.
+
+use super::types::AgentEvent;
+
+pub mod claude;
+
+/// A streaming translator: feeds raw provider frames (bytes,
+/// JSON values, line strings — whatever the provider speaks) and
+/// emits zero-or-more `AgentEvent`s per frame.
+///
+/// PR 0 ships only the trait + Claude skeleton. PR 1 fills in the
+/// translation logic and adds the ACP translator (mirror of the
+/// frontend `acp-translator.ts`).
+pub trait Translator: Send {
+    /// Frame type the provider speaks. For Claude Code stream-json
+    /// this is `serde_json::Value` (one parsed line per call). For
+    /// ACP it's the parsed frame struct.
+    type Frame;
+
+    /// Translate a single frame into zero-or-more events. Returning
+    /// `Vec` (not `Option`) because some provider frames produce
+    /// multiple events (e.g. a `message_start` with embedded
+    /// `tool_use` blocks).
+    fn translate(&mut self, frame: Self::Frame) -> Vec<AgentEvent>;
+}

--- a/agentmux-srv/src/agents/types.rs
+++ b/agentmux-srv/src/agents/types.rs
@@ -1,0 +1,291 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unified agent types shared between the agent pane (interactive)
+//! and the workflow Agent block (headless). See
+//! `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` §3 for the
+//! full design rationale.
+//!
+//! Wire format is camelCase via `serde(rename_all)` so the TS
+//! mirror in `frontend/types/gotypes.d.ts` requires no field
+//! translation.
+
+use serde::{Deserialize, Serialize};
+
+/// Identifies "which agent." Empty-string sentinels match the
+/// existing wstore `AgentInstance` conventions. All fields optional
+/// so callers can construct anything from "blank claude with ambient
+/// creds" (all empty) up to a fully-pinned named-agent continuation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRef {
+    /// FK to `db_identities.id`. Empty = blank singleton (ambient
+    /// creds, no env-var injection at spawn).
+    #[serde(default)]
+    pub identity_id: String,
+    /// FK to `db_memories.id`. Empty = blank singleton (vanilla CLI,
+    /// no system instructions injected).
+    #[serde(default)]
+    pub memory_id: String,
+    /// User-chosen instance name. Empty for one-shot launches.
+    /// Non-empty triggers the named-agent continuation path: the
+    /// runner looks up an existing `AgentInstance` by name and reuses
+    /// its `working_directory` + `session_id` if present.
+    #[serde(default)]
+    pub instance_name: String,
+    /// Optional explicit working directory override. Empty falls
+    /// back to `allocate_agent_workdir()` at run time.
+    #[serde(default)]
+    pub working_directory: String,
+}
+
+/// What the agent should do, plus the variables for `{{ }}` resolution
+/// inside `prompt`. The agent pane uses `prompt=<user-typed-text>`
+/// with an empty `context`. The workflow Agent block uses
+/// `prompt=<block.data.task>` resolved against `scope.outputs +
+/// scope.vars`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTask {
+    pub prompt: String,
+    /// Variable scope for template resolution inside `prompt`. Keys
+    /// are typically block ids or `var`/`env` namespaces; values are
+    /// JSON. The runner is responsible for resolution before spawn.
+    #[serde(default)]
+    pub context: serde_json::Map<String, serde_json::Value>,
+    /// Hard cap on turns. `None` = use the provider default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+}
+
+/// Discriminated streaming event. Same union for both the agent
+/// pane (renders into the UI) and the workflow Agent block
+/// (accumulates until `Done`, returns `AgentRunResult`).
+///
+/// Provider-specific extension goes through a `Custom` variant
+/// reserved here but intentionally not shipped Phase 1.5 — leave
+/// the enum open for it. See spec §8 risks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum AgentEvent {
+    /// Streaming text chunk from the assistant. Agent pane appends
+    /// to the visible transcript; workflow Agent block buffers
+    /// until `Done`.
+    AssistantText {
+        delta: String,
+    },
+    /// Tool invocation about to run. `input` is the provider's raw
+    /// tool input JSON; renderers may dispatch on `tool` name.
+    ToolUse {
+        tool_use_id: String,
+        tool: String,
+        input: serde_json::Value,
+    },
+    /// Tool execution result.
+    ToolResult {
+        tool_use_id: String,
+        output: serde_json::Value,
+        #[serde(default)]
+        is_error: bool,
+    },
+    /// Final cost + token accounting. Emitted once per run, before
+    /// `Done`.
+    Cost {
+        cost_usd: f64,
+        tokens: TokenCounts,
+    },
+    /// Run completed successfully. `response` is the final assistant
+    /// message text (the workflow Agent block's primary output).
+    /// `transcript` is the full ordered turn list for audit / replay.
+    Done {
+        response: String,
+        transcript: Vec<Turn>,
+    },
+    /// Run failed. `message` is the user-facing error.
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenCounts {
+    #[serde(default)]
+    pub input: u64,
+    #[serde(default)]
+    pub output: u64,
+    #[serde(default)]
+    pub cache_creation: u64,
+    #[serde(default)]
+    pub cache_read: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Turn {
+    /// `"user"` | `"assistant"` | `"tool_result"`.
+    pub role: String,
+    pub content: serde_json::Value,
+    pub timestamp_ms: i64,
+}
+
+/// Final structured result of a complete agent run — the value the
+/// workflow Agent block returns to downstream blocks. The agent
+/// pane discards this (it has already rendered the stream) but
+/// constructs the same struct for the audit log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunResult {
+    pub response: String,
+    pub tokens: TokenCounts,
+    pub cost_usd: f64,
+    pub transcript: Vec<Turn>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ────────────────────────────────────────────────────────────────
+    // Wire format — verify camelCase on the JSON side. The TS mirror
+    // in `frontend/types/gotypes.d.ts` depends on this; any drift
+    // becomes silent type errors at the IPC seam.
+    // ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn agent_ref_serializes_camelcase() {
+        let r = AgentRef {
+            identity_id: "id1".into(),
+            memory_id: "mem1".into(),
+            instance_name: "alice".into(),
+            working_directory: "/tmp/x".into(),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "identityId": "id1",
+                "memoryId": "mem1",
+                "instanceName": "alice",
+                "workingDirectory": "/tmp/x"
+            })
+        );
+    }
+
+    #[test]
+    fn agent_ref_defaults_round_trip() {
+        // Empty-string sentinels match the wstore convention so the
+        // frontend can omit fields it doesn't set.
+        let r: AgentRef = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(r, AgentRef::default());
+    }
+
+    #[test]
+    fn agent_event_assistant_text_shape() {
+        let ev = AgentEvent::AssistantText {
+            delta: "hi".into(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v, json!({ "type": "assistant_text", "delta": "hi" }));
+    }
+
+    #[test]
+    fn agent_event_tool_use_camelcase_id() {
+        let ev = AgentEvent::ToolUse {
+            tool_use_id: "tu_42".into(),
+            tool: "bash".into(),
+            input: json!({ "cmd": "ls" }),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "type": "tool_use",
+                "toolUseId": "tu_42",
+                "tool": "bash",
+                "input": { "cmd": "ls" }
+            })
+        );
+    }
+
+    #[test]
+    fn agent_event_cost_shape() {
+        let ev = AgentEvent::Cost {
+            cost_usd: 0.0123,
+            tokens: TokenCounts {
+                input: 100,
+                output: 50,
+                cache_creation: 0,
+                cache_read: 200,
+            },
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "type": "cost",
+                "costUsd": 0.0123,
+                "tokens": {
+                    "input": 100,
+                    "output": 50,
+                    "cacheCreation": 0,
+                    "cacheRead": 200
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn agent_event_roundtrips() {
+        let original = AgentEvent::Done {
+            response: "ok".into(),
+            transcript: vec![Turn {
+                role: "assistant".into(),
+                content: json!("hi"),
+                timestamp_ms: 1_700_000_000_000,
+            }],
+        };
+        let s = serde_json::to_string(&original).unwrap();
+        let parsed: AgentEvent = serde_json::from_str(&s).unwrap();
+        // Match the shape, not the exact equality (transcript Vec).
+        match parsed {
+            AgentEvent::Done {
+                response,
+                transcript,
+            } => {
+                assert_eq!(response, "ok");
+                assert_eq!(transcript.len(), 1);
+                assert_eq!(transcript[0].role, "assistant");
+                assert_eq!(transcript[0].timestamp_ms, 1_700_000_000_000);
+            }
+            _ => panic!("expected Done variant"),
+        }
+    }
+
+    #[test]
+    fn agent_run_result_shape() {
+        let r = AgentRunResult {
+            response: "hi".into(),
+            tokens: TokenCounts::default(),
+            cost_usd: 0.0,
+            transcript: vec![],
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        // costUsd at the result level, tokens nested with camelCase.
+        assert_eq!(
+            v,
+            json!({
+                "response": "hi",
+                "tokens": {
+                    "input": 0,
+                    "output": 0,
+                    "cacheCreation": 0,
+                    "cacheRead": 0
+                },
+                "costUsd": 0.0,
+                "transcript": []
+            })
+        );
+    }
+}

--- a/agentmux-srv/src/agents/types.rs
+++ b/agentmux-srv/src/agents/types.rs
@@ -99,7 +99,7 @@ pub enum AgentEvent {
     /// `transcript` is the full ordered turn list for audit / replay.
     Done {
         response: String,
-        transcript: Vec<Turn>,
+        transcript: Vec<AgentTurn>,
     },
     /// Run failed. `message` is the user-facing error.
     Error {
@@ -122,7 +122,7 @@ pub struct TokenCounts {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Turn {
+pub struct AgentTurn {
     /// `"user"` | `"assistant"` | `"tool_result"`.
     pub role: String,
     pub content: serde_json::Value,
@@ -139,7 +139,7 @@ pub struct AgentRunResult {
     pub response: String,
     pub tokens: TokenCounts,
     pub cost_usd: f64,
-    pub transcript: Vec<Turn>,
+    pub transcript: Vec<AgentTurn>,
 }
 
 #[cfg(test)]
@@ -240,7 +240,7 @@ mod tests {
     fn agent_event_roundtrips() {
         let original = AgentEvent::Done {
             response: "ok".into(),
-            transcript: vec![Turn {
+            transcript: vec![AgentTurn {
                 role: "assistant".into(),
                 content: json!("hi"),
                 timestamp_ms: 1_700_000_000_000,

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -1,3 +1,4 @@
+mod agents;
 mod backend;
 mod config;
 mod event_log;

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -110,7 +110,7 @@ pub enum AgentEvent {
     /// audit / replay.
     Done {
         response: String,
-        transcript: Vec<Turn>,
+        transcript: Vec<AgentTurn>,
     },
     /// Run failed. `message` is the user-facing error.
     Error { message: String },
@@ -127,7 +127,7 @@ pub struct TokenCounts {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Turn {
+pub struct AgentTurn {
     pub role: String,  // "user" | "assistant" | "tool_result"
     pub content: serde_json::Value,
     pub timestamp_ms: i64,
@@ -143,7 +143,7 @@ pub struct AgentRunResult {
     pub response: String,
     pub tokens: TokenCounts,
     pub cost_usd: f64,
-    pub transcript: Vec<Turn>,
+    pub transcript: Vec<AgentTurn>,
 }
 ```
 
@@ -170,7 +170,7 @@ type AgentEvent =
     | { type: "tool_use"; toolUseId: string; tool: string; input: unknown }
     | { type: "tool_result"; toolUseId: string; output: unknown; isError: boolean }
     | { type: "cost"; costUsd: number; tokens: TokenCounts }
-    | { type: "done"; response: string; transcript: Turn[] }
+    | { type: "done"; response: string; transcript: AgentTurn[] }
     | { type: "error"; message: string };
 
 type TokenCounts = {
@@ -180,7 +180,7 @@ type TokenCounts = {
     cacheRead: number;
 };
 
-type Turn = {
+type AgentTurn = {
     role: "user" | "assistant" | "tool_result";
     content: unknown;
     timestampMs: number;
@@ -190,7 +190,7 @@ type AgentRunResult = {
     response: string;
     tokens: TokenCounts;
     costUsd: number;
-    transcript: Turn[];
+    transcript: AgentTurn[];
 };
 ```
 

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -1,0 +1,363 @@
+# SPEC: Unified agent type system (Workflows Phase 1.5)
+
+**Date:** 2026-05-13
+**Status:** Draft — lands after PR #755 (Workflows Phase 1) merges
+**Author:** AgentA
+**Issue:** RFC #753 (Workflows pane), follow-up to PR #755
+**Related memory:** [`project_workflows_phase_1_5.md`](../../../../.claude/projects/C--Systems/memory/project_workflows_phase_1_5.md)
+
+---
+
+## 1. Why this PR exists
+
+PR #755 ships the Workflows Phase 1 MVP with a **stub Agent block** that returns `{ response: "[stub agent=...]", status: "stub" }`. RFC #753 specced this block as "a reference to a Forge agent definition," but two things have happened since 2026-05-08 when the RFC was written:
+
+1. **"Forge" is dead terminology.** v7 schema migrated `db_forge_agents` into `db_memories` ([#746](https://github.com/agentmuxai/agentmux/pull/746)). Identity + Memory landed as **in-pane tabs** ([#749](https://github.com/agentmuxai/agentmux/pull/749), [#750](https://github.com/agentmuxai/agentmux/pull/750)). v8 added named-agent continuation ([#816](https://github.com/agentmuxai/agentmux/pull/816)) with `instance_name` / `working_directory` / `display_hidden` columns. The Agent block needs to reference `(identity_bundle_id, memory_bundle_id, instance_name?)`, not a single `forge_agent_id`.
+
+2. **The agent pane already has the full runner pipeline.** Identity injection, memory binding, named-agent continuation, tool-chunk streaming via the new `agentmux-bashwrap` crate → WPS event channel ([#804](https://github.com/agentmuxai/agentmux/pull/804), [#809](https://github.com/agentmuxai/agentmux/pull/809)), cost capture from `cost_usd` result events. A workflow Agent block should be a **headless invocation of the same controller**, not a parallel implementation.
+
+This PR introduces shared types so the agent pane and the workflow Agent block consume one event stream, one cost record, one tool surface — DRY in the right place, single audit trail, ready for future workflow→agent→workflow composition.
+
+---
+
+## 2. Out of scope (deferred)
+
+- **Phase 2 trigger surface** (cron / webhook / dependency / schedule) — separate PR series after Phase 1.5.
+- **Sub-workflow invocation** (Workflow block calling another Workflow) — Phase 2.
+- **Function block sandbox** (`quickjs-rs`) — Phase 2.
+- **Cancellation / abort handle** — a deferred P2 from PR #755 ([`engine.rs:64`](../../agentmux-srv/src/workflows/executor/engine.rs)). Land separately.
+- **DNS-resolution-time SSRF validation** in the API block — a deferred P2 from PR #755, sibling concern but not gating Phase 1.5.
+- **Workflow Agent block streaming into the canvas** — Phase 1.5 delivers `Done` + `AgentRunResult` to downstream blocks; live per-token streaming into a hover-expanded canvas inspector is Phase 2.
+
+---
+
+## 3. Shared type definitions
+
+### 3.1 Rust (`agentmux-srv/src/agents/types.rs` — new module)
+
+```rust
+/// Identifies "which agent." Same shape used by the launch modal
+/// (interactive agent pane spawn) and the workflow Agent block
+/// (headless run). All fields optional — empty-string sentinel
+/// matches the existing wstore conventions on AgentInstance.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRef {
+    /// FK to db_identities.id. Empty = blank singleton (ambient
+    /// creds, no env-var injection).
+    #[serde(default)]
+    pub identity_id: String,
+    /// FK to db_memories.id. Empty = blank singleton (vanilla CLI).
+    #[serde(default)]
+    pub memory_id: String,
+    /// User-chosen instance name. Empty for one-shot launches.
+    /// Non-empty triggers the named-agent continuation path
+    /// (look up existing AgentInstance by name, reuse its
+    /// working_directory + session_id if present).
+    #[serde(default)]
+    pub instance_name: String,
+    /// Optional explicit working directory override. Empty falls
+    /// back to allocate_agent_workdir() at run time.
+    #[serde(default)]
+    pub working_directory: String,
+}
+
+/// What the agent should do, plus the variables for {{ }} resolution
+/// inside the prompt. The agent pane uses prompt=user-typed-text and
+/// an empty context; the workflow Agent block uses prompt=block.data.task
+/// resolved against scope.outputs + scope.vars.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentTask {
+    pub prompt: String,
+    #[serde(default)]
+    pub context: serde_json::Map<String, serde_json::Value>,
+    /// Hard cap on turns. None = use the provider default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_turns: Option<u32>,
+}
+
+/// Discriminated streaming event. Same union for both the agent
+/// pane (renders into the UI) and the workflow Agent block
+/// (accumulates until Done, returns AgentRunResult).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// Streaming text chunk from the assistant — agent pane appends
+    /// to its visible transcript; workflow Agent block buffers.
+    AssistantText { delta: String },
+    /// Tool invocation about to run. `input` is the provider's raw
+    /// tool input JSON; renderers may dispatch on tool name.
+    ToolUse {
+        tool_use_id: String,
+        tool: String,
+        input: serde_json::Value,
+    },
+    /// Tool execution result.
+    ToolResult {
+        tool_use_id: String,
+        output: serde_json::Value,
+        is_error: bool,
+    },
+    /// Final cost + token accounting. Emitted once per run.
+    Cost {
+        cost_usd: f64,
+        tokens: TokenCounts,
+    },
+    /// Run completed successfully. `response` is the final
+    /// assistant message text (the workflow Agent block's primary
+    /// output). `transcript` is the full ordered turn list for
+    /// audit / replay.
+    Done {
+        response: String,
+        transcript: Vec<Turn>,
+    },
+    /// Run failed. `message` is the user-facing error.
+    Error { message: String },
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenCounts {
+    #[serde(default)] pub input: u64,
+    #[serde(default)] pub output: u64,
+    #[serde(default)] pub cache_creation: u64,
+    #[serde(default)] pub cache_read: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Turn {
+    pub role: String,  // "user" | "assistant" | "tool_result"
+    pub content: serde_json::Value,
+    pub timestamp_ms: i64,
+}
+
+/// Final structured result of a complete agent run — the value the
+/// workflow Agent block returns to downstream blocks. The agent
+/// pane discards this (it's already rendered the stream), but
+/// constructs the same struct for the in-progress audit log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunResult {
+    pub response: String,
+    pub tokens: TokenCounts,
+    pub cost_usd: f64,
+    pub transcript: Vec<Turn>,
+}
+```
+
+### 3.2 TypeScript (`frontend/types/gotypes.d.ts` — re-exported via the existing serde→ts script)
+
+The Rust types are camelCase via `rename_all`, so the TS shape is automatic:
+
+```typescript
+type AgentRef = {
+    identityId?: string;
+    memoryId?: string;
+    instanceName?: string;
+    workingDirectory?: string;
+};
+
+type AgentTask = {
+    prompt: string;
+    context?: Record<string, unknown>;
+    maxTurns?: number;
+};
+
+type AgentEvent =
+    | { type: "assistant_text"; delta: string }
+    | { type: "tool_use"; toolUseId: string; tool: string; input: unknown }
+    | { type: "tool_result"; toolUseId: string; output: unknown; isError: boolean }
+    | { type: "cost"; costUsd: number; tokens: TokenCounts }
+    | { type: "done"; response: string; transcript: Turn[] }
+    | { type: "error"; message: string };
+
+type TokenCounts = {
+    input: number;
+    output: number;
+    cacheCreation: number;
+    cacheRead: number;
+};
+
+type Turn = {
+    role: "user" | "assistant" | "tool_result";
+    content: unknown;
+    timestampMs: number;
+};
+
+type AgentRunResult = {
+    response: string;
+    tokens: TokenCounts;
+    costUsd: number;
+    transcript: Turn[];
+};
+```
+
+---
+
+## 4. Backend architecture
+
+### 4.1 New module: `agentmux-srv/src/agents/`
+
+```
+agentmux-srv/src/agents/
+├── mod.rs              — pub re-exports
+├── types.rs            — AgentRef, AgentTask, AgentEvent, etc. (§3.1)
+├── runner.rs           — run_agent() unified entry point
+└── translator/
+    ├── mod.rs          — Translator trait
+    ├── claude.rs       — Claude Code stream-json → AgentEvent
+    └── acp.rs          — ACP frame → AgentEvent (already exists in part as frontend providers/acp-translator.ts; backend-side mirror)
+```
+
+### 4.2 The unified runner
+
+```rust
+/// Spawns the agent subprocess (claude / aider / ACP-compatible)
+/// per the AgentRef, drains its stdout, translates frames into
+/// AgentEvent, broadcasts them on `tx`. Returns a handle whose
+/// `final_result` future resolves to AgentRunResult when Done fires.
+pub async fn run_agent(
+    agent_ref: AgentRef,
+    task: AgentTask,
+    tx: mpsc::UnboundedSender<AgentEvent>,
+) -> Result<AgentRunHandle, AgentError> {
+    // 1. Resolve identity_id → Identity bundle (creds, env-var injection)
+    // 2. Resolve memory_id → Memory bundle (system instructions, working files)
+    // 3. Resolve instance_name → existing AgentInstance row or allocate new
+    // 4. Build spawn env (AGENTMUX_AGENT_ID, identity vars, bashwrap WPS endpoint)
+    // 5. Spawn subprocess via the existing shell controller
+    // 6. Pipe stdout through Translator::translate() → AgentEvent
+    // 7. Forward each AgentEvent on `tx`
+    // 8. On Done: build AgentRunResult, fulfill the handle's final_result
+}
+
+pub struct AgentRunHandle {
+    pub instance_id: String,
+    pub final_result: oneshot::Receiver<Result<AgentRunResult, String>>,
+}
+```
+
+### 4.3 Agent pane integration
+
+The current agent pane code in `agentmux-srv/src/backend/blockcontroller/shell.rs` is the spawn path. The refactor:
+
+- **Today**: shell controller spawns claude, parses stream-json via `ClaudeHistoryAdapter` in `agentmux-srv/src/backend/history/claude_adapter.rs`, persists turns into `db_messages`.
+- **After Phase 1.5**: shell controller calls `run_agent(agent_ref, task, tx)` where the tx is a fan-out: one sink writes turns to `db_messages` (preserved), another forwards `AgentEvent`s to the frontend via the existing `agentmux-bashwrap` WPS endpoint (so the agent pane's tool-chunk reducer keeps working unchanged).
+
+This is a *refactor*, not a rewrite: the agent pane's user-visible behavior is identical, the underlying spawn just goes through the unified runner.
+
+### 4.4 Workflow Agent block integration
+
+`agentmux-srv/src/workflows/executor/blocks/agent.rs` today returns the stub. Replacement:
+
+```rust
+pub async fn run(node: &FlowNode, scope: &ExecutionScope) -> Result<Value, String> {
+    let agent_ref: AgentRef = serde_json::from_value(
+        node.data.get("agent_ref").cloned().unwrap_or_default()
+    ).map_err(|e| format!("agent block: invalid agent_ref: {e}"))?;
+
+    let task_template = node.data.get("task").and_then(|v| v.as_str())
+        .ok_or_else(|| "agent block missing `task`".to_string())?;
+    let task = AgentTask {
+        prompt: scope.resolve(task_template),
+        context: scope_to_context_map(scope),
+        max_turns: node.data.get("max_turns").and_then(|v| v.as_u64()).map(|n| n as u32),
+    };
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let handle = agents::runner::run_agent(agent_ref, task, tx).await
+        .map_err(|e| e.to_string())?;
+
+    // Drain events, forwarding to the run broker so the canvas can
+    // surface per-turn progress in the workflow Agent block's
+    // hover-expanded inspector (Phase 2 UI). Phase 1.5 just collects.
+    while let Some(_ev) = rx.recv().await {
+        // Phase 2: re-emit as workflowrun:<id> events
+    }
+
+    let result = handle.final_result.await
+        .map_err(|e| format!("agent runner cancelled: {e}"))?
+        .map_err(|e| format!("agent run failed: {e}"))?;
+
+    Ok(json!({
+        "response": result.response,
+        "tokens": result.tokens,
+        "cost_usd": result.cost_usd,
+    }))
+}
+```
+
+The downstream block reads `{{<agent_block_id>.response}}` for the text and `{{<agent_block_id>.cost_usd}}` for cost.
+
+---
+
+## 5. Frontend architecture
+
+### 5.1 Existing translator pattern stays
+
+`frontend/app/view/agent/providers/claude-translator.ts` and `acp-translator.ts` already translate provider frames → internal events. Phase 1.5 keeps this pattern, with one change: the internal event type becomes the shared `AgentEvent` (from §3.2) instead of an agent-pane-private union. Both providers' translators output `AgentEvent` now.
+
+### 5.2 New consumer: workflow Agent block inspector
+
+When a user selects an Agent block in the workflows canvas and the run is in progress, an inspector panel subscribes to `workflowrun:<id>` events and renders the live `AgentEvent` stream (hover-expand tool blocks, accumulated `AssistantText`, final `Cost`). This is a copy-and-evolve of the agent pane's renderer, *not* a fresh component — the goal is to reuse `agent-view.tsx` block components where possible.
+
+Phase 1.5 ships the type plumbing + a minimal "final result" inspector. Phase 2 polish PR brings the full hover-expand parity.
+
+### 5.3 Reducer integration
+
+The agent pane uses a tool-chunk reducer (`frontend/app/store/agent-pane-state/reducer.ts`). Per the master reducer-stack status, slice #9 (browser pane) just shipped the reducer-routed dispatch pattern. Phase 1.5 introduces a `workflow-run-state/` reducer slice (slice #10) over the per-run `AgentEvent` stream. Commands: `RunStarted | BlockStarted | AgentEvent({ runId, blockId, event }) | BlockDone | RunDone`. The current `workflows-model.ts` view model gets demoted to a thin wrapper that dispatches into the reducer.
+
+This closes the third drift item from the memory note: workflows graduates onto the reducer-stack convention.
+
+---
+
+## 6. Migration plan
+
+| Step | Branch / PR | Description |
+|------|------------|-------------|
+| 0 | `feat/workflows-phase-1-5/types` | Land §3 types + `agents::runner::run_agent` skeleton. Wire stub claude-code spawn so the runner is callable but blocking. **Zero behavior change** for the agent pane. |
+| 1 | `feat/workflows-phase-1-5/refactor-shell-controller` | Refactor `agentmux-srv/src/backend/blockcontroller/shell.rs` to call `run_agent` for claude/aider spawns. Stream output stays identical at the WPS endpoint. Tests verify byte-identical event sequences before/after. |
+| 2 | `feat/workflows-phase-1-5/wire-workflow-block` | Replace `workflows/executor/blocks/agent.rs` stub with the real runner call (§4.4). Drop the `"[stub]"` test. |
+| 3 | `feat/workflows-phase-1-5/inspector` | Frontend: workflow Agent block inspector subscribed to `workflowrun:<id>` showing final `AgentRunResult` post-completion. Hover-expand parity deferred to Phase 2 polish. |
+| 4 | `feat/workflows-phase-1-5/reducer-slice` | Slice #10 reducer for workflow run state. Closes the "workflows-model.ts is not a reducer" drift item. |
+
+PRs 0–4 each independently shippable; Phase 1.5 closes when all four land. Estimated 2 weeks if one engineer dedicates focus.
+
+---
+
+## 7. Acceptance criteria
+
+- [ ] `AgentRef`, `AgentTask`, `AgentEvent`, `AgentRunResult` live in `agentmux-srv/src/agents/types.rs` and mirror exactly in `frontend/types/gotypes.d.ts` (camelCase, `rename_all` confirmed).
+- [ ] `run_agent()` spawns Claude Code, drains stream-json, and emits the unified `AgentEvent` sequence. Backend test verifies a recorded transcript replays into a known event sequence.
+- [ ] Agent pane spawn path goes through `run_agent()` — verified by a parity test that captures the WPS event stream before and after the refactor and asserts byte-equality.
+- [ ] Workflow Agent block runs a real claude task, returns `{response, tokens, cost_usd}` to the next block. End-to-end test: `Variables → Agent → Response` chain with `{{<agent_block_id>.response}}` template.
+- [ ] Workflow inspector renders `AgentRunResult` post-completion (markdown response + final cost).
+- [ ] No regression on the agent pane's existing tool-chunk reducer tests.
+- [ ] `cargo check` clean; `tsc --noEmit` clean (frontend untouched by Rust changes).
+
+---
+
+## 8. Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Shell controller refactor breaks agent pane behavior in subtle ways | High | Parity test captures the WPS event byte stream before refactor and asserts byte-equality after. Land PR 1 behind a feature flag if the parity test surfaces ANY diff. |
+| `AgentEvent` design forces a future provider to fork the enum | Medium | Reserve a `Custom { kind: String, data: Value }` variant for provider-specific extensions. Don't ship it Phase 1.5 — but the enum is designed not to preclude it. |
+| Workflow Agent block run blocks the executor thread for long agents | Medium | Phase 1 executor is per-block sequential; long agents *will* block. The "live SSE wiring" Phase 2 polish moves this off the request thread. Phase 1.5 documents the limitation. |
+| Named-agent continuation collides with workflow runs (same `instance_name`, two callers) | Medium | Workflow Agent block requires a `workflow_run_id` suffix on `instance_name` when set, or the AgentInstance row is locked by the workflow run. Phase 1.5 spec: workflow runs allocate fresh `instance_name` unless the user explicitly opts into a named instance. |
+| The agent pane's existing claude_adapter.rs duplicates translator logic | Low | PR 1 deprecates `claude_adapter.rs` in favor of `agents::translator::claude`. Migration is mechanical; deprecation comment + removal in PR 2. |
+
+---
+
+## 9. References
+
+- RFC #753 (Workflows pane)
+- PR #755 (Workflows Phase 1 — supersedes this in code, supersedes by this in design)
+- PR #816 (named-agent continuation + v8 schema)
+- PR #746 (v7 schema: Forge → Identity + Memory)
+- PR #749 (Memory pane), #750 (Identity pane)
+- PR #804 (`agentmux-bashwrap` β.A), #809 (β.B wiring)
+- Existing memory: [`project_workflows_phase_1_5.md`](../../../../.claude/projects/C--Systems/memory/project_workflows_phase_1_5.md)
+- Master reducer status: `docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md`

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -4,7 +4,6 @@
 **Status:** Draft — lands after PR #755 (Workflows Phase 1) merges
 **Author:** AgentA
 **Issue:** RFC #753 (Workflows pane), follow-up to PR #755
-**Related memory:** [`project_workflows_phase_1_5.md`](../../../../.claude/projects/C--Systems/memory/project_workflows_phase_1_5.md)
 
 ---
 
@@ -359,5 +358,4 @@ PRs 0–4 each independently shippable; Phase 1.5 closes when all four land. Est
 - PR #746 (v7 schema: Forge → Identity + Memory)
 - PR #749 (Memory pane), #750 (Identity pane)
 - PR #804 (`agentmux-bashwrap` β.A), #809 (β.B wiring)
-- Existing memory: [`project_workflows_phase_1_5.md`](../../../../.claude/projects/C--Systems/memory/project_workflows_phase_1_5.md)
 - Master reducer status: `docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md`

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -309,15 +309,24 @@ pub async fn run(node: &FlowNode, scope: &ExecutionScope) -> Result<Value, Strin
         .map_err(|e| format!("agent run failed: {e}"))?;
 
     // NOTE: This output object is *manually constructed* to match the
-    // existing workflow block convention (snake_case keys, like API's
-    // `status`/`body`, Condition's `result`, Response's `value`).
-    // Do NOT use `serde_json::to_value(&result)` here — that would
-    // emit camelCase (`costUsd`) because AgentRunResult carries
-    // `#[serde(rename_all = "camelCase")]` for IPC consistency with
-    // the frontend, breaking `{{<block_id>.cost_usd}}` templates.
+    // existing workflow block convention (all snake_case keys, like
+    // API's `status`/`body`, Condition's `result`, Response's `value`).
+    // Do NOT use `serde_json::to_value(&result)` or embed
+    // `result.tokens` directly — both AgentRunResult and TokenCounts
+    // carry `#[serde(rename_all = "camelCase")]` for IPC consistency
+    // with the frontend, which would produce `costUsd` / `cacheCreation`
+    // and break `{{<block_id>.cost_usd}}` /
+    // `{{<block_id>.tokens.cache_creation}}` templates. Flatten the
+    // token fields explicitly so the workflow-template surface stays
+    // uniformly snake_case.
     Ok(json!({
         "response": result.response,
-        "tokens": result.tokens,
+        "tokens": {
+            "input": result.tokens.input,
+            "output": result.tokens.output,
+            "cache_creation": result.tokens.cache_creation,
+            "cache_read": result.tokens.cache_read,
+        },
         "cost_usd": result.cost_usd,
     }))
 }

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -80,7 +80,7 @@ pub struct AgentTask {
 /// pane (renders into the UI) and the workflow Agent block
 /// (accumulates until Done, returns AgentRunResult).
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case", rename_all_fields = "camelCase")]
 pub enum AgentEvent {
     /// Streaming text chunk from the assistant — agent pane appends
     /// to its visible transcript; workflow Agent block buffers.
@@ -210,13 +210,39 @@ agentmux-srv/src/agents/
     └── acp.rs          — ACP frame → AgentEvent (already exists in part as frontend providers/acp-translator.ts; backend-side mirror)
 ```
 
-### 4.2 The unified runner
+### 4.2 What's shared, and what isn't
+
+An audit of the existing agent-pane code surfaced an important wrinkle: **the spawn function is NOT naturally shareable** between the two consumers.
+
+- The **agent pane** spawns `claude` as a long-lived PTY subprocess. User input flows into stdin, output streams forever, the session is multi-turn and interactive. There's no per-task lifecycle at the spawn level — `claude` itself owns the conversation.
+- The **workflow Agent block** is one-shot: send a task, drain events until `Done`, return `AgentRunResult` to the next block. No PTY, no stdin, no multi-turn.
+
+What IS naturally shareable is the **translator + event shape**. Both consumers receive Claude's stream-json on stdout; both want it converted to `AgentEvent`s. The pane's read loop and the workflow runner are *different spawn drivers* feeding the *same translator* and emitting the *same event union*.
+
+```
+                            ┌─→ AssistantText / ToolUse / ToolResult / Cost / Done
+ClaudeTranslator (shared) ──┤
+                            ↑
+        stream-json lines from claude stdout
+                            ↑
+       ┌────────────────────┴────────────────────┐
+   Pane PTY read loop                       Workflow one-shot runner
+   (multi-turn, interactive,                (`run_agent` — single
+   user stdin via PTY,                       task, no PTY, headless)
+   long-lived session)
+```
+
+### 4.3 The one-shot runner (workflows only)
 
 ```rust
-/// Spawns the agent subprocess (claude / aider / ACP-compatible)
-/// per the AgentRef, drains its stdout, translates frames into
-/// AgentEvent, broadcasts them on `tx`. Returns a handle whose
-/// `final_result` future resolves to AgentRunResult when Done fires.
+/// Spawn `claude` as a non-interactive one-shot for the workflow
+/// Agent block: prompt → drain stream-json → emit AgentEvents →
+/// resolve `final_result` with AgentRunResult on Done. Headless;
+/// no PTY, no stdin pipe back to the user.
+///
+/// The agent pane does NOT use this — it has its own multi-turn
+/// PTY-driven spawn in `blockcontroller/shell.rs` which shares only
+/// the translator.
 pub async fn run_agent(
     agent_ref: AgentRef,
     task: AgentTask,
@@ -224,12 +250,13 @@ pub async fn run_agent(
 ) -> Result<AgentRunHandle, AgentError> {
     // 1. Resolve identity_id → Identity bundle (creds, env-var injection)
     // 2. Resolve memory_id → Memory bundle (system instructions, working files)
-    // 3. Resolve instance_name → existing AgentInstance row or allocate new
-    // 4. Build spawn env (AGENTMUX_AGENT_ID, identity vars, bashwrap WPS endpoint)
-    // 5. Spawn subprocess via the existing shell controller
-    // 6. Pipe stdout through Translator::translate() → AgentEvent
-    // 7. Forward each AgentEvent on `tx`
-    // 8. On Done: build AgentRunResult, fulfill the handle's final_result
+    // 3. Allocate working directory (no continuation — workflows always
+    //    spawn fresh AgentInstance rows for audit clarity)
+    // 4. Spawn `claude --print --output-format=stream-json` with prompt
+    //    on argv, capturing stdout
+    // 5. Pipe stdout lines through ClaudeTranslator → AgentEvent
+    // 6. Forward each AgentEvent on `tx`
+    // 7. On Done: build AgentRunResult, fulfill the handle's final_result
 }
 
 pub struct AgentRunHandle {
@@ -238,14 +265,14 @@ pub struct AgentRunHandle {
 }
 ```
 
-### 4.3 Agent pane integration
+### 4.4 Agent pane integration
 
-The current agent pane code in `agentmux-srv/src/backend/blockcontroller/shell.rs` is the spawn path. The refactor:
+The agent pane code in `agentmux-srv/src/backend/blockcontroller/shell.rs` keeps its PTY model — that's what enables interactive multi-turn use. What changes is **how the read loop interprets stdout**:
 
-- **Today**: shell controller spawns claude, parses stream-json via `ClaudeHistoryAdapter` in `agentmux-srv/src/backend/history/claude_adapter.rs`, persists turns into `db_messages`.
-- **After Phase 1.5**: shell controller calls `run_agent(agent_ref, task, tx)` where the tx is a fan-out: one sink writes turns to `db_messages` (preserved), another forwards `AgentEvent`s to the frontend via the existing `agentmux-bashwrap` WPS endpoint (so the agent pane's tool-chunk reducer keeps working unchanged).
+- **Today**: read loop drains PTY stdout in 4 KB chunks, publishes each chunk to WPS as `EVENT_BLOCK_FILE` (raw terminal data, the pane renders it as a terminal).
+- **After Phase 1.5**: read loop additionally line-buffers stdout, feeds each parsed JSON line through `ClaudeTranslator`, and emits the resulting `AgentEvent`s on a second channel alongside the existing raw-chunk publish. The raw-chunk path stays byte-equal so the pane's tool-chunk reducer keeps working unchanged.
 
-This is a *refactor*, not a rewrite: the agent pane's user-visible behavior is identical, the underlying spawn just goes through the unified runner.
+This is an **additive** change — zero risk of breaking the pane's existing behavior. The new `AgentEvent` stream becomes available for the in-pane Identity/Memory cog tabs, future per-turn audit views, etc.
 
 ### 4.4 Workflow Agent block integration
 
@@ -314,27 +341,30 @@ This closes the third drift item from the memory note: workflows graduates onto 
 
 ## 6. Migration plan
 
+The plan was revised after the §4.2 audit: PR 1 no longer refactors the pane's spawn function (it doesn't fit). Instead, the pane keeps its PTY model and gains parallel `AgentEvent` emission via the shared translator.
+
 | Step | Branch / PR | Description |
 |------|------------|-------------|
-| 0 | `feat/workflows-phase-1-5/types` | Land §3 types + `agents::runner::run_agent` skeleton. Wire stub claude-code spawn so the runner is callable but blocking. **Zero behavior change** for the agent pane. |
-| 1 | `feat/workflows-phase-1-5/refactor-shell-controller` | Refactor `agentmux-srv/src/backend/blockcontroller/shell.rs` to call `run_agent` for claude/aider spawns. Stream output stays identical at the WPS endpoint. Tests verify byte-identical event sequences before/after. |
-| 2 | `feat/workflows-phase-1-5/wire-workflow-block` | Replace `workflows/executor/blocks/agent.rs` stub with the real runner call (§4.4). Drop the `"[stub]"` test. |
-| 3 | `feat/workflows-phase-1-5/inspector` | Frontend: workflow Agent block inspector subscribed to `workflowrun:<id>` showing final `AgentRunResult` post-completion. Hover-expand parity deferred to Phase 2 polish. |
-| 4 | `feat/workflows-phase-1-5/reducer-slice` | Slice #10 reducer for workflow run state. Closes the "workflows-model.ts is not a reducer" drift item. |
+| 0 | `agenta/workflows-phase-1-5-types` (#831) | Land §3 types + `agents::runner::run_agent` skeleton (`NotImplemented`) + `ClaudeTranslator` skeleton. **Zero behavior change** anywhere. |
+| 1 | `feat/workflows-phase-1-5-translator` | Implement `ClaudeTranslator::translate()` for the full stream-json frame set. Wire it into `shell.rs`'s read loop *additively*: existing raw-chunk WPS publish stays byte-equal, new `AgentEvent` stream emits in parallel on a second channel. Golden-file tests over recorded stream-json sessions verify the translation. |
+| 2 | `feat/workflows-phase-1-5-runner` | Implement `run_agent()` as a one-shot headless spawn (`claude --print --output-format=stream-json` style). Replace `workflows/executor/blocks/agent.rs` stub with a `run_agent` call. End-to-end test: `Variables → Agent → Response` chain. |
+| 3 | `feat/workflows-phase-1-5-inspector` | Frontend: workflow Agent block inspector subscribed to `workflowrun:<id>` showing final `AgentRunResult` post-completion. Hover-expand parity deferred to Phase 2 polish. Closes issue #830. |
+| 4 | `feat/workflows-phase-1-5-reducer-slice` | Slice #10 reducer for workflow run state. Closes the "workflows-model.ts is not a reducer" drift item. |
 
-PRs 0–4 each independently shippable; Phase 1.5 closes when all four land. Estimated 2 weeks if one engineer dedicates focus.
+PRs 0–4 each independently shippable. The pane's PTY behavior is untouched throughout; the byte-equal WPS path is preserved across all four PRs.
 
 ---
 
 ## 7. Acceptance criteria
 
-- [ ] `AgentRef`, `AgentTask`, `AgentEvent`, `AgentRunResult` live in `agentmux-srv/src/agents/types.rs` and mirror exactly in `frontend/types/gotypes.d.ts` (camelCase, `rename_all` confirmed).
-- [ ] `run_agent()` spawns Claude Code, drains stream-json, and emits the unified `AgentEvent` sequence. Backend test verifies a recorded transcript replays into a known event sequence.
-- [ ] Agent pane spawn path goes through `run_agent()` — verified by a parity test that captures the WPS event stream before and after the refactor and asserts byte-equality.
+- [ ] `AgentRef`, `AgentTask`, `AgentEvent`, `AgentRunResult`, `AgentTurn`, `TokenCounts` live in `agentmux-srv/src/agents/types.rs` and mirror exactly in `frontend/types/gotypes.d.ts` (camelCase via `serde(rename_all)` + `rename_all_fields`).
+- [ ] `ClaudeTranslator::translate()` converts the full stream-json frame set to `AgentEvent`s. Golden-file tests over recorded sessions verify the translation byte-for-byte.
+- [ ] Agent pane's `shell.rs` read loop emits `AgentEvent`s in parallel with its existing raw-chunk WPS publish. Byte-equal parity test on the raw-chunk path confirms zero regression on the pane.
+- [ ] `run_agent()` spawns `claude --print --output-format=stream-json`, drains the line stream through `ClaudeTranslator`, emits `AgentEvent`s, resolves `AgentRunResult` on `Done`.
 - [ ] Workflow Agent block runs a real claude task, returns `{response, tokens, cost_usd}` to the next block. End-to-end test: `Variables → Agent → Response` chain with `{{<agent_block_id>.response}}` template.
 - [ ] Workflow inspector renders `AgentRunResult` post-completion (markdown response + final cost).
 - [ ] No regression on the agent pane's existing tool-chunk reducer tests.
-- [ ] `cargo check` clean; `tsc --noEmit` clean (frontend untouched by Rust changes).
+- [ ] `cargo check` clean; `tsc --noEmit` clean.
 
 ---
 
@@ -342,11 +372,12 @@ PRs 0–4 each independently shippable; Phase 1.5 closes when all four land. Est
 
 | Risk | Severity | Mitigation |
 |------|----------|------------|
-| Shell controller refactor breaks agent pane behavior in subtle ways | High | Parity test captures the WPS event byte stream before refactor and asserts byte-equality after. Land PR 1 behind a feature flag if the parity test surfaces ANY diff. |
+| Pane's additive `AgentEvent` emission breaks existing behavior in subtle ways | Medium | The translator's output goes to a *new* channel, separate from the existing WPS raw-chunk path. Byte-equal parity test on the raw-chunk path is the gate before merge. |
+| `ClaudeTranslator` misinterprets a stream-json frame variant we haven't seen | Medium | Golden-file tests use real recorded sessions (long agent runs with tool use, errors, cancellations). Unknown frames return empty `Vec<AgentEvent>` rather than panic — the pane's raw-chunk path still publishes the underlying text. |
 | `AgentEvent` design forces a future provider to fork the enum | Medium | Reserve a `Custom { kind: String, data: Value }` variant for provider-specific extensions. Don't ship it Phase 1.5 — but the enum is designed not to preclude it. |
-| Workflow Agent block run blocks the executor thread for long agents | Medium | Phase 1 executor is per-block sequential; long agents *will* block. The "live SSE wiring" Phase 2 polish moves this off the request thread. Phase 1.5 documents the limitation. |
-| Named-agent continuation collides with workflow runs (same `instance_name`, two callers) | Medium | Workflow Agent block requires a `workflow_run_id` suffix on `instance_name` when set, or the AgentInstance row is locked by the workflow run. Phase 1.5 spec: workflow runs allocate fresh `instance_name` unless the user explicitly opts into a named instance. |
-| The agent pane's existing claude_adapter.rs duplicates translator logic | Low | PR 1 deprecates `claude_adapter.rs` in favor of `agents::translator::claude`. Migration is mechanical; deprecation comment + removal in PR 2. |
+| Workflow Agent block run blocks the executor thread for long agents | Medium | Phase 1 executor is per-block sequential; long agents *will* block. Phase 2 moves this off the request thread. Phase 1.5 documents the limitation. |
+| Workflow `run_agent` spawn collides with named-agent continuation | Low | Workflow runs always allocate fresh `instance_name` (never reuse). The named-agent continuation path stays exclusive to the pane. |
+| `claude_adapter.rs` (history file parser) duplicates translator logic | Low | The history parser stays — it operates on JSONL files for past-session browsing, not the live stream. Different lifetime, different inputs, no consolidation needed. |
 
 ---
 

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -96,6 +96,7 @@ pub enum AgentEvent {
     ToolResult {
         tool_use_id: String,
         output: serde_json::Value,
+        #[serde(default)]
         is_error: bool,
     },
     /// Final cost + token accounting. Emitted once per run.

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -274,7 +274,7 @@ The agent pane code in `agentmux-srv/src/backend/blockcontroller/shell.rs` keeps
 
 This is an **additive** change — zero risk of breaking the pane's existing behavior. The new `AgentEvent` stream becomes available for the in-pane Identity/Memory cog tabs, future per-turn audit views, etc.
 
-### 4.4 Workflow Agent block integration
+### 4.5 Workflow Agent block integration
 
 `agentmux-srv/src/workflows/executor/blocks/agent.rs` today returns the stub. Replacement:
 
@@ -307,6 +307,13 @@ pub async fn run(node: &FlowNode, scope: &ExecutionScope) -> Result<Value, Strin
         .map_err(|e| format!("agent runner cancelled: {e}"))?
         .map_err(|e| format!("agent run failed: {e}"))?;
 
+    // NOTE: This output object is *manually constructed* to match the
+    // existing workflow block convention (snake_case keys, like API's
+    // `status`/`body`, Condition's `result`, Response's `value`).
+    // Do NOT use `serde_json::to_value(&result)` here — that would
+    // emit camelCase (`costUsd`) because AgentRunResult carries
+    // `#[serde(rename_all = "camelCase")]` for IPC consistency with
+    // the frontend, breaking `{{<block_id>.cost_usd}}` templates.
     Ok(json!({
         "response": result.response,
         "tokens": result.tokens,

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -433,8 +433,7 @@ declare global {
     };
 
     type AgentTurn = {
-        /** "user" | "assistant" | "tool_result" */
-        role: string;
+        role: "user" | "assistant" | "tool_result";
         content: unknown;
         timestampMs: number;
     };

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -403,6 +403,57 @@ declare global {
         display_hidden?: boolean;
     };
 
+    // ────────────────────────────────────────────────────────────────
+    // Unified agent types (Workflows Phase 1.5, see
+    // docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md). Shared
+    // between the agent pane and the workflow Agent block. Mirror
+    // of agentmux-srv/src/agents/types.rs — camelCase via serde
+    // rename_all so the field shapes match without translation.
+    // ────────────────────────────────────────────────────────────────
+
+    /** Identifies "which agent" — same shape for launch modal + workflow Agent block. */
+    type AgentRef = {
+        identityId?: string;
+        memoryId?: string;
+        instanceName?: string;
+        workingDirectory?: string;
+    };
+
+    type AgentTask = {
+        prompt: string;
+        context?: Record<string, unknown>;
+        maxTurns?: number;
+    };
+
+    type TokenCounts = {
+        input: number;
+        output: number;
+        cacheCreation: number;
+        cacheRead: number;
+    };
+
+    type AgentTurn = {
+        /** "user" | "assistant" | "tool_result" */
+        role: string;
+        content: unknown;
+        timestampMs: number;
+    };
+
+    type AgentEvent =
+        | { type: "assistant_text"; delta: string }
+        | { type: "tool_use"; toolUseId: string; tool: string; input: unknown }
+        | { type: "tool_result"; toolUseId: string; output: unknown; isError?: boolean }
+        | { type: "cost"; costUsd: number; tokens: TokenCounts }
+        | { type: "done"; response: string; transcript: AgentTurn[] }
+        | { type: "error"; message: string };
+
+    type AgentRunResult = {
+        response: string;
+        tokens: TokenCounts;
+        costUsd: number;
+        transcript: AgentTurn[];
+    };
+
     /** v8 — one row of the launch modal's "Continue agent" dropdown.
      * Server-side join across instance + definition + bundle tables. */
     type NamedAgentRow = {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -442,7 +442,7 @@ declare global {
     type AgentEvent =
         | { type: "assistant_text"; delta: string }
         | { type: "tool_use"; toolUseId: string; tool: string; input: unknown }
-        | { type: "tool_result"; toolUseId: string; output: unknown; isError?: boolean }
+        | { type: "tool_result"; toolUseId: string; output: unknown; isError: boolean }
         | { type: "cost"; costUsd: number; tokens: TokenCounts }
         | { type: "done"; response: string; transcript: AgentTurn[] }
         | { type: "error"; message: string };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.848",
+  "version": "0.33.849",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.848",
+      "version": "0.33.849",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.845",
+  "version": "0.33.846",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.845",
+      "version": "0.33.846",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.849",
+  "version": "0.33.850",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.849",
+      "version": "0.33.850",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.850",
+  "version": "0.33.851",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.850",
+      "version": "0.33.851",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.847",
+  "version": "0.33.848",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.847",
+      "version": "0.33.848",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.846",
+  "version": "0.33.847",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.846",
+      "version": "0.33.847",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.851",
+  "version": "0.33.852",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.851",
+      "version": "0.33.852",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.851",
+  "version": "0.33.852",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.849",
+  "version": "0.33.850",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.848",
+  "version": "0.33.849",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.847",
+  "version": "0.33.848",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.850",
+  "version": "0.33.851",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.846",
+  "version": "0.33.847",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.845",
+  "version": "0.33.846",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
First PR in the Workflows Phase 1.5 migration plan. See [`docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md`](docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md) for the full design.

**Zero behavior change**: the agent pane and the (stub) workflow Agent block still take their existing code paths. This PR lands the *seam* — shared types + runner module surface — that PRs 1-4 fill in.

## Why

PR #755 shipped the workflow Agent block as a stub. RFC #753 specced it to reference a `forge_agent_id`, but Forge was renamed to Identity + Memory bundles (#746), v8 added named-agent continuation (#816), and the agent pane already has the full pipeline (identity injection, memory binding, tool-chunk streaming via bashwrap + WPS, cost capture).

A workflow Agent block should be a **headless invocation of the same controller**, not a parallel implementation. This PR sets up that seam.

## What ships

### Backend — new module `agentmux-srv/src/agents/`

- **`types.rs`** — `AgentRef` (which agent: identity / memory / instance_name / working_directory), `AgentTask` (prompt + context map + max_turns), `AgentEvent` (discriminated streaming union: `assistant_text` / `tool_use` / `tool_result` / `cost` / `done` / `error`), `TokenCounts`, `Turn`, `AgentRunResult`.
- **`runner.rs`** — `run_agent()` entry point + `AgentRunHandle` + `AgentError`. Returns `NotImplemented` in PR 0 so premature callers fail loudly. PR 1 wires the actual spawn pipeline.
- **`translator/mod.rs`** — `Translator` trait.
- **`translator/claude.rs`** — Claude Code stream-json skeleton (PR 1 supersedes the existing `backend/history/claude_adapter.rs`).

### Wire format

`#[serde(rename_all = "camelCase")]` on every struct + `rename_all_fields = "camelCase"` on `AgentEvent` so the discriminated union's per-variant fields are camelCase too (snake_case for the `type` tag). **7 wire-format tests** verify the exact JSON shapes.

### Frontend

TS mirror in `frontend/types/gotypes.d.ts` matches the Rust shapes — no translation at the IPC seam.

### Spec doc

`docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` lands alongside per the "specs ride with code PRs" rule. Covers §1 motivation (drift items since RFC #753), §3 type definitions, §4 backend architecture, §5 frontend, §6 5-PR migration plan, §7 acceptance criteria, §8 risks.

## What's NOT changed

- `backend/blockcontroller/shell.rs` (agent pane spawn) — refactor is **PR 1** (`/refactor-shell-controller`).
- `workflows/executor/blocks/agent.rs` (workflow stub) — replacement is **PR 2** (`/wire-workflow-block`).
- Frontend reducer slice #10 — **PR 4** (`/reducer-slice`).
- Workflow Agent block inspector — **PR 3** (`/inspector`).

Each subsequent PR is independently shippable.

## Test plan

- [x] `cargo test -p agentmux-srv agents` — 14 tests pass (types roundtrip, wire format, runner stub returns `NotImplemented`)
- [x] `npx tsc --noEmit` — clean for the new TS types
- [x] `cargo build -p agentmux-srv` — clean (warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)