### PR TITLE
feat(identity): pre-launch OAuth session manager + per-provider patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.866"
+version = "0.33.867"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.868"
+version = "0.33.869"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.867"
+version = "0.33.868"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.868"
+version = "0.33.869"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.866"
+version = "0.33.867"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.867"
+version = "0.33.868"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/identity/auth_patterns.rs
+++ b/agentmux-srv/src/identity/auth_patterns.rs
@@ -1,0 +1,332 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-provider stdout/stderr pattern matchers for the pre-launch
+//! OAuth flow. The `auth login` subprocess of each CLI provider
+//! emits an OAuth URL (or device code) to stdout/stderr in a slightly
+//! different shape. This module knows how to extract them.
+//!
+//! See `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` §4.
+
+/// What a pattern matcher extracted from a single line of provider output.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthPatternMatch {
+    /// CLI emitted an OAuth URL the user should open in a browser.
+    OAuthUrl(String),
+    /// CLI emitted a device-code pair (GitHub Copilot style).
+    DeviceCode {
+        /// The pairing code the user types into the verification URL.
+        code: String,
+        /// Where the user goes to enter the code.
+        verification_url: String,
+    },
+    /// CLI emitted a "logged in as <email>" line. Used to know we're
+    /// done and to populate the bundle's display name.
+    LoginSuccess { email: Option<String> },
+    /// CLI emitted an "authentication failed" line.
+    LoginFailure { message: String },
+}
+
+/// Try every pattern for the given provider against a single line of
+/// captured output. Returns the FIRST match found — patterns are
+/// listed by descending specificity in `patterns_for(provider_id)`.
+pub fn match_line(provider_id: &str, line: &str) -> Option<AuthPatternMatch> {
+    for matcher in patterns_for(provider_id) {
+        if let Some(m) = matcher(line) {
+            return Some(m);
+        }
+    }
+    // Universal fallback — any https URL during the auth phase is
+    // *probably* an OAuth URL. Last-resort: keep the URL but mark
+    // it as a generic OAuthUrl. The frontend will surface this for
+    // user paste-back if the specific matcher missed it.
+    if let Some(url) = extract_first_https_url(line) {
+        if looks_like_oauth_url(&url) {
+            return Some(AuthPatternMatch::OAuthUrl(url));
+        }
+    }
+    None
+}
+
+type LineMatcher = fn(&str) -> Option<AuthPatternMatch>;
+
+fn patterns_for(provider_id: &str) -> &'static [LineMatcher] {
+    match provider_id {
+        "claude" => &[match_claude_url, match_logged_in_as],
+        "codex" => &[match_codex_url, match_logged_in_as],
+        "gemini" => &[match_gemini_url, match_logged_in_as],
+        "copilot" => &[match_copilot_device_code, match_logged_in_as],
+        // API-key providers don't OAuth — these patterns never match.
+        // Listed here so the dispatch is exhaustive and adding a new
+        // provider always lands a code edit in this table.
+        "openclaw" | "kimi" | "pi" => &[],
+        _ => &[],
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Per-provider matchers
+// ────────────────────────────────────────────────────────────────────
+
+fn match_claude_url(line: &str) -> Option<AuthPatternMatch> {
+    // Claude Code emits something like:
+    //   "Open this URL in your browser to authorize:"
+    //   "https://console.anthropic.com/oauth/authorize?response_type=..."
+    if let Some(url) = extract_first_https_url(line) {
+        if url.contains("anthropic.com/oauth") || url.contains("console.anthropic.com") {
+            return Some(AuthPatternMatch::OAuthUrl(url));
+        }
+    }
+    None
+}
+
+fn match_codex_url(line: &str) -> Option<AuthPatternMatch> {
+    if let Some(url) = extract_first_https_url(line) {
+        if url.contains("auth.openai.com")
+            || url.contains("platform.openai.com")
+            || url.contains("openai.com/oauth")
+        {
+            return Some(AuthPatternMatch::OAuthUrl(url));
+        }
+    }
+    None
+}
+
+fn match_gemini_url(line: &str) -> Option<AuthPatternMatch> {
+    if let Some(url) = extract_first_https_url(line) {
+        if url.contains("accounts.google.com") || url.contains("oauth2.googleapis.com") {
+            return Some(AuthPatternMatch::OAuthUrl(url));
+        }
+    }
+    None
+}
+
+fn match_copilot_device_code(line: &str) -> Option<AuthPatternMatch> {
+    // GitHub device flow output:
+    //   "! First copy your one-time code: XXXX-YYYY"
+    //   "Then press Enter to open github.com in your browser..."
+    //   or
+    //   "Please visit https://github.com/login/device and enter code XXXX-YYYY"
+    let line_low = line.to_lowercase();
+    let mentions_device = line_low.contains("github.com/login/device")
+        || line_low.contains("one-time code")
+        || line_low.contains("enter code");
+    if !mentions_device {
+        return None;
+    }
+    let code = extract_device_code(line);
+    if let Some(code) = code {
+        // The URL is constant for GitHub device flow.
+        return Some(AuthPatternMatch::DeviceCode {
+            code,
+            verification_url: "https://github.com/login/device".to_string(),
+        });
+    }
+    None
+}
+
+fn match_logged_in_as(line: &str) -> Option<AuthPatternMatch> {
+    let line_low = line.to_lowercase();
+    if !line_low.contains("logged in") && !line_low.contains("authenticated") {
+        return None;
+    }
+    // Heuristic email extraction. We don't gate on it — `email`
+    // can be None and the bundle gets a default name.
+    let email = extract_email(line);
+    Some(AuthPatternMatch::LoginSuccess { email })
+}
+
+// ────────────────────────────────────────────────────────────────────
+// Generic helpers
+// ────────────────────────────────────────────────────────────────────
+
+fn extract_first_https_url(line: &str) -> Option<String> {
+    let start = line.find("https://")?;
+    let tail = &line[start..];
+    // URL ends at whitespace, quote, or backtick. Conservative — keeps
+    // ports, paths, query strings, fragments.
+    let end = tail
+        .find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '`' || c == ')')
+        .unwrap_or(tail.len());
+    Some(tail[..end].to_string())
+}
+
+fn looks_like_oauth_url(url: &str) -> bool {
+    let u = url.to_lowercase();
+    u.contains("oauth")
+        || u.contains("/authorize")
+        || u.contains("/login")
+        || u.contains("/auth")
+        || u.contains("device")
+}
+
+fn extract_email(line: &str) -> Option<String> {
+    // Conservative email extractor: find a token containing '@' with
+    // valid surrounding chars. Skips placeholders like "<email>".
+    for token in line.split_whitespace() {
+        let token = token.trim_matches(|c: char| !c.is_alphanumeric() && c != '@' && c != '.' && c != '-' && c != '_' && c != '+');
+        if !token.contains('@') {
+            continue;
+        }
+        let (local, domain) = token.split_once('@')?;
+        if local.is_empty() || domain.is_empty() {
+            continue;
+        }
+        if !domain.contains('.') {
+            continue;
+        }
+        return Some(token.to_string());
+    }
+    None
+}
+
+fn extract_device_code(line: &str) -> Option<String> {
+    // GitHub device codes look like XXXX-YYYY (uppercase alphanumeric).
+    // Find a token of the form `[A-Z0-9]{4}-[A-Z0-9]{4}`.
+    for token in line.split(|c: char| c.is_whitespace() || c == ':' || c == ',' || c == '.') {
+        if token.len() == 9 {
+            let bytes = token.as_bytes();
+            let is_code = bytes[4] == b'-'
+                && bytes[..4]
+                    .iter()
+                    .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit())
+                && bytes[5..]
+                    .iter()
+                    .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit());
+            if is_code {
+                return Some(token.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_url_matched() {
+        let line = "Open this URL in your browser to authorize: https://console.anthropic.com/oauth/authorize?response_type=code&state=xyz";
+        let m = match_line("claude", line);
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(_))));
+        if let Some(AuthPatternMatch::OAuthUrl(u)) = m {
+            assert!(u.contains("anthropic.com/oauth"));
+            assert!(u.contains("response_type=code"));
+        }
+    }
+
+    #[test]
+    fn codex_url_matched() {
+        let line = "Please visit https://auth.openai.com/u/login/identifier?state=abc to continue";
+        let m = match_line("codex", line);
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(u)) if u.contains("openai.com")));
+    }
+
+    #[test]
+    fn gemini_url_matched() {
+        let line = "Visit https://accounts.google.com/o/oauth2/auth?client_id=abc&scope=...";
+        let m = match_line("gemini", line);
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(u)) if u.contains("google.com")));
+    }
+
+    #[test]
+    fn copilot_device_code_matched() {
+        let line = "! First copy your one-time code: ABCD-1234";
+        let m = match_line("copilot", line);
+        if let Some(AuthPatternMatch::DeviceCode { code, verification_url }) = m {
+            assert_eq!(code, "ABCD-1234");
+            assert_eq!(verification_url, "https://github.com/login/device");
+        } else {
+            panic!("expected DeviceCode, got {m:?}");
+        }
+    }
+
+    #[test]
+    fn copilot_device_url_line_matched() {
+        let line = "Please visit https://github.com/login/device and enter code WXYZ-5678";
+        let m = match_line("copilot", line);
+        if let Some(AuthPatternMatch::DeviceCode { code, .. }) = m {
+            assert_eq!(code, "WXYZ-5678");
+        } else {
+            panic!("expected DeviceCode, got {m:?}");
+        }
+    }
+
+    #[test]
+    fn login_success_with_email() {
+        let m = match_line("claude", "Successfully logged in as asaf@example.com");
+        if let Some(AuthPatternMatch::LoginSuccess { email }) = m {
+            assert_eq!(email.as_deref(), Some("asaf@example.com"));
+        } else {
+            panic!("expected LoginSuccess, got {m:?}");
+        }
+    }
+
+    #[test]
+    fn login_success_without_email() {
+        let m = match_line("claude", "You are now authenticated.");
+        assert!(matches!(m, Some(AuthPatternMatch::LoginSuccess { email: None })));
+    }
+
+    #[test]
+    fn fallback_https_matches_for_unknown_providers() {
+        // Unknown provider, but the line has an OAuth-ish URL. The
+        // fallback should still catch it so the user gets the paste
+        // option in the UI.
+        let line = "Open https://example.com/oauth/authorize?state=x";
+        let m = match_line("future-provider", line);
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(_))));
+    }
+
+    #[test]
+    fn fallback_skips_non_oauth_https() {
+        // A line with an https URL that doesn't look like OAuth (e.g.
+        // a documentation link) shouldn't false-positive.
+        let line = "See https://docs.example.com/getting-started for details.";
+        let m = match_line("future-provider", line);
+        assert!(m.is_none());
+    }
+
+    #[test]
+    fn api_key_providers_match_nothing() {
+        // openclaw / kimi / pi don't have OAuth flow. Even if their
+        // output includes an https URL during onboarding, we don't
+        // want to misinterpret it as OAuth.
+        for provider in ["openclaw", "kimi", "pi"] {
+            let m = match_line(provider, "Get your API key at https://example.com/keys");
+            assert!(m.is_none(), "provider {provider} unexpectedly matched");
+        }
+    }
+
+    #[test]
+    fn url_extraction_trims_trailing_punctuation() {
+        let line = "Go to https://example.com/login. Press enter when done.";
+        let url = extract_first_https_url(line).expect("url");
+        // Period after the URL — extractor trims at the end. The exact
+        // behaviour depends on whether `.` counts as a URL char; for
+        // our use we accept either the URL with or without trailing
+        // dot — what matters is the user can paste it back and the
+        // provider's server tolerates the trailing punctuation.
+        assert!(url.starts_with("https://example.com/login"));
+    }
+
+    #[test]
+    fn email_extractor_ignores_placeholders() {
+        // `<email>` is a typical CLI placeholder shown in help text.
+        assert!(extract_email("Sign in as <email>").is_none());
+        // Plain "@example" with no TLD shouldn't match.
+        assert!(extract_email("Twitter handle: @example").is_none());
+    }
+
+    #[test]
+    fn device_code_extractor_recognises_correct_shape() {
+        assert_eq!(extract_device_code("code: ABCD-1234"), Some("ABCD-1234".to_string()));
+        assert_eq!(extract_device_code("the code is XYZW-0987 right here"), Some("XYZW-0987".to_string()));
+        // Wrong length, wrong separator — should miss.
+        assert_eq!(extract_device_code("code: ABC-1234"), None);
+        assert_eq!(extract_device_code("code: ABCD_1234"), None);
+        // Lowercase — GitHub uses uppercase only.
+        assert_eq!(extract_device_code("code: abcd-1234"), None);
+    }
+}

--- a/agentmux-srv/src/identity/auth_patterns.rs
+++ b/agentmux-srv/src/identity/auth_patterns.rs
@@ -36,16 +36,25 @@ pub fn match_line(provider_id: &str, line: &str) -> Option<AuthPatternMatch> {
             return Some(m);
         }
     }
-    // Universal fallback — any https URL during the auth phase is
-    // *probably* an OAuth URL. Last-resort: keep the URL but mark
-    // it as a generic OAuthUrl. The frontend will surface this for
-    // user paste-back if the specific matcher missed it.
+    // Universal fallback — any oauth-ish https URL gets surfaced for
+    // user paste-back if the specific matcher missed it. Skipped
+    // entirely for API-key providers because their onboarding output
+    // ("get your key at https://.../auth") would otherwise be
+    // mis-classified as OAuth and drive the wrong UI branch.
+    // (reagent P1 + codex P2 on PR #840.)
+    if is_api_key_provider(provider_id) {
+        return None;
+    }
     if let Some(url) = extract_first_https_url(line) {
         if looks_like_oauth_url(&url) {
             return Some(AuthPatternMatch::OAuthUrl(url));
         }
     }
     None
+}
+
+fn is_api_key_provider(provider_id: &str) -> bool {
+    matches!(provider_id, "openclaw" | "kimi" | "pi")
 }
 
 type LineMatcher = fn(&str) -> Option<AuthPatternMatch>;
@@ -143,12 +152,23 @@ fn match_logged_in_as(line: &str) -> Option<AuthPatternMatch> {
 fn extract_first_https_url(line: &str) -> Option<String> {
     let start = line.find("https://")?;
     let tail = &line[start..];
-    // URL ends at whitespace, quote, or backtick. Conservative — keeps
-    // ports, paths, query strings, fragments.
+    // URL ends at whitespace, quote, backtick, or closing bracket.
+    // Keeps ports, paths, query strings, fragments.
     let end = tail
         .find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == '`' || c == ')')
         .unwrap_or(tail.len());
-    Some(tail[..end].to_string())
+    let url = &tail[..end];
+    // Trim trailing sentence punctuation that a CLI message might
+    // append (e.g. "Authorize at https://...?state=xyz."). The
+    // browser would otherwise see an invalid URL. Be conservative —
+    // only strip end-of-sentence chars, not anything that could be
+    // part of a legitimate URL token. (reagent P1 on PR #840.)
+    let trimmed = url.trim_end_matches(|c: char| matches!(c, '.' | ',' | ';' | '!' | '?'));
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
 }
 
 fn looks_like_oauth_url(url: &str) -> bool {
@@ -168,7 +188,15 @@ fn extract_email(line: &str) -> Option<String> {
         if !token.contains('@') {
             continue;
         }
-        let (local, domain) = token.split_once('@')?;
+        // `if let` (not `?`) — `?` would exit the function and abort
+        // the search instead of just skipping this token. The `@`
+        // check above means split_once should always be Some here in
+        // practice, but the safe pattern is to never `?` inside a
+        // for-loop unless the function-exit semantics are intended.
+        // (reagent P1 / codex P2 on PR #840.)
+        let Some((local, domain)) = token.split_once('@') else {
+            continue;
+        };
         if local.is_empty() || domain.is_empty() {
             continue;
         }
@@ -301,14 +329,45 @@ mod tests {
 
     #[test]
     fn url_extraction_trims_trailing_punctuation() {
-        let line = "Go to https://example.com/login. Press enter when done.";
+        // Period, comma, semicolon, !, ? at the END of a URL are
+        // almost certainly sentence terminators, not URL chars.
+        // The browser would reject the URL with them attached.
+        // (reagent P1 on PR #840.)
+        let cases = [
+            ("Go to https://example.com/login.", "https://example.com/login"),
+            ("Open https://example.com/auth, then press Enter", "https://example.com/auth"),
+            ("Visit https://example.com/login!", "https://example.com/login"),
+            ("Done at https://example.com/oauth?state=xyz?", "https://example.com/oauth?state=xyz"),
+        ];
+        for (line, expected) in cases {
+            let url = extract_first_https_url(line).expect("url");
+            assert_eq!(url, expected, "for line: {line}");
+        }
+    }
+
+    #[test]
+    fn url_extraction_preserves_internal_punctuation() {
+        // Make sure we don't over-trim — query strings legitimately
+        // have `&` and `=`, paths can have `.`, etc.
+        let line = "Open https://example.com/path.html?key=value&other=v2";
         let url = extract_first_https_url(line).expect("url");
-        // Period after the URL — extractor trims at the end. The exact
-        // behaviour depends on whether `.` counts as a URL char; for
-        // our use we accept either the URL with or without trailing
-        // dot — what matters is the user can paste it back and the
-        // provider's server tolerates the trailing punctuation.
-        assert!(url.starts_with("https://example.com/login"));
+        assert_eq!(url, "https://example.com/path.html?key=value&other=v2");
+    }
+
+    #[test]
+    fn api_key_provider_fallback_returns_none() {
+        // Reagent P1 + codex P2 on PR #840: the universal fallback
+        // used to run for API-key providers. Their onboarding output
+        // ("get your key at https://.../auth") would mis-classify
+        // as OAuth and drive the wrong UI branch. Now: no fallback
+        // for openclaw/kimi/pi at all.
+        for provider in ["openclaw", "kimi", "pi"] {
+            let line = "Get your API key at https://example.com/auth/keys";
+            assert!(match_line(provider, line).is_none(), "{provider} matched");
+        }
+        // Whereas an unknown provider still gets the fallback.
+        let m = match_line("unknown-provider", "Open https://example.com/oauth/authorize");
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(_))));
     }
 
     #[test]

--- a/agentmux-srv/src/identity/auth_patterns.rs
+++ b/agentmux-srv/src/identity/auth_patterns.rs
@@ -136,6 +136,19 @@ fn match_copilot_device_code(line: &str) -> Option<AuthPatternMatch> {
 
 fn match_logged_in_as(line: &str) -> Option<AuthPatternMatch> {
     let line_low = line.to_lowercase();
+    // Negative forms ("not authenticated", "not logged in", "isn't
+    // authenticated", "n't logged in", "failed to authenticate") are
+    // status messages, not success — fall through. Reagent caught the
+    // bare `contains("authenticated")` matching error lines on PR #840.
+    if line_low.contains("not authenticated")
+        || line_low.contains("not logged in")
+        || line_low.contains("n't authenticated")
+        || line_low.contains("n't logged in")
+        || line_low.contains("failed to authenticate")
+        || line_low.contains("authentication failed")
+    {
+        return None;
+    }
     if !line_low.contains("logged in") && !line_low.contains("authenticated") {
         return None;
     }
@@ -295,6 +308,24 @@ mod tests {
     fn login_success_without_email() {
         let m = match_line("claude", "You are now authenticated.");
         assert!(matches!(m, Some(AuthPatternMatch::LoginSuccess { email: None })));
+    }
+
+    #[test]
+    fn login_success_skips_negative_forms() {
+        // Reagent P2 on PR #840: bare `contains("authenticated")`
+        // matched "Error: not authenticated" and "Authentication
+        // failed" lines, falsely promoting them to LoginSuccess.
+        for line in [
+            "Error: not authenticated",
+            "you are not authenticated",
+            "user isn't authenticated yet",
+            "You aren't logged in",
+            "failed to authenticate",
+            "Authentication failed",
+        ] {
+            let m = match_line("claude", line);
+            assert!(m.is_none(), "expected None for {line:?}, got {m:?}");
+        }
     }
 
     #[test]

--- a/agentmux-srv/src/identity/auth_session.rs
+++ b/agentmux-srv/src/identity/auth_session.rs
@@ -1,0 +1,464 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory manager for pre-launch OAuth sessions.
+//!
+//! See `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` §7.
+//!
+//! Each session represents one user-initiated "Connect with OAuth"
+//! attempt. The frontend creates a session via `start_session`,
+//! polls via `poll_session`, optionally pastes a callback URL via
+//! `submit_callback_url`, and cancels via `cancel_session`.
+//!
+//! PR A scope: the session-state machine + per-line stdout
+//! interpretation + lifecycle (timeout, cancel, cleanup). The
+//! actual CLI spawn lives in the handler (so it can use AppState's
+//! CLI resolver) but emits frames into this module via
+//! `record_line` / `record_exit`. That keeps this module pure and
+//! testable.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use super::auth_patterns::{match_line, AuthPatternMatch};
+
+/// Wall-clock cap on a single auth session. Past this, the session
+/// transitions to `Failed { reason: "timeout" }` and the spawned
+/// CLI (if any) is killed by the handler that owns the join handle.
+const SESSION_TIMEOUT_SECS: u64 = 600;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum AuthSessionStatus {
+    /// CLI is spawned, we're waiting for it to emit either a URL,
+    /// a device code, or a success line.
+    Pending,
+    /// CLI emitted an OAuth URL. Frontend surfaces this to the user
+    /// for paste-into-browser if auto-open failed.
+    UrlAvailable { auth_url: String },
+    /// CLI emitted a device code. Frontend renders it prominently.
+    CodeEmitted {
+        device_code: String,
+        verification_url: String,
+    },
+    /// CLI authenticated successfully. The handler captured the
+    /// credentials and created the bundle.
+    Success {
+        bundle_id: String,
+        /// Best-effort — extracted from the CLI's "logged in as..."
+        /// line. Used by the frontend to name the bundle.
+        email: Option<String>,
+    },
+    /// Auth attempt failed. `error` is a short human-readable phrase
+    /// suitable to render inline.
+    Failed { error: String },
+}
+
+impl AuthSessionStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Success { .. } | Self::Failed { .. })
+    }
+}
+
+#[derive(Debug)]
+struct Session {
+    provider_id: String,
+    into_bundle_id: Option<String>,
+    status: AuthSessionStatus,
+    /// Last URL or code we surfaced — kept across polls so the
+    /// frontend can repaint without re-receiving on every tick.
+    captured_url: Option<String>,
+    captured_device_code: Option<(String, String)>,
+    captured_email: Option<String>,
+    started_at: Instant,
+    /// All stdout/stderr lines we've seen, in order. Used for the
+    /// diagnostic "show me what the CLI said" panel and the
+    /// integration tests.
+    transcript: Vec<String>,
+}
+
+impl Session {
+    fn new(provider_id: String, into_bundle_id: Option<String>) -> Self {
+        Self {
+            provider_id,
+            into_bundle_id,
+            status: AuthSessionStatus::Pending,
+            captured_url: None,
+            captured_device_code: None,
+            captured_email: None,
+            started_at: Instant::now(),
+            transcript: Vec::new(),
+        }
+    }
+
+    fn timed_out(&self) -> bool {
+        self.started_at.elapsed() > Duration::from_secs(SESSION_TIMEOUT_SECS)
+    }
+}
+
+/// Public-facing handle returned by `start_session`. The handler
+/// owns the spawned CLI's child handle (so it can stdin-inject the
+/// pasted callback URL and kill on cancel); this manager owns the
+/// session state.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StartSessionResult {
+    pub session_id: String,
+    /// If the CLI emitted the URL synchronously (before this call
+    /// returns) — rare but happens for fast providers. Usually
+    /// `None`; the frontend polls and picks it up on the first tick.
+    pub auth_url: Option<String>,
+}
+
+/// Snapshot returned by `poll_session`. Mirrors `AuthSessionStatus`
+/// plus the provider id for renderer dispatch.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PollSessionResult {
+    pub provider_id: String,
+    #[serde(flatten)]
+    pub status: AuthSessionStatus,
+}
+
+#[derive(Default)]
+pub struct AuthSessionManager {
+    sessions: Arc<Mutex<HashMap<String, Session>>>,
+}
+
+impl AuthSessionManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allocate a new session id and store the initial Pending state.
+    /// The caller (handler) is responsible for spawning the CLI and
+    /// feeding stdout lines into `record_line`.
+    pub fn start_session(
+        &self,
+        provider_id: String,
+        into_bundle_id: Option<String>,
+    ) -> StartSessionResult {
+        let session_id = format!("auth-{}", uuid::Uuid::new_v4());
+        let session = Session::new(provider_id, into_bundle_id);
+        self.sessions
+            .lock()
+            .unwrap()
+            .insert(session_id.clone(), session);
+        StartSessionResult {
+            session_id,
+            auth_url: None,
+        }
+    }
+
+    /// Feed a single line of CLI stdout/stderr into the session.
+    /// Returns the pattern match (if any) so the handler can decide
+    /// to forward the URL elsewhere (e.g. broker event).
+    pub fn record_line(&self, session_id: &str, line: &str) -> Option<AuthPatternMatch> {
+        let mut sessions = self.sessions.lock().unwrap();
+        let session = sessions.get_mut(session_id)?;
+        session.transcript.push(line.to_string());
+        let m = match_line(&session.provider_id, line)?;
+        match &m {
+            AuthPatternMatch::OAuthUrl(url) => {
+                if session.captured_url.is_none() {
+                    session.captured_url = Some(url.clone());
+                    if matches!(session.status, AuthSessionStatus::Pending) {
+                        session.status = AuthSessionStatus::UrlAvailable {
+                            auth_url: url.clone(),
+                        };
+                    }
+                }
+            }
+            AuthPatternMatch::DeviceCode {
+                code,
+                verification_url,
+            } => {
+                if session.captured_device_code.is_none() {
+                    session.captured_device_code =
+                        Some((code.clone(), verification_url.clone()));
+                    if matches!(
+                        session.status,
+                        AuthSessionStatus::Pending | AuthSessionStatus::UrlAvailable { .. }
+                    ) {
+                        session.status = AuthSessionStatus::CodeEmitted {
+                            device_code: code.clone(),
+                            verification_url: verification_url.clone(),
+                        };
+                    }
+                }
+            }
+            AuthPatternMatch::LoginSuccess { email } => {
+                // Don't transition to Success here — the handler is
+                // responsible for confirming with authCheckCommand
+                // AND persisting the bundle row before declaring
+                // success. We just record the email for later.
+                if session.captured_email.is_none() {
+                    session.captured_email = email.clone();
+                }
+            }
+            AuthPatternMatch::LoginFailure { message: _ } => {
+                // Same — handler decides Failed status (it has more
+                // context: CLI exit code, auth check result, etc.).
+            }
+        }
+        Some(m)
+    }
+
+    /// Handler-side completion hook. Called when the CLI exits or
+    /// auth check confirms success. Transitions the session to a
+    /// terminal state.
+    pub fn finish_success(&self, session_id: &str, bundle_id: String) -> bool {
+        let mut sessions = self.sessions.lock().unwrap();
+        let Some(session) = sessions.get_mut(session_id) else {
+            return false;
+        };
+        if session.status.is_terminal() {
+            return false;
+        }
+        session.status = AuthSessionStatus::Success {
+            bundle_id,
+            email: session.captured_email.clone(),
+        };
+        true
+    }
+
+    pub fn finish_failure(&self, session_id: &str, error: String) -> bool {
+        let mut sessions = self.sessions.lock().unwrap();
+        let Some(session) = sessions.get_mut(session_id) else {
+            return false;
+        };
+        if session.status.is_terminal() {
+            return false;
+        }
+        session.status = AuthSessionStatus::Failed { error };
+        true
+    }
+
+    /// Poll a session's current status. Also sweeps timed-out
+    /// sessions: if the session has been Pending past
+    /// SESSION_TIMEOUT_SECS, transition to Failed and return that.
+    pub fn poll_session(&self, session_id: &str) -> Option<PollSessionResult> {
+        let mut sessions = self.sessions.lock().unwrap();
+        let session = sessions.get_mut(session_id)?;
+        if !session.status.is_terminal() && session.timed_out() {
+            session.status = AuthSessionStatus::Failed {
+                error: format!(
+                    "auth session timed out after {SESSION_TIMEOUT_SECS}s"
+                ),
+            };
+        }
+        Some(PollSessionResult {
+            provider_id: session.provider_id.clone(),
+            status: session.status.clone(),
+        })
+    }
+
+    /// Cancel a session. Returns true if the session existed and was
+    /// transitioned (caller's responsibility to kill any spawned CLI).
+    pub fn cancel_session(&self, session_id: &str) -> bool {
+        self.finish_failure(session_id, "cancelled by user".to_string())
+    }
+
+    /// Remove a session from the map. Caller should only invoke this
+    /// after the session is terminal AND the frontend has had time
+    /// to read the final state (typically after the next successful
+    /// poll). For PR A we just leave terminal sessions in the map;
+    /// PR B can add an LRU sweep.
+    pub fn remove(&self, session_id: &str) {
+        self.sessions.lock().unwrap().remove(session_id);
+    }
+
+    /// Read the full transcript of captured stdout/stderr lines.
+    /// Used by integration tests; exposed for completeness even
+    /// though no production caller currently reads it.
+    #[allow(dead_code)]
+    pub fn transcript(&self, session_id: &str) -> Option<Vec<String>> {
+        self.sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|s| s.transcript.clone())
+    }
+
+    /// Inject a force-elapsed `started_at` for the given session —
+    /// test helper so we can exercise the timeout transition without
+    /// actually waiting SESSION_TIMEOUT_SECS.
+    #[cfg(test)]
+    fn force_age(&self, session_id: &str) {
+        if let Some(s) = self.sessions.lock().unwrap().get_mut(session_id) {
+            s.started_at = Instant::now() - Duration::from_secs(SESSION_TIMEOUT_SECS + 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mgr() -> AuthSessionManager {
+        AuthSessionManager::new()
+    }
+
+    #[test]
+    fn start_creates_pending_session() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        assert!(!r.session_id.is_empty());
+        assert!(r.auth_url.is_none());
+        let p = m.poll_session(&r.session_id).expect("session exists");
+        assert_eq!(p.provider_id, "claude");
+        assert!(matches!(p.status, AuthSessionStatus::Pending));
+    }
+
+    #[test]
+    fn url_line_transitions_to_url_available() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        let _ = m.record_line(
+            &r.session_id,
+            "Open https://console.anthropic.com/oauth/authorize?state=xyz",
+        );
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::UrlAvailable { auth_url } => {
+                assert!(auth_url.contains("anthropic.com/oauth"));
+            }
+            other => panic!("expected UrlAvailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn device_code_line_transitions_to_code_emitted() {
+        let m = mgr();
+        let r = m.start_session("copilot".to_string(), None);
+        let _ = m.record_line(&r.session_id, "! Copy your one-time code: ABCD-1234");
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::CodeEmitted {
+                device_code,
+                verification_url,
+            } => {
+                assert_eq!(device_code, "ABCD-1234");
+                assert_eq!(verification_url, "https://github.com/login/device");
+            }
+            other => panic!("expected CodeEmitted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_success_line_does_not_transition_state_alone() {
+        // The CLI saying "logged in" isn't enough — the handler
+        // confirms via authCheck before declaring Success.
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        let _ = m.record_line(&r.session_id, "Successfully logged in as asaf@example.com");
+        let p = m.poll_session(&r.session_id).unwrap();
+        // Still pending — handler hasn't called finish_success yet.
+        assert!(matches!(p.status, AuthSessionStatus::Pending));
+    }
+
+    #[test]
+    fn finish_success_carries_email_from_transcript() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        let _ = m.record_line(&r.session_id, "Successfully logged in as asaf@example.com");
+        assert!(m.finish_success(&r.session_id, "bundle-1".to_string()));
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::Success { bundle_id, email } => {
+                assert_eq!(bundle_id, "bundle-1");
+                assert_eq!(email.as_deref(), Some("asaf@example.com"));
+            }
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cancel_transitions_to_failed() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        assert!(m.cancel_session(&r.session_id));
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::Failed { error } => assert!(error.contains("cancelled")),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn timeout_transitions_pending_to_failed_on_poll() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        m.force_age(&r.session_id);
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::Failed { error } => assert!(error.contains("timed out")),
+            other => panic!("expected timeout Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn terminal_states_cannot_be_re_transitioned() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        assert!(m.finish_success(&r.session_id, "bundle-1".to_string()));
+        // Second finish_failure is a no-op.
+        assert!(!m.finish_failure(&r.session_id, "should be ignored".to_string()));
+        let p = m.poll_session(&r.session_id).unwrap();
+        assert!(matches!(p.status, AuthSessionStatus::Success { .. }));
+    }
+
+    #[test]
+    fn multiple_url_lines_keep_the_first_url() {
+        // If the CLI emits the URL again later (some do), we don't
+        // overwrite — the first URL is what the user saw + pasted.
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        let _ = m.record_line(
+            &r.session_id,
+            "Open https://console.anthropic.com/oauth/authorize?state=first",
+        );
+        let _ = m.record_line(
+            &r.session_id,
+            "Open https://console.anthropic.com/oauth/authorize?state=second",
+        );
+        let p = m.poll_session(&r.session_id).unwrap();
+        match p.status {
+            AuthSessionStatus::UrlAvailable { auth_url } => {
+                assert!(auth_url.contains("state=first"));
+            }
+            _ => panic!("expected UrlAvailable"),
+        }
+    }
+
+    #[test]
+    fn remove_clears_session() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        m.remove(&r.session_id);
+        assert!(m.poll_session(&r.session_id).is_none());
+    }
+
+    #[test]
+    fn unknown_session_polls_to_none() {
+        let m = mgr();
+        assert!(m.poll_session("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn transcript_records_all_lines_including_non_matching() {
+        let m = mgr();
+        let r = m.start_session("claude".to_string(), None);
+        let _ = m.record_line(&r.session_id, "Starting auth flow...");
+        let _ = m.record_line(&r.session_id, "Open https://console.anthropic.com/oauth/authorize");
+        let _ = m.record_line(&r.session_id, "Waiting for callback...");
+        let t = m.transcript(&r.session_id).unwrap();
+        assert_eq!(t.len(), 3);
+        assert_eq!(t[0], "Starting auth flow...");
+        assert!(t[1].contains("anthropic.com/oauth"));
+        assert_eq!(t[2], "Waiting for callback...");
+    }
+}

--- a/agentmux-srv/src/identity/auth_session.rs
+++ b/agentmux-srv/src/identity/auth_session.rs
@@ -31,7 +31,11 @@ use super::auth_patterns::{match_line, AuthPatternMatch};
 const SESSION_TIMEOUT_SECS: u64 = 600;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(tag = "status", rename_all = "kebab-case")]
+#[serde(
+    tag = "status",
+    rename_all = "kebab-case",
+    rename_all_fields = "camelCase"
+)]
 pub enum AuthSessionStatus {
     /// CLI is spawned, we're waiting for it to emit either a URL,
     /// a device code, or a success line.
@@ -123,9 +127,20 @@ pub struct PollSessionResult {
     pub status: AuthSessionStatus,
 }
 
+/// Per-session "process refs" — the join handle for the drain task
+/// and the stdin sender for the callback-paste-back path. Held
+/// outside the `sessions` Mutex so cancellation can `.abort()` /
+/// drop without holding the state lock across an await.
+#[derive(Default)]
+struct ProcessRefs {
+    drain_tasks: HashMap<String, tokio::task::JoinHandle<()>>,
+    stdin_senders: HashMap<String, tokio::sync::mpsc::Sender<String>>,
+}
+
 #[derive(Default)]
 pub struct AuthSessionManager {
     sessions: Arc<Mutex<HashMap<String, Session>>>,
+    process_refs: Arc<Mutex<ProcessRefs>>,
 }
 
 impl AuthSessionManager {
@@ -256,10 +271,57 @@ impl AuthSessionManager {
         })
     }
 
-    /// Cancel a session. Returns true if the session existed and was
-    /// transitioned (caller's responsibility to kill any spawned CLI).
+    /// Cancel a session: transition state to Failed + abort the
+    /// spawned drain task (which kills the child via kill_on_drop).
+    /// Returns true if the state transition happened (false on
+    /// unknown / already-terminal session — the process refs are
+    /// torn down either way so a re-fired cancel is a no-op).
     pub fn cancel_session(&self, session_id: &str) -> bool {
-        self.finish_failure(session_id, "cancelled by user".to_string())
+        let transitioned =
+            self.finish_failure(session_id, "cancelled by user".to_string());
+        let mut refs = self.process_refs.lock().unwrap();
+        if let Some(handle) = refs.drain_tasks.remove(session_id) {
+            handle.abort();
+        }
+        refs.stdin_senders.remove(session_id);
+        transitioned
+    }
+
+    /// Register the drain task + stdin sender for a session. Called
+    /// by the handler immediately after spawning the CLI.
+    pub fn attach_process(
+        &self,
+        session_id: &str,
+        drain_task: tokio::task::JoinHandle<()>,
+        stdin_sender: tokio::sync::mpsc::Sender<String>,
+    ) {
+        let mut refs = self.process_refs.lock().unwrap();
+        refs.drain_tasks.insert(session_id.to_string(), drain_task);
+        refs.stdin_senders.insert(session_id.to_string(), stdin_sender);
+    }
+
+    /// Forward a pasted callback URL to the spawned CLI's stdin.
+    /// Returns true if the session has an attached stdin sender;
+    /// false if the session never spawned a CLI or the sender's
+    /// receiver was dropped.
+    pub async fn send_to_stdin(&self, session_id: &str, line: String) -> bool {
+        let sender = {
+            let refs = self.process_refs.lock().unwrap();
+            refs.stdin_senders.get(session_id).cloned()
+        };
+        match sender {
+            Some(s) => s.send(line).await.is_ok(),
+            None => false,
+        }
+    }
+
+    /// Drop a session's process refs without aborting them. Called
+    /// by the drain task itself when it exits normally so terminal
+    /// state lookups still work but the resources are reclaimed.
+    pub fn detach_process(&self, session_id: &str) {
+        let mut refs = self.process_refs.lock().unwrap();
+        refs.drain_tasks.remove(session_id);
+        refs.stdin_senders.remove(session_id);
     }
 
     /// Remove a session from the map. Caller should only invoke this
@@ -440,6 +502,53 @@ mod tests {
         let r = m.start_session("claude".to_string(), None);
         m.remove(&r.session_id);
         assert!(m.poll_session(&r.session_id).is_none());
+    }
+
+    #[test]
+    fn status_serializes_with_camelcase_field_names() {
+        // Codex P2 on PR #840: the per-variant fields used to
+        // serialize as auth_url / device_code / etc. (snake_case)
+        // while the rest of the wire is camelCase. Now uniformly
+        // camelCase via rename_all_fields.
+        let s = AuthSessionStatus::UrlAvailable {
+            auth_url: "https://example.com/oauth".to_string(),
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "status": "url-available",
+                "authUrl": "https://example.com/oauth"
+            })
+        );
+
+        let s = AuthSessionStatus::CodeEmitted {
+            device_code: "ABCD-1234".to_string(),
+            verification_url: "https://github.com/login/device".to_string(),
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "status": "code-emitted",
+                "deviceCode": "ABCD-1234",
+                "verificationUrl": "https://github.com/login/device"
+            })
+        );
+
+        let s = AuthSessionStatus::Success {
+            bundle_id: "bundle-1".to_string(),
+            email: Some("asaf@example.com".to_string()),
+        };
+        let v = serde_json::to_value(&s).unwrap();
+        assert_eq!(
+            v,
+            serde_json::json!({
+                "status": "success",
+                "bundleId": "bundle-1",
+                "email": "asaf@example.com"
+            })
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/identity/mod.rs
+++ b/agentmux-srv/src/identity/mod.rs
@@ -28,6 +28,8 @@
 //! entity) were prerequisites; Phase 3 (encrypted vault, OAuth flows)
 //! is deferred.
 
+pub mod auth_patterns;
+pub mod auth_session;
 pub mod resolver;
 
 pub use resolver::inject_identity_env;

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -673,6 +673,9 @@ async fn main() {
         // `seed + 1`; on a fresh DB seed=0, first saga gets id 1.
         saga_id_alloc: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(saga_id_seed)),
         saga_log: Arc::clone(&saga_log),
+        auth_session_manager: std::sync::Arc::new(
+            crate::identity::auth_session::AuthSessionManager::new(),
+        ),
     };
 
     // Saga durability PR 2 — resume-on-startup. Walk any sagas the

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -1,0 +1,262 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pre-launch OAuth flow RPC handlers.
+//!
+//! Five commands per `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` §7:
+//!
+//!   * `auth.start`           — `StartProviderAuth`
+//!   * `auth.poll`            — `PollProviderAuth`
+//!   * `auth.submitcallback`  — `SubmitAuthCallback`
+//!   * `auth.cancel`          — `CancelProviderAuth`
+//!   * `auth.submitapikey`    — `SubmitProviderApiKey`
+//!
+//! This module owns the RPC surface and dispatches into
+//! `crate::identity::auth_session::AuthSessionManager`. The actual
+//! provider-CLI spawn (which feeds stdout lines into the session
+//! via `record_line`) lands in a follow-up commit on this branch —
+//! these handlers ship the lifecycle plumbing and return clear
+//! "spawn not yet wired" errors for the callback/api-key paths so
+//! frontend (PR B) can integrate against the real shape.
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::backend::rpc::engine::WshRpcEngine;
+
+use super::AppState;
+
+pub const COMMAND_AUTH_START: &str = "auth.start";
+pub const COMMAND_AUTH_POLL: &str = "auth.poll";
+pub const COMMAND_AUTH_SUBMIT_CALLBACK: &str = "auth.submitcallback";
+pub const COMMAND_AUTH_CANCEL: &str = "auth.cancel";
+pub const COMMAND_AUTH_SUBMIT_API_KEY: &str = "auth.submitapikey";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StartProviderAuthReq {
+    provider_id: String,
+    /// Optional — when set, a successful auth adds an account to the
+    /// existing bundle. When None, a fresh bundle is created.
+    #[serde(default)]
+    into_bundle_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PollProviderAuthReq {
+    session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitAuthCallbackReq {
+    session_id: String,
+    /// The redirect URL the user pasted back (browser-didn't-open
+    /// fallback). The handler writes it to the spawned CLI's stdin.
+    callback_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CancelProviderAuthReq {
+    session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitProviderApiKeyReq {
+    provider_id: String,
+    /// Optional — same semantics as StartProviderAuth.into_bundle_id.
+    #[serde(default)]
+    into_bundle_id: Option<String>,
+    /// The API key the user pasted. Will be validated by running the
+    /// provider's authCheckCommand against it, then persisted as a
+    /// `SecretRef::PlaintextDev` (PR 1 of the storage spec) or
+    /// encrypted variant (PR 2).
+    api_key: String,
+    account_name: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AckResp {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let mgr = state.auth_session_manager.clone();
+    engine.register_handler(
+        COMMAND_AUTH_START,
+        Box::new(move |data, _ctx| {
+            let mgr = mgr.clone();
+            Box::pin(async move {
+                let req: StartProviderAuthReq = serde_json::from_value(data)
+                    .map_err(|e| format!("auth.start: {e}"))?;
+                tracing::info!(
+                    provider_id = %req.provider_id,
+                    into_bundle_id = ?req.into_bundle_id,
+                    "auth.start"
+                );
+                let r = mgr.start_session(req.provider_id, req.into_bundle_id);
+                Ok(Some(serde_json::to_value(&r).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let mgr = state.auth_session_manager.clone();
+    engine.register_handler(
+        COMMAND_AUTH_POLL,
+        Box::new(move |data, _ctx| {
+            let mgr = mgr.clone();
+            Box::pin(async move {
+                let req: PollProviderAuthReq = serde_json::from_value(data)
+                    .map_err(|e| format!("auth.poll: {e}"))?;
+                let snap = mgr
+                    .poll_session(&req.session_id)
+                    .ok_or_else(|| format!("auth.poll: unknown session {}", req.session_id))?;
+                Ok(Some(serde_json::to_value(&snap).unwrap_or_default()))
+            })
+        }),
+    );
+
+    let mgr = state.auth_session_manager.clone();
+    engine.register_handler(
+        COMMAND_AUTH_CANCEL,
+        Box::new(move |data, _ctx| {
+            let mgr = mgr.clone();
+            Box::pin(async move {
+                let req: CancelProviderAuthReq = serde_json::from_value(data)
+                    .map_err(|e| format!("auth.cancel: {e}"))?;
+                let ok = mgr.cancel_session(&req.session_id);
+                Ok(Some(
+                    serde_json::to_value(&AckResp {
+                        success: ok,
+                        error: if ok {
+                            None
+                        } else {
+                            Some(format!("unknown or already-terminal session: {}", req.session_id))
+                        },
+                    })
+                    .unwrap_or_default(),
+                ))
+            })
+        }),
+    );
+
+    // The next-commit-on-this-branch CLI spawn integration replaces
+    // these stubs. Returning a structured error lets frontend (PR B)
+    // exercise the unimplemented path explicitly during integration
+    // tests rather than getting an opaque server crash.
+    engine.register_handler(
+        COMMAND_AUTH_SUBMIT_CALLBACK,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let _req: SubmitAuthCallbackReq = serde_json::from_value(data)
+                    .map_err(|e| format!("auth.submitcallback: {e}"))?;
+                // TODO(PR A v2): write callback_url to spawned CLI's
+                // stdin (browser-didn't-open path). Until then,
+                // surface a clear "not yet wired" so frontend
+                // integration tests can assert against it.
+                Err::<Option<serde_json::Value>, String>(
+                    "auth.submitcallback: stdin injection lands in a follow-up commit"
+                        .to_string(),
+                )
+            })
+        }),
+    );
+
+    engine.register_handler(
+        COMMAND_AUTH_SUBMIT_API_KEY,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let _req: SubmitProviderApiKeyReq = serde_json::from_value(data)
+                    .map_err(|e| format!("auth.submitapikey: {e}"))?;
+                // TODO(PR A v2): run provider's authCheckCommand with
+                // the api_key in the appropriate env var; on success,
+                // persist via wstore as a new IdentityAccount row
+                // with kind=api_key + SecretRef::PlaintextDev.
+                Err::<Option<serde_json::Value>, String>(
+                    "auth.submitapikey: provider validation lands in a follow-up commit"
+                        .to_string(),
+                )
+            })
+        }),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Request shape parsing tests — verify the wire contract matches
+    // what the frontend (PR B) will send. The end-to-end RPC-engine
+    // invocation is covered at the integration level once the CLI
+    // spawn lands; the underlying AuthSessionManager behaviour is
+    // covered in `identity::auth_session::tests`.
+
+    #[test]
+    fn start_req_parses_minimal() {
+        let v = serde_json::json!({ "providerId": "claude" });
+        let r: StartProviderAuthReq = serde_json::from_value(v).unwrap();
+        assert_eq!(r.provider_id, "claude");
+        assert!(r.into_bundle_id.is_none());
+    }
+
+    #[test]
+    fn start_req_parses_with_bundle_id() {
+        let v = serde_json::json!({ "providerId": "codex", "intoBundleId": "bundle-1" });
+        let r: StartProviderAuthReq = serde_json::from_value(v).unwrap();
+        assert_eq!(r.provider_id, "codex");
+        assert_eq!(r.into_bundle_id.as_deref(), Some("bundle-1"));
+    }
+
+    #[test]
+    fn poll_req_round_trips() {
+        let v = serde_json::json!({ "sessionId": "auth-xyz" });
+        let r: PollProviderAuthReq = serde_json::from_value(v).unwrap();
+        assert_eq!(r.session_id, "auth-xyz");
+    }
+
+    #[test]
+    fn submit_callback_req_round_trips() {
+        let v = serde_json::json!({
+            "sessionId": "auth-xyz",
+            "callbackUrl": "https://example.com/cb?code=abc"
+        });
+        let r: SubmitAuthCallbackReq = serde_json::from_value(v).unwrap();
+        assert_eq!(r.session_id, "auth-xyz");
+        assert!(r.callback_url.contains("code=abc"));
+    }
+
+    #[test]
+    fn submit_api_key_req_round_trips() {
+        let v = serde_json::json!({
+            "providerId": "openclaw",
+            "apiKey": "sk-test",
+            "accountName": "my-key"
+        });
+        let r: SubmitProviderApiKeyReq = serde_json::from_value(v).unwrap();
+        assert_eq!(r.provider_id, "openclaw");
+        assert_eq!(r.api_key, "sk-test");
+        assert_eq!(r.account_name, "my-key");
+        assert!(r.into_bundle_id.is_none());
+    }
+
+    #[test]
+    fn ack_resp_omits_error_when_success() {
+        let r = AckResp { success: true, error: None };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v, serde_json::json!({ "success": true }));
+    }
+
+    #[test]
+    fn ack_resp_includes_error_when_failure() {
+        let r = AckResp { success: false, error: Some("boom".into()) };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(v, serde_json::json!({ "success": false, "error": "boom" }));
+    }
+}

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -41,6 +41,22 @@ struct StartProviderAuthReq {
     /// existing bundle. When None, a fresh bundle is created.
     #[serde(default)]
     into_bundle_id: Option<String>,
+    /// Resolved CLI path. The frontend calls `resolvecli` first to
+    /// install / locate the provider's CLI; the resulting path is
+    /// passed here. Keeps the provider table single-sourced in the
+    /// frontend.
+    cli_path: String,
+    /// e.g. `["auth", "login"]` from the provider definition's
+    /// `authLoginCommand` field.
+    auth_login_args: Vec<String>,
+    /// e.g. `["auth", "status", "--json"]` — used to confirm
+    /// authentication after the CLI emits its success line.
+    auth_check_args: Vec<String>,
+    /// Env vars to inject at spawn time. Per-provider auth
+    /// isolation env vars come here (CLAUDE_CONFIG_DIR, CODEX_HOME,
+    /// GEMINI_CLI_HOME, etc.).
+    #[serde(default)]
+    auth_env: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -98,10 +114,20 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                     .map_err(|e| format!("auth.start: {e}"))?;
                 tracing::info!(
                     provider_id = %req.provider_id,
+                    cli_path = %req.cli_path,
                     into_bundle_id = ?req.into_bundle_id,
                     "auth.start"
                 );
-                let r = mgr.start_session(req.provider_id, req.into_bundle_id);
+                let r = mgr.start_session(req.provider_id.clone(), req.into_bundle_id);
+                spawn_auth_cli(
+                    mgr,
+                    r.session_id.clone(),
+                    req.provider_id,
+                    req.cli_path,
+                    req.auth_login_args,
+                    req.auth_check_args,
+                    req.auth_env,
+                );
                 Ok(Some(serde_json::to_value(&r).unwrap_or_default()))
             })
         }),
@@ -147,24 +173,31 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
         }),
     );
 
-    // The next-commit-on-this-branch CLI spawn integration replaces
-    // these stubs. Returning a structured error lets frontend (PR B)
-    // exercise the unimplemented path explicitly during integration
-    // tests rather than getting an opaque server crash.
+    let mgr = state.auth_session_manager.clone();
     engine.register_handler(
         COMMAND_AUTH_SUBMIT_CALLBACK,
         Box::new(move |data, _ctx| {
+            let mgr = mgr.clone();
             Box::pin(async move {
-                let _req: SubmitAuthCallbackReq = serde_json::from_value(data)
+                let req: SubmitAuthCallbackReq = serde_json::from_value(data)
                     .map_err(|e| format!("auth.submitcallback: {e}"))?;
-                // TODO(PR A v2): write callback_url to spawned CLI's
-                // stdin (browser-didn't-open path). Until then,
-                // surface a clear "not yet wired" so frontend
-                // integration tests can assert against it.
-                Err::<Option<serde_json::Value>, String>(
-                    "auth.submitcallback: stdin injection lands in a follow-up commit"
-                        .to_string(),
-                )
+                let delivered = mgr
+                    .send_to_stdin(&req.session_id, req.callback_url)
+                    .await;
+                Ok(Some(
+                    serde_json::to_value(&AckResp {
+                        success: delivered,
+                        error: if delivered {
+                            None
+                        } else {
+                            Some(format!(
+                                "no stdin sender for session {} (process exited or session unknown)",
+                                req.session_id
+                            ))
+                        },
+                    })
+                    .unwrap_or_default(),
+                ))
             })
         }),
     );
@@ -175,17 +208,242 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
             Box::pin(async move {
                 let _req: SubmitProviderApiKeyReq = serde_json::from_value(data)
                     .map_err(|e| format!("auth.submitapikey: {e}"))?;
-                // TODO(PR A v2): run provider's authCheckCommand with
-                // the api_key in the appropriate env var; on success,
-                // persist via wstore as a new IdentityAccount row
-                // with kind=api_key + SecretRef::PlaintextDev.
+                // API-key path validates by running the provider's
+                // authCheckCommand with the key in the appropriate
+                // env var, then persists via wstore. That persistence
+                // is part of PR C (bundle auto-creation) per spec
+                // §10 — the validate-and-stash logic is here but
+                // wstore writes wait. For PR A we return an explicit
+                // error so frontend (PR B) sees a clear "not yet"
+                // signal while OAuth providers work end-to-end.
                 Err::<Option<serde_json::Value>, String>(
-                    "auth.submitapikey: provider validation lands in a follow-up commit"
+                    "auth.submitapikey: bundle persistence lands in PR C"
                         .to_string(),
                 )
             })
         }),
     );
+}
+
+/// Spawn the provider's auth-login CLI and drive the session through
+/// to a terminal state. Background-only — returns immediately. The
+/// drain task feeds stdout+stderr lines into
+/// `AuthSessionManager::record_line`; on a login-success pattern OR
+/// child exit, runs the provider's authCheckCommand to confirm and
+/// transitions to Success or Failed.
+fn spawn_auth_cli(
+    mgr: Arc<crate::identity::auth_session::AuthSessionManager>,
+    session_id: String,
+    provider_id: String,
+    cli_path: String,
+    auth_login_args: Vec<String>,
+    auth_check_args: Vec<String>,
+    auth_env: std::collections::HashMap<String, String>,
+) {
+    use std::process::Stdio;
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::process::Command;
+    use tokio::sync::mpsc;
+
+    // Channel for SubmitAuthCallback → CLI stdin forwarding.
+    // Buffer of 4 is enough — only one URL per session in normal use.
+    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(4);
+
+    let mgr_for_task = mgr.clone();
+    let session_id_for_task = session_id.clone();
+    let cli_path_for_check = cli_path.clone();
+    let auth_check_args_for_check = auth_check_args.clone();
+    let auth_env_for_check = auth_env.clone();
+
+    let handle = tokio::spawn(async move {
+        tracing::info!(
+            session_id = %session_id_for_task,
+            provider_id = %provider_id,
+            cli_path = %cli_path,
+            "auth.spawn: launching provider CLI"
+        );
+
+        // Spawn the CLI. kill_on_drop guarantees cleanup if our
+        // task is aborted (cancel path).
+        let mut child = match Command::new(&cli_path)
+            .args(&auth_login_args)
+            .envs(&auth_env)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("spawn `{cli_path}` failed: {e}"),
+                );
+                mgr_for_task.detach_process(&session_id_for_task);
+                return;
+            }
+        };
+
+        let stdout = child
+            .stdout
+            .take()
+            .expect("piped stdout");
+        let stderr = child
+            .stderr
+            .take()
+            .expect("piped stderr");
+        let mut stdin = child
+            .stdin
+            .take()
+            .expect("piped stdin");
+
+        // Stdin writer — forwards callback URLs (pasted back by the
+        // user when browser auto-open failed) into the CLI process.
+        let stdin_writer = tokio::spawn(async move {
+            while let Some(line) = stdin_rx.recv().await {
+                if stdin.write_all(line.as_bytes()).await.is_err() {
+                    break;
+                }
+                if stdin.write_all(b"\n").await.is_err() {
+                    break;
+                }
+                let _ = stdin.flush().await;
+            }
+        });
+
+        // Stdout drain — line-by-line into the session manager. When
+        // we see a login-success pattern, confirm via authCheckCommand
+        // and transition to Success. Don't break the loop — some CLIs
+        // continue printing after the success line.
+        let mgr_stdout = mgr_for_task.clone();
+        let sid_stdout = session_id_for_task.clone();
+        let cli_path_stdout = cli_path_for_check.clone();
+        let check_args_stdout = auth_check_args_for_check.clone();
+        let check_env_stdout = auth_env_for_check.clone();
+        let stdout_drain = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            let mut success_transitioned = false;
+            while let Ok(Some(line)) = lines.next_line().await {
+                let m = mgr_stdout.record_line(&sid_stdout, &line);
+                if !success_transitioned
+                    && matches!(
+                        m,
+                        Some(crate::identity::auth_patterns::AuthPatternMatch::LoginSuccess { .. })
+                    )
+                {
+                    if confirm_authenticated(
+                        &cli_path_stdout,
+                        &check_args_stdout,
+                        &check_env_stdout,
+                    )
+                    .await
+                    {
+                        // PR A: synthetic bundle id — PR C wires real
+                        // wstore-backed persistence. The frontend can
+                        // detect this placeholder (prefix
+                        // "pending-bundle-for-") and surface "saving…"
+                        // UI in the interim.
+                        let bundle_id =
+                            format!("pending-bundle-for-{}", sid_stdout);
+                        mgr_stdout.finish_success(&sid_stdout, bundle_id);
+                        success_transitioned = true;
+                    }
+                }
+            }
+        });
+
+        // Stderr drain — same matcher path. Some CLIs emit the OAuth
+        // URL on stderr (verbose logging style).
+        let mgr_stderr = mgr_for_task.clone();
+        let sid_stderr = session_id_for_task.clone();
+        let stderr_drain = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let _ = mgr_stderr.record_line(&sid_stderr, &line);
+            }
+        });
+
+        // Wait for the child to exit (or for our task to be aborted
+        // by cancel_session — in which case kill_on_drop handles the
+        // child).
+        let exit = child.wait().await;
+
+        // Let stdout/stderr drains catch any final lines.
+        let _ = stdout_drain.await;
+        let _ = stderr_drain.await;
+        // Stdin writer exits when the tx side is dropped (after this
+        // task ends) — abort defensively in case it's blocked on a
+        // pending receive.
+        stdin_writer.abort();
+
+        // Final transition if we haven't already hit Success on the
+        // login-pattern path. Re-run authCheck because some CLIs exit
+        // cleanly without printing a "logged in as" line.
+        match exit {
+            Ok(s) if s.success() => {
+                if confirm_authenticated(
+                    &cli_path_for_check,
+                    &auth_check_args_for_check,
+                    &auth_env_for_check,
+                )
+                .await
+                {
+                    let bundle_id =
+                        format!("pending-bundle-for-{}", session_id_for_task);
+                    mgr_for_task.finish_success(&session_id_for_task, bundle_id);
+                } else {
+                    mgr_for_task.finish_failure(
+                        &session_id_for_task,
+                        "CLI exited 0 but authentication check failed".to_string(),
+                    );
+                }
+            }
+            Ok(s) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("CLI exited with status {s}"),
+                );
+            }
+            Err(e) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("wait error: {e}"),
+                );
+            }
+        }
+
+        mgr_for_task.detach_process(&session_id_for_task);
+    });
+
+    mgr.attach_process(&session_id, handle, stdin_tx);
+}
+
+/// Run the provider's auth-check subcommand and return true if it
+/// exits 0. Failure modes (binary missing, network error, etc.) are
+/// all treated as "not authenticated" — the caller will then either
+/// keep waiting (drain task loop) or transition to Failed (exit
+/// fallback).
+async fn confirm_authenticated(
+    cli_path: &str,
+    args: &[String],
+    env: &std::collections::HashMap<String, String>,
+) -> bool {
+    use std::process::Stdio;
+    use tokio::process::Command;
+    match Command::new(cli_path)
+        .args(args)
+        .envs(env)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .status()
+        .await
+    {
+        Ok(s) => s.success(),
+        Err(_) => false,
+    }
 }
 
 #[cfg(test)]
@@ -200,18 +458,35 @@ mod tests {
 
     #[test]
     fn start_req_parses_minimal() {
-        let v = serde_json::json!({ "providerId": "claude" });
+        let v = serde_json::json!({
+            "providerId": "claude",
+            "cliPath": "/usr/bin/claude",
+            "authLoginArgs": ["login"],
+            "authCheckArgs": ["whoami"]
+        });
         let r: StartProviderAuthReq = serde_json::from_value(v).unwrap();
         assert_eq!(r.provider_id, "claude");
+        assert_eq!(r.cli_path, "/usr/bin/claude");
+        assert_eq!(r.auth_login_args, vec!["login"]);
+        assert_eq!(r.auth_check_args, vec!["whoami"]);
         assert!(r.into_bundle_id.is_none());
+        assert!(r.auth_env.is_empty());
     }
 
     #[test]
     fn start_req_parses_with_bundle_id() {
-        let v = serde_json::json!({ "providerId": "codex", "intoBundleId": "bundle-1" });
+        let v = serde_json::json!({
+            "providerId": "codex",
+            "cliPath": "/usr/bin/codex",
+            "authLoginArgs": ["auth", "login"],
+            "authCheckArgs": ["auth", "status"],
+            "authEnv": { "FOO": "bar" },
+            "intoBundleId": "bundle-1"
+        });
         let r: StartProviderAuthReq = serde_json::from_value(v).unwrap();
         assert_eq!(r.provider_id, "codex");
         assert_eq!(r.into_bundle_id.as_deref(), Some("bundle-1"));
+        assert_eq!(r.auth_env.get("FOO").map(String::as_str), Some("bar"));
     }
 
     #[test]

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod cli_handlers;
 mod files;
 mod app_api;
 mod forge_handlers;
+mod identity_handlers;
 mod messagebus;
 mod reactive;
 pub(crate) mod service;
@@ -92,6 +93,10 @@ pub struct AppState {
     /// adds resume-on-startup + `--diag sagas`.
     /// See `docs/specs/SPEC_SAGA_DURABILITY_2026-05-01.md`.
     pub saga_log: std::sync::Arc<crate::sagas::log::SagaLog>,
+    /// Pre-launch OAuth session state — one entry per in-flight
+    /// "Connect with OAuth" attempt from the launch modal. See
+    /// `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md`.
+    pub auth_session_manager: std::sync::Arc<crate::identity::auth_session::AuthSessionManager>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -57,6 +57,7 @@ pub(crate) fn test_state() -> AppState {
         // Saga durability (PR 1) — in-memory log so tests stay
         // hermetic. Production opens a file under the data dir.
         saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
+        auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
     }
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1183,6 +1183,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     // Workflow handlers (issue #753 — Workflows pane DAG executor)
     super::workflow_handlers::register_workflow_handlers(engine, &state);
 
+    // Pre-launch OAuth handlers (auth.start / poll / submitcallback /
+    // cancel / submitapikey — see docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md)
+    super::identity_handlers::register_identity_handlers(engine, &state);
+
     // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
     super::app_api::register_app_api_handlers(engine, &state);
 }

--- a/docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md
+++ b/docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md
@@ -1,0 +1,535 @@
+# Spec: Pre-launch OAuth flow — identity-first agent setup
+
+**Date:** 2026-05-14
+**Author:** AgentA
+**Status:** Draft
+**Companion to:** [`SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md`](SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md) — that spec covers *where* OAuth tokens are stored and how they refresh. This spec covers *when in the user flow* OAuth happens and how it binds to the agent.
+
+---
+
+## 1. Driving requirement
+
+> When I first launch an agent in AgentMux, the "Launch" button should be greyed out until I connect an identity for that provider via OAuth. A "Connect with OAuth" call-to-action sits in front of Launch. Authorizing creates an Identity bundle automatically; that bundle is bound to the agent I just launched. Future launches reuse the same bundle. New agents can optionally inherit existing bundles instead of forcing a re-auth.
+
+In short: **auth gates launch**, not the other way around. Today the launch flow tries OAuth *during* launch (`launch-flow.ts` Phase 2). Move it ahead of the Launch button.
+
+---
+
+## 2. Today's state (problem statement)
+
+The launch sequence in `frontend/app/view/agent/flows/launch-flow.ts`:
+
+1. **Phase 0** — container runtime check (host agents skip)
+2. **Phase 1** — CLI detection / npm install
+3. **Phase 2** — auth check → if not authenticated, *spawn login command in-line*, poll for 5 min, hope the user finishes the OAuth dance in their browser
+4. **Phase 3** — controller registration
+
+Concrete issues this produces:
+
+- **The "Launch" button is a lie.** A user clicks Launch with no auth set up; the modal goes through CLI install, then suddenly opens an OAuth browser tab. The user didn't agree to that — they thought they were clicking "start the agent."
+- **Auth state is scoped to the agent's working dir.** Per provider, `CLAUDE_CONFIG_DIR=<workdir>/.claude` etc. — so a fresh agent gets a fresh auth surface. Logging in once doesn't help the next agent.
+- **No first-class identity model in the launch UI.** Identity bundles exist in the schema (v7, [#746](https://github.com/agentmuxai/agentmux/pull/746)) and have their own pane, but the launch modal doesn't *require* one — users default to "blank singleton" which means "use ambient creds, hope for the best."
+- **URL fallback is implicit.** `launch-flow.ts` already captures an OAuth URL from the CLI's stdout and surfaces it via `setAuthUrl` so the user can copy/paste — but only if the CLI happens to print it. No universal fallback exists.
+- **Auth timeout collides with normal user pace.** 5-minute polling means a user who steps away mid-OAuth gets a "launch failed" message and has to retry from scratch.
+
+What's *right* today (and we keep):
+
+- Per-provider auth isolation env vars (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_CLI_HOME`, etc.) are already plumbed through.
+- Identity bundle schema exists (`db_identities` + `db_identity_accounts` + `db_identity_bindings`).
+- The companion storage spec defines where OAuth tokens persist.
+
+---
+
+## 3. Proposed UX flow
+
+### 3.1 First-time launch (no bundle exists for this provider)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Launch Agent                                                       │
+│                                                                     │
+│  Provider:  [Claude Code     ▼]      Identity: [Blank singleton ▼] │
+│                                                                     │
+│  ⚠ Claude Code requires an OAuth login before launch.              │
+│                                                                     │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │             🔐  Connect with OAuth                          │   │
+│  │                                                             │   │
+│  │   Opens browser → Anthropic login → returns to AgentMux.   │   │
+│  │   Tokens get saved into a new Identity bundle so the next  │   │
+│  │   agent doesn't have to re-authenticate.                   │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│  [Browser didn't open? Use auth URL]                                │
+│                                                                     │
+│                                          [ Launch ]  [Cancel]      │
+│                                            ^^^^^^^                  │
+│                                            disabled                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+User clicks **Connect with OAuth**. The browser opens; if it doesn't, the **Use auth URL** link expands an inline panel with the URL + Copy button.
+
+### 3.2 Mid-OAuth state
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Launch Agent                                                       │
+│                                                                     │
+│  ┌─────────────────────────────────────────────────────────────┐   │
+│  │   🔐  Waiting for OAuth …                                   │   │
+│  │                                                             │   │
+│  │   1. Authorize AgentMux in your browser tab.                │   │
+│  │   2. We'll detect the redirect and continue.                │   │
+│  │                                                             │   │
+│  │   URL not opening? Copy this and paste anywhere:            │   │
+│  │   https://console.anthropic.com/oauth/authorize?...  [📋]  │   │
+│  │                                                             │   │
+│  │                                          [ Cancel login ]  │   │
+│  └─────────────────────────────────────────────────────────────┘   │
+│                                                                     │
+│                                          [ Launch ]  [Cancel]      │
+│                                            disabled                 │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Post-auth (bundle exists, ready to launch)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Launch Agent                                                       │
+│                                                                     │
+│  Provider:  [Claude Code     ▼]                                    │
+│  Identity:  [Claude (asaf@example.com) ▼]   ✓ Authenticated        │
+│                                                                     │
+│  Instance name (optional): [___________________]                    │
+│                                                                     │
+│                                          [ Launch ]  [Cancel]      │
+│                                            ^^^^^^^^^               │
+│                                            enabled                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+The bundle the user just authenticated against is auto-selected. Launch enables.
+
+### 3.4 Second launch (bundle exists, just pick it)
+
+```
+Identity:  [Claude (asaf@example.com) ▼]
+           │  Claude (asaf@example.com)  ← default for new agents
+           │  Claude (work-account)
+           │  ─────────────
+           │  + Connect another OAuth account
+           │  ⊗ Blank singleton (ambient creds)
+```
+
+Users can pick a different existing bundle, or **+ Connect another OAuth account** to walk through 3.1 → 3.2 → 3.3 again with a new bundle name.
+
+### 3.5 Provider mismatch
+
+If a user picks a bundle that doesn't have an account for the selected provider, surface inline:
+
+```
+Provider:  [Codex CLI         ▼]
+Identity:  [Claude (asaf@example.com) ▼]
+           ⚠ This bundle has no Codex account. [ Connect Codex to this bundle ]
+                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                inline action
+```
+
+Clicking re-runs OAuth scoped to **add a new account row to the existing bundle**, not to create a new bundle.
+
+---
+
+## 4. Per-provider auth landscape
+
+`frontend/app/view/agent/providers/index.ts` defines 7 providers. Auth flow varies meaningfully:
+
+| Provider | `authType` | Real-world flow | Browser-open? | URL fallback? |
+|---|---|---|---|---|
+| Claude Code | `oauth` | Anthropic OAuth2 + PKCE → `localhost` callback (~Claude CLI's local listener) → writes `~/.claude/credentials.json` | Yes, CLI auto-opens | URL printed in stdout |
+| Codex CLI | `oauth` | OpenAI OAuth2 → callback | Yes | Less reliable |
+| Gemini CLI | `oauth` | Google OAuth2 + Cloud project context | Yes | Yes |
+| GitHub Copilot | `oauth` | GitHub OAuth (CLI uses device flow — pastes a code) | No (device-flow) | Native — device code is the fallback |
+| OpenClaw | `api-key` | User pastes key into onboarding wizard | N/A | N/A |
+| Kimi Code | `api-key` | Same | N/A | N/A |
+| Pi | `api-key` | Same | N/A | N/A |
+
+Implications for the spec:
+
+- **Three patterns to support**: browser-OAuth-with-callback (Claude/Codex/Gemini), device-code-flow (Copilot), API-key-paste (OpenClaw/Kimi/Pi).
+- **The "Connect with OAuth" button label/copy must adapt**: for API-key providers it's "Paste API key"; for device-flow it's "Get pairing code."
+- **All paths converge on the same outcome**: a new `IdentityAccount` row inside an `IdentityBundle` (existing or newly-created), with a `SecretRef` appropriate to the kind.
+
+### Provider-specific browser-failure recovery
+
+Best practices from OAuth ecosystem (RFC 8628 device authorization, [OAuth for Native Apps](https://datatracker.ietf.org/doc/html/rfc8252)):
+
+- **Claude Code**: CLI already supports `--use-existing-callback` flag (per its docs) which prints the URL and waits on stdin for the callback URL pasted back. Mirror this UX in our wrapper: detect "callback failed to open browser" → show URL → user pastes redirect URL into our input → we send it back to the CLI's stdin.
+- **Codex / Gemini**: Less documented, but both CLIs print the auth URL to stdout. Capture it via the existing `setAuthUrl` mechanism in `launch-flow.ts`. Add a textbox for the user to paste back the redirect URL.
+- **GitHub Copilot**: Device code is the *only* flow — show the code prominently with a copy button and the verification URL. No browser dependency at all.
+- **API key providers**: Modal with a password-style input. Validate by running the provider's `authCheckCommand` against the just-pasted key.
+
+---
+
+## 5. Identity bundle lifecycle
+
+### 5.1 Bundle states
+
+```
+                     ┌──────────────────┐
+                     │  Empty / new     │ ← user opens launch modal,
+                     │  (default)       │   no existing bundle for this provider
+                     └────────┬─────────┘
+                              │  Click "Connect with OAuth"
+                              ▼
+                     ┌──────────────────┐
+                     │  Awaiting auth   │ ← OAuth tab open, polling for redirect
+                     └────────┬─────────┘
+                  ┌───────────┴────────────┐
+            success │                      │ timeout / cancel
+                    ▼                      ▼
+       ┌──────────────────┐     ┌──────────────────┐
+       │  Authenticated   │     │  Empty / new     │
+       │  (bundle saved)  │     │  (back to start) │
+       └────────┬─────────┘     └──────────────────┘
+                │
+                │ User clicks Launch
+                ▼
+       ┌──────────────────┐
+       │  Bound to agent  │ ← `db_agent_instances.identity_id = <bundle.id>`
+       └──────────────────┘
+```
+
+### 5.2 New-bundle auto-creation
+
+When a first OAuth completes:
+
+1. Backend creates a `db_identities` row with `name = "<provider-display-name> (<email-from-token>)"`. Example: `"Claude (asaf@example.com)"`. User can rename later.
+2. Backend creates a `db_identity_accounts` row linked to the new bundle via `db_identity_bindings`, with `kind = "oauth"` and the appropriate `SecretRef` variant (see companion storage spec §4).
+3. Frontend reads back the new bundle id and selects it in the dropdown.
+
+### 5.3 Adding to existing bundle
+
+When user picks an existing bundle but clicks **+ Connect <provider>** for a provider missing from the bundle:
+
+1. Same OAuth flow.
+2. On completion, backend inserts a new `db_identity_accounts` row + binding under the *existing* bundle id.
+3. Bundle name stays unchanged.
+
+### 5.4 Reuse on subsequent launches
+
+When the user selects a previously-authenticated bundle and clicks Launch:
+
+1. Spawn-time resolver (`agentmux-srv/src/identity/resolver.rs`) reads `instance.identity_id`, looks up bindings for the requested provider, materializes credentials per the storage spec (§5).
+2. Refresh tokens are valid → CLI starts successfully without prompting. Storage spec's watcher (§6) keeps captures fresh.
+3. **No OAuth dialog appears.** This is the user-visible "I logged in once" promise.
+
+### 5.5 Bundle expiration / re-login
+
+If the storage spec's `last_refreshed_at_ms` exceeds the provider's known refresh-token TTL (e.g., Anthropic's documented ~90 days):
+
+1. The Identity dropdown shows the bundle with a warning badge: `⚠ Re-login required`.
+2. Selecting it disables Launch and surfaces a "Re-authenticate" CTA — same flow as 3.1 but pre-fills the bundle so we update its rows rather than create a fresh bundle.
+
+---
+
+## 6. Browser + URL fallback architecture
+
+### 6.1 Happy path (browser opens)
+
+```
+┌────────────┐    1. spawn OAuth helper
+│  Frontend  ├───────────────────────────────────────┐
+└─────┬──────┘                                       ▼
+      │                                       ┌─────────────┐
+      │ 2. poll for auth                      │ Backend RPC │
+      │    completion                         │ AuthStartOAuth
+      │                                       └──────┬──────┘
+      │                                              │ 3. spawn CLI
+      │                                              ▼
+      │                                       ┌─────────────┐
+      │                                       │ Provider CLI│ ← opens browser
+      │                                       │ (claude/...)│
+      │                                       └──────┬──────┘
+      │                                              │ 4. CLI's local
+      │                                              │    callback receives
+      │                                              ▼    redirect
+      │                                       ┌─────────────┐
+      │                                       │ Credentials │
+      │                                       │ on disk     │
+      │                                       └──────┬──────┘
+      │  5. poll detects auth                        │
+      │  ◄─────────────────────────────────────────  │
+      ▼                                              ▼
+┌────────────┐  6. capture creds → bundle  ┌──────────────┐
+│  Frontend  │◄───────────────────────────── Storage spec │
+└────────────┘    enable Launch              §6 watcher   │
+                                            └──────────────┘
+```
+
+### 6.2 Browser-didn't-open path
+
+```
+┌────────────┐    1. spawn OAuth helper
+│  Frontend  ├───────────────────────────────────────┐
+└─────┬──────┘                                       ▼
+      │                                       ┌─────────────┐
+      │ 2. user clicks                        │ Backend RPC │
+      │    "Browser didn't open"              │             │
+      │                                       └──────┬──────┘
+      │                                              │
+      │ 3. capture URL from CLI stdout               │
+      │ ◄─────────────────────────────────────────── │
+      ▼                                              │
+┌────────────┐                                       │
+│  Frontend  │  4. user copies, pastes into          │
+│  URL panel │     any browser (could be phone)      │
+└─────┬──────┘                                       │
+      │  5. user pastes back the resulting URL      │
+      ▼     (the redirect with the code)            │
+┌────────────┐                                       │
+│  Frontend  │  6. POST redirect URL                ▼
+└─────┬──────┘ ────────────────────────────► ┌─────────────┐
+      │                                       │ Backend RPC │
+      │                                       │ AuthCompleteOAuth
+      │                                       └──────┬──────┘
+      │                                              │ 7. write to CLI's
+      │                                              │    stdin
+      │                                              ▼
+      │                                       ┌─────────────┐
+      │                                       │ Provider CLI│
+      │                                       │ completes   │
+      │                                       │ token       │
+      │                                       │ exchange    │
+      │                                       └──────┬──────┘
+      │  8. poll → success                           │
+      ▼                                              ▼
+   enable Launch                              Storage spec §6
+```
+
+Key: the CLI's OAuth implementation is left intact. We're not implementing OAuth2 ourselves — we orchestrate the CLI through `stdin` so users who can't trigger a browser-auto-open path still complete the flow inside AgentMux.
+
+### 6.3 Device-flow path (Copilot)
+
+```
+┌────────────┐    1. spawn copilot auth login
+│  Frontend  ├──────────────────────► CLI
+└─────┬──────┘                          │
+      │                                 │ 2. CLI emits:
+      │                                 │    "Enter code XXXX-YYYY at"
+      │                                 │    "https://github.com/login/device"
+      │  3. parse + render               │
+      │ ◄────────────────────────────── │
+      ▼                                  ▼
+┌────────────┐
+│  Frontend  │  4. user follows URL on
+│  Code +    │     ANY device, enters code
+│  URL panel │
+└─────┬──────┘
+      │  5. backend keeps polling
+      │     CLI's stdout until success
+      ▼
+   enable Launch
+```
+
+### 6.4 API key path (OpenClaw / Kimi / Pi)
+
+```
+┌────────────┐
+│  Frontend  │  1. show password-input modal
+│  Modal     │
+└─────┬──────┘
+      │  2. user pastes key
+      ▼
+┌────────────┐
+│  Backend   │  3. run authCheckCommand against the key
+│  validate  │     to confirm it works
+└─────┬──────┘
+      │  4. success → save as SecretRef::PlaintextDev
+      │     (PR 2 of storage spec: encrypt with keyring)
+      ▼
+   enable Launch
+```
+
+---
+
+## 7. Backend RPCs (additions)
+
+New commands in `agentmux-srv/src/server/identity_handlers.rs`:
+
+```rust
+// Start OAuth — spawns the provider's `auth login` command, returns a
+// session token the frontend uses to track this attempt. Captures the
+// CLI's stdout for URL detection.
+StartProviderAuth { provider_id: String, into_bundle_id: Option<String> }
+  -> { session_id: String, auth_url: Option<String> }
+
+// Poll an in-flight auth session. Returns one of:
+//   - "pending"       — still waiting on user
+//   - "url-available" — captured an OAuth URL the user can paste
+//   - "code-emitted"  — device flow code (Copilot)
+//   - "success"       — credentials captured; bundle_id ready
+//   - "failed"        — CLI exited non-zero, timeout, or user cancelled
+PollProviderAuth { session_id: String }
+  -> { status: "pending" | "url-available" | "code-emitted" | "success" | "failed",
+       auth_url?: String, device_code?: { code: String, verification_url: String },
+       bundle_id?: String, error?: String }
+
+// Submit a callback URL the user pasted back (browser-didn't-open path).
+SubmitAuthCallback { session_id: String, callback_url: String }
+  -> { accepted: boolean, error?: String }
+
+// Cancel an in-flight auth session. Kills the spawned CLI.
+CancelProviderAuth { session_id: String }
+  -> {}
+
+// Submit an API key for kind=api-key providers.
+SubmitProviderApiKey { provider_id: String, into_bundle_id: Option<String>,
+                       api_key: String, account_name: String }
+  -> { success: boolean, bundle_id?: String, error?: String }
+```
+
+The 5-minute polling timeout in today's `launch-flow.ts` Phase 2 moves up into `PollProviderAuth` and shifts ownership to the modal — modal disables Connect button after timeout and surfaces a clear retry CTA, rather than reporting "launch failed."
+
+---
+
+## 8. Frontend state machine
+
+`launcher.tsx` gains a new pre-launch substate:
+
+```typescript
+type AuthState =
+    | { kind: "unauthenticated"; needsAuth: true }     // show Connect CTA
+    | { kind: "waiting"; sessionId: string; urlVisible: boolean; deviceCode?: string }
+    | { kind: "ready"; bundleId: string }              // enable Launch
+    | { kind: "expired"; bundleId: string };           // show Re-authenticate CTA
+
+const launchEnabled = () =>
+    authState().kind === "ready" || authState().kind === "expired" && hasFallbackCreds;
+```
+
+Selecting a bundle from the dropdown:
+- Bundle has account for selected provider AND `last_refreshed_at_ms` is fresh → `ready`
+- Bundle has account but `last_refreshed_at_ms` is stale → `expired`
+- Bundle has no account for this provider → `unauthenticated` with "Connect <provider> to this bundle"
+- Blank singleton → `unauthenticated` with "Connect with OAuth (creates new bundle)"
+
+---
+
+## 9. Migration from today's auth-on-launch
+
+Current code path (delete after this lands):
+
+- `frontend/app/view/agent/flows/launch-flow.ts` Phase 2 — auth-during-launch loop. **Becomes a no-op** because pre-launch enforces that auth has already happened. Keep it as a defensive fallback for one release (logs a warning + does the existing behavior) before removing in a follow-up.
+
+What stays:
+
+- Per-provider auth isolation env vars (`CLAUDE_CONFIG_DIR`, etc.) — pre-launch flow writes credentials into the same per-bundle path (storage spec §4), so the existing env-injection in `identity/resolver.rs` works unchanged.
+- `authCheckCommand` per provider — used at *poll* time to confirm the CLI sees the credentials we just captured.
+
+### Compat for existing users
+
+A user who upgrades and already had agents running with the old flow:
+
+1. Existing `db_agent_instances` rows have `identity_id = "blank"` → ambient creds (their working dir's `.claude/credentials.json`).
+2. The new launch modal warns: `⚠ Agent uses ambient credentials — connect to a bundle for portability?` with an inline migrate action.
+3. The migrate action runs OAuth once, captures into a new bundle, updates `identity_id` on the row.
+4. User who never migrates: ambient creds keep working until the working dir is deleted.
+
+---
+
+## 10. PR sequence
+
+### PR A — Backend RPCs + session manager
+
+- `agentmux-srv/src/identity/auth_session.rs` — in-memory session map, CLI spawn + stdout capture
+- `agentmux-srv/src/server/identity_handlers.rs` — the 5 RPCs in §7
+- Unit tests for: session timeout, URL extraction, callback injection, device-code parsing
+- Per-provider stdout-pattern matchers for URL detection (provider table in `auth_patterns.rs`)
+
+### PR B — Launch modal pre-auth UX
+
+- `frontend/app/view/launcher/launcher.tsx` — new `AuthState` machine, Connect CTA, URL panel, device-code panel, API-key modal
+- Identity dropdown enriched with bundle status (✓ / ⚠ / not connected)
+- Launch button gated on `authState().kind === "ready"`
+- Vitest unit tests for the state transitions
+
+### PR C — Bundle auto-creation + binding
+
+- Backend: on `success` event from PR A, insert `db_identities` + `db_identity_accounts` + `db_identity_bindings` rows in a transaction
+- Email extraction from provider tokens (provider-specific — Claude has it in JWT claim, Codex in profile endpoint)
+- Frontend: on RPC success, refresh bundle list + auto-select new bundle
+- Integration test: end-to-end "no bundles → Connect → bundle exists → Launch enabled"
+
+### PR D — Migration helper for legacy ambient-cred agents
+
+- One-time migration prompt (modal on first launch with `identity_id == "blank"`)
+- "Connect now" runs the same flow as PR B, but the success handler also updates the existing `db_agent_instances` row
+- Defer the deletion of `launch-flow.ts` Phase 2 until PR D ships
+
+### PR E — Device-flow polish (GitHub Copilot)
+
+- Custom panel for device-code rendering with big code + Open Verification URL button
+- Polish for "code expired" state (Copilot re-emits if user takes >15 min)
+
+### PR F — Expired bundle handling
+
+- `last_refreshed_at_ms` staleness check
+- "Re-authenticate this bundle" action — runs OAuth into the existing bundle (no new bundle row)
+- Per-provider TTL table (Anthropic ~90d, OpenAI ~30d, Google ~30d, GitHub effectively forever)
+
+PRs A–C ship the user-visible feature. D–F harden + clean up.
+
+---
+
+## 11. Risks + mitigations
+
+| Risk | Mitigation |
+|---|---|
+| CLI silently changes its OAuth URL format → URL extractor breaks | Per-provider regex with a fallback to "any `https://` line during the first 30s of stdout" |
+| User pastes wrong URL into callback box → CLI errors → cryptic state | Validate URL before submit: parse + check for `code=` or `state=` param. Reject inline. |
+| OAuth session leaks (user closes modal mid-flow) → orphan CLI proc | `CancelProviderAuth` on modal close. `tokio::spawn` task tied to session id; killed on session removal. |
+| User has two bundles for the same provider; picks the wrong one → wrong email/account | Show email in the dropdown label. Confirm modal when the bundle's email doesn't match the user's current GitHub identity (if known). |
+| API key validation makes a real API call against the key → first OAuth-like network round-trip | Use the provider's lightest "whoami" endpoint via `authCheckCommand`. Document this in the API key paste modal. |
+| Provider's `auth login` blocks on user input even after credentials exist | Skip the spawn entirely if `authCheckCommand` already says authenticated for the cred path we'd materialize. |
+| Device-flow code expires before user enters it | Auto-restart the device-flow CLI when the spawned proc exits with the "code expired" status; show a refreshed code in the UI. |
+
+---
+
+## 12. Acceptance criteria
+
+- [ ] Launch button is **disabled** when the selected provider has no authenticated bundle and the user has selected blank singleton.
+- [ ] Clicking **Connect with OAuth** spawns the provider's `auth login`, captures the URL, attempts auto-open in the system browser.
+- [ ] If auto-open fails or the user clicks "Use auth URL", the URL is displayed inline with a Copy button. Pasting the resulting redirect URL back into the modal completes the flow.
+- [ ] On success, a new Identity bundle is created (`db_identities` + accounts + binding rows in one transaction), auto-selected in the dropdown.
+- [ ] Launch enables. Clicking it spawns the agent with `identity_id = <new bundle id>`. Storage spec's resolver materializes the credentials.
+- [ ] Closing the modal mid-OAuth cancels the spawned CLI (no orphan).
+- [ ] Subsequent launches with the same bundle skip OAuth entirely.
+- [ ] Selecting a bundle that doesn't have an account for the selected provider surfaces the inline "Connect <provider> to this bundle" CTA.
+- [ ] API-key providers (OpenClaw / Kimi / Pi) show a password-style paste modal instead of an OAuth flow.
+- [ ] Device-flow provider (Copilot) shows the device code prominently with the verification URL.
+- [ ] Existing agents with `identity_id == "blank"` keep working; user is prompted (non-blocking) to migrate to a bundle.
+
+---
+
+## 13. Open questions
+
+1. **Should "Connect with OAuth" auto-launch the agent on success**, skipping the post-auth "now click Launch" step? Likely yes — but some users may want to inspect the bundle before launching. Default: auto-launch with an unobtrusive "Connecting account…" → "Launching agent…" status. User can cancel before Launch fires.
+2. **Where does the OAuth URL fallback panel live** — inside the launch modal as a slide-out, or as a separate dialog? Slide-out keeps context but compresses the layout on smaller windows.
+3. **Bundle naming** — auto-generated from email is decent but cumbersome (`Claude (asafebgi+aliasX@example.com)`). Should we offer a rename prompt immediately after first OAuth, or let users rename later via the Identity pane?
+4. **Should the launch modal show the bundle's other-provider accounts** ("This bundle also has GitHub authenticated")? Useful for users who think in cross-provider personas (work-asaf vs personal-asaf). Could clutter the dropdown.
+5. **Device flow on Claude/Codex/Gemini** — none currently support device flow out of the box. Worth exploring as a pure user-side fallback (we host a tiny local landing page that captures the redirect and shows the user a "paste this back" page).
+
+---
+
+## 14. References
+
+- Companion spec: [`SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md`](SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md) — token storage + refresh
+- v7 schema: [PR #746](https://github.com/agentmuxai/agentmux/pull/746) — Identity bundles + Memory
+- Identity pane: [PR #750](https://github.com/agentmuxai/agentmux/pull/750)
+- Launch modal current state: `frontend/app/view/launcher/launcher.tsx`, `frontend/app/view/agent/flows/launch-flow.ts`
+- Provider table: `frontend/app/view/agent/providers/index.ts`
+- Spawn-time resolver: `agentmux-srv/src/identity/resolver.rs`
+- RFC 8628 — OAuth 2.0 Device Authorization Grant
+- RFC 8252 — OAuth 2.0 for Native Apps (best practices for CLI tools)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.868",
+  "version": "0.33.869",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.868",
+      "version": "0.33.869",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.866",
+  "version": "0.33.867",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.866",
+      "version": "0.33.867",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.867",
+  "version": "0.33.868",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.867",
+      "version": "0.33.868",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.868",
+  "version": "0.33.869",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.867",
+  "version": "0.33.868",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.866",
+  "version": "0.33.867",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
**Draft** — first commit of Phase A from [`SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md`](docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md). The 5 RPC handlers (`StartProviderAuth` / `PollProviderAuth` / `SubmitAuthCallback` / `CancelProviderAuth` / `SubmitProviderApiKey`) land in a follow-up commit on this branch before review.

## What ships in this commit

### `agentmux-srv/src/identity/auth_patterns.rs`

Per-provider stdout/stderr matchers for the pre-launch OAuth flow:
- **claude** → anthropic.com OAuth URLs
- **codex** → openai.com OAuth URLs
- **gemini** → accounts.google.com OAuth URLs
- **copilot** → GitHub device flow (`ABCD-1234` code + `github.com/login/device` verification URL)
- **logged-in-as `<email>`** success lines (provider-agnostic)
- Universal `https://...oauth/...` fallback for unknown providers
- API-key providers (openclaw/kimi/pi) intentionally match nothing

**13 unit tests** covering happy paths + URL trimming, email placeholder rejection, device-code shape validation, fallback selectivity.

### `agentmux-srv/src/identity/auth_session.rs`

Pure session-state manager. The CLI spawn lives in the handler (next commit); this module owns:
- State machine: `Pending → UrlAvailable / CodeEmitted → Success / Failed`
- Line-by-line transcript capture
- Per-line pattern dispatch via `record_line`
- Terminal-state immutability (no Success→Failed transitions after fact)
- Timeout sweep (600s) at poll time
- Cancel = transition to `Failed { error: "cancelled" }`

**12 unit tests** for every transition + timeout + immutability + transcript + unknown-session safety.

### `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md`

The driving spec. Covers UX mockups, per-provider auth landscape (7 providers, 3 patterns), identity bundle lifecycle, browser + URL fallback architecture, the 5 RPCs, frontend state machine, migration path, PR sequence, risks, acceptance criteria.

## What's next on this branch

The handler module (`server/identity_handlers.rs`) that:
- Spawns the actual provider CLI via the existing `ResolveCli` machinery
- Drains stdout into the session manager's `record_line`
- Implements the 5 RPCs (start/poll/submit-callback/cancel/submit-api-key)
- Wires registration into `websocket.rs`

That commit lands before I mark this ready-for-review.

## Test plan

- [x] `cargo test -p agentmux-srv identity::auth` — 25 tests pass
- [x] No external behavior change (these modules aren't called yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)