### PR TITLE
fix(dnd): catch drops in dead spots between per-pane overlays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.863"
+version = "0.33.864"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.863"
+version = "0.33.864"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.863"
+version = "0.33.864"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.863"
+version = "0.33.864"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.863"
+version = "0.33.864"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.864"
+version = "0.33.865"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.864"
+version = "0.33.865"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.864"
+version = "0.33.865"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.864"
+version = "0.33.865"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.864"
+version = "0.33.865"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.865"
+version = "0.33.866"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.865"
+version = "0.33.866"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.865"
+version = "0.33.866"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.865"
+version = "0.33.866"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.865"
+version = "0.33.866"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.863"
+version = "0.33.864"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.865"
+version = "0.33.866"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.864"
+version = "0.33.865"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.863"
+version = "0.33.864"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.864"
+version = "0.33.865"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.865"
+version = "0.33.866"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.864"
+version = "0.33.865"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.865"
+version = "0.33.866"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.863"
+version = "0.33.864"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.863"
+version = "0.33.864"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.865"
+version = "0.33.866"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.864"
+version = "0.33.865"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.863"
+version = "0.33.864"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.865"
+version = "0.33.866"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.864"
+version = "0.33.865"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -490,11 +490,18 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         }
         if (!bestLeafId || !bestRect) return;
 
+        // Clamp the cursor offset to the chosen rect — see
+        // TileLayout.win32.tsx for full rationale. (codex P2 on PR #838.)
+        const clampedOffset = {
+            x: Math.max(bestRect.left, Math.min(bestRect.left + bestRect.width, offset.x)),
+            y: Math.max(bestRect.top, Math.min(bestRect.top + bestRect.height, offset.y)),
+        };
+
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
             nodeToMoveId: dragNodeId,
-            direction: determineDropDirection(bestRect, offset),
+            direction: determineDropDirection(bestRect, clampedOffset),
         } as LayoutTreeComputeMoveNodeAction);
     });
 

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -432,6 +432,7 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
     const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
+    let overlayContainerRef: HTMLDivElement | undefined;
 
     // Overlay is always positioned at top:0 so pragmatic-dnd drop targets
     // are registered in the correct location. pointer-events toggles between
@@ -445,8 +446,68 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));
 
+    // Fallback nearest-pane drop computation for dead spots between
+    // per-pane overlay-nodes. Mirrors TileLayout.win32.tsx — see that
+    // file for the design rationale.
+    const fallbackComputeDropDirection = throttle(50, (clientX: number, clientY: number) => {
+        const dragNodeId = globalDragNodeId;
+        if (!dragNodeId) return;
+        const container = props.layoutModel.displayContainerRef?.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
+
+        let bestLeafId: string | null = null;
+        let bestRect: { top: number; left: number; width: number; height: number } | null = null;
+        let bestDist = Infinity;
+        for (const leaf of props.layoutModel.leafs()) {
+            if (leaf.id === dragNodeId) continue;
+            const rect = props.layoutModel.getNodeRectById(leaf.id);
+            if (!rect) continue;
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const dx = offset.x - cx;
+            const dy = offset.y - cy;
+            const dist = dx * dx + dy * dy;
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestLeafId = leaf.id;
+                bestRect = rect;
+            }
+        }
+        if (!bestLeafId || !bestRect) return;
+
+        props.layoutModel.treeReducer({
+            type: LayoutTreeActionType.ComputeMove,
+            nodeId: bestLeafId,
+            nodeToMoveId: dragNodeId,
+            direction: determineDropDirection(bestRect, offset),
+        } as LayoutTreeComputeMoveNodeAction);
+    });
+
+    onMount(() => {
+        if (!overlayContainerRef) return;
+        const cleanup = dropTargetForElements({
+            element: overlayContainerRef,
+            canDrop: ({ source }) => source.data.type === tileItemType,
+            onDrag: ({ location }) => {
+                if (location.current.dropTargets[0]?.element !== overlayContainerRef) return;
+                const cursor = location.current.input;
+                fallbackComputeDropDirection(cursor.clientX, cursor.clientY);
+            },
+            onDragLeave: () => {
+                props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            },
+            onDrop: () => {
+                setCurrentDragPayload(null);
+                props.layoutModel.onDrop();
+            },
+        });
+        onCleanup(cleanup);
+    });
+
     return (
-        <div class="overlay-container" style={overlayStyle()}>
+        <div ref={overlayContainerRef} class="overlay-container" style={overlayStyle()}>
             <Key each={leafs()} by={(node) => node.id}>
                 {(node) => <OverlayNode layoutModel={props.layoutModel} node={node()} />}
             </Key>

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -457,6 +457,19 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         const containerRect = container.getBoundingClientRect();
         const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
 
+        // Origin-rect guard — see TileLayout.win32.tsx for rationale.
+        const originRect = props.layoutModel.getNodeRectById(dragNodeId);
+        if (
+            originRect &&
+            offset.x >= originRect.left &&
+            offset.x <= originRect.left + originRect.width &&
+            offset.y >= originRect.top &&
+            offset.y <= originRect.top + originRect.height
+        ) {
+            props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            return;
+        }
+
         let bestLeafId: string | null = null;
         let bestRect: { top: number; left: number; width: number; height: number } | null = null;
         let bestDist = Infinity;

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -413,6 +413,7 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
     const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
+    let overlayContainerRef: HTMLDivElement | undefined;
 
     // Overlay is always positioned at top:0 so pragmatic-dnd drop targets
     // are registered in the correct location. pointer-events toggles between
@@ -426,8 +427,68 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));
 
+    // Fallback nearest-pane drop computation for dead spots between
+    // per-pane overlay-nodes. Mirrors TileLayout.win32.tsx — see that
+    // file for the design rationale.
+    const fallbackComputeDropDirection = throttle(50, (clientX: number, clientY: number) => {
+        const dragNodeId = globalDragNodeId;
+        if (!dragNodeId) return;
+        const container = props.layoutModel.displayContainerRef?.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
+
+        let bestLeafId: string | null = null;
+        let bestRect: { top: number; left: number; width: number; height: number } | null = null;
+        let bestDist = Infinity;
+        for (const leaf of props.layoutModel.leafs()) {
+            if (leaf.id === dragNodeId) continue;
+            const rect = props.layoutModel.getNodeRectById(leaf.id);
+            if (!rect) continue;
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const dx = offset.x - cx;
+            const dy = offset.y - cy;
+            const dist = dx * dx + dy * dy;
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestLeafId = leaf.id;
+                bestRect = rect;
+            }
+        }
+        if (!bestLeafId || !bestRect) return;
+
+        props.layoutModel.treeReducer({
+            type: LayoutTreeActionType.ComputeMove,
+            nodeId: bestLeafId,
+            nodeToMoveId: dragNodeId,
+            direction: determineDropDirection(bestRect, offset),
+        } as LayoutTreeComputeMoveNodeAction);
+    });
+
+    onMount(() => {
+        if (!overlayContainerRef) return;
+        const cleanup = dropTargetForElements({
+            element: overlayContainerRef,
+            canDrop: ({ source }) => source.data.type === tileItemType,
+            onDrag: ({ location }) => {
+                if (location.current.dropTargets[0]?.element !== overlayContainerRef) return;
+                const cursor = location.current.input;
+                fallbackComputeDropDirection(cursor.clientX, cursor.clientY);
+            },
+            onDragLeave: () => {
+                props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            },
+            onDrop: () => {
+                setCurrentDragPayload(null);
+                props.layoutModel.onDrop();
+            },
+        });
+        onCleanup(cleanup);
+    });
+
     return (
-        <div class="overlay-container" style={overlayStyle()}>
+        <div ref={overlayContainerRef} class="overlay-container" style={overlayStyle()}>
             <Key each={leafs()} by={(node) => node.id}>
                 {(node) => <OverlayNode layoutModel={props.layoutModel} node={node()} />}
             </Key>

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -471,11 +471,18 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         }
         if (!bestLeafId || !bestRect) return;
 
+        // Clamp the cursor offset to the chosen rect — see
+        // TileLayout.win32.tsx for full rationale. (codex P2 on PR #838.)
+        const clampedOffset = {
+            x: Math.max(bestRect.left, Math.min(bestRect.left + bestRect.width, offset.x)),
+            y: Math.max(bestRect.top, Math.min(bestRect.top + bestRect.height, offset.y)),
+        };
+
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
             nodeToMoveId: dragNodeId,
-            direction: determineDropDirection(bestRect, offset),
+            direction: determineDropDirection(bestRect, clampedOffset),
         } as LayoutTreeComputeMoveNodeAction);
     });
 

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -438,6 +438,19 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         const containerRect = container.getBoundingClientRect();
         const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
 
+        // Origin-rect guard — see TileLayout.win32.tsx for rationale.
+        const originRect = props.layoutModel.getNodeRectById(dragNodeId);
+        if (
+            originRect &&
+            offset.x >= originRect.left &&
+            offset.x <= originRect.left + originRect.width &&
+            offset.y >= originRect.top &&
+            offset.y <= originRect.top + originRect.height
+        ) {
+            props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            return;
+        }
+
         let bestLeafId: string | null = null;
         let bestRect: { top: number; left: number; width: number; height: number } | null = null;
         let bestDist = Infinity;

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -519,6 +519,25 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         const containerRect = container.getBoundingClientRect();
         const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
 
+        // If the cursor is inside the ORIGIN pane's rect, treat as a
+        // no-op drag — the user's slight wiggle within their own pane
+        // should not pick a "nearest other pane" target. Without this,
+        // a tiny drag-and-release on the same pane in a multi-pane
+        // layout would commit a Move to the closest neighbor on
+        // release. The drop is still caught by onDrop below (clearing
+        // the payload) so the cross-window monitor won't tear off.
+        const originRect = props.layoutModel.getNodeRectById(dragNodeId);
+        if (
+            originRect &&
+            offset.x >= originRect.left &&
+            offset.x <= originRect.left + originRect.width &&
+            offset.y >= originRect.top &&
+            offset.y <= originRect.top + originRect.height
+        ) {
+            props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            return;
+        }
+
         let bestLeafId: string | null = null;
         let bestRect: { top: number; left: number; width: number; height: number } | null = null;
         let bestDist = Infinity;

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -558,11 +558,26 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         }
         if (!bestLeafId || !bestRect) return;
 
+        // Clamp the cursor offset to the chosen rect — by definition
+        // the cursor is OUTSIDE every pane rect when this fallback
+        // runs (dead spot). determineDropDirection returns undefined
+        // for any point outside the supplied dimensions, which would
+        // make this fallback a no-op without clamping. Clamping
+        // resolves the cursor to the nearest edge of the chosen rect,
+        // which gives the natural quadrant for the drop: drag-into-
+        // gutter-right-of-paneA → clamps to paneA.right → returns
+        // Right quadrant of paneA → pane lands between A and B.
+        // (codex P2 on PR #838.)
+        const clampedOffset = {
+            x: Math.max(bestRect.left, Math.min(bestRect.left + bestRect.width, offset.x)),
+            y: Math.max(bestRect.top, Math.min(bestRect.top + bestRect.height, offset.y)),
+        };
+
         props.layoutModel.treeReducer({
             type: LayoutTreeActionType.ComputeMove,
             nodeId: bestLeafId,
             nodeToMoveId: dragNodeId,
-            direction: determineDropDirection(bestRect, offset),
+            direction: determineDropDirection(bestRect, clampedOffset),
         } as LayoutTreeComputeMoveNodeAction);
     });
 

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -482,6 +482,7 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
     const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
+    let overlayContainerRef: HTMLDivElement | undefined;
 
     // Overlay is always positioned at top:0 so pragmatic-dnd drop targets
     // are registered in the correct location. pointer-events toggles between
@@ -495,8 +496,90 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));
 
+    // Fallback nearest-pane drop computation for "dead spots" inside the
+    // overlay container but outside any per-pane overlay-node (gutters
+    // between panes, edges of the layout, etc.). Each per-pane overlay
+    // is sized exactly to its tile's bounding rect, so cursors landing
+    // in the gap have no per-pane drop target — without this fallback
+    // the drag produces no placeholder and a release in that gap
+    // either does nothing or (if pragmatic-dnd's drop never fires) is
+    // misinterpreted by the cross-window monitor as a tear-off.
+    //
+    // The fallback finds the nearest leaf to the cursor (Euclidean
+    // distance to rect center) and runs the same ComputeMove action
+    // the per-pane onDrag would have run. Only fires when this
+    // container is the INNERMOST matched drop target — when the
+    // cursor is over an overlay-node, the per-pane logic takes
+    // precedence and this no-ops.
+    const fallbackComputeDropDirection = throttle(50, (clientX: number, clientY: number) => {
+        const dragNodeId = globalDragNodeId;
+        if (!dragNodeId) return;
+        const container = props.layoutModel.displayContainerRef?.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        const offset = { x: clientX - containerRect.x, y: clientY - containerRect.y };
+
+        let bestLeafId: string | null = null;
+        let bestRect: { top: number; left: number; width: number; height: number } | null = null;
+        let bestDist = Infinity;
+        for (const leaf of props.layoutModel.leafs()) {
+            if (leaf.id === dragNodeId) continue;
+            const rect = props.layoutModel.getNodeRectById(leaf.id);
+            if (!rect) continue;
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const dx = offset.x - cx;
+            const dy = offset.y - cy;
+            const dist = dx * dx + dy * dy;
+            if (dist < bestDist) {
+                bestDist = dist;
+                bestLeafId = leaf.id;
+                bestRect = rect;
+            }
+        }
+        if (!bestLeafId || !bestRect) return;
+
+        props.layoutModel.treeReducer({
+            type: LayoutTreeActionType.ComputeMove,
+            nodeId: bestLeafId,
+            nodeToMoveId: dragNodeId,
+            direction: determineDropDirection(bestRect, offset),
+        } as LayoutTreeComputeMoveNodeAction);
+    });
+
+    onMount(() => {
+        if (!overlayContainerRef) return;
+        const cleanup = dropTargetForElements({
+            element: overlayContainerRef,
+            canDrop: ({ source }) => source.data.type === tileItemType,
+            onDrag: ({ location }) => {
+                // Skip when an inner per-pane overlay also matches — that
+                // path has higher specificity and already handled this.
+                if (location.current.dropTargets[0]?.element !== overlayContainerRef) return;
+                const cursor = location.current.input;
+                fallbackComputeDropDirection(cursor.clientX, cursor.clientY);
+            },
+            onDragLeave: () => {
+                // Only clear when this container was the innermost match;
+                // a transition INTO an inner overlay-node should not
+                // clear (the inner's onDrag will set a fresh action).
+                props.layoutModel.treeReducer({ type: LayoutTreeActionType.ClearPendingAction });
+            },
+            onDrop: () => {
+                // Catches drops that landed in a dead spot. Clearing the
+                // payload here is critical — without it, the cross-window
+                // dragend monitor (CrossWindowDragMonitor.win32.tsx) would
+                // see a still-set payload and either return-to-source or
+                // (in some race paths) trigger an unwanted tear-off.
+                setCurrentDragPayload(null);
+                props.layoutModel.onDrop();
+            },
+        });
+        onCleanup(cleanup);
+    });
+
     return (
-        <div class="overlay-container" style={overlayStyle()}>
+        <div ref={overlayContainerRef} class="overlay-container" style={overlayStyle()}>
             <Key each={leafs()} by={(node) => node.id}>
                 {(node) => <OverlayNode layoutModel={props.layoutModel} node={node()} />}
             </Key>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.865",
+  "version": "0.33.866",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.865",
+      "version": "0.33.866",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.863",
+  "version": "0.33.864",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.863",
+      "version": "0.33.864",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.864",
+  "version": "0.33.865",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.864",
+      "version": "0.33.865",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.863",
+  "version": "0.33.864",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.865",
+  "version": "0.33.866",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.864",
+  "version": "0.33.865",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
**User report**: while dragging a pane, releasing it in dead spots inside the main window (gutter between panes, edges of the layout) sometimes produces no drop indicator. On release, the system spawns a new window instead of dropping in-place.

## Root cause

Each pane's `overlay-node` is sized exactly to its tile's bounding rect, so the gap between tiles (`--gap-size-px`, plus tile-layout edges) is a true dead spot — pragmatic-dnd finds no matched drop target, fires no `onDrag` / `onDrop`, and the cross-window drag monitor interprets the absent in-window drop as a potential tear-off.

## Fix

Register a **fallback drop target on `.overlay-container`** (the parent of every per-pane overlay-node, sized to the full display area). When pragmatic-dnd's hit test resolves to the container as the innermost matched target — i.e. cursor is in a dead spot, no per-pane match — the fallback:

1. **`onDrag`** — finds the leaf whose bounding-rect center is closest to the cursor (Euclidean distance, excluding the dragged pane itself), runs the same `ComputeMove` action a per-pane `onDrag` would have. Placeholder appears, user sees the drop indicator.
2. **`onDragLeave`** — clears the pending action when cursor leaves the container entirely.
3. **`onDrop`** — clears the cross-window drag payload (prevents the tear-off path) and commits the pending action.

When the cursor IS over a per-pane overlay-node, the fallback **no-ops** (it checks `dropTargets[0] === container` before running), so per-pane behavior is untouched.

Mirrored across all three platforms (win32, darwin, linux).

## Test plan

- [ ] Drag a pane into a clear pane area → per-pane overlay highlights as before
- [ ] Drag a pane into the gap between two panes → drop indicator NOW appears (was missing)
- [ ] Drag a pane near the edge of the layout (outside any tile) → drop indicator appears for the nearest pane
- [ ] Release in a dead spot → drop applies to nearest-pane direction, NO new window
- [ ] Release outside the window → tear-off still works (cursor not over `.overlay-container`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)