### PR TITLE
fix(launcher): cover UpdateWindowMeta + WindowMetaUpdated in match arms

### DIFF
--- a/.changesets/1778846479-fix-launcher-add-updatewindowmeta-windowmetaupdated-match-ar-zc9h.md
+++ b/.changesets/1778846479-fix-launcher-add-updatewindowmeta-windowmetaupdated-match-ar-zc9h.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(launcher): add UpdateWindowMeta + WindowMetaUpdated match arms (pre-existing main breakage)

--- a/agentmux-launcher/src/event_log.rs
+++ b/agentmux-launcher/src/event_log.rs
@@ -304,7 +304,8 @@ fn event_version(e: &Event) -> u64 {
         | Event::LayoutSplitHorizontalApplied { version, .. }
         | Event::LayoutSplitVerticalApplied { version, .. }
         | Event::LayoutCleared { version, .. }
-        | Event::LayoutTreeReplaced { version, .. } => *version,
+        | Event::LayoutTreeReplaced { version, .. }
+        | Event::WindowMetaUpdated { version, .. } => *version,
     }
 }
 

--- a/agentmux-launcher/src/ipc/server.rs
+++ b/agentmux-launcher/src/ipc/server.rs
@@ -872,6 +872,10 @@ async fn enforce_register_first(
             "Layout command is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
             false,
         ),
+        Command::UpdateWindowMeta { .. } => (
+            "UpdateWindowMeta is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+            false,
+        ),
     };
     // Phase E.1b — connection-private error; sentinel version=0
     // (codex P2 #610). See parse-error path for rationale.

--- a/agentmux-launcher/src/reducer/mod.rs
+++ b/agentmux-launcher/src/reducer/mod.rs
@@ -527,11 +527,12 @@ pub fn update(state: &mut State, cmd: Command, ctx: &Ctx) -> Vec<Event> {
         | Command::LayoutSplitHorizontal { .. }
         | Command::LayoutSplitVertical { .. }
         | Command::LayoutClear { .. }
-        | Command::LayoutSetTree { .. } => {
+        | Command::LayoutSetTree { .. }
+        | Command::UpdateWindowMeta { .. } => {
             let v = state.bump_version();
             vec![Event::Error {
                 code: agentmux_common::ipc::ErrorCode::InvalidCommand,
-                message: "Layout command is a srv-pipe command; sent to launcher pipe by mistake".to_string(),
+                message: "Srv-pipe command (Layout/UpdateWindowMeta) sent to launcher pipe by mistake".to_string(),
                 fatal: false,
                 version: v,
             }]


### PR DESCRIPTION
Main is currently broken: `cargo check -p agentmux-launcher --release` fails with 3× E0004 because the launcher's match arms don't cover `Command::UpdateWindowMeta` (added by #856) or `Event::WindowMetaUpdated`.

Caught when trying to produce a fresh portable build today after the RFC #857 rebase batch (#866-#869) + #873 landed.

- `ipc/server.rs:651`: added the same 'srv-pipe command sent to launcher pipe by mistake' message used by Layout commands
- `reducer/mod.rs:87`: joined to the existing Layout-or pattern, message generalized
- `event_log.rs:245`: added WindowMetaUpdated to the version-extractor or-pattern

`cargo check -p agentmux-launcher --release` clean after fix.

Will unblock `task package` builds on main.