### PR TITLE
feat(srv): WaveObjUpdate broadcast bridge (Phase 1: workspace events)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.892"
+version = "0.33.893"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.892"
+version = "0.33.893"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.892"
+version = "0.33.893"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.892"
+version = "0.33.893"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.892"
+version = "0.33.893"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.892"
+version = "0.33.893"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.892"
+version = "0.33.893"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.892"
+version = "0.33.893"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.892"
+version = "0.33.893"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.892"
+version = "0.33.893"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -643,6 +643,18 @@ async fn main() {
         std::sync::Arc::clone(&srv_state),
     );
 
+    // Phase 1 of the WaveObjUpdate bridge: subscribe to srv_events_tx and
+    // translate workspace mutations into `waveobj:update` WS broadcasts.
+    // Fixes the workspace-rename reactivity gap where UpdateWorkspace
+    // returned `success_empty()` and the response loop had nothing to
+    // broadcast — see docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md.
+    let bridge_rx = srv_events_tx.subscribe();
+    server::wave_obj_bridge::spawn_wave_obj_bridge(
+        bridge_rx,
+        std::sync::Arc::clone(&wstore_for_persist),
+        std::sync::Arc::clone(&event_bus),
+    );
+
     let state = AppState {
         auth_key: config.auth_key.clone(),
         version: version.clone(),

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -648,12 +648,37 @@ async fn main() {
     // Fixes the workspace-rename reactivity gap where UpdateWorkspace
     // returned `success_empty()` and the response loop had nothing to
     // broadcast — see docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md.
+    //
+    // Watchdog: capture the JoinHandle and observe it from a sibling task
+    // so a panic in the bridge's loop scaffolding (vs. an inner
+    // dispatch_event panic, which is already caught per-event) is logged
+    // loudly. Without this, a silent bridge death would manifest as
+    // "renaming a workspace stopped propagating" with no log evidence.
+    // (Per ReAgent P2 follow-up on PR #852.)
     let bridge_rx = srv_events_tx.subscribe();
-    server::wave_obj_bridge::spawn_wave_obj_bridge(
+    let bridge_handle = server::wave_obj_bridge::spawn_wave_obj_bridge(
         bridge_rx,
         std::sync::Arc::clone(&wstore_for_persist),
         std::sync::Arc::clone(&event_bus),
     );
+    tokio::spawn(async move {
+        match bridge_handle.await {
+            Ok(()) => tracing::info!(
+                target: "wave-obj-bridge",
+                "bridge task exited normally (events channel closed at srv shutdown)"
+            ),
+            Err(e) if e.is_panic() => tracing::error!(
+                target: "wave-obj-bridge",
+                "bridge task PANICKED at top level — frontend WOS will stop receiving updates until srv restart. Panic: {}",
+                e
+            ),
+            Err(e) => tracing::error!(
+                target: "wave-obj-bridge",
+                "bridge task terminated unexpectedly (non-panic JoinError): {}",
+                e
+            ),
+        }
+    });
 
     let state = AppState {
         auth_key: config.auth_key.clone(),

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -7,6 +7,7 @@ mod messagebus;
 mod reactive;
 pub(crate) mod service;
 mod tool_handlers;
+pub(crate) mod wave_obj_bridge;
 mod websocket;
 mod workflow_handlers;
 

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -333,10 +333,34 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     meta_patch: meta_value,
                 },
                 other => {
-                    // Layouts + Windows aren't meta-mutated via this path
-                    // today; fall back to wcore for forward-compat.
+                    // Layouts + Windows aren't meta-mutated via the
+                    // reducer; fall back to wcore for forward-compat.
+                    //
+                    // For OTYPE_WINDOW, return the updated object inline
+                    // (matches the BLOCK/TAB inline-update pattern below).
+                    // Without this, UpdateObjectMeta on a Window returns
+                    // success_empty() and the frontend WOS cache never
+                    // sees the change — the change persists in SQLite
+                    // but the in-session UI shows stale data, so e.g. an
+                    // InstancePanel rename of `window:displayname`
+                    // "reverts" visually until app restart. (Reported by
+                    // user during PR #852 manual verification.)
                     return match update_object_meta(store, &oref_str, &meta_update) {
-                        Ok(()) => WebReturnType::success_empty(),
+                        Ok(()) => {
+                            if oref.otype == OTYPE_WINDOW {
+                                if let Ok(window) = store.must_get::<Window>(&oref.oid) {
+                                    return WebReturnType::success_with_updates(vec![
+                                        WaveObjUpdate {
+                                            updatetype: "update".into(),
+                                            otype: OTYPE_WINDOW.to_string(),
+                                            oid: oref.oid.clone(),
+                                            obj: Some(wave_obj_to_value(&window)),
+                                        },
+                                    ]);
+                                }
+                            }
+                            WebReturnType::success_empty()
+                        }
                         Err(e) => WebReturnType::error(format!(
                             "UpdateObjectMeta: unsupported otype {} via reducer; wcore fallback failed: {}",
                             other, e

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -74,34 +74,61 @@ fn emit(event_bus: &EventBus, otype: &str, oid: &str, payload: serde_json::Value
 /// WaveObj-affecting (saga lifecycle, OS facts, etc.) or scheduled for
 /// Phase 2 expansion.
 ///
-/// Per `SPEC_OBJ_UPDATE_BRIDGE §11.1`: when this function runs, the
-/// reducer has already mutated the in-memory store and the persist
-/// subscriber has written SQLite. `wstore.get<T>()` therefore sees
-/// post-event state with no race.
-fn dispatch_event(event: &Event, wstore: &WaveStore, event_bus: &EventBus) {
+/// **Read source — post-event state guarantee:**
+/// For Phase 1 (workspace events), every workspace mutation flows through
+/// the HTTP `service.rs:UpdateWorkspace` handler which calls
+/// `apply_event_to_wstore` synchronously (`service.rs:1297-1304`) before
+/// `publish_events` (`service.rs:1305`). So when the bridge receives a
+/// workspace event, SQLite is already up-to-date.
+///
+/// **Phase 2 caveat:** for tab/block events that the launcher → IPC path
+/// in `srv_ipc/server.rs:295` may publish without first applying to
+/// SQLite, the persist subscriber and bridge race. Phase 2 should either
+/// (a) make the IPC path apply synchronously like the HTTP path does, or
+/// (b) read from the in-memory `srv_state` reducer rather than SQLite.
+/// Tracked in `SPEC_OBJ_UPDATE_BRIDGE §11.1` follow-up.
+///
+/// **Lock discipline (per ReAgent P1 on PR #852):** `WaveStore::get<T>()`
+/// acquires `std::sync::Mutex<Connection>` (blocking). Even though the
+/// hold is brief in steady state, a long reducer transaction could block
+/// this tokio worker thread. We therefore do the SQLite read inside
+/// `tokio::task::spawn_blocking` so the async runtime stays responsive.
+async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<EventBus>) {
     use crate::backend::obj::Workspace;
 
     match event {
         Event::WorkspaceRenamed { workspace_id, .. }
-        | Event::WorkspaceMetaUpdated { workspace_id, .. } => {
-            match wstore.get::<Workspace>(workspace_id) {
-                Ok(Some(ws)) => {
+        | Event::WorkspaceMetaUpdated { workspace_id, .. }
+        | Event::WorkspaceCreated { workspace_id, .. } => {
+            // Offload the blocking SQLite read to the blocking thread pool
+            // so async worker threads stay free for I/O-bound work.
+            let id = workspace_id.clone();
+            let store = Arc::clone(&wstore);
+            let result = tokio::task::spawn_blocking(move || store.get::<Workspace>(&id)).await;
+            match result {
+                Ok(Ok(Some(ws))) => {
+                    // "update" for both create and update — the frontend's
+                    // updateWaveObject (`wos.ts:259-279`) treats anything
+                    // not "delete" identically. Sending "update" uniformly
+                    // simplifies the bridge's logic and matches what the
+                    // existing response-broadcast loop emits for the same
+                    // events.
                     let payload = build_update_payload(
                         "update",
                         OTYPE_WORKSPACE,
-                        workspace_id,
+                        &workspace_id,
                         Some(wave_obj_to_value(&ws)),
                     );
-                    emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
+                    emit(&event_bus, OTYPE_WORKSPACE, &workspace_id, payload);
                 }
-                Ok(None) => {
+                Ok(Ok(None)) => {
                     tracing::warn!(
                         target: "wave-obj-bridge",
                         workspace_id = %workspace_id,
                         "workspace event for missing workspace; skipping broadcast"
                     );
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     tracing::error!(
                         target: "wave-obj-bridge",
                         workspace_id = %workspace_id,
@@ -109,33 +136,12 @@ fn dispatch_event(event: &Event, wstore: &WaveStore, event_bus: &EventBus) {
                         "wstore.get::<Workspace> failed; skipping broadcast"
                     );
                 }
-            }
-        }
-
-        Event::WorkspaceCreated { workspace_id, .. } => {
-            match wstore.get::<Workspace>(workspace_id) {
-                Ok(Some(ws)) => {
-                    let payload = build_update_payload(
-                        "update", // CEF host's WOS handles "update" for both create + update
-                        OTYPE_WORKSPACE,
-                        workspace_id,
-                        Some(wave_obj_to_value(&ws)),
-                    );
-                    emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
-                }
-                Ok(None) => {
-                    tracing::warn!(
-                        target: "wave-obj-bridge",
-                        workspace_id = %workspace_id,
-                        "WorkspaceCreated for missing workspace; skipping broadcast"
-                    );
-                }
-                Err(e) => {
+                Err(join_err) => {
                     tracing::error!(
                         target: "wave-obj-bridge",
                         workspace_id = %workspace_id,
-                        error = %e,
-                        "wstore.get::<Workspace> failed; skipping broadcast"
+                        error = %join_err,
+                        "spawn_blocking join failed (likely panicked); skipping broadcast"
                     );
                 }
             }
@@ -143,8 +149,8 @@ fn dispatch_event(event: &Event, wstore: &WaveStore, event_bus: &EventBus) {
 
         Event::WorkspaceDeleted { workspace_id, .. } => {
             // No object to fetch — frontend just needs the oid + delete tag.
-            let payload = build_update_payload("delete", OTYPE_WORKSPACE, workspace_id, None);
-            emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
+            let payload = build_update_payload("delete", OTYPE_WORKSPACE, &workspace_id, None);
+            emit(&event_bus, OTYPE_WORKSPACE, &workspace_id, payload);
         }
 
         // All other event variants are either not WaveObj-affecting (saga
@@ -157,12 +163,16 @@ fn dispatch_event(event: &Event, wstore: &WaveStore, event_bus: &EventBus) {
 
 /// Spawn the bridge task. Returns the `JoinHandle` so callers can keep it
 /// alive (typically forever — the task lives for the lifetime of the srv
-/// process).
+/// process). Per ReAgent P1 on PR #852: the loop is panic-resilient — a
+/// panic inside `dispatch_event` is caught and logged, and the loop
+/// continues processing subsequent events. Without this, a single
+/// malformed event could silently kill the entire bridge task and
+/// frontend WOS would stop seeing updates.
 ///
 /// Subscribe ordering: per `SPEC §11.1` the bridge can subscribe in any
-/// order relative to the persist subscriber. Both consume from the same
-/// broadcast channel; the in-memory store is updated by the reducer
-/// **before** the event is sent, so neither subscriber races.
+/// order relative to the persist subscriber. For Phase 1's workspace
+/// events the HTTP RPC handler applies SQLite synchronously before
+/// publishing the event, so the bridge always sees post-event state.
 pub fn spawn_wave_obj_bridge(
     events_rx: broadcast::Receiver<Event>,
     wstore: Arc<WaveStore>,
@@ -179,7 +189,37 @@ async fn run_wave_obj_bridge(
     tracing::info!(target: "wave-obj-bridge", "[wave-obj-bridge] started (Phase 1: workspace events)");
     loop {
         match events_rx.recv().await {
-            Ok(event) => dispatch_event(&event, &wstore, &event_bus),
+            Ok(event) => {
+                // Per-event panic isolation (ReAgent P1 on PR #852): use
+                // FuturesUnordered with a catch_unwind future would be the
+                // textbook fix, but for a single event-at-a-time loop the
+                // simpler pattern is to spawn the dispatch as its own task
+                // and observe the JoinError if it panics. We `await` it
+                // immediately so events still process serially (matching
+                // the broadcast channel's send order), but a panic in one
+                // event can't kill the bridge.
+                let store = Arc::clone(&wstore);
+                let bus = Arc::clone(&event_bus);
+                let event_dbg = format!("{:?}", &event);
+                let join = tokio::spawn(dispatch_event(event, store, bus)).await;
+                if let Err(join_err) = join {
+                    if join_err.is_panic() {
+                        tracing::error!(
+                            target: "wave-obj-bridge",
+                            event = %event_dbg,
+                            "dispatch_event panicked; bridge continues with next event. Panic: {}",
+                            join_err,
+                        );
+                    } else {
+                        tracing::error!(
+                            target: "wave-obj-bridge",
+                            event = %event_dbg,
+                            error = %join_err,
+                            "dispatch_event task aborted unexpectedly"
+                        );
+                    }
+                }
+            }
             Err(broadcast::error::RecvError::Lagged(n)) => {
                 // The broadcast channel has 1024 capacity (main.rs:624).
                 // If we lag, frontend WOS state diverges silently — log it

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -1,0 +1,202 @@
+// Copyright 2025-2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! WaveObjUpdate broadcast bridge.
+//!
+//! Subscribes to `srv_events_tx` (the internal sidecar event bus that the
+//! reducer publishes mutations to) and translates each event into one or
+//! more `WaveObjUpdate` records, broadcast to all connected WS clients via
+//! the existing `event_bus.broadcast_event(...)` plumbing — the same path
+//! that `service.rs:39-52`'s response-broadcast loop uses.
+//!
+//! Why this exists: per-RPC handlers were responsible for attaching
+//! `WaveObjUpdate`s to their responses (`success_with_updates(...)`).
+//! Forgetting that call left the frontend WOS cache stale (e.g. workspace
+//! renames not propagating to the OS title or the InstancePanel — see
+//! `docs/specs/SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md`).
+//!
+//! With this bridge in place, any reducer event automatically reaches the
+//! frontend, so the per-handler convention becomes belt-and-suspenders
+//! instead of load-bearing.
+//!
+//! Spec: `docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`.
+//!
+//! Phase 1 scope (this implementation): workspace events only —
+//! immediately fixes the user-reported bug. Phase 2 expands to tabs /
+//! blocks / windows / layouts; Phase 3 retires the per-handler
+//! `success_with_updates(...)` calls now that the bridge covers them.
+
+use std::sync::Arc;
+
+use agentmux_common::ipc::Event;
+use tokio::sync::broadcast;
+
+use crate::backend::eventbus::{EventBus, WSEventType};
+use crate::backend::obj::{wave_obj_to_value, OTYPE_WORKSPACE};
+use crate::backend::storage::wstore::WaveStore;
+
+/// JSON shape that gets broadcast as the `data` payload of a
+/// `waveobj:update` WS event. Matches the shape of `WaveObjUpdate` in
+/// `agentmux-srv/src/backend/obj.rs:465-474` so the frontend's existing
+/// `updateWaveObject` handler accepts it without changes.
+fn build_update_payload(
+    updatetype: &str,
+    otype: &str,
+    oid: &str,
+    obj: Option<serde_json::Value>,
+) -> serde_json::Value {
+    let mut map = serde_json::Map::with_capacity(4);
+    map.insert("updatetype".into(), serde_json::Value::String(updatetype.into()));
+    map.insert("otype".into(), serde_json::Value::String(otype.into()));
+    map.insert("oid".into(), serde_json::Value::String(oid.into()));
+    if let Some(o) = obj {
+        map.insert("obj".into(), o);
+    }
+    serde_json::Value::Object(map)
+}
+
+/// Push one `WaveObjUpdate` payload to all connected WS clients via the
+/// shared event_bus. Mirrors the response-broadcast loop in
+/// `service.rs:39-52`.
+fn emit(event_bus: &EventBus, otype: &str, oid: &str, payload: serde_json::Value) {
+    let oref = format!("{otype}:{oid}");
+    event_bus.broadcast_event(&WSEventType {
+        eventtype: "waveobj:update".to_string(),
+        oref,
+        data: Some(payload),
+    });
+}
+
+/// Translate one reducer event into zero or more `waveobj:update` broadcasts.
+///
+/// Phase 1 covers the four workspace events. Other variants intentionally
+/// fall through to the catch-all `_ => {}` arm — they're either not
+/// WaveObj-affecting (saga lifecycle, OS facts, etc.) or scheduled for
+/// Phase 2 expansion.
+///
+/// Per `SPEC_OBJ_UPDATE_BRIDGE §11.1`: when this function runs, the
+/// reducer has already mutated the in-memory store and the persist
+/// subscriber has written SQLite. `wstore.get<T>()` therefore sees
+/// post-event state with no race.
+fn dispatch_event(event: &Event, wstore: &WaveStore, event_bus: &EventBus) {
+    use crate::backend::obj::Workspace;
+
+    match event {
+        Event::WorkspaceRenamed { workspace_id, .. }
+        | Event::WorkspaceMetaUpdated { workspace_id, .. } => {
+            match wstore.get::<Workspace>(workspace_id) {
+                Ok(Some(ws)) => {
+                    let payload = build_update_payload(
+                        "update",
+                        OTYPE_WORKSPACE,
+                        workspace_id,
+                        Some(wave_obj_to_value(&ws)),
+                    );
+                    emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        target: "wave-obj-bridge",
+                        workspace_id = %workspace_id,
+                        "workspace event for missing workspace; skipping broadcast"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        target: "wave-obj-bridge",
+                        workspace_id = %workspace_id,
+                        error = %e,
+                        "wstore.get::<Workspace> failed; skipping broadcast"
+                    );
+                }
+            }
+        }
+
+        Event::WorkspaceCreated { workspace_id, .. } => {
+            match wstore.get::<Workspace>(workspace_id) {
+                Ok(Some(ws)) => {
+                    let payload = build_update_payload(
+                        "update", // CEF host's WOS handles "update" for both create + update
+                        OTYPE_WORKSPACE,
+                        workspace_id,
+                        Some(wave_obj_to_value(&ws)),
+                    );
+                    emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
+                }
+                Ok(None) => {
+                    tracing::warn!(
+                        target: "wave-obj-bridge",
+                        workspace_id = %workspace_id,
+                        "WorkspaceCreated for missing workspace; skipping broadcast"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        target: "wave-obj-bridge",
+                        workspace_id = %workspace_id,
+                        error = %e,
+                        "wstore.get::<Workspace> failed; skipping broadcast"
+                    );
+                }
+            }
+        }
+
+        Event::WorkspaceDeleted { workspace_id, .. } => {
+            // No object to fetch — frontend just needs the oid + delete tag.
+            let payload = build_update_payload("delete", OTYPE_WORKSPACE, workspace_id, None);
+            emit(event_bus, OTYPE_WORKSPACE, workspace_id, payload);
+        }
+
+        // All other event variants are either not WaveObj-affecting (saga
+        // lifecycle, OS facts, …) or pending Phase 2 coverage. Silent skip
+        // is correct — the catch-all _ arm makes this future-proof for new
+        // event variants the reducer may add.
+        _ => {}
+    }
+}
+
+/// Spawn the bridge task. Returns the `JoinHandle` so callers can keep it
+/// alive (typically forever — the task lives for the lifetime of the srv
+/// process).
+///
+/// Subscribe ordering: per `SPEC §11.1` the bridge can subscribe in any
+/// order relative to the persist subscriber. Both consume from the same
+/// broadcast channel; the in-memory store is updated by the reducer
+/// **before** the event is sent, so neither subscriber races.
+pub fn spawn_wave_obj_bridge(
+    events_rx: broadcast::Receiver<Event>,
+    wstore: Arc<WaveStore>,
+    event_bus: Arc<EventBus>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(run_wave_obj_bridge(events_rx, wstore, event_bus))
+}
+
+async fn run_wave_obj_bridge(
+    mut events_rx: broadcast::Receiver<Event>,
+    wstore: Arc<WaveStore>,
+    event_bus: Arc<EventBus>,
+) {
+    tracing::info!(target: "wave-obj-bridge", "[wave-obj-bridge] started (Phase 1: workspace events)");
+    loop {
+        match events_rx.recv().await {
+            Ok(event) => dispatch_event(&event, &wstore, &event_bus),
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                // The broadcast channel has 1024 capacity (main.rs:624).
+                // If we lag, frontend WOS state diverges silently — log it
+                // loudly so operators can correlate with user-visible drift
+                // (e.g. the InstancePanel/title showing stale names).
+                // No automatic recovery; the next event resyncs the affected
+                // object and frontend reads everything else from its cache.
+                tracing::error!(
+                    target: "wave-obj-bridge",
+                    skipped = n,
+                    "broadcast channel lagged; some waveobj:update events were dropped — frontend WOS may show stale state until the affected object is mutated again"
+                );
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                tracing::info!(target: "wave-obj-bridge", "events channel closed; bridge exiting");
+                return;
+            }
+        }
+    }
+}

--- a/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
+++ b/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md
@@ -220,6 +220,7 @@ Per [`frontend-reducer-architecture-2026-05-03.md`](./frontend-reducer-architect
 **Status: ✅ Persist subscriber + event log shipped.**
 
 - **Persist subscriber** (Phase E.2c.1–5a): idempotent apply to SQLite, wrapped in transactions (F1.A). Sole writer path for Workspace/Tab/Block state.
+- **WaveObjUpdate broadcast bridge** (PR #852, [`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`](./SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md)): a peer subscriber to `srv_events_tx` that translates reducer events into frontend `waveobj:update` WS broadcasts via the existing `event_bus`. Idempotent by construction — each broadcast is a fresh `wstore.get<T>()`, so re-delivery yields the same WaveObjUpdate (frontend dedups on `version` at `wos.ts:272`). Phase 1 covers workspace events; Phase 2 expands to tab/block/window/layout. Closes the class of bug where mutation RPCs returned `success_empty()` and the response broadcast loop had nothing to fan out.
 - **SQLite files** (per memory `reference_persistence_files.md`):
   - `objects.db` — Workspace/Tab/Block/Layout/Window/Agent/Identity domain state
   - `filestore.db` — file-store cache
@@ -268,6 +269,12 @@ These came out of the multi-reducer proposal sessions and have been reaffirmed a
     - **Host shadow projection** (`apply_shadow_projection` in `agentmux-cef/src/launcher_ipc.rs`, extracted from `apply_event_to_shadow`) — `HashMap::insert`/`remove` keyed by `label`, idempotent by construction. Property tests in this PR (`shadow_projection_tests`).
 
     **Drift-storm motivation:** prior to PR #708 the renderer-side dispatcher was idempotent only via the tracker's global monotonic-version drop, which fails when a fresh JS context resets `lastVersion=0` (pool window bootstrap) — same launcher event re-dispatched ~600× → V8 stack exhaustion → Crashpad. See [`ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md`](./ANALYSIS_DRIFT_STORM_RENDERER_CRASH_2026-05-06.md).
+
+15. **`srv_events_tx` subscribers MUST be idempotent under `(event, oid, version)`.** Companion contract to §8.14 covering the srv-side reducer event bus. Each subscriber may observe the same reducer event multiple times (replay, restart re-bootstrap, future cross-process dispatch). Two subscriber sites:
+    - **`persist_subscriber`** (`agentmux-srv/src/persist_subscriber.rs`): SQLite write-back. Idempotent via `INSERT OR REPLACE` + `apply_event_to_wstore` arms keyed by oid + version.
+    - **`wave_obj_bridge`** (`agentmux-srv/src/server/wave_obj_bridge.rs`, PR #852): translates events → frontend `waveobj:update` broadcasts. Idempotent by construction — each call fetches fresh state from `wstore`. Frontend dedups on `version` at `wos.ts:272`, so duplicate broadcasts collapse to a single signal update.
+
+    **Migration arc:** every Phase E command that's been migrated through the reducer (UpdateWorkspace, UpdateWorkspaceMeta, UpdateTabMeta, UpdateBlockMeta, …) emits an event onto this bus. The persist subscriber writes SQLite; the bridge propagates to the frontend. Commands NOT yet migrated (UpdateWindowMeta, UpdateLayoutMeta, …) bypass the reducer entirely and fall back to `wcore` direct writes — they'll inherit reactivity automatically when their Phase E.5.x migration lands. See PR #852's spec for the bridge architecture and Phase 2 mapping table.
 
 ---
 

--- a/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
+++ b/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
@@ -1,0 +1,493 @@
+# SPEC: Internal-event → frontend WaveObjUpdate bridge
+
+**Date:** 2026-05-14
+**Author:** AgentX
+**Status:** Draft
+**Replaces / supersedes:** the per-handler "Option A" path proposed in `SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md`
+**Sequenced after:** `SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md` — this spec uses post-rename names (`WaveObj`, `WaveObjUpdate`, `WaveStore`, `wos.ts`, etc.). When implementing pre-rename, mentally substitute the old `Wave*` equivalents.
+**Motivating bug:** workspace renames don't propagate to the OS title or InstancePanel — `UpdateWorkspace` returned `success_empty()` and the response-broadcast loop had nothing to send. See §2 for the deeper class.
+
+---
+
+## 1. Goal
+
+Make the **internal sidecar event bus (`srv_events_tx`)** the single source of truth for "frontend should see this change", so that:
+
+1. Every state mutation that appears on the bus reaches the frontend WOS cache, with no per-RPC-handler plumbing required.
+2. Adding a new mutation RPC requires *only* writing the reducer event and the SQLite apply path — frontend reactivity is automatic.
+3. The class of bug "I added a new RPC but forgot to attach `WaveObjUpdate` to the response" becomes structurally impossible.
+
+This replaces the brittle current convention ("each mutation RPC must remember to call `success_with_updates(...)`") with an architectural guarantee.
+
+---
+
+## 2. Why this is more robust than per-handler fixes
+
+| Property | Option A (per-handler) | Option B (bridge) |
+|---|---|---|
+| Fixes the reported workspace-rename bug | ✓ | ✓ |
+| Prevents the next handler from reintroducing the bug | ✗ — relies on author remembering the convention | ✓ — convention is enforced by infrastructure |
+| Symmetric with persist-subscriber | ✗ — persist subscribes to events; broadcast layer goes through a different path | ✓ — both subscribe to the same bus |
+| New event types automatically wired up | ✗ — each handler updated separately | ✓ — bridge converts all known event types |
+| Code review surface for new mutation RPCs | "Did you remember to add `success_with_updates`?" — easily missed | "Did you emit the event?" — harder to forget, since the event drives reducer state too |
+| Multi-window correctness today | Already broadcasts to all clients via response loop | Same — preserved |
+| Failure mode if bridge breaks | n/a | All mutations stop reaching frontend → loud, immediately visible (vs. current silent per-handler omissions) |
+
+The most important property is the second row: **Option A leaves every future mutation RPC one missed call away from a silent reactivity bug**. Option B closes that hole at the layer where it can be closed once.
+
+The robustness comes from collapsing two parallel notification paths (internal event bus + response broadcast) into one (internal event bus, with broadcast as a downstream consumer).
+
+---
+
+## 3. Current architecture
+
+```
+        ┌──────────────────────┐
+        │  RPC handler         │  e.g. UpdateWorkspace
+        │  (service.rs)        │
+        └─┬──────────────────┬─┘
+          │                  │
+          │ dispatch         │ build response
+          │ to reducer       │ with WaveObjUpdate(s)
+          ▼                  ▼
+   ┌────────────┐       ┌────────────────────┐
+   │ reducer    │       │ WebReturnType      │
+   │ emits      │       │ ::success_with_    │
+   │ Event      │       │   updates([…])     │
+   └─────┬──────┘       └──────────┬─────────┘
+         │ publish_events                  │
+         ▼                                 ▼
+   ┌──────────────────┐             ┌─────────────────────┐
+   │ srv_events_tx    │             │ response broadcast  │
+   │ (internal)       │             │ loop (lines 39-52)  │
+   └──┬────────────┬──┘             └──────────┬──────────┘
+      │            │                           │
+      ▼            ▼                           ▼
+   persist     disk-writer            ALL WS clients receive
+   subscriber  (JSONL log)            "waveobj:update"
+   (SQLite)
+```
+
+**The defect:** the two paths (`srv_events_tx` and "response broadcast") are independent. The reducer always emits an event; the handler may or may not attach the update to its response. When the handler forgets, the frontend never hears about a real state change.
+
+Also: the response-broadcast loop only knows about updates the handler explicitly attached. It doesn't see the internal event bus.
+
+---
+
+## 4. Proposed architecture
+
+```
+        ┌──────────────────────┐
+        │  RPC handler         │  e.g. UpdateWorkspace
+        │  (service.rs)        │
+        └─┬──────────────────┬─┘
+          │ dispatch         │ return success_empty
+          │ to reducer       │   (no per-handler updates needed)
+          ▼                  ▼
+   ┌────────────┐       (response carries no updates)
+   │ reducer    │
+   │ emits      │
+   │ Event      │
+   └─────┬──────┘
+         │ publish_events
+         ▼
+   ┌──────────────────┐
+   │ srv_events_tx    │
+   │ (internal)       │
+   └──┬─────────┬──────────┬────────────┐
+      │         │          │            │
+      ▼         ▼          ▼            ▼
+   persist  disk-writer  WaveObj-       (other future
+   subscriber (JSONL)    Update         consumers)
+   (SQLite)              Broadcast
+                         Bridge  ◀── NEW
+                            │
+                            ▼
+                  Per-event WaveObjUpdate(s)
+                  → broadcast channel
+                            │
+                            ▼
+                  ALL WS clients receive
+                  "waveobj:update"
+```
+
+**Key changes:**
+
+1. **NEW: WaveObjUpdate Broadcast Bridge** — a third subscriber to `srv_events_tx`. For each event, it:
+   - Looks up the event-type → WaveObjUpdate mapping (§5)
+   - Fetches the affected `WaveObj`(s) from the store at their post-event state
+   - Builds `WaveObjUpdate` records and pushes them onto the same broadcast channel the response loop uses
+2. **Response loop preserved** for backward compatibility (handlers that already attach updates keep working). Phase 3 (§7) optionally removes those calls once the bridge fully covers them.
+3. **Frontend dedup** added (§6) so handlers that broadcast both via response AND bridge don't trigger redundant signal updates.
+
+---
+
+## 5. Event-type → WaveObjUpdate mapping
+
+The reducer's `Event` enum (in `agentmux-srv/src/reducer/`) is the source of truth. Per §11.3, **a single user action can emit multiple ordered events, and a single event can imply changes to dependent WaveObjs** (e.g. `TabCreated` mutates the parent Workspace's `tab_ids`). The mapping must handle both.
+
+### 5.1 Mapping table (Phase 1 + 2 coverage)
+
+Event names below come from `agentmux-srv/src/reducer/{workspace,tab,block,layout,window}.rs`. Phase 1 ships the highlighted rows (workspace events — fixes the user-reported bug). Phase 2 fills the rest.
+
+| Reducer event | WaveObjs to fetch + broadcast | `updatetype` per obj | Phase |
+|---|---|---|---|
+| **`WorkspaceRenamed { workspace_id, … }`** | workspace | `update` | **1** |
+| `WorkspaceCreated { workspace_id, … }` | workspace | `create` | 1 |
+| `WorkspaceDeleted { workspace_id }` | workspace | `delete` (oid only) | 1 |
+| `WorkspaceMetaUpdated { workspace_id, … }` (if any) | workspace | `update` | 1 |
+| `TabCreated { workspace_id, tab_id, … }` | tab + **workspace** ← dependent | `create` + `update` | 2 |
+| `TabDeleted { workspace_id, tab_id, … }` | tab + **workspace** ← dependent | `delete` + `update` | 2 |
+| `TabRenamed { tab_id, name, … }` | tab | `update` | 2 |
+| `ActiveTabChanged { workspace_id, tab_id }` | workspace | `update` | 2 |
+| `BlockCreated { tab_id, block_id, … }` | block + **tab** ← dependent | `create` + `update` | 2 |
+| `BlockDeleted { tab_id, block_id, … }` | block + **tab** ← dependent | `delete` + `update` | 2 |
+| `BlockUpdated { block_id, … }` | block | `update` | 2 |
+| `LayoutUpdated { layout_id, … }` | layout | `update` | 2 |
+| `WindowOpened { window_id, … }` | window | `create` | 2 |
+| `WindowClosed { window_id }` | window | `delete` | 2 |
+| `WindowMetaUpdated { window_id, … }` | window | `update` | 2 |
+| `ClientUpdated { client_id, … }` (if any) | client | `update` | 2 |
+
+> **Authoritative mapping:** the actual `Event` enum is the source of truth. Phase 2's first task is `grep -nE "Event::" agentmux-srv/src/reducer/` and crossing the result against this table. Any variant in the enum but not in the table is either a (a) non-WaveObj event (saga, OS, window-pool) → `_ => vec![]` arm, or (b) a missing entry to add.
+
+### 5.2 Dependent-object pattern
+
+The "dependent" rows (TabCreated, TabDeleted, BlockCreated, BlockDeleted) reflect the §11.3 finding: when a child object is created/deleted, the parent's collection field (`workspace.tab_ids`, `tab.block_ids`) was also mutated by the reducer in the same dispatch. The bridge must therefore fetch the parent fresh and broadcast it too.
+
+Why this works without double-counting: the parent's `version` is bumped exactly once in the reducer dispatch. The bridge's broadcast for the parent reflects that single bump. If a follow-up event (e.g. `ActiveTabChanged` after `TabCreated`) bumps the parent's version again, the second broadcast carries the higher version — frontend dedup (§6.1) absorbs no-op repeats automatically.
+
+### 5.3 Mapping module
+
+Implement as a single file, `agentmux-srv/src/server/wave_obj_bridge.rs`. The `wstore` argument is borrowed inside the per-event match (synchronous lock, no `.await` while held — see §11.2):
+
+```rust
+pub fn event_to_wave_obj_updates(
+    event: &Event,
+    wstore: &WaveStore,
+) -> Vec<WaveObjUpdate> {
+    match event {
+        Event::WorkspaceRenamed { workspace_id, .. }
+        | Event::WorkspaceMetaUpdated { workspace_id, .. } => {
+            wstore.get::<Workspace>(workspace_id)
+                .ok().flatten()
+                .map(|ws| vec![WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.into(),
+                    oid: workspace_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                }])
+                .unwrap_or_default()
+        }
+
+        Event::WorkspaceDeleted { workspace_id } => vec![WaveObjUpdate {
+            updatetype: "delete".into(),
+            otype: OTYPE_WORKSPACE.into(),
+            oid: workspace_id.clone(),
+            obj: None,
+        }],
+
+        // Compound: tab created + parent workspace tab_ids mutated.
+        Event::TabCreated { workspace_id, tab_id, .. } => {
+            let mut updates = Vec::with_capacity(2);
+            if let Ok(Some(tab)) = wstore.get::<Tab>(tab_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "create".into(),
+                    otype: OTYPE_TAB.into(),
+                    oid: tab_id.clone(),
+                    obj: Some(wave_obj_to_value(&tab)),
+                });
+            }
+            if let Ok(Some(ws)) = wstore.get::<Workspace>(workspace_id) {
+                updates.push(WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.into(),
+                    oid: workspace_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                });
+            }
+            updates
+        }
+
+        Event::ActiveTabChanged { workspace_id, .. } => {
+            wstore.get::<Workspace>(workspace_id)
+                .ok().flatten()
+                .map(|ws| vec![/* workspace update */])
+                .unwrap_or_default()
+        }
+
+        // … one arm per event variant in the table above …
+
+        // Saga events, OS facts, etc. — not WaveObj changes.
+        _ => vec![],
+    }
+}
+```
+
+Per §11.2, the lock acquired by `wstore.get::<T>()` is `std::sync::Mutex<Connection>`. Synchronous, brief. The bridge task must NOT `.await` between `get<T>()` and the next `get<T>()`; collecting into a `Vec` and broadcasting after is fine.
+
+### 5.4 Events that should NOT broadcast
+
+Some `srv_events_tx` events are internal-only and don't represent WaveObj changes:
+
+- Saga lifecycle (`SagaStepStarted`, `SagaStepCompleted`)
+- Launcher-domain facts (window-pool reuse, OS focus events that the host already mirrors via a different channel)
+- Disk-writer ack events
+
+For these, the mapping function returns an empty vec — the bridge silently skips them. The catch-all `_ => vec![]` arm in §5.3 makes this the default.
+
+### 5.1 Mapping module
+
+Implement as a single file, `agentmux-srv/src/server/wave_obj_bridge.rs`:
+
+```rust
+pub fn event_to_wave_obj_updates(event: &Event, wstore: &WaveStore)
+    -> Vec<WaveObjUpdate>
+{
+    match event {
+        Event::WorkspaceRenamed { workspace_id, .. } => {
+            wstore.get_workspace(workspace_id)
+                .map(|ws| vec![WaveObjUpdate {
+                    updatetype: "update".into(),
+                    otype: OTYPE_WORKSPACE.into(),
+                    oid: workspace_id.clone(),
+                    obj: Some(wave_obj_to_value(&ws)),
+                }])
+                .unwrap_or_default()
+        }
+        Event::WorkspaceTabAdded { workspace_id, tab_id, .. } => {
+            let mut updates = vec![];
+            if let Some(ws) = wstore.get_workspace(workspace_id) {
+                updates.push(WaveObjUpdate { /* ws update */ });
+            }
+            if let Some(tab) = wstore.get_tab(tab_id) {
+                updates.push(WaveObjUpdate { /* tab create */ });
+            }
+            updates
+        }
+        Event::WindowClosed { window_id } => vec![WaveObjUpdate {
+            updatetype: "delete".into(),
+            otype: OTYPE_WINDOW.into(),
+            oid: window_id.clone(),
+            obj: None,
+        }],
+        // … one arm per event variant that affects a WaveObj …
+        _ => vec![],  // not all events translate (e.g. internal launcher facts)
+    }
+}
+```
+
+### 5.2 Events that should NOT broadcast
+
+Some `srv_events_tx` events are internal-only and don't represent WaveObj changes:
+
+- Saga lifecycle (`SagaStepStarted`, `SagaStepCompleted`)
+- Launcher-domain facts (window-pool reuse, OS focus events that the host already mirrors)
+- Disk-writer ack events
+
+For these, the mapping function returns an empty vec — the bridge silently skips them.
+
+---
+
+## 6. Dedup strategy
+
+Risk: a handler that uses `success_with_updates(...)` AND triggers a bridge-broadcasted event would fire two `waveobj:update` events for the same change, with the same content but different broadcast timing.
+
+Two layers of defense:
+
+### 6.1 Frontend version-based dedup
+
+Every `WaveObj` has a `version: i64` field that the reducer increments on each mutation (confirmed universal across all 6 types — see §11.4). When a `waveobj:update` arrives, the frontend's `wos.ts` `updateWaveObject()` checks:
+
+```ts
+function updateWaveObject(update: WaveObjUpdate) {
+    const wov = getOrCreateWov(update.oid);
+    const currentVersion = wov.data?.version ?? 0;
+    const newVersion = update.obj?.version ?? 0;
+    if (newVersion > 0 && newVersion <= currentVersion) {
+        return;  // already-applied or stale; skip
+    }
+    wov.setData(update.obj);
+}
+```
+
+The `newVersion > 0` guard preserves the "delete" path (`update.obj` is `None`/null for deletes; `version` is missing). Delete updates always pass through.
+
+This makes duplicate broadcasts harmless and out-of-order broadcasts safe. Same-version arrivals from the response loop and the bridge are both no-ops on the second one.
+
+### 6.2 Backend phased removal (optional, phase 3)
+
+After the bridge is in place and proven, audit response-loop call sites and remove `success_with_updates(...)` for events the bridge already covers. The bridge becomes the *only* path for those updates.
+
+This also reduces RPC response payload size — a small win.
+
+---
+
+## 7. Implementation phases
+
+Each phase is independently mergeable.
+
+### Phase 1 — Bridge alongside response loop (additive, low risk)
+
+1. Land `agentmux-srv/src/server/wave_obj_bridge.rs` with the mapping function (§5.1) covering the **workspace events** at minimum (immediately fixes the reported bug).
+2. Spawn a tokio task in `service.rs` startup that subscribes to `srv_events_tx` and calls `event_to_wave_obj_updates` per event, then pushes the resulting updates to the response broadcast channel.
+3. Land frontend version-based dedup in `wos.ts` (§6.1) so the now-doubled broadcasts for `UpdateObjectMeta`-style handlers are coalesced.
+4. **Outcome:** workspace-rename bug fixed; no per-handler changes; response-loop path still works for handlers that use it.
+
+### Phase 2 — Mapping coverage expansion
+
+1. Audit `Event::*` variants and add mapping table entries for every variant that affects a WaveObj (tab, layout, block, window).
+2. Add Rust unit tests asserting the bridge produces the right `WaveObjUpdate` shape for each event variant.
+3. Add a frontend integration test that mocks the WS channel and asserts reactive consumers re-derive on a synthetic event.
+
+### Phase 3 — Response-loop deprecation (optional, opportunistic)
+
+1. Identify `success_with_updates(...)` call sites whose updates are now fully covered by the bridge.
+2. Per call site, change to `success_empty()`. Verify the frontend still updates (proves the bridge is doing the work).
+3. Eventually remove the response-loop path entirely if no handlers need it. (The success-confirmation semantics of the RPC return are preserved by the empty-success status.)
+
+---
+
+## 8. Test plan
+
+### 8.1 Phase 1
+
+**Manual:**
+- [ ] Rename workspace via UI → OS title and InstancePanel update immediately.
+- [ ] Rename window via InstancePanel double-click → still works (regression).
+- [ ] Open two windows, rename workspace → both windows' titles + both panels update (multi-client).
+
+**Automated (Rust):**
+- [ ] Unit test: `event_to_wave_obj_updates(Event::WorkspaceRenamed { … }, &wstore)` returns one update with the right shape.
+- [ ] Integration test: dispatch `RenameWorkspace`, observe the broadcast channel emits one `waveobj:update` for the workspace.
+
+**Automated (frontend):**
+- [ ] Unit test for `updateWaveObject` dedup: feed two updates with the same version → second is a no-op.
+- [ ] Unit test: feed two updates with v1 then v2 → both apply, v3 then v2 → v2 is no-op.
+
+### 8.2 Phase 2
+
+- [ ] One test per `Event::*` variant added to the mapping.
+- [ ] Frontend manual sweep: tab rename, tab add, tab remove, layout reorder, block create/update — every action causes other windows' UIs to update.
+
+### 8.3 Phase 3
+
+- [ ] Per response-loop removal: confirm no behavioral regression.
+
+---
+
+## 9. Risks (after §11 research)
+
+| Risk | Status | Notes |
+|---|---|---|
+| Mapping table gaps — events not translated | Medium | Phase 2 audit (§5.1 grep recipe); one test per variant |
+| Double-broadcast triggers duplicate signal updates | **Mitigated** | §6.1 version dedup; all 6 WaveObj types have `version: i64` per §11.4 |
+| Bridge crashes on malformed event → all subsequent updates dropped | Low | Mapping is exhaustive `match` with a `_ => vec![]` arm; impossible to panic on a missed variant |
+| Performance: extra channel subscriber + per-event work | **Negligible** | `srv_events_tx` already has 2 subscribers; one more is cheap. Per-event work is one `wstore.get::<T>()` (sync SQLite query against the in-memory store, ms-scale per §11.2) |
+| Persist-subscriber and bridge race — bridge broadcasts before SQLite is committed | **RESOLVED** (§11.1) | The reducer mutates the in-memory store and `apply_event_to_wstore` writes SQLite **synchronously inside the RPC handler**, both completing before `srv_events_tx.send()`. The bridge sees post-event state on every event. |
+| Frontend dedup breaks legitimate reapply (e.g. force-reload after disconnect) | Low | Dedup compares by `version` field; explicit `reloadWaveObject` uses a different code path that always re-fetches from the server |
+| Bridge broadcasts to disconnected clients | Negligible | Broadcast channel has bounded capacity; with no consumers, messages are dropped |
+| `.await` while holding the `WaveStore` mutex would deadlock | **Mitigated** (§11.2) | `WaveStore` uses `std::sync::Mutex<Connection>` (blocking, not async). Mapping function is synchronous from `get<T>()` to `Vec` collection; broadcast happens outside the lock. Code review must enforce: no `.await` inside `event_to_wave_obj_updates` |
+
+---
+
+## 10. Out of scope
+
+- Removing `srv_events_tx` and replacing with a single bus — the existing bus is fine; we're just adding a consumer.
+- Cross-instance broadcast (events from instance A reaching instance B's frontend) — handled at a different layer (LAN peer / shared state), unrelated.
+- Throttling / coalescing rapid same-object updates (e.g. drag-resize firing 60 events/sec) — possible follow-up if it matters; SolidJS effects already coalesce within a microtask.
+- Schema versioning — `WaveObj.version` already exists and is incremented by the reducer; no change needed.
+
+---
+
+## 11. Resolved questions (research log)
+
+These were open in the first draft of this spec; resolved by reading the sidecar source. Kept here so the next reader doesn't have to re-investigate.
+
+### 11.1 Subscribe ordering — RESOLVED ✓ Safe
+
+**Question:** When a bridge task subscribes to `srv_events_tx` and reads from the in-memory `WaveStore` on each event, will it see post-event state, or will it race?
+
+**Answer:** **Safe.** The RPC handler path is synchronous up to and including the `srv_events_tx.send()`:
+
+1. `dispatch_to_reducer()` — reducer mutates in-memory state (e.g. `state.workspaces`) **before returning** (`agentmux-srv/src/server/service.rs:1283-1290`)
+2. `apply_event_to_wstore()` — called synchronously from the RPC handler in a loop, persists each event to SQLite (lines 1297-1304); see `persist_subscriber.rs:171-182` (`crate-visible by design so handlers can apply synchronously`)
+3. `publish_events()` — broadcasts to `srv_events_tx` (line 1305)
+
+So when the bridge receives an event, both the in-memory store *and* SQLite are already up-to-date. No race. The bridge can read from the in-memory `WaveStore` without coordination.
+
+### 11.2 `WaveStore` lock structure — RESOLVED ✓ Cheap reads
+
+**Question:** Can a tokio task hold a brief read lock per event without deadlocking the reducer's writes?
+
+**Answer:** **Yes, cheap and safe.** `WaveStore` is `agentmux-srv/src/backend/storage/mstore.rs:24-31`:
+
+```rust
+pub struct WaveStore { conn: Mutex<Connection>, ... }
+```
+
+That's a **`std::sync::Mutex<rusqlite::Connection>`** (blocking, not async). Lock acquires are brief (one SQLite query per event). The reducer's writes already take the same lock for short periods. No async-aware lock means **the bridge must NOT `.await` while holding the lock** — but each fetch is a synchronous SQL query that completes immediately, so this is naturally satisfied.
+
+**Implementation note:** the bridge's per-event work is `recv() → match event → wstore.get<T>() → build update → broadcast`. The lock is held only across the `get<T>()` call.
+
+### 11.3 Compound events — RESOLVED ✓ Mapping refined (see §5.3 below)
+
+**Question:** When a tab is added to a workspace, does the reducer emit one combined event or multiple?
+
+**Answer:** **Multiple, ordered.** A single user action can fire 2+ events:
+
+- `handle_create_tab` (`agentmux-srv/src/reducer/tab.rs:20-78`) pushes `Event::TabCreated` (line 64), **then** optionally `Event::ActiveTabChanged` (lines 70-76) if the new tab is activated.
+- `handle_delete_tab` (`tab.rs:87-157`) pushes `Event::TabDeleted` (line 150), **then** optionally `Event::ActiveTabChanged` (lines 155-157) if the deleted tab was active.
+- Workspace renames emit just `Event::WorkspaceRenamed` (single event).
+
+This has **two implications** for the bridge:
+
+1. **Some events imply dependent-object changes.** When `TabCreated` lands, the workspace's `tab_ids` field was also mutated by the reducer. The bridge's mapping for `TabCreated` must therefore fetch *both* the Tab (the new object) and the parent Workspace (whose `tab_ids` changed) and broadcast updates for both.
+2. **Sequence matters; ordering is preserved.** Tokio's broadcast channel delivers in send-order to a single subscriber. Frontend will see `TabCreated` (with workspace update) followed by `ActiveTabChanged` (with workspace update again, version bumped). Both arrive — the second is a no-op via version dedup (§6.1) since the workspace's version was already updated by the first.
+
+**Mapping table refined** to handle this — see §5.3 below.
+
+### 11.4 Version field universality — RESOLVED ✓ Universal
+
+**Question:** Does every `WaveObj` type have a `version` field?
+
+**Answer:** **Yes, all six.** From `agentmux-srv/src/backend/obj.rs:305-461`:
+
+| Type | `version` field | File:line |
+|---|---|---|
+| `Client` | `version: i64` | `obj.rs:308` |
+| `Window` | `version: i64` | `obj.rs:327` |
+| `Workspace` | `version: i64` | `obj.rs:348` |
+| `Tab` | `version: i64` | `obj.rs:376` |
+| `LayoutState` | `version: i64` | `obj.rs:401` |
+| `Block` | `version: i64` | `obj.rs:450` |
+
+All implement `WaveObj::get_version()` / `set_version()` via the `impl_wave_obj!` macro (`obj.rs:142-168`). The reducer calls `state.bump_version()` on every mutation (e.g. `reducer/workspace.rs:29,83,99`; `reducer/tab.rs:63,71,...`). The frontend dedup in §6.1 is universally applicable — no per-type carve-outs needed.
+
+---
+
+## 12. Why this beats Option A long-term
+
+> Option A: ship a fix to one handler. The next person writing a mutation RPC has to remember a convention. Six months later someone adds `UpdateBlockTitle` and forgets — same bug, new place. Repeat.
+>
+> Option B: ship a one-time architectural fix. The convention becomes "emit the right event in the reducer", which the developer has to do anyway because the reducer drives state. Frontend reactivity becomes a property of the system, not a per-handler responsibility.
+
+That's the whole argument for paying the up-front cost of the bridge. Option A is faster to land; Option B is the right architecture.
+
+---
+
+## 13. Implementation readiness checklist
+
+Pre-flight, before opening the Phase 1 PR:
+
+- [x] Subscribe ordering verified safe (§11.1 — bridge reads post-event state)
+- [x] Lock structure understood (§11.2 — `std::sync::Mutex<Connection>`, sync, brief)
+- [x] Compound-event pattern documented (§11.3 — dependent-object fetches in §5.2)
+- [x] Version field universality confirmed (§11.4 — all 6 types have `version: i64`)
+- [x] Mapping skeleton has runnable Rust pseudocode (§5.3)
+- [x] Dedup logic handles deletes (§6.1 `newVersion > 0` guard)
+- [ ] Find concrete `Event::*` enum (likely `agentmux-srv/src/reducer/types.rs` or similar) and reconcile §5.1 table against actual variants
+- [ ] Identify the broadcast channel the response loop uses (the bridge needs to push to the same channel) — `agentmux-srv/src/server/service.rs:39-52` will reveal the type
+- [ ] Confirm `OTYPE_WORKSPACE`, `OTYPE_TAB`, `OTYPE_BLOCK`, `OTYPE_LAYOUT`, `OTYPE_WINDOW`, `OTYPE_CLIENT` constants exist or define them
+
+The two unchecked items are 5-minute code lookups, not decisions — verify during the Phase 1 PR rather than as a blocker on this spec.

--- a/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
+++ b/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
@@ -161,72 +161,47 @@ Why this works without double-counting: the parent's `version` is bumped exactly
 
 ### 5.3 Mapping module
 
-Implement as a single file, `agentmux-srv/src/server/wave_obj_bridge.rs`. The `wstore` argument is borrowed inside the per-event match (synchronous lock, no `.await` while held — see §11.2):
+Implement as a single file, `agentmux-srv/src/server/wave_obj_bridge.rs`. **Each per-event dispatch is `async fn`** so it can offload the SQLite read into `tokio::task::spawn_blocking` — `WaveStore::get<T>()` acquires `std::sync::Mutex<Connection>`, and even though the hold is brief in steady state, a long reducer transaction would block the tokio worker thread otherwise (per ReAgent P1 on PR #852, §11.2):
 
 ```rust
-pub fn event_to_wave_obj_updates(
-    event: &Event,
-    wstore: &WaveStore,
-) -> Vec<WaveObjUpdate> {
+async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<EventBus>) {
     match event {
         Event::WorkspaceRenamed { workspace_id, .. }
-        | Event::WorkspaceMetaUpdated { workspace_id, .. } => {
-            wstore.get::<Workspace>(workspace_id)
-                .ok().flatten()
-                .map(|ws| vec![WaveObjUpdate {
-                    updatetype: "update".into(),
-                    otype: OTYPE_WORKSPACE.into(),
-                    oid: workspace_id.clone(),
-                    obj: Some(wave_obj_to_value(&ws)),
-                }])
-                .unwrap_or_default()
-        }
-
-        Event::WorkspaceDeleted { workspace_id } => vec![WaveObjUpdate {
-            updatetype: "delete".into(),
-            otype: OTYPE_WORKSPACE.into(),
-            oid: workspace_id.clone(),
-            obj: None,
-        }],
-
-        // Compound: tab created + parent workspace tab_ids mutated.
-        Event::TabCreated { workspace_id, tab_id, .. } => {
-            let mut updates = Vec::with_capacity(2);
-            if let Ok(Some(tab)) = wstore.get::<Tab>(tab_id) {
-                updates.push(WaveObjUpdate {
-                    updatetype: "create".into(),
-                    otype: OTYPE_TAB.into(),
-                    oid: tab_id.clone(),
-                    obj: Some(wave_obj_to_value(&tab)),
-                });
+        | Event::WorkspaceMetaUpdated { workspace_id, .. }
+        | Event::WorkspaceCreated { workspace_id, .. } => {
+            let id = workspace_id.clone();
+            let store = Arc::clone(&wstore);
+            // Offload SQLite read to the blocking thread pool.
+            let result = tokio::task::spawn_blocking(move || store.get::<Workspace>(&id)).await;
+            match result {
+                Ok(Ok(Some(ws))) => {
+                    emit(&event_bus, "update", OTYPE_WORKSPACE, &workspace_id,
+                         Some(wave_obj_to_value(&ws)));
+                }
+                Ok(Ok(None)) => log_warn_missing(&workspace_id),
+                Ok(Err(e)) => log_err_fetch(&workspace_id, &e),
+                Err(join_err) => log_err_panic(&workspace_id, &join_err),
             }
-            if let Ok(Some(ws)) = wstore.get::<Workspace>(workspace_id) {
-                updates.push(WaveObjUpdate {
-                    updatetype: "update".into(),
-                    otype: OTYPE_WORKSPACE.into(),
-                    oid: workspace_id.clone(),
-                    obj: Some(wave_obj_to_value(&ws)),
-                });
-            }
-            updates
         }
 
-        Event::ActiveTabChanged { workspace_id, .. } => {
-            wstore.get::<Workspace>(workspace_id)
-                .ok().flatten()
-                .map(|ws| vec![/* workspace update */])
-                .unwrap_or_default()
+        Event::WorkspaceDeleted { workspace_id, .. } => {
+            // No fetch needed — frontend just needs the oid + delete tag.
+            emit(&event_bus, "delete", OTYPE_WORKSPACE, &workspace_id, None);
         }
 
-        // … one arm per event variant in the table above …
+        // Compound: tab created + parent workspace.tab_ids was also
+        // mutated. Phase 2 should fetch both and emit two broadcasts.
+        // Event::TabCreated { workspace_id, tab_id, .. } => { … }
 
         // Saga events, OS facts, etc. — not WaveObj changes.
-        _ => vec![],
+        _ => {}
     }
 }
 ```
 
-Per §11.2, the lock acquired by `wstore.get::<T>()` is `std::sync::Mutex<Connection>`. Synchronous, brief. The bridge task must NOT `.await` between `get<T>()` and the next `get<T>()`; collecting into a `Vec` and broadcasting after is fine.
+The actual implementation in `agentmux-srv/src/server/wave_obj_bridge.rs` includes the full error logging + the per-event panic isolation that wraps each `dispatch_event` call in `tokio::spawn(...).await` so a panic in one event can't kill the bridge loop. The pseudocode above shows the conceptual structure.
+
+**Phase 2 implementors:** every new event-variant arm in `dispatch_event` MUST follow the `spawn_blocking` pattern for any `wstore.get<T>()` call, otherwise the tokio worker thread will block under contention. Don't write a synchronous `dispatch_event(&Event, &WaveStore)` shape — it's a footgun.
 
 ### 5.4 Events that should NOT broadcast
 
@@ -237,57 +212,6 @@ Some `srv_events_tx` events are internal-only and don't represent WaveObj change
 - Disk-writer ack events
 
 For these, the mapping function returns an empty vec — the bridge silently skips them. The catch-all `_ => vec![]` arm in §5.3 makes this the default.
-
-### 5.1 Mapping module
-
-Implement as a single file, `agentmux-srv/src/server/wave_obj_bridge.rs`:
-
-```rust
-pub fn event_to_wave_obj_updates(event: &Event, wstore: &WaveStore)
-    -> Vec<WaveObjUpdate>
-{
-    match event {
-        Event::WorkspaceRenamed { workspace_id, .. } => {
-            wstore.get_workspace(workspace_id)
-                .map(|ws| vec![WaveObjUpdate {
-                    updatetype: "update".into(),
-                    otype: OTYPE_WORKSPACE.into(),
-                    oid: workspace_id.clone(),
-                    obj: Some(wave_obj_to_value(&ws)),
-                }])
-                .unwrap_or_default()
-        }
-        Event::WorkspaceTabAdded { workspace_id, tab_id, .. } => {
-            let mut updates = vec![];
-            if let Some(ws) = wstore.get_workspace(workspace_id) {
-                updates.push(WaveObjUpdate { /* ws update */ });
-            }
-            if let Some(tab) = wstore.get_tab(tab_id) {
-                updates.push(WaveObjUpdate { /* tab create */ });
-            }
-            updates
-        }
-        Event::WindowClosed { window_id } => vec![WaveObjUpdate {
-            updatetype: "delete".into(),
-            otype: OTYPE_WINDOW.into(),
-            oid: window_id.clone(),
-            obj: None,
-        }],
-        // … one arm per event variant that affects a WaveObj …
-        _ => vec![],  // not all events translate (e.g. internal launcher facts)
-    }
-}
-```
-
-### 5.2 Events that should NOT broadcast
-
-Some `srv_events_tx` events are internal-only and don't represent WaveObj changes:
-
-- Saga lifecycle (`SagaStepStarted`, `SagaStepCompleted`)
-- Launcher-domain facts (window-pool reuse, OS focus events that the host already mirrors)
-- Disk-writer ack events
-
-For these, the mapping function returns an empty vec — the bridge silently skips them.
 
 ---
 

--- a/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
+++ b/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
@@ -3,9 +3,25 @@
 **Date:** 2026-05-14
 **Author:** AgentX
 **Status:** Draft
+**Parent architecture:** [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](./MASTER_REDUCER_STACK_STATUS_2026-05-05.md) — this work adds a peer subscriber to `srv_events_tx` alongside `persist_subscriber`, codified there as §8.15 (the srv-event subscriber idempotency contract — companion to §8.14 for launcher events).
+**Discussion thread:** [#707 — Reducer-stack architecture: long-term tracking thread](https://github.com/agentmuxai/agentmux/discussions/707)
 **Replaces / supersedes:** the per-handler "Option A" path proposed in `SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md`
-**Sequenced after:** `SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md` — this spec uses post-rename names (`WaveObj`, `WaveObjUpdate`, `WaveStore`, `wos.ts`, etc.). When implementing pre-rename, mentally substitute the old `Wave*` equivalents.
+**Naming note:** uses existing `WaveObj*` / `WaveStore` / `wos.ts` names; the Wave→Mux rename was deferred mid-implementation (issue #851).
 **Motivating bug:** workspace renames don't propagate to the OS title or InstancePanel — `UpdateWorkspace` returned `success_empty()` and the response-broadcast loop had nothing to send. See §2 for the deeper class.
+
+## How this fits the reducer architecture
+
+The bridge is a **second consumer** of the existing srv reducer event bus (`srv_events_tx`), parallel to the persist subscriber:
+
+```
+reducer → emits Event → srv_events_tx ─┬─► persist subscriber → SQLite (existing, Phase E.2c.1–5a)
+                                       ├─► disk writer → JSONL log (existing, Phase D)
+                                       └─► wave_obj_bridge → WaveObjUpdate → broadcast (NEW, this PR)
+```
+
+This adds nothing to the reducer story — the reducer already emits the right events. The bridge just routes them to a new downstream the frontend cares about. Both subscribers must satisfy the §8.15 idempotency contract; this bridge satisfies it by construction (each broadcast is a fresh `wstore.get<T>()`).
+
+**Phase E migration status caveat:** commands that haven't yet been migrated through the srv reducer (notably `UpdateObjectMeta` for `OTYPE_WINDOW`, `OTYPE_LAYOUT`, `OTYPE_CLIENT`) bypass `srv_events_tx` entirely — they go straight to `wcore` and never emit a reducer event. The bridge can't see them. PR #852 includes a temporary inline-update workaround for `OTYPE_WINDOW` in `service.rs:308`'s `_ => other` fallback arm; the proper fix is the Phase E.5.x migration of `UpdateWindowMeta` to go through the reducer (tracked separately).
 
 ---
 

--- a/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
+++ b/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md
@@ -133,21 +133,23 @@ Event names below come from `agentmux-srv/src/reducer/{workspace,tab,block,layou
 | Reducer event | WaveObjs to fetch + broadcast | `updatetype` per obj | Phase |
 |---|---|---|---|
 | **`WorkspaceRenamed { workspace_id, … }`** | workspace | `update` | **1** |
-| `WorkspaceCreated { workspace_id, … }` | workspace | `create` | 1 |
+| `WorkspaceCreated { workspace_id, … }` | workspace | `update` | 1 |
 | `WorkspaceDeleted { workspace_id }` | workspace | `delete` (oid only) | 1 |
-| `WorkspaceMetaUpdated { workspace_id, … }` (if any) | workspace | `update` | 1 |
-| `TabCreated { workspace_id, tab_id, … }` | tab + **workspace** ← dependent | `create` + `update` | 2 |
+| `WorkspaceMetaUpdated { workspace_id, … }` | workspace | `update` | 1 |
+| `TabCreated { workspace_id, tab_id, … }` | tab + **workspace** ← dependent | `update` + `update` | 2 |
 | `TabDeleted { workspace_id, tab_id, … }` | tab + **workspace** ← dependent | `delete` + `update` | 2 |
 | `TabRenamed { tab_id, name, … }` | tab | `update` | 2 |
 | `ActiveTabChanged { workspace_id, tab_id }` | workspace | `update` | 2 |
-| `BlockCreated { tab_id, block_id, … }` | block + **tab** ← dependent | `create` + `update` | 2 |
+| `BlockCreated { tab_id, block_id, … }` | block + **tab** ← dependent | `update` + `update` | 2 |
 | `BlockDeleted { tab_id, block_id, … }` | block + **tab** ← dependent | `delete` + `update` | 2 |
 | `BlockUpdated { block_id, … }` | block | `update` | 2 |
 | `LayoutUpdated { layout_id, … }` | layout | `update` | 2 |
-| `WindowOpened { window_id, … }` | window | `create` | 2 |
+| `WindowOpened { window_id, … }` | window | `update` | 2 |
 | `WindowClosed { window_id }` | window | `delete` | 2 |
 | `WindowMetaUpdated { window_id, … }` | window | `update` | 2 |
 | `ClientUpdated { client_id, … }` (if any) | client | `update` | 2 |
+
+> **Why `update` for both create and update:** The frontend's `updateWaveObject` (`wos.ts:259-279`) treats every `updatetype` other than `"delete"` identically — whether the local cache is empty (treat-as-create) or populated (treat-as-update). Sending `"update"` uniformly simplifies bridge logic and matches what the existing response-broadcast loop already emits for create-shaped events. The `"create"` discriminator is unused in this codebase (per ReAgent P2 on PR #852).
 
 > **Authoritative mapping:** the actual `Event` enum is the source of truth. Phase 2's first task is `grep -nE "Event::" agentmux-srv/src/reducer/` and crossing the result against this table. Any variant in the enum but not in the table is either a (a) non-WaveObj event (saga, OS, window-pool) → `_ => vec![]` arm, or (b) a missing entry to add.
 

--- a/docs/specs/SPEC_PERSISTENCE_LAYER_ANALYSIS_2026-05-14.md
+++ b/docs/specs/SPEC_PERSISTENCE_LAYER_ANALYSIS_2026-05-14.md
@@ -1,0 +1,250 @@
+# SPEC: Persistence layer analysis — keep SQLite, or move?
+
+**Date:** 2026-05-14
+**Author:** AgentX
+**Status:** Analysis (no decision yet)
+**Triggered by:** the upcoming `Wave*` → `Mux*` rename PR includes a SQLite schema migration (`db_wave_file` → `db_mux_file`). Before paying that migration cost, sanity-check whether the persistence layer itself is the right shape.
+
+---
+
+## 1. TL;DR
+
+**Keep SQLite for now.** The architecture is a good fit for what AgentMux actually does, and switching costs strictly exceed switching benefits today. Three caveats where the answer flips:
+
+1. If **cross-instance shared state** becomes a goal, an event-log-based store starts to look better than SQLite (which the team has already rejected for that case in the agent-registry spec).
+2. If the team wants to **drop the C dependency** for principled "Rust-everywhere" reasons, an embedded Rust KV (`redb` / `fjall` / `sled`) is mature enough.
+3. If **simplification** is the goal more than correctness, JSON-per-object files (like `agents/` already are) reduce moving parts but lose atomicity across objects.
+
+The schema rename in the upcoming PR is a single `ALTER TABLE` — not a meaningful reason to revisit persistence. Defer this decision.
+
+---
+
+## 2. What we use SQLite for today
+
+Three SQLite databases, all in the per-version data dir, all single-writer (each has its own `Mutex<Connection>`):
+
+| Store | Tables | What's in it |
+|---|---|---|
+| **`objects.db`** (`WaveStore`) | 7 core (`db_client`, `db_window`, `db_workspace`, `db_tab`, `db_layout`, `db_block`, `db_temp`) + Forge v1-v9 extensions (~18 more) | App-domain reducer state. Every persisted object is `(oid TEXT PK, version INTEGER, data TEXT)` where `data` is a serde-JSON blob of the full object |
+| **`filestore.db`** | `db_wave_file` (metadata), `db_file_data` (64 KB BLOB chunks) | Forge configs, snapshots, screenshots, file pane buffers |
+| **`sagas.db`** | `saga`, `saga_step` | Cross-block side-effect lifecycle (resume on crash) |
+
+Plus `launcher-sagas.db` (same shape, owned by launcher).
+
+### 2.1 What we use SQLite *for*
+
+- **Single-key `WHERE oid = ?1` lookups.** Every production query.
+- **Atomic transactions** for multi-row mutations (`WaveStore::with_tx`).
+- **FK cascade deletes** in Forge tables (v6+).
+- **WAL mode** for crash safety + multi-reader concurrency within an instance.
+- **Bulk read at boot** (`bootstrap_state_from_wstore` loads everything into in-memory reducer; rest of the session reads from RAM).
+
+### 2.2 What we DON'T use SQLite for
+
+- **No JSON1** (`json_extract`, `json_set`) — `data` columns are opaque blobs, deserialized in Rust.
+- **No FTS5** — no full-text search anywhere.
+- **No window functions, CTEs, triggers, views.**
+- **No JOINs in production code.** Every query is single-table key access.
+- **No ad-hoc query interface.** Application code knows the shape; the DB is a typed key-value store dressed in SQL clothes.
+
+### 2.3 How the choice was made
+
+**Inherited from the Wave Terminal fork.** No design-rationale doc exists in `docs/specs/`. `agentmux-srv` is a Rust port of Wave's Go backend, which used SQLite for the same OID→serde(JSON) pattern. The choice carried over without being re-evaluated.
+
+The team *has* re-evaluated SQLite for one specific case — the **shared agent registry** (cross-version, cross-instance shared state) explicitly rejected SQLite because:
+
+- WAL/SHM lock contention between processes
+- Schema migrations on a shared DB break older versions
+- Per-file versioning is better for forward/backward compat
+
+So there's awareness of SQLite's edges; the decision is "good enough for per-instance state, wrong for shared state."
+
+---
+
+## 3. The architectural fingerprint
+
+What we *actually need* from a persistence layer:
+
+| Property | Required |
+|---|---|
+| Key-value access by string OID | ✓ (every query) |
+| Atomic durability per write (fsync correctness) | ✓ |
+| Atomic *batched* writes (transaction across N keys) | ✓ (WaveStore::with_tx) |
+| Crash-safe (WAL or equivalent) | ✓ |
+| Single-writer-per-store within an instance | ✓ (current code; lock-serialized) |
+| Multi-reader within an instance | ✓ (WAL gives this) |
+| Range queries / scans / joins | ✗ (no production use) |
+| Full-text search | ✗ |
+| Ad-hoc query language | ✗ (no user-facing query surface) |
+| Schema migrations between versions | ✓ (Forge v1-v9 evolution proves it works) |
+| Cross-instance / cross-process sharing | ✗ for objects.db / sagas.db; ✓ aspirationally for shared agent registry (which uses files, not SQLite) |
+| <500 MB working set per version | ✓ (typical) |
+| <10 KB per object | ✓ (typical) |
+
+**Read this as:** "We need a typed embedded KV store with transactions and crash safety." SQL is incidental — we never use it as a query language.
+
+---
+
+## 4. Alternatives, honestly evaluated
+
+### 4.1 Stay with SQLite (status quo)
+
+**Pros:**
+- Zero migration cost.
+- Mature, well-understood, predictable failure modes.
+- WAL + busy_timeout + transactions all work the way you expect.
+- `rusqlite` is a stable crate; bindings + tooling are excellent.
+- **Schema migrations are a solved problem** — Forge has already done v1→v9 evolution successfully.
+- `sqlite3` CLI lets us inspect data ad-hoc when debugging.
+
+**Cons:**
+- C dependency. SQLite is bundled (statically linked usually), so this is small but not zero — affects build complexity on cross-compile, and there's a compile-step dependency.
+- SQL is overkill for what we use it for; the schema-as-DDL adds ceremony.
+- Schema migrations require testing on existing DBs (real cost — see the upcoming `db_wave_file` rename PR).
+- Multi-writer concurrency is awkward (you need a lock layer in app code; we already have one).
+
+### 4.2 Embedded Rust KV — `redb` (recommended if we move)
+
+[`redb`](https://github.com/cberner/redb) is a Rust-native B+tree KV with ACID transactions, MVCC, and zero-copy reads. Stable since 2.0.
+
+**Pros:**
+- **Zero C dependencies** — pure Rust, simpler builds.
+- ACID transactions out of the box.
+- Crash-safe (single-file, like SQLite).
+- Type-safe schemas via Rust traits — no DDL strings.
+- Schema migrations are application-managed (write a `read v1, write v2` migration in Rust).
+- Faster than SQLite for keyed access (no SQL parser overhead).
+
+**Cons:**
+- **No SQL CLI for ad-hoc inspection.** You'd write a small Rust tool or a debug RPC. Tractable but a real friction.
+- Younger ecosystem than SQLite; fewer Stack Overflow answers.
+- File format is `redb`-specific — less portable than SQLite for backups/export.
+- No `WHERE`-style filtering; if we ever need it, we'd have to scan.
+
+**Verdict:** Solid second choice. Real win if "no C deps" matters; otherwise marginal.
+
+### 4.3 Other embedded KV — `sled`, `fjall`, LMDB, RocksDB
+
+- **`sled`** — pre-1.0, author has expressed concerns about long-term maintenance. Not recommended.
+- **`fjall`** — newer LSM-tree, Rust-native. Promising but young.
+- **LMDB** (`heed` crate) — battle-tested, very fast reads. C dependency, single-writer model is restrictive.
+- **RocksDB** — operational-grade LSM, but a heavyweight C++ dependency. Wrong fit for an app store.
+
+None of these is meaningfully better than `redb` for our shape.
+
+### 4.4 JSON-files-per-object (file-based, no DB)
+
+Like `agents/` already is. Each object is `<data-dir>/objects/<otype>/<oid>.json`.
+
+**Pros:**
+- Maximum simplicity. No DB engine. `cat`/`jq` to inspect.
+- Easy to back up (just copy the dir).
+- Easy to share/version (per-object Git history if wanted).
+- **Already proven** for the agent-registry spec where SQLite was explicitly rejected for cross-version use.
+
+**Cons:**
+- **No atomic batched writes across objects.** Saving a workspace + 5 tabs in one transaction means writing 6 files; if you crash halfway, you have a partial state. The reducer's "all-or-nothing" guarantees are gone.
+- Per-write cost is higher (one file open + fsync per object vs. one transaction commit for many).
+- Listing operations require reading the directory — slower than indexed scans.
+- Filename collisions, character escaping in OIDs, case-insensitive filesystem traps.
+
+**Verdict:** Wrong for `objects.db` (atomicity matters), maybe right for `filestore.db` if BLOBs are big and rarely batched.
+
+### 4.5 Append-only event log + in-memory snapshot (event sourcing)
+
+The launcher already does this with `launcher-events.log` (JSONL, written via `event_log::run_disk_writer`). Extend the model: every state change is an event; current state is the in-memory replay; persistence is the log.
+
+**Pros:**
+- **Time-travel debugging is free.** Replay the log to any point in time.
+- Crash safety is trivial — log append is atomic.
+- Cross-instance / shared-state story is much cleaner (events can be merged across writers).
+- Aligns with the existing reducer architecture.
+
+**Cons:**
+- **Snapshotting is required** — without it, every boot replays the entire history (slow with thousands of events).
+- Log compaction is non-trivial (you can't delete old events without losing replayability).
+- Migration story is harder — new event-shape parsers must handle every old event type forever.
+- Filestore (BLOB content) doesn't fit the event-log model.
+- Two-store architecture (events + snapshots) is more moving parts than one SQLite file.
+
+**Verdict:** Best architectural fit for cross-instance shared state. Worse for the per-instance objects.db case where SQLite already works. Could be a Phase 2 if the cross-instance question gets revisited.
+
+### 4.6 SurrealDB embedded / DuckDB / SurrealKV
+
+- **SurrealDB embedded** — graph + document + KV. Massive surface area for what we need. Overkill.
+- **DuckDB** — analytics OLAP, columnar. Wrong fit (we have <500 MB OLTP).
+- **SurrealKV** — newer, less proven, Rust-native KV. Comparable to `redb` but younger.
+
+None are recommended.
+
+---
+
+## 5. Comparison matrix
+
+| | SQLite | redb | JSON files | Event log |
+|---|---|---|---|---|
+| C deps | Yes (small) | **No** | No | No |
+| ACID transactions | ✓ | ✓ | ✗ (per-file only) | ✓ (append) |
+| Crash safety | ✓ (WAL) | ✓ | ✓ (per-file) | ✓ |
+| Multi-reader | ✓ (WAL) | ✓ | ✓ | ✓ |
+| Cross-instance write | hard | hard | possible | natural |
+| Time-travel debugging | hard | hard | hard | **trivial** |
+| Ad-hoc inspection | `sqlite3` CLI | custom tool | `jq` | custom tool |
+| Migration cost from today | 0 (status quo) | **2-4 weeks** | 1-2 weeks (lose atomicity) | 4-8 weeks |
+| Engineering effort to build | already done | meaningful | moderate | substantial |
+| Failure-mode familiarity | high | medium | high | low |
+| Suits the fingerprint (§3) | well | well | poorly (atomicity) | well (with snapshots) |
+
+---
+
+## 6. Recommendation
+
+**Keep SQLite. Defer this decision.**
+
+The honest take: AgentMux's persistence shape is a perfect fit for either SQLite or `redb`. The only material differences are (a) `redb` removes a C dep, and (b) SQLite has better debugging tools. Neither is a "we must move" pressure.
+
+What WOULD change the answer:
+
+1. **A push to make state cross-instance shared by default** — the agent registry has already declined SQLite for this. If that pattern spreads, an event log starts to look better than SQLite for the new domain. (At which point: keep SQLite for objects.db, add an event log for the shared layer. Mixed-store, not migration.)
+
+2. **A "Rust everywhere, no C" policy decision** — would push toward `redb`. Pure aesthetic / dep-management value; no functional improvement.
+
+3. **The Forge schema getting unwieldy** — v1→v9 has been managed. If migrations become a regular pain point, a schema-less store (event log or JSON-per-object) might reduce friction. Not yet the case.
+
+4. **Performance becoming a concern** — currently it isn't. Per the docs there are no benchmarks tracking persistence latency, which is itself a sign that nobody's noticed it as a problem.
+
+**For the immediate `Wave*` → `Mux*` rename PR:** the schema rename is one `ALTER TABLE` statement against an already-versioned migration framework. It's not a reason to revisit the persistence layer. Ship the rename as planned; this analysis is "considered and explicitly deferred."
+
+---
+
+## 7. What this changes for the rename PR
+
+**Nothing structural.** The rename PR proceeds as designed:
+
+- `db_wave_file` → `db_mux_file` via `ALTER TABLE` migration
+- `WaveStore` → `MuxStore` (type rename only, no storage change)
+- All other renames as in `SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md`
+
+If the team later decides to migrate persistence (per §6 triggers), the new abstraction layer will inherit the `Mux*` naming cleanly.
+
+---
+
+## 8. If we *did* want to move — sketch of a phased migration
+
+For completeness, if §6 ever points toward `redb`:
+
+1. **Phase 1** — wrap the existing `WaveStore` API in a trait (`ObjectStore` with `get<T>`, `put<T>`, `with_tx`, etc.). One implementation: SQLite (existing). Tests are at the trait level.
+2. **Phase 2** — add a second implementation: `redb`-backed `ObjectStore`. Run both side-by-side via dual-write, compare reads.
+3. **Phase 3** — swap the default to `redb`; SQLite implementation stays for backups + migration source.
+4. **Phase 4** — one-shot migration tool reads SQLite, writes `redb`, verifies, swaps.
+5. **Phase 5** — drop SQLite implementation.
+
+Estimated 2-4 weeks of focused work to do safely. Not justified today.
+
+---
+
+## 9. Open questions (none blocking)
+
+1. Is there interest in cross-instance shared state beyond the agent registry? If yes, that pushes toward event-sourcing for the new layer (independent of objects.db).
+2. Has anyone benchmarked SQLite's perf in AgentMux under heavy load (e.g. a swarm of 50 agents writing concurrently)? If not, the "no perf concerns" claim is by-vibe, not by-data.
+3. Does the team have an opinion on the C-deps-vs-Rust-only tradeoff? If "drop C deps" becomes policy, the answer here flips toward `redb`.

--- a/docs/specs/SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md
+++ b/docs/specs/SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md
@@ -1,0 +1,171 @@
+# SPEC: Reactive Workspace + Object Sync (frontend reactivity gap)
+
+**Date:** 2026-05-14
+**Author:** AgentX
+**Status:** Draft
+**Reported by:** user — "when I update the starter workspace to a new string, it doesnt update the task bar or even the status bar version panel"
+**Related:** PR #841 (window-title format), `SPEC_WINDOW_INSTANCE_NAMING_CLEANUP_2026-05-14.md`
+
+---
+
+## 1. Problem
+
+Renaming a **workspace** does not propagate reactively to:
+
+- The OS taskbar / window title (`document.title` set by `installWindowTitleEffect()` in `app-init.ts`)
+- The bottom-right **InstancePanel**'s window-list rows (`resolveName()` in `InstancePanel.tsx`)
+
+Both surfaces are *supposed* to react via `atoms.workspace()?.name` / `getObjectValue<Workspace>(...)?.name` — and they would, if the workspace cache received an update event. It doesn't.
+
+This is a single bug shaped two ways: a per-RPC defect (workspace mutations don't broadcast) and a class-of-bug shaped like "the convention to attach `WaveObjUpdate` to the response is easy to forget for new mutation RPCs."
+
+For comparison: **window display-name renames work fine** — they go through a different RPC (`ObjectService.UpdateObjectMeta`) that *does* attach updates to the response.
+
+---
+
+## 2. Root cause
+
+### 2.1 The signal-death chain
+
+| # | Layer | File:line | What happens |
+|---|-------|-----------|--------------|
+| 1 | Frontend mutation call | `frontend/app/store/services.ts:172-173` | `WorkspaceService.UpdateWorkspace(workspaceId, name)` over RPC |
+| 2 | Backend RPC handler | `agentmux-srv/src/server/service.rs:1274-1307` | Dispatches `RenameWorkspace` → reducer; applies emitted `WorkspaceRenamed` event to SQLite via `apply_event_to_wstore` (line 1298); publishes event to internal `srv_events_tx` channel (line 1305); **returns `WebReturnType::success_empty()` (line 1306)** ← bug |
+| 3 | Response broadcast loop | `agentmux-srv/src/server/service.rs:39-52` | Iterates `result.updates` and broadcasts each to all connected WS clients as `waveobj:update`. **Empty response → nothing to broadcast.** |
+| 4 | Frontend WS event handler | `frontend/app/store/wos.ts:259-279` | `updateWaveObject()` would call `wov.setData()`, triggering SolidJS signal reactivity. **Never invoked because no event arrives.** |
+| 5 | Reactive consumers | `frontend/app/store/global.ts:62-66` (`atoms.workspace()`), `frontend/app-init.ts:518-544` (title effect), `frontend/app/statusbar/InstancePanel.tsx:142-153` (panel `resolveName`) | All depend on the WOS-cached `Workspace` signal. **Signal never changes → memos/effects never re-run.** |
+
+### 2.2 Why `window:displayname` works (the working comparison)
+
+`InstancePanel.tsx:171-175` calls:
+```ts
+ObjectService.UpdateObjectMeta(makeORef("window", windowId), { "window:displayname": name })
+```
+
+Backend handler `agentmux-srv/src/server/service.rs:308-390` returns:
+```rust
+WebReturnType::success_with_updates(vec![WaveObjUpdate {
+    updatetype: "update".into(),
+    otype: OTYPE_WINDOW.to_string(),
+    oid: oref.oid.clone(),
+    obj: Some(wave_obj_to_value(&window)),
+}])
+```
+
+The inline `WaveObjUpdate` triggers the broadcast loop, which fires `waveobj:update` to every connected client, which updates the WOS cache, which trips the reactive signal. The whole chain works because the response carries the change.
+
+**The convention for mutation RPCs is: write to store + publish events + return updated objects in response. UpdateWorkspace skipped step 3.**
+
+---
+
+## 3. Scope — confirmed and likely-broken
+
+### 3.1 Confirmed broken
+
+- `UpdateWorkspace` (`agentmux-srv/src/server/service.rs:1274-1307`) — workspace name rename. The reported case.
+
+### 3.2 Suspected broken (audit needed)
+
+Any backend mutation RPC handler that publishes events to `srv_events_tx` but does not also return a `WaveObjUpdate` in the response will exhibit the same bug. Audit by grepping handlers that:
+- call `publish_events()` or write to `srv_events_tx`, and
+- end with `WebReturnType::success_empty()`
+
+Likely suspects (by name only — needs verification):
+- Workspace tab list mutations (`AddTab`, `RemoveTab`, `ReorderTab` on workspace)
+- Workspace `activetabid` change (when user switches tabs — the title's `atoms.activeTabId()` needs this to update)
+- Other workspace meta updates beyond `name`
+- Tab renames (`TabRename` if it exists; if it goes through `UpdateObjectMeta` it's fine, but if it has a dedicated handler it might be broken)
+
+### 3.3 Confirmed working (do not touch)
+
+- `UpdateObjectMeta` for `window:displayname` — returns inline update.
+- Block updates via `UpdateObjectMeta` — same path.
+
+---
+
+## 4. Fix options
+
+### 4.1 Option A — per-handler fix (surgical)
+
+For each broken handler, add the inline update to the response.
+
+```rust
+// agentmux-srv/src/server/service.rs:1274-1307 — UpdateWorkspace
+// AFTER the existing publish_events() call:
+
+let updated_ws = state.wstore.lock().unwrap().get_workspace(&workspace_id).cloned();
+match updated_ws {
+    Some(ws) => WebReturnType::success_with_updates(vec![WaveObjUpdate {
+        updatetype: "update".into(),
+        otype: OTYPE_WORKSPACE.to_string(),
+        oid: workspace_id.clone(),
+        obj: Some(wave_obj_to_value(&ws)),
+    }]),
+    None => WebReturnType::success_empty(),
+}
+```
+
+**Pros:** Minimal, surgical, easy to review per handler.
+**Cons:** The next person who adds a mutation RPC and forgets the convention reintroduces this exact bug in a new place. Doesn't catch the class.
+
+### 4.2 Option B — broadcast bridge (architectural)
+
+Bridge `srv_events_tx` → frontend `waveobj:update` so any event published internally automatically becomes a frontend update event. Make the per-handler convention a belt instead of a suspender.
+
+Sketch:
+1. New task in `agentmux-srv/src/server/service.rs` subscribes to `srv_events_tx` at startup.
+2. For each event type that affects a `WaveObj` (`WorkspaceRenamed`, `WorkspaceTabAdded`, `WorkspaceTabRemoved`, `TabRenamed`, `BlockUpdated`, …), translate to a `WaveObjUpdate` and broadcast to all WS clients via the same broadcast channel the response loop uses.
+3. The per-handler "return updates in response" pattern stays for synchronous-RPC-completion cases, but it's no longer the only signal — the bridge guarantees that anything that changes in the store gets seen.
+
+**Pros:** Fixes the whole class. New mutations automatically wire up. Self-healing.
+**Cons:** Risk of double-broadcast (both the response loop AND the bridge fire) — needs dedup. Bigger surface change. Needs careful event-type-to-WaveObjUpdate mapping table.
+
+### 4.3 Recommendation
+
+**Ship Option A for `UpdateWorkspace` immediately** (one-line behavior fix, addresses the user-reported bug today). **Open a follow-up issue for Option B** with a complete audit of `srv_events_tx` event types that should fan out as `WaveObjUpdate`s, plus a dedup/idempotency story.
+
+---
+
+## 5. Test plan
+
+### 5.1 Manual — for Option A
+
+- [ ] Open AgentMux. Default workspace name visible somewhere (e.g. status bar via InstancePanel or settings panel).
+- [ ] Rename the workspace to "Pulse" via the workspace settings UI.
+- [ ] **Expected:** OS taskbar title updates from `Window 1 - <tab> - AgentMux` to `Pulse - <tab> - AgentMux` immediately.
+- [ ] **Expected:** Open InstancePanel (click version chip). The window row shows `Pulse` (not `Window 1`).
+- [ ] Rename back to empty / different. Title + panel update again.
+- [ ] Rename a workspace assigned to a different (not-current) window. That window's row in InstancePanel updates; current window unaffected.
+
+### 5.2 Automated
+
+- [ ] Add a Rust unit test for `UpdateWorkspace` that inspects the returned `updates` field and asserts a `WaveObjUpdate` of `otype: "workspace"` with the new name in `obj`.
+- [ ] (If time) frontend integration test: mock the WS channel, fire a `waveobj:update` for a workspace, assert `atoms.workspace()` re-derives.
+
+### 5.3 Regression — confirm window:displayname unaffected
+
+- [ ] InstancePanel double-click rename flow still updates title + panel (this is the path that was already working).
+
+---
+
+## 6. Out of scope (for this PR)
+
+- Option B (broadcast bridge) — separate follow-up.
+- Audit of every other `success_empty()`-returning mutation RPC — separate follow-up.
+- The "starter workspace" terminology in the user's report — that's the workspace assigned at startup; no rename needed in code.
+- Workspace.name validation (length cap, character set, etc.) — orthogonal.
+
+---
+
+## 7. Risk
+
+- **Low risk** for Option A: adds a fetch + serialize after `publish_events()`. Same shape as the working `UpdateObjectMeta` handler. The fetch happens after the SQLite write completes, so there's no race.
+- **One subtle correctness concern:** `state.wstore.lock().unwrap()` — if this lock is contested under load, the fetch could block briefly. Same lock is already taken inside `publish_events()` upstream, so no new deadlock surface; the brief hold is pre-existing.
+
+---
+
+## 8. Open questions
+
+1. **Are there other "name-like" fields on workspace** (e.g. `description`, `icon`) that have the same RPC shape? If yes, the same fix pattern applies.
+2. **Does `RenameTab` exist as a dedicated handler** or does it route through `UpdateObjectMeta`? If dedicated, audit it for the same bug.
+3. **For the broadcast bridge (Option B):** which `Event::*` variants in the reducer should fan out as `WaveObjUpdate`? Need a mapping table — likely all the `*Renamed`, `*Updated`, `*Created`, `*Deleted` variants for objects with frontend-visible representations.

--- a/docs/specs/SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md
+++ b/docs/specs/SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md
@@ -1,0 +1,347 @@
+# SPEC: `Wave*` → `Mux*` rename (purge Wave Terminal branding)
+
+**Date:** 2026-05-14
+**Author:** AgentX
+**Status:** ❌ **Deferred — not worth refactoring at this time** (decision 2026-05-14, mid-implementation)
+**Decision context:** The mechanical sweep was attempted (~150 files modified, sweeps for symbols / strings / module paths / SQL schema / env vars). Build verification surfaced ~30 remaining cross-references that needed careful handling (path-prefix resolution like `wps::Foo` vs `::wps::`, relative imports, comments, etc.). Each successive grep pass found more straggler references. The cost-benefit flipped — the rename is purely cosmetic (it removes leftover Wave Terminal branding but changes no behavior) and the sweep was getting deeper than the value justified.
+**Outcome:** All 5 `Wave*` types stay (`WaveObj`, `WaveObjUpdate`, `WaveStore`, `WaveWindow`, etc.). Module names stay (`wos.ts`, `wps.ts`, `wstore.rs`, `wps.rs`, `gotypes.d.ts`). Wire string `"waveobj:update"` stays. SQLite table `db_wave_file` stays. Env vars stay. The bridge PR (`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`) ships on the existing Wave* names.
+**If revisited later:** the analysis below is still valid — the surface area, the migration shape, the open questions are all resolved. Pick this up if/when it stops feeling like cosmetic churn (e.g. as part of a broader "kill all Wave Terminal artifacts" effort, or alongside a real architectural change that touches the same files anyway).
+
+---
+
+## 1. Goal (deferred — kept for record)
+
+Replace the `Wave*` type prefix (leftover from the Wave Terminal fork) with `Mux*` across Rust + TypeScript + module names. No semantic change — purely a rename so the codebase reads like an AgentMux codebase, not a Wave Terminal one.
+
+This is a pre-flight cleanup so the upcoming bridge PR (`SPEC_OBJ_UPDATE_BRIDGE_*`) can ship on clean naming from day one.
+
+---
+
+## 2. Scope (measured)
+
+```bash
+grep -rE "WaveObj|WaveStore" agentmux-{srv,cef,common}/src frontend | wc -l   # 386
+grep -rEl "WaveObj|WaveStore" agentmux-{srv,cef,common}/src frontend | wc -l  # 67 files
+```
+
+**11 distinct `Wave*` types** detected (`grep -rE "\bWave[A-Z][a-zA-Z]+" agentmux-srv/src agentmux-common/src`):
+
+```
+WaveEvent
+WaveEvents
+WaveFile
+WaveFiles
+WaveInfoData
+WaveLock
+WaveNotificationOptions
+WaveObj
+WaveObjUpdate
+WaveStore
+WaveWindow
+```
+
+Plus module/file/function names:
+
+- `frontend/app/store/wos.ts` (module — `WOS` namespace import everywhere)
+- `agentmux-srv/src/backend/storage/wstore.rs`
+- `wave_obj_to_value()` (helper function)
+- `getWaveObjectAtom`, `getWaveObjectValue` (frontend helpers)
+- `wpsSubscribeToObject` (the `wps` prefix — possibly "wave pub/sub")
+- `WAS` / `WAV` if any (didn't find but worth grepping)
+
+---
+
+## 3. Rename table
+
+| Old | New | Notes |
+|---|---|---|
+| **Type definitions (Rust + TS)** | | |
+| `WaveObj` (trait, Rust) | `MuxObj` | `agentmux-srv/src/backend/obj.rs:121-138` |
+| `WaveObjUpdate` (struct, Rust + TS wire type) | `MuxObjUpdate` | The wire format; both sides must match in the same PR |
+| `WaveStore` (Rust) | `MuxStore` | `agentmux-srv/src/backend/storage/wstore.rs` |
+| `WaveWindow` (TS type) | `MuxWindow` | In `frontend/types/gotypes.d.ts` |
+| `WaveEvent`, `WaveEvents` | `MuxEvent`, `MuxEvents` | |
+| `WaveFile`, `WaveFiles` | `MuxFile`, `MuxFiles` | |
+| `WaveInfoData` | `MuxInfoData` | |
+| `WaveLock` | `MuxLock` | |
+| `WaveNotificationOptions` | `MuxNotificationOptions` | |
+| **Helper functions** | | |
+| `wave_obj_to_value()` | `mux_obj_to_value()` | |
+| `getWaveObjectAtom` | `getMuxObjectAtom` | |
+| `getWaveObjectValue` | `getMuxObjectValue` | |
+| `reloadWaveObject` | `reloadMuxObject` | |
+| `loadAndPinWaveObject` | `loadAndPinMuxObject` | |
+| `updateWaveObject` (internal) | `updateMuxObject` | |
+| `wpsSubscribeToObject`, `wpsReconnectHandler` | `mpsSubscribeToObject`, `mpsReconnectHandler` | **Confirmed:** `wps` stands for **"Wave PubSub"** (per the module's structure in `agentmux-srv/src/backend/wps.rs:60` and `frontend/app/store/wps.ts:146`). Rename to `mps` ("Mux PubSub") for consistency with `mstore` / `mos`. |
+| **Module / file names** | | |
+| `frontend/app/store/wos.ts` | `frontend/app/store/mos.ts` | All importers update path |
+| `WOS` namespace import (`import * as WOS from ...`) | `MOS` | 19 importers |
+| `agentmux-srv/src/backend/storage/wstore.rs` | `agentmux-srv/src/backend/storage/mstore.rs` | Module declaration + 50+ `use` statements |
+| `agentmux-srv/src/backend/wps.rs` | `agentmux-srv/src/backend/mps.rs` | Wave PubSub module → Mux PubSub. Sweep `use ...::wps::...` across crate |
+| `frontend/app/store/wps.ts` | `frontend/app/store/mps.ts` | Same; 6 frontend importers |
+| `frontend/types/gotypes.d.ts` | `frontend/types/srv-types.d.ts` | 2074-line type bindings file; the filename used to reference the (now-defunct) Go source. New name describes where the types come from today: the `agentmux-srv` sidecar. The file is in the global ambient-type lookup (`declare global { ... }`), so renaming doesn't require import updates anywhere — just rename the file. `tsconfig.json` uses `include: ["frontend/**/*"]` so it auto-discovers. |
+| **Wire-protocol strings** | | |
+| `"waveobj:update"` (WebSocket eventtype discriminator) | `"muxobj:update"` | **5 occurrences:** `agentmux-srv/src/server/app_api.rs:399,816`; `service.rs:45`; `websocket.rs:125,541` (plus frontend handler in `app/store/global.ts`). Backend + frontend must change in the same commit. See §10.1 for migration concerns. |
+| **Database schema** | | |
+| `db_wave_file` (SQLite table) | `db_mux_file` | **11 SQL statements** reference this table name (CREATE, INSERT, SELECT, UPDATE, DELETE, INDEX). Requires a schema migration — see §11.2. |
+| **Runtime env / globals** | | |
+| `__WAVE_SERVER_WS_ENDPOINT__` (window global) | `__MUX_SERVER_WS_ENDPOINT__` | Injected by launcher/CEF at boot. See §10.3 for deprecation strategy. |
+| `__WAVE_SERVER_WEB_ENDPOINT__` | `__MUX_SERVER_WEB_ENDPOINT__` | Same. |
+| **Constants** | | |
+| `OTYPE_*` (e.g. `OTYPE_WORKSPACE`) | unchanged | These don't have `Wave` in the name; keep |
+| **Comments and docs** | | |
+| `WaveStore: generic OID-based CRUD for WaveObj types.` (`wstore.rs:1`) | `MuxStore: generic OID-based CRUD for MuxObj types.` | Update the doc comments too |
+| `// generated by cmd/generate/main-generatets.go` (`gotypes.d.ts:4`) | Remove — stale; no Go file exists in repo (no codegen pipeline today). Add `// Hand-maintained type bindings; keep in sync with agentmux-srv/src/backend/obj.rs` instead. | Side cleanup |
+
+### 3.1 Names NOT to rename (out of scope)
+
+- `OTYPE_*` constants — they're already brand-neutral.
+- `WOS` references in **comments and old log lines** if any exist in archived specs / changelog — leave history alone.
+- External-protocol field names (e.g. `oref`, `oid`, `otype`) — those are wire format; renaming is a separate breaking change.
+- File names of historical specs that have `Wave` in them — historical record.
+
+---
+
+## 4. File renames (with `git mv`)
+
+| Old path | New path |
+|---|---|
+| `frontend/app/store/wos.ts` | `frontend/app/store/mos.ts` |
+| `agentmux-srv/src/backend/storage/wstore.rs` | `agentmux-srv/src/backend/storage/mstore.rs` |
+| `agentmux-srv/src/backend/storage/wstore.test.rs` (if exists) | `mstore.test.rs` |
+
+Use `git mv` so the rename history is preserved across blame.
+
+After renames, update:
+
+- `mod wstore;` → `mod mstore;` in the parent `mod.rs` (Rust)
+- All `use ...::wstore::...` paths
+- All TS imports — sweep is mechanical (`@/store/wos` → `@/store/mos`, `@/app/store/wos` → `@/app/store/mos`)
+
+---
+
+## 5. PR sequencing (within this PR)
+
+Do all renames in **one commit**, not many small ones. Reason: a `WaveObj` partial-rename build is broken; PR reviewers and bisect want a single coherent transition.
+
+Order of operations inside the commit:
+
+1. `git mv` the files.
+2. Sweep Rust source: `sed -i 's/WaveObj/MuxObj/g; s/WaveStore/MuxStore/g; ...'` across `agentmux-{srv,cef,common}/src` and `frontend`.
+3. Update doc comments.
+4. Update `gotypes.d.ts` (stale codegen comment + the `WaveWindow` type name).
+5. `cargo check --workspace` + `npx tsc --noEmit` until clean.
+6. Run existing tests (`npm test`, `cargo test -p agentmux-srv`).
+
+The bump CLI runs at the end as usual.
+
+---
+
+## 6. Why one big commit, not staged
+
+Tempting to think "rename Rust first, then frontend in a second commit" — but the wire types (`WaveObjUpdate`) are shared. A staged commit would have either the Rust or the TS side referring to a name that no longer exists. Single-commit transitions are easier to revert if something breaks in CI.
+
+The cost (one big diff) is offset by the fact that the diff is purely mechanical and reviewable as such.
+
+---
+
+## 7. Test plan
+
+### 7.1 Build verification
+
+- [ ] `cargo check --workspace` clean
+- [ ] `cargo build --release -p agentmux-srv -p agentmux-cef -p agentmux-launcher -p agentmux-bashwrap -p agentmux-common`
+- [ ] `npx tsc --noEmit -p tsconfig.json` clean
+- [ ] `npm run build:dev` (frontend prod bundle) succeeds
+- [ ] `npm run build:prod` succeeds
+- [ ] `npx vitest run` — full frontend test suite passes
+- [ ] `cargo test --workspace` passes
+
+### 7.2 Functional verification
+
+This is a pure rename — there should be ZERO behavioral changes. The verification is:
+
+- [ ] `task dev` boots, window opens, frontend loads
+- [ ] Workspace + tab + block + window operations work exactly as before
+- [ ] InstancePanel renames a window successfully
+- [ ] Existing PR #841 reactive title still works
+- [ ] No new warnings beyond pre-existing ones (run `cargo build` twice, diff warnings)
+
+### 7.3 Grep verification
+
+After the commit, these should return zero hits (or only intentional history/comment mentions):
+
+```bash
+grep -rE "\bWave[A-Z]" agentmux-srv/src agentmux-cef/src agentmux-common/src frontend
+grep -rE "WaveObj|WaveStore|WaveWindow" agentmux-srv/src agentmux-cef/src agentmux-common/src frontend
+grep -rE "from \"@/store/wos\"|from \"@/app/store/wos\"" frontend
+```
+
+---
+
+## 8. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Missed references → build error | Comprehensive grep before commit; CI catches what grep misses |
+| External dependency uses `Wave*` (e.g. another repo, e2e tests) | Search a5af-org for `WaveObj` / `WaveStore` callers; coordinate or stage |
+| `WaveWindow` mentioned in user-facing docs (agentmux-docs) | Coordinate a docs PR in lockstep (cite `agentmux-docs` PR template) |
+| Bisect/blame disruption | `git mv` preserves rename for blame; large mechanical diff is annotated as such in PR title |
+| Stale CI cache → old types persist in dist/ | `task clean` before package build |
+| `task package` outputs include old name in binary metadata (file properties, About modal) | About modal text was already brand-neutral; check |
+| Performance regression hiding in the diff | Mechanical rename has no runtime impact; perf tests unchanged |
+
+### 8.1 What could go wrong despite all the care
+
+A type name appearing inside a **string literal** (e.g. logged as `"WaveObj"`, used as a JSON discriminator field value) won't be caught by symbol rename. Need a separate grep pass for string mentions:
+
+```bash
+grep -rE '"WaveObj|"WaveStore|"WaveWindow' agentmux-{srv,cef,common}/src frontend
+```
+
+If any hits exist, those are protocol/wire mentions and may require coordinated handling (e.g. a backwards-compat alias for one release).
+
+---
+
+## 9. Coordination with other PRs
+
+### 9.1 The bridge PR (`SPEC_OBJ_UPDATE_BRIDGE_*`)
+
+This rename PR is **sequenced before** the bridge PR. Update the bridge spec post-merge of this PR to use the new names (`MuxObj`, `MuxObjUpdate`, `MuxStore`, `mux_obj_to_value`). Already noted in the bridge spec §13 implementation readiness.
+
+### 9.2 The docs repo (`agentmux-docs`)
+
+The docs glossary still references `WaveObj` as a type concept implicitly through `WaveWindow`. Open a coordinated docs PR in lockstep that:
+- Updates `glossary.md` to use `MuxWindow` if it ever appears (unlikely — the glossary mostly talks about "window" the concept)
+- Doesn't drag in the `Wave*` legacy mention currently in the docs (search for it)
+
+### 9.3 External consumers
+
+If any e2e test repos or agent SDK packages import types named `WaveObj` from `@a5af/...`, those need updates. Discovery: `gh search code 'WaveObj' --owner a5af`.
+
+---
+
+## 10. Resolved questions (research log)
+
+These were open in the first draft of this spec; resolved by reading the source. Kept here so the next reader doesn't have to re-investigate.
+
+### 10.1 Wire-protocol string `"waveobj:update"` — RESOLVED ✓ Lockstep rename
+
+**Question:** Is the `"waveobj:update"` WebSocket eventtype safe to rename?
+
+**Answer:** **Yes, in the same commit as the type rename.** The string is a discriminator in the WS message envelope, present at:
+- Rust backend: `agentmux-srv/src/server/{app_api.rs:399,816, service.rs:45, websocket.rs:125,541}` — 5 emit sites
+- Frontend: `frontend/app/store/global.ts` — listener handler
+
+Both ends ship from this repo in a single release. The rename to `"muxobj:update"` is safe as a single-commit lockstep change — there's no external consumer of the WS protocol (no mobile client, no third-party SDK that subscribes).
+
+**One subtle migration concern:** if a user runs an older portable + the new build simultaneously and they ever talked to each other (they don't — each instance has its own backend), the protocol mismatch would matter. Since instances are isolated, this is a non-issue.
+
+### 10.2 SQLite table `db_wave_file` — RESOLVED ✓ Schema migration required
+
+**Question:** Is renaming the `db_wave_file` SQLite table safe?
+
+**Answer:** **Requires a SQLite schema migration**, but the codebase already has a migration framework for this. The 11 SQL statements that reference the table all live in `agentmux-srv/src/backend/storage/filestore/` (filestore implementation).
+
+**Migration approach:**
+
+```sql
+-- Migration script (new schema version)
+ALTER TABLE db_wave_file RENAME TO db_mux_file;
+-- Also rename any indexes:
+ALTER INDEX idx_db_wave_file_* RENAME TO idx_db_mux_file_*;  -- if any
+```
+
+The rename PR must:
+1. Bump the schema version constant (locate via grep `SCHEMA_VERSION` or similar in `agentmux-srv/src/backend/storage/`).
+2. Add a migration entry that renames the table on existing databases.
+3. Update all 11 SQL statements to reference `db_mux_file`.
+4. Verify by running against an existing database from a prior version — the migration should be idempotent and lossless.
+
+**Why the type name `WaveFile` is separate from the table name:** The Rust struct in `filestore/types.rs:39` is the in-memory representation; the SQL is the on-disk representation. Both rename together for consistency, but they're independent string surfaces — both must be updated in the rename PR.
+
+### 10.3 Env vars `__WAVE_SERVER_*` — RESOLVED ✓ Internal-only, rename in-place
+
+**Question:** Are `__WAVE_SERVER_WS_ENDPOINT__` and `__WAVE_SERVER_WEB_ENDPOINT__` window globals safe to rename, or are they external-facing?
+
+**Answer:** **Internal-only.** These are runtime-injected globals on `window` set by the CEF host as part of the initial page bootstrap. Their consumers are:
+- The renderer process's `bootstrap.ts` / equivalent (reads them once, then passes resolved values into the app)
+- No documented external consumer (no extension SDK, no agent-side runtime that reads them)
+
+**Decision:** rename in-place to `__MUX_SERVER_WS_ENDPOINT__` / `__MUX_SERVER_WEB_ENDPOINT__` in the same commit. No backward-compat alias needed — both setter (Rust host code) and reader (frontend bootstrap) update together.
+
+If we discover during the PR that an external consumer DOES read these (e.g. a debug tool, a test helper), add an alias:
+```js
+window.__MUX_SERVER_WS_ENDPOINT__ = window.__WAVE_SERVER_WS_ENDPOINT__ = "...";  // dual-name for one release
+```
+…and deprecate the old name in a follow-up.
+
+### 10.4 `wps` prefix — RESOLVED ✓ Stands for "Wave PubSub", rename to `mps`
+
+**Question:** What does `wps` stand for, and should it rename to `mps`?
+
+**Answer:** **"Wave PubSub"** — confirmed by inspecting the module at `agentmux-srv/src/backend/wps.rs:60` (defines `WaveEvent` and the pub/sub broker, ~800 lines) and `frontend/app/store/wps.ts:146` (exports the matching JS-side handler).
+
+Rename to `mps` for consistency. The files `wps.rs` and `wps.ts` also rename (see §3 rename table). 6 frontend files import from `@/store/wps` — mechanical sed sweep.
+
+### 10.5 `gotypes.d.ts` codegen — RESOLVED ✓ Hand-maintained, safe to rename
+
+**Question:** Is `gotypes.d.ts` regenerated by some hidden codegen pipeline that would overwrite our changes?
+
+**Answer:** **No codegen pipeline exists.** Verified:
+- `find . -name "*.go"` returns 0 results — the file's `// generated by cmd/generate/main-generatets.go` header is stale.
+- No Taskfile entry, no npm script, no Cargo build script references `gotypes`, `generate-ts`, `ts-rs`, `specta`, or `typeshare`.
+- `tsconfig.json` uses `include: ["frontend/**/*"]` — the file is auto-discovered, no explicit path lock.
+
+Safe to:
+- Rename file to `srv-types.d.ts` (the user-chosen name).
+- Update the stale header to `// Hand-maintained type bindings; keep in sync with agentmux-srv/src/backend/{obj.rs, rpc_types.rs, wps.rs}`.
+
+### 10.6 Other hidden references — RESOLVED ✓ Audit clean
+
+| Category | Hits | Action |
+|---|---|---|
+| Cargo features `WAVE_*` | none | OK |
+| npm package names | none | OK |
+| CSS classes `.wave-*` | none | OK |
+| localStorage / sessionStorage keys | none | OK |
+| File extensions / lock filenames | none | OK |
+| HTTP route paths | one handler `handle_wave_file` (function name only; URL path `/agentmux/file` is brand-neutral) | Rename function via the type rename sweep |
+| Activity telemetry fields `waveaifgminutes`, `waveaiactiveminutes` | in `gotypes.d.ts` field names | **Out of scope** — these are backwards-compat activity-tracking field names that would break analytics dashboards if renamed. Leave for a separate analytics-schema-migration PR. |
+
+---
+
+## 11. Naming sanity check (all 9 `Wave*` types verified)
+
+| Type | Definition site (verified) |
+|---|---|
+| `WaveEvent` | `agentmux-srv/src/backend/wps.rs:60` |
+| `WaveFile` | `agentmux-srv/src/backend/storage/filestore/types.rs:39` |
+| `WaveLock` | `agentmux-srv/src/backend/base.rs:189` |
+| `WaveInfoData` | `agentmux-srv/src/backend/rpc_types.rs:1106` |
+| `WaveNotificationOptions` | `agentmux-srv/src/backend/rpc_types.rs:1145` |
+| `WaveObj` (trait) | `agentmux-srv/src/backend/obj.rs:121` |
+| `WaveObjUpdate` (struct) | `agentmux-srv/src/backend/obj.rs:468` |
+| `WaveStore` | `agentmux-srv/src/backend/storage/wstore.rs:24` |
+| `WaveWindow` (TS) | `frontend/types/gotypes.d.ts` (global) |
+
+All 9 accounted for, each with a single definition site (no duplicate-define traps).
+
+---
+
+## 12. Implementation readiness checklist
+
+Pre-flight, before opening the rename PR:
+
+- [x] All 9 `Wave*` type definitions verified at single sites (§11)
+- [x] Wire-protocol string `"waveobj:update"` rename scoped + lockstep (§10.1)
+- [x] SQLite schema migration plan documented (§10.2)
+- [x] Env-var rename strategy decided (§10.3)
+- [x] `wps` prefix expansion confirmed (§10.4)
+- [x] `gotypes.d.ts` codegen status verified (§10.5)
+- [x] Hidden-reference audit complete (§10.6)
+- [x] File renames identified with `git mv` (§4)
+- [ ] Locate `SCHEMA_VERSION` constant in `agentmux-srv/src/backend/storage/` — needed for §11.2 migration
+- [ ] Confirm migration framework supports `ALTER TABLE ... RENAME TO ...` (SQLite 3.25+ does)
+
+The two unchecked items are 5-minute lookups during the PR, not spec blockers.

--- a/docs/specs/SPEC_WINDOW_INSTANCE_NAMING_CLEANUP_2026-05-14.md
+++ b/docs/specs/SPEC_WINDOW_INSTANCE_NAMING_CLEANUP_2026-05-14.md
@@ -1,0 +1,216 @@
+# SPEC: Window/Instance Naming Cleanup
+
+**Date:** 2026-05-14
+**Author:** AgentX
+**Status:** Draft — needs scope decision
+**Related:** PR #841 (window-title format) surfaced this; recent specs `SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md`, `SPEC_WINDOW_RENAME_2026_04_27.md`, `SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md`
+
+---
+
+## 1. Problem
+
+The terms **"window"** and **"instance"** are used inconsistently across types, atoms, RPCs, UI copy, and specs. Most notably "instance" is overloaded between two genuinely different concepts:
+
+- **Window-rank-within-an-instance** — `(1)`, `(2)`, `(3)` shown after the version in the StatusBar (`StatusBar.tsx:92`), populated by `getInstanceNumber()` RPC into `windowInstanceNumAtom`.
+- **A separate AgentMux instance** (a whole launcher → srv → host process tree, see §3) — multiple instances run side-by-side (portable + dev + different versions), per `CLAUDE.md "Multiple Instances Run in Parallel"`. This is the LAN-discoverable thing in `LanStatus.tsx:43` ("N other AgentMux instances on LAN").
+
+These are not the same thing. Today the codebase (and copy) blurs them.
+
+A second axis of drift: which token identifies a window in code?
+
+- `windowId` — backend UUID (OID on `WaveWindow`)
+- `label` — launcher-assigned symbolic name (`"main"`, `"window-pool-..."`)
+- `instanceNumber` — 1-based rank within this AgentMux instance
+
+Three identifiers, three semantics, used together in `WindowEntry = { label, windowId }` (frontend/app/store/global.ts:148) plus a separate `windowInstanceNumAtom`.
+
+---
+
+## 2. Audit (one-line summary per surface)
+
+### 2.1 Type / data-model layer
+
+| Term | Meaning | Where | Verdict |
+|------|---------|-------|---------|
+| `WaveWindow` | Persisted backend data object | `frontend/types/gotypes.d.ts:1708`, generated from Go | Legacy from Wave Terminal — **keep** (touching this is a multi-repo schema rename) |
+| `Workspace` | Workspace assigned to a window | gotypes | Keep |
+| `Tab` | Tab inside a workspace | gotypes | Keep |
+
+### 2.2 Frontend atoms (the front line)
+
+| Atom | Type / purpose | File | Issue |
+|------|---------------|------|-------|
+| `openWindowEntriesAtom` | `WindowEntry[]` — list of open windows in this instance | `global.ts:149` | OK |
+| `openWindowLabelsAtom` | `string[]` — labels only, derived | `global.ts:140` | OK |
+| `windowCountAtom` | total count | `global.ts:133` | OK |
+| `windowInstanceNumAtom` | this window's rank | `global.ts:132` | **Misleading name** — it IS rank-within-instance, but "instance number" reads like "which instance am I" instead of "which window in my instance" |
+
+### 2.3 RPC / IPC
+
+| Method | Signature | File | Issue |
+|--------|-----------|------|-------|
+| `openNewWindow()` | — | `custom.d.ts:115` | OK |
+| `focusWindow(label)` | by label | `custom.d.ts:138` | OK |
+| `closeWindow()` / `closeWindowByLabel(label)` | — | `custom.d.ts:116,255` | OK |
+| `getWindowLabel()` | this window's label | `custom.d.ts:?` | OK |
+| `listWindowInstances()` | returns `[{ label, windowId }]` for THIS instance | `custom.d.ts:130` | **Misnomer — returns windows, not instances** |
+| `getInstanceNumber()` | returns this window's rank | `custom.d.ts:139` | **"InstanceNumber" but it's window-rank** |
+
+### 2.4 UI copy (user-visible)
+
+| Surface | Text | File | Issue |
+|---------|------|------|-------|
+| StatusBar tooltip | "Click for instance panel" | `StatusBar.tsx:85` | **Says "instance" — confusing** |
+| StatusBar aria-label | "AgentMux version — open instance panel" | `StatusBar.tsx:86` | **Same** |
+| InstancePanel header | "This process — N window(s)" | `InstancePanel.tsx:271` | **Wrong — "this process" is the renderer; the panel actually lists all windows in the instance** (see §3.1) |
+| InstancePanel aria-label | "AgentMux instance panel" | `InstancePanel.tsx:231` | **Says "instance"** |
+| InstancePanel row tooltip | "This window — double-click to rename (F2)" | `InstancePanel.tsx:322` | OK |
+| LanStatus | "N other AgentMux instances on LAN" | `LanStatus.tsx:43` | **Correct usage** — these really are separate instances (separate process trees) |
+
+### 2.5 Component / file names
+
+| Name | File | Notes |
+|------|------|-------|
+| `InstancePanel` (component) | `frontend/app/statusbar/InstancePanel.tsx` | The thing it shows is a list of WINDOWS, not instances |
+| `.instance-panel-*` (CSS) | InstancePanel.tsx + scss | Implementation detail; safe to keep |
+
+### 2.6 Specs
+
+- `SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md` — predates this cleanup; uses "instance" throughout
+- `SPEC_WINDOW_RENAME_2026_04_27.md` — drifts toward "window" naming
+- `SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md` — uses "window" + "tab"
+- `specs/instance-indicator.md` — older
+
+---
+
+## 3. Process hierarchy
+
+An "AgentMux instance" is **not one process** — it's a process **tree**, rooted at one launcher, sharing one data dir and one Job Object (Windows). A baseline single-window dev session has **4 processes**, plus shared Chromium subprocesses, plus more as panes and windows are opened:
+
+```
+agentmux-launcher.exe                    [1]  Job Object owner; single-instance pipe; saga coord; spawns srv + host
+├── agentmux-srv.exe                     [2]  Rust backend sidecar (DB, RPC, agent runner)
+│   └── agentmux-srv --crash-monitor          srv crash watchdog (counted as part of srv)
+└── agentmux-cef.exe                     [3]  CEF "browser" process — host; owns OS windows; IPC bridge
+    ├── agentmux-cef --type=renderer     [4]  Chromium renderer for this window's HTML/JS context
+    ├── agentmux-cef --type=gpu-process       shared (1 per host)
+    ├── agentmux-cef --type=utility …         shared per service (network, storage, …)
+    └── (more renderers spawn per browser pane / per additional window)
+```
+
+| # | Process | Role | Lifetime | Count per instance |
+|---|---------|------|----------|--------------------|
+| 1 | `agentmux-launcher.exe` | Job-Object root, single-instance enforcement, saga coord, splash, srv lifecycle | Whole instance | 1 |
+| 2 | `agentmux-srv*.exe` | Rust backend sidecar (DB, RPC, agent runner) | Whole instance | 1 (+1 crash-monitor child) |
+| 3 | `agentmux-cef.exe` (host / "browser process") | CEF browser process; owns OS windows; IPC bridge to renderers | Whole instance | 1 |
+| 4 | `agentmux-cef --type=renderer` | Chromium renderer; runs frontend JS for one browser context | One per browser context (window or browser pane) | 1+ (≥1 per OS window, +1 per browser pane) |
+| – | `agentmux-cef --type=gpu-process` | Shared GPU compositor | Whole host | 1 |
+| – | `agentmux-cef --type=utility …` | Per-service Chromium utilities (network, storage, audio, …) | As CEF demands | 2–N |
+
+### 3.1 What this means for terminology
+
+- **"Process"** is ambiguous from the renderer's POV — there are many processes in one AgentMux instance. The InstancePanel header `"This process — N windows"` (`InstancePanel.tsx:271`) is **misleading**: the panel lists all windows in the **instance** via IPC to the host, not "this process" (which is just the renderer this JS is running in).
+- **"Instance"** is the right word for the user-meaningful unit — it's the whole tree. Distinct AgentMux versions, dev + portable, etc. each get their own instance (separate launcher, separate srv, separate host, separate data dir, separate Job Object).
+
+## 4. Canonical terminology
+
+> **`instance`** = an AgentMux process **tree** rooted at one launcher. Owns one Job Object, one data dir, one srv, one host, and all the Chromium subprocesses the host spawns. Multiple instances run in parallel (portable + dev + per-version) per `CLAUDE.md "Multiple Instances Run in Parallel"`.
+>
+> **`window`** = an OS window owned by an instance's host. One instance can have many windows. Each window has a `windowId` UUID, a launcher `label`, and a rank within the instance.
+>
+> **`pane`** / **`browser pane`** = a Chromium browser embedded inside a window for browser-widget tabs. Each browser pane spawns its own renderer (and possibly additional utility processes) — implementation detail, not part of the conceptual model.
+>
+> **`label`** = launcher-assigned symbolic name for a window inside an instance (`"main"`, `"window-pool-..."`). Internal/IPC-only; not user-facing.
+>
+> **`windowId`** = backend OID for the persisted `WaveWindow`. Internal; not user-facing.
+>
+> **`window rank`** (or just "N" in `Window N`) = a window's 1-based position in `openWindowEntriesAtom` within its instance. Cosmetic only — used for the title fallback and the StatusBar `(N)` chip.
+>
+> **`process`** = an OS process. **Avoid in user-facing copy** — too ambiguous (4+ per instance). Reserve for internal docs / process-management code.
+
+### 4.1 Rules
+
+1. **No "instance" in same-instance window contexts.** "Instance" refers to the whole process tree — not to a window within it.
+2. **Drop "process" from user-facing copy where the conceptual unit is the instance.** The InstancePanel says "This process — N windows" — change to "This instance — N windows" (or "Open windows", which sidesteps the question).
+3. **Drop "instance number" from user-facing copy.** It's a window rank — call it that or just say `Window N`.
+4. **Internal tokens (`label`, `windowId`) stay** — they identify windows in IPC and backend storage and aren't part of the conceptual model the user thinks about.
+5. **`WaveWindow` stays.** Renaming it would touch generated Go types, the schema, and unrelated repos. The conceptual mismatch (`Wave*`) is a leftover from the Wave Terminal fork — orthogonal to this cleanup.
+6. **`pane` is the term for embedded browser surfaces** — don't call them "windows" in code or copy.
+
+---
+
+## 5. Tiered cleanup
+
+Tiered so we can pick a scope. T1 is purely UI copy, T4 touches RPC + Go. Each tier is independently mergeable.
+
+### T1 — User-facing copy only (low risk, ~5 lines)
+
+| File | Change |
+|------|--------|
+| `StatusBar.tsx:85` | `data-tip="Click for instance panel"` → `data-tip="Click to open window list"` |
+| `StatusBar.tsx:86` | `aria-label="AgentMux version — open instance panel"` → `aria-label="AgentMux version — open window list"` |
+| `InstancePanel.tsx:231` | `aria-label="AgentMux instance panel"` → `aria-label="Open windows"` |
+| `InstancePanel.tsx:271` | `"This process — N window(s)"` → `"This instance — N window(s)"` (or `"Open windows — N"`) — see §3.1: the panel lists windows in the **instance**, not in "this process" (which is just the renderer) |
+
+No code path changes. No spec breakage. **Safe to ship in any PR.**
+
+### T2 — Frontend atom rename (medium risk, ~20 sites)
+
+| Old | New | Rationale |
+|-----|-----|-----------|
+| `windowInstanceNumAtom` / `setWindowInstanceNumAtom` | `windowRankAtom` / `setWindowRankAtom` | "Rank" matches what it actually is (1-based position within the instance) |
+
+Touches: `global.ts:132`, `app-init.ts:97-98` (callsite around `getInstanceNumber()`), `StatusBar.tsx:4,17`. ~5 files, mechanical rename.
+
+Mention in CHANGELOG / VERSION_HISTORY because consumers in non-frontend repos that import the atom would break (probably none).
+
+### T3 — RPC / IPC rename (higher risk, requires host update + frontend update in lockstep)
+
+| Old | New |
+|-----|-----|
+| `getInstanceNumber()` (RPC) | `getWindowRank()` |
+| `listWindowInstances()` (RPC) | `listOpenWindows()` |
+
+Touches:
+- `frontend/types/custom.d.ts:130,139`
+- `frontend/util/cef-api.ts:428`
+- `agentmux-cef/src/...` (Rust handlers — find via `grep -rn "getInstanceNumber\|listWindowInstances" agentmux-cef/`)
+- `agentmux-launcher/src/...` if the launcher exposes these names
+
+Needs a same-PR rename of both Rust and frontend; can't ship them split. Search for any external consumers (e.g. e2e tests, deploy scripts).
+
+### T4 — Component / file rename (cosmetic but invasive)
+
+| Old | New |
+|-----|-----|
+| `InstancePanel` (component) | `WindowListPanel` |
+| `frontend/app/statusbar/InstancePanel.tsx` | `frontend/app/statusbar/WindowListPanel.tsx` |
+| `.instance-panel-*` CSS classes | `.window-list-panel-*` (or leave as implementation detail) |
+| `SPEC_VERSION_INSTANCE_PANEL_2026_04_25.md` | Add note "renamed to Window List in 2026-05" — don't rename the historic spec file |
+
+Touches the component file, its scss, all importers (`StatusBar.tsx` + tests). CSS rename is optional — if we leave the class names alone (they're implementation detail), this drops to ~3 files.
+
+---
+
+## 6. Recommendation
+
+Ship **T1 + T2 in one PR** alongside or right after PR #841 lands. Both are low-risk, mostly-mechanical, and resolve the most user-visible confusion.
+
+**Defer T3 + T4** to a second PR after T1+T2 settles. T3 needs a Rust-side change and a careful migration; T4 is a big touch for a cosmetic win and can wait.
+
+---
+
+## 7. Out of scope
+
+- **`WaveWindow` / `WaveObj` rename** — these are generated from Go schema, used across the persisted DB layer; renaming is a multi-week project, unrelated to this cleanup.
+- **`label` → something else** — `label` is the established launcher-IPC term, used in production. Renaming would churn `agentmux-launcher/`, `agentmux-cef/`, splash, single-instance pipe, etc. Not worth it.
+- **`workspace.name` semantics** — orthogonal; workspace naming is its own concept.
+
+---
+
+## 8. Open questions
+
+1. Confirm **T1 + T2 scope** is what we want for the next PR (vs deferring everything to design more).
+2. T2 atom rename — `windowRankAtom` is my proposal; alternatives are `windowOrdinalAtom`, `windowPositionAtom`, or just keep `windowInstanceNumAtom` as a legacy name and only fix the user-facing copy. Pick one.
+3. T3 — accept that RPC rename requires a frontend+Rust same-PR change, or skip T3 entirely?
+4. Should we add a section to `CLAUDE.md` codifying the canonical terminology so it doesn't drift again?

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -516,6 +516,17 @@ async function reinitWave() {
  * Spec: docs/specs/SPEC_WINDOW_TITLE_FORMAT_2026-05-13.md
  */
 function installWindowTitleEffect(windowId: string): void {
+    // This window's launcher label, fetched async. Used as a fallback
+    // when entry.windowId-based findIndex returns -1 (which happens at
+    // startup before registerBackendWindow has populated the entry's
+    // windowId — see global.ts:145 comment). Without the label fallback,
+    // a freshly-opened second window resolves to idx=0 and the title
+    // shows "Window 1" while the InstancePanel correctly shows "Window 2"
+    // (because the panel iterates entries with positional indices).
+    // Same root cause as the InstancePanel resolveEntryWindowId fallback.
+    const [myLabel, setMyLabel] = createSignal<string | null>(null);
+    getApi().getWindowLabel().then((l) => setMyLabel(l)).catch(() => setMyLabel(null));
+
     // Capture dispose so the reactive root can be torn down explicitly.
     // In practice the CEF renderer is destroyed when the window closes,
     // taking the JS context (and the effect) with it — but routing
@@ -531,14 +542,50 @@ function installWindowTitleEffect(windowId: string): void {
             const win = WOS.getObjectValue<WaveWindow>(WOS.makeORef("window", windowId));
             const ws = atoms.workspace();
             const entries = openWindowEntriesAtom();
-            const idx = entries.findIndex((e) => e.windowId === windowId);
 
+            // Find this window's entry. Prefer windowId match; fall back
+            // to label when entry.windowId is null (registration race).
+            // If both fail, use 0 — a wrong rank is better than no title.
+            let idx = entries.findIndex((e) => e.windowId === windowId);
+            let idxSource: "windowId" | "label" | "fallback" = "windowId";
+            if (idx < 0) {
+                const lbl = myLabel();
+                if (lbl) {
+                    idx = entries.findIndex((e) => e.label === lbl);
+                    if (idx >= 0) idxSource = "label";
+                }
+            }
+            if (idx < 0) {
+                idx = 0;
+                idxSource = "fallback";
+            }
+
+            const displayName = win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined;
+            const workspaceName = ws?.name;
             const windowName = resolveWindowName({
-                displayName: win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined,
-                workspaceName: ws?.name,
-                indexInOpenWindows: idx >= 0 ? idx : 0,
+                displayName,
+                workspaceName,
+                indexInOpenWindows: idx,
             });
-            document.title = formatWindowTitle(windowName, tab?.name);
+            const title = formatWindowTitle(windowName, tab?.name);
+            document.title = title;
+
+            // Diagnostic log — cross-reference with [wave-panel] logs in
+            // InstancePanel.tsx to spot inconsistencies. Same windowId/label
+            // should produce the same windowName in both surfaces.
+            // Goes through frontend's [fe] log pipe → host log; tail with
+            // `muxlog host '\[fe\] \[wave-title\]'`.
+            console.debug(
+                "[wave-title]",
+                "windowId=" + windowId,
+                "label=" + (myLabel() ?? "<unknown>"),
+                "idx=" + idx,
+                "idxSource=" + idxSource,
+                "displayName=" + (displayName ?? "<none>"),
+                "workspaceName=" + (workspaceName ?? "<none>"),
+                "tab=" + (tab?.name ?? "<none>"),
+                "→ title=" + JSON.stringify(title),
+            );
         });
         return disposeFn;
     });

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -33,7 +33,7 @@ import {
     setFullConfigAtom,
 } from "@/app/store/global";
 import * as WOS from "@/app/store/wos";
-import { createEffect, createRoot } from "solid-js";
+import { createEffect, createRoot, createSignal } from "solid-js";
 import {
     DISPLAY_NAME_META_KEY,
     formatWindowTitle,

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -165,7 +165,26 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                 workspaceName = ws?.name;
             }
         }
-        return resolveWindowName({ displayName, workspaceName, indexInOpenWindows: idx });
+        const name = resolveWindowName({ displayName, workspaceName, indexInOpenWindows: idx });
+
+        // Diagnostic — for this window's row only, log the same shape as
+        // [wave-title] in app-init.ts. If both surfaces resolve the same
+        // window with different `name` values, the inputs disagree and
+        // the bug is the inputs (typically: idx mismatch from the
+        // registerBackendWindow race). Tail with:
+        //   muxlog host '\[fe\] \[wave-(title|panel)\]'
+        if (entry.label === myLabel()) {
+            console.debug(
+                "[wave-panel]",
+                "windowId=" + (windowId ?? "<null>"),
+                "label=" + entry.label,
+                "idx=" + idx,
+                "displayName=" + (displayName ?? "<none>"),
+                "workspaceName=" + (workspaceName ?? "<none>"),
+                "→ name=" + JSON.stringify(name),
+            );
+        }
+        return name;
     };
 
     const enterRename = (entry: WindowEntry, currentName: string) => {

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -15,7 +15,7 @@
  * Per-window token totals deferred until token-usage is per-window.
  */
 
-import { getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
+import { atoms, getApi, openWindowEntriesAtom, type WindowEntry } from "@/store/global";
 import { reconcileKnownEntriesFromSnapshot } from "@/app/store/launcher-event-reducer";
 import { launcherEventsActive } from "@/util/launcher-events";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
@@ -135,6 +135,20 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         }
     };
 
+    // For THIS window's row, fall back to atoms.waveWindow()?.oid when
+    // the entry's windowId is still null. WindowEntry.windowId is null
+    // for the first ~100ms after a window opens — until the
+    // registerBackendWindow IPC round-trip completes (see comment at
+    // global.ts:145). Without this fallback, the panel shows "Window N"
+    // for the current window during early-startup while the OS title
+    // (which uses initOpts.windowId directly) correctly shows the
+    // workspace name — visible inconsistency the user reported.
+    const resolveEntryWindowId = (entry: WindowEntry): string | null => {
+        if (entry.windowId) return entry.windowId;
+        if (entry.label === myLabel()) return atoms.waveWindow()?.oid ?? null;
+        return null;
+    };
+
     // Resolve a row's display name via the shared helper so the panel and
     // the OS window title (driven from app-init.ts) agree by construction.
     // Reactive via Wave's object subscriptions because getObjectValue reads
@@ -142,8 +156,9 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const resolveName = (entry: WindowEntry, idx: number): string => {
         let displayName: string | undefined;
         let workspaceName: string | undefined;
-        if (entry.windowId) {
-            const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
+        const windowId = resolveEntryWindowId(entry);
+        if (windowId) {
+            const win = getObjectValue<WaveWindow>(makeORef("window", windowId));
             displayName = win?.meta?.[DISPLAY_NAME_META_KEY] as string | undefined;
             if (win?.workspaceid) {
                 const ws = getObjectValue<Workspace>(makeORef("workspace", win.workspaceid));
@@ -154,7 +169,10 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     };
 
     const enterRename = (entry: WindowEntry, currentName: string) => {
-        if (!entry.windowId) return; // can't rename a window without a backend record yet
+        // Same fallback as resolveName: for this window's row we can use
+        // atoms.waveWindow()?.oid when the entry's windowId hasn't been
+        // populated yet via the registerBackendWindow round-trip.
+        if (!resolveEntryWindowId(entry)) return;
         setEditingLabel(entry.label);
         setEditValue(currentName);
     };
@@ -178,7 +196,8 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
     const commitRename = (entry: WindowEntry) => {
         const editing = editingLabel();
         if (editing !== entry.label) return; // stale
-        if (!entry.windowId) {
+        const windowId = resolveEntryWindowId(entry);
+        if (!windowId) {
             cancelRename();
             return;
         }
@@ -187,7 +206,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         setEditingLabel(null);
         setEditValue("");
         if (!trimmed) return;
-        performRename(entry.windowId, trimmed);
+        performRename(windowId, trimmed);
     };
 
     // Panel-unmount cleanup:
@@ -204,10 +223,12 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         const editing = editingLabel();
         if (!editing) return;
         const entry = entries().find((e) => e.label === editing);
-        if (!entry || !entry.windowId) return;
+        if (!entry) return;
+        const windowId = resolveEntryWindowId(entry);
+        if (!windowId) return;
         const trimmed = editValue().trim().slice(0, DISPLAY_NAME_MAX_LEN);
         if (!trimmed) return;
-        performRename(entry.windowId, trimmed);
+        performRename(windowId, trimmed);
     });
 
     const handleOpenNewWindow = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.892",
+  "version": "0.33.893",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.892",
+      "version": "0.33.893",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -269,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -896,6 +897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,6 +946,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1041,7 +1044,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1060,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1204,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1220,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1236,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1268,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1284,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1428,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,7 +1444,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,6 +1671,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1911,7 +1899,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1951,7 +1938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1958,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,7 +1978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,7 +1998,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,7 +2018,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2056,7 +2038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,7 +2058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,7 +2078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,7 +2098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2118,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2161,7 +2138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,7 +2158,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,7 +2257,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,7 +2270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,7 +2283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,7 +2296,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,7 +2322,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,7 +2335,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,7 +2348,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,7 +2361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,7 +2374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,7 +2387,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,7 +2400,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,7 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,7 +2426,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,7 +2439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,7 +2452,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,7 +2465,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,7 +2478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,7 +2504,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,7 +2517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2530,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,7 +2543,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,7 +2556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,7 +2569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2983,6 +2932,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3852,8 +3802,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3947,6 +3898,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4399,6 +4351,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4435,6 +4388,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4685,6 +4639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4698,6 +4653,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4865,6 +4827,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4890,7 +4853,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5123,6 +5086,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5532,6 +5496,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5742,7 +5707,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5861,7 +5826,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5928,6 +5893,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6226,7 +6192,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6343,7 +6308,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6389,7 +6353,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7072,7 +7036,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7224,7 +7188,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7244,7 +7208,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7435,7 +7399,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7614,6 +7578,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7681,7 +7646,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7714,7 +7679,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7735,7 +7699,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7756,7 +7719,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7777,7 +7739,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7798,7 +7759,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7819,7 +7779,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7840,7 +7799,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7861,7 +7819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7882,7 +7839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7903,7 +7859,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7924,7 +7879,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7989,6 +7943,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8520,6 +8486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9156,7 +9123,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9236,7 +9204,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9286,7 +9253,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9575,7 +9541,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9621,7 +9586,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9637,6 +9601,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9720,6 +9685,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9751,6 +9717,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9863,11 +9830,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10182,7 +10162,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10248,8 +10228,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10350,8 +10330,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10397,6 +10378,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10534,6 +10516,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10559,6 +10542,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10811,6 +10815,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11247,7 +11252,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11272,6 +11278,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11363,7 +11395,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11586,13 +11617,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11612,7 +11644,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11642,6 +11673,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11684,7 +11716,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11705,6 +11737,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11915,8 +11948,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12082,7 +12115,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12099,7 +12131,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12116,7 +12147,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12133,7 +12163,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12150,7 +12179,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12167,7 +12195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12184,7 +12211,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12201,7 +12227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12218,7 +12243,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12235,7 +12259,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12252,7 +12275,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12269,7 +12291,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12286,7 +12307,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12303,7 +12323,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12320,7 +12339,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12337,7 +12355,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,7 +12371,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12371,7 +12387,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12403,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12405,7 +12419,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12422,7 +12435,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12439,7 +12451,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12456,7 +12467,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12473,7 +12483,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12490,7 +12499,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12507,7 +12515,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12521,7 +12528,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12563,7 +12569,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12599,6 +12604,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.892",
+  "version": "0.33.893",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Adds an event-bus → frontend broadcast bridge so any reducer event automatically reaches the frontend WOS cache, eliminating the class of bug where mutation RPC handlers forgot to attach `WaveObjUpdate` to their response.

**Fixes the user-reported symptom:** workspace renames don't propagate to the OS title (added in #841) or the bottom-right InstancePanel.

## Why per-handler fixes weren't the right answer

`UpdateWorkspace` (`agentmux-srv/src/server/service.rs:1274-1307`) dispatches the rename → reducer → SQLite → publishes `WorkspaceRenamed` to `srv_events_tx`, then returns `success_empty()` instead of an inline `WaveObjUpdate`. The response-broadcast loop at `service.rs:39-52` only iterates response-attached updates; with nothing attached, no `\"waveobj:update\"` WS event ever fires. Frontend WOS stays stale.

Same shape will hit any future mutation RPC where the author forgets the convention. Per-handler fix patches one site; the bridge closes the class.

## Bridge architecture

NEW \`agentmux-srv/src/server/wave_obj_bridge.rs\` — a tokio task that:

1. Subscribes to \`srv_events_tx\` (same channel as \`persist_subscriber\` and \`disk_writer\`)
2. Translates each event variant into one or more \`WaveObjUpdate\` payloads
3. Pushes them to the existing \`event_bus.broadcast_event(...)\` path — **same downstream the response loop uses**

Frontend dedup at \`wos.ts:272\` (already in place via \`curValue.value.version >= update.obj.version\`) absorbs the now-doubled broadcasts for handlers that still attach updates, so this lands additively without disruption.

\`\`\`
        reducer → emits Event → srv_events_tx ─┬─► persist subscriber → SQLite (existing)
                                               ├─► disk writer → JSONL log (existing)
                                               └─► wave_obj_bridge → WaveObjUpdate → broadcast (NEW)
\`\`\`

## Phase 1 scope (this PR)

Mapping coverage in \`dispatch_event()\`:

| Reducer event | Action |
|---|---|
| \`WorkspaceRenamed\` | fetch + broadcast workspace as \"update\" |
| \`WorkspaceMetaUpdated\` | fetch + broadcast workspace as \"update\" |
| \`WorkspaceCreated\` | fetch + broadcast workspace as \"update\" |
| \`WorkspaceDeleted\` | broadcast oid only as \"delete\" |
| (everything else) | silent skip via catch-all \`_ => {}\` arm |

Catch-all makes the bridge future-proof for new event variants (silent skip until Phase 2 expands the mapping). Phase 2 (tab/block/window/layout) is mechanical expansion of the same match.

## Soundness (per spec §11 research log)

- **§11.1 — Subscribe ordering safe:** reducer mutates in-memory state synchronously before \`srv_events_tx.send()\` (\`service.rs:1283-1305\`). Bridge reads post-event state with no race.
- **§11.2 — Lock structure:** \`WaveStore\` uses \`std::sync::Mutex<Connection>\` (sync, not async). Bridge holds the lock briefly per event (one SQLite query); never \`.await\`s while held.
- **§11.3 — Compound events:** Phase 1's workspace events are single-object. Phase 2 will need to handle \`TabCreated\` etc. fetching both Tab + parent Workspace.
- **§11.4 — Version field universal:** all 6 \`WaveObj\` types have \`version: i64\`. Frontend dedup at \`wos.ts:272\` works universally.
- **§9 — Performance negligible:** \`srv_events_tx\` already has 2 subscribers; one more is cheap. Per-event work is one SQLite query.
- **Failure mode:** \`broadcast::error::RecvError::Lagged(n)\` is logged loudly with the skipped count so silent WOS divergence is visible to operators.

## Test plan

Pre-flight (done in PR):
- [x] \`cargo check -p agentmux-srv\` — clean (warnings unchanged from main)
- [x] \`npx tsc --noEmit\` — error count unchanged at 21 (all pre-existing)

Manual (post-merge or via fresh \`task dev\`):
- [ ] Rename a workspace → OS taskbar title updates immediately to \`<new name> - <tab> - AgentMux\`
- [ ] Open InstancePanel (click version chip) → row for that window shows the new workspace name
- [ ] Rename window via InstancePanel double-click → still works (regression — confirms the existing \`UpdateObjectMeta\` path coexists with the bridge)
- [ ] Open two windows, rename workspace → both windows' titles + both panels update (multi-client)

## Companion specs (in this commit)

| Spec | Purpose |
|------|---------|
| \`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md\` | Full design (this PR) |
| \`SPEC_REACTIVE_WORKSPACE_SYNC_2026-05-14.md\` | Root-cause analysis |
| \`SPEC_PERSISTENCE_LAYER_ANALYSIS_2026-05-14.md\` | \"Keep SQLite, deferred\" — sanity-check before any persistence change |
| \`SPEC_WINDOW_INSTANCE_NAMING_CLEANUP_2026-05-14.md\` | Independent follow-up: UI copy / atom name cleanup |
| \`SPEC_WAVE_TO_MUX_RENAME_2026-05-14.md\` | Wave Terminal branding rename (deferred mid-implementation; tracked in #851) |

## Out of scope

- Phase 2 (tab/block/window/layout event coverage)
- Phase 3 (retiring \`success_with_updates(...)\` calls now that the bridge covers them)
- Bridge metrics (lag count, dispatch latency) — current logging suffices