### PR TITLE
feat(auth): AuthState reducer for pre-launch OAuth (PR B-1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.870"
+version = "0.33.871"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.870"
+version = "0.33.871"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.870"
+version = "0.33.871"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.870"
+version = "0.33.871"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.870"
+version = "0.33.871"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.869"
+version = "0.33.870"
 dependencies = [
  "agentmux-common",
  "async-stream",
@@ -1546,9 +1546,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "285efcf12ef41bec907b3000d5ffaeb54191d4d9d83c0d6157e6cbc2db255e64"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
  "bitflags 2.11.1",
  "libc",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.870"
+version = "0.33.871"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.869"
+version = "0.33.870"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.870"
+version = "0.33.871"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.870"
+version = "0.33.871"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.869"
+version = "0.33.870"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.870"
+version = "0.33.871"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.870"
+version = "0.33.871"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.869"
+version = "0.33.870"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/frontend/app/view/agent/auth/auth-state.test.ts
+++ b/frontend/app/view/agent/auth/auth-state.test.ts
@@ -134,6 +134,7 @@ describe("auth-state reducer", () => {
             const seeded = seed({ kind: "waiting", sessionId: "s1" });
             const r = update(seeded, {
                 type: "Polled",
+                sessionId: "s1",
                 status: { status: "pending" },
             });
             expect(r.state).toBe(seeded);
@@ -144,11 +145,13 @@ describe("auth-state reducer", () => {
             const seeded = seed({ kind: "waiting", sessionId: "s1" });
             const r1 = update(seeded, {
                 type: "Polled",
+                sessionId: "s1",
                 status: { status: "url-available", authUrl: "https://x" },
             });
             expect(r1.state.authUrl).toBe("https://x");
             const r2 = update(r1.state, {
                 type: "Polled",
+                sessionId: "s1",
                 status: { status: "url-available", authUrl: "https://x" },
             });
             expect(r2.events).toEqual([]);
@@ -158,6 +161,7 @@ describe("auth-state reducer", () => {
             const seeded = seed({ kind: "waiting", sessionId: "s1" });
             const r1 = update(seeded, {
                 type: "Polled",
+                sessionId: "s1",
                 status: {
                     status: "code-emitted",
                     deviceCode: "ABCD-1234",
@@ -170,6 +174,7 @@ describe("auth-state reducer", () => {
             });
             const r2 = update(r1.state, {
                 type: "Polled",
+                sessionId: "s1",
                 status: {
                     status: "code-emitted",
                     deviceCode: "ABCD-1234",
@@ -188,6 +193,7 @@ describe("auth-state reducer", () => {
             });
             const r = update(seeded, {
                 type: "Polled",
+                sessionId: "s1",
                 status: {
                     status: "success",
                     bundleId: "new-bundle",
@@ -210,11 +216,89 @@ describe("auth-state reducer", () => {
             const seeded = seed({ kind: "waiting", sessionId: "s1" });
             const r = update(seeded, {
                 type: "Polled",
+                sessionId: "s1",
                 status: { status: "failed", error: "timeout" },
             });
             expect(r.state.kind).toBe("failed");
             expect(r.state.error).toBe("timeout");
             expect(r.state.sessionId).toBe("");
+        });
+
+        // Codex P1 on PR #845: a poll response from a cancelled or
+        // superseded session must NOT mutate state.
+        it("drops a stale `success` for a different session", () => {
+            const seeded = seed({
+                kind: "waiting",
+                sessionId: "s2",
+                providerId: "claude",
+                bundleId: "current-bundle",
+            });
+            const r = update(seeded, {
+                type: "Polled",
+                sessionId: "s1", // old session
+                status: {
+                    status: "success",
+                    bundleId: "wrong-bundle",
+                    email: "u@x.com",
+                },
+            });
+            expect(r.state).toBe(seeded);
+            expect(r.events[0]).toMatchObject({
+                type: "post-close-command-dropped",
+                commandType: "Polled",
+            });
+        });
+
+        it("drops a stale `failed` after CancelClicked cleared sessionId", () => {
+            // User clicks Connect → s1 starts → user clicks Cancel →
+            // state.sessionId becomes "" → late `failed` from s1 must
+            // not flip state to "failed" with the old error.
+            const seeded = seed({
+                kind: "unauthenticated",
+                sessionId: "",
+                providerId: "claude",
+            });
+            const r = update(seeded, {
+                type: "Polled",
+                sessionId: "s1",
+                status: { status: "failed", error: "old timeout" },
+            });
+            expect(r.state).toBe(seeded);
+            expect(r.state.error).toBe("");
+            expect(r.events[0]).toMatchObject({
+                type: "post-close-command-dropped",
+            });
+        });
+
+        it("drops a stale poll after Selected swapped the bundle", () => {
+            // Mid-OAuth on session s1 (bundle b1) → user picks bundle
+            // b2 → state.sessionId cleared → late `success` from s1
+            // must not flip state to ready with bundle from old session.
+            const sessionGoingOn = seed({
+                kind: "waiting",
+                sessionId: "s1",
+                providerId: "claude",
+                bundleId: "b1",
+            });
+            const afterSelected = update(sessionGoingOn, {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b2",
+                outcome: "ready",
+            }).state;
+            expect(afterSelected.sessionId).toBe(""); // sanity
+            const r = update(afterSelected, {
+                type: "Polled",
+                sessionId: "s1",
+                status: {
+                    status: "success",
+                    bundleId: "wrong",
+                    email: null,
+                },
+            });
+            expect(r.state).toBe(afterSelected);
+            expect(r.state.bundleId).toBe("b2");
+            expect(r.state.kind).toBe("ready");
         });
     });
 

--- a/frontend/app/view/agent/auth/auth-state.test.ts
+++ b/frontend/app/view/agent/auth/auth-state.test.ts
@@ -1,0 +1,335 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { initialState, update, type AuthState } from "./auth-state";
+
+const seed = (overrides: Partial<AuthState> = {}): AuthState => ({
+    ...initialState(),
+    ...overrides,
+});
+
+describe("auth-state reducer", () => {
+    describe("Selected", () => {
+        it("transitions to `ready` when the bundle is authenticated", () => {
+            const r = update(initialState(), {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b1",
+                outcome: "ready",
+            });
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.providerId).toBe("claude");
+            expect(r.state.bundleId).toBe("b1");
+            expect(r.events[0]).toMatchObject({
+                type: "selection-changed",
+                kind: "ready",
+            });
+        });
+
+        it("transitions to `expired` for stale bundles", () => {
+            const r = update(initialState(), {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b1",
+                outcome: "expired",
+            });
+            expect(r.state.kind).toBe("expired");
+        });
+
+        it("transitions to `unauthenticated` for needs-account and needs-bundle", () => {
+            for (const outcome of ["needs-account", "needs-bundle"] as const) {
+                const r = update(initialState(), {
+                    type: "Selected",
+                    providerId: "claude",
+                    bundleId: "b1",
+                    outcome,
+                });
+                expect(r.state.kind).toBe("unauthenticated");
+            }
+        });
+
+        it("clears prior session + error state on selection change", () => {
+            const dirty = seed({
+                kind: "failed",
+                sessionId: "s1",
+                authUrl: "https://x",
+                error: "oops",
+            });
+            const r = update(dirty, {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b1",
+                outcome: "ready",
+            });
+            expect(r.state.sessionId).toBe("");
+            expect(r.state.authUrl).toBe("");
+            expect(r.state.error).toBe("");
+        });
+
+        it("is idempotent on identical selection", () => {
+            const seeded = seed({
+                providerId: "claude",
+                bundleId: "b1",
+                kind: "ready",
+            });
+            const r = update(seeded, {
+                type: "Selected",
+                providerId: "claude",
+                bundleId: "b1",
+                outcome: "ready",
+            });
+            expect(r.state).toBe(seeded);
+            expect(r.events).toEqual([]);
+        });
+    });
+
+    describe("ConnectClicked", () => {
+        it("transitions unauthenticated → waiting and emits start-requested", () => {
+            const seeded = seed({
+                kind: "unauthenticated",
+                providerId: "claude",
+                bundleId: "",
+            });
+            const r = update(seeded, { type: "ConnectClicked" });
+            expect(r.state.kind).toBe("waiting");
+            expect(r.events[0]).toMatchObject({
+                type: "start-requested",
+                providerId: "claude",
+            });
+        });
+
+        it("transitions expired → waiting (re-auth path)", () => {
+            const seeded = seed({ kind: "expired", providerId: "codex" });
+            const r = update(seeded, { type: "ConnectClicked" });
+            expect(r.state.kind).toBe("waiting");
+        });
+
+        it("clears prior error when re-attempting after Failed", () => {
+            const seeded = seed({
+                kind: "failed",
+                error: "previous failure",
+                providerId: "claude",
+            });
+            const r = update(seeded, { type: "ConnectClicked" });
+            expect(r.state.kind).toBe("waiting");
+            expect(r.state.error).toBe("");
+        });
+
+        it("is dropped (no transition) from ready / waiting / idle", () => {
+            for (const kind of ["ready", "waiting", "idle"] as const) {
+                const seeded = seed({ kind });
+                const r = update(seeded, { type: "ConnectClicked" });
+                expect(r.state).toBe(seeded);
+                expect(r.events[0]).toMatchObject({
+                    type: "post-close-command-dropped",
+                });
+            }
+        });
+    });
+
+    describe("Polled", () => {
+        it("`pending` is a no-op", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "s1" });
+            const r = update(seeded, {
+                type: "Polled",
+                status: { status: "pending" },
+            });
+            expect(r.state).toBe(seeded);
+            expect(r.events).toEqual([]);
+        });
+
+        it("`url-available` captures the URL idempotently", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "s1" });
+            const r1 = update(seeded, {
+                type: "Polled",
+                status: { status: "url-available", authUrl: "https://x" },
+            });
+            expect(r1.state.authUrl).toBe("https://x");
+            const r2 = update(r1.state, {
+                type: "Polled",
+                status: { status: "url-available", authUrl: "https://x" },
+            });
+            expect(r2.events).toEqual([]);
+        });
+
+        it("`code-emitted` captures device code idempotently", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "s1" });
+            const r1 = update(seeded, {
+                type: "Polled",
+                status: {
+                    status: "code-emitted",
+                    deviceCode: "ABCD-1234",
+                    verificationUrl: "https://github.com/login/device",
+                },
+            });
+            expect(r1.state.deviceCode).toEqual({
+                code: "ABCD-1234",
+                verificationUrl: "https://github.com/login/device",
+            });
+            const r2 = update(r1.state, {
+                type: "Polled",
+                status: {
+                    status: "code-emitted",
+                    deviceCode: "ABCD-1234",
+                    verificationUrl: "https://github.com/login/device",
+                },
+            });
+            expect(r2.events).toEqual([]);
+        });
+
+        it("`success` flips to ready and clears transients", () => {
+            const seeded = seed({
+                kind: "waiting",
+                sessionId: "s1",
+                authUrl: "https://x",
+                deviceCode: { code: "X", verificationUrl: "Y" },
+            });
+            const r = update(seeded, {
+                type: "Polled",
+                status: {
+                    status: "success",
+                    bundleId: "new-bundle",
+                    email: "u@x.com",
+                },
+            });
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.bundleId).toBe("new-bundle");
+            expect(r.state.sessionId).toBe("");
+            expect(r.state.authUrl).toBe("");
+            expect(r.state.deviceCode).toBeNull();
+            expect(r.events[0]).toMatchObject({
+                type: "succeeded",
+                bundleId: "new-bundle",
+                email: "u@x.com",
+            });
+        });
+
+        it("`failed` flips to failed with error", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "s1" });
+            const r = update(seeded, {
+                type: "Polled",
+                status: { status: "failed", error: "timeout" },
+            });
+            expect(r.state.kind).toBe("failed");
+            expect(r.state.error).toBe("timeout");
+            expect(r.state.sessionId).toBe("");
+        });
+    });
+
+    describe("CancelClicked", () => {
+        it("transitions waiting → unauthenticated and emits cancel-requested", () => {
+            const seeded = seed({
+                kind: "waiting",
+                sessionId: "s1",
+                authUrl: "https://x",
+            });
+            const r = update(seeded, { type: "CancelClicked" });
+            expect(r.state.kind).toBe("unauthenticated");
+            expect(r.state.sessionId).toBe("");
+            expect(r.state.authUrl).toBe("");
+            expect(r.events[0]).toMatchObject({
+                type: "cancel-requested",
+                sessionId: "s1",
+            });
+        });
+
+        it("is dropped from non-waiting states", () => {
+            const seeded = seed({ kind: "ready" });
+            const r = update(seeded, { type: "CancelClicked" });
+            expect(r.events[0]).toMatchObject({
+                type: "post-close-command-dropped",
+            });
+        });
+    });
+
+    describe("CallbackSubmitted", () => {
+        it("emits callback-submit-requested when waiting with a session", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "s1" });
+            const r = update(seeded, {
+                type: "CallbackSubmitted",
+                callbackUrl: "https://cb?code=x",
+            });
+            expect(r.state).toBe(seeded); // no state change
+            expect(r.events[0]).toMatchObject({
+                type: "callback-submit-requested",
+                sessionId: "s1",
+                callbackUrl: "https://cb?code=x",
+            });
+        });
+
+        it("is dropped without an active session", () => {
+            const seeded = seed({ kind: "waiting", sessionId: "" });
+            const r = update(seeded, {
+                type: "CallbackSubmitted",
+                callbackUrl: "x",
+            });
+            expect(r.events[0]).toMatchObject({
+                type: "post-close-command-dropped",
+            });
+        });
+    });
+
+    describe("ApiKey path", () => {
+        it("ApiKeySubmitted transitions to waiting + emits request", () => {
+            const seeded = seed({
+                kind: "unauthenticated",
+                providerId: "openclaw",
+                bundleId: "",
+            });
+            const r = update(seeded, {
+                type: "ApiKeySubmitted",
+                apiKey: "sk-test",
+                accountName: "default",
+            });
+            expect(r.state.kind).toBe("waiting");
+            expect(r.events[0]).toMatchObject({
+                type: "api-key-submit-requested",
+                providerId: "openclaw",
+                apiKey: "sk-test",
+            });
+        });
+
+        it("ApiKeyAccepted flips to ready with the new bundle", () => {
+            const seeded = seed({ kind: "waiting", providerId: "openclaw" });
+            const r = update(seeded, {
+                type: "ApiKeyAccepted",
+                bundleId: "new-key-bundle",
+            });
+            expect(r.state.kind).toBe("ready");
+            expect(r.state.bundleId).toBe("new-key-bundle");
+        });
+    });
+
+    describe("Disposed gate", () => {
+        it("Disposed sets closed=true", () => {
+            const r = update(initialState(), { type: "Disposed" });
+            expect(r.state.closed).toBe(true);
+        });
+
+        it("Disposed is idempotent", () => {
+            const r1 = update(initialState(), { type: "Disposed" });
+            const r2 = update(r1.state, { type: "Disposed" });
+            expect(r2.state).toBe(r1.state);
+            expect(r2.events).toEqual([]);
+        });
+
+        it("commands after Disposed are no-ops emitting post-close-command-dropped", () => {
+            const closed = update(initialState(), { type: "Disposed" }).state;
+            const r = update(closed, {
+                type: "Selected",
+                providerId: "x",
+                bundleId: "y",
+                outcome: "ready",
+            });
+            expect(r.state).toBe(closed);
+            expect(r.events).toEqual([
+                {
+                    type: "post-close-command-dropped",
+                    commandType: "Selected",
+                },
+            ]);
+        });
+    });
+});

--- a/frontend/app/view/agent/auth/auth-state.ts
+++ b/frontend/app/view/agent/auth/auth-state.ts
@@ -1,0 +1,442 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pre-launch OAuth state machine — frontend side of the flow defined
+ * in `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` §8.
+ *
+ * Pure reducer (`update(state, command) → { state, events }`) — no
+ * RPC, no DOM. The `AgentLaunchModal` owns one instance per open;
+ * effects (RPC calls, URL paste, etc.) are run by the modal in
+ * response to emitted events.
+ *
+ * Why a reducer (not a tangle of `createSignal`s): the auth flow has
+ * 5 transient states (idle/unauthenticated/waiting/ready/expired) and
+ * 8 commands that mutate them. The combinations are non-trivial — a
+ * poll result while the user is mid-cancel, a callback URL paste
+ * while the session is already terminal, an API-key submit when the
+ * dropdown swaps mid-flight. The reducer makes each transition a
+ * single clearly-named case with idempotency rules, and the unit
+ * tests pin every combo.
+ *
+ * Backend wire types are mirrored in `frontend/types/gotypes.d.ts`
+ * (`AuthSessionStatus` etc.). This module imports those globals so
+ * `Selected` / `Polled` carry the same shapes the RPC handlers
+ * return.
+ */
+
+/** Mirrors the wire `AuthSessionStatus` from
+ *  `agentmux-srv/src/identity/auth_session.rs` (camelCase via
+ *  `rename_all_fields`). Pulled inline here as a TS type because the
+ *  Rust enum doesn't currently surface in `gotypes.d.ts`. */
+export type AuthSessionStatusWire =
+    | { status: "pending" }
+    | { status: "url-available"; authUrl: string }
+    | { status: "code-emitted"; deviceCode: string; verificationUrl: string }
+    | { status: "success"; bundleId: string; email: string | null }
+    | { status: "failed"; error: string };
+
+/** Outcome of the modal's bundle/provider selection. The view computes
+ *  this from the dropdown + the loaded `IdentityBundle` / `Memory`
+ *  lists and dispatches `Selected` once. */
+export type SelectionOutcome =
+    | "ready" // bundle has authenticated account for this provider
+    | "expired" // bundle has account but stale (re-auth needed)
+    | "needs-account" // bundle exists but no account for this provider
+    | "needs-bundle"; // blank singleton — Connect creates new bundle
+
+export interface AuthState {
+    /** Terminal flag set by `Disposed`. Post-close commands are no-ops. */
+    closed: boolean;
+    /** What the view should render. The `unauthenticated` and
+     *  `expired` kinds drive different copy in the inline CTA. */
+    kind: "idle" | "unauthenticated" | "waiting" | "ready" | "expired" | "failed";
+    /** Selected provider id ("claude", "codex", "openclaw", ...). */
+    providerId: string;
+    /** Selected identity bundle id. Empty when no bundle picked OR
+     *  blank singleton (`needs-bundle`). */
+    bundleId: string;
+    /** Active backend session id when `kind === "waiting"`. */
+    sessionId: string;
+    /** Captured OAuth URL — surface in the inline panel if the
+     *  browser didn't open. */
+    authUrl: string;
+    /** Captured device-flow code (Copilot path). */
+    deviceCode: { code: string; verificationUrl: string } | null;
+    /** Last error message — populated on `Failed` so the inline
+     *  banner can render it. Cleared by the next selection or
+     *  connect attempt. */
+    error: string;
+}
+
+export const initialState = (): AuthState => ({
+    closed: false,
+    kind: "idle",
+    providerId: "",
+    bundleId: "",
+    sessionId: "",
+    authUrl: "",
+    deviceCode: null,
+    error: "",
+});
+
+export type AuthCommand =
+    /**
+     * The view's dropdown selection settled. The view computes which
+     * `outcome` applies from the bundle data it just loaded and
+     * passes it in — the reducer doesn't need to re-derive.
+     */
+    | {
+          type: "Selected";
+          providerId: string;
+          bundleId: string;
+          outcome: SelectionOutcome;
+      }
+    /**
+     * The user clicked "Connect with OAuth". The view will fire the
+     * `StartProviderAuth` RPC on the corresponding event; this
+     * command just transitions to `waiting`.
+     */
+    | { type: "ConnectClicked" }
+    /**
+     * RPC returned with a session id (and possibly an immediate
+     * URL — claude tends to print the URL within the first frame
+     * of stdout).
+     */
+    | { type: "SessionStarted"; sessionId: string; authUrl?: string }
+    /**
+     * Poll returned a non-terminal status. The reducer extracts
+     * the relevant fields. Multiple polls returning the same data
+     * are idempotent (no event re-fired).
+     */
+    | { type: "Polled"; status: AuthSessionStatusWire }
+    /**
+     * The user clicked "Cancel login". The view fires
+     * `CancelProviderAuth` on the corresponding event.
+     */
+    | { type: "CancelClicked" }
+    /**
+     * The user pasted a callback URL into the URL panel. View fires
+     * `SubmitAuthCallback`. No state change here — we wait for the
+     * next poll to see "success" or "failed".
+     */
+    | { type: "CallbackSubmitted"; callbackUrl: string }
+    /**
+     * API-key path: user pasted a key into the modal. View fires
+     * `SubmitProviderApiKey`; reducer transitions to a brief
+     * `waiting` state with no session id (the RPC is synchronous).
+     */
+    | { type: "ApiKeySubmitted"; apiKey: string; accountName: string }
+    /**
+     * Backend confirmed an API-key bundle creation. Mirrors
+     * `Polled { status: "success" }` for the API-key path.
+     */
+    | { type: "ApiKeyAccepted"; bundleId: string }
+    /**
+     * Modal close / unmount. Idempotent.
+     */
+    | { type: "Disposed" };
+
+export type AuthEvent =
+    | {
+          type: "selection-changed";
+          providerId: string;
+          bundleId: string;
+          kind: AuthState["kind"];
+      }
+    | { type: "start-requested"; providerId: string; bundleId: string }
+    | { type: "session-started"; sessionId: string; authUrl: string }
+    | { type: "url-available"; authUrl: string }
+    | {
+          type: "device-code-emitted";
+          code: string;
+          verificationUrl: string;
+      }
+    | { type: "succeeded"; bundleId: string; email: string | null }
+    | { type: "failed"; error: string }
+    | { type: "cancel-requested"; sessionId: string }
+    | { type: "callback-submit-requested"; sessionId: string; callbackUrl: string }
+    | {
+          type: "api-key-submit-requested";
+          providerId: string;
+          bundleId: string;
+          apiKey: string;
+          accountName: string;
+      }
+    | { type: "api-key-accepted"; bundleId: string }
+    | { type: "disposed" }
+    | { type: "post-close-command-dropped"; commandType: string };
+
+export interface ReducerResult {
+    state: AuthState;
+    events: AuthEvent[];
+}
+
+const selectionKind = (outcome: SelectionOutcome): AuthState["kind"] => {
+    switch (outcome) {
+        case "ready":
+            return "ready";
+        case "expired":
+            return "expired";
+        case "needs-account":
+        case "needs-bundle":
+            return "unauthenticated";
+    }
+};
+
+export function update(state: AuthState, command: AuthCommand): ReducerResult {
+    if (state.closed && command.type !== "Disposed") {
+        return {
+            state,
+            events: [
+                { type: "post-close-command-dropped", commandType: command.type },
+            ],
+        };
+    }
+
+    switch (command.type) {
+        case "Selected": {
+            const nextKind = selectionKind(command.outcome);
+            const next: AuthState = {
+                ...state,
+                providerId: command.providerId,
+                bundleId: command.bundleId,
+                kind: nextKind,
+                sessionId: "",
+                authUrl: "",
+                deviceCode: null,
+                error: "",
+            };
+            // Idempotency: same provider+bundle+outcome → no event.
+            if (
+                state.providerId === next.providerId &&
+                state.bundleId === next.bundleId &&
+                state.kind === nextKind
+            ) {
+                return { state, events: [] };
+            }
+            return {
+                state: next,
+                events: [
+                    {
+                        type: "selection-changed",
+                        providerId: next.providerId,
+                        bundleId: next.bundleId,
+                        kind: nextKind,
+                    },
+                ],
+            };
+        }
+
+        case "ConnectClicked": {
+            if (state.kind !== "unauthenticated" && state.kind !== "expired" && state.kind !== "failed") {
+                // No-op — can't start auth from `ready` / `waiting` /
+                // `idle`. Surface it via the dropped event so a misfire
+                // shows up in the audit ring.
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "post-close-command-dropped",
+                            commandType: "ConnectClicked",
+                        },
+                    ],
+                };
+            }
+            return {
+                state: { ...state, kind: "waiting", error: "" },
+                events: [
+                    {
+                        type: "start-requested",
+                        providerId: state.providerId,
+                        bundleId: state.bundleId,
+                    },
+                ],
+            };
+        }
+
+        case "SessionStarted": {
+            const authUrl = command.authUrl ?? "";
+            return {
+                state: {
+                    ...state,
+                    sessionId: command.sessionId,
+                    authUrl,
+                    kind: "waiting",
+                },
+                events: [
+                    {
+                        type: "session-started",
+                        sessionId: command.sessionId,
+                        authUrl,
+                    },
+                ],
+            };
+        }
+
+        case "Polled": {
+            return foldPolled(state, command.status);
+        }
+
+        case "CancelClicked": {
+            if (state.kind !== "waiting" || state.sessionId === "") {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "post-close-command-dropped",
+                            commandType: "CancelClicked",
+                        },
+                    ],
+                };
+            }
+            return {
+                state: {
+                    ...state,
+                    kind: "unauthenticated",
+                    sessionId: "",
+                    authUrl: "",
+                    deviceCode: null,
+                },
+                events: [{ type: "cancel-requested", sessionId: state.sessionId }],
+            };
+        }
+
+        case "CallbackSubmitted": {
+            if (state.kind !== "waiting" || state.sessionId === "") {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "post-close-command-dropped",
+                            commandType: "CallbackSubmitted",
+                        },
+                    ],
+                };
+            }
+            return {
+                state,
+                events: [
+                    {
+                        type: "callback-submit-requested",
+                        sessionId: state.sessionId,
+                        callbackUrl: command.callbackUrl,
+                    },
+                ],
+            };
+        }
+
+        case "ApiKeySubmitted": {
+            return {
+                state: { ...state, kind: "waiting", error: "" },
+                events: [
+                    {
+                        type: "api-key-submit-requested",
+                        providerId: state.providerId,
+                        bundleId: state.bundleId,
+                        apiKey: command.apiKey,
+                        accountName: command.accountName,
+                    },
+                ],
+            };
+        }
+
+        case "ApiKeyAccepted": {
+            return {
+                state: {
+                    ...state,
+                    kind: "ready",
+                    bundleId: command.bundleId,
+                    sessionId: "",
+                    authUrl: "",
+                    deviceCode: null,
+                    error: "",
+                },
+                events: [{ type: "api-key-accepted", bundleId: command.bundleId }],
+            };
+        }
+
+        case "Disposed": {
+            if (state.closed) return { state, events: [] };
+            return {
+                state: { ...state, closed: true },
+                events: [{ type: "disposed" }],
+            };
+        }
+    }
+}
+
+function foldPolled(state: AuthState, status: AuthSessionStatusWire): ReducerResult {
+    switch (status.status) {
+        case "pending": {
+            // No state change — keep `waiting`. Pure tick; the modal's
+            // poll loop is what's interesting, not this transition.
+            return { state, events: [] };
+        }
+        case "url-available": {
+            if (state.authUrl === status.authUrl) return { state, events: [] };
+            return {
+                state: { ...state, authUrl: status.authUrl },
+                events: [{ type: "url-available", authUrl: status.authUrl }],
+            };
+        }
+        case "code-emitted": {
+            const prior = state.deviceCode;
+            if (
+                prior &&
+                prior.code === status.deviceCode &&
+                prior.verificationUrl === status.verificationUrl
+            ) {
+                return { state, events: [] };
+            }
+            return {
+                state: {
+                    ...state,
+                    deviceCode: {
+                        code: status.deviceCode,
+                        verificationUrl: status.verificationUrl,
+                    },
+                },
+                events: [
+                    {
+                        type: "device-code-emitted",
+                        code: status.deviceCode,
+                        verificationUrl: status.verificationUrl,
+                    },
+                ],
+            };
+        }
+        case "success": {
+            return {
+                state: {
+                    ...state,
+                    kind: "ready",
+                    bundleId: status.bundleId,
+                    sessionId: "",
+                    authUrl: "",
+                    deviceCode: null,
+                    error: "",
+                },
+                events: [
+                    {
+                        type: "succeeded",
+                        bundleId: status.bundleId,
+                        email: status.email,
+                    },
+                ],
+            };
+        }
+        case "failed": {
+            return {
+                state: {
+                    ...state,
+                    kind: "failed",
+                    sessionId: "",
+                    deviceCode: null,
+                    error: status.error,
+                },
+                events: [{ type: "failed", error: status.error }],
+            };
+        }
+    }
+}

--- a/frontend/app/view/agent/auth/auth-state.ts
+++ b/frontend/app/view/agent/auth/auth-state.ts
@@ -105,11 +105,14 @@ export type AuthCommand =
      */
     | { type: "SessionStarted"; sessionId: string; authUrl?: string }
     /**
-     * Poll returned a non-terminal status. The reducer extracts
-     * the relevant fields. Multiple polls returning the same data
-     * are idempotent (no event re-fired).
+     * Poll returned a status for the session identified by
+     * `sessionId`. The reducer drops the result if it doesn't match
+     * the currently-active session — guards against stale polls from
+     * a cancelled or superseded session that would otherwise flip
+     * state to a wrong `bundleId` (codex P1 on PR #845). Multiple
+     * polls returning the same data are idempotent (no event re-fired).
      */
-    | { type: "Polled"; status: AuthSessionStatusWire }
+    | { type: "Polled"; sessionId: string; status: AuthSessionStatusWire }
     /**
      * The user clicked "Cancel login". The view fires
      * `CancelProviderAuth` on the corresponding event.
@@ -275,6 +278,26 @@ export function update(state: AuthState, command: AuthCommand): ReducerResult {
         }
 
         case "Polled": {
+            // Drop stale polls from cancelled / superseded sessions
+            // (codex P1 on PR #845). The view passes the sessionId
+            // the RPC was issued against; if it doesn't match the
+            // currently-active session the result is from an old
+            // attempt that the user already left behind.
+            if (
+                state.kind !== "waiting" ||
+                state.sessionId === "" ||
+                command.sessionId !== state.sessionId
+            ) {
+                return {
+                    state,
+                    events: [
+                        {
+                            type: "post-close-command-dropped",
+                            commandType: "Polled",
+                        },
+                    ],
+                };
+            }
             return foldPolled(state, command.status);
         }
 

--- a/frontend/app/view/agent/auth/index.ts
+++ b/frontend/app/view/agent/auth/index.ts
@@ -1,0 +1,12 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+export type {
+    AuthCommand,
+    AuthEvent,
+    AuthSessionStatusWire,
+    AuthState,
+    ReducerResult,
+    SelectionOutcome,
+} from "./auth-state";
+export { initialState, update } from "./auth-state";

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.869",
+  "version": "0.33.870",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.870",
+  "version": "0.33.871",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
First slice of PR B from \`docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md\` §10. **Stacked on #840** — please merge that first.

## Why split

Spec PR B bundles reducer + modal wiring. The modal touches ~6 new UI panels (Connect CTA, URL fallback, device-code panel, API-key paste, Launch gate, status badges) so the wiring will be ~400+ LOC. Shipping the reducer first gets the state machine reviewed before the UI lands on top of it — same pattern that worked for the workflow-run-state slice on #844.

## Summary

- New module \`frontend/app/view/agent/auth/\` — pure reducer (\`update(state, command) → { state, events }\`).
- \`AuthCommand\`: \`Selected\` / \`ConnectClicked\` / \`SessionStarted\` / \`Polled\` / \`CancelClicked\` / \`CallbackSubmitted\` / \`ApiKeySubmitted\` / \`ApiKeyAccepted\` / \`Disposed\`.
- \`AuthState.kind\`: \`idle | unauthenticated | waiting | ready | expired | failed\`.
- \`Polled\` folds the wire \`AuthSessionStatus\` (Pending / UrlAvailable / CodeEmitted / Success / Failed) into state with idempotency on URL + device-code captures.
- Same post-close-command-dropped gate as slice #9 + #10; \`Disposed\` is the terminal flag.
- 23 unit tests covering every command + idempotency edges + the dropped-from-wrong-state path.

## What's NOT in this PR

- The 5 RPC calls (\`StartProviderAuth\` / \`PollProviderAuth\` / \`SubmitAuthCallback\` / \`CancelProviderAuth\` / \`SubmitProviderApiKey\`) — those are wired by PR B' on top.
- \`AgentLaunchModal.tsx\` integration — same.
- Identity-dropdown bundle-status badges (✓ / ⚠ / not connected) — these compute outcomes; PR B' adds the loader + dispatch.

## Test plan

- [x] \`npx vitest run frontend/app/view/agent/auth\` — 23 pass
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)