### PR TITLE
feat(agents): ClaudeTranslator implementation (Workflows Phase 1.5 PR 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.854"
+version = "0.33.855"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.854"
+version = "0.33.855"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.854"
+version = "0.33.855"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.854"
+version = "0.33.855"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.854"
+version = "0.33.855"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.855"
+version = "0.33.856"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.855"
+version = "0.33.856"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.855"
+version = "0.33.856"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.855"
+version = "0.33.856"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.855"
+version = "0.33.856"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.853"
+version = "0.33.854"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.853"
+version = "0.33.854"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.853"
+version = "0.33.854"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.853"
+version = "0.33.854"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.853"
+version = "0.33.854"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.852"
+version = "0.33.853"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.852"
+version = "0.33.853"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.852"
+version = "0.33.853"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.852"
+version = "0.33.853"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.852"
+version = "0.33.853"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.852"
+version = "0.33.853"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.854"
+version = "0.33.855"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.855"
+version = "0.33.856"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.853"
+version = "0.33.854"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.853"
+version = "0.33.854"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.852"
+version = "0.33.853"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.855"
+version = "0.33.856"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.854"
+version = "0.33.855"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.854"
+version = "0.33.855"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.855"
+version = "0.33.856"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.853"
+version = "0.33.854"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.852"
+version = "0.33.853"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.853"
+version = "0.33.854"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.852"
+version = "0.33.853"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.855"
+version = "0.33.856"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.854"
+version = "0.33.855"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.855"
+version = "0.33.856"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.853"
+version = "0.33.854"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.854"
+version = "0.33.855"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.852"
+version = "0.33.853"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -3,49 +3,254 @@
 
 //! Claude Code stream-json → `AgentEvent` translator.
 //!
-//! Claude Code emits one JSON object per line. Top-level shape:
+//! Mirrors the frontend reference implementation at
+//! `frontend/app/view/agent/providers/claude-translator.ts` so the
+//! workflow Agent block can consume the same stream without
+//! round-tripping through the renderer. Handled frames:
 //!
-//!   ```json
-//!   {"type":"stream_event","event":{...}}
-//!   {"type":"message_start","message":{...}}
-//!   {"type":"result","cost_usd":0.001,"usage":{...}}
-//!   ```
+//! - `stream_event.content_block_start.content_block.type=text` —
+//!   starts a text block; subsequent `text_delta`s belong to it.
+//! - `stream_event.content_block_start.content_block.type=tool_use` —
+//!   starts an in-flight tool_use; subsequent `input_json_delta`s
+//!   accumulate; `content_block_stop` emits the finalized
+//!   `AgentEvent::ToolUse`.
+//! - `stream_event.content_block_delta.delta.type=text_delta` —
+//!   `AgentEvent::AssistantText` (also accumulated into the final
+//!   response).
+//! - `stream_event.content_block_delta.delta.type=input_json_delta` —
+//!   appends to the pending tool_use's partial_json.
+//! - `stream_event.content_block_stop` — flushes the pending
+//!   tool_use.
+//! - `user.message.content[].type=tool_result` — emits
+//!   `AgentEvent::ToolResult`.
+//! - `result.cost_usd` + `result.usage` — emits
+//!   `AgentEvent::Cost` followed by `AgentEvent::Done`. The Done's
+//!   `response` is the explicit `result.result` field if present,
+//!   otherwise the accumulated text from streamed text_deltas.
 //!
-//! The frontend has the reference implementation at
-//! `frontend/app/view/agent/providers/claude-translator.ts`. This
-//! module mirrors its logic on the backend so the workflow Agent
-//! block can consume the same stream without round-tripping through
-//! the frontend.
+//! Unknown frame types and malformed shapes produce an empty `Vec`
+//! rather than panicking — the runner falls back to whatever the
+//! parallel raw-byte WPS path published, so an unfamiliar frame
+//! degrades gracefully.
 //!
-//! PR 0 ships the SKELETON only — `translate()` accepts a frame but
-//! returns an empty `Vec`. PR 1 fills in the logic and replaces
-//! `agentmux-srv/src/backend/history/claude_adapter.rs` (which
-//! currently has the only backend-side parsing).
+//! `thinking_delta` and `message_delta` / `message_stop` are
+//! discarded (the agent pane filters them too).
 
-use serde_json::Value;
+use std::collections::HashMap;
 
-use super::super::types::AgentEvent;
+use serde_json::{Map, Value};
+
+use super::super::types::{AgentEvent, AgentTurn, TokenCounts};
 use super::Translator;
 
 #[derive(Debug, Default)]
 pub struct ClaudeTranslator {
-    /// Running buffer for partial events that span multiple frames.
-    /// Reserved for PR 1 wiring; not used in PR 0.
-    _buffer: Vec<u8>,
+    /// In-flight tool_use between `content_block_start` (type=tool_use)
+    /// and `content_block_stop`. Cleared on stop.
+    pending_tool: Option<PendingToolUse>,
+    /// Map from `tool_use_id` to its tool name, populated when a
+    /// tool_use lands so a later `tool_result` can carry the name
+    /// for renderers. Phase 1.5 doesn't surface tool name on the
+    /// `ToolResult` event (the id is enough for downstream matching),
+    /// but the map is kept for future use.
+    #[allow(dead_code)]
+    tool_names: HashMap<String, String>,
+    /// Streamed text accumulated since the last assistant turn, used
+    /// as the `Done.response` if the `result` frame has no explicit
+    /// `result` text field.
+    accumulated_response: String,
+    /// Per-turn transcript built up as `assistant` / `user` frames land.
+    transcript: Vec<AgentTurn>,
+}
+
+#[derive(Debug)]
+struct PendingToolUse {
+    id: String,
+    name: String,
+    partial_json: String,
 }
 
 impl ClaudeTranslator {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Reset all in-flight state. Intended for re-use of the same
+    /// translator across distinct runs (rare; usually each run gets
+    /// a fresh translator).
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
 }
 
 impl Translator for ClaudeTranslator {
-    fn translate(&mut self, _frame: Value) -> Vec<AgentEvent> {
-        // PR 1 lands the translation logic. The skeleton keeps the
-        // surface area visible so PR 1 is a focused fill-in.
-        Vec::new()
+    fn translate(&mut self, frame: Value) -> Vec<AgentEvent> {
+        let mut out = Vec::new();
+        let Some(frame_type) = frame.get("type").and_then(|v| v.as_str()) else {
+            return out;
+        };
+        match frame_type {
+            "stream_event" => handle_stream_event(self, &frame, &mut out),
+            "user" => handle_user_message(self, &frame, &mut out),
+            "assistant" => handle_assistant_message(self, &frame, &mut out),
+            "result" => handle_result(self, &frame, &mut out),
+            _ => {}
+        }
+        out
     }
+}
+
+fn handle_stream_event(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEvent>) {
+    let Some(event) = frame.get("event") else {
+        return;
+    };
+    let Some(ev_type) = event.get("type").and_then(|v| v.as_str()) else {
+        return;
+    };
+    match ev_type {
+        "content_block_start" => {
+            let Some(block) = event.get("content_block") else {
+                return;
+            };
+            if block.get("type").and_then(|v| v.as_str()) == Some("tool_use") {
+                let id = block.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                let name = block.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                t.tool_names.insert(id.clone(), name.clone());
+                t.pending_tool = Some(PendingToolUse {
+                    id,
+                    name,
+                    partial_json: String::new(),
+                });
+            }
+        }
+        "content_block_delta" => {
+            let Some(delta) = event.get("delta") else {
+                return;
+            };
+            match delta.get("type").and_then(|v| v.as_str()) {
+                Some("text_delta") => {
+                    if let Some(text) = delta.get("text").and_then(|v| v.as_str()) {
+                        t.accumulated_response.push_str(text);
+                        out.push(AgentEvent::AssistantText {
+                            delta: text.to_string(),
+                        });
+                    }
+                }
+                Some("input_json_delta") => {
+                    if let (Some(pending), Some(partial)) =
+                        (&mut t.pending_tool, delta.get("partial_json").and_then(|v| v.as_str()))
+                    {
+                        pending.partial_json.push_str(partial);
+                    }
+                }
+                _ => {} // thinking_delta and other variants — discard
+            }
+        }
+        "content_block_stop" => {
+            if let Some(pending) = t.pending_tool.take() {
+                // Parse accumulated JSON; on failure, emit the raw
+                // string so downstream sees SOMETHING rather than
+                // silently dropping the call.
+                let input: Value = serde_json::from_str(&pending.partial_json)
+                    .unwrap_or(Value::String(pending.partial_json));
+                out.push(AgentEvent::ToolUse {
+                    tool_use_id: pending.id,
+                    tool: pending.name,
+                    input,
+                });
+            }
+        }
+        _ => {} // message_start, message_delta, message_stop — discard
+    }
+}
+
+fn handle_user_message(_t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEvent>) {
+    let Some(content) = frame
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    else {
+        return;
+    };
+    for block in content {
+        if block.get("type").and_then(|v| v.as_str()) != Some("tool_result") {
+            continue;
+        }
+        let tool_use_id = block
+            .get("tool_use_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        // `content` on a tool_result may be a string or an array of
+        // content parts — preserve whichever shape arrived.
+        let output = block.get("content").cloned().unwrap_or(Value::Null);
+        let is_error = block
+            .get("is_error")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        out.push(AgentEvent::ToolResult {
+            tool_use_id,
+            output,
+            is_error,
+        });
+    }
+}
+
+fn handle_assistant_message(t: &mut ClaudeTranslator, frame: &Value, _out: &mut Vec<AgentEvent>) {
+    // Record the turn into the transcript — used as part of `Done`.
+    // Don't emit per-block events here; the streaming path already
+    // emitted them via stream_event deltas.
+    let Some(message) = frame.get("message") else {
+        return;
+    };
+    let content = message.get("content").cloned().unwrap_or(Value::Null);
+    t.transcript.push(AgentTurn {
+        role: "assistant".to_string(),
+        content,
+        timestamp_ms: now_ms(),
+    });
+}
+
+fn handle_result(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEvent>) {
+    let cost_usd = frame
+        .get("cost_usd")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let tokens = parse_usage(frame.get("usage"));
+    out.push(AgentEvent::Cost { cost_usd, tokens });
+
+    let response = frame
+        .get("result")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| std::mem::take(&mut t.accumulated_response));
+    let transcript = std::mem::take(&mut t.transcript);
+    out.push(AgentEvent::Done {
+        response,
+        transcript,
+    });
+}
+
+fn parse_usage(usage: Option<&Value>) -> TokenCounts {
+    let Some(usage) = usage.and_then(|v| v.as_object()) else {
+        return TokenCounts::default();
+    };
+    let take = |m: &Map<String, Value>, k: &str| -> u64 {
+        m.get(k).and_then(|v| v.as_u64()).unwrap_or(0)
+    };
+    TokenCounts {
+        input: take(usage, "input_tokens"),
+        output: take(usage, "output_tokens"),
+        cache_creation: take(usage, "cache_creation_input_tokens"),
+        cache_read: take(usage, "cache_read_input_tokens"),
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -53,13 +258,252 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn text_delta(text: &str) -> Value {
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": { "type": "text_delta", "text": text }
+            }
+        })
+    }
+
+    fn tool_use_start(id: &str, name: &str) -> Value {
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_start",
+                "content_block": { "type": "tool_use", "id": id, "name": name }
+            }
+        })
+    }
+
+    fn input_json_delta(partial: &str) -> Value {
+        json!({
+            "type": "stream_event",
+            "event": {
+                "type": "content_block_delta",
+                "delta": { "type": "input_json_delta", "partial_json": partial }
+            }
+        })
+    }
+
+    fn content_block_stop() -> Value {
+        json!({
+            "type": "stream_event",
+            "event": { "type": "content_block_stop" }
+        })
+    }
+
     #[test]
-    fn skeleton_returns_empty_for_any_frame() {
-        // Regression guard — PR 1 replaces this with shape-specific
-        // tests. Until then, any caller of `translate` gets an empty
-        // event list, signalling "skeleton — needs implementation".
+    fn text_delta_emits_assistant_text() {
+        let mut t = ClaudeTranslator::new();
+        let events = t.translate(text_delta("hello"));
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::AssistantText { delta } => assert_eq!(delta, "hello"),
+            other => panic!("expected AssistantText, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn streaming_text_accumulates_for_done_response() {
+        // No explicit `result.result` — `Done.response` should be the
+        // concatenation of streamed text_deltas.
+        let mut t = ClaudeTranslator::new();
+        t.translate(text_delta("Hello "));
+        t.translate(text_delta("world"));
+        let events = t.translate(json!({ "type": "result", "cost_usd": 0.01 }));
+        // Expect Cost + Done
+        assert_eq!(events.len(), 2);
+        match &events[1] {
+            AgentEvent::Done { response, .. } => assert_eq!(response, "Hello world"),
+            other => panic!("expected Done with accumulated text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_use_emits_only_on_content_block_stop() {
+        let mut t = ClaudeTranslator::new();
+        // Start doesn't emit yet.
+        assert!(t.translate(tool_use_start("t1", "Bash")).is_empty());
+        // Delta accumulates, doesn't emit.
+        assert!(t.translate(input_json_delta(r#"{"command":"#)).is_empty());
+        assert!(t.translate(input_json_delta(r#""ls"}"#)).is_empty());
+        // Stop flushes.
+        let events = t.translate(content_block_stop());
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolUse {
+                tool_use_id,
+                tool,
+                input,
+            } => {
+                assert_eq!(tool_use_id, "t1");
+                assert_eq!(tool, "Bash");
+                assert_eq!(input, &json!({ "command": "ls" }));
+            }
+            other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn malformed_tool_input_falls_back_to_raw_string() {
+        let mut t = ClaudeTranslator::new();
+        t.translate(tool_use_start("t1", "Edit"));
+        t.translate(input_json_delta(r#"{"this is bad json"#));
+        let events = t.translate(content_block_stop());
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolUse { input, .. } => {
+                // Falls back to the partial string so the
+                // downstream consumer sees SOMETHING.
+                assert_eq!(input, &json!(r#"{"this is bad json"#));
+            }
+            other => panic!("expected ToolUse fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn user_tool_result_emits_event() {
+        let mut t = ClaudeTranslator::new();
+        let events = t.translate(json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "t3",
+                    "content": "command output here",
+                    "is_error": false
+                }]
+            }
+        }));
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolResult {
+                tool_use_id,
+                output,
+                is_error,
+            } => {
+                assert_eq!(tool_use_id, "t3");
+                assert_eq!(output, &json!("command output here"));
+                assert!(!is_error);
+            }
+            other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_result_is_error_propagates() {
+        let mut t = ClaudeTranslator::new();
+        let events = t.translate(json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "t4",
+                    "content": "permission denied",
+                    "is_error": true
+                }]
+            }
+        }));
+        match &events[0] {
+            AgentEvent::ToolResult { is_error, .. } => assert!(is_error),
+            other => panic!("expected ToolResult with is_error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn result_emits_cost_then_done_with_explicit_response() {
+        let mut t = ClaudeTranslator::new();
+        let events = t.translate(json!({
+            "type": "result",
+            "cost_usd": 0.0123,
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 200
+            },
+            "result": "final answer text"
+        }));
+        assert_eq!(events.len(), 2);
+        match &events[0] {
+            AgentEvent::Cost { cost_usd, tokens } => {
+                assert_eq!(*cost_usd, 0.0123);
+                assert_eq!(tokens.input, 100);
+                assert_eq!(tokens.output, 50);
+                assert_eq!(tokens.cache_creation, 0);
+                assert_eq!(tokens.cache_read, 200);
+            }
+            other => panic!("expected Cost first, got {other:?}"),
+        }
+        match &events[1] {
+            AgentEvent::Done { response, .. } => {
+                assert_eq!(response, "final answer text");
+            }
+            other => panic!("expected Done second, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn assistant_message_added_to_transcript() {
+        let mut t = ClaudeTranslator::new();
+        // Assistant frame produces NO events directly (the streaming
+        // path emits the per-block events); it contributes to the
+        // transcript captured at Done.
+        let events = t.translate(json!({
+            "type": "assistant",
+            "message": {
+                "content": [{ "type": "text", "text": "hello" }]
+            }
+        }));
+        assert!(events.is_empty());
+        // The transcript shows up on Done.
+        let done = t.translate(json!({ "type": "result", "cost_usd": 0.0 }));
+        match &done[1] {
+            AgentEvent::Done { transcript, .. } => {
+                assert_eq!(transcript.len(), 1);
+                assert_eq!(transcript[0].role, "assistant");
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_frame_returns_empty() {
+        let mut t = ClaudeTranslator::new();
+        assert!(t.translate(json!({ "type": "system" })).is_empty());
+        assert!(t.translate(json!({ "type": "stream_event", "event": { "type": "message_stop" } })).is_empty());
+        assert!(t.translate(json!({ "type": "stream_event", "event": { "type": "message_delta" } })).is_empty());
+    }
+
+    #[test]
+    fn malformed_or_missing_type_returns_empty() {
         let mut t = ClaudeTranslator::new();
         assert!(t.translate(json!({})).is_empty());
-        assert!(t.translate(json!({ "type": "stream_event" })).is_empty());
+        assert!(t.translate(json!(null)).is_empty());
+        assert!(t.translate(json!("not an object")).is_empty());
+        assert!(t.translate(json!(42)).is_empty());
+    }
+
+    #[test]
+    fn reset_clears_in_flight_state() {
+        let mut t = ClaudeTranslator::new();
+        t.translate(tool_use_start("t5", "Edit"));
+        t.translate(input_json_delta(r#"{"x":1}"#));
+        t.translate(text_delta("partial response"));
+
+        t.reset();
+
+        // After reset, a content_block_stop should not emit because
+        // the pending_tool was cleared.
+        assert!(t.translate(content_block_stop()).is_empty());
+        // And the accumulated response is gone.
+        let done = t.translate(json!({ "type": "result", "cost_usd": 0.0 }));
+        match &done[1] {
+            AgentEvent::Done { response, .. } => assert_eq!(response, ""),
+            other => panic!("expected empty Done response, got {other:?}"),
+        }
     }
 }

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -164,7 +164,7 @@ fn handle_stream_event(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<Ag
     }
 }
 
-fn handle_user_message(_t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEvent>) {
+fn handle_user_message(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<AgentEvent>) {
     let Some(content) = frame
         .get("message")
         .and_then(|m| m.get("content"))
@@ -189,14 +189,37 @@ fn handle_user_message(_t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<A
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
         out.push(AgentEvent::ToolResult {
-            tool_use_id,
-            output,
+            tool_use_id: tool_use_id.clone(),
+            output: output.clone(),
             is_error,
+        });
+        // Also record the tool_result in the transcript so Done.transcript
+        // is the full ordered turn list (assistant turns + tool_result
+        // turns), not just the assistant side. Codex P2 on PR #833.
+        t.transcript.push(AgentTurn {
+            role: "tool_result".to_string(),
+            content: serde_json::json!({
+                "tool_use_id": tool_use_id,
+                "content": output,
+                "is_error": is_error,
+            }),
+            timestamp_ms: now_ms(),
         });
     }
 }
 
 fn handle_assistant_message(t: &mut ClaudeTranslator, frame: &Value, _out: &mut Vec<AgentEvent>) {
+    // Skip partial snapshots — when Claude is launched with
+    // --include-partial-messages it emits top-level `assistant`
+    // frames with `partial: true` for each streaming delta before
+    // the final consolidated turn. Recording every snapshot would
+    // produce duplicate transcript entries per turn. Frontend
+    // translator does the same skip
+    // (frontend/app/view/agent/providers/claude-translator.ts).
+    // Reagent P1 + codex P2 on PR #833.
+    if frame.get("partial").and_then(|v| v.as_bool()) == Some(true) {
+        return;
+    }
     // Record the turn into the transcript — used as part of `Done`.
     // Don't emit per-block events here; the streaming path already
     // emitted them via stream_event deltas.
@@ -485,6 +508,102 @@ mod tests {
         assert!(t.translate(json!(null)).is_empty());
         assert!(t.translate(json!("not an object")).is_empty());
         assert!(t.translate(json!(42)).is_empty());
+    }
+
+    #[test]
+    fn skips_partial_assistant_snapshots() {
+        // When Claude is launched with --include-partial-messages it
+        // streams partial assistant frames with `partial: true` before
+        // the final consolidated turn. Recording each would duplicate
+        // transcript entries. Reagent P1 on PR #833.
+        let mut t = ClaudeTranslator::new();
+        // Three partial snapshots — all should be ignored.
+        t.translate(json!({
+            "type": "assistant",
+            "partial": true,
+            "message": { "content": [{ "type": "text", "text": "h" }] }
+        }));
+        t.translate(json!({
+            "type": "assistant",
+            "partial": true,
+            "message": { "content": [{ "type": "text", "text": "he" }] }
+        }));
+        t.translate(json!({
+            "type": "assistant",
+            "partial": true,
+            "message": { "content": [{ "type": "text", "text": "hello" }] }
+        }));
+        // Now the consolidated turn (partial: false / absent).
+        t.translate(json!({
+            "type": "assistant",
+            "message": { "content": [{ "type": "text", "text": "hello" }] }
+        }));
+        let done = t.translate(json!({ "type": "result", "cost_usd": 0.0 }));
+        match &done[1] {
+            AgentEvent::Done { transcript, .. } => {
+                assert_eq!(
+                    transcript.len(),
+                    1,
+                    "only the consolidated turn should land; got {transcript:?}"
+                );
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tool_result_recorded_in_transcript() {
+        // Codex P2 on PR #833: Done.transcript must be the full
+        // ordered turn list (assistant + tool_result), not just the
+        // assistant side. Audit/replay needs the whole conversation.
+        let mut t = ClaudeTranslator::new();
+        // Assistant turn 1.
+        t.translate(json!({
+            "type": "assistant",
+            "message": {
+                "content": [{
+                    "type": "tool_use",
+                    "id": "t1",
+                    "name": "Bash",
+                    "input": { "command": "ls" }
+                }]
+            }
+        }));
+        // Tool result.
+        t.translate(json!({
+            "type": "user",
+            "message": {
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": "output",
+                    "is_error": false
+                }]
+            }
+        }));
+        // Final assistant turn.
+        t.translate(json!({
+            "type": "assistant",
+            "message": {
+                "content": [{ "type": "text", "text": "done" }]
+            }
+        }));
+        let done = t.translate(json!({ "type": "result", "cost_usd": 0.0 }));
+        match &done[1] {
+            AgentEvent::Done { transcript, .. } => {
+                assert_eq!(transcript.len(), 3, "got {transcript:?}");
+                assert_eq!(transcript[0].role, "assistant");
+                assert_eq!(transcript[1].role, "tool_result");
+                assert_eq!(transcript[2].role, "assistant");
+                // Verify the tool_result turn carries the structured
+                // content payload — not just the bare output.
+                let tr = &transcript[1].content;
+                assert_eq!(tr["tool_use_id"], json!("t1"));
+                assert_eq!(tr["content"], json!("output"));
+                assert_eq!(tr["is_error"], json!(false));
+            }
+            other => panic!("expected Done, got {other:?}"),
+        }
     }
 
     #[test]

--- a/agentmux-srv/src/agents/translator/claude.rs
+++ b/agentmux-srv/src/agents/translator/claude.rs
@@ -148,11 +148,22 @@ fn handle_stream_event(t: &mut ClaudeTranslator, frame: &Value, out: &mut Vec<Ag
         }
         "content_block_stop" => {
             if let Some(pending) = t.pending_tool.take() {
-                // Parse accumulated JSON; on failure, emit the raw
-                // string so downstream sees SOMETHING rather than
-                // silently dropping the call.
-                let input: Value = serde_json::from_str(&pending.partial_json)
-                    .unwrap_or(Value::String(pending.partial_json));
+                // Anthropic's stream starts every tool_use with an
+                // implicit `input: {}` and only sends input_json_delta
+                // chunks when there ARE arguments. Treat an empty
+                // partial_json as the canonical no-arg object instead
+                // of falling through to the parse-failure path, which
+                // would emit Value::String("") and break downstream
+                // tool runners expecting an object. Codex P2 on PR #833.
+                let input: Value = if pending.partial_json.is_empty() {
+                    Value::Object(Map::new())
+                } else {
+                    // Non-empty: parse, fall back to the raw string
+                    // on failure so a malformed stream surfaces
+                    // SOMETHING rather than silently dropping.
+                    serde_json::from_str(&pending.partial_json)
+                        .unwrap_or(Value::String(pending.partial_json))
+                };
                 out.push(AgentEvent::ToolUse {
                     tool_use_id: pending.id,
                     tool: pending.name,
@@ -367,6 +378,23 @@ mod tests {
                 assert_eq!(input, &json!({ "command": "ls" }));
             }
             other => panic!("expected ToolUse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_arg_tool_emits_empty_object() {
+        // No input_json_delta between start and stop — codex P2 on
+        // PR #833. The fallback path used to emit Value::String(""),
+        // which broke downstream tool runners. Now emits {}.
+        let mut t = ClaudeTranslator::new();
+        t.translate(tool_use_start("t1", "Echo"));
+        let events = t.translate(content_block_stop());
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::ToolUse { input, .. } => {
+                assert_eq!(input, &json!({}));
+            }
+            other => panic!("expected ToolUse with empty object input, got {other:?}"),
         }
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -779,10 +779,11 @@ impl Controller for ShellController {
                 } else {
                     None
                 };
-            // Per-block line-buffer. Capped to AGENT_LINE_BUFFER_CAP
+            // Per-block line-buffer (raw bytes — see
+            // `extract_agent_events`). Capped to AGENT_LINE_BUFFER_CAP
             // so a producer that never emits a newline can't grow
             // the buffer unboundedly.
-            let mut line_buf = String::new();
+            let mut line_buf: Vec<u8> = Vec::new();
 
             loop {
                 match reader.read(&mut buf) {
@@ -998,29 +999,38 @@ const AGENT_LINE_BUFFER_CAP: usize = 1024 * 1024;
 /// events the translator emitted. Caller is responsible for
 /// publishing them.
 ///
+/// Buffers RAW BYTES (not lossy-decoded strings) so a multi-byte
+/// UTF-8 character split across two PTY reads decodes cleanly when
+/// the complete line arrives. Decoding each chunk lossily would
+/// insert U+FFFD into the middle of words for non-ASCII content
+/// (CJK, emoji, accented chars), silently corrupting
+/// `AssistantText`/`Done.response` while the parallel raw-byte WPS
+/// path stays correct — workflow consumers would have no way to
+/// recover. Reagent P1 + codex P2 on PR #833.
+///
 /// Pure function — split out from `accumulate_and_translate` so the
 /// line-buffering + JSON-fast-reject + translator-call logic is
 /// unit-testable without spinning up a broker.
 fn extract_agent_events(
-    line_buf: &mut String,
+    line_buf: &mut Vec<u8>,
     chunk: &[u8],
     translator: &mut crate::agents::translator::claude::ClaudeTranslator,
 ) -> Vec<crate::agents::types::AgentEvent> {
     use crate::agents::translator::Translator as _;
     let mut out: Vec<crate::agents::types::AgentEvent> = Vec::new();
-    // Lossy UTF-8 — interactive PTYs occasionally emit byte sequences
-    // mid-codepoint at chunk boundaries; replacing invalid bytes with
-    // U+FFFD is correct since the actual byte stream is already
-    // captured by the raw-chunk path.
-    line_buf.push_str(&String::from_utf8_lossy(chunk));
+    line_buf.extend_from_slice(chunk);
     if line_buf.len() > AGENT_LINE_BUFFER_CAP {
         // No newline in a megabyte — definitely not stream-json.
         // Reset to keep memory bounded.
         line_buf.clear();
         return out;
     }
-    while let Some(nl) = line_buf.find('\n') {
-        let line: String = line_buf.drain(..=nl).collect();
+    while let Some(nl) = line_buf.iter().position(|&b| b == b'\n') {
+        let line_bytes: Vec<u8> = line_buf.drain(..=nl).collect();
+        // Decode the COMPLETE line as lossy UTF-8 — split codepoints
+        // are now fully present, so lossy-vs-strict only matters for
+        // genuinely malformed bytes which would also fail strict.
+        let line = String::from_utf8_lossy(&line_bytes);
         let trimmed = line.trim_end_matches(['\n', '\r']);
         if !trimmed.starts_with('{') {
             // Fast-reject: stream-json frames are JSON objects.
@@ -1042,7 +1052,7 @@ fn extract_agent_events(
 fn accumulate_and_translate(
     broker: &wps::Broker,
     block_id: &str,
-    line_buf: &mut String,
+    line_buf: &mut Vec<u8>,
     chunk: &[u8],
     translator: &mut crate::agents::translator::claude::ClaudeTranslator,
 ) {
@@ -1595,7 +1605,7 @@ mod tests {
     #[test]
     fn extract_agent_events_full_line_translates() {
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let line =
             br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}}
 "#;
@@ -1615,7 +1625,7 @@ mod tests {
         // calls. The buffer must accumulate across calls and only emit
         // once the newline arrives.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         // First chunk: prefix of the JSON, no newline.
         let events = extract_agent_events(
             &mut buf,
@@ -1642,7 +1652,7 @@ mod tests {
         // Interactive pane output (ANSI escapes, prompts, blank lines)
         // must not produce events.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let pty_text = b"\x1b[2K\x1b[0;0H> some prompt\n[m\nplain text\n";
         let events = extract_agent_events(&mut buf, pty_text, &mut t);
         assert!(events.is_empty(), "got unexpected events: {events:?}");
@@ -1656,7 +1666,7 @@ mod tests {
         // PTYs in cooked mode often emit \r\n. Trimming should accept
         // both.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let line = br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"crlf"}}}
 "#;
         // Replace the \n with \r\n.
@@ -1672,7 +1682,7 @@ mod tests {
         // A line that starts with `{` but isn't valid JSON should be
         // silently dropped.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let events = extract_agent_events(&mut buf, b"{not_valid_json\n", &mut t);
         assert!(events.is_empty());
     }
@@ -1682,7 +1692,7 @@ mod tests {
         // A producer that never emits newlines for >1 MiB triggers
         // the buffer reset so memory stays bounded.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let chunk = vec![b'x'; AGENT_LINE_BUFFER_CAP + 1];
         let events = extract_agent_events(&mut buf, &chunk, &mut t);
         assert!(events.is_empty());
@@ -1694,11 +1704,53 @@ mod tests {
     }
 
     #[test]
+    fn extract_agent_events_preserves_utf8_across_read_boundary() {
+        // Reagent P1 / Codex P2 on PR #833: a multi-byte UTF-8
+        // character split across two PTY reads must decode cleanly
+        // once the complete line arrives, not lossy-decode each
+        // half into U+FFFD.
+        //
+        // 'こんにちは' = e3 81 93 / e3 82 93 / e3 81 ab / e3 81 a1 / e3 81 af
+        // Each char is 3 bytes. Split a line mid-character to verify
+        // the buffered-bytes path preserves the codepoint.
+        let mut t = ClaudeTranslator::new();
+        let mut buf: Vec<u8> = Vec::new();
+        let frame = r#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"こんにちは"}}}
+"#;
+        let frame_bytes = frame.as_bytes();
+        // Split at byte 60 — somewhere inside one of the multi-byte
+        // sequences of こんにちは (which starts around byte 75 in the
+        // JSON). Use a position that's clearly inside the codepoint
+        // run.
+        let split = frame_bytes
+            .iter()
+            .position(|&b| b == 0xe3)
+            .expect("expected to find a multi-byte codepoint")
+            + 1; // split right after the leading byte (mid-codepoint)
+        let (a, b) = frame_bytes.split_at(split);
+        let events = extract_agent_events(&mut buf, a, &mut t);
+        // First chunk had no newline.
+        assert!(events.is_empty());
+        let events = extract_agent_events(&mut buf, b, &mut t);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::AssistantText { delta } => {
+                assert_eq!(
+                    delta, "こんにちは",
+                    "UTF-8 must round-trip cleanly across read boundary; got {delta:?}"
+                );
+                assert!(!delta.contains('\u{FFFD}'), "no replacement chars");
+            }
+            other => panic!("expected AssistantText, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn extract_agent_events_two_lines_one_chunk() {
         // PTY can also deliver multiple complete lines in a single
         // read(). Verify they're all processed.
         let mut t = ClaudeTranslator::new();
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         let two_lines = br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"a"}}}
 {"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"b"}}}
 "#;

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -757,9 +757,33 @@ impl Controller for ShellController {
         let block_id_read = self.block_id.clone();
         let broker_read = self.broker.clone();
         let inner_read = self.inner.clone();
+        let is_agent_read = is_agent;
         tokio::task::spawn_blocking(move || {
             let mut reader = reader;
             let mut buf = [0u8; PTY_READ_BUF_SIZE];
+
+            // Phase 1.5 PR 1 (additive): if this is an agent pane,
+            // also try to interpret stdout as Claude Code stream-json
+            // line-by-line, feeding successful parses through
+            // ClaudeTranslator and emitting AgentEvents on a new WPS
+            // scope `agent_event:<block_id>`. The existing raw-chunk
+            // path stays byte-equal — interactive panes (which don't
+            // emit JSON) see no behavior change because every line
+            // fails the JSON parse and is silently dropped. The
+            // future stream-json-mode pane and the workflow inspector
+            // (issue #830 / Phase 1.5 PR 3) will be the first real
+            // consumers.
+            let mut translator: Option<crate::agents::translator::claude::ClaudeTranslator> =
+                if is_agent_read {
+                    Some(crate::agents::translator::claude::ClaudeTranslator::new())
+                } else {
+                    None
+                };
+            // Per-block line-buffer. Capped to AGENT_LINE_BUFFER_CAP
+            // so a producer that never emits a newline can't grow
+            // the buffer unboundedly.
+            let mut line_buf = String::new();
+
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break, // EOF
@@ -773,6 +797,15 @@ impl Controller for ShellController {
                                 &buf[..n],
                                 None, // PTY output is raw terminal data; no FileStore write-through
                             );
+                            if let Some(ref mut t) = translator {
+                                accumulate_and_translate(
+                                    broker,
+                                    &block_id_read,
+                                    &mut line_buf,
+                                    &buf[..n],
+                                    t,
+                                );
+                            }
                         }
                     }
                     Err(e) => {
@@ -954,6 +987,76 @@ impl Controller for ShellController {
 // ---- File operation helpers ----
 
 /// Append data to a block's terminal output file, publish a WPS event,
+/// Maximum size of the per-block line buffer used by the agent-event
+/// translation path. Past this, the buffer is reset (a producer that
+/// never emits a newline can't grow it unboundedly). 1 MiB is far
+/// beyond any plausible stream-json frame size.
+const AGENT_LINE_BUFFER_CAP: usize = 1024 * 1024;
+
+/// Append `chunk` to `line_buf`, drain complete lines, JSON-parse
+/// each, and run successful parses through `translator`. Returns the
+/// events the translator emitted. Caller is responsible for
+/// publishing them.
+///
+/// Pure function — split out from `accumulate_and_translate` so the
+/// line-buffering + JSON-fast-reject + translator-call logic is
+/// unit-testable without spinning up a broker.
+fn extract_agent_events(
+    line_buf: &mut String,
+    chunk: &[u8],
+    translator: &mut crate::agents::translator::claude::ClaudeTranslator,
+) -> Vec<crate::agents::types::AgentEvent> {
+    use crate::agents::translator::Translator as _;
+    let mut out: Vec<crate::agents::types::AgentEvent> = Vec::new();
+    // Lossy UTF-8 — interactive PTYs occasionally emit byte sequences
+    // mid-codepoint at chunk boundaries; replacing invalid bytes with
+    // U+FFFD is correct since the actual byte stream is already
+    // captured by the raw-chunk path.
+    line_buf.push_str(&String::from_utf8_lossy(chunk));
+    if line_buf.len() > AGENT_LINE_BUFFER_CAP {
+        // No newline in a megabyte — definitely not stream-json.
+        // Reset to keep memory bounded.
+        line_buf.clear();
+        return out;
+    }
+    while let Some(nl) = line_buf.find('\n') {
+        let line: String = line_buf.drain(..=nl).collect();
+        let trimmed = line.trim_end_matches(['\n', '\r']);
+        if !trimmed.starts_with('{') {
+            // Fast-reject: stream-json frames are JSON objects.
+            // Skips ANSI escapes, prompts, blank lines, etc.
+            continue;
+        }
+        let Ok(frame) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        out.extend(translator.translate(frame));
+    }
+    out
+}
+
+/// Publish the events `extract_agent_events` produced on the WPS
+/// scope `agent_event:<block_id>`. Phase 1.5 PR 1 hook for agent
+/// panes. Called only when `is_agent` is true at spawn time (see
+/// read-task closure in `start()`).
+fn accumulate_and_translate(
+    broker: &wps::Broker,
+    block_id: &str,
+    line_buf: &mut String,
+    chunk: &[u8],
+    translator: &mut crate::agents::translator::claude::ClaudeTranslator,
+) {
+    for event in extract_agent_events(line_buf, chunk, translator) {
+        broker.publish(wps::WaveEvent {
+            event: format!("agent_event:{}", block_id),
+            scopes: vec![],
+            sender: String::new(),
+            persist: 0,
+            data: Some(serde_json::to_value(&event).unwrap_or_default()),
+        });
+    }
+}
+
 /// and write-through to FileStore (if provided).
 ///
 /// Port of Go's `HandleAppendBlockFile`.
@@ -1480,5 +1583,126 @@ mod tests {
         handle_append_block_file(&broker, block_id, filename, b"line three\n", Some(&fs));
         let stat_after = fs.stat(block_id, filename).unwrap().unwrap();
         assert_eq!(stat_after.size, (line1.len() + line2.len() + b"line three\n".len()) as i64);
+    }
+
+    // ────────────────────────────────────────────────────────────────
+    // extract_agent_events — Phase 1.5 PR 1
+    // ────────────────────────────────────────────────────────────────
+
+    use crate::agents::translator::claude::ClaudeTranslator;
+    use crate::agents::types::AgentEvent;
+
+    #[test]
+    fn extract_agent_events_full_line_translates() {
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let line =
+            br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}}
+"#;
+        let events = extract_agent_events(&mut buf, line, &mut t);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::AssistantText { delta } => assert_eq!(delta, "hello"),
+            other => panic!("expected AssistantText, got {other:?}"),
+        }
+        // Buffer drained.
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn extract_agent_events_chunked_line_accumulates() {
+        // PTY can deliver a single logical line across multiple read()
+        // calls. The buffer must accumulate across calls and only emit
+        // once the newline arrives.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        // First chunk: prefix of the JSON, no newline.
+        let events = extract_agent_events(
+            &mut buf,
+            br#"{"type":"stream_event","event":{"type":"content_"#,
+            &mut t,
+        );
+        assert!(events.is_empty());
+        // Second chunk: rest of the JSON + newline.
+        let events = extract_agent_events(
+            &mut buf,
+            br#"block_delta","delta":{"type":"text_delta","text":"hi"}}}
+"#,
+            &mut t,
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AgentEvent::AssistantText { delta } => assert_eq!(delta, "hi"),
+            other => panic!("expected AssistantText, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_agent_events_drops_non_json_lines() {
+        // Interactive pane output (ANSI escapes, prompts, blank lines)
+        // must not produce events.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let pty_text = b"\x1b[2K\x1b[0;0H> some prompt\n[m\nplain text\n";
+        let events = extract_agent_events(&mut buf, pty_text, &mut t);
+        assert!(events.is_empty(), "got unexpected events: {events:?}");
+        // Buffer drained — only the trailing line (if any) is retained.
+        // Here every chunk had a newline at the end, so buf is empty.
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn extract_agent_events_drops_carriage_returns() {
+        // PTYs in cooked mode often emit \r\n. Trimming should accept
+        // both.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let line = br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"crlf"}}}
+"#;
+        // Replace the \n with \r\n.
+        let mut bytes: Vec<u8> = line.to_vec();
+        let last = bytes.len() - 1;
+        bytes.insert(last, b'\r');
+        let events = extract_agent_events(&mut buf, &bytes, &mut t);
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn extract_agent_events_drops_malformed_json() {
+        // A line that starts with `{` but isn't valid JSON should be
+        // silently dropped.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let events = extract_agent_events(&mut buf, b"{not_valid_json\n", &mut t);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn extract_agent_events_resets_oversized_buffer() {
+        // A producer that never emits newlines for >1 MiB triggers
+        // the buffer reset so memory stays bounded.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let chunk = vec![b'x'; AGENT_LINE_BUFFER_CAP + 1];
+        let events = extract_agent_events(&mut buf, &chunk, &mut t);
+        assert!(events.is_empty());
+        assert!(
+            buf.is_empty(),
+            "buffer should reset past cap, was {} bytes",
+            buf.len()
+        );
+    }
+
+    #[test]
+    fn extract_agent_events_two_lines_one_chunk() {
+        // PTY can also deliver multiple complete lines in a single
+        // read(). Verify they're all processed.
+        let mut t = ClaudeTranslator::new();
+        let mut buf = String::new();
+        let two_lines = br#"{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"a"}}}
+{"type":"stream_event","event":{"type":"content_block_delta","delta":{"type":"text_delta","text":"b"}}}
+"#;
+        let events = extract_agent_events(&mut buf, two_lines, &mut t);
+        assert_eq!(events.len(), 2);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.854",
+  "version": "0.33.855",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.854",
+      "version": "0.33.855",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.853",
+  "version": "0.33.854",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.853",
+      "version": "0.33.854",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.852",
+  "version": "0.33.853",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.852",
+      "version": "0.33.853",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.855",
+  "version": "0.33.856",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.855",
+      "version": "0.33.856",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.854",
+  "version": "0.33.855",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.853",
+  "version": "0.33.854",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.852",
+  "version": "0.33.853",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.855",
+  "version": "0.33.856",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Second PR in the Workflows Phase 1.5 series (after [#831](https://github.com/agentmuxai/agentmux/pull/831)). Implements the backend translator that converts Claude Code stream-json frames into unified `AgentEvent`s. Tracked in discussion [#832](https://github.com/agentmuxai/agentmux/discussions/832).

## What ships

### `ClaudeTranslator::translate()` (`agentmux-srv/src/agents/translator/claude.rs`)

Mirrors the frontend reference at `frontend/app/view/agent/providers/claude-translator.ts` so the workflow Agent block can consume the same stream without round-tripping through the renderer.

Handled frame shapes:
- `stream_event.content_block_start.content_block.type=tool_use` — starts an in-flight tool_use. Subsequent `input_json_delta`s accumulate. `content_block_stop` emits `AgentEvent::ToolUse` with the parsed JSON input (falls back to raw `partial_json` string on parse failure, so downstream never silently drops a tool call).
- `stream_event.content_block_delta.text_delta` — emits `AgentEvent::AssistantText` AND accumulates into the final `Done.response`.
- `user.message.content[].type=tool_result` — emits `AgentEvent::ToolResult` preserving content shape (string or array) and `is_error` flag.
- `assistant.message` — recorded into the transcript captured at `Done`.
- `result.cost_usd` + `result.usage` — emits `AgentEvent::Cost` followed by `AgentEvent::Done`. `usage` maps Claude SDK field names (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`) to `TokenCounts`. `Done.response` uses `result.result` if present, else the accumulated streaming text.

### Graceful degradation

Unknown frames, malformed shapes, missing fields, and non-object inputs all return an empty `Vec<AgentEvent>` rather than panicking. The runner's parallel raw-byte WPS path still publishes the underlying text, so unfamiliar frames degrade gracefully.

`thinking_delta`, `message_delta`, `message_stop` are discarded (consistent with the frontend translator).

### Tests

10 unit tests cover:
- text streaming with accumulated response
- tool_use start/delta/stop with JSON input parsing
- malformed input fallback to raw string
- tool_result success + error cases
- result frame emitting Cost+Done in order
- assistant transcript capture
- unknown frame silence
- malformed input silence
- reset state isolation

## What's NOT in this PR

- **shell.rs wiring** — the next commit on this branch wires the translator into the pane's read loop additively. The raw-chunk WPS path stays byte-equal; AgentEvents emit on a new parallel channel.
- **Golden-file tests over recorded sessions** — the unit tests cover the structural cases; golden files land alongside the shell.rs wiring once a real recording exists.

## Test plan

- [x] `cargo test -p agentmux-srv agents` — 24 tests pass (14 prior + 10 new)
- [x] No frontend changes — `tsc --noEmit` unchanged
- [x] Build clean (warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)