### PR TITLE
fix(layout): hold overlayTransform 150ms so placeholder exit fade is visible (#836)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.866"
+version = "0.33.867"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.866"
+version = "0.33.867"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.866"
+version = "0.33.867"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.866"
+version = "0.33.867"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -72,6 +72,37 @@ function TileLayoutComponent(props: TileLayoutProps) {
         }, 50);
     });
 
+    // Issue #836: hold the on-screen overlayTransform for 150ms after
+    // activeDrag flips false, so the Placeholder's inner-div exit fade
+    // (also 150ms) stays visible. Without this, overlayTransform()
+    // recomputes the moment onDrop fires and moves the entire
+    // .placeholder-container off-screen (top = 2*height) before the
+    // .exiting CSS transition can play. We cache the last in-drag
+    // transform and serve it during the hold window, then release.
+    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
+    const [overlayHold, setOverlayHold] = createSignal(false);
+    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
+    createEffect(() => {
+        const active = layoutModel.activeDrag();
+        const xf = overlayTransform();
+        if (active) {
+            setHeldOverlayTransform(xf as JSX.CSSProperties);
+            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
+            setOverlayHold(false);
+        } else if (heldOverlayTransform()) {
+            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
+            setOverlayHold(true);
+            overlayHoldTimer = setTimeout(() => {
+                setOverlayHold(false);
+                setHeldOverlayTransform(undefined);
+                overlayHoldTimer = null;
+            }, 150);
+        }
+    });
+    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
+    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
+        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
+
     const gapSizePx = () => layoutModel.gapSizePx();
     const animationTimeS = () => layoutModel.animationTimeS();
 
@@ -131,8 +162,8 @@ function TileLayoutComponent(props: TileLayoutProps) {
             <NodeBackdrops layoutModel={layoutModel} />
             <MagnifiedPaneOverlay layoutModel={layoutModel} />
 
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...overlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} />
+            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
+            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
         </div>
     );
 }
@@ -426,11 +457,14 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
 interface OverlayNodeWrapperProps {
     layoutModel: LayoutModel;
+    // Issue #836: effective overlay transform that holds the last in-drag
+    // value for 150ms after onDrop so .placeholder-container does not
+    // teleport off-screen before the inner .placeholder exit fade plays.
+    effectiveOverlayTransform: () => JSX.CSSProperties | undefined;
 }
 
 const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
-    const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
     let overlayContainerRef: HTMLDivElement | undefined;
 
@@ -439,9 +473,14 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     // "none" (pass-through for normal clicks) and "auto" (receive drag events).
     // activeDrag is set by pragmatic-dnd's onDragStart callback which fires
     // AFTER the browser commits the drag, so this toggle is safe.
+    //
+    // Issue #836: the transform comes from effectiveOverlayTransform (held
+    // during the 150ms exit window) but pointer-events flips to "none"
+    // IMMEDIATELY when activeDrag goes false — we don't want the held
+    // overlay to intercept clicks during the hold.
     const isActiveDrag = () => props.layoutModel.activeDrag();
     const overlayStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...overlayTransform(),
+        ...props.effectiveOverlayTransform(),
         top: "0px",
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -71,6 +71,37 @@ function TileLayoutComponent(props: TileLayoutProps) {
         }, 50);
     });
 
+    // Issue #836: hold the on-screen overlayTransform for 150ms after
+    // activeDrag flips false, so the Placeholder's inner-div exit fade
+    // (also 150ms) stays visible. Without this, overlayTransform()
+    // recomputes the moment onDrop fires and moves the entire
+    // .placeholder-container off-screen (top = 2*height) before the
+    // .exiting CSS transition can play. We cache the last in-drag
+    // transform and serve it during the hold window, then release.
+    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
+    const [overlayHold, setOverlayHold] = createSignal(false);
+    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
+    createEffect(() => {
+        const active = layoutModel.activeDrag();
+        const xf = overlayTransform();
+        if (active) {
+            setHeldOverlayTransform(xf as JSX.CSSProperties);
+            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
+            setOverlayHold(false);
+        } else if (heldOverlayTransform()) {
+            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
+            setOverlayHold(true);
+            overlayHoldTimer = setTimeout(() => {
+                setOverlayHold(false);
+                setHeldOverlayTransform(undefined);
+                overlayHoldTimer = null;
+            }, 150);
+        }
+    });
+    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
+    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
+        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
+
     const gapSizePx = () => layoutModel.gapSizePx();
     const animationTimeS = () => layoutModel.animationTimeS();
 
@@ -133,8 +164,8 @@ function TileLayoutComponent(props: TileLayoutProps) {
             <NodeBackdrops layoutModel={layoutModel} />
             <MagnifiedPaneOverlay layoutModel={layoutModel} />
 
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...overlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} />
+            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
+            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
         </div>
     );
 }
@@ -407,11 +438,14 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
 interface OverlayNodeWrapperProps {
     layoutModel: LayoutModel;
+    // Issue #836: effective overlay transform that holds the last in-drag
+    // value for 150ms after onDrop so .placeholder-container does not
+    // teleport off-screen before the inner .placeholder exit fade plays.
+    effectiveOverlayTransform: () => JSX.CSSProperties | undefined;
 }
 
 const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
-    const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
     let overlayContainerRef: HTMLDivElement | undefined;
 
@@ -420,9 +454,14 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     // "none" (pass-through for normal clicks) and "auto" (receive drag events).
     // activeDrag is set by pragmatic-dnd's onDragStart callback which fires
     // AFTER the browser commits the drag, so this toggle is safe.
+    //
+    // Issue #836: the transform comes from effectiveOverlayTransform (held
+    // during the 150ms exit window) but pointer-events flips to "none"
+    // IMMEDIATELY when activeDrag goes false — we don't want the held
+    // overlay to intercept clicks during the hold.
     const isActiveDrag = () => props.layoutModel.activeDrag();
     const overlayStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...overlayTransform(),
+        ...props.effectiveOverlayTransform(),
         top: "0px",
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -61,6 +61,44 @@ function TileLayoutComponent(props: TileLayoutProps) {
     const overlayTransform = () => layoutModel.overlayTransform();
     const isResizing = () => layoutModel.isResizing();
 
+    // Issue #836: hold the on-screen overlayTransform for 150ms after
+    // activeDrag flips false, so the Placeholder's inner-div exit fade
+    // (also 150ms) stays visible. Without this, overlayTransform()
+    // recomputes the moment onDrop fires and moves the entire
+    // .placeholder-container off-screen (top = 2*height) before the
+    // .exiting CSS transition can play. We cache the last in-drag
+    // transform and serve it during the hold window, then release.
+    const [heldOverlayTransform, setHeldOverlayTransform] = createSignal<JSX.CSSProperties | undefined>(undefined);
+    const [overlayHold, setOverlayHold] = createSignal(false);
+    let overlayHoldTimer: ReturnType<typeof setTimeout> | null = null;
+    createEffect(() => {
+        const active = layoutModel.activeDrag();
+        const xf = overlayTransform();
+        if (active) {
+            // Drag in progress: cache the live transform and clear any pending release.
+            setHeldOverlayTransform(xf as JSX.CSSProperties);
+            if (overlayHoldTimer) { clearTimeout(overlayHoldTimer); overlayHoldTimer = null; }
+            setOverlayHold(false);
+        } else if (heldOverlayTransform()) {
+            // Drag just ended (or page initial state with no cached value, skip).
+            // Hold the last in-drag transform for 150ms to match the Placeholder
+            // exit-fade duration, then release. A new drag during the hold window
+            // resets cleanly via the active branch above.
+            if (overlayHoldTimer) clearTimeout(overlayHoldTimer);
+            setOverlayHold(true);
+            overlayHoldTimer = setTimeout(() => {
+                setOverlayHold(false);
+                setHeldOverlayTransform(undefined);
+                overlayHoldTimer = null;
+            }, 150);
+        }
+    });
+    onCleanup(() => { if (overlayHoldTimer) clearTimeout(overlayHoldTimer); });
+    // Effective transform for overlay-positioned surfaces: hold the last
+    // in-drag transform during the exit window, otherwise use the live one.
+    const effectiveOverlayTransform = (): JSX.CSSProperties | undefined =>
+        overlayHold() ? heldOverlayTransform() ?? undefined : (overlayTransform() as JSX.CSSProperties | undefined);
+
     // Track animate state.
     //
     // Issue #774 / SPEC_TAB_CONTENT_REVEAL_GATE: the prior 50 ms was
@@ -154,8 +192,8 @@ function TileLayoutComponent(props: TileLayoutProps) {
             <NodeBackdrops layoutModel={layoutModel} />
             <MagnifiedPaneOverlay layoutModel={layoutModel} />
 
-            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...overlayTransform() }} />
-            <OverlayNodeWrapper layoutModel={layoutModel} />
+            <Placeholder layoutModel={layoutModel} style={{ top: "10000px", ...effectiveOverlayTransform() }} />
+            <OverlayNodeWrapper layoutModel={layoutModel} effectiveOverlayTransform={effectiveOverlayTransform} />
         </div>
     );
 }
@@ -476,11 +514,14 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
 interface OverlayNodeWrapperProps {
     layoutModel: LayoutModel;
+    // Issue #836: effective overlay transform that holds the last in-drag
+    // value for 150ms after onDrop so .placeholder-container does not
+    // teleport off-screen before the inner .placeholder exit fade plays.
+    effectiveOverlayTransform: () => JSX.CSSProperties | undefined;
 }
 
 const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     const leafs = () => props.layoutModel.leafs();
-    const overlayTransform = () => props.layoutModel.overlayTransform();
     const activeDrag = () => props.layoutModel.activeDrag();
     let overlayContainerRef: HTMLDivElement | undefined;
 
@@ -489,9 +530,14 @@ const OverlayNodeWrapper = (props: OverlayNodeWrapperProps) => {
     // "none" (pass-through for normal clicks) and "auto" (receive drag events).
     // activeDrag is set by pragmatic-dnd's onDragStart callback which fires
     // AFTER the browser commits the drag, so this toggle is safe.
+    //
+    // Issue #836: the transform comes from effectiveOverlayTransform (held
+    // during the 150ms exit window) but pointer-events flips to "none"
+    // IMMEDIATELY when activeDrag goes false — we don't want the held
+    // overlay to intercept clicks during the hold.
     const isActiveDrag = () => props.layoutModel.activeDrag();
     const overlayStyle = createMemo<JSX.CSSProperties>(() => ({
-        ...overlayTransform(),
+        ...props.effectiveOverlayTransform(),
         top: "0px",
         "pointer-events": isActiveDrag() ? "auto" : "none",
     }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.866",
+  "version": "0.33.867",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.866",
+      "version": "0.33.867",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.866",
+  "version": "0.33.867",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Closes #836.

## Summary

After the compositor-only DnD placeholder work landed (#829 → #837 → #838), the inner `.placeholder` element's exit fade rarely played in practice. Root cause: on `onDrop`, `activeDrag` flips to `false`, which makes `overlayTransform()` recompute and move the entire `.placeholder-container` off-screen (top = `2 * height`). The inner `.placeholder` is still mounted with `.exiting` for 150ms trying to fade, but its parent is already off-screen.

## Fix

In `TileLayoutComponent` (all three platform files), cache the last in-drag `overlayTransform` and serve it from a new `effectiveOverlayTransform()` accessor during a 150ms hold window that matches the Placeholder's exit-fade duration. Pass the accessor into `OverlayNodeWrapper` so its `overlay-container` also stays put during the hold — but pointer-events flips to `none` IMMEDIATELY when `activeDrag` goes false, so the held overlay never intercepts clicks during the hold window.

A new drag during the hold resets cleanly via the `active` branch of the `createEffect`, clearing the timer and the hold flag.

Applied identically to `win32`, `darwin`, `linux` per PR #838's port.

## Test plan

- [ ] Drag a pane to a new drop zone; observe placeholder fade-out on release
- [ ] Quickly start a second drag mid-fade; placeholder reappears at new target without flicker
- [ ] Click outside drop zones during the 150ms hold window — clicks pass through (pointer-events: none)
- [ ] No regressions to drag-over/drag-leave/drop computation

🤖 Generated with [Claude Code](https://claude.com/claude-code)