### PR TITLE
diag(live-log): overlay-side chunks memo logging

### DIFF
--- a/.changesets/1778940672-diag-live-log-log-overlay-render-side-chunks-view-1gcq.md
+++ b/.changesets/1778940672-diag-live-log-log-overlay-render-side-chunks-view-1gcq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(live-log): log overlay render-side chunks view

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -38,7 +38,15 @@ const KIND_CLASS: Record<string, string> = {
 export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     let scrollRef: HTMLDivElement | undefined;
 
-    const chunks = createMemo(() => props.node.log?.chunks ?? []);
+    const chunks = createMemo(() => {
+        const c = props.node.log?.chunks ?? [];
+        // Live-log diag: report render-side view of chunks so we can
+        // diff against reducer-side append count. If reducer says 58
+        // appended but this memo evaluates to length=0, the render
+        // is reading a stale node reference (prop reactivity break).
+        console.log(`[live-log-diag] overlay chunks memo toolId=${(props.node.id ?? "?").slice(0, 14)} renderedLen=${c.length} logOpen=${props.node.log?.open}`);
+        return c;
+    });
     /**
      * Phase 3 fallback rules — refined after codex P1 on PR #803.
      *


### PR DESCRIPTION
Follow-up to #885. The reducer is appending 58+ chunks but the overlay still shows 'Running...'. This adds console.log inside ToolOverlayLog's chunks memo to definitively diff render-side vs reducer-side counts.

If render says renderedLen=0 while reducer logged appendedCount=58, prop reactivity is broken between documentAtom → DocumentRow → ToolBlock → ToolBlockOverlay → ToolOverlayLog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)