### PR TITLE
devx(phase 1): Cargo workspace.package.version inheritance (RFC #857)

### DIFF
--- a/.bump.json
+++ b/.bump.json
@@ -7,29 +7,9 @@
       "path": "version"
     },
     {
-      "file": "agentmux-srv/Cargo.toml",
+      "file": "Cargo.toml",
       "type": "toml",
-      "path": "package.version"
-    },
-    {
-      "file": "agentmux-cef/Cargo.toml",
-      "type": "toml",
-      "path": "package.version"
-    },
-    {
-      "file": "agentmux-launcher/Cargo.toml",
-      "type": "toml",
-      "path": "package.version"
-    },
-    {
-      "file": "agentmux-common/Cargo.toml",
-      "type": "toml",
-      "path": "package.version"
-    },
-    {
-      "file": "agentmux-bashwrap/Cargo.toml",
-      "type": "toml",
-      "path": "package.version"
+      "path": "workspace.package.version"
     }
   ],
   "lockfiles": [
@@ -39,16 +19,13 @@
     }
   ],
   "_npm_lockfile_note": "npm lockfile sync is handled by scripts/bump-wrapper.sh because bump-cli's 'npm-version' strategy fails with 'Unknown error' inside its temporary git state and silently skips the lockfile. Use scripts/bump-wrapper.sh instead of bare bump.",
+  "_phase1_note": "RFC #857 Phase 1: 5 member Cargo.toml entries collapsed to 1 workspace root entry using Cargo workspace.package inheritance (version.workspace = true on each member).",
   "git": {
     "add": [
       "package.json",
       "package-lock.json",
       "Cargo.lock",
-      "agentmux-srv/Cargo.toml",
-      "agentmux-cef/Cargo.toml",
-      "agentmux-launcher/Cargo.toml",
-      "agentmux-common/Cargo.toml",
-      "agentmux-bashwrap/Cargo.toml"
+      "Cargo.toml"
     ],
     "commitMessage": "chore: bump version to {{version}}"
   }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.33.895"
+version = "0.33.896"
 dependencies = [
  "anyhow",
  "base64",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.33.895"
+version = "0.33.896"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.33.895"
+version = "0.33.896"
 dependencies = [
  "dirs",
  "serde",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.33.895"
+version = "0.33.896"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.33.895"
+version = "0.33.896"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 resolver = "2"
 members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common", "agentmux-bashwrap"]
 
+# Shared workspace metadata — members inherit `version` via
+# `version.workspace = true` so a single bump touches one Cargo.toml.
+# RFC #857 Phase 1.
+[workspace.package]
+version = "0.33.895"
+
 [profile.release]
 strip = true
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.33.895"
+version = "0.33.896"
 
 [profile.release]
 strip = true

--- a/agentmux-bashwrap/Cargo.toml
+++ b/agentmux-bashwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-bashwrap"
-version = "0.33.895"
+version.workspace = true
 edition = "2021"
 description = "AgentMux streaming bash wrapper + PreToolUse hook helper"
 authors = ["AgentMux Corp"]

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-cef"
-version = "0.33.895"
+version.workspace = true
 description = "AgentMux Host — Desktop app with bundled Chromium"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-common/Cargo.toml
+++ b/agentmux-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-common"
-version = "0.33.895"
+version.workspace = true
 edition = "2021"
 description = "Shared utilities for AgentMux crates"
 

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-launcher"
-version = "0.33.895"
+version.workspace = true
 description = "AgentMux Launcher — Job Object + IPC + saga coordinator + srv lifecycle"
 authors = ["AgentMux Corp"]
 edition = "2021"

--- a/agentmux-srv/Cargo.toml
+++ b/agentmux-srv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentmux-srv"
-version = "0.33.895"
+version.workspace = true
 edition = "2021"
 description = "AgentMux Rust backend server"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.33.895",
+  "version": "0.33.896",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.33.895",
+      "version": "0.33.896",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.33.895",
+  "version": "0.33.896",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Summary

Adopts Cargo workspace version inheritance: adds `[workspace.package]` with `version = "..."` to root `Cargo.toml`, and changes each member crate's `version = "..."` to `version.workspace = true`. Updates `.bump.json` to point at the workspace root only (5 member Cargo.toml targets collapsed to 1 workspace target).

Phase 1 of multi-agent version coordination spec (`docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md`, RFC #857). Stack:
- ✅ Phase 0 — PR #860 (conflict-marker hook)
- ✅ Phase 3 — applied directly (`dismiss_stale_reviews: true` on `main`)
- ✅ Phase 1 — this PR

## Effect on multi-agent conflicts

A `bump patch` now touches **3 files** (`package.json`, `Cargo.toml`, `Cargo.lock`) instead of **9**. Member crate Cargo.tomls (`agentmux-srv`, `-cef`, `-launcher`, `-common`, `-bashwrap`) no longer carry a `version` line — they inherit from the workspace.

Concrete numbers from this PR's own bump (0.33.895 → 0.33.896):
```
 Cargo.lock   | 10 +++++-----
 Cargo.toml   |  2 +-
 package.json |  2 +-
 3 files changed, 7 insertions(+), 7 deletions(-)
```

Previous bumps changed 5+ Cargo.toml files in addition to those 3. Every concurrent-bump conflict on a member Cargo.toml is now eliminated.

## Verification

- ✅ `cargo metadata --no-deps` reports all 5 members at version 0.33.896
- ✅ `cargo check -p agentmux-srv` compiles clean (pre-existing warnings only)
- ✅ `bump verify` reports both targets consistent
- ✅ `bump patch --dry-run` shows only `package.json` + root `Cargo.toml` would be touched
- ✅ Round-trip `bump patch` succeeded — committed `chore: bump version to 0.33.896` modifying exactly those 3 files

## Files changed (this PR)

Setup commits:
- `Cargo.toml` — add `[workspace.package]` with version field
- `agentmux-srv/Cargo.toml` — `version = "0.33.895"` → `version.workspace = true`
- `agentmux-cef/Cargo.toml` — same
- `agentmux-launcher/Cargo.toml` — same
- `agentmux-common/Cargo.toml` — same
- `agentmux-bashwrap/Cargo.toml` — same
- `.bump.json` — remove 5 member entries, simplify git.add list

Then a follow-up `bump patch` commit to verify and bump for ship.

## Reversibility

To revert, copy the workspace-level `version` back into each member's `[package]` block and restore `.bump.json`. ~30 LOC. No data migration.

## Next

Phase 2 (Changesets) is the bigger ergonomic win — it eliminates per-PR version bumps entirely. Phase 1 is the prerequisite that makes Phase 2 simpler. Will land Phases 4/5 (lockfile bot, auto-rebase on green) after Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)