### PR TITLE
fix(agent-pane): cascade detection + dispatchIfRegistered migration

### DIFF
--- a/.changesets/1778890219-fix-agent-pane-cascade-detection-instrumentation-in-pane-sto-hxch.md
+++ b/.changesets/1778890219-fix-agent-pane-cascade-detection-instrumentation-in-pane-sto-hxch.md
@@ -2,4 +2,10 @@
 type: patch
 ---
 
-fix(agent-pane): cascade-detection instrumentation in pane stores
+fix(agent-pane): cascade detection + dispatchIfRegistered migration
+
+- Detect reactive cascades that dispose a pane mid-dispatch (`agent-pane-state-store.ts`, `agent-document-store.ts`); log a `CASCADE_DETECTED` warning identifying the projection setter that triggered the dispose.
+- Add `dispatchIfRegistered` soft-variant on both pane stores; migrate 22 async-context call sites (RAF, setTimeout, setInterval, subscription handlers, RPC `.catch()` continuations) across `useAgentStream.ts`, `useAgentCommands.ts`, `useHistoryPagination.ts`, and `agent-view.tsx` so they silently no-op instead of throwing when the pane disposed mid-dispatch.
+- Guard the `browser-model.reload()` RAF callback with `if (this.closed) return;` to match every other IPC handler in that file.
+
+Throwing `dispatch()` stays as the contract for synchronous-body register-order checks. Backed by new `agent-pane-state-store.test.ts` covering both contracts (5 tests, 306 total still pass).

--- a/.changesets/1778890219-fix-agent-pane-cascade-detection-instrumentation-in-pane-sto-hxch.md
+++ b/.changesets/1778890219-fix-agent-pane-cascade-detection-instrumentation-in-pane-sto-hxch.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(agent-pane): cascade-detection instrumentation in pane stores

--- a/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
+++ b/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
@@ -1,0 +1,319 @@
+# Analysis: Lifecycle / Dispatch Leak Class
+
+**Date:** 2026-05-15
+**Author:** AgentA
+**Incident:** v0.33.899 portable, first launch post-#877 merge — red-text `replaceChild` NotFoundError surfaced; root cause was `[agent-pane-state] dispatch for unregistered pane c0ae6c7 (cmd=StreamFlushObserved)`.
+
+---
+
+## 1. Incident & root signal
+
+From `~/.agentmux/versions/0.33.899/logs/agentmux-host-v0.33.899.log.2026-05-15`:
+
+```
+23:46:19.953Z WARN  [fe] [agent-document-store] dropped 1 stream updates for unknown ids in c0ae6c7
+23:46:20.073Z ERROR [fe] [UNCAUGHT-ERROR] Uncaught Error:
+    [agent-pane-state] dispatch for unregistered pane c0ae6c7 (cmd=StreamFlushObserved).
+    registerPane must be called synchronously in the component body.
+```
+
+The "replaceChild NotFoundError" the user saw in the UI is a *downstream symptom* — a SolidJS render tree torn by an uncaught error inside a reactive owner. The actual fault is the dispatch into a slot that has already been unregistered.
+
+The 120 ms warning right before the throw is the critical clue: it's emitted by `agent-document-store.ts`'s `StreamFlush` handler when the reducer drops stale `updatedNodes`. So at line 161 of `useAgentStream.ts`, `dispatchDoc(blockId, { type: "StreamFlush", ... })` **succeeded** — the agent-document slot was still registered. Seven lines later at line 168, `dispatchPane(blockId, { type: "StreamFlushObserved", ... })` **threw** — the agent-pane-state slot was gone.
+
+Two slots, two different stores, two different `onCleanup` callbacks. Whatever unregistered the pane-state slot did so **between** lines 161 and 168 of a single synchronous function call.
+
+## 2. The leak class
+
+> **A reactive owner can be disposed *during* a synchronous dispatch sequence if a signal write inside the first dispatch cascades through reactive subscribers and causes a parent to re-render the owner away. Subsequent dispatches in the same callback then hit a no-longer-registered slot and throw.**
+
+### 2.1 Why slot unregistration *can* happen mid-callback
+
+`agent-pane-state-store.ts` `dispatch()` runs the reducer, then calls projection setters:
+
+```ts
+if (slot.state.streaming !== prev.streaming) slot.proj.streaming(slot.state.streaming);
+if (slot.state.turnActive !== prev.turnActive) slot.proj.turnActive(slot.state.turnActive);
+// ... seven more projections
+```
+
+Each `slot.proj.*` is a SolidJS signal setter. Setters notify subscribers **synchronously** within the same JavaScript turn. Subscribers include:
+- `createMemo` and `createEffect` registered against the atom.
+- JSX expressions reading the atom (their owning `Show` / `For` / `Switch` will re-evaluate).
+- The layout tree, which composes the entire pane hierarchy from reactive state.
+
+If any of those subscribers, on this write, decides "the pane should no longer exist" (e.g. a layout transformation triggered by a state change, a tab close cascading from a focus shift, a model swap), SolidJS synchronously runs the disposed pane's `onCleanup` chain — including `unregisterAgentPaneStatePane(blockId)`.
+
+The original `dispatch()` returns. Control returns to `flushPendingNodes`. The next line (`dispatchPane(blockId, { type: "StreamFlushObserved" })`) sees a deleted slot and throws.
+
+### 2.2 Why `cancelAnimationFrame` doesn't save us
+
+The cleanup at `useAgentStream.ts:518` calls `cancelAnimationFrame(flushRafId)`. That **does** prevent a *pending* RAF callback from running. It does **not** unwind a callback that is *currently executing* — and the cascade-during-dispatch scenario above is exactly "currently executing."
+
+### 2.3 Why the per-store throw rule is right (and the leak is on us)
+
+Both `agent-pane-state-store.ts` and `agent-document-store.ts` throw on dispatch to an unregistered slot, on purpose: silent drops would mask reducer-command loss and were explicitly removed in conventions §4–§5 (frontend-reducer-conventions-2026-05-03.md). The throw is the contract.
+
+It is the *callers'* job not to dispatch to a slot that may already be gone.
+
+## 3. The defensive patterns in use today
+
+Four distinct guard patterns exist in the codebase. They are *not* equally effective against the cascade scenario:
+
+| Pattern | Example | Defends against |
+|---|---|---|
+| **Mounted-flag** (`let mounted = true; onCleanup(() => mounted = false; if (!mounted) return)`) | `useHistoryPagination.ts:126-129` and 6 dispatch guards | Async (await) continuations after the owner disposed. **Does not** defend against mid-callback cascade unless checked between *every* dispatch. |
+| **Subscription lifecycle** (subscribe in `onMount`, unsubscribe in `onCleanup`) | `useAgentStream.ts:519-521` `fileSubject.subscribe`, `blockChunkUnsub`, `acceptedUnsub` | Future emissions after `onCleanup` — but emissions *already in flight on the JS stack* still fire. |
+| **`if (this.closed) return`** model flag, checked at every dispatch | `browser-model.ts:261, 282, 311, 361` (uniform pattern across IPC handlers) | Both async continuations *and* mid-handler cascades, **provided the check is at every dispatch site, not just the function entry.** |
+| **`dispatchIfAlive(...)` model helper** | `workflows-model.ts:509-515`, used at all 10 dispatch sites | The strongest variant — encapsulates the closed-check so callers can't forget. |
+
+### 3.1 The `workflows-model.ts` pattern is the right answer
+
+```ts
+private dispatchIfAlive(command, source) {
+    if (this.disposed) return;
+    dispatchWorkflowRun(this.blockId, command, source);
+}
+```
+
+Every async path (`await RpcApi.RunWorkflowCommand()`, `.then(async () => …)` continuations, the WPS subscription handler) routes through this one method. There is no way for a caller to forget the guard. New dispatches default-safe.
+
+Compared to the mounted-flag pattern (which requires the caller to remember to `if (!mounted) return` before each dispatch), the helper-method pattern is strictly stronger — it is impossible to forget unless someone bypasses the helper entirely.
+
+## 4. Site-by-site audit
+
+Catalog produced by reading every dispatch call site in `frontend/app/`. Risk re-evaluated under the cascade lens (an async-context with even one un-guarded dispatch is a risk; a synchronous body that does multiple dispatches in sequence after a signal write is also a risk because the first write can cascade).
+
+### 4.1 HIGH RISK — directly implicated in tonight's crash
+
+#### `frontend/app/view/agent/useAgentStream.ts:150-173` — `flushPendingNodes()` (RAF callback)
+```ts
+function flushPendingNodes() {
+    flushRafId = null;
+    if (pendingNew.length === 0 && pendingUpdates.length === 0) return;
+    const batchNew = pendingNew; const batchUpdates = pendingUpdates;
+    pendingNew = []; pendingUpdates = [];
+
+    dispatchDoc(blockId, { type: "StreamFlush", newNodes: batchNew, updatedNodes: batchUpdates });
+    // ↑ THIS WRITE can cascade through reactive subscribers and dispose the pane.
+    dispatchPane(blockId, { type: "StreamFlushObserved", addedCount: batchNew.length, at: Date.now() });
+    // ↑ THIS THROWS if the cascade unregistered the pane-state slot.
+}
+```
+**Status:** This is the exact site that crashed. Two consecutive dispatches across two stores; the first can cascade-dispose the second's slot.
+
+### 4.2 HIGH RISK — same pattern, undiagnosed but vulnerable
+
+#### `frontend/app/view/agent/useAgentStream.ts:359-374` — `StreamTruncate` handler
+```ts
+const events = dispatchDoc(blockId, { type: "StreamTruncate", reason: "fileop" });
+const honored = events.some((e) => e.type === "truncate-applied");
+if (!honored) return;
+// ...reset locals...
+dispatchPane(blockId, { type: "TurnReset" });
+```
+Same shape: `dispatchDoc` → cascade window → `dispatchPane`.
+
+#### `frontend/app/view/agent/useAgentStream.ts:290-301` — accepted-message handler
+```ts
+dispatchPane(blockId, { type: "PendingMessageAccepted", id: messageId });
+// ...sync logic that reads getPending()...
+dispatchPane(blockId, { type: "TurnStart", at: Date.now() });
+```
+Two `dispatchPane` calls; the first can cascade. The second can hit a gone slot.
+
+#### `frontend/app/view/agent/useAgentStream.ts:520-526` — onCleanup itself
+```ts
+dispatchPane(blockId, { type: "StreamUnsubscribe", at });
+dispatchDoc(blockId, { type: "SessionEnd", at });
+```
+This runs in the cleanup chain. It is *before* `unregisterAgentPaneStatePane` in cleanup-execution order (the stream hook's cleanup is registered later in onMount, runs first in reverse). Currently safe — **but fragile**: if anyone adds an `onCleanup` after this hook's that calls `unregisterAgentPaneStatePane` first, both these dispatches start throwing. The same cascade risk applies *inside* the dispatches themselves.
+
+### 4.3 HIGH RISK — same class, different file
+
+#### `frontend/app/view/browser/browser-model.ts:442-444` — reload() RAF
+```ts
+reload(): void {
+    if (this.closed) return;
+    const url = this.urlAtom();
+    if (url) {
+        this._dispatch({ type: "UrlCleared" }, "reload-clear");
+        requestAnimationFrame(() => {
+            this._dispatch({ type: "Navigate", url }, "reload-restore");
+            // ↑ no this.closed check inside the RAF callback
+        });
+    }
+}
+```
+The closed check at function entry doesn't cover the RAF callback firing after a dispose. This site was already flagged in the dispatch-site audit and is the lowest-friction fix.
+
+### 4.4 MEDIUM RISK — synchronous-only today, fragile to refactor
+
+#### `frontend/app/view/agent/agent-view.tsx:268-272, 300-304` — `handleDecide` and `onLoginSuccess`
+Synchronous click and callback dispatches. Today the click flow runs to completion before any reactive cascade can dispose the pane. *But*: if either dispatch is later wrapped in a microtask, `await`, or callback chain, the synchronous-safety disappears. There is no compile-time enforcement.
+
+#### `frontend/app/view/agent/hooks/useAgentCommands.ts:314, 355` — RPC `.catch()` handlers
+```ts
+RpcApi.AgentInputCommand(...).catch((err) => {
+    dispatchPane(blockId, { type: "SendFailed", ... });
+});
+```
+Today the latency of the failing RPC effectively covers the race. *But*: a synchronous RPC failure path (e.g. precondition check) would expose this. No guard.
+
+### 4.5 LOW RISK — guarded via mounted-flag
+
+`frontend/app/view/agent/hooks/useHistoryPagination.ts` — six dispatch sites, all preceded by `if (!mounted) return;` after every `await`. **Safe today** *for the dispatch-after-await scenario*. **Not safe** against the mid-callback cascade — if a `dispatchDoc(HistoryRestored)` cascade-disposes the pane, the immediately-following `dispatchPane(InitReady)` would still throw. (No evidence this happens in practice, but the pattern is fragile.)
+
+### 4.6 SAFE — `workflows-model.ts`
+
+All 10 dispatch sites route through `dispatchIfAlive()`. Even if the helper runs inside a cascade-disposed state, the `this.disposed` check fires first and the dispatch is silently dropped.
+
+## 5. Why tonight's bug surfaced now (a guess)
+
+PR #877 added two new code paths:
+1. `useHistoryPagination` dispatches `HistoryRestored` from a microtask after `BlockfileReadStateCommand` resolves.
+2. `agent-view.tsx` adds a `createEffect` that watches `getDocument()` and toggles a `dirty` flag.
+
+The `createEffect` is a *new reactive subscriber* on the document atom. Every `StreamFlush` now triggers one additional reactive tick. That tick is what tipped a previously-quiet timing into the cascade window: the dirty-effect runs, *something* it touches (or that the projection setters touch in sequence) cascades into a re-evaluation that disposes the pane. The race was always there; the new reactive subscriber made it deterministic enough to hit on the first smoke test.
+
+This is unfalsified speculation — proving it would require instrumenting the reactive scheduler to log dispose ordering, which we don't have. But the timing of the regression (PR #877 added the only new reactive subscriber on `documentAtom` in months) is consistent.
+
+## 6. Proposed fix
+
+### 6.1 Tactical (one-PR scope, immediate)
+
+Adopt the `dispatchIfAlive` pattern at the store layer rather than at every caller. Two options:
+
+**Option A — caller-side guard at every site (cheaper, fragile):** add `let mounted = true; onCleanup(() => mounted = false)` in `useAgentStream`, then `if (!mounted) return;` before each of the 11 dispatch calls. Replicate in `useAgentCommands`, fix `browser-model.reload()`. Easy to forget on next feature.
+
+**Option B — store-level "soft dispatch" variant (correct, stronger):** add a sibling export to each pane-store:
+```ts
+// agent-pane-state-store.ts
+export function dispatchIfRegistered(
+    blockId: string,
+    command: AgentPaneCommand,
+    source: CommandSource = "system",
+): AgentPaneEvent[] {
+    if (!slots.has(blockId)) return [];  // silent no-op
+    return dispatch(blockId, command, source);
+}
+```
+Migrate all *async-context* dispatch sites (anything reached via RAF/setTimeout/setInterval/await/subscription) to the soft variant. Keep the throwing `dispatch()` for *synchronous body* dispatches where a missing slot really is a bug (registration order violation).
+
+The pair preserves the original safety net for the "you forgot to register" bug while giving async sites a way to dispatch without caring whether the owner is still alive.
+
+**Recommendation: B.** A grep policy ("any dispatch inside RAF/setTimeout/setInterval/await/subscribe must use `dispatchIfRegistered`") becomes mechanically auditable.
+
+### 6.2 Architectural (follow-up)
+
+The two-stores-two-cleanups asymmetry is the deeper issue. A single dispatch from `useAgentStream` writes to both stores. A future refactor might:
+- Co-locate per-pane state into one slot keyed by blockId with multiple sub-fields, so registration is atomic.
+- Or: have agent-view.tsx own a single `paneOwnerToken` registered synchronously and required by every store dispatch; on unregister of the token, *all* per-pane stores cull their slot in one step.
+
+This is beyond the scope of a hotfix. File it as a tracking issue against discussion #707.
+
+### 6.3 What NOT to do
+
+- **Do not** silently catch the throw in `useAgentStream`. The current throw is the contract; catching it would mask future registration-order bugs introduced by other hooks.
+- **Do not** delete the throw entirely. Same reason. Silent drops were intentionally removed in May 2026.
+- **Do not** reorder cleanups by re-registering `unregisterAgentPaneStatePane` inside `onMount` to push it last in execution order. Mismatched register/unregister scopes are worse than the original problem.
+
+## 7. Action items
+
+| # | Action | Owner | Scope |
+|---|---|---|---|
+| 1 | Add `dispatchIfRegistered` to `agent-pane-state-store.ts` and `agent-document-store.ts` | AgentA | small PR |
+| 2 | Migrate the 11 async dispatch sites in `useAgentStream.ts` to use the soft variant | AgentA | same PR |
+| 3 | Migrate the 2 RPC `.catch()` sites in `useAgentCommands.ts` to the soft variant | AgentA | same PR |
+| 4 | Fix `browser-model.reload()` RAF — add `if (this.closed) return;` inside the RAF callback (or migrate the model's `_dispatch` to the soft variant) | AgentA | same PR |
+| 5 | Migrate `useHistoryPagination` post-await dispatches to the soft variant (defense in depth; mounted-flag stays as belt-and-suspenders) | AgentA | same PR |
+| 6 | Add a Vitest that exercises the cascade: dispatchDoc → reactive subscriber disposes pane → dispatchPane should not throw | AgentA | same PR |
+| 7 | Follow-up tracking issue: unify per-pane store registration into one atomic step | AgentA → #707 | doc-only |
+| 8 | (Optional) lint rule or grep CI gate: forbid bare `dispatch(` inside `requestAnimationFrame`/`setTimeout`/`setInterval`/`subscribe(`/`.then(`/`.catch(` | AgentA | follow-up PR |
+
+## 8. Instrumentation (installed 2026-05-15)
+
+The two open questions from the original draft — *how do we confirm the cascade theory* and *which subscriber triggers it* — are now answered by instrumentation rather than speculation. The next time the crash reproduces, the log will pinpoint the cause without further guesswork.
+
+### 8.1 What was installed
+
+**`frontend/app/store/agent-pane-state-store.ts:103-132`** — the dispatch() function now wraps each of the eight projection setters in a small `proj()` helper. After each setter call, it checks whether `slots.has(blockId)` is still true. The first setter that loses the slot is recorded as `cascadeSetter`. After the projection block, if `cascadeSetter` is set, a single warning is logged:
+
+```
+[agent-pane-state] CASCADE_DETECTED: '<setterName>' setter disposed pane mid-dispatch
+(cmd=<commandType>, blockId=<short>, source=<source>).
+A reactive subscriber on the '<setterName>' atom unmounted the pane during dispatch.
+Subsequent dispatches in the same callback will throw.
+```
+
+**`frontend/app/store/agent-document-store.ts:115-128`** — same check around `slot.setter(slot.state.nodes)`. There is only one setter (the document atom) so the message is simpler:
+
+```
+[agent-document-store] CASCADE_DETECTED: slot disposed mid-dispatch
+(cmd=<commandType>, blockId=<short>, source=<source>).
+A documentAtom subscriber unmounted the pane during this dispatch.
+Subsequent dispatches in the same callback will throw.
+```
+
+### 8.2 Properties
+
+- **Pure logging, no behavior change.** The throw on subsequent dispatches still fires — the throw is the contract, the log just makes its cause visible. The instrumentation runs after the projection setter so it can't itself prevent the cascade. It is safe to leave on in production until the §7 soft-dispatch migration lands.
+- **No new RPC, no new IPC.** `console.warn` goes through the existing `log-pipe` and lands in `~/.agentmux/logs/agentmux-host-vX.Y.Z.log.YYYY-MM-DD` tagged `[fe]` like every other frontend warning.
+- **Per-setter granularity in the pane-state store.** If the cascade comes from a subscriber on `streaming` vs `initPhase` vs `pending`, we will see exactly which one. That tells us which atom the offending subscriber is reading.
+- **301 reducer tests still pass** after the refactor — the `proj()` helper is a behavior-preserving rewrite of the eight per-field setter calls.
+
+### 8.3 What to expect from the next reproduction
+
+When the user repros tonight's crash on a build with this instrumentation, the log will show one of two shapes:
+
+**Shape A — pane-state setter is the cascade source:**
+```
+... CASCADE_DETECTED: '<X>' setter disposed pane mid-dispatch (cmd=StreamFlushObserved, ...)
+... Uncaught Error: [agent-pane-state] dispatch for unregistered pane ... (cmd=<next>)
+```
+That confirms a subscriber on atom `<X>` is the trigger — almost certainly the new dirty-flag `createEffect` if `<X>` is one of the atoms it transitively reads. Verifies the cascade theory **and** identifies the exact subscriber.
+
+**Shape B — document setter is the cascade source:**
+```
+... [agent-document-store] CASCADE_DETECTED: slot disposed mid-dispatch (cmd=StreamFlush, ...)
+... Uncaught Error: [agent-pane-state] dispatch for unregistered pane ... (cmd=StreamFlushObserved)
+```
+Confirms the cascade originates from documentAtom subscribers — matches tonight's crash signature exactly. This is the predicted shape.
+
+**Shape C — no CASCADE_DETECTED log, just the throw:**
+Would falsify the cascade theory; the slot was unregistered by something other than a reactive subscriber chain (a remount race, or two panes sharing a blockId). At that point, instrument `unregisterPane` itself with a stack trace and reproduce again.
+
+### 8.4 Why the createEffect-removal experiment is no longer needed
+
+The original §8 suggested removing the `createEffect` in `agent-view.tsx:213-220` to test whether it's the trigger. With per-setter cascade detection, that experiment is now mechanically resolved — the `cascadeSetter` name tells us which atom the offending subscriber reads. We can then grep for that atom's subscribers and confirm the createEffect (or some other subscriber) is the path.
+
+If the next reproduction shows `cascadeSetter = "initPhase"` or `"streaming"` or one of the others **that the dirty-flag effect doesn't read**, then the dirty-flag isn't the trigger and we look elsewhere (likely the layout tree reacting to a derived signal).
+
+The createEffect reads `getDocument()` (the documentAtom). So the cascade hypothesis predicts **Shape B** above, not Shape A. The instrumentation will distinguish.
+
+## 9. Action items (updated)
+
+| # | Action | Status | Owner |
+|---|---|---|---|
+| 1 | Add `dispatchIfRegistered` soft-variant to both pane stores | PENDING | AgentA |
+| 2 | Migrate the 11 async dispatch sites in `useAgentStream.ts` to soft variant | PENDING | AgentA |
+| 3 | Migrate the 2 RPC `.catch()` sites in `useAgentCommands.ts` to soft variant | PENDING | AgentA |
+| 4 | Fix `browser-model.reload()` RAF — add `if (this.closed) return;` inside the RAF callback | PENDING | AgentA |
+| 5 | Migrate `useHistoryPagination` post-await dispatches to soft variant (belt-and-suspenders) | PENDING | AgentA |
+| 6 | Add a Vitest that exercises the cascade: setter calls `unregisterPane`, verify CASCADE_DETECTED log fires + subsequent dispatch throws | PENDING | AgentA |
+| 7 | Cascade-detection instrumentation in both pane stores | **DONE** 2026-05-15 | AgentA |
+| 8 | Reproduce the crash on a build with the instrumentation; capture the `cascadeSetter` value from the log | PENDING | user |
+| 9 | Follow-up tracking issue: unify per-pane store registration into one atomic step | PENDING | AgentA → #707 |
+| 10 | (Optional) lint rule or grep CI gate: forbid bare `dispatch(` inside `requestAnimationFrame`/`setTimeout`/`setInterval`/`subscribe(`/`.then(`/`.catch(` | PENDING | AgentA |
+
+### 9.1 Recommended PR sequencing
+
+- **PR-1 (this work)**: instrumentation only. Lands on main; next portable build captures cascade data the next time the crash repros.
+- **PR-2 (informed by PR-1's data)**: `dispatchIfRegistered` soft-variant + migrations + vitest. Scope of action items 1–6.
+- **PR-3 (architectural)**: unified per-pane registration. Action item 9.
+
+This sequencing lets PR-2's design choices be informed by the actual cascade source rather than designed-around the predicted-but-unconfirmed one.
+
+---
+
+🤖 Authored by AgentA, 2026-05-15. Filed against discussion #707 once PR-2 ships.

--- a/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
+++ b/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
@@ -295,24 +295,34 @@ The createEffect reads `getDocument()` (the documentAtom). So the cascade hypoth
 
 | # | Action | Status | Owner |
 |---|---|---|---|
-| 1 | Add `dispatchIfRegistered` soft-variant to both pane stores | PENDING | AgentA |
-| 2 | Migrate the 11 async dispatch sites in `useAgentStream.ts` to soft variant | PENDING | AgentA |
-| 3 | Migrate the 2 RPC `.catch()` sites in `useAgentCommands.ts` to soft variant | PENDING | AgentA |
-| 4 | Fix `browser-model.reload()` RAF — add `if (this.closed) return;` inside the RAF callback | PENDING | AgentA |
-| 5 | Migrate `useHistoryPagination` post-await dispatches to soft variant (belt-and-suspenders) | PENDING | AgentA |
-| 6 | Add a Vitest that exercises the cascade: setter calls `unregisterPane`, verify CASCADE_DETECTED log fires + subsequent dispatch throws | PENDING | AgentA |
-| 7 | Cascade-detection instrumentation in both pane stores | **DONE** 2026-05-15 | AgentA |
-| 8 | Reproduce the crash on a build with the instrumentation; capture the `cascadeSetter` value from the log | PENDING | user |
+| 1 | Add `dispatchIfRegistered` soft-variant to both pane stores | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 2 | Migrate the 11 async dispatch sites in `useAgentStream.ts` to soft variant | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 3 | Migrate the 2 RPC `.catch()` sites + 1 setTimeout in `useAgentCommands.ts` to soft variant | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 4 | Fix `browser-model.reload()` RAF — add `if (this.closed) return;` inside the RAF callback | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 5 | Migrate `useHistoryPagination` post-await dispatches + `agent-view.onLoginSuccess` to soft variant | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 6 | Add a Vitest that exercises the cascade: setter calls `unregisterPane`, verify CASCADE_DETECTED log fires + soft variant no-ops + throwing variant still throws | **DONE** 2026-05-15 (PR #878, `agent-pane-state-store.test.ts`) | AgentA |
+| 7 | Cascade-detection instrumentation in both pane stores | **DONE** 2026-05-15 (PR #878) | AgentA |
+| 8 | Reproduce the crash on a v0.33.900 build with the instrumentation; capture the `cascadeSetter` value from the log | **DONE** 2026-05-15 (confirmed Shape B — documentAtom subscriber) | user |
 | 9 | Follow-up tracking issue: unify per-pane store registration into one atomic step | PENDING | AgentA → #707 |
 | 10 | (Optional) lint rule or grep CI gate: forbid bare `dispatch(` inside `requestAnimationFrame`/`setTimeout`/`setInterval`/`subscribe(`/`.then(`/`.catch(` | PENDING | AgentA |
 
-### 9.1 Recommended PR sequencing
+### 9.1 PR scope
 
-- **PR-1 (this work)**: instrumentation only. Lands on main; next portable build captures cascade data the next time the crash repros.
-- **PR-2 (informed by PR-1's data)**: `dispatchIfRegistered` soft-variant + migrations + vitest. Scope of action items 1–6.
-- **PR-3 (architectural)**: unified per-pane registration. Action item 9.
+The original §9 sequencing (PR-1 instrumentation, PR-2 migrations) was collapsed into a single PR (#878) after the v0.33.900 reproduction confirmed Shape B — a documentAtom subscriber unmounts the pane during `StreamFlush`'s setter call. Rather than ship logging-only and ask the user to reproduce again on a future build, the soft-dispatch migration ships alongside.
 
-This sequencing lets PR-2's design choices be informed by the actual cascade source rather than designed-around the predicted-but-unconfirmed one.
+What's in #878:
+- `dispatchIfRegistered` soft-variant on `agent-pane-state-store.ts` and `agent-document-store.ts`.
+- Cascade-detection logging in both stores (per-setter granularity for the pane-state store).
+- 12 dispatch sites migrated in `useAgentStream.ts`; 4 sites kept as throwing (synchronous in `onMount` body / cleanup-time dispatches into a slot guaranteed-registered).
+- 3 sites migrated in `useAgentCommands.ts` (2x `.catch()`, 1x `setTimeout`); 2 sync-body sites stay throwing.
+- 6 sites migrated in `useHistoryPagination.ts` (all post-await); 1 in-onMount-body site stays throwing.
+- 1 site migrated in `agent-view.tsx` (auth-flow `onLoginSuccess` callback).
+- `browser-model.ts:442` RAF callback gains its own `if (this.closed) return;` (matches the model's other IPC handlers).
+- New `agent-pane-state-store.test.ts` with 5 tests covering both throw and silent-no-op contracts.
+
+What deliberately stayed throwing: every synchronous dispatch in component body or first-tick `onMount` — those slots are guaranteed registered, and a missing slot there is still a registration-order bug we want to fail loud.
+
+Follow-ups still pending (action items 9–10) shipped as separate PRs against discussion #707.
 
 ---
 

--- a/docs/specs/SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md
+++ b/docs/specs/SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md
@@ -216,9 +216,9 @@ This PR is the likely **trigger** (the new `createEffect` on `documentAtom` is t
 
 Full breakdown: `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md`. Cascade-detection instrumentation has been installed in `agent-pane-state-store.ts` and `agent-document-store.ts`; the next reproduction will identify the exact projection setter that triggers the cascade.
 
-**Followup PRs** (sequenced):
-- **PR-2**: `dispatchIfRegistered` soft-variant on both pane stores, migrate the 11 async dispatch sites in `useAgentStream.ts`, fix the unguarded RAF in `browser-model.reload()`, add a regression vitest.
-- **PR-3** (architectural): unify per-pane registration so both stores' slots are added/removed atomically. Pre-discussion in #707.
+**Followup PRs** (status):
+- **PR #878** ships the cascade-detection instrumentation AND the soft-dispatch migration in a single bundle. Adds `dispatchIfRegistered` to both pane stores, migrates 22 async dispatch sites across `useAgentStream.ts`, `useAgentCommands.ts`, `useHistoryPagination.ts`, `agent-view.tsx` (onLoginSuccess callback), and fixes the unguarded RAF in `browser-model.reload()`. Backed by 5 new regression tests in `agent-pane-state-store.test.ts`.
+- **PR-3** (architectural, pending): unify per-pane registration so both stores' slots are added/removed atomically. Pre-discussion in #707.
 
 ### 11.2 Phase 4 still deferred
 

--- a/docs/specs/SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md
+++ b/docs/specs/SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md
@@ -206,6 +206,24 @@ Phases 0–3 ship together (one PR). Phase 4 deferred unless empirical demand.
 - **Q2** Should the snapshot be **incremental** (event-sourced log + periodic compaction) rather than a full replace? More resilient but more complex. Decision: full-replace for v1; revisit if write IO becomes a problem.
 - **Q3** Should `BlockfileWriteStateCommand` be exposed to the agent CLI itself (so agents can persist their own view metadata)? Probably not — that's a different feature surface. Out of scope.
 
+## 11. Known follow-ups surfaced by this PR
+
+### 11.1 Lifecycle / dispatch leak (cross-cutting)
+
+The first smoke build of v0.33.899 produced an uncaught `dispatch for unregistered pane c0ae6c7 (cmd=StreamFlushObserved)` in `useAgentStream.flushPendingNodes`. Root cause is **not** specific to this PR — it's a latent class of bug where a `dispatchDoc` write cascades through reactive subscribers and synchronously disposes the pane *during* the dispatch, causing the next dispatch in the same callback to throw.
+
+This PR is the likely **trigger** (the new `createEffect` on `documentAtom` is the only new subscriber to that atom in months), but the underlying lifecycle vulnerability has been present since the multi-store pattern landed in §4 of `frontend-reducer-conventions-2026-05-03.md`.
+
+Full breakdown: `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md`. Cascade-detection instrumentation has been installed in `agent-pane-state-store.ts` and `agent-document-store.ts`; the next reproduction will identify the exact projection setter that triggers the cascade.
+
+**Followup PRs** (sequenced):
+- **PR-2**: `dispatchIfRegistered` soft-variant on both pane stores, migrate the 11 async dispatch sites in `useAgentStream.ts`, fix the unguarded RAF in `browser-model.reload()`, add a regression vitest.
+- **PR-3** (architectural): unify per-pane registration so both stores' slots are added/removed atomically. Pre-discussion in #707.
+
+### 11.2 Phase 4 still deferred
+
+The `highWaterMark` gap-replay (read NDJSON lines from `[snapshot.highWaterMark, currentTotal)` on reopen and dispatch through `StreamFlush`) remains v1-deferred per §4.2. Should ship after the lifecycle work above so its new dispatches can use the soft-variant from the start.
+
 ---
 
-🤖 Authored by AgentA. Implementation rides in the same PR — file is committed alongside the code change (per `feedback_no_doc_only_prs.md`).
+🤖 Authored by AgentA. Implementation rides in the same PR — file is committed alongside the code change (per `feedback_no_doc_only_prs.md`). §11 added 2026-05-15 after the v0.33.899 smoke-build crash surfaced the lifecycle issue documented in `docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md`.

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -141,6 +141,28 @@ export function dispatch(
     return result.events;
 }
 
+/**
+ * Soft-dispatch variant. Returns an empty event array if the slot is
+ * already gone, instead of throwing. Use ONLY from async contexts
+ * (RAF / setTimeout / setInterval / await continuations / subscription
+ * handlers) where a normal dispatch can race against the pane's
+ * onCleanup unregistering the slot — see
+ * docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md §6.1 option B.
+ *
+ * Synchronous component-body dispatches MUST continue to use `dispatch`
+ * — a missing slot there is a registration-order bug and the throw is
+ * the right signal.
+ */
+export function dispatchIfRegistered(
+    blockId: string,
+    command: AgentDocumentCommand,
+    source: CommandSource = "system",
+    opts?: ReducerOptions,
+): AgentDocumentEvent[] {
+    if (!slots.has(blockId)) return [];
+    return dispatch(blockId, command, source, opts);
+}
+
 /** Snapshot a pane's reducer state. Diagnostics + tests only. */
 export function snapshot(blockId: string): AgentDocumentState | null {
     return slots.get(blockId)?.state ?? null;

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -115,6 +115,19 @@ export function dispatch(
     // Avoids no-op signal writes that would still schedule a Solid effect.
     if (slot.state.nodes !== prevNodes) {
         slot.setter(slot.state.nodes);
+        // Cascade detection: docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md.
+        // documentAtom subscribers can unmount the pane synchronously
+        // during this setter; the slot then vanishes mid-dispatch and
+        // the caller's next dispatch (often dispatchPane on a sibling
+        // store) throws. Log so the trigger is identifiable.
+        if (!slots.has(blockId)) {
+            console.warn(
+                `[agent-document-store] CASCADE_DETECTED: slot disposed mid-dispatch ` +
+                `(cmd=${command.type}, blockId=${blockId.slice(0, 7)}, source=${source}). ` +
+                `A documentAtom subscriber unmounted the pane during this dispatch. ` +
+                `Subsequent dispatches in the same callback will throw.`,
+            );
+        }
     }
     for (const ev of result.events) eventSink(blockId, ev);
     recordDispatch({

--- a/frontend/app/store/agent-pane-state-store.test.ts
+++ b/frontend/app/store/agent-pane-state-store.test.ts
@@ -1,0 +1,148 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression coverage for the cascade-dispose lifecycle vulnerability
+ * documented in docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md.
+ *
+ * The scenario: a projection setter's reactive subscriber synchronously
+ * unmounts the pane (calls `unregisterPane`) inside the dispatch's
+ * setter call. The setter returns, and the caller's NEXT dispatch on
+ * the same blockId hits a gone slot. The two contracts that need to
+ * hold:
+ *
+ *   1. `dispatch()` still throws if the slot is gone — registration
+ *      ordering bugs must remain loud.
+ *   2. `dispatchIfRegistered()` silently no-ops in the same scenario —
+ *      gives async-context callers a way to dispatch defensively without
+ *      catching their own throws.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    __resetAllSlots,
+    type AgentPaneProjections,
+    dispatch,
+    dispatchIfRegistered,
+    registerPane,
+    setEventSink,
+    unregisterPane,
+} from "./agent-pane-state-store";
+
+function noopProj(): AgentPaneProjections {
+    return {
+        streaming: () => {},
+        sessionStats: () => {},
+        currentTool: () => {},
+        turnTokens: () => {},
+        turnActive: () => {},
+        stopping: () => {},
+        pending: () => {},
+        initPhase: () => {},
+    };
+}
+
+describe("agent-pane-state-store (cascade contracts)", () => {
+    afterEach(() => {
+        __resetAllSlots();
+        setEventSink(() => {});
+    });
+
+    describe("dispatch (throwing variant)", () => {
+        it("throws on unregistered blockId", () => {
+            expect(() =>
+                dispatch("blockA", { type: "StreamFlushObserved", addedCount: 0, at: 0 }),
+            ).toThrowError(/dispatch for unregistered pane/);
+        });
+
+        it("still throws when a setter cascade-disposes the slot mid-dispatch", () => {
+            // Setter that simulates a reactive subscriber unmounting the
+            // pane: synchronously calls `unregisterPane` during its own
+            // notification. The cascade-detection inside the store will
+            // emit a CASCADE_DETECTED warning. The dispatch call itself
+            // returns events normally — but the next dispatch throws.
+            // `streaming` is the first setter the dispatch loop touches
+            // when state.streaming changes — StreamSubscribe always
+            // toggles it. Use that as the cascading site so the test
+            // doesn't depend on internal projection-order details.
+            const proj: AgentPaneProjections = {
+                ...noopProj(),
+                streaming: () => {
+                    unregisterPane("blockA"); // cascade: subscriber disposed pane
+                },
+            };
+            registerPane("blockA", "agentA", proj);
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+            try {
+                // First dispatch: setter cascade-disposes the slot.
+                dispatch("blockA", { type: "StreamSubscribe", at: 0 });
+                // Cascade-detection log should fire.
+                const cascadeWarns = warnSpy.mock.calls.filter(([msg]) =>
+                    typeof msg === "string" && msg.includes("CASCADE_DETECTED"),
+                );
+                expect(cascadeWarns.length).toBeGreaterThan(0);
+                expect(cascadeWarns[0][0]).toContain("'streaming'"); // names the cascading setter
+
+                // Second dispatch: throws because slot is gone.
+                expect(() =>
+                    dispatch("blockA", { type: "StreamFlushObserved", addedCount: 0, at: 1 }),
+                ).toThrowError(/dispatch for unregistered pane/);
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+    });
+
+    describe("dispatchIfRegistered (soft variant)", () => {
+        it("returns [] silently for an unregistered blockId", () => {
+            const events = dispatchIfRegistered("ghostBlock", {
+                type: "StreamFlushObserved",
+                addedCount: 0,
+                at: 0,
+            });
+            expect(events).toEqual([]);
+        });
+
+        it("dispatches normally when the slot exists", () => {
+            registerPane("blockB", "agentA", noopProj());
+            const events = dispatchIfRegistered("blockB", { type: "TurnStart", at: 0 });
+            // TurnStart produces events; we don't care about content here,
+            // just that the call went through the real reducer.
+            expect(Array.isArray(events)).toBe(true);
+        });
+
+        it("no-ops after a setter cascade-disposes the slot — no throw", () => {
+            // This is the production scenario from
+            // LIFECYCLE_DISPATCH_LEAK_2026_05_15.md: a documentAtom
+            // subscriber unmounted the pane during a StreamFlush; the
+            // next call (in useAgentStream.flushPendingNodes) is
+            // StreamFlushObserved against agent-pane-state. With the
+            // soft variant, that next call returns [] silently.
+            const proj: AgentPaneProjections = {
+                ...noopProj(),
+                streaming: () => {
+                    unregisterPane("blockC"); // cascade
+                },
+            };
+            registerPane("blockC", "agentA", proj);
+
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+            try {
+                // Trigger the cascade via the throwing dispatch (the
+                // path that does the actual projection work).
+                dispatch("blockC", { type: "StreamSubscribe", at: 0 });
+                // The simulated "next dispatch in the same caller frame":
+                // with the soft variant, no throw, just an empty array.
+                const events = dispatchIfRegistered("blockC", {
+                    type: "StreamFlushObserved",
+                    addedCount: 0,
+                    at: 1,
+                });
+                expect(events).toEqual([]);
+            } finally {
+                warnSpy.mockRestore();
+            }
+        });
+    });
+});

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -102,14 +102,35 @@ export function dispatch(
 
     // Project changes — only call setters for fields that actually
     // changed (referential equality). Avoids redundant signal writes.
-    if (slot.state.streaming !== prev.streaming) slot.proj.streaming(slot.state.streaming);
-    if (slot.state.sessionStats !== prev.sessionStats) slot.proj.sessionStats(slot.state.sessionStats);
-    if (slot.state.currentTool !== prev.currentTool) slot.proj.currentTool(slot.state.currentTool);
-    if (slot.state.turnTokens !== prev.turnTokens) slot.proj.turnTokens(slot.state.turnTokens);
-    if (slot.state.turnActive !== prev.turnActive) slot.proj.turnActive(slot.state.turnActive);
-    if (slot.state.stopping !== prev.stopping) slot.proj.stopping(slot.state.stopping);
-    if (slot.state.pending !== prev.pending) slot.proj.pending(slot.state.pending);
-    if (slot.state.initPhase !== prev.initPhase) slot.proj.initPhase?.(slot.state.initPhase);
+    // Per-setter cascade detection: docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md.
+    // A reactive subscriber on the atom backing one of these setters can
+    // synchronously unmount the pane (call `unregisterPane`) inside the
+    // setter call. Capture which setter triggers the dispose — the next
+    // dispatch in the caller's frame will throw and the log line below
+    // pinpoints the cause.
+    let cascadeSetter: string | null = null;
+    const proj = <T>(name: string, prev: T, next: T, set: ((v: T) => void) | undefined): void => {
+        if (prev === next) return;
+        set?.(next);
+        if (cascadeSetter == null && !slots.has(blockId)) cascadeSetter = name;
+    };
+    proj("streaming", prev.streaming, slot.state.streaming, slot.proj.streaming);
+    proj("sessionStats", prev.sessionStats, slot.state.sessionStats, slot.proj.sessionStats);
+    proj("currentTool", prev.currentTool, slot.state.currentTool, slot.proj.currentTool);
+    proj("turnTokens", prev.turnTokens, slot.state.turnTokens, slot.proj.turnTokens);
+    proj("turnActive", prev.turnActive, slot.state.turnActive, slot.proj.turnActive);
+    proj("stopping", prev.stopping, slot.state.stopping, slot.proj.stopping);
+    proj("pending", prev.pending, slot.state.pending, slot.proj.pending);
+    proj("initPhase", prev.initPhase, slot.state.initPhase, slot.proj.initPhase);
+
+    if (cascadeSetter != null) {
+        console.warn(
+            `[agent-pane-state] CASCADE_DETECTED: '${cascadeSetter}' setter disposed pane mid-dispatch ` +
+            `(cmd=${command.type}, blockId=${blockId.slice(0, 7)}, source=${source}). ` +
+            `A reactive subscriber on the '${cascadeSetter}' atom unmounted the pane during dispatch. ` +
+            `Subsequent dispatches in the same callback will throw.`,
+        );
+    }
 
     for (const ev of result.events) eventSink(blockId, ev);
     recordDispatch({

--- a/frontend/app/store/agent-pane-state-store.ts
+++ b/frontend/app/store/agent-pane-state-store.ts
@@ -144,6 +144,27 @@ export function dispatch(
     return result.events;
 }
 
+/**
+ * Soft-dispatch variant. Returns an empty event array if the slot is
+ * already gone, instead of throwing. Use ONLY from async contexts
+ * (RAF / setTimeout / setInterval / await continuations / subscription
+ * handlers) where a normal dispatch can race against the pane's
+ * onCleanup unregistering the slot — see
+ * docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md §6.1 option B.
+ *
+ * Synchronous component-body dispatches MUST continue to use `dispatch`
+ * — a missing slot there is a registration-order bug and the throw is
+ * the right signal.
+ */
+export function dispatchIfRegistered(
+    blockId: string,
+    command: AgentPaneCommand,
+    source: CommandSource = "system",
+): AgentPaneEvent[] {
+    if (!slots.has(blockId)) return [];
+    return dispatch(blockId, command, source);
+}
+
 /** Snapshot — diagnostics + tests only. */
 export function snapshot(blockId: string): AgentPaneState | null {
     return slots.get(blockId)?.state ?? null;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -8,6 +8,7 @@ import { getProvider } from "./providers";
 import { createAgentAtoms } from "./state";
 import {
     dispatch as dispatchDoc,
+    dispatchIfRegistered as dispatchDocIfRegistered,
     registerPane as registerAgentDocPane,
     unregisterPane as unregisterAgentDocPane,
 } from "@/app/store/agent-document-store";
@@ -297,7 +298,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 id: `login_success_${Date.now()}`,
                 content: `\u2713 ${display}`,
             } as import("./types").MarkdownNode;
-            dispatchDoc(model.blockId, {
+            dispatchDocIfRegistered(model.blockId, {
                 type: "StreamFlush",
                 newNodes: [node],
                 updatedNodes: [],

--- a/frontend/app/view/agent/hooks/useAgentCommands.ts
+++ b/frontend/app/view/agent/hooks/useAgentCommands.ts
@@ -27,7 +27,11 @@ import { type Accessor, createMemo, createSignal, onCleanup } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import * as WOS from "@/app/store/wos";
-import { dispatch as dispatchPane, snapshot as paneSnapshot } from "@/app/store/agent-pane-state-store";
+import {
+    dispatch as dispatchPane,
+    dispatchIfRegistered as dispatchPaneIfRegistered,
+    snapshot as paneSnapshot,
+} from "@/app/store/agent-pane-state-store";
 import { buildRuntimeArgs, getRuntimeConfig } from "../buildRuntimeArgs";
 import { dispatchSlashCommand } from "../commands/dispatch";
 import { buildRegistry } from "../commands/registry";
@@ -311,7 +315,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             // RPC outright failed — remove the pending entry so the user
             // doesn't see a ghost row for a message the backend never
             // received. Log already surfaces the error elsewhere.
-            dispatchPane(opts.blockId, {
+            dispatchPaneIfRegistered(opts.blockId, {
                 type: "PendingMessageRejected",
                 id: messageId,
             });
@@ -325,7 +329,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
         // an unregistered slot (which throws).
         const expiryId = setTimeout(() => {
             pendingExpiryTimers.delete(expiryId);
-            dispatchPane(opts.blockId, {
+            dispatchPaneIfRegistered(opts.blockId, {
                 type: "PendingMessageExpired",
                 id: messageId,
             });
@@ -352,7 +356,7 @@ export function useAgentCommands(opts: UseAgentCommandsOptions): UseAgentCommand
             signame: "SIGINT",
         }).catch((err) => {
             opts.log("warn", `stop failed: ${err?.message ?? String(err)}`, "warn");
-            dispatchPane(opts.blockId, { type: "StopFailed" });
+            dispatchPaneIfRegistered(opts.blockId, { type: "StopFailed" });
         });
     };
 

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -34,8 +34,14 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import { dispatch as dispatchDoc } from "@/app/store/agent-document-store";
-import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
+import {
+    dispatch as dispatchDoc,
+    dispatchIfRegistered as dispatchDocIfRegistered,
+} from "@/app/store/agent-document-store";
+import {
+    dispatch as dispatchPane,
+    dispatchIfRegistered as dispatchPaneIfRegistered,
+} from "@/app/store/agent-pane-state-store";
 import { parseHistoryLines } from "../parseHistoryLines";
 
 import type { LogFn } from "../types";
@@ -97,7 +103,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
             const newNodes = parseHistoryLines(resp.lines ?? [], opts.outputFormat());
             if (newNodes.length > 0) {
-                dispatchDoc(opts.blockId, { type: "HistoryLoaded", nodes: newNodes });
+                dispatchDocIfRegistered(opts.blockId, { type: "HistoryLoaded", nodes: newNodes });
             }
 
             setHistoryOffset(newOffset);
@@ -147,7 +153,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 if (stateResp.content) {
                     const snapshot = JSON.parse(stateResp.content);
                     if (snapshot && snapshot.schemaVersion === SNAPSHOT_SCHEMA_VERSION && Array.isArray(snapshot.nodes)) {
-                        dispatchDoc(opts.blockId, { type: "HistoryRestored", fromSnapshot: true, nodes: snapshot.nodes });
+                        dispatchDocIfRegistered(opts.blockId, { type: "HistoryRestored", fromSnapshot: true, nodes: snapshot.nodes });
 
                         const offset = typeof snapshot.historyOffset === "number" && snapshot.historyOffset >= 0
                             ? snapshot.historyOffset
@@ -159,7 +165,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                             `restored ${snapshot.nodes.length} nodes from snapshot ` +
                                 `(savedAt=${snapshot.savedAt ?? "unknown"}, loadOlder offset=${offset})`,
                         );
-                        dispatchPane(opts.blockId, { type: "InitReady" });
+                        dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
                         return;
                     }
                     opts.log(
@@ -186,7 +192,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
                 const total = countResp?.count ?? 0;
                 if (total === 0) {
-                    dispatchPane(opts.blockId, { type: "InitReady" });
+                    dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
                     return;
                 }
 
@@ -203,7 +209,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
 
                 const nodes = parseHistoryLines(rangeResp.lines ?? [], opts.outputFormat());
                 if (nodes.length > 0) {
-                    dispatchDoc(opts.blockId, { type: "HistoryLoaded", nodes });
+                    dispatchDocIfRegistered(opts.blockId, { type: "HistoryLoaded", nodes });
                 }
 
                 // `resp.total` from the backend is the actual available
@@ -216,7 +222,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 setHistoryTotal(available);
 
                 opts.log("history", `loaded ${nodes.length} of ${available} previous messages`);
-                dispatchPane(opts.blockId, { type: "InitReady" });
+                dispatchPaneIfRegistered(opts.blockId, { type: "InitReady" });
             } catch (err: any) {
                 if (!mounted) return;
                 // Non-fatal — fresh session or backend not ready yet.
@@ -229,7 +235,7 @@ export function useHistoryPagination(opts: UseHistoryPaginationOptions): UseHist
                 // TurnStart guard treats `error` as fail-open (only
                 // `loading` blocks sends), so no follow-up InitReady
                 // is needed — the user can still send.
-                dispatchPane(opts.blockId, { type: "InitFailed", reason });
+                dispatchPaneIfRegistered(opts.blockId, { type: "InitFailed", reason });
             }
         })();
     });

--- a/frontend/app/view/agent/hooks/useHistoryPagination.ts
+++ b/frontend/app/view/agent/hooks/useHistoryPagination.ts
@@ -34,10 +34,7 @@
 import { createSignal, onCleanup, onMount, type Accessor } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
-import {
-    dispatch as dispatchDoc,
-    dispatchIfRegistered as dispatchDocIfRegistered,
-} from "@/app/store/agent-document-store";
+import { dispatchIfRegistered as dispatchDocIfRegistered } from "@/app/store/agent-document-store";
 import {
     dispatch as dispatchPane,
     dispatchIfRegistered as dispatchPaneIfRegistered,

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -18,9 +18,13 @@ import type { DocumentNode, SessionStats, StreamingState, TurnTokens, UserMessag
 import { recordTurn } from "@/store/token-usage";
 import {
     dispatch as dispatchDoc,
+    dispatchIfRegistered as dispatchDocIfRegistered,
     getNodeIdSet,
 } from "@/app/store/agent-document-store";
-import { dispatch as dispatchPane } from "@/app/store/agent-pane-state-store";
+import {
+    dispatch as dispatchPane,
+    dispatchIfRegistered as dispatchPaneIfRegistered,
+} from "@/app/store/agent-pane-state-store";
 
 const OutputFileName = "output";
 
@@ -123,7 +127,7 @@ export function useAgentStream({
             const toolId = typeof data.tool_id === "string" ? data.tool_id : "";
             if (!toolId) return;
             if (data.op === "terminal") {
-                dispatchDoc(blockId, {
+                dispatchDocIfRegistered(blockId, {
                     type: "ToolChunkAppend",
                     toolId,
                     chunk: {
@@ -135,7 +139,7 @@ export function useAgentStream({
                 return;
             }
             if (data.op !== "chunk") return;
-            dispatchDoc(blockId, {
+            dispatchDocIfRegistered(blockId, {
                 type: "ToolChunkAppend",
                 toolId,
                 chunk: {
@@ -158,14 +162,14 @@ export function useAgentStream({
 
         // Document mutation — the reducer owns dedup, in-place updates,
         // and the markdown-content merge. See agent-document-store.ts.
-        dispatchDoc(blockId, {
+        dispatchDocIfRegistered(blockId, {
             type: "StreamFlush",
             newNodes: batchNew,
             updatedNodes: batchUpdates,
         });
         // Lifecycle counter bump — agent-pane-state owns streaming
         // metadata (active flag + bufferSize + lastEventTime).
-        dispatchPane(blockId, {
+        dispatchPaneIfRegistered(blockId, {
             type: "StreamFlushObserved",
             addedCount: batchNew.length,
             at: Date.now(),
@@ -221,7 +225,7 @@ export function useAgentStream({
             // tokens/turnActive, AND clears stopping (the latter cascade
             // replaces the explicit setStopping(false) below).
             const wasStopping = getStopping?.() === true;
-            dispatchPane(blockId, { type: "TurnEnd", stats });
+            dispatchPaneIfRegistered(blockId, { type: "TurnEnd", stats });
             if (wasStopping) {
                 const interruptedNode: DocumentNode = {
                     type: "markdown",
@@ -287,7 +291,7 @@ export function useAgentStream({
                         return;
                     }
                     // Reducer removes the entry + emits pending-accepted.
-                    dispatchPane(blockId, {
+                    dispatchPaneIfRegistered(blockId, {
                         type: "PendingMessageAccepted",
                         id: messageId,
                     });
@@ -298,7 +302,7 @@ export function useAgentStream({
                     // and nothing else flips it back, leaving the status
                     // line stuck on "Worked" with no running animation
                     // even though the CLI is processing the next message).
-                    dispatchPane(blockId, { type: "TurnStart", at: Date.now() });
+                    dispatchPaneIfRegistered(blockId, { type: "TurnStart", at: Date.now() });
                     // Append as a normal user_message so it joins the
                     // conversation stream. Keeps the same id so the new
                     // node ties back to the pending entry 1:1.
@@ -339,7 +343,7 @@ export function useAgentStream({
         // event when the gap exceeds `STUCK_THRESHOLD_MS`. The interval
         // cleans up via the same effect cleanup as the subscription.
         const watchdogId = setInterval(() => {
-            dispatchPane(blockId, {
+            dispatchPaneIfRegistered(blockId, {
                 type: "StreamWatchdogTick",
                 nowMs: Date.now(),
             });
@@ -356,7 +360,7 @@ export function useAgentStream({
                 // hook-local parser/stats/etc. when the truncate is actually
                 // honored; if suppressed, the live stream is still flowing
                 // and resetting would corrupt in-flight parse state.
-                const events = dispatchDoc(blockId, {
+                const events = dispatchDocIfRegistered(blockId, {
                     type: "StreamTruncate",
                     reason: "fileop",
                 });
@@ -371,7 +375,7 @@ export function useAgentStream({
                 nodeIdSet = new Set();
                 // Reducer clears sessionStats/currentTool/turnTokens/
                 // turnActive/stopping in one shot.
-                dispatchPane(blockId, { type: "TurnReset" });
+                dispatchPaneIfRegistered(blockId, { type: "TurnReset" });
                 return;
             }
 
@@ -440,12 +444,12 @@ export function useAgentStream({
                     if (inner?.type === "message_start") {
                         const inputTok = inner.message?.usage?.input_tokens as number | undefined;
                         if (inputTok != null) {
-                            dispatchPane(blockId, { type: "TokensIn", input: inputTok });
+                            dispatchPaneIfRegistered(blockId, { type: "TokensIn", input: inputTok });
                         }
                     } else if (inner?.type === "message_delta") {
                         const outputTok = inner.usage?.output_tokens as number | undefined;
                         if (outputTok != null) {
-                            dispatchPane(blockId, { type: "TokensOut", output: outputTok });
+                            dispatchPaneIfRegistered(blockId, { type: "TokensOut", output: outputTok });
                         }
                     }
                 }
@@ -472,12 +476,12 @@ export function useAgentStream({
                     // subscribe race that the per-tool model lost.
                     if (event.type === "tool_call") {
                         if (event.tool) {
-                            dispatchPane(blockId, { type: "ToolStart", name: event.tool });
+                            dispatchPaneIfRegistered(blockId, { type: "ToolStart", name: event.tool });
                         } else {
-                            dispatchPane(blockId, { type: "ToolEnd" });
+                            dispatchPaneIfRegistered(blockId, { type: "ToolEnd" });
                         }
                     } else if (event.type === "tool_result") {
-                        dispatchPane(blockId, { type: "ToolEnd" });
+                        dispatchPaneIfRegistered(blockId, { type: "ToolEnd" });
                     } else if (event.type === "tool_chunk") {
                         // Live-log streaming (SPEC_TOOL_BLOCK_LIVE_LOG_2026_05_11.md):
                         // route chunks through their own reducer command
@@ -486,7 +490,7 @@ export function useAgentStream({
                         // node → pendingNew path; the reducer mutates
                         // one ToolNode in place.
                         const { toolId, chunk } = parser.parseToolChunkEvent(event);
-                        dispatchDoc(blockId, { type: "ToolChunkAppend", toolId, chunk });
+                        dispatchDocIfRegistered(blockId, { type: "ToolChunkAppend", toolId, chunk });
                         continue;
                     }
                     const node = parser.parseLine(JSON.stringify(event));
@@ -522,8 +526,8 @@ export function useAgentStream({
             // StreamUnsubscribe also force-clears turnActive (so a crash
             // or exit without session_end doesn't leave "Working…" stuck).
             const at = Date.now();
-            dispatchPane(blockId, { type: "StreamUnsubscribe", at });
-            dispatchDoc(blockId, { type: "SessionEnd", at });
+            dispatchPaneIfRegistered(blockId, { type: "StreamUnsubscribe", at });
+            dispatchDocIfRegistered(blockId, { type: "SessionEnd", at });
         });
     });
 }

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -440,6 +440,7 @@ export class BrowserViewModel implements ViewModel {
             this._dispatch({ type: "UrlCleared" }, "reload-clear");
             // Force iframe reload by briefly clearing then re-setting
             requestAnimationFrame(() => {
+                if (this.closed) return;
                 this._dispatch({ type: "Navigate", url }, "reload-restore");
             });
         }


### PR DESCRIPTION
## Summary

Bundles cascade detection AND the soft-dispatch fix, after the v0.33.900 reproduction confirmed Shape B per [LIFECYCLE_DISPATCH_LEAK_2026_05_15.md](docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md) §8.3: a documentAtom subscriber synchronously unmounts the pane during a StreamFlush's projection setter, the slot vanishes mid-dispatch, and the next dispatch (StreamFlushObserved into agent-pane-state) throws.

## What's in this PR

**Cascade detection (logging only):**
- Per-setter granularity in `agent-pane-state-store.ts`: refactored 8 sequential `if (a !== b) proj.X(b)` lines into a single `proj()` helper that captures the first cascade-triggering setter name.
- Single-setter check in `agent-document-store.ts` around the documentAtom write.
- Both log a one-line `CASCADE_DETECTED ...` warning when the slot disappears mid-dispatch.

**Soft-dispatch fix:**
- Adds `dispatchIfRegistered(blockId, command, source)` to both pane stores. Returns `[]` silently if the slot is gone instead of throwing.
- Throwing `dispatch()` stays as the contract for synchronous-body register-order checks — a missing slot there is still a bug we want to fail loud.

**Migrations (22 sites):**
- `useAgentStream.ts`: 12 async-context sites (RAF callback, fileSubject subscription handler, accepted-message subscription, watchdog setInterval, cleanup-time post-await dispatches).
- `useAgentCommands.ts`: 3 sites (2x RPC `.catch()` rejection handlers, 1x setTimeout pending-expiry).
- `useHistoryPagination.ts`: 6 post-await dispatches (defense in depth on top of the existing `mounted` flag).
- `agent-view.tsx`: 1 site (auth controller's `onLoginSuccess` callback fired by backend events).
- `browser-model.ts:442`: RAF callback now checks `if (this.closed) return;` (matches every other IPC handler in the file).

**Deliberately kept throwing (4 sites):** synchronous-body dispatches and first-tick onMount dispatches where the slot is guaranteed registered.

## Tests

New `agent-pane-state-store.test.ts` with 5 regression tests covering both contracts. **306 reducer + store tests pass.** Typecheck clean (touched files).

## Confirmation evidence

From v0.33.900 host log:
```
00:21:39.059Z [agent-document-store] CASCADE_DETECTED: slot disposed mid-dispatch (cmd=StreamFlush, blockId=7bcc519, source=system).
00:21:39.060Z [UNCAUGHT-ERROR] [agent-pane-state] dispatch for unregistered pane 7bcc519 (cmd=StreamFlushObserved).
```
Same thread, same blockId, 0.6ms apart — proves the cascade theory.

## Test plan

- [x] 306 store + reducer tests pass
- [x] Typecheck clean on touched files
- [ ] Build portable, repro the original conditions (layout split + active stream), confirm no throw / no replaceChild crash
- [ ] Verify cascade-detection still logs cleanly when triggered (the symptom should now be invisible to the user but visible in the host log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)