### PR TITLE
feat(srv): migrate UpdateWindowMeta through reducer (Phase E.5.x, closes #855)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.893"
+version = "0.33.894"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.893"
+version = "0.33.894"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.893"
+version = "0.33.894"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.893"
+version = "0.33.894"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.893"
+version = "0.33.894"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.893"
+version = "0.33.894"
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.893"
+version = "0.33.894"
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.893"
+version = "0.33.894"
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-common/src/ipc.rs
+++ b/agentmux-common/src/ipc.rs
@@ -395,6 +395,16 @@ pub enum Command {
         block_id: String,
         meta_patch: serde_json::Value,
     },
+    /// Phase E.5.x — apply a meta-patch to a window's `meta` map.
+    /// Same pass-through shape as `UpdateWorkspaceMeta`. Migrated
+    /// through the reducer per issue #855 so `Event::WindowMetaUpdated`
+    /// lands on `srv_events_tx` and the WaveObjUpdate broadcast bridge
+    /// picks it up — replaces the wcore-direct fallback that bypassed
+    /// reducer + bridge entirely.
+    UpdateWindowMeta {
+        window_id: String,
+        meta_patch: serde_json::Value,
+    },
     /// Phase E.5.5 — move a tab from one workspace to another.
     /// Reducer:
     /// * Removes `tab_id` from `src_workspace_id.tab_ids`.
@@ -1274,6 +1284,15 @@ pub enum Event {
     /// what changed without needing the prior state.
     WorkspaceMetaUpdated {
         workspace_id: String,
+        meta_patch: serde_json::Value,
+        version: u64,
+    },
+    /// Phase E.5.x (issue #855) — meta-patch applied to a window's
+    /// `meta` map. Same shape as `WorkspaceMetaUpdated`. Persist
+    /// subscriber merges into wstore; WaveObjUpdate bridge translates
+    /// to a frontend `waveobj:update` broadcast.
+    WindowMetaUpdated {
+        window_id: String,
         meta_patch: serde_json::Value,
         version: u64,
     },

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.893"
+version = "0.33.894"
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.893"
+version = "0.33.894"
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/agentmux-srv/src/event_log.rs
+++ b/agentmux-srv/src/event_log.rs
@@ -283,6 +283,7 @@ fn event_version(e: &Event) -> u64 {
         | Event::WorkspaceRenamed { version, .. }
         | Event::TabRenamed { version, .. }
         | Event::WorkspaceMetaUpdated { version, .. }
+        | Event::WindowMetaUpdated { version, .. }
         | Event::TabMetaUpdated { version, .. }
         | Event::BlockMetaUpdated { version, .. }
         | Event::TabMoved { version, .. }

--- a/agentmux-srv/src/persist_subscriber.rs
+++ b/agentmux-srv/src/persist_subscriber.rs
@@ -247,6 +247,11 @@ pub(crate) fn apply_event_to_wstore(
             meta_patch,
             ..
         } => apply_workspace_meta_updated(wstore, workspace_id, meta_patch),
+        Event::WindowMetaUpdated {
+            window_id,
+            meta_patch,
+            ..
+        } => apply_window_meta_updated(wstore, window_id, meta_patch),
         Event::TabMetaUpdated {
             tab_id,
             meta_patch,
@@ -729,6 +734,24 @@ fn apply_workspace_meta_updated(
     Ok(())
 }
 
+/// Phase E.5.x (issue #855) — apply a meta-patch to a window's `meta`
+/// map. Same shape as `apply_workspace_meta_updated`. Silent no-op if
+/// the window doesn't exist in wstore (preserves the idempotency
+/// contract — duplicate or stale events fold to no-op).
+fn apply_window_meta_updated(
+    wstore: &WaveStore,
+    window_id: &str,
+    meta_patch: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut window) = wstore.get::<Window>(window_id)? else {
+        return Ok(());
+    };
+    if merge_meta_patch(&mut window.meta, meta_patch) {
+        wstore.update(&mut window)?;
+    }
+    Ok(())
+}
+
 /// Phase E.5.3 — apply a meta-patch to a tab's `meta` map.
 fn apply_tab_meta_updated(
     wstore: &WaveStore,
@@ -965,6 +988,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::WorkspaceRenamed { .. } => "WorkspaceRenamed",
         Event::TabRenamed { .. } => "TabRenamed",
         Event::WorkspaceMetaUpdated { .. } => "WorkspaceMetaUpdated",
+        Event::WindowMetaUpdated { .. } => "WindowMetaUpdated",
         Event::TabMetaUpdated { .. } => "TabMetaUpdated",
         Event::BlockMetaUpdated { .. } => "BlockMetaUpdated",
         Event::TabMoved { .. } => "TabMoved",

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -152,6 +152,10 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
             block_id,
             meta_patch,
         } => block::handle_update_block_meta(state, block_id, meta_patch),
+        Command::UpdateWindowMeta {
+            window_id,
+            meta_patch,
+        } => window::handle_update_window_meta(state, window_id, meta_patch),
         Command::MoveTab {
             tab_id,
             src_workspace_id,

--- a/agentmux-srv/src/reducer/window.rs
+++ b/agentmux-srv/src/reducer/window.rs
@@ -100,3 +100,32 @@ pub(super) fn handle_switch_workspace(
         version: v,
     }]
 }
+
+/// Phase E.5.x (issue #855) — apply a meta-patch to a window. Pass-
+/// through to `Event::WindowMetaUpdated`; the persist subscriber
+/// performs the merge against wstore. Same shape as
+/// `handle_update_workspace_meta` — reducer state does NOT track
+/// window meta, the migration property is "every mutation goes
+/// through the reducer's broadcast bus" so the WaveObjUpdate bridge
+/// can fan out to the frontend.
+///
+/// The validation is best-effort: reducer state's `windows` map only
+/// holds windows for which a workspace mapping has been registered
+/// (via `handle_create_window`). Windows created via wcore-direct
+/// paths (legacy bootstrap) won't appear there but still exist in
+/// wstore. So we don't error on missing — the persist subscriber's
+/// `apply_window_meta_updated` will silently no-op if the window
+/// genuinely doesn't exist in wstore either, matching the
+/// idempotency contract for the bridge to broadcast (or skip).
+pub(super) fn handle_update_window_meta(
+    state: &mut State,
+    window_id: String,
+    meta_patch: serde_json::Value,
+) -> Vec<Event> {
+    let v = state.bump_version();
+    vec![Event::WindowMetaUpdated {
+        window_id,
+        meta_patch,
+        version: v,
+    }]
+}

--- a/agentmux-srv/src/server/service.rs
+++ b/agentmux-srv/src/server/service.rs
@@ -332,35 +332,22 @@ async fn dispatch_service(state: &AppState, call: &WebCallType) -> WebReturnType
                     block_id: oref.oid.clone(),
                     meta_patch: meta_value,
                 },
+                t if t == OTYPE_WINDOW => agentmux_common::ipc::Command::UpdateWindowMeta {
+                    window_id: oref.oid.clone(),
+                    meta_patch: meta_value,
+                },
                 other => {
-                    // Layouts + Windows aren't meta-mutated via the
-                    // reducer; fall back to wcore for forward-compat.
-                    //
-                    // For OTYPE_WINDOW, return the updated object inline
-                    // (matches the BLOCK/TAB inline-update pattern below).
-                    // Without this, UpdateObjectMeta on a Window returns
-                    // success_empty() and the frontend WOS cache never
-                    // sees the change — the change persists in SQLite
-                    // but the in-session UI shows stale data, so e.g. an
-                    // InstancePanel rename of `window:displayname`
-                    // "reverts" visually until app restart. (Reported by
-                    // user during PR #852 manual verification.)
+                    // Remaining otypes (Layout, Client, Temp) aren't
+                    // meta-mutated via the reducer yet; fall back to
+                    // wcore for forward-compat. They publish no event,
+                    // so the WaveObjUpdate bridge can't see them — the
+                    // frontend cache stays stale until next bootstrap
+                    // (deemed acceptable since these aren't user-edited).
+                    // Future Phase E.5.x migrations can add reducer arms
+                    // for any of these following the OTYPE_WINDOW pattern
+                    // above (per issue #855 retro).
                     return match update_object_meta(store, &oref_str, &meta_update) {
-                        Ok(()) => {
-                            if oref.otype == OTYPE_WINDOW {
-                                if let Ok(window) = store.must_get::<Window>(&oref.oid) {
-                                    return WebReturnType::success_with_updates(vec![
-                                        WaveObjUpdate {
-                                            updatetype: "update".into(),
-                                            otype: OTYPE_WINDOW.to_string(),
-                                            oid: oref.oid.clone(),
-                                            obj: Some(wave_obj_to_value(&window)),
-                                        },
-                                    ]);
-                                }
-                            }
-                            WebReturnType::success_empty()
-                        }
+                        Ok(()) => WebReturnType::success_empty(),
                         Err(e) => WebReturnType::error(format!(
                             "UpdateObjectMeta: unsupported otype {} via reducer; wcore fallback failed: {}",
                             other, e

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -32,7 +32,7 @@ use agentmux_common::ipc::Event;
 use tokio::sync::broadcast;
 
 use crate::backend::eventbus::{EventBus, WSEventType};
-use crate::backend::obj::{wave_obj_to_value, OTYPE_WORKSPACE};
+use crate::backend::obj::{wave_obj_to_value, OTYPE_WINDOW, OTYPE_WORKSPACE};
 use crate::backend::storage::wstore::WaveStore;
 
 /// JSON shape that gets broadcast as the `data` payload of a
@@ -94,7 +94,7 @@ fn emit(event_bus: &EventBus, otype: &str, oid: &str, payload: serde_json::Value
 /// this tokio worker thread. We therefore do the SQLite read inside
 /// `tokio::task::spawn_blocking` so the async runtime stays responsive.
 async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<EventBus>) {
-    use crate::backend::obj::Workspace;
+    use crate::backend::obj::{Window, Workspace};
 
     match event {
         Event::WorkspaceRenamed { workspace_id, .. }
@@ -151,6 +151,51 @@ async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<Eve
             // No object to fetch — frontend just needs the oid + delete tag.
             let payload = build_update_payload("delete", OTYPE_WORKSPACE, &workspace_id, None);
             emit(&event_bus, OTYPE_WORKSPACE, &workspace_id, payload);
+        }
+
+        // Phase E.5.x (issue #855) — window meta updates now flow through
+        // the reducer; this arm picks them up and broadcasts the updated
+        // Window to the frontend WOS cache. Replaces the previous
+        // service.rs:308 wcore-direct workaround that had to inline the
+        // WaveObjUpdate in the handler response.
+        Event::WindowMetaUpdated { window_id, .. } => {
+            let id = window_id.clone();
+            let store = Arc::clone(&wstore);
+            let result = tokio::task::spawn_blocking(move || store.get::<Window>(&id)).await;
+            match result {
+                Ok(Ok(Some(window))) => {
+                    let payload = build_update_payload(
+                        "update",
+                        OTYPE_WINDOW,
+                        &window_id,
+                        Some(wave_obj_to_value(&window)),
+                    );
+                    emit(&event_bus, OTYPE_WINDOW, &window_id, payload);
+                }
+                Ok(Ok(None)) => {
+                    tracing::warn!(
+                        target: "wave-obj-bridge",
+                        window_id = %window_id,
+                        "WindowMetaUpdated for missing window; skipping broadcast"
+                    );
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        target: "wave-obj-bridge",
+                        window_id = %window_id,
+                        error = %e,
+                        "wstore.get::<Window> failed; skipping broadcast"
+                    );
+                }
+                Err(join_err) => {
+                    tracing::error!(
+                        target: "wave-obj-bridge",
+                        window_id = %window_id,
+                        error = %join_err,
+                        "spawn_blocking join failed (likely panicked); skipping broadcast"
+                    );
+                }
+            }
         }
 
         // All other event variants are either not WaveObj-affecting (saga

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.893",
+  "version": "0.33.894",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.893",
+      "version": "0.33.894",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -4388,7 +4388,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11617,8 +11616,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.893",
+  "version": "0.33.894",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes #855. Replaces the wcore-direct fallback for `OTYPE_WINDOW` that PR #852 shipped as a temporary workaround. Window meta updates now flow through the standard reducer → persist + bridge path, fitting cleanly into the Phase E migration arc and master spec §8.15 (srv-event subscriber idempotency contract).

## Why

PR #852 surfaced the gap: `service.rs:308` `UpdateObjectMeta` handler routes WORKSPACE/TAB/BLOCK through the reducer (Phase E.5.3) but Window fell into the `_ => other` arm that uses wcore-direct. With no event published, the bridge couldn't see the change → frontend WOS cache stayed stale → window display-name renames "reverted" visually until app restart. PR #852 added an inline-update workaround in the wcore-direct branch; this PR retires that workaround by completing the migration.

## Flow

```
service.rs UpdateObjectMeta(OTYPE_WINDOW, meta_patch)
  ↓
Command::UpdateWindowMeta { window_id, meta_patch }                    ← NEW (ipc.rs)
  ↓ dispatch_to_reducer
reducer/window.rs::handle_update_window_meta                           ← NEW
  ↓ emits
Event::WindowMetaUpdated { window_id, meta_patch, version }            ← NEW (ipc.rs)
  ↓ publish_events → srv_events_tx
  ├─► persist_subscriber → apply_window_meta_updated → wstore SQLite   ← NEW
  └─► wave_obj_bridge → broadcast WaveObjUpdate (frontend WS)          ← NEW arm
```

Mirrors the existing `UpdateWorkspaceMeta` shape exactly — pass-through reducer (no in-memory state mutation; reducer state doesn't track window meta), persist subscriber merges into `wstore`, bridge broadcasts the updated Window to the frontend WOS cache.

## Files

| File | Change |
|------|--------|
| `agentmux-common/src/ipc.rs` | NEW `Command::UpdateWindowMeta` + `Event::WindowMetaUpdated` |
| `agentmux-srv/src/reducer.rs` | dispatch arm for `Command::UpdateWindowMeta` |
| `agentmux-srv/src/reducer/window.rs` | NEW `handle_update_window_meta` |
| `agentmux-srv/src/persist_subscriber.rs` | NEW `apply_window_meta_updated` + match arm + `event_kind_name` entry |
| `agentmux-srv/src/event_log.rs` | exhaustive `event_version` match (added `WindowMetaUpdated`) |
| `agentmux-srv/src/server/service.rs` | route `OTYPE_WINDOW` through `Command::UpdateWindowMeta`; **drop the inline-update workaround** from PR #852 |
| `agentmux-srv/src/server/wave_obj_bridge.rs` | NEW `dispatch_event` arm for `Event::WindowMetaUpdated` (uses same `spawn_blocking` + error-logging pattern as the workspace arm) |

## What stays

- The `_ => other` wcore-fallback branch in `service.rs:UpdateObjectMeta` still exists for `OTYPE_LAYOUT`, `OTYPE_CLIENT`, `OTYPE_TEMP` (no user-facing meta paths today). Future Phase E.5.x PRs can migrate any of them following the same `OTYPE_WINDOW` template.
- Bridge spec's mapping table (§5.1) already listed `WindowMetaUpdated` as a Phase 2 row; this PR just lights it up. Other Phase 2 rows (TabCreated, BlockCreated, etc.) remain unimplemented in the bridge.

## Soundness

- §8.15 (master spec): `apply_window_meta_updated` is silent no-op if the window doesn't exist in `wstore` — matches the persist subscriber idempotency contract.
- Bridge arm for `Event::WindowMetaUpdated` uses the same `tokio::task::spawn_blocking` pattern as the workspace arm (per ReAgent P1 on PR #852).
- Reducer doesn't validate window existence (best-effort) because `state.windows` only holds windows registered via `handle_create_window`; legacy bootstrap-created windows live in wstore but not state. This matches the persist arm's silent-skip behavior.

## Test plan

Pre-flight (done in PR):
- [x] `cargo check -p agentmux-srv` — clean (warnings unchanged from main)

Manual (post-merge or via fresh `task dev`):
- [ ] Open InstancePanel → double-click row → rename window → Enter
- [ ] **Expected**: title + panel update immediately to the new name (no "revert" visual)
- [ ] Close + reopen the window: persisted display name comes back

## Companion

- Master spec [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md) §8.15 (srv-event subscriber contract) — this PR adds another command that emits onto the bus
- Bridge spec [`SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md) §5.1 — `WindowMetaUpdated` Phase 2 row, now lit up
- Issue [#855](https://github.com/agentmuxai/agentmux/issues/855) — the follow-up filed during PR #852 review; this PR closes it