### PR TITLE
devx(phase 2): changesets workflow — zero version conflicts in feature PRs (RFC #857)

### DIFF
--- a/.changesets/1778835927-devx-phase-2-adopt-changesets-workflow-rfc-857.md
+++ b/.changesets/1778835927-devx-phase-2-adopt-changesets-workflow-rfc-857.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+devx(phase 2): adopt changesets workflow (RFC #857)

--- a/.changesets/README.md
+++ b/.changesets/README.md
@@ -1,0 +1,72 @@
+# Changesets
+
+This directory holds **pending changeset files** — one per PR that wants to
+contribute to the next release. RFC #857 Phase 2 / spec
+`docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md`.
+
+## Why
+
+Multiple agents commit to this repo concurrently. When every PR ran
+`bump patch`, version files (`package.json`, `Cargo.toml`, `Cargo.lock`,
+`package-lock.json`) became near-100% conflict surface. The
+"version downgrade P1" finding from reagent fired on every forward-merge.
+
+Changesets fix this: a feature PR adds **one new file** with a unique name
+(`<timestamp>-<slug>.md`). That file never conflicts with another PR's
+changeset. The version bump happens once, in a dedicated release commit.
+
+## Author flow (in a feature PR)
+
+```bash
+task changeset -- patch "fix(auth): cancel in-flight session on selection swap"
+# or:
+scripts/changeset.sh patch "fix(auth): cancel in-flight session on selection swap"
+```
+
+This creates `.changesets/1747298400-fix-auth-cancel-in-flight.md`:
+
+```markdown
+---
+type: patch
+---
+
+fix(auth): cancel in-flight session on selection swap
+```
+
+Then commit the changeset file alongside your code changes. **Do NOT run
+`bump patch`** — the release step owns version bumps now.
+
+Allowed types: `patch`, `minor`, `major`. If the changesets in a release
+include any `major`, the release is major. Otherwise minor wins over patch.
+
+## Release flow (separate PR, periodic or on-demand)
+
+```bash
+task release
+```
+
+This:
+
+1. Scans `.changesets/*.md`, aggregates descriptions
+2. Picks the highest bump type (major > minor > patch)
+3. Runs `scripts/bump-wrapper.sh <type>` to bump version
+4. Appends entries to `VERSION_HISTORY.md`
+5. Deletes consumed `.changesets/*.md` files
+6. Stages all changes (the bump commit + the changeset deletes)
+
+The releaser then commits with a message like
+`chore: release v0.33.897` and opens a PR. That PR is the **only** PR that
+touches `package.json` / `Cargo.toml` / lockfiles.
+
+## What if I'm fixing a small thing and don't need a release?
+
+Then don't add a changeset. The PR ships without forcing a version bump.
+
+## Conflict surface comparison
+
+| Today (post-Phase 1) | With changesets |
+|---|---|
+| 4 version files modified per PR | 0 version files; 1 unique `.changesets/<id>.md` |
+| `bump patch` collisions between agents | Filenames are unique by timestamp+slug |
+| Lockfile rebuild per PR (~130 line diff) | Lockfile rebuild only in release PR |
+| Forward-merge causes version-downgrade P1 | Forward-merge is conflict-free |

--- a/.changesets/README.md
+++ b/.changesets/README.md
@@ -12,8 +12,10 @@ Multiple agents commit to this repo concurrently. When every PR ran
 "version downgrade P1" finding from reagent fired on every forward-merge.
 
 Changesets fix this: a feature PR adds **one new file** with a unique name
-(`<timestamp>-<slug>.md`). That file never conflicts with another PR's
-changeset. The version bump happens once, in a dedicated release commit.
+(`<timestamp>-<slug>-<rand4>.md` — the 4-char random suffix prevents the rare
+case where two agents create a changeset in the same second with the same
+slug). That file never conflicts with another PR's changeset. The version
+bump happens once, in a dedicated release commit.
 
 ## Author flow (in a feature PR)
 
@@ -61,6 +63,38 @@ touches `package.json` / `Cargo.toml` / lockfiles.
 ## What if I'm fixing a small thing and don't need a release?
 
 Then don't add a changeset. The PR ships without forcing a version bump.
+
+## Escape hatch: local-only version bumps for build labels
+
+When iterating on a feature, you may want to bump the version locally so
+your build artifacts (e.g. `agentmux-0.33.897-x64-portable.zip`) are
+distinguishable from the previous build on disk for side-by-side comparison.
+That's fine — the changesets pattern only governs what hits a PR's commit
+history, not what you do on your own checkout.
+
+**Recommended:**
+
+```bash
+task package:local           # patch bump (default)
+task package:local -- minor  # or minor / major
+```
+
+This temporarily bumps the version, runs `task package`, and **restores all
+version files to their original content on exit** — including on Ctrl-C or
+build failure. Zero git mutation. The artifact lands on Desktop with the
+bumped-label filename you can compare against the previous build.
+
+**If you need the raw `bump` for some reason:**
+
+```bash
+bump patch -m "local: smoke" --commit
+task package
+git reset --hard HEAD~1      # discard the bump commit before pushing
+```
+
+**Don't** push a `chore: bump version` commit from your feature branch —
+it'll cause the same version-conflict mess the changesets pattern is
+designed to avoid. The release PR owns canonical version bumps.
 
 ## Conflict surface comparison
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -157,22 +157,24 @@ Output: `~/Desktop/agentmux-{version}-x64-portable/` and `.zip`
 
 ---
 
-## Version Management
+## Version Management (Changesets — RFC #857 Phase 2)
 
-**Before releasing, ensure version consistency across all files:**
+**Feature PRs do not bump the version.** Add a changeset instead:
 
 ```bash
-# Bump version (updates package.json, Cargo.toml, etc.)
-./bump-version.sh patch --message "Your change description"
-
-# Verify consistency
-bump verify
-
-# Push with tags
-git push origin <branch> --tags
+task changeset -- patch "fix(scope): short description"
+# Allowed bump types: patch | minor | major
 ```
 
-**Critical:** Always use `bump-version.sh` — never manually edit version numbers.
+This creates `.changesets/<id>.md`. Commit it with your code. Version bumps live in dedicated **release PRs** which consume all pending changesets at once:
+
+```bash
+task release         # processes .changesets/, bumps version, updates VERSION_HISTORY
+git commit -m "chore: release v<X.Y.Z>"
+git push -u origin agenta/release-vX.Y.Z
+```
+
+See `.changesets/README.md` and `docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md` for rationale.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,43 +133,38 @@ Works identically across `task dev`, portable, and install builds. Logs auto-rot
 
 ## Version Management
 
-**CRITICAL:** Always use `@a5af/bump-cli` - never manually edit version numbers.
+**As of RFC #857 Phase 2, feature PRs use the changesets workflow — do NOT run `bump patch` in feature PRs.** Version bumps happen in dedicated release PRs that consume pending changesets.
 
-### Install bump-cli (one-time)
+### Feature PR workflow
+
+Add a changeset describing your change:
 
 ```bash
-# Configure npm for @a5af GitHub Packages (requires GITHUB_TOKEN with read:packages)
-echo "@a5af:registry=https://npm.pkg.github.com" >> ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-npm install -g @a5af/bump-cli
+task changeset -- patch "fix(auth): short description"
+# OR: task changeset -- minor "feat(...): description"
+# OR: task changeset -- major "breaking change description"
 ```
 
-### Mandatory Workflow
+This creates `.changesets/<unix-ts>-<slug>.md`. Commit it alongside your code changes. **Do not bump `package.json` or any Cargo.toml** — the release step owns that.
 
-**Step 1: Bump version** (updates ALL files automatically via `.bump.json`)
+The conflict surface is now zero version files per feature PR: agents committing in parallel get unique filenames automatically.
+
+### Release PR workflow (separate, periodic)
+
 ```bash
-bump patch -m "Description"
-# OR: bump minor / bump major / bump 1.2.3
+task release            # consume all .changesets/, bump, update history (no commit yet)
+git diff --staged       # review what would land
+git commit -m "chore: release v<X.Y.Z>"
+git push -u origin agenta/release-vX.Y.Z
 ```
 
-This updates: `package.json`, `package-lock.json`, `Cargo.lock`, `agentmux-srv/Cargo.toml`, `agentmux-cef/Cargo.toml`, `agentmux-launcher/Cargo.toml`, `agentmux-common/Cargo.toml`, `VERSION_HISTORY.md`
+The release script picks the highest bump type across pending changesets (major > minor > patch), runs `scripts/bump-wrapper.sh`, appends to `VERSION_HISTORY.md`, and deletes the consumed changesets.
 
-**Step 2: Verify consistency**
-```bash
-bump verify
-```
+### Background
 
-**Step 3: Rebuild binaries**
-```bash
-task build:backend
-```
+`@a5af/bump-cli` is still installed and used internally by the release script. The `.bump.json` config now targets only the workspace root (`Cargo.toml` + `package.json` + lockfiles) thanks to Phase 1's workspace-version-inheritance — see `docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md`.
 
-**Step 4: Commit and push**
-```bash
-# bump --commit stages and commits all version files automatically:
-bump patch -m "Description" --commit
-git push origin <branch>
-```
+If you absolutely need to manually bump (e.g. rebuilding tooling locally), `bump patch -m "..." --commit` still works — but **don't push it in a feature PR**.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -204,17 +204,25 @@ Local build outputs from `task package` on the host platform:
 
 Other platform tasks (`task package:macos`, `task package:msix`) are TODO stubs in `Taskfile.yml`. The full release artifact set (macOS DMG, Windows installer, Windows MSIX, Linux .deb) is produced by [`agentmuxai/agentmux-builder`](https://github.com/agentmuxai/agentmux-builder) — see [§Releases](#releases) for the artifact catalog.
 
-## Version Management
+## Version Management (Changesets)
 
-Always use [`@a5af/bump-cli`](https://github.com/a5af/bump-cli) — never edit version numbers manually.
+**Feature PRs add a changeset, not a version bump.** RFC #857 Phase 2.
 
 ```bash
-bump patch -m "Description" --commit   # bump, stage, and commit all version files
-bump verify                            # check all files are consistent
-bump show                              # display current version state
+task changeset -- patch "fix(scope): short description"
+# Allowed bump types: patch | minor | major
 ```
 
-Config lives in `.bump.json`. See [BUILD.md](./BUILD.md) for the full workflow.
+This creates a uniquely-named `.changesets/<id>.md` you commit with your code. Parallel-agent PRs never conflict on version files because they each have their own changeset filename.
+
+A separate **release PR** consumes pending changesets:
+
+```bash
+task release    # processes .changesets/, bumps version, updates VERSION_HISTORY
+git commit -m "chore: release v<X.Y.Z>"
+```
+
+The release flow internally uses [`@a5af/bump-cli`](https://github.com/a5af/bump-cli) via `scripts/bump-wrapper.sh`. Config lives in `.bump.json`. See [BUILD.md](./BUILD.md), [.changesets/README.md](./.changesets/README.md), and [docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md](./docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md) for the full workflow.
 
 ## Releases
 
@@ -249,12 +257,15 @@ gh workflow run tauri-build.yml -R agentmuxai/agentmux-builder -f ref=v0.33.0
 ### Full release checklist
 
 ```bash
-# 1. Bump version and commit
-bump patch -m "Description" --commit
-bump verify
+# 1. Consume pending changesets, bump version, update VERSION_HISTORY
+task release
+git diff --staged                      # review what would land
+git commit -m "chore: release v0.X.Y"
+git push -u origin agenta/release-v0.X.Y
+# ... open release PR, merge to main after review
 
-# 2. Push and tag
-git push origin main
+# 2. Tag once merged on main
+git checkout main && git pull
 git tag v0.X.Y && git push origin v0.X.Y
 
 # 3. Trigger the builder (builds all platforms, creates GitHub Release)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,6 +22,16 @@ vars:
     WINGET_PACKAGE: AgentMux.AgentMux
 
 tasks:
+    changeset:
+        desc: Author a new changeset file. Usage — task changeset -- patch "fix(...): description"
+        cmds:
+            - bash scripts/changeset.sh {{.CLI_ARGS}}
+
+    release:
+        desc: Consume pending changesets, bump version, update VERSION_HISTORY (no commit). Pass `--dry-run` to preview. RFC #857 Phase 2.
+        cmds:
+            - bash scripts/release.sh {{.CLI_ARGS}}
+
     dev:
         desc: Run AgentMux in development mode (Vite hot reload).
         cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,6 +32,11 @@ tasks:
         cmds:
             - bash scripts/release.sh {{.CLI_ARGS}}
 
+    package:local:
+        desc: Build a portable ZIP with a temporarily-bumped version label (for side-by-side build comparisons). Restores version files on exit — no git mutation, no pushed bump commit. Usage — task package:local (defaults to patch bump) or task package:local -- minor.
+        cmds:
+            - bash scripts/package-local.sh {{.CLI_ARGS}}
+
     dev:
         desc: Run AgentMux in development mode (Vite hot reload).
         cmds:

--- a/docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md
+++ b/docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md
@@ -173,38 +173,50 @@ Update `.bump.json` to point at the workspace root only.
 **Effect:** Conflict surface drops from 9 → 4 files (root Cargo.toml, package.json,
 Cargo.lock, package-lock.json + VERSION_HISTORY.md).
 
-### Phase 2 — Don't bump in feature PRs (changeset-style)
+### Phase 2 — Don't bump in feature PRs (changeset-style) — IMPLEMENTED
 
-Adopt the [Changesets](https://github.com/changesets/changesets) pattern:
+Adopted a lightweight, self-hosted changesets pattern (not the
+`@changesets/cli` npm package — that's built for npm monorepos and would
+have needed adaptation for our mixed Cargo + npm workspace anyway):
 
-- Feature PRs add a **changeset file** (`.changesets/<hash>.md`) instead of
-  bumping version. Format:
+**Files added:**
+- `.changesets/README.md` — workflow + format docs
+- `.changesets/.gitkeep` — placeholder so the dir exists post-rm
+- `scripts/changeset.sh` — author tool (creates `.changesets/<ts>-<slug>.md`)
+- `scripts/release.sh` — consumer tool (aggregates, bumps, history, deletes,
+  stages; does NOT commit — caller commits + PRs)
+- `Taskfile.yml` — `task changeset` + `task release` wrappers
+- `CLAUDE.md` + `BUILD.md` — updated workflow docs
 
-  ```markdown
-  ---
-  type: patch
-  ---
-  fix(auth): cancel in-flight session on selection change
-  ```
+**Feature PR workflow now:**
+```bash
+task changeset -- patch "fix(scope): description"
+# Creates .changesets/<unix-ts>-<slug>.md — UNIQUE filename, never conflicts.
+# Commit it alongside your code. DO NOT run `bump patch`.
+```
 
-- A `release` PR (opened by a bot on schedule, or manually) consumes all
-  pending changeset files, bumps version, regenerates lockfiles, updates
-  `VERSION_HISTORY.md`, and merges to main.
+**Release PR workflow:**
+```bash
+task release           # processes pending changesets, bumps, updates VERSION_HISTORY
+git diff --staged      # review
+git commit -m "chore: release v<X.Y.Z>"
+git push -u origin agenta/release-vX.Y.Z
+```
 
-This eliminates the version-bump conflict entirely — feature PRs only touch
-their own `.changesets/<hash>.md` file (unique hash per PR = no conflict).
+Bump type aggregation: highest of all pending changesets wins
+(major > minor > patch).
 
-**Cost:**
-- Bot config (~1 day setup, can use existing tools or hand-roll).
-- Reagent rule update: don't flag missing version bump on feature PRs.
-- Tooling migration: agents stop running `bump patch`; they run
-  `bump changeset` or just write the changeset file directly.
+**Reagent prompt update (separate, lives in `a5af/reagent`):**
+The prompt's "Version Bump Validation" section currently flags any PR
+without a version diff as P1. Once reagent's container redeploys with an
+update to `prompts/review.md` recognizing `.changesets/*.md` as satisfying
+the rule, all feature PRs go through reagent cleanly. Until then, feature
+PRs will get a stale P1 — addressed by a brief comment or a5af approval
+override.
 
-**Risk:** Medium — depends on whether the release PR can be auto-merged or
-needs human review (acceptable either way).
-
-**Effect:** Conflict surface drops to **zero** version-files per feature PR.
-Lockfile noise concentrates on one release PR.
+**Conflict surface:** zero version files per feature PR. Concurrent agents
+get unique changeset filenames automatically. Lockfile noise concentrates
+on the release PR only.
 
 ### Phase 3 — Enable `dismiss_stale_reviews`
 

--- a/scripts/changeset.sh
+++ b/scripts/changeset.sh
@@ -48,16 +48,19 @@ fi
 DIR="$REPO_ROOT/.changesets"
 mkdir -p "$DIR"
 
-# Build a filename: <unix-ts>-<slug-of-description>.md
+# Build a filename: <unix-ts>-<slug>-<rand4>.md
 # Slug: lowercase, replace anything non-alphanumeric with `-`, collapse, trim.
+# rand4 suffix: codex P2 on #865 — two agents running this in the same second
+# with the same slug would otherwise overwrite each other's changeset.
 TS="$(date +%s)"
 SLUG="$(printf '%s' "$DESC" \
     | tr '[:upper:]' '[:lower:]' \
     | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
     | cut -c1-60)"
 [[ -z "$SLUG" ]] && SLUG="change"
+RAND="$(head -c 100 /dev/urandom | tr -dc 'a-z0-9' | head -c 4)"
 
-FILE="$DIR/${TS}-${SLUG}.md"
+FILE="$DIR/${TS}-${SLUG}-${RAND}.md"
 
 cat >"$FILE" <<EOF
 ---

--- a/scripts/changeset.sh
+++ b/scripts/changeset.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# changeset.sh — author a new changeset file.
+#
+# Usage:
+#   scripts/changeset.sh <type> "<description>"
+#
+# Example:
+#   scripts/changeset.sh patch "fix(auth): cancel in-flight session on selection swap"
+#
+# Allowed types: patch | minor | major
+#
+# Produces:
+#   .changesets/<unix-ts>-<slug>.md
+#
+# The file's frontmatter holds the bump type; the body is the description.
+# RFC #857 Phase 2 / spec docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md.
+
+set -euo pipefail
+
+TYPE="${1:-}"
+DESC="${2:-}"
+
+if [[ -z "$TYPE" || -z "$DESC" ]]; then
+    cat >&2 <<EOF
+Usage: $0 <patch|minor|major> "<description>"
+
+Example:
+    $0 patch "fix(auth): cancel in-flight session on selection swap"
+EOF
+    exit 1
+fi
+
+case "$TYPE" in
+    patch|minor|major) ;;
+    *)
+        echo "ERROR: type must be one of: patch | minor | major (got: $TYPE)" >&2
+        exit 1
+        ;;
+esac
+
+# Locate repo root (the script may be invoked from anywhere).
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "ERROR: not inside a git repository." >&2
+    exit 1
+fi
+
+DIR="$REPO_ROOT/.changesets"
+mkdir -p "$DIR"
+
+# Build a filename: <unix-ts>-<slug-of-description>.md
+# Slug: lowercase, replace anything non-alphanumeric with `-`, collapse, trim.
+TS="$(date +%s)"
+SLUG="$(printf '%s' "$DESC" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-60)"
+[[ -z "$SLUG" ]] && SLUG="change"
+
+FILE="$DIR/${TS}-${SLUG}.md"
+
+cat >"$FILE" <<EOF
+---
+type: $TYPE
+---
+
+$DESC
+EOF
+
+echo "Wrote $FILE" >&2
+echo "$FILE"

--- a/scripts/package-local.sh
+++ b/scripts/package-local.sh
@@ -37,8 +37,7 @@ echo ">>> package-local: starting at v$ORIG_VERSION" >&2
 # Capture working-tree state of files bump-cli will rewrite, so we can
 # restore them byte-for-byte regardless of whether bump-cli leaves staged
 # changes behind.
-TMPDIR="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR"' EXIT
+BACKUP_DIR="$(mktemp -d)"
 
 VERSION_FILES=(
     package.json
@@ -48,30 +47,33 @@ VERSION_FILES=(
 )
 for f in "${VERSION_FILES[@]}"; do
     if [[ -f "$f" ]]; then
-        cp "$f" "$TMPDIR/$(basename "$f").bak"
+        cp "$f" "$BACKUP_DIR/$(basename "$f").bak"
     fi
 done
 
-# Bump in-place (no --commit). bump-cli handles Cargo workspace inheritance
-# via .bump.json (Phase 1 collapsed 5 member Cargo.toml targets to 1 root).
-bump "$BUMP_TYPE"
-NEW_VERSION="$(node -p "require('./package.json').version")"
-echo ">>> package-local: temporarily bumped to v$NEW_VERSION for build" >&2
-
 # Restore on exit no matter what (build failure, Ctrl-C, etc).
+# Reagent P1 on #865 round 2: restore_files MUST run before BACKUP_DIR is
+# deleted, otherwise the rm wipes the backups before they can be read. The
+# trap below runs restore first, then cleans up.
 restore_files() {
     echo >&2
     echo ">>> package-local: restoring working-tree to v$ORIG_VERSION" >&2
     for f in "${VERSION_FILES[@]}"; do
-        if [[ -f "$TMPDIR/$(basename "$f").bak" ]]; then
-            cp "$TMPDIR/$(basename "$f").bak" "$f"
+        if [[ -f "$BACKUP_DIR/$(basename "$f").bak" ]]; then
+            cp "$BACKUP_DIR/$(basename "$f").bak" "$f"
         fi
     done
     # Drop any staging bump-cli did.
     git reset -q -- "${VERSION_FILES[@]}" 2>/dev/null || true
     echo ">>> package-local: working tree restored." >&2
 }
-trap 'rm -rf "$TMPDIR"; restore_files' EXIT
+trap 'restore_files; rm -rf "$BACKUP_DIR"' EXIT
+
+# Bump in-place (no --commit). bump-cli handles Cargo workspace inheritance
+# via .bump.json (Phase 1 collapsed 5 member Cargo.toml targets to 1 root).
+bump "$BUMP_TYPE"
+NEW_VERSION="$(node -p "require('./package.json').version")"
+echo ">>> package-local: temporarily bumped to v$NEW_VERSION for build" >&2
 
 # Run the actual package build.
 task package

--- a/scripts/package-local.sh
+++ b/scripts/package-local.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# package-local.sh — produce a labeled portable build by temporarily bumping
+# the version, packaging, then restoring the original version files.
+#
+# Use case: comparing two builds side-by-side on Desktop. `task package`
+# names artifacts `agentmux-<version>-x64-portable.zip`; if the version
+# doesn't change between builds, the new ZIP overwrites the old. This script
+# bumps once, builds once, and restores so your working tree is clean
+# afterward — no `git reset` dance, no accidentally-pushed bump commits.
+#
+# Usage:
+#   scripts/package-local.sh          # patch bump (default)
+#   scripts/package-local.sh patch    # explicit
+#   scripts/package-local.sh minor
+#   scripts/package-local.sh major
+#
+# RFC #857 Phase 2 escape hatch — see .changesets/README.md.
+
+set -euo pipefail
+
+BUMP_TYPE="${1:-patch}"
+
+case "$BUMP_TYPE" in
+    patch|minor|major) ;;
+    *)
+        echo "ERROR: bump type must be patch | minor | major (got: $BUMP_TYPE)" >&2
+        exit 1
+        ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ORIG_VERSION="$(node -p "require('./package.json').version")"
+echo ">>> package-local: starting at v$ORIG_VERSION" >&2
+
+# Capture working-tree state of files bump-cli will rewrite, so we can
+# restore them byte-for-byte regardless of whether bump-cli leaves staged
+# changes behind.
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+VERSION_FILES=(
+    package.json
+    package-lock.json
+    Cargo.lock
+    Cargo.toml
+)
+for f in "${VERSION_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        cp "$f" "$TMPDIR/$(basename "$f").bak"
+    fi
+done
+
+# Bump in-place (no --commit). bump-cli handles Cargo workspace inheritance
+# via .bump.json (Phase 1 collapsed 5 member Cargo.toml targets to 1 root).
+bump "$BUMP_TYPE"
+NEW_VERSION="$(node -p "require('./package.json').version")"
+echo ">>> package-local: temporarily bumped to v$NEW_VERSION for build" >&2
+
+# Restore on exit no matter what (build failure, Ctrl-C, etc).
+restore_files() {
+    echo >&2
+    echo ">>> package-local: restoring working-tree to v$ORIG_VERSION" >&2
+    for f in "${VERSION_FILES[@]}"; do
+        if [[ -f "$TMPDIR/$(basename "$f").bak" ]]; then
+            cp "$TMPDIR/$(basename "$f").bak" "$f"
+        fi
+    done
+    # Drop any staging bump-cli did.
+    git reset -q -- "${VERSION_FILES[@]}" 2>/dev/null || true
+    echo ">>> package-local: working tree restored." >&2
+}
+trap 'rm -rf "$TMPDIR"; restore_files' EXIT
+
+# Run the actual package build.
+task package
+
+echo >&2
+echo ">>> package-local: build complete." >&2
+echo ">>> Artifact at: ~/Desktop/agentmux-${NEW_VERSION}-x64-portable.zip" >&2
+echo ">>> Working tree is back at v$ORIG_VERSION — no git mutation." >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# release.sh — consume pending .changesets/*.md, bump, update history, delete.
+#
+# Reads every `.changesets/*.md`, picks the highest bump type from their
+# frontmatter (major > minor > patch), runs scripts/bump-wrapper.sh to bump
+# the version (which handles both Cargo workspace + package.json + lockfiles
+# via .bump.json), appends entries to VERSION_HISTORY.md, deletes the consumed
+# changesets, and stages everything. The caller (a developer or a bot)
+# commits the staged changes and opens a release PR.
+#
+# Usage:
+#   scripts/release.sh [--dry-run]
+#
+# RFC #857 Phase 2 / spec docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$REPO_ROOT" ]]; then
+    echo "ERROR: not inside a git repository." >&2
+    exit 1
+fi
+cd "$REPO_ROOT"
+
+shopt -s nullglob
+CHANGESETS=(.changesets/[0-9]*.md)
+
+if (( ${#CHANGESETS[@]} == 0 )); then
+    echo "No pending changesets. Nothing to release." >&2
+    exit 0
+fi
+
+echo "Found ${#CHANGESETS[@]} pending changeset(s):" >&2
+for f in "${CHANGESETS[@]}"; do
+    echo "  - ${f#.changesets/}" >&2
+done
+echo >&2
+
+# Determine highest bump type. Order: major > minor > patch.
+RELEASE_TYPE="patch"
+for f in "${CHANGESETS[@]}"; do
+    TYPE="$(awk '/^---$/{n++;next} n==1 && /^type:/{print $2; exit}' "$f" | tr -d '[:space:]')"
+    case "$TYPE" in
+        major) RELEASE_TYPE="major"; break ;;
+        minor) [[ "$RELEASE_TYPE" != "major" ]] && RELEASE_TYPE="minor" ;;
+        patch) ;;
+        *)
+            echo "WARNING: $f has unknown type '$TYPE', treating as patch." >&2
+            ;;
+    esac
+done
+
+echo "Release type: $RELEASE_TYPE" >&2
+
+# Capture descriptions (body after the second --- marker).
+DESCRIPTIONS=()
+for f in "${CHANGESETS[@]}"; do
+    BODY="$(awk '/^---$/{n++;next} n==2 {print}' "$f" | sed '/^$/d')"
+    while IFS= read -r line; do
+        DESCRIPTIONS+=("$line")
+    done <<<"$BODY"
+done
+
+if (( DRY_RUN )); then
+    echo >&2
+    echo "DRY RUN — would bump $RELEASE_TYPE with these entries:" >&2
+    for d in "${DESCRIPTIONS[@]}"; do
+        echo "  - $d" >&2
+    done
+    exit 0
+fi
+
+# Bump version + sync lockfiles. The wrapper handles --commit; we run WITHOUT
+# --commit so we can fold the version-history update + changeset deletes into
+# the same final commit.
+if [[ ! -x scripts/bump-wrapper.sh ]]; then
+    echo "ERROR: scripts/bump-wrapper.sh not found or not executable." >&2
+    exit 1
+fi
+
+# bump-cli reads "current" from package.json and computes "next"; we capture
+# both for the history entry.
+CURRENT_VERSION="$(node -p "require('./package.json').version")"
+scripts/bump-wrapper.sh "$RELEASE_TYPE"
+NEW_VERSION="$(node -p "require('./package.json').version")"
+
+echo "Bumped $CURRENT_VERSION -> $NEW_VERSION" >&2
+
+# Append to VERSION_HISTORY.md (create if missing).
+HISTORY="VERSION_HISTORY.md"
+if [[ ! -f "$HISTORY" ]]; then
+    echo "# Version History" >"$HISTORY"
+    echo >>"$HISTORY"
+fi
+
+# Insert the new entry at the top (after the # heading).
+TMP="$(mktemp)"
+TODAY="$(date +%Y-%m-%d)"
+{
+    head -n1 "$HISTORY"
+    echo
+    echo "## $NEW_VERSION — $TODAY"
+    echo
+    for d in "${DESCRIPTIONS[@]}"; do
+        echo "- $d"
+    done
+    echo
+    tail -n +2 "$HISTORY"
+} >"$TMP"
+mv "$TMP" "$HISTORY"
+
+# Delete consumed changesets.
+git rm -q -- "${CHANGESETS[@]}"
+
+# Stage version history + bump-cli's outputs.
+git add -- "$HISTORY"
+
+echo >&2
+echo "Release prepared (NOT committed). Review with: git diff --staged" >&2
+echo "Then commit and push:" >&2
+echo "  git commit -m 'chore: release v$NEW_VERSION'" >&2
+echo "  git push -u origin <branch>" >&2

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -117,8 +117,11 @@ mv "$TMP" "$HISTORY"
 # Delete consumed changesets.
 git rm -q -- "${CHANGESETS[@]}"
 
-# Stage version history + bump-cli's outputs.
-git add -- "$HISTORY"
+# Stage version history + lockfiles. bump-wrapper.sh in no-commit mode
+# syncs `package-lock.json` on-disk but does NOT stage it (see its line
+# 23-24); we stage explicitly here so the release commit ships consistent
+# versions across package.json + package-lock.json. Reagent P1 on #865.
+git add -- "$HISTORY" package-lock.json
 
 echo >&2
 echo "Release prepared (NOT committed). Review with: git diff --staged" >&2


### PR DESCRIPTION
## Summary

Adopts a lightweight, self-hosted changesets workflow. Feature PRs no longer touch version files; they add a uniquely-named `.changesets/<ts>-<slug>.md`. A dedicated release PR consumes pending changesets, bumps once, updates VERSION_HISTORY, deletes consumed files.

Phase 2 of multi-agent version coordination spec (`docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md`, RFC #857).

## Why self-hosted, not `@changesets/cli`?

The npm `@changesets/cli` is built for npm monorepos. We're a Cargo workspace + a single npm root + lockfiles. Two ~50-line shell scripts + a Taskfile task are cleaner than wedging a monorepo tool sideways. The existing `scripts/bump-wrapper.sh` (lockfile-sync workaround for bump-cli quirks) is reused by `scripts/release.sh`.

## Author workflow

```bash
task changeset -- patch "fix(auth): cancel in-flight session on selection swap"
# OR: task changeset -- minor "feat(...): description"
# OR: task changeset -- major "breaking change description"
```

Creates `.changesets/<unix-ts>-<slug>.md` like:
```
---
type: patch
---

fix(auth): cancel in-flight session on selection swap
```

Commit it alongside code changes. **Do NOT run `bump patch`** — release owns version bumps now.

## Release workflow (separate PR)

```bash
task release           # processes pending changesets
                       #   - picks highest bump type (major > minor > patch)
                       #   - runs scripts/bump-wrapper.sh
                       #   - appends to VERSION_HISTORY.md
                       #   - deletes consumed changesets
                       #   - stages everything (does NOT commit)
git diff --staged      # review
git commit -m "chore: release v<X.Y.Z>"
git push -u origin agenta/release-vX.Y.Z
```

## Conflict surface

| Phase | Per-PR conflict files |
|---|---|
| Pre-Phase-1 | 9 (package.json + 6 Cargo.toml + Cargo.lock + package-lock.json) |
| Post-Phase-1 | 4 (package.json + root Cargo.toml + 2 lockfiles) |
| **Post-Phase-2 (this PR)** | **0** (unique `.changesets/<id>.md` per PR) |

Parallel agents never collide on changeset filenames — timestamp prefix guarantees uniqueness.

## Reagent dependency

Reagent's prompt today flags any PR without a version diff as P1. A separate PR in `a5af/reagent` (TBD) updates `prompts/review.md` to recognize `.changesets/*.md` as satisfying the rule. Until reagent's container redeploys, feature PRs that use the changesets pattern will get a stale P1 from the bot — address with a brief comment or a5af-approval override.

Note: reagent #155 (LGTM-as-COMMENTED fix) is merged but not yet deployed (Docker not available on dev box). Same deploy blocker applies to whatever rule-update PR I ship next.

## Self-referencing

This PR includes its own changeset: `.changesets/<ts>-devx-phase-2-adopt-changesets-workflow-rfc-857.md`. The release PR that lands first after this merges will consume it.

## Files

- `.changesets/README.md` — author workflow + format docs
- `.changesets/.gitkeep` — dir placeholder
- `scripts/changeset.sh` (100755) — author tool
- `scripts/release.sh` (100755) — release tool
- `Taskfile.yml` — adds `changeset` + `release` tasks
- `CLAUDE.md` — updates "Version Management" section
- `BUILD.md` — same
- `docs/specs/SPEC_MULTI_AGENT_VERSION_COORDINATION_2026_05_15.md` — marks Phase 2 implemented

## Verification

- ✅ `scripts/changeset.sh patch "test"` creates the expected file
- ✅ `scripts/release.sh --dry-run` correctly aggregates pending changesets, picks highest type, displays preview
- ✅ Pre-commit hook (Phase 0) passes — no conflict markers
- ✅ Scripts committed as 100755 (verified via `git ls-files -s`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)