### PR TITLE
fix(live-log): tool overlay renders chunks live (createMemo broke prop reactivity)

### DIFF
--- a/.changesets/1778940672-diag-live-log-log-overlay-render-side-chunks-view-1gcq.md
+++ b/.changesets/1778940672-diag-live-log-log-overlay-render-side-chunks-view-1gcq.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(live-log): log overlay render-side chunks view

--- a/.changesets/1778941681-fix-live-log-tool-overlay-must-access-props-node-inline-not--zbkp.md
+++ b/.changesets/1778941681-fix-live-log-tool-overlay-must-access-props-node-inline-not--zbkp.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(live-log): tool overlay must access props.node inline (not via createMemo) for live chunk rendering

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -38,7 +38,15 @@ const KIND_CLASS: Record<string, string> = {
 export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     let scrollRef: HTMLDivElement | undefined;
 
-    const chunks = createMemo(() => props.node.log?.chunks ?? []);
+    const chunks = createMemo(() => {
+        const c = props.node.log?.chunks ?? [];
+        // Live-log diag: report render-side view of chunks so we can
+        // diff against reducer-side append count. If reducer says 58
+        // appended but this memo evaluates to length=0, the render
+        // is reading a stale node reference (prop reactivity break).
+        console.log(`[live-log-diag] overlay chunks memo toolId=${(props.node.id ?? "?").slice(0, 14)} renderedLen=${c.length} logOpen=${props.node.log?.open}`);
+        return c;
+    });
     /**
      * Phase 3 fallback rules — refined after codex P1 on PR #803.
      *

--- a/frontend/app/view/agent/components/ToolOverlayLog.tsx
+++ b/frontend/app/view/agent/components/ToolOverlayLog.tsx
@@ -15,7 +15,7 @@
  * ANSI parsing lands in Phase γ (perf + worker offload) per the spec.
  */
 
-import { For, Match, Show, Switch, createEffect, createMemo, type JSX } from "solid-js";
+import { For, Match, Show, Switch, createEffect, type JSX } from "solid-js";
 // `Show` retained for fallback ToolOverlayResult sub-tree.
 import type { ToolNode } from "../types";
 import { BashOutputViewer } from "./BashOutputViewer";
@@ -38,15 +38,17 @@ const KIND_CLASS: Record<string, string> = {
 export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
     let scrollRef: HTMLDivElement | undefined;
 
-    const chunks = createMemo(() => {
-        const c = props.node.log?.chunks ?? [];
-        // Live-log diag: report render-side view of chunks so we can
-        // diff against reducer-side append count. If reducer says 58
-        // appended but this memo evaluates to length=0, the render
-        // is reading a stale node reference (prop reactivity break).
-        console.log(`[live-log-diag] overlay chunks memo toolId=${(props.node.id ?? "?").slice(0, 14)} renderedLen=${c.length} logOpen=${props.node.log?.open}`);
-        return c;
-    });
+    // INLINE prop access pattern (matches MarkdownBlock lines 18-23) —
+    // wrapping `props.node.log?.chunks` in createMemo broke reactivity
+    // for in-place ToolNode updates (ToolChunkAppend only mutates log,
+    // not the array length, and the memo's tracked dependencies did
+    // not fire on those updates — verified via diag in PR #884/#885/#886
+    // where the reducer appended 58+ chunks but the memo evaluated
+    // exactly once per overlay mount with log=undefined). Solid's
+    // JSX-expression auto-wrapping IS reactive end-to-end through
+    // multi-layer prop chains; createMemo's manual tracking is not.
+    // Read every gate inline at JSX time so each repaint sees the
+    // latest log state.
     /**
      * Phase 3 fallback rules — refined after codex P1 on PR #803.
      *
@@ -71,9 +73,10 @@ export const ToolOverlayLog = (props: ToolOverlayLogProps): JSX.Element => {
      * every tool that streamed any output — exit codes, diffs, and
      * highlighted Read content were silently dropped post-completion.
      */
-    const isStreaming = createMemo(() => props.node.log?.open === true);
-    const hasChunks = createMemo(() => chunks().length > 0);
-    const hasResult = createMemo(() => props.node.result != null);
+    const isStreaming = () => props.node.log?.open === true;
+    const hasChunks = () => (props.node.log?.chunks?.length ?? 0) > 0;
+    const hasResult = () => props.node.result != null;
+    const chunks = () => props.node.log?.chunks ?? [];
 
     // Auto-stick to bottom while the user hasn't scrolled away. The
     // threshold is forgiving — within 40px of the bottom counts as


### PR DESCRIPTION
## The fix

User reported tool overlay shows 'Running...' then dumps full result at end. After 3 rounds of diagnostic PRs (#884/#885/#886), the chain proved:

- bashwrap publishes ✓
- srv broker delivers ✓ (matched_routes=1)
- frontend handler receives ✓ (58 chunks)
- reducer appends ✓ (58 appends, 0 drops for the same toolId)
- **overlay's chunks memo: 0 re-evaluations after mount** ✗

createMemo's tracker did not propagate through Solid's multi-layer prop chain for in-place ToolNode mutations (where the array length is unchanged and only `log.chunks` on one node is replaced).

MarkdownBlock already documented this exact issue at lines 18-23: *'Access props.node.X at each site so Solid's reactivity tracks the read.'* Apply the same pattern to ToolOverlayLog: replace all four createMemo() wrappers with inline arrow-function accessors. JSX-expression reactivity (Switch/Match gates, ChunkList prop) is auto-wrapped by Solid and fires reliably on prop updates.

## Diff

```diff
-import { For, Match, Show, Switch, createEffect, createMemo, type JSX } from "solid-js";
+import { For, Match, Show, Switch, createEffect, type JSX } from "solid-js";
-const chunks = createMemo(() => props.node.log?.chunks ?? []);
-const isStreaming = createMemo(() => props.node.log?.open === true);
-const hasChunks = createMemo(() => chunks().length > 0);
-const hasResult = createMemo(() => props.node.result != null);
+const isStreaming = () => props.node.log?.open === true;
+const hasChunks = () => (props.node.log?.chunks?.length ?? 0) > 0;
+const hasResult = () => props.node.result != null;
+const chunks = () => props.node.log?.chunks ?? [];
```

## Test plan

- [x] Typecheck clean
- [ ] Smoke: launch agent, run `ls -la` or similar bash tool, confirm tool overlay shows lines streaming as they arrive (not 'Running...' until end)
- [ ] Smoke: short-running command (`echo hi`) still shows the output (replay-on-subscribe from #883)
- [ ] No regression: completed tools with structured results (BashOutputViewer, DiffViewer) still display correctly

## Follow-up

Strip diag logs from #884/#885/#886 in a separate PR once user verifies live rendering works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)