### PR TITLE
diag(live-log): temporary tracing for tool_chunk delivery path

### DIFF
--- a/.changesets/1778937152-diag-live-log-temporary-tracing-for-tool-chunk-delivery-path-9yez.md
+++ b/.changesets/1778937152-diag-live-log-temporary-tracing-for-tool-chunk-delivery-path-9yez.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(live-log): temporary tracing for tool_chunk delivery path

--- a/agentmux-srv/src/backend/wps.rs
+++ b/agentmux-srv/src/backend/wps.rs
@@ -315,10 +315,35 @@ impl Broker {
 
         let client = match &inner.client {
             Some(c) => c,
-            None => return,
+            None => {
+                // Live-log diagnostic.
+                if event.event == "tool_chunk" {
+                    tracing::warn!(
+                        target: "live-log-diag",
+                        event = %event.event,
+                        scopes = ?event.scopes,
+                        "broker has no client — event dropped before delivery",
+                    );
+                }
+                return;
+            }
         };
 
         let route_ids = Self::get_matching_routes(&inner, &event);
+        // Live-log diagnostic — log how many routes the tool_chunk
+        // event matched. Zero matches = no subscriber registered for
+        // the event/scope combo at publish time.
+        if event.event == "tool_chunk" {
+            let sub_for_event_exists = inner.sub_map.contains_key(&event.event);
+            tracing::info!(
+                target: "live-log-diag",
+                event = %event.event,
+                scopes = ?event.scopes,
+                matched_routes = route_ids.len(),
+                has_subs_for_event = sub_for_event_exists,
+                "broker publish — route match summary",
+            );
+        }
         for route_id in route_ids {
             client.send_event(&route_id, event.clone());
         }

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -332,6 +332,24 @@ async fn handle_wps_publish(
     State(state): State<AppState>,
     Json(req): Json<WpsPublishRequest>,
 ) -> impl IntoResponse {
+    // Live-log diagnostic (temporary — track gap from
+    // SPEC_STREAMING_BASH_RUNNER §6 user-visible regression).
+    // Logs every publish so we can see whether tool_chunk events
+    // reach the endpoint and how the broker routes them.
+    if req.event == "tool_chunk" {
+        let data_preview = serde_json::to_string(&req.data)
+            .ok()
+            .map(|s| s.chars().take(120).collect::<String>())
+            .unwrap_or_default();
+        tracing::info!(
+            target: "live-log-diag",
+            event = %req.event,
+            scopes = ?req.scopes,
+            persist = req.persist,
+            data_preview = %data_preview,
+            "wps publish received",
+        );
+    }
     let event = crate::backend::wps::WaveEvent {
         event: req.event,
         scopes: req.scopes,

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -337,16 +337,32 @@ async fn handle_wps_publish(
     // Logs every publish so we can see whether tool_chunk events
     // reach the endpoint and how the broker routes them.
     if req.event == "tool_chunk" {
-        let data_preview = serde_json::to_string(&req.data)
-            .ok()
-            .map(|s| s.chars().take(120).collect::<String>())
+        // Metadata only — do NOT log req.data. Bash tool output can
+        // contain credentials, request payloads, etc. Codex P2 #884
+        // round 1.
+        let op = req.data.get("op").and_then(|v| v.as_str()).unwrap_or("?");
+        let kind = req.data.get("kind").and_then(|v| v.as_str()).unwrap_or("?");
+        let content_len = req
+            .data
+            .get("content")
+            .and_then(|v| v.as_str())
+            .map(|s| s.len())
+            .unwrap_or(0);
+        let tool_id = req
+            .data
+            .get("tool_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.chars().take(14).collect::<String>())
             .unwrap_or_default();
         tracing::info!(
             target: "live-log-diag",
             event = %req.event,
             scopes = ?req.scopes,
             persist = req.persist,
-            data_preview = %data_preview,
+            op = %op,
+            kind = %kind,
+            tool_id = %tool_id,
+            content_len,
             "wps publish received",
         );
     }

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -122,10 +122,22 @@ export function useAgentStream({
         eventType: "tool_chunk",
         scope: `block:${blockId}`,
         handler: (event: any) => {
+            // Live-log diagnostic — temporary, ship-and-strip after we
+            // confirm the chunks-not-showing-live regression closes.
+            // Logs every tool_chunk receipt + the reason for each
+            // early-return so we can see, in the host log, exactly
+            // where the chain breaks (subscribe → receive → dispatch).
             const data = event?.data;
-            if (!data || typeof data !== "object") return;
+            if (!data || typeof data !== "object") {
+                console.warn(`[live-log-diag] tool_chunk dropped: no data object`, event);
+                return;
+            }
             const toolId = typeof data.tool_id === "string" ? data.tool_id : "";
-            if (!toolId) return;
+            if (!toolId) {
+                console.warn(`[live-log-diag] tool_chunk dropped: no tool_id`, data);
+                return;
+            }
+            console.log(`[live-log-diag] tool_chunk received op=${data.op} toolId=${toolId.slice(0, 14)} contentLen=${(data.content ?? "").length}`);
             if (data.op === "terminal") {
                 dispatchDocIfRegistered(blockId, {
                     type: "ToolChunkAppend",
@@ -138,7 +150,10 @@ export function useAgentStream({
                 });
                 return;
             }
-            if (data.op !== "chunk") return;
+            if (data.op !== "chunk") {
+                console.warn(`[live-log-diag] tool_chunk dropped: op=${data.op} (expected chunk|terminal)`, data);
+                return;
+            }
             dispatchDocIfRegistered(blockId, {
                 type: "ToolChunkAppend",
                 toolId,

--- a/frontend/app/view/agent/useAgentStream.ts
+++ b/frontend/app/view/agent/useAgentStream.ts
@@ -127,14 +127,17 @@ export function useAgentStream({
             // Logs every tool_chunk receipt + the reason for each
             // early-return so we can see, in the host log, exactly
             // where the chain breaks (subscribe → receive → dispatch).
+            // Metadata-only logging — do NOT log `data` or `event`.
+            // Bash tool output (chunk content) can carry secrets;
+            // codex P2 #884 round 2.
             const data = event?.data;
             if (!data || typeof data !== "object") {
-                console.warn(`[live-log-diag] tool_chunk dropped: no data object`, event);
+                console.warn(`[live-log-diag] tool_chunk dropped: no data object (event-keys=${Object.keys(event ?? {}).join(",")})`);
                 return;
             }
             const toolId = typeof data.tool_id === "string" ? data.tool_id : "";
             if (!toolId) {
-                console.warn(`[live-log-diag] tool_chunk dropped: no tool_id`, data);
+                console.warn(`[live-log-diag] tool_chunk dropped: no tool_id (op=${data.op ?? "?"} kind=${data.kind ?? "?"} contentLen=${(data.content ?? "").length})`);
                 return;
             }
             console.log(`[live-log-diag] tool_chunk received op=${data.op} toolId=${toolId.slice(0, 14)} contentLen=${(data.content ?? "").length}`);
@@ -151,7 +154,7 @@ export function useAgentStream({
                 return;
             }
             if (data.op !== "chunk") {
-                console.warn(`[live-log-diag] tool_chunk dropped: op=${data.op} (expected chunk|terminal)`, data);
+                console.warn(`[live-log-diag] tool_chunk dropped: op=${data.op} (expected chunk|terminal) toolId=${toolId.slice(0, 14)} kind=${data.kind ?? "?"} contentLen=${(data.content ?? "").length}`);
                 return;
             }
             dispatchDocIfRegistered(blockId, {


### PR DESCRIPTION
## Summary

Diagnostic-only PR to find where live-log chunks are dropping despite all components reporting healthy. User reports tool overlay shows 'Running...' then dumps full result at end — no live streaming. 6-check static-analysis session exhausted without identifying the gap.

This PR adds gated tracing (\`target: \"live-log-diag\"\`) at the three suspect points so the next repro pinpoints which step breaks:

| Component | Where | What logs |
|---|---|---|
| WPS publish endpoint | \`agentmux-srv/src/server/mod.rs::handle_wps_publish\` | tool_chunk publish receipt: event, scopes, persist, 120-char data preview |
| Broker publish | \`agentmux-srv/src/backend/wps.rs::Broker::publish\` | matched_routes count, has_subs_for_event, silent-drop case when inner.client is None |
| Frontend handler | \`frontend/app/view/agent/useAgentStream.ts\` tool_chunk handler | console.log on entry (op/toolId/contentLen) + console.warn on each early-return reason |

## How to read the resulting log

After running a Bash tool in the rebuilt portable, grep \`live-log-diag\` and \`[live-log-diag]\` against the host + srv logs:

\`\`\`
muxlog host '\[live-log-diag\]'
grep live-log-diag ~/.agentmux/logs/agentmuxsrv-v0.33.X-windows.x64.log.YYYY-MM-DD
\`\`\`

Expected flow if working:
1. srv: \`wps publish received\` (one per chunk)
2. srv: \`route match summary\` with \`matched_routes >= 1\` and \`has_subs_for_event = true\`
3. host: \`[live-log-diag] tool_chunk received\` for each chunk

Whatever step is missing or has the wrong values tells us the gap.

## Strip plan

Once the bug is identified and the real fix lands, strip the three diag blocks. They're scoped to \`event == \"tool_chunk\"\` so production noise is bounded, but they shouldn't ship long-term.

## Test plan

- [x] Builds clean (\`cargo build --release -p agentmux-srv\`, \`tsc --noEmit\`)
- [ ] Build a portable, run a Bash tool, capture log entries, identify gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)