### PR TITLE
diag(live-log): reducer-side tool-chunk audit logs

### DIFF
--- a/.changesets/1778939168-diag-live-log-log-reducer-tool-chunk-drop-append-o821.md
+++ b/.changesets/1778939168-diag-live-log-log-reducer-tool-chunk-drop-append-o821.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(live-log): log reducer tool-chunk drop+append

--- a/frontend/app/store/agent-document-store.ts
+++ b/frontend/app/store/agent-document-store.ts
@@ -51,6 +51,16 @@ let eventSink: EventSink = (blockId, event) => {
         console.warn(
             `[agent-document-store] dropped ${event.updateDropped} stream updates for unknown ids in ${blockId.slice(0, 7)}`,
         );
+    } else if (event.type === "tool-chunk-dropped") {
+        // Live-log diagnostic (temporary): surface reducer drops so we
+        // can tell if chunks arrive before the matching ToolNode exists.
+        console.warn(
+            `[live-log-diag] reducer dropped chunk for ${blockId.slice(0, 7)} toolId=${event.toolId.slice(0, 14)} reason=${event.reason}`,
+        );
+    } else if (event.type === "tool-chunk-appended") {
+        console.log(
+            `[live-log-diag] reducer appended chunk for ${blockId.slice(0, 7)} toolId=${event.toolId.slice(0, 14)} totalChunks=${event.chunkCount}`,
+        );
     }
 };
 


### PR DESCRIPTION
Follow-up to #884. The earlier diag confirmed the **entire transport chain works** (bashwrap publishes → broker routes with persist=1024 → frontend handler receives chunks). But user still sees no live render. This patch adds the missing piece: surface the reducer's **tool-chunk-appended** and **tool-chunk-dropped** audit events to console so we can tell whether chunks land in state or get dropped by findToolIndex.

Strip with #884 once the underlying bug is identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)