### PR TITLE
feat(bridge): Phase 2 — tab/block/window/layout event arms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.896"
+version = "0.33.897"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.896"
+version = "0.33.897"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.896"
+version = "0.33.897"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.896"
+version = "0.33.897"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.896"
+version = "0.33.897"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.897"
+version = "0.33.898"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.897"
+version = "0.33.898"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.897"
+version = "0.33.898"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.897"
+version = "0.33.898"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.897"
+version = "0.33.898"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.33.896"
+version = "0.33.898"
 
 [profile.release]
 strip = true

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -33,8 +33,8 @@ use tokio::sync::broadcast;
 
 use crate::backend::eventbus::{EventBus, WSEventType};
 use crate::backend::obj::{
-    wave_obj_to_value, Tab, WaveObj, OTYPE_BLOCK, OTYPE_LAYOUT, OTYPE_TAB, OTYPE_WINDOW,
-    OTYPE_WORKSPACE,
+    wave_obj_to_value, Client, Tab, WaveObj, OTYPE_BLOCK, OTYPE_CLIENT, OTYPE_LAYOUT, OTYPE_TAB,
+    OTYPE_WINDOW, OTYPE_WORKSPACE,
 };
 use crate::backend::storage::wstore::WaveStore;
 
@@ -127,6 +127,58 @@ async fn emit_fetched<T: WaveObj + Send + 'static>(
 fn emit_delete(event_bus: &EventBus, otype: &'static str, oid: &str) {
     let payload = build_update_payload("delete", otype, oid, None);
     emit(event_bus, otype, oid, payload);
+}
+
+/// Broadcast the singleton `Client` WaveObj. SrvWindowOpened /
+/// SrvWindowClosed mutate `Client.windowids` (per
+/// `apply_srv_window_opened` in persist_subscriber.rs:518) so renderers
+/// holding a pinned Client need to see the new windowids list — without
+/// this broadcast they'd render stale window membership until reload.
+/// Codex P2 on PR #861.
+///
+/// Client is a singleton — the first `get_all::<Client>()` row is THE
+/// client. Same lookup pattern persist_subscriber uses.
+async fn emit_client_singleton(
+    wstore: &Arc<WaveStore>,
+    event_bus: &Arc<EventBus>,
+    context: &'static str,
+) {
+    let store = Arc::clone(wstore);
+    let result = tokio::task::spawn_blocking(move || store.get_all::<Client>()).await;
+    match result {
+        Ok(Ok(clients)) => {
+            if let Some(client) = clients.into_iter().next() {
+                let oid = client.oid.clone();
+                let payload = build_update_payload(
+                    "update",
+                    OTYPE_CLIENT,
+                    &oid,
+                    Some(wave_obj_to_value(&client)),
+                );
+                emit(event_bus, OTYPE_CLIENT, &oid, payload);
+            } else {
+                tracing::warn!(
+                    target: "wave-obj-bridge",
+                    ctx = context,
+                    "no Client row in wstore; skipping Client broadcast"
+                );
+            }
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                ctx = context, error = %e,
+                "wstore.get_all::<Client> failed; skipping broadcast"
+            );
+        }
+        Err(je) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                ctx = context, error = %je,
+                "spawn_blocking join failed during Client lookup"
+            );
+        }
+    }
 }
 
 /// Layout events all reference a `tab_id`; the affected WaveObj is the
@@ -236,16 +288,34 @@ async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<Eve
         }
 
         // ----- Window (Phase 2 + #855) -----
-        Event::WindowMetaUpdated { window_id, .. }
-        | Event::SrvWindowOpened { window_id, .. }
-        | Event::SrvWindowWorkspaceChanged { window_id, .. } => {
+        Event::WindowMetaUpdated { window_id, .. } => {
             emit_fetched::<Window>(
-                &wstore, &event_bus, OTYPE_WINDOW, window_id, "Window*",
+                &wstore, &event_bus, OTYPE_WINDOW, window_id, "WindowMetaUpdated",
             )
             .await;
         }
+        Event::SrvWindowWorkspaceChanged { window_id, .. } => {
+            emit_fetched::<Window>(
+                &wstore, &event_bus, OTYPE_WINDOW, window_id, "SrvWindowWorkspaceChanged",
+            )
+            .await;
+        }
+        // SrvWindowOpened/Closed: the persist path
+        // (apply_srv_window_opened / apply_srv_window_closed) ALSO
+        // mutates Client.windowids inside the same transaction, so
+        // renderers with a pinned Client need to see the updated
+        // singleton too — otherwise their window list lags behind
+        // until reload. (Codex P2 on PR #861.)
+        Event::SrvWindowOpened { window_id, .. } => {
+            emit_fetched::<Window>(
+                &wstore, &event_bus, OTYPE_WINDOW, window_id, "SrvWindowOpened",
+            )
+            .await;
+            emit_client_singleton(&wstore, &event_bus, "SrvWindowOpened").await;
+        }
         Event::SrvWindowClosed { window_id, .. } => {
             emit_delete(&event_bus, OTYPE_WINDOW, &window_id);
+            emit_client_singleton(&wstore, &event_bus, "SrvWindowClosed").await;
         }
 
         // ----- Tab (Phase 2) -----
@@ -360,24 +430,22 @@ async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<Eve
                 .await;
         }
 
-        // ----- Layout (Phase 2) -----
-        // All layout events affect the LayoutState that the named tab
-        // references via `tab.layoutstate`. emit_layout_for_tab handles
-        // the tab → layoutstate id → LayoutState chain.
+        // ----- Layout (Phase 2 — partial) -----
+        // ONLY the focused/magnified events are persisted by
+        // `apply_event_to_wstore` (persist_subscriber.rs:289-292).
+        // The other 11 layout-tree events (Insert/Delete/Move/Swap/
+        // Resize/Replace/Split*/Clear/TreeReplaced) are persisted via
+        // wcore-direct in their RPC handlers — they DON'T appear in
+        // `apply_event_to_wstore`. If the bridge tried to broadcast
+        // LayoutState for those, `wstore.get<LayoutState>` could return
+        // pre-event tree state (subscriber and bridge race; only this
+        // one is the unsafe direction). Tracked as a follow-up issue
+        // for the layout-tree-event persistence migration. Until then,
+        // those handlers' existing `success_with_updates(...)` response
+        // broadcasts cover the frontend (Codex P2 on PR #861).
         Event::FocusedNodeChanged { tab_id, .. }
-        | Event::MagnifiedNodeChanged { tab_id, .. }
-        | Event::LayoutNodeInserted { tab_id, .. }
-        | Event::LayoutNodeInsertedAtIndex { tab_id, .. }
-        | Event::LayoutNodeDeleted { tab_id, .. }
-        | Event::LayoutNodeMoved { tab_id, .. }
-        | Event::LayoutNodesSwapped { tab_id, .. }
-        | Event::LayoutNodesResized { tab_id, .. }
-        | Event::LayoutNodeReplaced { tab_id, .. }
-        | Event::LayoutSplitHorizontalApplied { tab_id, .. }
-        | Event::LayoutSplitVerticalApplied { tab_id, .. }
-        | Event::LayoutCleared { tab_id, .. }
-        | Event::LayoutTreeReplaced { tab_id, .. } => {
-            emit_layout_for_tab(&wstore, &event_bus, tab_id, "Layout*").await;
+        | Event::MagnifiedNodeChanged { tab_id, .. } => {
+            emit_layout_for_tab(&wstore, &event_bus, tab_id, "Focused/MagnifiedNodeChanged").await;
         }
 
         // Saga lifecycle, launcher-domain events, OS facts, etc. — not

--- a/agentmux-srv/src/server/wave_obj_bridge.rs
+++ b/agentmux-srv/src/server/wave_obj_bridge.rs
@@ -32,7 +32,10 @@ use agentmux_common::ipc::Event;
 use tokio::sync::broadcast;
 
 use crate::backend::eventbus::{EventBus, WSEventType};
-use crate::backend::obj::{wave_obj_to_value, OTYPE_WINDOW, OTYPE_WORKSPACE};
+use crate::backend::obj::{
+    wave_obj_to_value, Tab, WaveObj, OTYPE_BLOCK, OTYPE_LAYOUT, OTYPE_TAB, OTYPE_WINDOW,
+    OTYPE_WORKSPACE,
+};
 use crate::backend::storage::wstore::WaveStore;
 
 /// JSON shape that gets broadcast as the `data` payload of a
@@ -67,141 +70,319 @@ fn emit(event_bus: &EventBus, otype: &str, oid: &str, payload: serde_json::Value
     });
 }
 
+/// Fetch one WaveObj by oid and broadcast it as a `waveobj:update`. The
+/// SQLite read is offloaded to the blocking thread pool per ReAgent P1
+/// on PR #852 (WaveStore is `std::sync::Mutex<Connection>`; brief in
+/// steady state but a long reducer transaction would block the tokio
+/// worker thread). Silently logs + skips on missing/error to satisfy
+/// the §8.15 idempotency contract — duplicate or stale events fold to
+/// no-op.
+async fn emit_fetched<T: WaveObj + Send + 'static>(
+    wstore: &Arc<WaveStore>,
+    event_bus: &Arc<EventBus>,
+    otype: &'static str,
+    oid: String,
+    context: &'static str,
+) {
+    let id = oid.clone();
+    let store = Arc::clone(wstore);
+    let result = tokio::task::spawn_blocking(move || store.get::<T>(&id)).await;
+    match result {
+        Ok(Ok(Some(obj))) => {
+            let payload = build_update_payload(
+                "update",
+                otype,
+                &oid,
+                Some(wave_obj_to_value(&obj)),
+            );
+            emit(event_bus, otype, &oid, payload);
+        }
+        Ok(Ok(None)) => {
+            tracing::warn!(
+                target: "wave-obj-bridge",
+                oid = %oid, otype = otype, ctx = context,
+                "object not found in wstore; skipping broadcast"
+            );
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                oid = %oid, otype = otype, ctx = context, error = %e,
+                "wstore.get failed; skipping broadcast"
+            );
+        }
+        Err(join_err) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                oid = %oid, otype = otype, ctx = context, error = %join_err,
+                "spawn_blocking join failed (likely panicked); skipping broadcast"
+            );
+        }
+    }
+}
+
+/// Broadcast a "delete" `waveobj:update` for the given oid. No fetch
+/// needed — the frontend's `updateWaveObject` (`wos.ts:263-265`) handles
+/// the delete arm with just the oid.
+fn emit_delete(event_bus: &EventBus, otype: &'static str, oid: &str) {
+    let payload = build_update_payload("delete", otype, oid, None);
+    emit(event_bus, otype, oid, payload);
+}
+
+/// Layout events all reference a `tab_id`; the affected WaveObj is the
+/// `LayoutState` referenced by the tab's `layoutstate` field. Two
+/// SQLite reads chained inside one `spawn_blocking` to keep the lock
+/// hold short.
+async fn emit_layout_for_tab(
+    wstore: &Arc<WaveStore>,
+    event_bus: &Arc<EventBus>,
+    tab_id: String,
+    context: &'static str,
+) {
+    use crate::backend::obj::LayoutState;
+    let id_for_log = tab_id.clone();
+    let store = Arc::clone(wstore);
+    let result = tokio::task::spawn_blocking(move || -> Result<Option<LayoutState>, _> {
+        match store.get::<Tab>(&tab_id) {
+            Ok(Some(tab)) => {
+                if tab.layoutstate.is_empty() {
+                    Ok(None)
+                } else {
+                    store.get::<LayoutState>(&tab.layoutstate)
+                }
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(e),
+        }
+    })
+    .await;
+    match result {
+        Ok(Ok(Some(layout))) => {
+            let layout_id = layout.oid.clone();
+            let payload = build_update_payload(
+                "update",
+                OTYPE_LAYOUT,
+                &layout_id,
+                Some(wave_obj_to_value(&layout)),
+            );
+            emit(event_bus, OTYPE_LAYOUT, &layout_id, payload);
+        }
+        Ok(Ok(None)) => {
+            tracing::warn!(
+                target: "wave-obj-bridge",
+                tab_id = %id_for_log, ctx = context,
+                "layout event but tab/layoutstate not found; skipping broadcast"
+            );
+        }
+        Ok(Err(e)) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                tab_id = %id_for_log, ctx = context, error = %e,
+                "wstore.get failed during layout resolution; skipping broadcast"
+            );
+        }
+        Err(join_err) => {
+            tracing::error!(
+                target: "wave-obj-bridge",
+                tab_id = %id_for_log, ctx = context, error = %join_err,
+                "spawn_blocking join failed during layout resolution"
+            );
+        }
+    }
+}
+
 /// Translate one reducer event into zero or more `waveobj:update` broadcasts.
 ///
-/// Phase 1 covers the four workspace events. Other variants intentionally
-/// fall through to the catch-all `_ => {}` arm — they're either not
-/// WaveObj-affecting (saga lifecycle, OS facts, etc.) or scheduled for
-/// Phase 2 expansion.
-///
 /// **Read source — post-event state guarantee:**
-/// For Phase 1 (workspace events), every workspace mutation flows through
-/// the HTTP `service.rs:UpdateWorkspace` handler which calls
-/// `apply_event_to_wstore` synchronously (`service.rs:1297-1304`) before
-/// `publish_events` (`service.rs:1305`). So when the bridge receives a
-/// workspace event, SQLite is already up-to-date.
+/// For events emitted via the HTTP `service.rs` RPC handlers,
+/// `apply_event_to_wstore` is called synchronously (`service.rs:1297-1304`
+/// for workspace; equivalent path for tab/block/window/layout commands)
+/// before `publish_events` (`service.rs:1305`). So when the bridge
+/// receives such an event, SQLite is already up-to-date.
 ///
-/// **Phase 2 caveat:** for tab/block events that the launcher → IPC path
-/// in `srv_ipc/server.rs:295` may publish without first applying to
-/// SQLite, the persist subscriber and bridge race. Phase 2 should either
-/// (a) make the IPC path apply synchronously like the HTTP path does, or
-/// (b) read from the in-memory `srv_state` reducer rather than SQLite.
-/// Tracked in `SPEC_OBJ_UPDATE_BRIDGE §11.1` follow-up.
+/// **IPC-path caveat:** the launcher → IPC path in `srv_ipc/server.rs:295`
+/// dispatches reducer events directly without first calling
+/// `apply_event_to_wstore`; the persist subscriber and bridge then race.
+/// At time of writing none of the events the bridge handles are emitted
+/// via that path (verified for `Command::UpdateWindowMeta` and the
+/// workspace family). When that changes, options are: (a) make the IPC
+/// path apply synchronously like HTTP does, or (b) read from the
+/// in-memory `srv_state` reducer rather than SQLite. Tracked in
+/// `SPEC_OBJ_UPDATE_BRIDGE §11.1`.
 ///
-/// **Lock discipline (per ReAgent P1 on PR #852):** `WaveStore::get<T>()`
-/// acquires `std::sync::Mutex<Connection>` (blocking). Even though the
-/// hold is brief in steady state, a long reducer transaction could block
-/// this tokio worker thread. We therefore do the SQLite read inside
-/// `tokio::task::spawn_blocking` so the async runtime stays responsive.
+/// **Lock discipline (per ReAgent P1 on PR #852):** every `wstore.get<T>()`
+/// is wrapped in `tokio::task::spawn_blocking` via the helpers above so
+/// the async runtime stays responsive even under reducer-transaction
+/// contention.
+///
+/// **Coverage:** Phase 1 + 2 covers workspace, window, tab, block, layout
+/// events. Saga events, OS facts, launcher-domain events all fall through
+/// to the catch-all `_ => {}` arm.
 async fn dispatch_event(event: Event, wstore: Arc<WaveStore>, event_bus: Arc<EventBus>) {
-    use crate::backend::obj::{Window, Workspace};
+    use crate::backend::obj::{Block, Window, Workspace};
 
     match event {
+        // ----- Workspace -----
         Event::WorkspaceRenamed { workspace_id, .. }
         | Event::WorkspaceMetaUpdated { workspace_id, .. }
         | Event::WorkspaceCreated { workspace_id, .. } => {
-            // Offload the blocking SQLite read to the blocking thread pool
-            // so async worker threads stay free for I/O-bound work.
-            let id = workspace_id.clone();
-            let store = Arc::clone(&wstore);
-            let result = tokio::task::spawn_blocking(move || store.get::<Workspace>(&id)).await;
-            match result {
-                Ok(Ok(Some(ws))) => {
-                    // "update" for both create and update — the frontend's
-                    // updateWaveObject (`wos.ts:259-279`) treats anything
-                    // not "delete" identically. Sending "update" uniformly
-                    // simplifies the bridge's logic and matches what the
-                    // existing response-broadcast loop emits for the same
-                    // events.
-                    let payload = build_update_payload(
-                        "update",
-                        OTYPE_WORKSPACE,
-                        &workspace_id,
-                        Some(wave_obj_to_value(&ws)),
-                    );
-                    emit(&event_bus, OTYPE_WORKSPACE, &workspace_id, payload);
-                }
-                Ok(Ok(None)) => {
-                    tracing::warn!(
-                        target: "wave-obj-bridge",
-                        workspace_id = %workspace_id,
-                        "workspace event for missing workspace; skipping broadcast"
-                    );
-                }
-                Ok(Err(e)) => {
-                    tracing::error!(
-                        target: "wave-obj-bridge",
-                        workspace_id = %workspace_id,
-                        error = %e,
-                        "wstore.get::<Workspace> failed; skipping broadcast"
-                    );
-                }
-                Err(join_err) => {
-                    tracing::error!(
-                        target: "wave-obj-bridge",
-                        workspace_id = %workspace_id,
-                        error = %join_err,
-                        "spawn_blocking join failed (likely panicked); skipping broadcast"
-                    );
-                }
-            }
+            emit_fetched::<Workspace>(
+                &wstore, &event_bus, OTYPE_WORKSPACE, workspace_id, "Workspace*",
+            )
+            .await;
         }
-
         Event::WorkspaceDeleted { workspace_id, .. } => {
-            // No object to fetch — frontend just needs the oid + delete tag.
-            let payload = build_update_payload("delete", OTYPE_WORKSPACE, &workspace_id, None);
-            emit(&event_bus, OTYPE_WORKSPACE, &workspace_id, payload);
+            emit_delete(&event_bus, OTYPE_WORKSPACE, &workspace_id);
         }
 
-        // Phase E.5.x (issue #855) — window meta updates now flow through
-        // the reducer; this arm picks them up and broadcasts the updated
-        // Window to the frontend WOS cache. Replaces the previous
-        // service.rs:308 wcore-direct workaround that had to inline the
-        // WaveObjUpdate in the handler response.
-        Event::WindowMetaUpdated { window_id, .. } => {
-            let id = window_id.clone();
-            let store = Arc::clone(&wstore);
-            let result = tokio::task::spawn_blocking(move || store.get::<Window>(&id)).await;
-            match result {
-                Ok(Ok(Some(window))) => {
-                    let payload = build_update_payload(
-                        "update",
-                        OTYPE_WINDOW,
-                        &window_id,
-                        Some(wave_obj_to_value(&window)),
-                    );
-                    emit(&event_bus, OTYPE_WINDOW, &window_id, payload);
-                }
-                Ok(Ok(None)) => {
-                    tracing::warn!(
-                        target: "wave-obj-bridge",
-                        window_id = %window_id,
-                        "WindowMetaUpdated for missing window; skipping broadcast"
-                    );
-                }
-                Ok(Err(e)) => {
-                    tracing::error!(
-                        target: "wave-obj-bridge",
-                        window_id = %window_id,
-                        error = %e,
-                        "wstore.get::<Window> failed; skipping broadcast"
-                    );
-                }
-                Err(join_err) => {
-                    tracing::error!(
-                        target: "wave-obj-bridge",
-                        window_id = %window_id,
-                        error = %join_err,
-                        "spawn_blocking join failed (likely panicked); skipping broadcast"
-                    );
-                }
-            }
+        // ----- Window (Phase 2 + #855) -----
+        Event::WindowMetaUpdated { window_id, .. }
+        | Event::SrvWindowOpened { window_id, .. }
+        | Event::SrvWindowWorkspaceChanged { window_id, .. } => {
+            emit_fetched::<Window>(
+                &wstore, &event_bus, OTYPE_WINDOW, window_id, "Window*",
+            )
+            .await;
+        }
+        Event::SrvWindowClosed { window_id, .. } => {
+            emit_delete(&event_bus, OTYPE_WINDOW, &window_id);
         }
 
-        // All other event variants are either not WaveObj-affecting (saga
-        // lifecycle, OS facts, …) or pending Phase 2 coverage. Silent skip
-        // is correct — the catch-all _ arm makes this future-proof for new
-        // event variants the reducer may add.
+        // ----- Tab (Phase 2) -----
+        // TabCreated also touches the parent workspace's tab_ids field
+        // (reducer mutates both in one dispatch). Broadcast both so the
+        // frontend WOS sees the new Tab AND the updated parent ordering.
+        Event::TabCreated {
+            workspace_id,
+            tab_id,
+            ..
+        } => {
+            emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, tab_id, "TabCreated").await;
+            emit_fetched::<Workspace>(
+                &wstore, &event_bus, OTYPE_WORKSPACE, workspace_id, "TabCreated parent",
+            )
+            .await;
+        }
+        Event::TabDeleted {
+            workspace_id,
+            tab_id,
+            ..
+        } => {
+            emit_delete(&event_bus, OTYPE_TAB, &tab_id);
+            emit_fetched::<Workspace>(
+                &wstore, &event_bus, OTYPE_WORKSPACE, workspace_id, "TabDeleted parent",
+            )
+            .await;
+        }
+        Event::TabRenamed { tab_id, .. } | Event::TabMetaUpdated { tab_id, .. } => {
+            emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, tab_id, "Tab*").await;
+        }
+        Event::ActiveTabChanged { workspace_id, .. }
+        | Event::TabReordered { workspace_id, .. }
+        | Event::TabsReorderedBulk { workspace_id, .. } => {
+            emit_fetched::<Workspace>(
+                &wstore,
+                &event_bus,
+                OTYPE_WORKSPACE,
+                workspace_id,
+                "ActiveTab/Reorder",
+            )
+            .await;
+        }
+        Event::TabMoved {
+            tab_id,
+            src_workspace_id,
+            dst_workspace_id,
+            ..
+        } => {
+            emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, tab_id, "TabMoved").await;
+            emit_fetched::<Workspace>(
+                &wstore,
+                &event_bus,
+                OTYPE_WORKSPACE,
+                src_workspace_id,
+                "TabMoved src",
+            )
+            .await;
+            emit_fetched::<Workspace>(
+                &wstore,
+                &event_bus,
+                OTYPE_WORKSPACE,
+                dst_workspace_id,
+                "TabMoved dst",
+            )
+            .await;
+        }
+
+        // ----- Block (Phase 2) -----
+        // BlockCreated/BlockDeleted touch the parent tab's blockids field.
+        Event::BlockCreated {
+            tab_id, block_id, ..
+        } => {
+            emit_fetched::<Block>(
+                &wstore, &event_bus, OTYPE_BLOCK, block_id, "BlockCreated",
+            )
+            .await;
+            emit_fetched::<Tab>(
+                &wstore, &event_bus, OTYPE_TAB, tab_id, "BlockCreated parent",
+            )
+            .await;
+        }
+        Event::BlockDeleted {
+            tab_id, block_id, ..
+        } => {
+            emit_delete(&event_bus, OTYPE_BLOCK, &block_id);
+            emit_fetched::<Tab>(
+                &wstore, &event_bus, OTYPE_TAB, tab_id, "BlockDeleted parent",
+            )
+            .await;
+        }
+        Event::BlockMetaUpdated { block_id, .. } => {
+            emit_fetched::<Block>(
+                &wstore,
+                &event_bus,
+                OTYPE_BLOCK,
+                block_id,
+                "BlockMetaUpdated",
+            )
+            .await;
+        }
+        Event::BlockMoved {
+            block_id,
+            src_tab_id,
+            dst_tab_id,
+            ..
+        } => {
+            emit_fetched::<Block>(&wstore, &event_bus, OTYPE_BLOCK, block_id, "BlockMoved").await;
+            emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, src_tab_id, "BlockMoved src")
+                .await;
+            emit_fetched::<Tab>(&wstore, &event_bus, OTYPE_TAB, dst_tab_id, "BlockMoved dst")
+                .await;
+        }
+
+        // ----- Layout (Phase 2) -----
+        // All layout events affect the LayoutState that the named tab
+        // references via `tab.layoutstate`. emit_layout_for_tab handles
+        // the tab → layoutstate id → LayoutState chain.
+        Event::FocusedNodeChanged { tab_id, .. }
+        | Event::MagnifiedNodeChanged { tab_id, .. }
+        | Event::LayoutNodeInserted { tab_id, .. }
+        | Event::LayoutNodeInsertedAtIndex { tab_id, .. }
+        | Event::LayoutNodeDeleted { tab_id, .. }
+        | Event::LayoutNodeMoved { tab_id, .. }
+        | Event::LayoutNodesSwapped { tab_id, .. }
+        | Event::LayoutNodesResized { tab_id, .. }
+        | Event::LayoutNodeReplaced { tab_id, .. }
+        | Event::LayoutSplitHorizontalApplied { tab_id, .. }
+        | Event::LayoutSplitVerticalApplied { tab_id, .. }
+        | Event::LayoutCleared { tab_id, .. }
+        | Event::LayoutTreeReplaced { tab_id, .. } => {
+            emit_layout_for_tab(&wstore, &event_bus, tab_id, "Layout*").await;
+        }
+
+        // Saga lifecycle, launcher-domain events, OS facts, etc. — not
+        // WaveObj changes. The catch-all keeps the bridge future-proof
+        // for new event variants the reducer may add.
         _ => {}
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.896",
+  "version": "0.33.897",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.896",
+      "version": "0.33.897",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -4388,7 +4388,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11617,8 +11616,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.897",
+  "version": "0.33.898",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.897",
+      "version": "0.33.898",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -896,6 +897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,6 +946,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1041,7 +1044,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1060,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1204,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1220,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1236,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1268,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1284,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1428,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,7 +1444,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,6 +1671,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1911,7 +1899,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1951,7 +1938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1958,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,7 +1978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,7 +1998,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,7 +2018,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2056,7 +2038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,7 +2058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,7 +2078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,7 +2098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2118,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2161,7 +2138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,7 +2158,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,7 +2257,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,7 +2270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,7 +2283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,7 +2296,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,7 +2322,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,7 +2335,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,7 +2348,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,7 +2361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,7 +2374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,7 +2387,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,7 +2400,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,7 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,7 +2426,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,7 +2439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,7 +2452,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,7 +2465,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,7 +2478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,7 +2504,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,7 +2517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2530,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,7 +2543,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,7 +2556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,7 +2569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2983,6 +2932,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3852,8 +3802,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3947,6 +3898,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4399,6 +4351,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4435,6 +4388,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4685,6 +4639,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4698,6 +4653,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4865,6 +4827,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4890,7 +4853,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5123,6 +5086,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5532,6 +5496,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5742,7 +5707,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5861,7 +5826,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5928,6 +5893,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6226,7 +6192,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6343,7 +6308,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6389,7 +6353,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7072,7 +7036,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7224,7 +7188,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7244,7 +7208,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7435,7 +7399,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7614,6 +7578,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7681,7 +7646,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7714,7 +7679,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7735,7 +7699,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7756,7 +7719,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7777,7 +7739,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7798,7 +7759,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7819,7 +7779,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7840,7 +7799,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7861,7 +7819,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7882,7 +7839,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7903,7 +7859,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7924,7 +7879,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7989,6 +7943,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8520,6 +8486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9156,7 +9123,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9236,7 +9204,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9286,7 +9253,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9575,7 +9541,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9621,7 +9586,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9637,6 +9601,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9720,6 +9685,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9751,6 +9717,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9863,11 +9830,24 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10182,7 +10162,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10248,8 +10228,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10350,8 +10330,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10397,6 +10378,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10534,6 +10516,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10559,6 +10542,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10811,6 +10815,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11247,7 +11252,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11272,6 +11278,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11363,7 +11395,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11586,13 +11617,14 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11612,7 +11644,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11642,6 +11673,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11684,7 +11716,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11705,6 +11737,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -11915,8 +11948,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12082,7 +12115,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12099,7 +12131,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12116,7 +12147,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12133,7 +12163,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12150,7 +12179,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12167,7 +12195,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12184,7 +12211,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12201,7 +12227,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12218,7 +12243,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12235,7 +12259,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12252,7 +12275,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12269,7 +12291,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12286,7 +12307,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12303,7 +12323,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12320,7 +12339,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12337,7 +12355,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12354,7 +12371,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12371,7 +12387,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,7 +12403,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12405,7 +12419,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12422,7 +12435,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12439,7 +12451,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12456,7 +12467,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12473,7 +12483,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12490,7 +12499,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12507,7 +12515,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12521,7 +12528,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12563,7 +12569,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12599,6 +12604,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.897",
+  "version": "0.33.898",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.896",
+  "version": "0.33.897",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Closes out the Phase 2 roadmap from `SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md` §5.1 + §7. After this PR, the WaveObjUpdate broadcast bridge covers every srv-reducer event whose persistence path is through `apply_event_to_wstore` (one layout subset deferred to #864 — see below).

## Refactor: helpers

Phase 1 had ~60 lines of `tokio::task::spawn_blocking` + `match result { … }` + `tracing::warn!` boilerplate per event arm. Three helpers extracted:

| Helper | Purpose |
|--------|---------|
| `emit_fetched<T: WaveObj + Send + 'static>(..., otype, oid, ctx)` | Generic fetch + broadcast. Wraps `wstore.get<T>` in `spawn_blocking`, handles missing/error/panic with structured `tracing` logs |
| `emit_delete(event_bus, otype, oid)` | Sync broadcast of a `"delete"` `WaveObjUpdate` (no fetch needed; frontend handles delete with just the oid) |
| `emit_layout_for_tab(..., tab_id, ctx)` | Layout events reference `tab_id`; the affected WaveObj is the `LayoutState` referenced by `tab.layoutstate`. Two SQLite reads chained inside ONE `spawn_blocking` to keep the lock cycle minimal |
| `emit_client_singleton(..., ctx)` | SrvWindowOpened/Closed mutate `Client.windowids` (singleton) — broadcasts the Client too so renderers with a pinned Client see the new windowids |

## Coverage added

| Domain | Events |
|--------|--------|
| **Window** (beyond #855) | `SrvWindowOpened`, `SrvWindowClosed`, `SrvWindowWorkspaceChanged` |
| **Tab** | `TabCreated`, `TabDeleted`, `TabRenamed`, `TabMetaUpdated`, `ActiveTabChanged`, `TabReordered`, `TabsReorderedBulk`, `TabMoved` |
| **Block** | `BlockCreated`, `BlockDeleted`, `BlockMetaUpdated`, `BlockMoved` |
| **Layout (subset)** | `FocusedNodeChanged`, `MagnifiedNodeChanged` only |

### What's NOT in this PR (deferred to #864)

The 11 layout-tree event variants — `LayoutNodeInserted`, `LayoutNodeInsertedAtIndex`, `LayoutNodeDeleted`, `LayoutNodeMoved`, `LayoutNodesSwapped`, `LayoutNodesResized`, `LayoutNodeReplaced`, `LayoutSplitHorizontalApplied`, `LayoutSplitVerticalApplied`, `LayoutCleared`, `LayoutTreeReplaced` — were initially included but then dropped per Codex P2 review.

**Reason:** `apply_event_to_wstore` only persists `FocusedNodeChanged` + `MagnifiedNodeChanged`; the other 11 events are persisted via wcore-direct calls inside the layout RPC handlers, NOT through the persist subscriber. Bridge fetching `LayoutState` for those events could read pre-event tree state.

Frontend coverage for the dropped 11 events is provided by the layout handlers' existing inline `success_with_updates(...)` response broadcasts. **Tracked in [#864](https://github.com/agentmuxai/agentmux/issues/864)** — Phase E.5.x migration of layout-tree events through `apply_event_to_wstore`. Once that lands, the bridge arms can be added back trivially via `emit_layout_for_tab`.

## Dependent-object handling (spec §5.2)

- `TabCreated`/`TabDeleted` → broadcast Tab + parent Workspace (`workspace.tab_ids` changed)
- `TabMoved` → broadcast Tab + src Workspace + dst Workspace
- `BlockCreated`/`BlockDeleted` → broadcast Block + parent Tab (`tab.blockids` changed)
- `BlockMoved` → broadcast Block + src Tab + dst Tab
- `SrvWindowOpened`/`SrvWindowClosed` → broadcast Window (or delete) + Client (singleton's `windowids` changed) [Codex P2 fix]

Frontend version-dedup at `wos.ts:272` absorbs back-to-back broadcasts that arrive when a follow-up event re-fires the same parent.

## IPC-path race caveat (carried forward, not introduced)

`srv_ipc/server.rs:295` dispatches reducer events without first calling `apply_event_to_wstore`. Today none of the bridge-handled events flow through that path. The dispatch_event docstring documents both options if/when that changes.

## Soundness

- Lock discipline (per ReAgent P1 on #852): every `wstore.get<T>` is wrapped in `spawn_blocking` via the helpers — async runtime stays responsive
- §8.15 idempotency: every helper logs + skips on missing/error, so duplicate or stale events fold to no-op (frontend dedup picks up the rest via `version`)
- Per-event panic isolation in the bridge spawn loop is unchanged from #852 — applies to all new arms automatically

## Test plan

Pre-flight (done):
- [x] `cargo check -p agentmux-srv` clean (warnings unchanged from main)

Manual (post-merge or via fresh `task dev`):
- [ ] Open a tab, rename it: title (which uses tab.name) updates, no app restart needed
- [ ] Create a new tab in workspace: appears in tab bar across all renderers; second window's panel sees it too (multi-client)
- [ ] Move a tab between workspaces: source + dest workspaces update concurrently
- [ ] Open a 2nd window: Client.windowids broadcast lands, panel updates
- [ ] Close a tab: leaf tab disappears, workspace `activetabid` shifts

## References

- Spec: [`docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_OBJ_UPDATE_BRIDGE_2026-05-14.md) §5.1 mapping table, §5.2 dependent-object pattern, §7 phase plan
- Master spec: [`MASTER_REDUCER_STACK_STATUS_2026-05-05.md`](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md) §8.15 srv-event subscriber contract
- Discussion: [#707](https://github.com/agentmuxai/agentmux/discussions/707)
- Predecessors: PR #852 (Phase 1 — workspace), PR #856 (#855 — UpdateWindowMeta migration)
- Follow-up: [#864](https://github.com/agentmuxai/agentmux/issues/864) (layout-tree event persistence migration)