### PR TITLE
fix(dnd): hardcode placeholder-sizer transition to 120ms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.862"
+version = "0.33.863"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.862"
+version = "0.33.863"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.862"
+version = "0.33.863"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.862"
+version = "0.33.863"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.862"
+version = "0.33.863"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.862"
+version = "0.33.863"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.862"
+version = "0.33.863"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.862"
+version = "0.33.863"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.862"
+version = "0.33.863"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.862"
+version = "0.33.863"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -162,13 +162,17 @@
         }
         // `.placeholder-sizer` only changes transform during drag-move
         // (width/height are set once per zone change and snap instantly
-        // — that's the whole point of the two-div split). Keeping the
-        // transition-property narrow to `transform` is what makes the
-        // drag-move compositor-only.
+        // — that's the whole point of the two-div split). Use a
+        // FIXED 120ms duration rather than var(--animation-time-s)
+        // because that variable defaults to 0 for all current layouts
+        // (see DefaultAnimationTimeS in layoutModel.ts — never
+        // overridden in production), so deriving the placeholder
+        // animation from it makes drag-move instantaneous and defeats
+        // the whole point of the two-div split. 120ms matches the
+        // inner `.placeholder` opacity/scale transitions so the
+        // visual response is uniform across enter / drag-move / exit.
         .placeholder-sizer {
-            transition-duration: var(--animation-time-s);
-            transition-timing-function: linear;
-            transition-property: transform;
+            transition: transform 120ms ease-out;
         }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.862",
+  "version": "0.33.863",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.862",
+      "version": "0.33.863",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.862",
+  "version": "0.33.863",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Follow-up to [#829](https://github.com/agentmuxai/agentmux/pull/829). User-reported regression: drop-zone enter fade works, but continued drag between zones snaps instantly instead of smoothing.

## Root cause

AgentY's PR #829 wired the new `placeholder-sizer` drag-move transition to `var(--animation-time-s)`:

```scss
&.animate {
    .placeholder-sizer {
        transition-property: transform;
        transition-duration: var(--animation-time-s);
    }
}
```

But that CSS variable comes from `layoutModel.animationTimeS()`, which defaults to `0` (see `DefaultAnimationTimeS` at `agentmux-srv/.../layoutModel.ts:103`) and has **no setter** anywhere in the codebase. So `--animation-time-s` is permanently `0s` for every layout in production.

Net effect: the `&.animate .placeholder-sizer { transition: transform 0s }` rule is a no-op. The `.placeholder` inner element has its own hardcoded `transition: opacity 120ms ease-out, transform 120ms ease-out` so the enter fade-in / scale plays correctly — but the drag-move between zones is instantaneous, defeating the whole compositor-only point of the two-div split.

## Fix

Give `.placeholder-sizer` a fixed 120ms transition duration. Matches the inner `.placeholder` opacity/scale durations so the visual response is uniform across enter / drag-move / exit. `.tile-node` still uses `var(--animation-time-s)` (= 0) so pane split/close/rebalance behavior is unchanged — only the drop-zone indicator gets the fixed-duration smoothing.

## Test plan

- [ ] Drag a pane — drop-zone fades in (unchanged)
- [ ] Continue dragging across zones — placeholder now smoothly transitions between positions (was snapping before this fix)
- [ ] Release — drop-zone fades out (unchanged)
- [ ] `prefers-reduced-motion`: no transitions (the existing `@media` block's `&.animate .placeholder-sizer { transition: none }` still wins via source order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)