### PR TITLE
feat(browser-pane): live page title and real favicon in pane header

### DIFF
--- a/.changesets/1778847303-feat-browser-pane-live-page-title-and-favicon-in-pane-header-9jqj.md
+++ b/.changesets/1778847303-feat-browser-pane-live-page-title-and-favicon-in-pane-header-9jqj.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(browser-pane): live page title and favicon in pane header

--- a/.changesets/1778864777-fix-876-preserve-window-title-on-none-free-cef-string-list-b-vrkc.md
+++ b/.changesets/1778864777-fix-876-preserve-window-title-on-none-free-cef-string-list-b-vrkc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(#876): preserve window title on None + free CEF string-list buffer + favicon fallback (reagent P1+P1+P2 commandeer)

--- a/agentmux-cef/src/browser_pane/callbacks.rs
+++ b/agentmux-cef/src/browser_pane/callbacks.rs
@@ -238,7 +238,7 @@ pub fn on_loading_state_change_browser_pane(
 /// `state.browsers` under labels like `browser-pane-<uuid>-<seq>`. Find the
 /// label whose browser handle matches the given one by `is_same`, then
 /// strip the prefix and the trailing `-<seq>` to recover the uuid.
-fn resolve_pane_block_id(state: &Arc<AppState>, browser: &Browser) -> Option<String> {
+pub(crate) fn resolve_pane_block_id(state: &Arc<AppState>, browser: &Browser) -> Option<String> {
     // Phase H.2.b — reducer-aware iteration with fallback.
     state
         .list_browsers()

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -196,6 +196,15 @@ wrap_display_handler! {
             let mut inner = self.inner.lock();
             inner.on_title_change(browser, title);
         }
+
+        fn on_favicon_urlchange(
+            &self,
+            browser: Option<&mut Browser>,
+            icon_urls: Option<&mut CefStringList>,
+        ) {
+            let mut inner = self.inner.lock();
+            inner.on_favicon_urlchange(browser, icon_urls);
+        }
     }
 }
 

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -117,8 +117,14 @@ impl AgentMuxHandler {
             }
         }
         // For Alloy-style native windows on Windows, update via Win32 API.
+        // Reagent P1 on #876: only call SetWindowTextW when CEF gave us an
+        // actual title. CEF fires `on_title_change` with `title = None` in
+        // several paths (e.g. about:blank, popup blockers) — passing "" to
+        // SetWindowTextW would blank the application window title in those
+        // cases. Preserve the existing title by skipping the Win32 update
+        // when title is None.
         #[cfg(target_os = "windows")]
-        {
+        if title.is_some() {
             if let Some(browser) = browser.as_ref() {
                 if let Some(host) = browser.host() {
                     let hwnd = host.window_handle();
@@ -178,18 +184,30 @@ impl AgentMuxHandler {
         // Collect favicon URLs from the CefStringList. The list is an in-param
         // provided by CEF — we read via the raw sys API so we don't need to
         // consume (move) the borrowed reference.
+        //
+        // Reagent P1 on #876: `cef_string_list_value` writes into a
+        // `cef_string_t` whose `str_` field points at a freshly-allocated
+        // buffer owned by the list value (with `dtor` set to release it).
+        // Dropping `value` as a plain Rust struct would leak that buffer on
+        // every favicon URL CEF reports. After reading the string, we must
+        // invoke the dtor manually to free the buffer.
         let urls: Vec<String> = if let Some(list) = icon_urls {
             let raw: *mut cef::sys::_cef_string_list_t = list.into();
             if let Some(raw_ref) = unsafe { raw.as_mut() } {
                 let count = unsafe { cef::sys::cef_string_list_size(raw_ref) };
                 (0..count)
                     .filter_map(|i| unsafe {
-                        let mut value = std::mem::zeroed();
-                        (cef::sys::cef_string_list_value(raw_ref, i, &mut value) > 0)
-                            .then_some(value)
-                    })
-                    .map(|value| {
-                        CefString::from(std::ptr::from_ref(&value)).to_string()
+                        let mut value: cef::sys::cef_string_t = std::mem::zeroed();
+                        if cef::sys::cef_string_list_value(raw_ref, i, &mut value) > 0 {
+                            let s = CefString::from(std::ptr::from_ref(&value)).to_string();
+                            // Free the buffer CEF allocated into `value.str_`.
+                            if let Some(dtor) = value.dtor {
+                                dtor(value.str_);
+                            }
+                            Some(s)
+                        } else {
+                            None
+                        }
                     })
                     .collect()
             } else {

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -107,6 +107,8 @@ impl AgentMuxHandler {
     fn on_title_change(&mut self, browser: Option<&mut Browser>, title: Option<&CefString>) {
         debug_assert_ne!(currently_on(ThreadId::UI), 0);
 
+        let title_str = title.map(|t| t.to_string()).unwrap_or_default();
+
         // Update the window title via CEF Views.
         let mut browser = browser.cloned();
         if let Some(browser_view) = browser_view_get_for_browser(browser.as_mut()) {
@@ -117,12 +119,11 @@ impl AgentMuxHandler {
         // For Alloy-style native windows on Windows, update via Win32 API.
         #[cfg(target_os = "windows")]
         {
-            if let (Some(browser), Some(title)) = (browser.as_ref(), title) {
+            if let Some(browser) = browser.as_ref() {
                 if let Some(host) = browser.host() {
                     let hwnd = host.window_handle();
                     if !hwnd.0.is_null() {
-                        let title_wide: Vec<u16> = title
-                            .to_string()
+                        let title_wide: Vec<u16> = title_str
                             .encode_utf16()
                             .chain(std::iter::once(0))
                             .collect();
@@ -136,6 +137,80 @@ impl AgentMuxHandler {
                 }
             }
         }
+
+        // Emit live title to frontend for browser panes.
+        if self.is_browser_pane {
+            if let Some(b) = browser.as_ref() {
+                if let Some(block_id) =
+                    crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
+                {
+                    let block_id_short: String = block_id.chars().take(7).collect();
+                    tracing::info!(
+                        "[browser-pane:diag][{}] emit-title-change title={:?}",
+                        block_id_short,
+                        title_str,
+                    );
+                    crate::events::emit_event_from_state(
+                        &self.state,
+                        "browser-pane-title-change",
+                        &serde_json::json!({ "block_id": block_id, "title": title_str }),
+                    );
+                }
+            }
+        }
+    }
+
+    fn on_favicon_urlchange(
+        &mut self,
+        browser: Option<&mut Browser>,
+        icon_urls: Option<&mut CefStringList>,
+    ) {
+        if !self.is_browser_pane {
+            return;
+        }
+        let Some(b) = browser.as_deref() else { return };
+        let Some(block_id) =
+            crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
+        else {
+            return;
+        };
+
+        // Collect favicon URLs from the CefStringList. The list is an in-param
+        // provided by CEF — we read via the raw sys API so we don't need to
+        // consume (move) the borrowed reference.
+        let urls: Vec<String> = if let Some(list) = icon_urls {
+            let raw: *mut cef::sys::_cef_string_list_t = list.into();
+            if let Some(raw_ref) = unsafe { raw.as_mut() } {
+                let count = unsafe { cef::sys::cef_string_list_size(raw_ref) };
+                (0..count)
+                    .filter_map(|i| unsafe {
+                        let mut value = std::mem::zeroed();
+                        (cef::sys::cef_string_list_value(raw_ref, i, &mut value) > 0)
+                            .then_some(value)
+                    })
+                    .map(|value| {
+                        CefString::from(std::ptr::from_ref(&value)).to_string()
+                    })
+                    .collect()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        let block_id_short: String = block_id.chars().take(7).collect();
+        tracing::info!(
+            "[browser-pane:diag][{}] emit-favicon-urls count={} first={:?}",
+            block_id_short,
+            urls.len(),
+            urls.first(),
+        );
+        crate::events::emit_event_from_state(
+            &self.state,
+            "browser-pane-favicon-urls",
+            &serde_json::json!({ "block_id": block_id, "urls": urls }),
+        );
     }
 
     fn on_after_created(&mut self, browser: Option<&mut Browser>) {

--- a/docs/specs/SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md
+++ b/docs/specs/SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md
@@ -1,0 +1,430 @@
+# Browser Pane: Live Favicon + Page Title in Pane Header
+
+**Date:** 2026-05-15  
+**Status:** Proposed  
+**Author:** AgentY  
+**Depends on:** browser-pane-reducer-roadmap.md Phase 6 (this spec IS Phase 6, broken into two independent sub-features)
+
+---
+
+## Summary
+
+When the embedded browser pane navigates to a page, the pane header shows:
+- **Icon:** `globe` (FontAwesome) — static, never changes regardless of the loaded page
+- **Title:** `"Browser"` — static fallback, never updates from the actual page title
+
+This spec wires both to live data from CEF. After this change the pane header shows the real page favicon as its icon, and the real `<title>` as its name — exactly like a browser tab.
+
+---
+
+## Current State Analysis
+
+### What exists (and works)
+
+| Component | Status | File |
+|-----------|--------|------|
+| `TitleChanged` reducer command | ✅ Fully implemented | `frontend/app/store/browser-pane-state/reducer.ts:172` |
+| `title` cell in `BrowserPaneState` | ✅ Fully implemented | `frontend/app/store/browser-pane-state/types.ts:73` |
+| `title` projection → `setTitle(next)` | ✅ Wired in `BrowserViewModel` | `browser-model.ts:234` |
+| `viewName` returns `titleAtom()` | ✅ Plumbed to header | `browser-model.ts:250` |
+| `faviconUrl` cell in state | ✅ Exists, derived from URL | `types.ts:91` |
+| `faviconUrlAtom` signal on model | ✅ Exists | `browser-model.ts:110` |
+| Rust `on_title_change` handler | ✅ Fires on page load | `agentmux-cef/src/client/mod.rs:107` |
+| CEF `on_favicon_urlchange` trait method | ✅ Available in cef-146 binding | `ImplDisplayHandler::on_favicon_urlchange` |
+| `resolve_pane_block_id()` | ✅ Already works | `browser_pane/callbacks.rs:241` |
+
+### What is missing (the gap)
+
+**Title gap:** `on_title_change` (line 107 in `client/mod.rs`) only calls `SetWindowTextW`. It does NOT check `is_browser_pane` and does NOT emit `browser-pane-title-change` IPC. The frontend has no subscription to any title event.
+
+**Favicon gap:** `on_favicon_urlchange` is not overridden anywhere in `AgentMuxHandler`. The current `deriveFaviconUrl(url)` in the reducer constructs `origin/favicon.ico` — a guess that fails for sites using `/wp-content/...`, `/assets/...`, or Apple touch icons.
+
+**Icon rendering gap:** `ViewModel.viewIcon` type is `Accessor<string | IconButtonDecl>`. `getViewIconElem()` in `blockframe.tsx:154` only renders FontAwesome icon strings or `IconButtonDecl` buttons. It has no code path for image URLs. Showing a real favicon requires either extending the type or rendering an `<img>` from inside the view model.
+
+---
+
+## Design
+
+Two independent sub-features. Each is a small, self-contained PR.
+
+### Sub-feature 1: Live page title (simpler — do first)
+
+No new UI changes. The title already flows to the header — the only gap is the IPC bridge.
+
+**Rust: emit title change for panes**
+
+In `agentmux-cef/src/client/mod.rs`, `on_title_change` (line 107), add a pane branch after the existing `SetWindowTextW` block:
+
+```rust
+fn on_title_change(&mut self, browser: Option<&mut Browser>, title: Option<&CefString>) {
+    // ... existing window title code ...
+
+    // Emit title to frontend for browser panes.
+    if self.is_browser_pane {
+        if let Some(browser) = browser.as_deref() {
+            if let Some(block_id) = crate::browser_pane::callbacks::resolve_pane_block_id(
+                &self.state, browser,
+            ) {
+                let title_str = title.map(|t| t.to_string()).unwrap_or_default();
+                let block_id_short: String = block_id.chars().take(7).collect();
+                tracing::info!(
+                    "[browser-pane:diag][{}] emit-title-change title={:?}",
+                    block_id_short, title_str,
+                );
+                crate::events::emit_event_from_state(
+                    &self.state,
+                    "browser-pane-title-change",
+                    &serde_json::json!({ "block_id": block_id, "title": title_str }),
+                );
+            }
+        }
+    }
+}
+```
+
+Note: `resolve_pane_block_id` is currently a `fn` (not `pub fn`) in `callbacks.rs`. It needs to be made `pub(crate)` for this call site.
+
+**Frontend: subscribe in `BrowserViewModel`**
+
+In `browser-model.ts`, alongside the existing `browser-pane-nav-state` subscription (around line 260), add:
+
+```typescript
+void listenEvent<{ block_id: string; title: string }>(
+    "browser-pane-title-change",
+    (payload) => {
+        if (this.closed) {
+            this.diag(`post-close-event-dropped name=browser-pane-title-change`);
+            return;
+        }
+        if (payload.block_id !== this.blockId) return;
+        this.diag(`title-change recv title=${JSON.stringify(payload.title)}`);
+        this._dispatch({ type: "TitleChanged", title: payload.title }, "title-change");
+    }
+).then((unsub) => {
+    this.diag(`sub-registered name=browser-pane-title-change`);
+    if (this.closed) unsub();
+    else this._titleUnsub = unsub;
+});
+```
+
+Add `private _titleUnsub: (() => void) | null = null;` with the other unsub fields, and null+call it in `dispose()`.
+
+**Result:** The pane header title updates on every page navigation. `TITLE_FALLBACK = "Browser"` remains the initial value and the fallback for pages that emit an empty title.
+
+---
+
+### Sub-feature 2: Live favicon in pane header (more involved)
+
+This requires changes in three layers: Rust (emit real URLs), frontend state (override derived URL), and blockframe (render image).
+
+#### Layer A: Rust — emit real favicon URLs
+
+`AgentMuxHandler` implements `ImplDisplayHandler`. The `on_favicon_urlchange` method already has a no-op default in the trait. Override it in `agentmux-cef/src/client/mod.rs` (alongside `on_title_change`):
+
+```rust
+fn on_favicon_urlchange(
+    &mut self,
+    browser: Option<&mut Browser>,
+    icon_urls: Option<&mut CefStringList>,
+) {
+    if !self.is_browser_pane {
+        return;
+    }
+    let Some(browser) = browser.as_deref() else { return };
+    let Some(block_id) = crate::browser_pane::callbacks::resolve_pane_block_id(
+        &self.state, browser,
+    ) else { return };
+
+    let urls: Vec<String> = icon_urls
+        .map(|list| {
+            (0..list.len())
+                .filter_map(|i| list.get(i).map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let block_id_short: String = block_id.chars().take(7).collect();
+    tracing::info!(
+        "[browser-pane:diag][{}] emit-favicon-urls count={} urls={:?}",
+        block_id_short,
+        urls.len(),
+        urls,
+    );
+
+    crate::events::emit_event_from_state(
+        &self.state,
+        "browser-pane-favicon-urls",
+        &serde_json::json!({ "block_id": block_id, "urls": urls }),
+    );
+}
+```
+
+CEF fires `on_favicon_urlchange` for each navigation once the page's `<link rel="icon">` elements are parsed. `icon_urls` contains the full URL list in document order; the first one is usually the primary favicon.
+
+#### Layer B: Frontend state — `FaviconUrlConfirmed` command
+
+The current `faviconUrl` cell is a **derived projection** of `url` — no independent input command exists. For real favicon URLs from CEF we need an override command.
+
+**In `types.ts`**, add to `BrowserPaneCommand`:
+
+```typescript
+/**
+ * Host emitted the page's actual favicon URLs from on_favicon_urlchange.
+ * Overrides the guessed `origin/favicon.ico` derivation. An empty `urls`
+ * array clears back to the derived value. Idempotent on identical url.
+ */
+| { type: "FaviconUrlsReceived"; urls: string[] }
+```
+
+And to `BrowserPaneState`, add a flag to track whether favicon was overridden:
+
+```typescript
+/** When true, faviconUrl came from an explicit on_favicon_urlchange event
+ *  and should not be overwritten by URL derivation. Cleared on Navigate
+ *  so each new page starts from the derived heuristic until CEF reports. */
+faviconOverridden: boolean;
+```
+
+**In `reducer.ts`**, handle `FaviconUrlsReceived`:
+
+```typescript
+case "FaviconUrlsReceived": {
+    // Pick first URL; caller provides the list in document order.
+    const next = command.urls[0] ?? "";
+    if (next === state.faviconUrl && state.faviconOverridden) {
+        return { state, events: [] };
+    }
+    return {
+        state: { ...state, faviconUrl: next, faviconOverridden: next !== "" },
+        events: [{ type: "favicon-urls-received", url: next }],
+    };
+}
+```
+
+And clear `faviconOverridden` in the `Navigate` case:
+
+```typescript
+case "Navigate": {
+    return {
+        state: {
+            ...state,
+            loading: true,
+            error: null,
+            url: command.url,
+            faviconUrl: deriveFaviconUrl(command.url),  // heuristic while real one loads
+            faviconOverridden: false,
+        },
+        events: [{ type: "navigate", url: command.url }],
+    };
+}
+```
+
+**In `browser-model.ts`**, subscribe to the new event:
+
+```typescript
+void listenEvent<{ block_id: string; urls: string[] }>(
+    "browser-pane-favicon-urls",
+    (payload) => {
+        if (this.closed) return;
+        if (payload.block_id !== this.blockId) return;
+        this.diag(`favicon-urls recv count=${payload.urls.length}`);
+        this._dispatch({ type: "FaviconUrlsReceived", urls: payload.urls }, "favicon-urls");
+    }
+).then((unsub) => {
+    if (this.closed) unsub();
+    else this._faviconUnsub = unsub;
+});
+```
+
+#### Layer C: Render favicon image in pane header
+
+**The constraint:** `ViewModel.viewIcon` is typed `Accessor<string | IconButtonDecl>`. `getBlockHeaderIcon()` in `blockutil.tsx:120` takes a `string`, converts it to a FontAwesome class, and returns `<i class="fa-solid fa-..."/>`. It has no image path for `favicon.ico` URLs.
+
+**Chosen approach: extend `ViewModel.viewIcon` to accept `JSX.Element`**
+
+This is the minimal-change path that avoids wrapping a favicon image inside a button affordance.
+
+**Step 1: Update `custom.d.ts`**
+
+```typescript
+interface ViewModel {
+    viewType?: string;
+    viewIcon?: Accessor<string | IconButtonDecl | JSX.Element>;  // add JSX.Element
+    viewName?: Accessor<string>;
+    // ...
+}
+```
+
+**Step 2: Update `getViewIconElem` in `blockframe.tsx:154`**
+
+```typescript
+function getViewIconElem(viewIconUnion: string | IconButtonDecl | JSX.Element, blockData: Block): JSX.Element {
+    if (viewIconUnion == null || typeof viewIconUnion === "string") {
+        const viewIcon = viewIconUnion as string;
+        return <div class="block-frame-view-icon">{getBlockHeaderIcon(viewIcon, blockData)}</div>;
+    } else if (isJSXElement(viewIconUnion)) {
+        // Raw JSX — wrap in the same container so layout is consistent.
+        return <div class="block-frame-view-icon">{viewIconUnion as JSX.Element}</div>;
+    } else {
+        return <IconButton decl={viewIconUnion as IconButtonDecl} className="block-frame-view-icon" />;
+    }
+}
+```
+
+`isJSXElement` is a simple runtime discriminator:
+
+```typescript
+function isJSXElement(v: unknown): boolean {
+    // SolidJS JSX elements are objects with a $$typeof symbol or a
+    // function component — not a plain string, not a number.
+    // An IconButtonDecl is a POJO with elemtype:"iconbutton"; a JSX element
+    // produced by solid-js is a function or an object without elemtype.
+    if (typeof v === "function") return true;
+    if (typeof v === "object" && v !== null && !("elemtype" in v)) return true;
+    return false;
+}
+```
+
+**Step 3: `BrowserViewModel.viewIcon` becomes a memo**
+
+In `browser-model.ts`, replace:
+
+```typescript
+viewIcon: Accessor<string> = () => "globe";
+```
+
+with:
+
+```typescript
+viewIcon: Accessor<string | JSX.Element> = createMemo(() => {
+    const url = this.faviconUrlAtom();
+    if (!url) return "globe";
+    return (
+        <img
+            class="browser-pane-favicon"
+            src={url}
+            alt=""
+            onError={(e) => {
+                // Hide broken image; blockframe falls back to globe below.
+                (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+            width={14}
+            height={14}
+        />
+    ) as JSX.Element;
+});
+```
+
+**Step 4: CSS — `browser-pane-favicon`**
+
+In `browser-view.scss` (or a new `browser-model.scss`):
+
+```scss
+.browser-pane-favicon {
+    width: 14px;
+    height: 14px;
+    object-fit: contain;
+    display: block;
+    border-radius: 2px;
+}
+```
+
+The `.block-frame-view-icon` container is already `14px` wide (matches FontAwesome icon slot). No layout changes needed.
+
+---
+
+## Rendering result
+
+Before:
+
+```
+[🌐] Browser
+```
+
+After navigating to `https://github.com`:
+
+```
+[🐙] github / reagent · Pull Request #156
+```
+
+(favicon from `https://github.com/favicon.ico`, title from page `<title>`)
+
+The title truncates via the existing `.block-frame-view-type` ellipsis CSS — no additional work needed.
+
+---
+
+## Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Page has no `<link rel="icon">` | CEF may not fire `on_favicon_urlchange`; `faviconUrl` stays at `origin/favicon.ico` heuristic |
+| Favicon 404 or broken | `<img onError>` hides the element; `.block-frame-view-icon` renders empty (acceptable — title still shows) |
+| `on_title_change` emits empty string | Reducer folds to `TITLE_FALLBACK = "Browser"` (existing Invariant 6) |
+| Pane closed before event arrives | `_dispatch` guard in model no-ops; unsubs called in `dispose()` |
+| Multiple favicon URLs from CEF | First URL used; this is the primary favicon per HTML spec |
+
+---
+
+## Files changed
+
+### Sub-feature 1 (title)
+- `agentmux-cef/src/client/mod.rs` — add IPC emit in `on_title_change` for panes
+- `agentmux-cef/src/browser_pane/callbacks.rs` — make `resolve_pane_block_id` `pub(crate)`
+- `frontend/app/view/browser/browser-model.ts` — add `browser-pane-title-change` subscription, `_titleUnsub`
+
+### Sub-feature 2 (favicon)
+- `agentmux-cef/src/client/mod.rs` — add `on_favicon_urlchange` override
+- `agentmux-cef/src/browser_pane/callbacks.rs` — `resolve_pane_block_id` already `pub(crate)` from sub-feature 1
+- `frontend/app/store/browser-pane-state/types.ts` — add `FaviconUrlsReceived` command, `faviconOverridden` field, `favicon-urls-received` event
+- `frontend/app/store/browser-pane-state/reducer.ts` — handle `FaviconUrlsReceived`, clear `faviconOverridden` in `Navigate`
+- `frontend/types/custom.d.ts` — extend `ViewModel.viewIcon` union to include `JSX.Element`
+- `frontend/app/block/blockframe.tsx` — `getViewIconElem` handles JSX.Element, `isJSXElement` discriminator
+- `frontend/app/view/browser/browser-model.ts` — `viewIcon` memo, `browser-pane-favicon-urls` subscription, `_faviconUnsub`
+- `frontend/app/view/browser/browser-view.scss` — `.browser-pane-favicon` sizing
+
+---
+
+## Testing
+
+```
+# Verify title updates on navigation
+1. Open browser pane → navigate to https://github.com
+2. Header should update from "Browser" to "GitHub · Build and ship software on a single, collaborative platform · GitHub"
+   (or truncated version)
+3. Navigate to https://www.rust-lang.org
+4. Header should update to "Rust Programming Language"
+
+# Verify title fallback
+5. Navigate to about:blank → header should remain "Browser" (empty title folds to fallback)
+
+# Verify favicon appears  
+6. Open browser pane → navigate to https://github.com
+7. Globe icon in header should be replaced by GitHub's favicon image
+8. Navigate to https://news.ycombinator.com
+9. Orange Y favicon should appear
+
+# Verify favicon error fallback
+10. Navigate to a page with a 404 favicon
+11. Icon slot should render empty (no broken image icon)
+
+# Verify pane lifecycle safety
+12. Close a pane while it's still loading — no errors in console
+    grep: muxlog host '[browser-pane:diag]' should show post-close-event-dropped, not an exception
+```
+
+---
+
+## Relation to browser-pane-reducer-roadmap.md
+
+This spec is what the roadmap calls "Phase 6" — the actual product features. The roadmap's Phase 5 (slot audit / diag panel) is not a prerequisite for these changes; both sub-features are additive and don't restructure any existing state transitions. They can ship independently of Phase 5.
+
+The roadmap's caution about PR #737 (regression from trying to migrate + feature in one PR) is addressed here by splitting into two tiny PRs that are purely additive.
+
+---
+
+## PR order
+
+1. **`agenty/browser-pane-live-title`** — Sub-feature 1 only (~60 lines changed)
+2. **`agenty/browser-pane-live-favicon`** — Sub-feature 2 only (~150 lines changed)
+
+No blocking dependency between the two; they touch non-overlapping code except both use `resolve_pane_block_id` (sub-feature 1 makes it `pub(crate)`, sub-feature 2 uses it). Sub-feature 2 PR should rebase on sub-feature 1.

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -300,6 +300,15 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                         alt=""
                         width={14}
                         height={14}
+                        onLoad={(e) => {
+                            // Reagent P2 on #876: SolidJS reuses the same
+                            // <img> DOM node when `src` reactively changes,
+                            // so a `display:none` from a prior failed
+                            // favicon persists across `src` swaps and hides
+                            // all subsequent valid favicons. Reset on every
+                            // successful load.
+                            (e.currentTarget as HTMLImageElement).style.display = "";
+                        }}
                         onError={(e) => {
                             (e.currentTarget as HTMLImageElement).style.display = "none";
                         }}

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -288,7 +288,27 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
     const onContextMenu = (e: MouseEvent) => {
         handleHeaderContextMenu(e, blockData(), props.viewModel, props.nodeModel.isMagnified(), props.nodeModel.toggleMagnify, props.nodeModel.onClose);
     };
-    const viewIconElem = createMemo(() => getViewIconElem(viewIconUnion(), blockData()));
+    const viewFaviconUrl = createMemo(() => util.useAtomValueSafe(props.viewModel?.viewFaviconUrl));
+    const viewIconElem = createMemo(() => {
+        const favUrl = viewFaviconUrl();
+        if (favUrl) {
+            return (
+                <div class="block-frame-view-icon">
+                    <img
+                        class="browser-pane-favicon"
+                        src={favUrl}
+                        alt=""
+                        width={14}
+                        height={14}
+                        onError={(e) => {
+                            (e.currentTarget as HTMLImageElement).style.display = "none";
+                        }}
+                    />
+                </div>
+            );
+        }
+        return getViewIconElem(viewIconUnion(), blockData());
+    });
 
     const preIconButtonElem: JSX.Element = preIconButton
         ? <IconButton decl={preIconButton} className="block-frame-preicon-button" />

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -80,6 +80,7 @@ export function update(
                     error: null,
                     url: command.url,
                     faviconUrl: deriveFaviconUrl(command.url),
+                    faviconOverridden: false,
                 },
                 events: [{ type: "navigate", url: command.url }],
             };
@@ -175,6 +176,17 @@ export function update(
             return {
                 state: { ...state, title: next },
                 events: [{ type: "title-changed", title: next }],
+            };
+        }
+
+        case "FaviconUrlsReceived": {
+            const next = command.urls[0] ?? "";
+            if (next === state.faviconUrl && state.faviconOverridden === (next !== "")) {
+                return { state, events: [] };
+            }
+            return {
+                state: { ...state, faviconUrl: next, faviconOverridden: next !== "" },
+                events: [{ type: "favicon-urls-received", url: next }],
             };
         }
 

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -143,11 +143,18 @@ export function update(
 
         case "UrlConfirmed": {
             if (state.url === command.url) return { state, events: [] };
+            // Reagent P2 on #876: preserve a CEF-reported favicon across
+            // redirects + hash-changes. Only re-derive the heuristic favicon
+            // if no real favicon has overridden it. Otherwise the user sees
+            // the real favicon flash to the heuristic on every nav event.
+            const faviconUrl = state.faviconOverridden
+                ? state.faviconUrl
+                : deriveFaviconUrl(command.url);
             return {
                 state: {
                     ...state,
                     url: command.url,
-                    faviconUrl: deriveFaviconUrl(command.url),
+                    faviconUrl,
                 },
                 events: [{ type: "url-confirmed", url: command.url }],
             };

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -180,12 +180,21 @@ export function update(
         }
 
         case "FaviconUrlsReceived": {
-            const next = command.urls[0] ?? "";
-            if (next === state.faviconUrl && state.faviconOverridden === (next !== "")) {
+            // Reagent P2 on #876: when CEF reports an empty favicon-URL list
+            // (page has no <link rel="icon"> tags), fall back to the
+            // heuristic-derived favicon from the page URL rather than ""
+            // — matches the types.ts doc comment for FaviconUrlsReceived
+            // and the page-navigation paths above that already derive on
+            // navigation. The override flag stays false so a later real
+            // favicon report can replace it.
+            const cefUrl = command.urls[0];
+            const next = cefUrl ?? deriveFaviconUrl(state.url);
+            const overridden = cefUrl !== undefined;
+            if (next === state.faviconUrl && state.faviconOverridden === overridden) {
                 return { state, events: [] };
             }
             return {
-                state: { ...state, faviconUrl: next, faviconOverridden: next !== "" },
+                state: { ...state, faviconUrl: next, faviconOverridden: overridden },
                 events: [{ type: "favicon-urls-received", url: next }],
             };
         }

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -80,15 +80,17 @@ export interface BrowserPaneState {
      *  and superseded by `UrlConfirmed` (host's `browser-pane-nav-state`
      *  reporting the post-redirect final URL). */
     url: string;
-    /** Pane favicon URL — derived from `url`'s origin via
-     *  `${origin}/favicon.ico`. Empty string when `url` is empty or
-     *  unparseable; the view falls back to a globe icon in that case.
-     *  Computed by `deriveFaviconUrl` inside every transition that
-     *  writes `url` (Navigate, UrlConfirmed, UrlCleared) — there is
-     *  no `FaviconChanged` command, since the cell isn't an
-     *  independent input. Catalog reference: row 1.faviconUrlAtom in
-     *  `docs/specs/browser-pane-state-catalog.md`. */
+    /** Pane favicon URL. Initially derived from `url`'s origin via
+     *  `${origin}/favicon.ico`; overridden by a real URL when CEF
+     *  fires `on_favicon_urlchange` (command `FaviconUrlsReceived`).
+     *  Empty string when `url` is empty or unparseable; the view
+     *  falls back to the globe icon in that case. */
     faviconUrl: string;
+    /** True once a `FaviconUrlsReceived` command with a non-empty
+     *  URL has been applied — prevents the derived-from-URL heuristic
+     *  from overwriting a real favicon. Cleared by `Navigate` so each
+     *  new page starts fresh from the heuristic until CEF reports. */
+    faviconOverridden: boolean;
 }
 
 /**
@@ -127,6 +129,7 @@ export const initialState = (): BrowserPaneState => ({
     title: TITLE_FALLBACK,
     url: "",
     faviconUrl: "",
+    faviconOverridden: false,
 });
 
 export type BrowserPaneCommand =
@@ -205,6 +208,12 @@ export type BrowserPaneCommand =
      */
     | { type: "PaneClicked" }
     /**
+     * CEF fired `on_favicon_urlchange` with the page's real favicon URL list.
+     * The first URL is used; an empty array clears the override and falls back
+     * to the heuristic derivation. Idempotent on identical URL.
+     */
+    | { type: "FaviconUrlsReceived"; urls: string[] }
+    /**
      * The pane is being torn down. After this command runs, every
      * subsequent command on this state is a no-op. Idempotent —
      * dispatching `Disposed` twice is a no-op the second time.
@@ -225,6 +234,7 @@ export type BrowserPaneEvent =
     | { type: "url-confirmed"; url: string }
     | { type: "url-cleared" }
     | { type: "pane-clicked" }
+    | { type: "favicon-urls-received"; url: string }
     | { type: "disposed" }
     /** Invariant fire — emitted instead of mutating state when a
      *  command targets a closed pane. Surfaced for diagnostics so

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -87,6 +87,7 @@ export class BrowserViewModel implements ViewModel {
 
     viewIcon: Accessor<string> = () => "globe";
     viewName: Accessor<string>;
+    viewFaviconUrl: Accessor<string>;
     viewText: Accessor<string | HeaderElem[]> = () => [];
     noPadding: Accessor<boolean> = () => true;
 
@@ -141,6 +142,12 @@ export class BrowserViewModel implements ViewModel {
      * shows the blue focus border and keyboard shortcuts target it.
      */
     private _clickUnsub: (() => void) | null = null;
+
+    /** Unsubscribe from `browser-pane-title-change` IPC events. */
+    private _titleUnsub: (() => void) | null = null;
+
+    /** Unsubscribe from `browser-pane-favicon-urls` IPC events. */
+    private _faviconUnsub: (() => void) | null = null;
 
     blockAtom: Accessor<Block | undefined>;
 
@@ -248,6 +255,43 @@ export class BrowserViewModel implements ViewModel {
         installEventSinkOnce();
 
         this.viewName = createMemo(() => this.titleAtom());
+        this.viewFaviconUrl = createMemo(() => this.faviconUrlAtom());
+
+        // Subscribe to live title changes fired by CEF's on_title_change.
+        void listenEvent<{ block_id: string; title: string }>(
+            "browser-pane-title-change",
+            (payload) => {
+                if (this.closed) {
+                    this.diag(`post-close-event-dropped name=browser-pane-title-change`);
+                    return;
+                }
+                if (payload.block_id !== this.blockId) return;
+                this.diag(`title-change recv title=${JSON.stringify(payload.title)}`);
+                this._dispatch({ type: "TitleChanged", title: payload.title }, "title-change");
+            },
+        ).then((unsub) => {
+            this.diag(`sub-registered name=browser-pane-title-change`);
+            if (this.closed) unsub();
+            else this._titleUnsub = unsub;
+        });
+
+        // Subscribe to real favicon URLs fired by CEF's on_favicon_urlchange.
+        void listenEvent<{ block_id: string; urls: string[] }>(
+            "browser-pane-favicon-urls",
+            (payload) => {
+                if (this.closed) {
+                    this.diag(`post-close-event-dropped name=browser-pane-favicon-urls`);
+                    return;
+                }
+                if (payload.block_id !== this.blockId) return;
+                this.diag(`favicon-urls recv count=${payload.urls.length}`);
+                this._dispatch({ type: "FaviconUrlsReceived", urls: payload.urls }, "favicon-urls");
+            },
+        ).then((unsub) => {
+            this.diag(`sub-registered name=browser-pane-favicon-urls`);
+            if (this.closed) unsub();
+            else this._faviconUnsub = unsub;
+        });
 
         // Subscribe to nav-state updates fired by the backend on every
         // `on_load_end_pane`. This is the source of truth for address bar +
@@ -444,6 +488,14 @@ export class BrowserViewModel implements ViewModel {
         if (this._clickUnsub) {
             this._clickUnsub();
             this._clickUnsub = null;
+        }
+        if (this._titleUnsub) {
+            this._titleUnsub();
+            this._titleUnsub = null;
+        }
+        if (this._faviconUnsub) {
+            this._faviconUnsub();
+            this._faviconUnsub = null;
         }
         // Drop the slot AFTER the Disposed dispatch — the projection
         // for `closed:true` runs first, so any consumer reading

--- a/frontend/app/view/browser/browser-view.scss
+++ b/frontend/app/view/browser/browser-view.scss
@@ -1,6 +1,14 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+.browser-pane-favicon {
+    width: 14px;
+    height: 14px;
+    object-fit: contain;
+    display: block;
+    border-radius: 2px;
+}
+
 .browser-view {
     display: flex;
     flex-direction: column;

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -433,6 +433,9 @@ declare global {
     interface ViewModel {
         viewType: string;
         viewIcon?: Accessor<string | IconButtonDecl>;
+        /** When set, overrides the FA icon in the block header with a favicon <img>.
+         *  The consumer (blockframe) falls back to viewIcon if this is empty string. */
+        viewFaviconUrl?: Accessor<string>;
         viewName?: Accessor<string>;
         /** When provided, the header name becomes an inline editable text field. */
         setViewName?: (name: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- **Live title:** CEF's `on_title_change` now emits `browser-pane-title-change` IPC when `is_browser_pane` is true. `BrowserViewModel` subscribes and dispatches `TitleChanged` into the existing slice-#9 reducer. The pane header title updates on every navigation instead of staying at `"Browser"`.
- **Real favicon:** New `on_favicon_urlchange` override in `AgentMuxHandler` emits `browser-pane-favicon-urls` with the page's actual favicon URL list from `<link rel="icon">`. Frontend subscribes and dispatches the new `FaviconUrlsReceived` command, which overrides the `origin/favicon.ico` heuristic. The heuristic still appears immediately on navigate (before CEF reports); `FaviconUrlsReceived` replaces it once the page loads. Cleared on `Navigate` so each page starts fresh.
- **Favicon in header:** `ViewModel` gains `viewFaviconUrl?: Accessor<string>`. Blockframe renders a 14×14 `<img>` in the icon slot when set, with an `onError` fallback to empty (the `viewIcon` globe shows in that case). `BrowserViewModel.viewFaviconUrl` wires directly to `faviconUrlAtom`.
- Spec: `docs/specs/SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md`

## Files changed

| File | Change |
|------|--------|
| `agentmux-cef/src/client/mod.rs` | `on_title_change` pane emit + `on_favicon_urlchange` override |
| `agentmux-cef/src/client/handlers.rs` | `on_favicon_urlchange` delegation |
| `agentmux-cef/src/browser_pane/callbacks.rs` | `resolve_pane_block_id` → `pub(crate)` |
| `frontend/types/custom.d.ts` | `viewFaviconUrl` on `ViewModel` |
| `frontend/app/store/browser-pane-state/types.ts` | `FaviconUrlsReceived` command, `faviconOverridden` field, event |
| `frontend/app/store/browser-pane-state/reducer.ts` | Handle `FaviconUrlsReceived`, clear `faviconOverridden` in `Navigate` |
| `frontend/app/block/blockframe.tsx` | Render `<img>` when `viewFaviconUrl` is set |
| `frontend/app/view/browser/browser-model.ts` | `viewFaviconUrl`, title + favicon subscriptions + dispose cleanup |
| `frontend/app/view/browser/browser-view.scss` | `.browser-pane-favicon` sizing |

## Test plan

- [ ] Open browser pane → navigate to any site → pane header title updates from `"Browser"` to the real page title
- [ ] Globe icon replaced by site favicon after page loads
- [ ] Navigate to a new URL → title + favicon both update
- [ ] Close pane while loading → no console errors (`post-close-event-dropped` in diag log, no exceptions)
- [ ] Site with 404 favicon → icon slot empty (no broken image), title still works
- [ ] `muxlog host '[browser-pane:diag]'` shows `emit-title-change`, `emit-favicon-urls`, `title-change recv`, `favicon-urls recv` in sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)