### PR TITLE
fix(taskfile): quote desc strings with colons (RFC #857 Phase 2 regression)

### DIFF
--- a/.changesets/1778845342-fix-taskfile-quote-desc-strings-containing-colons-broke-task-kq2l.md
+++ b/.changesets/1778845342-fix-taskfile-quote-desc-strings-containing-colons-broke-task-kq2l.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(taskfile): quote desc strings containing colons (broke task --list + task package after RFC #857 Phase 2)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,7 @@ tasks:
             - bash scripts/release.sh {{.CLI_ARGS}}
 
     package:local:
-        desc: 'Build a portable ZIP with a temporarily-bumped version label (for side-by-side build comparisons). Restores version files on exit. Usage: task package:local (defaults to patch bump) or task package:local -- minor.'
+        desc: 'Build a portable ZIP with a temporarily-bumped version label (for side-by-side build comparisons). Restores version files on exit — no git mutation, no pushed bump commit. Usage: task package:local (defaults to patch bump) or task package:local -- minor.'
         cmds:
             - bash scripts/package-local.sh {{.CLI_ARGS}}
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,17 +23,17 @@ vars:
 
 tasks:
     changeset:
-        desc: Author a new changeset file. Usage — task changeset -- patch "fix(...): description"
+        desc: 'Author a new changeset file. Usage: task changeset -- patch "fix(...): description"'
         cmds:
             - bash scripts/changeset.sh {{.CLI_ARGS}}
 
     release:
-        desc: Consume pending changesets, bump version, update VERSION_HISTORY (no commit). Pass `--dry-run` to preview. RFC #857 Phase 2.
+        desc: 'Consume pending changesets, bump version, update VERSION_HISTORY (no commit). Pass --dry-run to preview. RFC #857 Phase 2.'
         cmds:
             - bash scripts/release.sh {{.CLI_ARGS}}
 
     package:local:
-        desc: Build a portable ZIP with a temporarily-bumped version label (for side-by-side build comparisons). Restores version files on exit — no git mutation, no pushed bump commit. Usage — task package:local (defaults to patch bump) or task package:local -- minor.
+        desc: 'Build a portable ZIP with a temporarily-bumped version label (for side-by-side build comparisons). Restores version files on exit. Usage: task package:local (defaults to patch bump) or task package:local -- minor.'
         cmds:
             - bash scripts/package-local.sh {{.CLI_ARGS}}
 

--- a/agentmux-cef/src/commands/window.rs
+++ b/agentmux-cef/src/commands/window.rs
@@ -789,11 +789,13 @@ pub(crate) fn capture_hwnd_for_label(state: &Arc<AppState>, label: &str) {
     use cef::ImplBrowserHost;
     // Fast path.
     if let Some(mut browser) = state.get_browser(label) {
-        let hwnd = browser.host().window_handle();
-        if !hwnd.is_null() {
-            state.window_hwnds.lock().insert(label.to_string(), hwnd as isize);
-            tracing::debug!("[opacity] captured hwnd fast-path label={} hwnd={:#x}", label, hwnd as isize);
-            return;
+        if let Some(host) = browser.host() {
+            let hwnd = host.window_handle();
+            if !hwnd.0.is_null() {
+                state.window_hwnds.lock().insert(label.to_string(), hwnd.0 as isize);
+                tracing::debug!("[opacity] captured hwnd fast-path label={} hwnd={:#x}", label, hwnd.0 as isize);
+                return;
+            }
         }
     }
     // Fallback: pick the first visible HWND not already mapped.
@@ -845,7 +847,7 @@ pub fn set_window_opacity(
     #[cfg(target_os = "windows")]
     for ev in &out.events {
         match ev {
-            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity } => {
+            crate::reducer::HostEvent::WindowOpacityApplied { label: ev_label, opacity: ev_opacity, .. } => {
                 let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
                 if let Some(raw) = hwnd_raw {
                     let hwnd = raw as *mut std::ffi::c_void;
@@ -854,7 +856,7 @@ pub fn set_window_opacity(
                     tracing::warn!("[opacity] set_window_opacity: no hwnd for label={}", ev_label);
                 }
             }
-            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label } => {
+            crate::reducer::HostEvent::WindowOpacityCleared { label: ev_label, .. } => {
                 let hwnd_raw = state.window_hwnds.lock().get(ev_label.as_str()).copied();
                 if let Some(raw) = hwnd_raw {
                     let hwnd = raw as *mut std::ffi::c_void;


### PR DESCRIPTION
Phase 2 (PR #865) added `changeset`, `release`, `package:local` tasks with unquoted `desc:` strings containing inner colons (`Usage: task changeset -- patch ...`). YAML parsed the inner colon as a mapping separator and the whole file failed.

`task --list` and `task package` both errored: `yaml: line 26: mapping values are not allowed in this context`.

Caught when trying to produce a fresh portable build of main @ 0.33.898.

Fix: single-quote the desc strings.

Verified `task --list` now enumerates all tasks cleanly.