### PR TITLE
fix(live-log): plumb 'persist' field through WPS publish endpoint

### DIFF
--- a/.changesets/1778933880-fix-live-log-plumb-persist-field-through-wps-publish-endpoin-mr8z.md
+++ b/.changesets/1778933880-fix-live-log-plumb-persist-field-through-wps-publish-endpoin-mr8z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(live-log): plumb 'persist' field through WPS publish endpoint

--- a/agentmux-srv/src/reducer.rs
+++ b/agentmux-srv/src/reducer.rs
@@ -249,6 +249,7 @@ mod tests {
             | Event::WorkspaceMetaUpdated { version, .. }
             | Event::TabMetaUpdated { version, .. }
             | Event::BlockMetaUpdated { version, .. }
+            | Event::WindowMetaUpdated { version, .. }
             | Event::TabMoved { version, .. }
             | Event::BlockMoved { version, .. }
             | Event::FocusedNodeChanged { version, .. }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -298,16 +298,26 @@ async fn stub_501() -> impl IntoResponse {
 
 /// Wire shape for `POST /agentmux/wps/publish`. Mirrors `WaveEvent`
 /// but keeps the field set narrow for what `agentmux-bashwrap`
-/// actually needs (no `sender`, no `persist`).
+/// actually needs (no `sender`).
 #[derive(serde::Deserialize)]
 struct WpsPublishRequest {
-    /// WPS event name. We use `tool_chunk:<tool_use_id>` for
-    /// streaming chunks, but the handler is general-purpose.
+    /// WPS event name. We use a fixed `tool_chunk` for every
+    /// streaming chunk (the tool_use_id lives in the payload), but
+    /// the handler is general-purpose.
     event: String,
     /// Optional scope filters (e.g. `["block:<id>"]`) so only
     /// subscribers watching that block receive the event.
     #[serde(default)]
     scopes: Vec<String>,
+    /// Per-scope event ring size. Lets late subscribers replay
+    /// events that landed before they subscribed. agentmux-bashwrap
+    /// sets this to 1024 for `tool_chunk` so the frontend's
+    /// subscription (installed on pane mount) picks up chunks that
+    /// flew before Claude's stream-json caught up enough to surface
+    /// the tool_use_id. Zero (or omitted) disables persistence —
+    /// pure fan-out. See SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §6.
+    #[serde(default)]
+    persist: usize,
     /// Free-form payload. For tool_chunk events this is the
     /// `{op, kind, content, timestamp}` shape from
     /// `SPEC_STREAMING_BASH_RUNNER_2026_05_11.md` §4.3.
@@ -326,7 +336,7 @@ async fn handle_wps_publish(
         event: req.event,
         scopes: req.scopes,
         sender: String::new(),
-        persist: 0,
+        persist: req.persist,
         data: Some(req.data),
     };
     state.broker.publish(event);

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -325,3 +325,60 @@ async fn reactive_poller_status() {
     assert!(json.is_object());
 }
 
+
+#[tokio::test]
+async fn wps_publish_accepts_persist_field() {
+    // Regression for SPEC_STREAMING_BASH_RUNNER_2026_05_11.md §6.1
+    // (and PR β.B): WpsPublishRequest previously dropped the `persist`
+    // field on deserialization, so every tool_chunk publish went to
+    // the broker with persist=0. Late-subscribing frontends never got
+    // replay history, defeating the per-block subscription strategy.
+    //
+    // This test exercises the deserialize + handler-200 path with a
+    // 1024-persist body matching what agentmux-bashwrap actually
+    // sends. Broker-level persistence semantics are covered by
+    // wps.rs::tests::test_event_persistence.
+    let app = test_router();
+    let body = serde_json::json!({
+        "event": "tool_chunk",
+        "scopes": ["block:abc123"],
+        "persist": 1024,
+        "data": {
+            "op": "chunk",
+            "kind": "stdout",
+            "content": "hello\n",
+            "timestamp": 1_700_000_000_000_u64,
+            "tool_id": "toolu_test"
+        }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/wps/publish")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn wps_publish_omits_persist_defaults_to_zero() {
+    // Defensive: a publisher that doesn't include the persist field
+    // should still succeed (serde default 0 → pure fan-out, no replay).
+    let app = test_router();
+    let body = serde_json::json!({
+        "event": "tool_chunk",
+        "scopes": ["block:abc123"],
+        "data": { "op": "chunk", "kind": "stdout", "content": "x", "timestamp": 0_u64, "tool_id": "t" }
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/agentmux/wps/publish")
+        .header("X-AuthKey", "test-secret-key")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
## Summary

Closes the β.B work for streaming bash output. `agentmux-bashwrap` was already sending `persist: 1024` on every tool_chunk publish, and the broker already supported per-scope event-ring persistence — but the srv-side `WpsPublishRequest` struct dropped the field on deserialization, so the broker's `persist_event()` never fired. Late subscribers (the normal case, since Claude buffers stream-json until well after `agentmux-bashwrap` has started running) got no replay history.

## The bug

`agentmux-srv/src/server/mod.rs:303-315`:

\`\`\`rust
#[derive(serde::Deserialize)]
struct WpsPublishRequest {
    event: String,
    scopes: Vec<String>,
    data: serde_json::Value,
    // ← persist field missing
}
\`\`\`

Handler at line 321-334 then hardcoded `persist: 0` on the WaveEvent. Broker's `publish()` at `agentmux-srv/src/backend/wps.rs:312` only invokes `persist_event(...)` when `event.persist > 0`. So every tool_chunk publish was pure fan-out with no history.

Visible symptom: tool overlay's live-log feed appeared empty until the *next* chunk after subscription. Short-running commands (`ls`, `echo`, fast `grep`) finished before the renderer learned the tool_use_id, leaving the overlay empty even after completion — only the eventual final `tool_result` block appeared.

## Fix

\`\`\`rust
#[derive(serde::Deserialize)]
struct WpsPublishRequest {
    event: String,
    #[serde(default)] scopes: Vec<String>,
    #[serde(default)] persist: usize,  // ← new, defaults to 0
    data: serde_json::Value,
}
\`\`\`

Handler forwards `req.persist` to the WaveEvent. Default 0 keeps non-bashwrap publishers (which omit the field) on the pure-fan-out path — no behavior change for them.

## Tests

Two integration tests against `test_router()`:

- `wps_publish_accepts_persist_field` — POST with `persist: 1024` returns 200.
- `wps_publish_omits_persist_defaults_to_zero` — POST without the field still works.

Both pass. Broker-level persistence semantics are already covered by `agentmux-srv/src/backend/wps.rs:843::test_event_persistence` — this PR closes the wire-gap that prevented the existing persistence path from firing.

## Adjacent fix

The `agentmux-srv` test binary previously failed to compile with E0004: missing match arm for `Event::WindowMetaUpdated` in `reducer.rs::extract_version`. Added the arm so the new tests can run. Pre-existing bug, unrelated cause, but blocking — and the fix is two characters.

## Test plan

- [x] Both new tests pass (`cargo test --release -p agentmux-srv server::tests::wps_publish`).
- [x] Release build clean (`cargo build --release -p agentmux-srv`).
- [ ] Smoke: launch a Claude agent in a fresh portable, run `ls -la` (a fast command), confirm the tool overlay shows the directory listing in real time (not empty until tool_result).
- [ ] Smoke: long-running command (`npm install` or equivalent), confirm chunks arrive within ~50ms of the wrapper emitting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)