### PR TITLE
feat(workflows): Agent inspector + workflowrun subscription (Phase 1.5 PR 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.867"
+version = "0.33.868"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.868"
+version = "0.33.869"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.868"
+version = "0.33.869"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.867"
+version = "0.33.868"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.868"
+version = "0.33.869"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.867"
+version = "0.33.868"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.868"
+version = "0.33.869"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.867"
+version = "0.33.868"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/server/workflow_handlers.rs
+++ b/agentmux-srv/src/server/workflow_handlers.rs
@@ -232,6 +232,59 @@ pub fn register_workflow_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                     let mut output = String::new();
                     let mut error = String::new();
                     while let Some(ev) = handle.events.recv().await {
+                        // For terminal events, persist the final row
+                        // BEFORE publishing the event. The frontend
+                        // subscription path refreshes the runs list on
+                        // RunDone / RunFailed, and if the publish
+                        // happens first the refresh sees a stale
+                        // `running` row (codex P2 on PR #843).
+                        let is_terminal = matches!(
+                            ev,
+                            RunEvent::RunDone { .. } | RunEvent::RunFailed { .. }
+                        );
+                        if is_terminal {
+                            match &ev {
+                                RunEvent::RunDone { output: o, .. } => {
+                                    last_status = RunStatus::Done;
+                                    // Engine already unwraps Response's
+                                    // `{ "value": ... }` wrapper.
+                                    output = match o {
+                                        serde_json::Value::String(s) => s.clone(),
+                                        other => {
+                                            serde_json::to_string(other).unwrap_or_default()
+                                        }
+                                    };
+                                }
+                                RunEvent::RunFailed { error: e, .. } => {
+                                    last_status = RunStatus::Failed;
+                                    error = e.clone();
+                                }
+                                _ => unreachable!(),
+                            }
+                            let states = handle.final_states.lock().await.clone();
+                            let row = WorkflowRun {
+                                id: run_id_for_drain.clone(),
+                                workflow_id: workflow_id_for_drain.clone(),
+                                status: last_status.as_str().to_string(),
+                                started_at,
+                                ended_at: now_ms(),
+                                block_states: states,
+                                output: output.clone(),
+                                error: error.clone(),
+                            };
+                            match wstore_for_drain.workflow_run_update(&row) {
+                                Ok(0) => tracing::warn!(
+                                    run_id = %run_id_for_drain,
+                                    "workflow_run_update: placeholder row missing (race?)"
+                                ),
+                                Ok(_) => {}
+                                Err(e) => tracing::warn!(
+                                    run_id = %run_id_for_drain,
+                                    error = %e,
+                                    "workflow_run_update failed"
+                                ),
+                            }
+                        }
                         broker_for_drain.publish(WaveEvent {
                             event: format!("workflowrun:{}", run_id_for_drain),
                             scopes: vec![],
@@ -239,45 +292,6 @@ pub fn register_workflow_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                             persist: 0,
                             data: Some(serde_json::to_value(&ev).unwrap_or_default()),
                         });
-                        match &ev {
-                            RunEvent::RunDone { output: o, .. } => {
-                                last_status = RunStatus::Done;
-                                // Engine already unwraps Response's
-                                // `{ "value": ... }` wrapper.
-                                output = match o {
-                                    serde_json::Value::String(s) => s.clone(),
-                                    other => serde_json::to_string(other).unwrap_or_default(),
-                                };
-                            }
-                            RunEvent::RunFailed { error: e, .. } => {
-                                last_status = RunStatus::Failed;
-                                error = e.clone();
-                            }
-                            _ => {}
-                        }
-                    }
-                    let states = handle.final_states.lock().await.clone();
-                    let row = WorkflowRun {
-                        id: run_id_for_drain.clone(),
-                        workflow_id: workflow_id_for_drain,
-                        status: last_status.as_str().to_string(),
-                        started_at,
-                        ended_at: now_ms(),
-                        block_states: states,
-                        output,
-                        error,
-                    };
-                    match wstore_for_drain.workflow_run_update(&row) {
-                        Ok(0) => tracing::warn!(
-                            run_id = %run_id_for_drain,
-                            "workflow_run_update: placeholder row missing (race?)"
-                        ),
-                        Ok(_) => {}
-                        Err(e) => tracing::warn!(
-                            run_id = %run_id_for_drain,
-                            error = %e,
-                            "workflow_run_update failed"
-                        ),
                     }
                 });
 

--- a/agentmux-srv/src/workflows/executor/blocks/agent.rs
+++ b/agentmux-srv/src/workflows/executor/blocks/agent.rs
@@ -55,7 +55,23 @@ pub async fn run(node: &FlowNode, scope: &ExecutionScope) -> Result<Value, Strin
     let agent_ref: AgentRef = match node.data.get("agent_ref") {
         Some(v) => serde_json::from_value(v.clone())
             .map_err(|e| format!("agent block: invalid agent_ref: {e}"))?,
-        None => AgentRef::default(),
+        None => {
+            // Pre-Phase-1.5 nodes persisted a single `forge_agent_id`
+            // string; the runner can't honor it because identity and
+            // memory are now separate bundles. Surface the legacy data
+            // in the log so the user knows why the agent launches
+            // blank (#835).
+            if let Some(legacy) = node.data.get("forge_agent_id").and_then(|v| v.as_str()) {
+                if !legacy.is_empty() {
+                    tracing::warn!(
+                        block_id = %node.id,
+                        legacy_forge_agent_id = %legacy,
+                        "agent block: legacy `forge_agent_id` ignored — re-pick identity/memory after Phase 1.5 PR 3"
+                    );
+                }
+            }
+            AgentRef::default()
+        }
     };
 
     let max_turns = node
@@ -152,4 +168,29 @@ mod tests {
     // `run_agent_with_bin` entry point instead of `std::env::set_var`
     // (unsound under concurrent test execution in Rust 1.81+).
     // Reagent P2 on PR #834.
+
+    /// Reproduces the parse-only path of `run()` for a node carrying
+    /// legacy `forge_agent_id` (no `agent_ref`). The runner shim isn't
+    /// invoked — the assertion is that we accept the node and fall back
+    /// to a default `AgentRef`. The deprecation warning fires as a side
+    /// effect; we keep this test free of `tracing` plumbing.
+    #[test]
+    fn legacy_forge_agent_id_falls_back_to_default_ref() {
+        let data = json!({
+            "kind": "agent",
+            "task": "hi",
+            "forge_agent_id": "legacy-id-123"
+        });
+        let agent_ref: AgentRef = match data.get("agent_ref") {
+            Some(v) => serde_json::from_value(v.clone()).unwrap(),
+            None => AgentRef::default(),
+        };
+        assert_eq!(agent_ref, AgentRef::default());
+        // Confirms the legacy field is still present in node.data — the
+        // production path reads it for the warn-log; tests don't.
+        assert_eq!(
+            data.get("forge_agent_id").and_then(|v| v.as_str()),
+            Some("legacy-id-123")
+        );
+    }
 }

--- a/frontend/app/view/workflows/block-registry.ts
+++ b/frontend/app/view/workflows/block-registry.ts
@@ -45,11 +45,18 @@ export const BLOCK_REGISTRY: Record<BlockKind, BlockKindMeta> = {
     agent: {
         kind: "agent",
         label: "Agent",
-        description: "Run a Forge agent with a per-call task prompt.",
+        description: "Run an agent with a per-call task prompt.",
         color: "#3b82f6",
         icon: "sparkles",
         defaultData: {
-            forge_agent_id: "",
+            // Phase 1.5: forge_agent_id was replaced by AgentRef (#835).
+            // Empty strings = blank singletons (ambient creds, vanilla CLI).
+            agent_ref: {
+                identityId: "",
+                memoryId: "",
+                instanceName: "",
+                workingDirectory: "",
+            },
             task: "",
         },
         inputs: [{ id: "in", label: "in", type: "any" }],

--- a/frontend/app/view/workflows/workflows-model.ts
+++ b/frontend/app/view/workflows/workflows-model.ts
@@ -9,6 +9,7 @@
 import { BlockNodeModel } from "@/app/block/blocktypes";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
 import { getWaveObjectAtom, makeORef } from "@/app/store/wos";
 import { createMemo, createSignal, type Accessor } from "solid-js";
 
@@ -86,6 +87,23 @@ export class WorkflowsViewModel implements ViewModel {
     errorAtom: Accessor<string | null> = this._error[0];
     setError = this._error[1];
 
+    // ── Per-block last-run result (Phase 1.5 PR 3 — #830) ──────────
+    //
+    // Keyed by the workflow block id. Populated from `BlockDone` /
+    // `BlockError` events on the active run; cleared on `newWorkflow`
+    // and when the user starts a new run.
+    private _blockResults = createSignal<Record<string, AgentBlockResult>>({});
+    blockResultsAtom: Accessor<Record<string, AgentBlockResult>> = this._blockResults[0];
+    setBlockResults = this._blockResults[1];
+
+    blockResultAtom(blockId: string): AgentBlockResult | undefined {
+        return this.blockResultsAtom()[blockId];
+    }
+
+    // Active `workflowrun:<id>` subscription. Stored so we can
+    // unsubscribe on dispose / when the run changes.
+    private activeRunUnsub: (() => void) | null = null;
+
     selectedNodeAtom: Accessor<FlowNode | null>;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
@@ -138,6 +156,11 @@ export class WorkflowsViewModel implements ViewModel {
         this.setRunEvents([]);
         this.setActiveRunId(null);
         this.setRuns([]);
+        this.setBlockResults({});
+        if (this.activeRunUnsub) {
+            this.activeRunUnsub();
+            this.activeRunUnsub = null;
+        }
     }
 
     /** Persist the current draft. Returns the saved id. */
@@ -168,25 +191,85 @@ export class WorkflowsViewModel implements ViewModel {
         }
         this.setRunning(true);
         this.setRunEvents([]);
+        this.setBlockResults({});
         try {
             const r = await RpcApi.RunWorkflowCommand(TabRpcClient, { workflow_id: id });
             this.setActiveRunId(r.run_id);
-            // The backend now inserts a `running` placeholder row
-            // synchronously before this RPC resolves and drains the
-            // executor in a background tokio::spawn that lands the
-            // final UPDATE later. This refresh picks up the placeholder
-            // immediately so the Runs panel shows the new entry; the
-            // row's transition from `running` → `done`/`failed`
-            // requires a `workflowrun:<id>` WPS subscription, which is
-            // deferred to Phase 1 PR-4 polish — tracked in issue #830.
-            // Until then users see the placeholder and must re-open
-            // the workflow to see the final state.
+            this.subscribeRun(r.run_id, id);
+            // Backend inserts a `running` placeholder row synchronously
+            // before this RPC resolves; the subscription above picks up
+            // the `RunDone` / `RunFailed` transition and re-refreshes
+            // the runs list (Phase 1.5 PR 3, closes #830).
             await this.refreshRuns(id);
         } catch (e) {
             this.setError(`Run failed: ${(e as Error).message ?? e}`);
         } finally {
             this.setRunning(false);
         }
+    }
+
+    /** Subscribe to `workflowrun:<runId>` WPS events for the active run.
+     *  Replaces any prior subscription. The backend publishes one event
+     *  per `RunEvent` variant — we drive the run-panel + per-block
+     *  result cache off them and refresh the run row on terminal events. */
+    private subscribeRun(runId: string, workflowId: string): void {
+        if (this.activeRunUnsub) {
+            this.activeRunUnsub();
+            this.activeRunUnsub = null;
+        }
+        this.activeRunUnsub = waveEventSubscribe({
+            eventType: `workflowrun:${runId}`,
+            scope: "",
+            handler: (event) => {
+                const data = (event as { data?: RunEventWire }).data;
+                if (!data) return;
+                this.applyRunEvent(data);
+                if (data.kind === "run_done" || data.kind === "run_failed") {
+                    // Refresh once the placeholder row has been UPDATEd
+                    // by the backend's drain task. Backend writes the
+                    // row after sending the terminal event, so a small
+                    // microtask delay is enough.
+                    void this.refreshRuns(workflowId);
+                    if (this.activeRunUnsub) {
+                        this.activeRunUnsub();
+                        this.activeRunUnsub = null;
+                    }
+                }
+            },
+        });
+    }
+
+    /** Fold one `RunEvent` into the model's reactive state. Kept in the
+     *  view model for Phase 1.5; slice #10 (PR 4) will move this into a
+     *  pure reducer per the master reducer-stack pattern. */
+    private applyRunEvent(ev: RunEventWire): void {
+        switch (ev.kind) {
+            case "block_done":
+                if (ev.block_id) {
+                    this.setBlockResults((prev) => ({
+                        ...prev,
+                        [ev.block_id!]: parseBlockOutput(ev.output),
+                    }));
+                }
+                break;
+            case "block_error":
+                if (ev.block_id) {
+                    this.setBlockResults((prev) => ({
+                        ...prev,
+                        [ev.block_id!]: { response: "", error: ev.error ?? "block failed" },
+                    }));
+                }
+                break;
+            default:
+                break;
+        }
+        this.appendRunEvent({
+            kind: ev.kind,
+            block_id: ev.block_id,
+            output: ev.output,
+            error: ev.error,
+            at: Date.now(),
+        });
     }
 
     async refreshRuns(workflowId: string): Promise<void> {
@@ -294,9 +377,10 @@ export class WorkflowsViewModel implements ViewModel {
     }
 
     dispose(): void {
-        // No subscriptions to tear down yet. When we add a wave-event
-        // subscription for `workflowrun:<id>` events (Phase 1 PR-4) we
-        // unsubscribe here.
+        if (this.activeRunUnsub) {
+            this.activeRunUnsub();
+            this.activeRunUnsub = null;
+        }
     }
 }
 
@@ -306,6 +390,48 @@ export interface RunEventEntry {
     output?: unknown;
     error?: string;
     at: number;
+}
+
+/** Shape of one `workflowrun:<id>` event payload as emitted by
+ *  `agentmux-srv/src/workflows/executor/engine.rs::RunEvent`
+ *  (`#[serde(tag = "kind", rename_all = "snake_case")]`). */
+interface RunEventWire {
+    kind:
+        | "run_started"
+        | "block_started"
+        | "block_done"
+        | "block_error"
+        | "run_done"
+        | "run_failed";
+    run_id?: string;
+    workflow_id?: string;
+    block_id?: string;
+    output?: unknown;
+    error?: string;
+}
+
+/** What we render in the Agent block inspector for the last run. */
+export interface AgentBlockResult {
+    response: string;
+    costUsd?: number;
+    error?: string;
+}
+
+/** Pull the response text + cost out of the `BlockDone.output` shape
+ *  emitted by `workflows/executor/blocks/agent.rs` (spec §4.3). The
+ *  block returns `{ response, tokens, cost_usd }` — variables/api/etc.
+ *  blocks return arbitrary shapes that we fall back to JSON-stringify. */
+function parseBlockOutput(output: unknown): AgentBlockResult {
+    if (output && typeof output === "object") {
+        const o = output as Record<string, unknown>;
+        if (typeof o["response"] === "string") {
+            return {
+                response: o["response"],
+                costUsd: typeof o["cost_usd"] === "number" ? (o["cost_usd"] as number) : undefined,
+            };
+        }
+    }
+    return { response: typeof output === "string" ? output : JSON.stringify(output ?? null) };
 }
 
 function makeId(prefix: string): string {

--- a/frontend/app/view/workflows/workflows-model.ts
+++ b/frontend/app/view/workflows/workflows-model.ts
@@ -201,6 +201,12 @@ export class WorkflowsViewModel implements ViewModel {
             // the `RunDone` / `RunFailed` transition and re-refreshes
             // the runs list (Phase 1.5 PR 3, closes #830).
             await this.refreshRuns(id);
+            // Race recovery: ultra-fast workflows can finish + persist
+            // their final row before we subscribe (codex P2 on #843).
+            // If the just-refreshed row is already terminal, backfill
+            // blockResults from `block_states` so the inspector still
+            // shows per-block output.
+            this.maybeBackfillFromTerminalRun(r.run_id);
         } catch (e) {
             this.setError(`Run failed: ${(e as Error).message ?? e}`);
         } finally {
@@ -225,10 +231,9 @@ export class WorkflowsViewModel implements ViewModel {
                 if (!data) return;
                 this.applyRunEvent(data);
                 if (data.kind === "run_done" || data.kind === "run_failed") {
-                    // Refresh once the placeholder row has been UPDATEd
-                    // by the backend's drain task. Backend writes the
-                    // row after sending the terminal event, so a small
-                    // microtask delay is enough.
+                    // Backend now writes the row update BEFORE
+                    // publishing the terminal event (codex P2 on #843),
+                    // so a refresh here lands the final state.
                     void this.refreshRuns(workflowId);
                     if (this.activeRunUnsub) {
                         this.activeRunUnsub();
@@ -237,6 +242,34 @@ export class WorkflowsViewModel implements ViewModel {
                 }
             },
         });
+    }
+
+    /** Look up the active run in the just-refreshed runs list and, if
+     *  it's already terminal, populate `blockResults` from its
+     *  `block_states` map. Covers the codex P2 race for fast workflows
+     *  whose `workflowrun:<id>` events fire before this client
+     *  subscribes. Subscription teardown happens regardless. */
+    private maybeBackfillFromTerminalRun(runId: string): void {
+        // Already populated by streaming events? Nothing to do.
+        if (Object.keys(this.blockResultsAtom()).length > 0) return;
+        const row = this.runsAtom().find((r) => r.id === runId);
+        if (!row || (row.status !== "done" && row.status !== "failed")) return;
+        const states = row.block_states ?? {};
+        const next: Record<string, AgentBlockResult> = {};
+        for (const [blockId, st] of Object.entries(states)) {
+            if (st.status === "done") {
+                next[blockId] = parseBlockOutput(st.output);
+            } else if (st.status === "error") {
+                next[blockId] = { response: "", error: st.error ?? "block failed" };
+            }
+        }
+        if (Object.keys(next).length > 0) {
+            this.setBlockResults(next);
+        }
+        if (this.activeRunUnsub) {
+            this.activeRunUnsub();
+            this.activeRunUnsub = null;
+        }
     }
 
     /** Fold one `RunEvent` into the model's reactive state. Kept in the

--- a/frontend/app/view/workflows/workflows-view.tsx
+++ b/frontend/app/view/workflows/workflows-view.tsx
@@ -1,8 +1,10 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { For, Show, type JSX } from "solid-js";
+import { createResource, For, Show, type JSX } from "solid-js";
 
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { BLOCK_KINDS, blockMeta } from "./block-registry";
 import type { WorkflowsViewModel } from "./workflows-model";
 import type { BlockKind, FlowNode } from "./workflows-types";
@@ -241,8 +243,12 @@ const Canvas = (p: { model: WorkflowsViewModel }): JSX.Element => {
 
 function nodeSummary(n: FlowNode): string {
     switch (n.data.kind) {
-        case "agent":
-            return `task: ${truncate((n.data["task"] as string) ?? "")}`;
+        case "agent": {
+            const ref = readAgentRef(n);
+            const task = (n.data["task"] as string) ?? "";
+            const who = ref.instanceName || ref.identityId || "blank";
+            return `${who} · ${truncate(task)}`;
+        }
         case "api":
             return `${(n.data["method"] as string) ?? "GET"} ${truncate((n.data["url"] as string) ?? "")}`;
         case "condition":
@@ -292,13 +298,7 @@ const InspectorForm = (p: { model: WorkflowsViewModel; node: FlowNode }): JSX.El
             <div class="workflows-inspector-title">{meta.label}</div>
             <div class="workflows-inspector-id">{p.node.id}</div>
             <Show when={p.node.data.kind === "agent"}>
-                <Field label="Forge agent id">
-                    <input
-                        class="workflows-input"
-                        value={(p.node.data["forge_agent_id"] as string) ?? ""}
-                        onInput={(e) => update({ forge_agent_id: e.currentTarget.value })}
-                    />
-                </Field>
+                <AgentRefEditor node={p.node} update={update} />
                 <Field label="Task ({{...}} interpolation supported)">
                     <textarea
                         class="workflows-input"
@@ -307,6 +307,7 @@ const InspectorForm = (p: { model: WorkflowsViewModel; node: FlowNode }): JSX.El
                         onInput={(e) => update({ task: e.currentTarget.value })}
                     />
                 </Field>
+                <AgentResultPanel model={p.model} blockId={p.node.id} />
             </Show>
             <Show when={p.node.data.kind === "api"}>
                 <Field label="Method">
@@ -419,6 +420,132 @@ const VariablesEditor = (p: {
                 + Add
             </button>
         </div>
+    );
+};
+
+// ── AgentRef editor ───────────────────────────────────────────────────
+//
+// PR 3 of Phase 1.5 (closes #835). Replaces the prior single
+// `forge_agent_id` text field with separate identity / memory /
+// instance-name pickers backed by the launch-modal RPCs.
+
+interface AgentRefShape {
+    identityId: string;
+    memoryId: string;
+    instanceName: string;
+    workingDirectory: string;
+}
+
+function readAgentRef(n: FlowNode): AgentRefShape {
+    const raw = n.data["agent_ref"] as Partial<AgentRefShape> | undefined;
+    if (raw && typeof raw === "object") {
+        return {
+            identityId: raw.identityId ?? "",
+            memoryId: raw.memoryId ?? "",
+            instanceName: raw.instanceName ?? "",
+            workingDirectory: raw.workingDirectory ?? "",
+        };
+    }
+    // Legacy pre-#835 nodes persisted `forge_agent_id`. Phase 1.5 PR 2
+    // (#834) wired the executor to read `agent_ref` only — a legacy
+    // node now launches blank claude. Surface that explicitly rather
+    // than silently coercing the old id into anything.
+    const legacy = n.data["forge_agent_id"];
+    if (typeof legacy === "string" && legacy.length > 0) {
+        console.warn(
+            `[workflows] Agent block ${n.id} uses legacy forge_agent_id="${legacy}"; re-pick identity/memory after PR 3.`,
+        );
+    }
+    return { identityId: "", memoryId: "", instanceName: "", workingDirectory: "" };
+}
+
+const AgentRefEditor = (p: {
+    node: FlowNode;
+    update: (patch: Record<string, unknown>) => void;
+}): JSX.Element => {
+    const [identities] = createResource(() =>
+        RpcApi.ListIdentityBundlesCommand(TabRpcClient, {}).catch(() => [] as IdentityBundle[]),
+    );
+    const [memories] = createResource(() =>
+        RpcApi.ListMemoriesCommand(TabRpcClient, {}).catch(() => [] as Memory[]),
+    );
+    const ref = () => readAgentRef(p.node);
+    const setRef = (patch: Partial<AgentRefShape>) =>
+        p.update({ agent_ref: { ...ref(), ...patch } });
+
+    return (
+        <>
+            <Field label="Identity">
+                <select
+                    class="workflows-input"
+                    value={ref().identityId}
+                    onChange={(e) => setRef({ identityId: e.currentTarget.value })}
+                >
+                    <option value="">— Blank (ambient creds) —</option>
+                    <For each={(identities() ?? []).filter((b) => !b.is_blank)}>
+                        {(bundle) => <option value={bundle.id}>{bundle.name}</option>}
+                    </For>
+                </select>
+            </Field>
+            <Field label="Memory">
+                <select
+                    class="workflows-input"
+                    value={ref().memoryId}
+                    onChange={(e) => setRef({ memoryId: e.currentTarget.value })}
+                >
+                    <option value="">— Blank (vanilla CLI) —</option>
+                    <For each={(memories() ?? []).filter((m) => !m.is_blank)}>
+                        {(memory) => <option value={memory.id}>{memory.name}</option>}
+                    </For>
+                </select>
+            </Field>
+            <Field label="Instance name (optional, for named-agent continuation)">
+                <input
+                    class="workflows-input"
+                    value={ref().instanceName}
+                    onInput={(e) => setRef({ instanceName: e.currentTarget.value })}
+                    placeholder="leave blank for one-shot"
+                />
+            </Field>
+        </>
+    );
+};
+
+// ── Agent result panel ────────────────────────────────────────────────
+//
+// Shows the most recent run's BlockDone output for the selected Agent
+// block. Subscribed via the model (`workflowrun:<id>` events → §5.2).
+// Phase 1.5 ships final-result rendering only; hover-expand tool stream
+// is deferred to Phase 2 polish.
+
+const AgentResultPanel = (p: {
+    model: WorkflowsViewModel;
+    blockId: string;
+}): JSX.Element => {
+    const result = () => p.model.blockResultAtom(p.blockId);
+    return (
+        <Show when={result()}>
+            {(r) => (
+                <div class="workflows-agent-result">
+                    <div class="workflows-agent-result-label">Last run</div>
+                    <Show
+                        when={r().error}
+                        fallback={
+                            <>
+                                <pre class="workflows-agent-result-text">{r().response}</pre>
+                                <Show when={r().costUsd != null}>
+                                    <div class="workflows-agent-result-cost">
+                                        ${r().costUsd!.toFixed(4)}
+                                    </div>
+                                </Show>
+                            </>
+                        }
+                    >
+                        <pre class="workflows-agent-result-error">{r().error}</pre>
+                    </Show>
+                </div>
+            )}
+        </Show>
     );
 };
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.868",
+  "version": "0.33.869",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.867",
+  "version": "0.33.868",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
Closes #830, closes #835. Phase 1.5 PR 3 per `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` §6 row 3. Tracking discussion: #832.

## Summary

- **#835 — Agent block migrated from `forge_agent_id` to `agent_ref`.** Block-registry default data now ships `{ agent_ref: { identityId, memoryId, instanceName, workingDirectory }, task }`. Inspector replaces the single text field with separate identity / memory `<select>` pickers (populated via `ListIdentityBundlesCommand` + `ListMemoriesCommand`) plus an optional instance-name input for named-agent continuation. Backend `blocks/agent.rs` logs a deprecation warning when a node still carries `forge_agent_id` so legacy workflows surface visibly rather than silently launching blank.
- **#830 — Frontend subscribes to `workflowrun:<run_id>` events.** Model wires `waveEventSubscribe` on `run()`, applies `BlockDone` / `BlockError` into a per-block result cache, and refreshes the runs list on `RunDone` / `RunFailed`. Inspector now shows last-run response + cost for the selected Agent block. Subscription tears down on completion, `newWorkflow`, or `dispose`.
- Removes the Phase 1 \`TODO Phase 1 PR-4\` comment that warned the placeholder row never transitioned to done/failed without manual refresh.

## Scope notes

- Hover-expand tool stream rendering is deferred to Phase 2 polish per spec §5.2 — this PR ships final-result rendering only.
- Slice #10 reducer migration is PR 4 — the view model still folds events directly; PR 4 moves the same logic into a pure reducer.
- Memory picker shows non-blank bundles only (mirrors `AgentLaunchModal`'s pattern; the runtime injection layer for workflow-block memory is the same path the pane uses).

## Test plan

- [x] `cargo test -p agentmux-srv workflows::executor::blocks::agent` — 3 pass (incl. new `legacy_forge_agent_id_falls_back_to_default_ref`)
- [x] `tsc --noEmit` clean on the three changed frontend files
- [ ] Open workflows pane → drop Agent block → identity dropdown populates with bundles
- [ ] Run workflow → run-panel row transitions from \`running\` → \`done\` / \`failed\` without manual refresh
- [ ] Select Agent block after run completes → "Last run" panel shows response + cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)