### PR TITLE
feat(title): "Window - Tab - AgentMux" format, no version, reactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1546,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.869"
+version = "0.33.870"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.869"
+version = "0.33.870"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
+++ b/docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
@@ -1,0 +1,269 @@
+# SPEC: Window Title Format — `Window - Tab - AgentMux`
+
+**Date:** 2026-05-13
+**Author:** AgentX
+**Status:** Draft
+**Affects:** All release types — `task dev`, `task dev:standalone`, portable ZIP, installed builds, on Windows / macOS / Linux
+
+---
+
+## 1. Goal
+
+Change the OS window title (the string Windows shows in the taskbar, macOS shows in the title bar, and Linux WMs show in the title bar / dock) to:
+
+```
+{Window Name} - {Tab Name} - AgentMux
+```
+
+- No version anywhere.
+- Identical format across all release types and platforms.
+- Most-specific identifier first so taskbar/dock truncation surfaces the useful part.
+
+### 1.1 Examples
+
+| Window state                                   | Title                                |
+| ---------------------------------------------- | ------------------------------------ |
+| Default unnamed window, "Shell" tab            | `Window 1 - Shell - AgentMux`        |
+| Window with workspace "Pulse", "Logs" tab      | `Pulse - Logs - AgentMux`            |
+| User-renamed instance "Debug Session", "Sysinfo" | `Debug Session - Sysinfo - AgentMux` |
+| Pop-out / pool window, "Browser" tab           | `Window 2 - Browser - AgentMux`      |
+
+---
+
+## 2. Current Behavior (what we're replacing)
+
+`document.title` is set in three places in `frontend/app-init.ts`:
+
+- `app-init.ts:306` — `document.title = "AgentMux ${appVersion}"` (initial, e.g. `"AgentMux 0.33.860"`)
+- `app-init.ts:485` — `document.title = "AgentMux ${appVersion} - ${initialTab.name}"` (reinitWave path)
+- `app-init.ts:590` — same as 485 (initWave path)
+
+`appVersion` is fetched once via `getApi().getAboutModalDetails().version`, which originates from `agentmux-cef/src/ipc.rs:121` (`env!("CARGO_PKG_VERSION")`).
+
+The OS window title is then driven by CEF's `OnTitleChange` mirroring `document.title` to the native window:
+
+- `agentmux-cef/src/client/mod.rs:107-139` — `on_title_change()`:
+  - macOS / Linux: `window.set_title(title)` (CEF Views API)
+  - Windows: `SetWindowTextW(hwnd, title)` (Win32) — overrides CEF's mirror with the exact `document.title`
+- `agentmux-cef/src/client/handlers.rs:195-198` — DisplayHandler wrapper
+
+**Default before document.title is written:** `index.html:7` → `<title>AgentMux</title>`.
+
+---
+
+## 3. Data Sources (already exist — no new schema)
+
+The frontend already exposes the data needed for the new format. Both come from the same atoms / objects the bottom-right **InstancePanel** uses (the panel that opens when you click the version in the status bar).
+
+### 3.1 Window Name — three-tier resolution
+
+Lifted from `frontend/app/element/InstancePanel.tsx:142-153` (do not duplicate; extract to a shared helper):
+
+1. **`win.meta["window:displayname"]`** — user-set instance name. Stored on the `WaveWindow` object's meta map. 64-char max (`InstancePanel.tsx:28`).
+
+   Rename UX already exists today in the InstancePanel (the panel that opens when clicking the version chip in the status bar):
+   - **Double-click** a window row → inline editor (`InstancePanel.tsx:304`)
+   - **F2** while a row is focused → inline editor (`InstancePanel.tsx:316`)
+   - **Enter** commits, **Esc** cancels, **blur** commits (`:349-357`)
+   - Empty-after-trim silently reverts; `maxLength={64}` on the input
+   - Persisted via `ObjectService.UpdateObjectMeta(makeORef("window", windowId), { "window:displayname": name })` (`:171-174`)
+
+   This title-format change therefore inherits the existing rename UX wholesale — no new UI work for renaming.
+2. **`workspace.name`** — workspace assigned to the window, when no display name is set.
+3. **`"Window N"`** — 1-indexed positional fallback, where N comes from `openWindowEntriesAtom` order (`StatusBar.tsx:4`, `InstancePanel.tsx:56`). This is what unnamed windows currently show in the panel and matches user expectation.
+
+### 3.2 Tab Name
+
+`tab.name` — `Tab` WaveObj field (already wired through to the active-tab atoms used by `app-init.ts:485,590`). Same source the existing title uses.
+
+### 3.3 Static suffix
+
+Literal `"AgentMux"`. No build flavor / dev / portable suffix (per request — uniform across release types).
+
+---
+
+## 4. Implementation
+
+### 4.1 New helper: `frontend/util/window-title.ts`
+
+Extract the three-tier resolution from `InstancePanel.tsx` into a shared module so both the status-bar panel and the title computation use one implementation.
+
+```ts
+// Pseudocode shape
+export function resolveWindowName(
+    win: WaveWindow | undefined,
+    workspace: Workspace | undefined,
+    indexInOpenWindows: number,
+): string {
+    const display = (win?.meta?.["window:displayname"] ?? "").trim();
+    if (display) return display;
+    if (workspace?.name) return workspace.name;
+    return `Window ${indexInOpenWindows + 1}`;
+}
+
+export function formatWindowTitle(windowName: string, tabName: string | undefined): string {
+    // Tab name omitted if empty so we don't render "Foo -  - AgentMux".
+    return tabName?.trim()
+        ? `${windowName} - ${tabName} - AgentMux`
+        : `${windowName} - AgentMux`;
+}
+```
+
+Then refactor `InstancePanel.tsx:142-153` to call `resolveWindowName` so the panel and the OS title can never disagree.
+
+### 4.2 Replace the three `document.title` writes in `app-init.ts`
+
+Remove the version concatenation. Compute the new title from the same atoms `InstancePanel` reads (`openWindowEntriesAtom`, the per-window `WaveWindow` via `getObjectValue`, the active workspace, the active `tab.name`).
+
+| Line | Before                                                          | After                                                |
+| ---- | --------------------------------------------------------------- | ---------------------------------------------------- |
+| 306  | `document.title = "AgentMux ${appVersion}"`                     | `document.title = formatWindowTitle(windowName, undefined)` (yields `Window N - AgentMux`) |
+| 485  | `document.title = "AgentMux ${appVersion} - ${initialTab.name}"` | `document.title = formatWindowTitle(windowName, initialTab.name)` (yields `Window N - Tab - AgentMux`) |
+| 590  | (duplicate of 485)                                              | same                                                 |
+
+`appVersion` lookup at `app-init.ts:305` becomes dead code for title purposes — keep only if used elsewhere; otherwise drop.
+
+### 4.3 Make the title reactive
+
+Today the title is set once at init. The new format must update when:
+
+- Active tab changes (`tab.name` changes, or user switches tabs)
+- Window display name is renamed (`win.meta["window:displayname"]` changes)
+- Workspace assigned to the window changes (affects fallback)
+- Window's position in `openWindowEntriesAtom` changes (affects "Window N" fallback)
+
+Wire a SolidJS `createEffect` (or jotai subscription, matching the existing pattern around `app-init.ts:485-590`) that recomputes and writes `document.title` whenever any of the inputs change. Unsubscribe on window close.
+
+The reactive write replaces all three current writes — those three sites only existed because the title needed to be re-set on each init path.
+
+### 4.4 Native side — no change
+
+`agentmux-cef/src/client/mod.rs:107-139` already mirrors `document.title` verbatim to the OS window via `SetWindowTextW` (Windows) and `window.set_title` (macOS/Linux). Once the frontend writes the right string, the OS title is correct on every platform with no Rust change.
+
+### 4.5 `index.html` default — change
+
+`index.html:7`: `<title>AgentMux</title>` is shown only during the brief window before the first `document.title` write. Leave as-is — `"AgentMux"` is a reasonable transitional value and matches the suffix in the new format.
+
+---
+
+## 5. Release-Type × Platform Coverage
+
+The fix is **frontend-only** and the frontend bundle is identical across every release type — so the format applies uniformly with no per-build gating, no feature flag, no platform conditional.
+
+### 5.1 Release-type matrix
+
+Every release path in `Taskfile.yml` is exercised:
+
+| Release type                       | Taskfile target                | Bundle source                | Covered? |
+| ---------------------------------- | ------------------------------ | ---------------------------- | -------- |
+| Dev (launcher in loop, Windows)    | `task dev`                     | Vite HMR (`frontend/`)       | Yes      |
+| Dev (host direct, all OS)          | `task dev:standalone`          | Vite HMR (`frontend/`)       | Yes      |
+| Portable ZIP (Windows)             | `task package`                 | `frontend/dist/` (bundled)   | Yes      |
+| AppImage (Linux)                   | `task package:linux`           | `frontend/dist/` (bundled)   | Yes      |
+| MSIX (Windows Store)               | `task package:msix` *(TODO)*   | `frontend/dist/` (bundled)   | Auto, when implemented |
+| macOS .app / .dmg                  | `task package:macos` *(TODO)*  | `frontend/dist/` (bundled)   | Auto, when implemented |
+| Installed via `install-linux-desktop.sh` | (launches existing portable / AppImage build) | n/a — same bundled frontend | Yes |
+
+The two TODO packages need no spec follow-up — they bundle the same `frontend/dist/` and route titles through the same CEF host, so they pick up the new format the day they're implemented.
+
+### 5.2 Per-platform native title sink
+
+`document.title` reaches the OS via different APIs on each platform. All three are already wired in `agentmux-cef/src/client/mod.rs:107-139`:
+
+| OS              | API used                                                               | Source line               |
+| --------------- | ---------------------------------------------------------------------- | ------------------------- |
+| Windows         | `SetWindowTextW(hwnd, ...)` (Win32) — overrides CEF's mirror           | `client/mod.rs:130`       |
+| macOS           | `window.set_title(...)` → CEF Views → AppKit `[NSWindow setTitle:]`    | `client/mod.rs:114`       |
+| Linux X11       | `window.set_title(...)` → CEF Views → `_NET_WM_NAME` / `XStoreName`    | `client/mod.rs:114`       |
+| Linux Wayland   | `window.set_title(...)` → CEF Views → `xdg_toplevel.set_title(...)`    | `client/mod.rs:114`       |
+
+Whatever string `document.title` holds, all four sinks render it verbatim. **No Rust change needed.**
+
+### 5.3 Wayland `app_id` is unrelated — leave alone
+
+On Wayland, the *icon-matching identifier* (`xdg_toplevel.set_app_id`) is separate from the window title. AgentMux already overrides `app_id` to the literal `"agentmux"` (so GNOME/KWin/sway match the window to `agentmux.desktop`):
+
+- `agentmux-cef/src/app.rs:175,195,215` — `install_linux_window_properties_override` writes `wayland_app_id = "agentmux"` and X11 `wm_class = "agentmux"`
+
+This is the **icon binding**, not the user-facing title, and it must remain `"agentmux"` regardless of the title format. Confirm during testing that `xdg_toplevel.set_app_id("agentmux")` still emits — the title-format change doesn't go near this code path, but a regression check is cheap.
+
+### 5.4 Build-flavor distinction in title — explicitly out of scope
+
+The format is identical for dev / portable / installed builds. If a user runs `task dev` and a portable ZIP simultaneously, both windows show the same `Window N - Tab - AgentMux`. The version-button in the bottom-right status bar (`StatusBar.tsx:84`) remains the way to tell them apart.
+
+---
+
+## 6. Where the version still appears (out of scope, intentionally kept)
+
+The version remains visible in places that aren't the OS window title:
+
+- **Status bar bottom-right** — `StatusBar.tsx:84` (`v{version}` button — the entry point to InstancePanel).
+- **About modal** — wherever `getAboutModalDetails().version` is rendered.
+- **Per-window splash / launcher logs** — `agentmux-launcher.log` includes version stamps.
+
+Leave these alone — they're how the user discovers the running version. The change is specifically the OS window title.
+
+---
+
+## 7. Test Plan
+
+### 7.1 Manual
+
+**Behavior (run on each release type at least once):**
+
+- [ ] Default fresh window: title is `Window 1 - Shell - AgentMux`
+- [ ] Open a 2nd window: title of 2nd is `Window 2 - <tab> - AgentMux`
+- [ ] Switch tabs: title updates immediately to new `tab.name`
+- [ ] Open InstancePanel (click version chip in status bar) → double-click a window row → type "Debug Session" → Enter: OS title becomes `Debug Session - <tab> - AgentMux` immediately
+- [ ] Same flow but press Esc instead of Enter: OS title unchanged
+- [ ] Rename to whitespace-only string: silently reverts; OS title unchanged
+- [ ] Rename to a 64-char string: title shows full 64-char window name (no truncation in `document.title`; OS may visually truncate in taskbar)
+- [ ] Assign a workspace whose `name` is "Pulse": title becomes `Pulse - <tab> - AgentMux`
+- [ ] Tear off / pop-out a pane: pop-out window also follows the format
+
+**Platform sweep (each renders title via a different OS API — §5.2):**
+
+- [ ] Windows — taskbar entry shows `Window N - Tab - AgentMux` (verifies `SetWindowTextW`)
+- [ ] macOS — title bar + Dock label show the same string (verifies CEF Views → AppKit)
+- [ ] Linux X11 — title bar + taskbar entry show the same (verifies `_NET_WM_NAME`)
+- [ ] Linux Wayland (GNOME or KWin) — title bar shows the same string AND `xdg_toplevel.set_app_id("agentmux")` is still emitted (regression check on §5.3 — icon must still bind to `agentmux.desktop`)
+
+**Release-type sweep:**
+
+- [ ] `task dev` (Windows) — launcher path
+- [ ] `task dev:standalone` (Windows or Linux)
+- [ ] `task package` → portable ZIP, extract, launch — title identical to dev (no version)
+- [ ] `task package:linux` → AppImage, launch — title identical to dev (no version)
+
+### 7.2 Automated
+
+- [ ] Unit test for `formatWindowTitle` (omit tab when empty; otherwise three-part join)
+- [ ] Unit test for `resolveWindowName` (display name → workspace → "Window N" fallback chain)
+- [ ] Refactor `InstancePanel.tsx` to call `resolveWindowName`; existing visual behavior unchanged
+- [ ] No existing test asserts on `document.title` format (`frontend/app/block/autotitle.test.ts` is about block titles, not window titles) — no test breakage expected
+
+---
+
+## 8. Open Questions
+
+1. **What if `tab.name` is empty/whitespace?** Spec currently says fall back to `Window - AgentMux` (drop the empty middle slot). Confirm this is preferred over `Window - (untitled) - AgentMux`.
+
+   Note on separator collisions: tab names or window names that themselves contain ` - ` will produce visually ambiguous titles (e.g. a tab literally named "Foo - Bar" yields `Window - Foo - Bar - AgentMux`). Acceptable trade-off — `|` would dodge this but the user chose `-`. If it becomes a problem, switch to ` — ` (em dash) or escape inner hyphens.
+2. **Active vs window-scoped tab name.** A window has multiple tabs but only one is active at a time. The title should reflect the *active* tab in that window — confirm there's an existing per-window active-tab atom (likely yes, since tabs render correctly today).
+3. **Truncation.** Windows taskbar truncates long titles aggressively. With `Window Name - Tab Name - AgentMux`, the suffix may get cut first — that's the intended priority (lose `AgentMux` before losing `Window`/`Tab`). No code action needed; just noting.
+
+---
+
+## 9. Files Changed (estimate)
+
+| File                                                | Change                                                                  |
+| --------------------------------------------------- | ----------------------------------------------------------------------- |
+| `frontend/util/window-title.ts`                 | **NEW** — `resolveWindowName`, `formatWindowTitle`                      |
+| `frontend/app-init.ts`                              | Remove 3 title writes (lines 306, 485, 590); replace with reactive effect |
+| `frontend/app/element/InstancePanel.tsx`            | Refactor name resolution to call `resolveWindowName`                    |
+| `frontend/util/window-title.test.ts`            | **NEW** — unit tests for the helper                                     |
+| `agentmux-cef/src/client/mod.rs`                    | None                                                                    |
+| `agentmux-cef/src/client/handlers.rs`               | None                                                                    |
+| `agentmux-cef/src/ipc.rs`                           | None (`getAboutModalDetails().version` still serves StatusBar / About) |
+
+Estimated diff size: ~150 lines net (most of it the new helper + tests).

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -21,6 +21,7 @@ import {
     initGlobal,
     initGlobalEventSubs,
     loadConnStatus,
+    openWindowEntriesAtom,
     pushFlashError,
     pushNotification,
     removeNotificationById,
@@ -32,6 +33,12 @@ import {
     setFullConfigAtom,
 } from "@/app/store/global";
 import * as WOS from "@/app/store/wos";
+import { createEffect, createRoot } from "solid-js";
+import {
+    DISPLAY_NAME_META_KEY,
+    formatWindowTitle,
+    resolveWindowName,
+} from "@/util/window-title";
 import { loadFonts } from "@/util/fontutil";
 import { primeAccountCache } from "@/app/view/identity/identity-model";
 import { setKeyUtilPlatform } from "@/util/keyutil";
@@ -53,7 +60,6 @@ import {
 // Do NOT call getApi() at module level: this file is statically imported by
 // bootstrap.ts before setupCefApi() runs, so window.api does not exist yet.
 let platform: NodeJS.Platform;
-let appVersion: string;
 let savedInitOpts: AgentMuxInitOpts = null;
 
 window.WOS = WOS;
@@ -302,8 +308,10 @@ export async function initApp() {
     }
     // Assign deferred module-level values now.
     platform = getApi().getPlatform();
-    appVersion = getApi().getAboutModalDetails().version;
-    document.title = `AgentMux ${appVersion}`;
+    // Note: document.title is left at the index.html default ("AgentMux")
+    // until installWindowTitleEffect() runs at the end of initWave(). The
+    // body is `visibility: hidden` during init so users don't see the
+    // bare "AgentMux" pre-init title.
 
     // Phase B.7.3.1 — install `window.__agentmux_launcher_event` BEFORE
     // any host-touching call. The host's `launcher_event_bridge` may
@@ -482,7 +490,9 @@ async function reinitWave() {
     const initialTab = await WOS.reloadWaveObject<Tab>(WOS.makeORef("tab", savedInitOpts.tabId));
     await WOS.reloadWaveObject<LayoutState>(WOS.makeORef("layout", initialTab.layoutstate));
     reloadAllWorkspaceTabs(ws);
-    document.title = `AgentMux ${appVersion} - ${initialTab.name}`; // TODO update with tab name change
+    // Title is driven by installWindowTitleEffect() (set up in initWave)
+    // and reacts to atom changes — reinitWave's reloads update the atoms,
+    // the effect re-runs, document.title updates. No imperative write needed.
     getApi().setWindowInitStatus("wave-ready");
     setReinitVersion((v) => v + 1);
     setUpdaterStatusAtom(getApi().getUpdaterStatus());
@@ -490,6 +500,41 @@ async function reinitWave() {
     setTimeout(() => {
         globalRefocus();
     }, 50);
+}
+
+/**
+ * Install the reactive document.title effect for this window. Title format:
+ *
+ *     {Window Name} - {Tab Name} - AgentMux
+ *
+ * Window Name resolves via the same three-tier rule the InstancePanel uses
+ * (user display name → workspace name → "Window N"). The effect re-runs
+ * automatically whenever any input atom changes — tab switches, window
+ * rename, workspace re-assign, or the window's position in
+ * `openWindowEntriesAtom` shifts.
+ *
+ * Spec: docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
+ */
+function installWindowTitleEffect(windowId: string): void {
+    createRoot(() => {
+        createEffect(() => {
+            const activeTabId = atoms.activeTabId();
+            const tab = activeTabId
+                ? WOS.getObjectValue<Tab>(WOS.makeORef("tab", activeTabId))
+                : undefined;
+            const win = WOS.getObjectValue<WaveWindow>(WOS.makeORef("window", windowId));
+            const ws = atoms.workspace();
+            const entries = openWindowEntriesAtom();
+            const idx = entries.findIndex((e) => e.windowId === windowId);
+
+            const windowName = resolveWindowName({
+                displayName: win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined,
+                workspaceName: ws?.name,
+                indexInOpenWindows: idx >= 0 ? idx : 0,
+            });
+            document.title = formatWindowTitle(windowName, tab?.name);
+        });
+    });
 }
 
 function reloadAllWorkspaceTabs(ws: Workspace) {
@@ -587,7 +632,7 @@ async function initWave(initOpts: AgentMuxInitOpts) {
     WOS.wpsSubscribeToObject(WOS.makeORef("workspace", waveWindow.workspaceid));
     tlog("loadAllWorkspaceTabs", t);
 
-    document.title = `AgentMux ${appVersion} - ${initialTab.name}`; // TODO update with tab name change
+    installWindowTitleEffect(initOpts.windowId);
 
     t = performance.now();
     registerGlobalKeys();

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -516,7 +516,13 @@ async function reinitWave() {
  * Spec: docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
  */
 function installWindowTitleEffect(windowId: string): void {
-    createRoot(() => {
+    // Capture dispose so the reactive root can be torn down explicitly.
+    // In practice the CEF renderer is destroyed when the window closes,
+    // taking the JS context (and the effect) with it — but routing
+    // through `beforeunload` keeps the pattern correct if the renderer
+    // ever outlives a single window load (e.g. in-place navigation,
+    // future host-driven reload paths). Per ReAgent review on PR #841.
+    const dispose = createRoot((disposeFn) => {
         createEffect(() => {
             const activeTabId = atoms.activeTabId();
             const tab = activeTabId
@@ -534,7 +540,9 @@ function installWindowTitleEffect(windowId: string): void {
             });
             document.title = formatWindowTitle(windowName, tab?.name);
         });
+        return disposeFn;
     });
+    window.addEventListener("beforeunload", () => dispose(), { once: true });
 }
 
 function reloadAllWorkspaceTabs(ws: Workspace) {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -23,9 +23,11 @@ import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
 import { getObjectValue, makeORef } from "@/store/wos";
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
-
-const DISPLAY_NAME_META_KEY = "window:displayname";
-const DISPLAY_NAME_MAX_LEN = 64;
+import {
+    DISPLAY_NAME_MAX_LEN,
+    DISPLAY_NAME_META_KEY,
+    resolveWindowName,
+} from "@/util/window-title";
 
 interface InstancePanelProps {
     anchorRect: DOMRect | null;
@@ -133,23 +135,22 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         }
     };
 
-    // Resolve a row's display name in priority order:
-    //   1. user-set name in Window meta (`window:displayname`)
-    //   2. workspace.name (when the user has named the workspace)
-    //   3. index-based fallback "Window N"
-    // Returns the resolved string for rendering. Reactive via Wave's
-    // object subscriptions because getObjectValue reads through atoms.
+    // Resolve a row's display name via the shared helper so the panel and
+    // the OS window title (driven from app-init.ts) agree by construction.
+    // Reactive via Wave's object subscriptions because getObjectValue reads
+    // through atoms — when meta or workspace.name changes, this re-runs.
     const resolveName = (entry: WindowEntry, idx: number): string => {
+        let displayName: string | undefined;
+        let workspaceName: string | undefined;
         if (entry.windowId) {
             const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
-            const userName = (win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined)?.trim();
-            if (userName) return userName;
+            displayName = win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined;
             if (win?.workspaceid) {
                 const ws = getObjectValue<Workspace>(makeORef("workspace", win.workspaceid));
-                if (ws?.name?.trim()) return ws.name.trim();
+                workspaceName = ws?.name;
             }
         }
-        return `Window ${idx + 1}`;
+        return resolveWindowName({ displayName, workspaceName, indexInOpenWindows: idx });
     };
 
     const enterRename = (entry: WindowEntry, currentName: string) => {

--- a/frontend/util/window-title.test.ts
+++ b/frontend/util/window-title.test.ts
@@ -1,0 +1,126 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { formatWindowTitle, resolveWindowName } from "./window-title";
+
+describe("resolveWindowName", () => {
+    it("uses display name when set", () => {
+        expect(
+            resolveWindowName({
+                displayName: "Debug Session",
+                workspaceName: "Pulse",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Debug Session");
+    });
+
+    it("trims display name", () => {
+        expect(
+            resolveWindowName({
+                displayName: "   Spaced Out   ",
+                workspaceName: undefined,
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Spaced Out");
+    });
+
+    it("falls through when display name is whitespace-only", () => {
+        expect(
+            resolveWindowName({
+                displayName: "   ",
+                workspaceName: "Pulse",
+                indexInOpenWindows: 4,
+            }),
+        ).toBe("Pulse");
+    });
+
+    it("falls through to workspace name when display name is undefined", () => {
+        expect(
+            resolveWindowName({
+                displayName: undefined,
+                workspaceName: "Pulse",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Pulse");
+    });
+
+    it("falls through to workspace name when display name is null", () => {
+        expect(
+            resolveWindowName({
+                displayName: null,
+                workspaceName: "Pulse",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Pulse");
+    });
+
+    it("trims workspace name", () => {
+        expect(
+            resolveWindowName({
+                displayName: "",
+                workspaceName: "  Stratum  ",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Stratum");
+    });
+
+    it("falls through to positional when both names are missing", () => {
+        expect(
+            resolveWindowName({
+                displayName: "",
+                workspaceName: "",
+                indexInOpenWindows: 0,
+            }),
+        ).toBe("Window 1");
+    });
+
+    it("uses 1-indexed positional", () => {
+        expect(
+            resolveWindowName({
+                displayName: undefined,
+                workspaceName: undefined,
+                indexInOpenWindows: 4,
+            }),
+        ).toBe("Window 5");
+    });
+});
+
+describe("formatWindowTitle", () => {
+    it("joins all three parts when tab name is present", () => {
+        expect(formatWindowTitle("Main", "Shell")).toBe("Main - Shell - AgentMux");
+    });
+
+    it("trims tab name", () => {
+        expect(formatWindowTitle("Main", "  Shell  ")).toBe("Main - Shell - AgentMux");
+    });
+
+    it("omits the empty middle slot when tab name is empty", () => {
+        expect(formatWindowTitle("Main", "")).toBe("Main - AgentMux");
+    });
+
+    it("omits the empty middle slot when tab name is whitespace-only", () => {
+        expect(formatWindowTitle("Main", "   ")).toBe("Main - AgentMux");
+    });
+
+    it("omits the empty middle slot when tab name is undefined", () => {
+        expect(formatWindowTitle("Main", undefined)).toBe("Main - AgentMux");
+    });
+
+    it("omits the empty middle slot when tab name is null", () => {
+        expect(formatWindowTitle("Main", null)).toBe("Main - AgentMux");
+    });
+
+    it("preserves user names that contain the separator literal", () => {
+        // Documented trade-off in the spec §8 — '-' inside a name is
+        // visually ambiguous with the separator but not corrupted.
+        expect(formatWindowTitle("Foo - Bar", "Logs")).toBe("Foo - Bar - Logs - AgentMux");
+    });
+
+    it("renders 64-char window names without truncating", () => {
+        const longName = "A".repeat(64);
+        const out = formatWindowTitle(longName, "X");
+        expect(out.startsWith(longName)).toBe(true);
+        expect(out).toBe(`${longName} - X - AgentMux`);
+    });
+});

--- a/frontend/util/window-title.ts
+++ b/frontend/util/window-title.ts
@@ -1,0 +1,55 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Window-title resolution shared between the OS window title (driven from
+ * `app-init.ts`) and the bottom-right InstancePanel that lists open windows.
+ *
+ * Spec: docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
+ */
+
+const TITLE_SEPARATOR = " - ";
+const APP_NAME = "AgentMux";
+
+/** Key under `WaveWindow.meta` where the user-set instance name is stored. 64-char max. */
+export const DISPLAY_NAME_META_KEY = "window:displayname";
+export const DISPLAY_NAME_MAX_LEN = 64;
+
+export interface ResolveWindowNameOpts {
+    /** Value of `WaveWindow.meta["window:displayname"]` if set. */
+    displayName?: string | null;
+    /** Value of the assigned workspace's `name` if any. */
+    workspaceName?: string | null;
+    /** 0-indexed position in `openWindowEntriesAtom`; rendered as "Window N" where N = index + 1. */
+    indexInOpenWindows: number;
+}
+
+/**
+ * Three-tier resolution matching the InstancePanel rules:
+ *   1. user-set display name (trimmed; empty falls through)
+ *   2. workspace name (trimmed; empty falls through)
+ *   3. positional fallback "Window N"
+ */
+export function resolveWindowName(opts: ResolveWindowNameOpts): string {
+    const display = (opts.displayName ?? "").trim();
+    if (display) return display;
+    const ws = (opts.workspaceName ?? "").trim();
+    if (ws) return ws;
+    return `Window ${opts.indexInOpenWindows + 1}`;
+}
+
+/**
+ * Format the OS window title. Tab name omitted (no empty middle slot) when
+ * absent, since not every init path has a tab loaded yet.
+ *
+ *   formatWindowTitle("Main", "Shell")  → "Main - Shell - AgentMux"
+ *   formatWindowTitle("Main", "")       → "Main - AgentMux"
+ *   formatWindowTitle("Main", undefined)→ "Main - AgentMux"
+ */
+export function formatWindowTitle(windowName: string, tabName: string | null | undefined): string {
+    const tab = (tabName ?? "").trim();
+    if (tab) {
+        return `${windowName}${TITLE_SEPARATOR}${tab}${TITLE_SEPARATOR}${APP_NAME}`;
+    }
+    return `${windowName}${TITLE_SEPARATOR}${APP_NAME}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.869",
+  "version": "0.33.870",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.869",
+      "version": "0.33.870",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -269,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -896,6 +897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,6 +946,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1041,7 +1044,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1060,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1204,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1220,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1236,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1268,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1284,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1428,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,7 +1444,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,6 +1671,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1911,7 +1899,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1951,7 +1938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1958,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,7 +1978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,7 +1998,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,7 +2018,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2056,7 +2038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,7 +2058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,7 +2078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,7 +2098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2118,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2161,7 +2138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,7 +2158,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,7 +2257,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,7 +2270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,7 +2283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,7 +2296,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,7 +2322,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,7 +2335,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,7 +2348,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,7 +2361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,7 +2374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,7 +2387,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,7 +2400,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,7 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,7 +2426,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,7 +2439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,7 +2452,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,7 +2465,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,7 +2478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,7 +2504,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,7 +2517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2530,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,7 +2543,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,7 +2556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,7 +2569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2983,6 +2932,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3852,8 +3802,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3947,6 +3898,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4399,6 +4351,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4435,6 +4388,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4685,6 +4639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4698,6 +4653,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4865,6 +4827,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4890,7 +4853,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5123,6 +5086,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5532,6 +5496,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5742,7 +5707,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5861,7 +5826,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5928,6 +5893,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6226,7 +6192,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6343,7 +6308,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6389,7 +6353,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7072,7 +7036,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7224,7 +7188,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7244,7 +7208,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7435,7 +7399,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7614,6 +7578,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7681,7 +7646,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7714,7 +7679,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7735,7 +7699,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7756,7 +7719,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7777,7 +7739,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7798,7 +7759,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7819,7 +7779,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7840,7 +7799,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7861,7 +7819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7882,7 +7839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7903,7 +7859,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7924,7 +7879,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7989,6 +7943,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8520,6 +8486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9156,7 +9123,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9236,7 +9204,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9286,7 +9253,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9575,7 +9541,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9621,7 +9586,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9637,6 +9601,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9720,6 +9685,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9751,6 +9717,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9863,11 +9830,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10182,7 +10162,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10248,8 +10228,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10350,8 +10330,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10397,6 +10378,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10534,6 +10516,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10559,6 +10542,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10811,6 +10815,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11247,7 +11252,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11272,6 +11278,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11363,7 +11395,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11586,13 +11617,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11612,7 +11644,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11642,6 +11673,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11684,7 +11716,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11705,6 +11737,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11915,8 +11948,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12082,7 +12115,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12099,7 +12131,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12116,7 +12147,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12133,7 +12163,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12150,7 +12179,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12167,7 +12195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12184,7 +12211,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12201,7 +12227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12218,7 +12243,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12235,7 +12259,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12252,7 +12275,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12269,7 +12291,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12286,7 +12307,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12303,7 +12323,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12320,7 +12339,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12337,7 +12355,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,7 +12371,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12371,7 +12387,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12403,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12405,7 +12419,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12422,7 +12435,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12439,7 +12451,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12456,7 +12467,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12473,7 +12483,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12490,7 +12499,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12507,7 +12515,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12521,7 +12528,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12563,7 +12569,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12599,6 +12604,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.869",
+  "version": "0.33.870",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Replaces the static `AgentMux ${ver} - ${initialTab.name}` title (which had a known TODO to react to tab changes — `app-init.ts:485,590`) with the format requested:

```
{Window Name} - {Tab Name} - AgentMux
```

- **No version anywhere** in the OS title (still in StatusBar `v{version}` chip and the About modal).
- **Identical across all release types** — `task dev`, `task dev:standalone`, portable ZIP, AppImage, and the future MSIX / macOS packages.
- **Frontend-only.** CEF already mirrors `document.title` verbatim to `SetWindowTextW` (Windows) / CEF Views `set_title` (macOS / Linux X11 / Linux Wayland) at `agentmux-cef/src/client/mod.rs:107-139` — no Rust edits needed.

## Window Name resolution

Same three-tier rule the bottom-right `InstancePanel` already uses for the open-windows list (so the panel and the taskbar title can never disagree):

1. `WaveWindow.meta["window:displayname"]` — user-set (rename gesture exists today: open InstancePanel via the version chip → double-click a row, or F2 → 64-char inline editor)
2. `workspace.name` — when the window has a named workspace
3. `Window N` — 1-indexed positional fallback

## Reactive

A single `createEffect` (installed once at the end of `initWave`) re-runs when any of these changes:

- Active tab changes (`atoms.activeTabId()` → `tab.name`)
- Window display name changes (rename via InstancePanel)
- Workspace assignment changes (`atoms.workspace().name`)
- Window's position in `openWindowEntriesAtom` shifts

## Files

- **NEW** `frontend/util/window-title.ts` — pure `resolveWindowName` + `formatWindowTitle` helpers + `DISPLAY_NAME_META_KEY` constant
- **NEW** `frontend/util/window-title.test.ts` — 16 unit tests covering the resolution chain, trimming, separator collisions, 64-char names, missing tab name
- **REFACTOR** `frontend/app/statusbar/InstancePanel.tsx` — inline three-tier resolution (lines 142-153) replaced by `resolveWindowName(...)` call
- **REWIRE** `frontend/app-init.ts` — three imperative `document.title = ...` writes (lines 306, 485, 590) replaced by one `installWindowTitleEffect(windowId)` call; module-level `appVersion` removed (was title-only)
- **NEW** `docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md` — release-type × platform matrix, native-sink table, Wayland `app_id` non-impact note, full test plan

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npx vitest run frontend/util/window-title.test.ts` — 16/16 pass
- [x] HMR'd successfully into a running `task dev` session (no console errors, frontend reload reported `✅ Main application loaded successfully`)
- [ ] **Manual** — visually confirm in the running window:
  - [ ] Default unnamed window: title is `Window 1 - <active tab> - AgentMux`
  - [ ] Switch tabs: title updates immediately
  - [ ] Open InstancePanel → double-click row → rename to "Debug Session" → Enter: title becomes `Debug Session - <tab> - AgentMux`
  - [ ] Press Esc instead: title unchanged
  - [ ] Pop-out / tear off a pane: pop-out follows the same format
- [ ] Build a portable ZIP (`task package`), launch — title format identical (no version)
- [ ] Cross-platform sweep (macOS, Linux X11, Linux Wayland) — title renders correctly via each respective OS API; Wayland `xdg_toplevel.set_app_id("agentmux")` still emits (icon binding unchanged)

## Spec

Full design + open questions in `docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md`.