### PR TITLE
fix+feat(dev): status-bar window count + task dev:local for ephemeral version bumps

### DIFF
--- a/.changesets/1778912540-fix-statusbar-show-total-window-count-instead-of-per-window--ycdw.md
+++ b/.changesets/1778912540-fix-statusbar-show-total-window-count-instead-of-per-window--ycdw.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): show total window count instead of per-window ordinal

--- a/.changesets/1778913803-feat-taskfile-add-task-dev-local-mirror-of-package-local-auae.md
+++ b/.changesets/1778913803-feat-taskfile-add-task-dev-local-mirror-of-package-local-auae.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(taskfile): add task dev:local mirror of package:local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,14 @@
 | Command | Use When | Auto-Updates? |
 |---------|----------|---------------|
 | `task dev` | **Development** (Vite hot reload, launcher-in-loop on Windows) | Yes - hot reload |
+| `task dev:local` | **Dev with ephemeral version bump** — same as `task dev` but temporarily bumps `package.json`/`Cargo.toml` for this session and restores on Ctrl+C. Use when you want the dev build to advertise a unique version (so you can tell which merge it corresponds to) and when you need to force cargo's incremental cache to recompile after a workspace-version-affecting change. No git mutation. | Yes - hot reload |
 | `task dev:standalone` | Debug the no-launcher fallback path (host invoked directly, Phase B features bypassed) | Yes - hot reload |
 | `task package` | **Portable release builds** | No |
+| `task package:local` | **Portable build with ephemeral version bump** — same as `task package` but bumps the version for this build only and restores on exit. Use when you want side-by-side portable comparisons or just a unique version label. No git mutation. | No |
 
 On Windows, `task dev` builds a production-parallel layout in `dist/cef-dev/` (launcher at root, host + DLLs + srv in `runtime/`) and invokes `agentmux-launcher.exe` — so the Job Object, single-instance pipe, saga coordinator, splash, and launcher-spawned srv paths are exercised in dev exactly as in package builds. On Linux/macOS, `task dev` still invokes the host directly (Phase 7 cross-platform parity will integrate the launcher). See `docs/specs/SPEC_LAUNCHER_DEV_INTEGRATION_2026-05-13.md`.
+
+**Why `:local` variants exist:** under the RFC #857 changeset workflow, feature PRs no longer bump `package.json` / `Cargo.toml` — version files stay pinned across many merges until a release PR consumes the pending changesets. That's clean for git history but it means dev/portable builds across multiple merges share the same version label, and cargo's incremental cache may serve stale `.o` files because `CARGO_PKG_VERSION` doesn't change. The `:local` scripts (`scripts/dev-local.sh`, `scripts/package-local.sh`) wrap an ephemeral `bump patch` around the build, then restore the working tree on exit (including Ctrl+C and crashes). The bump is per-build only — never committed, never pushed. See `.changesets/README.md` for the broader RFC #857 context.
 
 ### Build System
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,11 @@ tasks:
         cmds:
             - bash scripts/package-local.sh {{.CLI_ARGS}}
 
+    dev:local:
+        desc: 'Run task dev with a temporarily-bumped version label so the dev build advertises a unique version and cargo''s incremental cache cannot serve stale .o files. Restores version files on Ctrl+C — no git mutation, no pushed bump commit. Usage: task dev:local (defaults to patch bump) or task dev:local -- minor.'
+        cmds:
+            - bash scripts/dev-local.sh {{.CLI_ARGS}}
+
     dev:
         desc: Run AgentMux in development mode (Vite hot reload).
         cmds:

--- a/docs/specs/SPEC_STATUS_BAR_WINDOW_COUNT_2026_05_16.md
+++ b/docs/specs/SPEC_STATUS_BAR_WINDOW_COUNT_2026_05_16.md
@@ -1,0 +1,90 @@
+# SPEC: Status-Bar Window-Count Display
+
+**Status:** Draft / shipping with PR
+**Date:** 2026-05-16
+**Author:** AgentA
+
+---
+
+## 1. Problem
+
+The status bar in every AgentMux window shows the app version followed by a parenthesized number, e.g.:
+
+```
+v0.33.900 (2)
+```
+
+The `(2)` is the **per-window instance ordinal** — window #2 shows `(2)`, window #5 shows `(5)`. The number is different in every window. Users have reported this is unclear: it tells you *which* window you're in but not *how many* windows are open in total.
+
+The intent — based on user feedback — is that the number should help answer "how many AgentMux windows do I have open right now?" That answer is the same in every window, and it's more often the question users want answered.
+
+## 2. Goals
+
+- **G1** The number rendered to the right of the version is the **total active window count**, identical in every window.
+- **G2** The display still hides when there's only one window (no useful information to convey).
+- **G3** Behavior updates reactively when windows open or close.
+- **G4** No backend changes — both source signals already exist in `frontend/app/store/global.ts`.
+
+## 3. Non-goals
+
+- Surfacing which window you're currently in. The instance ordinal can be moved into the instance panel popover (the same popover anchored on the version) for users who still care; out of scope for this spec.
+- Multi-monitor or workspace awareness — count is over all AgentMux windows on this machine, not filtered by anything.
+
+## 4. Current state
+
+`frontend/app/statusbar/StatusBar.tsx:80-94`:
+
+```tsx
+<button ... class="status-version clickable" ...>
+    v{version}
+    <Show when={windowCount() > 1}>
+        <span class="instance-num"> ({instanceNum()})</span>
+    </Show>
+</button>
+```
+
+- `instanceNum()` = `windowInstanceNumAtom` (per-window ordinal, set when the window is created).
+- `windowCount()` = `windowCountAtom` (total active windows, updated as windows open/close).
+- Both atoms are declared at `frontend/app/store/global.ts:132-133` and already kept in sync by the existing window-management plumbing.
+
+## 5. Proposed change
+
+Swap the rendered atom from `instanceNum()` to `windowCount()`:
+
+```tsx
+<button ... class="status-version clickable" ...>
+    v{version}
+    <Show when={windowCount() > 1}>
+        <span class="instance-num"> ({windowCount()})</span>
+    </Show>
+</button>
+```
+
+`<Show when={windowCount() > 1}>` already gates the display correctly — when only one window is open, the parenthesis is hidden.
+
+`instanceNum` accessor stays imported (currently unused after the swap) only if we also surface it inside the instance-panel popover (see §3 non-goal — deferred). Otherwise drop the unused import.
+
+## 6. Edge cases
+
+| Case | Handling |
+|---|---|
+| First-window startup before `windowCountAtom` is initialized | Default value is `1` (see `global.ts:133`); Show hides parenthesis until count rises. Same as today. |
+| Window closes mid-render | Reactive update; next paint shows new count. SolidJS signal semantics handle this. |
+| Two windows open then one closes | Other window's count drops from `2` → `1`; Show hides the parenthesis. |
+| User opens 10 windows | Renders `v0.33.900 (10)`. No truncation. |
+
+## 7. Risk
+
+Trivial. One-line swap of accessors; no new state, no new signals, no test fixture change. Manual smoke is sufficient.
+
+## 8. Test plan
+
+- [ ] Single window — status bar shows `v<X.Y.Z>`, no parenthesis.
+- [ ] Open second window — both windows show `v<X.Y.Z> (2)`.
+- [ ] Open third — all three show `(3)`.
+- [ ] Close one — remaining show `(2)`.
+- [ ] Close down to one — parenthesis hides.
+
+---
+
+🤖 Authored by AgentA, 2026-05-16. Implementation ships in the same PR per `feedback_no_doc_only_prs.md`.

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getApi, windowInstanceNumAtom, windowCountAtom, backendStatusAtom } from "@/store/global";
+import { getApi, windowCountAtom, backendStatusAtom } from "@/store/global";
 import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
@@ -14,7 +14,6 @@ import "./StatusBar.scss";
 
 const StatusBar = (): JSX.Element => {
     const version = getApi().getAboutModalDetails()?.version ?? "";
-    const instanceNum = windowInstanceNumAtom;
     const windowCount = windowCountAtom;
 
     let versionRef!: HTMLButtonElement;
@@ -89,7 +88,7 @@ const StatusBar = (): JSX.Element => {
                         >
                             v{version}
                             <Show when={windowCount() > 1}>
-                                <span class="instance-num"> ({instanceNum()})</span>
+                                <span class="instance-num"> ({windowCount()})</span>
                             </Show>
                         </button>
                     </Show>

--- a/scripts/dev-local.sh
+++ b/scripts/dev-local.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# dev-local.sh — run `task dev` with a temporarily-bumped version label,
+# then restore the original version files on exit.
+#
+# Use case: under the RFC #857 changeset workflow, feature PRs no longer
+# bump `package.json` / `Cargo.toml`. The dev build's version label stays
+# pinned to the last release PR's version across many merges, which:
+#   - makes it hard to tell "which merge does this dev build correspond
+#     to" from the version alone, and
+#   - lets cargo's incremental cache serve stale `.o` files because
+#     CARGO_PKG_VERSION doesn't change across `task dev` invocations.
+#
+# This script mirrors `scripts/package-local.sh`: bump in-place, run
+# `task dev`, restore working-tree on exit (Ctrl+C, dev-loop crash,
+# anything). No git mutation, no commit.
+#
+# Usage:
+#   scripts/dev-local.sh          # patch bump (default)
+#   scripts/dev-local.sh patch    # explicit
+#   scripts/dev-local.sh minor
+#   scripts/dev-local.sh major
+#
+# RFC #857 Phase 2 escape hatch — see .changesets/README.md.
+
+set -euo pipefail
+
+BUMP_TYPE="${1:-patch}"
+
+case "$BUMP_TYPE" in
+    patch|minor|major) ;;
+    *)
+        echo "ERROR: bump type must be patch | minor | major (got: $BUMP_TYPE)" >&2
+        exit 1
+        ;;
+esac
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ORIG_VERSION="$(node -p "require('./package.json').version")"
+echo ">>> dev-local: starting at v$ORIG_VERSION" >&2
+
+# Capture working-tree state of files bump-cli will rewrite, so we can
+# restore them byte-for-byte regardless of whether bump-cli leaves staged
+# changes behind.
+BACKUP_DIR="$(mktemp -d)"
+
+VERSION_FILES=(
+    package.json
+    package-lock.json
+    Cargo.lock
+    Cargo.toml
+)
+for f in "${VERSION_FILES[@]}"; do
+    if [[ -f "$f" ]]; then
+        cp "$f" "$BACKUP_DIR/$(basename "$f").bak"
+    fi
+done
+
+# Restore on exit no matter what (Ctrl+C, dev-loop crash, etc).
+# restore_files MUST run before BACKUP_DIR is deleted — the trap below
+# runs restore first, then cleans up the backups.
+restore_files() {
+    echo >&2
+    echo ">>> dev-local: restoring working-tree to v$ORIG_VERSION" >&2
+    for f in "${VERSION_FILES[@]}"; do
+        if [[ -f "$BACKUP_DIR/$(basename "$f").bak" ]]; then
+            cp "$BACKUP_DIR/$(basename "$f").bak" "$f"
+        fi
+    done
+    # Drop any staging bump-cli did.
+    git reset -q -- "${VERSION_FILES[@]}" 2>/dev/null || true
+    echo ">>> dev-local: working tree restored." >&2
+}
+trap 'restore_files; rm -rf "$BACKUP_DIR"' EXIT
+
+# Bump in-place (no --commit). bump-cli handles Cargo workspace inheritance
+# via .bump.json (Phase 1 collapsed 5 member Cargo.toml targets to 1 root).
+bump "$BUMP_TYPE"
+NEW_VERSION="$(node -p "require('./package.json').version")"
+echo ">>> dev-local: temporarily bumped to v$NEW_VERSION for dev session" >&2
+echo ">>> dev-local: launching task dev — Ctrl+C to stop, restore is automatic" >&2
+
+# Run the actual dev loop. It blocks until the user kills it; the EXIT
+# trap then fires `restore_files`.
+task dev
+
+echo >&2
+echo ">>> dev-local: dev loop exited." >&2
+echo ">>> Working tree is back at v$ORIG_VERSION — no git mutation." >&2


### PR DESCRIPTION
## Summary

Two related improvements for the test/dev experience:

### 1. Status-bar window count fix

`StatusBar.tsx:92` previously rendered `windowInstanceNumAtom` (per-window ordinal — window #2 showed `(2)`, window #5 showed `(5)`). Swap to `windowCountAtom` so all windows display the same number — the total of active AgentMux windows. The existing `<Show when={windowCount() > 1}>` gate preserves the hide-when-1 behavior. Drop the now-unused `windowInstanceNumAtom` import.

Spec: `docs/specs/SPEC_STATUS_BAR_WINDOW_COUNT_2026_05_16.md`.

### 2. New `task dev:local`

Under the RFC #857 changeset workflow, feature PRs no longer bump version files — `package.json` / `Cargo.toml` stay pinned across many merges. Two consequences:
- Dev/portable builds share the same version label across merges, so "which merge does this build correspond to?" is unanswerable from the version alone.
- Cargo's incremental cache can serve stale `.o` files because `CARGO_PKG_VERSION` doesn't change. We hit this twice during #877/#878 portable iteration — once shipped without `"(ambient creds)"` sentinel strings, once a hard-link cache fooled `cargo clean -p`.

`task package:local` already solves this for portables. Add the analogous `task dev:local`:
- In-place `bump patch` (or `minor`/`major` via CLI args).
- Run `task dev`.
- EXIT trap restores `package.json` + lockfiles + `Cargo.toml` on Ctrl+C or crash, byte-for-byte.
- No git mutation, no pushed bump commits.

CLAUDE.md updated with both `:local` variants and a `Why :local variants exist` explainer.

## Diff

- `frontend/app/statusbar/StatusBar.tsx`: 1-line atom swap + drop unused import.
- `scripts/dev-local.sh`: new file, mirror of `scripts/package-local.sh`.
- `Taskfile.yml`: new `dev:local` entry alongside `package:local`.
- `CLAUDE.md`: table + explainer updated.
- `docs/specs/SPEC_STATUS_BAR_WINDOW_COUNT_2026_05_16.md`: spec for change #1.

## Test plan

- [x] Typecheck clean.
- [ ] Window count: open second window, both status bars show `(2)`. Close one, parenthesis hides.
- [ ] `task dev:local`: starts dev with bumped version label; Ctrl+C restores working tree to original version.
- [ ] `task dev:local minor` / `major`: explicit bump types work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)