### PR TITLE
feat(agent): install stage Phase α — install modal with live npm progress

### DIFF
--- a/.changesets/1779024954-feat-agent-install-stage-phase-agent-pane-install-modal-with-cddu.md
+++ b/.changesets/1779024954-feat-agent-install-stage-phase-agent-pane-install-modal-with-cddu.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(agent): install stage Phase α — agent-pane install modal with live npm progress

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -713,6 +713,7 @@ async fn main() {
         auth_session_manager: std::sync::Arc::new(
             crate::identity::auth_session::AuthSessionManager::new(),
         ),
+        install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
     };
 
     // Saga durability PR 2 — resume-on-startup. Walk any sagas the

--- a/agentmux-srv/src/server/cli_handlers.rs
+++ b/agentmux-srv/src/server/cli_handlers.rs
@@ -10,10 +10,12 @@ use super::AppState;
 
 /// Register CLI-related RPC handlers (resolvecli, checkcliauth, runclilogin).
 pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
-    // resolvecli → detect or install a CLI tool for an agent provider
+    // resolvecli → detect or install a CLI tool for an agent provider.
     // Each AgentMux version gets its own isolated CLI install at:
-    //   ~/.agentmux/<AGENTMUX_VERSION>/cli/<provider>/
-    // Never falls back to system PATH.
+    //   <agentmux_home>/instances/v<AGENTMUX_VERSION>/cli/<provider>/
+    // (shared with `install.start` / `install.check` and the frontend
+    // launch path; resolved via `DataPaths::from_env()`).
+    // Never falls back to system PATH for npm-backed providers.
     let broker_resolve = state.broker.clone();
     engine.register_handler(
         COMMAND_RESOLVE_CLI,
@@ -32,16 +34,22 @@ pub fn register_cli_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     "ResolveCli"
                 );
 
-                // Resolve home directory
-                let home = std::env::var("HOME")
-                    .or_else(|_| std::env::var("USERPROFILE"))
-                    .map_err(|_| "cannot determine home directory".to_string())?;
-
-                // Versioned install directory: ~/.agentmux/<version>/cli/<provider>/
-                let provider_dir = format!(
-                    "{}/.agentmux/{}/cli/{}",
-                    home, AGENTMUX_VERSION, cmd.provider_id
-                );
+                // Canonical install directory — shared with
+                // `install.start` / `install.check` and the frontend's
+                // `agent-model.ts::resolveCliDir`. Resolves to
+                // `<agentmux_home>/instances/v<version>/cli/<provider>/`
+                // via `DataPaths::from_env()` so portable, installed,
+                // and `AGENTMUX_HOME_OVERRIDE` modes all agree.
+                let paths = agentmux_common::DataPaths::from_env()
+                    .ok_or_else(|| "DataPaths::from_env() failed".to_string())?;
+                let provider_dir = paths
+                    .home_dir
+                    .join("instances")
+                    .join(format!("v{AGENTMUX_VERSION}"))
+                    .join("cli")
+                    .join(&cmd.provider_id)
+                    .to_string_lossy()
+                    .to_string();
                 // npm binary path — the only valid location for installed CLIs.
                 let npm_bin = if cfg!(windows) {
                     format!("{}/node_modules/.bin/{}.cmd", provider_dir, cmd.cli_command)

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -321,6 +321,7 @@ fn spawn_install_task(
         if let Err(e) = std::fs::create_dir_all(&provider_dir) {
             emit_done(&broker, false, Some(format!("mkdir {}: {e}", provider_dir.display())));
             registry.drop_session(&session_id);
+            registry.release_provider(&provider_id);
             return;
         }
         let provider_dir_str = provider_dir.to_string_lossy().to_string();

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -98,6 +98,16 @@ fn is_safe_provider_id(s: &str) -> bool {
         && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 
+/// CLI command names are joined into the bin-resolution path; same
+/// allowlist as provider ids, plus `.` (some real CLIs include dots,
+/// e.g. `eslint.cmd`).
+fn is_safe_cli_command(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 64
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+        && !s.contains("..")
+}
+
 /// Canonical install directory for a provider —
 /// `~/.agentmux/<version>/cli/<provider>/`. `install.start` writes
 /// here and `install.check` reads the same path so the frontend's
@@ -196,6 +206,12 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     return Err(format!(
                         "install.check: invalid provider id {:?}",
                         req.provider_id
+                    ));
+                }
+                if !is_safe_cli_command(&req.cli_command) {
+                    return Err(format!(
+                        "install.check: invalid cli command {:?}",
+                        req.cli_command
                     ));
                 }
                 let installed = resolve_installed_bin(&req.provider_id, &req.cli_command).is_some();
@@ -383,6 +399,17 @@ fn spawn_install_task(
                 let _ = child.kill().await;
                 let _ = stdout_task.await;
                 let _ = stderr_task.await;
+                // Wipe the partial install so a retry doesn't inherit
+                // a half-written package-lock.json. Best-effort —
+                // logging only on failure.
+                if let Err(e) = std::fs::remove_dir_all(&provider_dir) {
+                    tracing::warn!(
+                        session_id = %session_id,
+                        provider_dir = %provider_dir.display(),
+                        error = %e,
+                        "install.cancel: remove partial dir failed"
+                    );
+                }
                 emit_done(&broker, false, Some("cancelled".into()));
             }
         }
@@ -393,7 +420,7 @@ fn spawn_install_task(
 
 #[cfg(test)]
 mod tests {
-    use super::is_safe_provider_id;
+    use super::{is_safe_cli_command, is_safe_provider_id};
 
     #[test]
     fn safe_provider_ids_accepted() {
@@ -418,6 +445,32 @@ mod tests {
             &"x".repeat(65),
         ] {
             assert!(!is_safe_provider_id(id), "{id:?} should be rejected");
+        }
+    }
+
+    #[test]
+    fn safe_cli_commands_accepted() {
+        for cmd in ["claude", "claude-code", "kimi.cmd", "agentmux-srv", "open_claw"] {
+            assert!(is_safe_cli_command(cmd), "{cmd} should be accepted");
+        }
+    }
+
+    #[test]
+    fn unsafe_cli_commands_rejected() {
+        for cmd in [
+            "",
+            "../etc/passwd",
+            "../../etc/passwd",
+            "a/b",
+            "a\\b",
+            "a b",
+            "..",
+            "a..b",
+            "a/../b",
+            "\0null",
+            &"x".repeat(65),
+        ] {
+            assert!(!is_safe_cli_command(cmd), "{cmd:?} should be rejected");
         }
     }
 }

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -178,6 +178,12 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         req.provider_id
                     ));
                 }
+                if !is_safe_cli_command(&req.cli_command) {
+                    return Err(format!(
+                        "install.start: invalid cli command {:?}",
+                        req.cli_command
+                    ));
+                }
                 if req.npm_package.is_empty() {
                     return Err(format!(
                         "install.start: provider {} has no npm_package — only npm-installable providers are supported in Phase α",

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -109,18 +109,20 @@ fn is_safe_cli_command(s: &str) -> bool {
 }
 
 /// Canonical install directory for a provider —
-/// `~/.agentmux/<version>/cli/<provider>/`. `install.start` writes
-/// here and `install.check` reads the same path so the frontend's
-/// "is installed?" probe matches what `install.start` produces.
+/// `<agentmux_home>/instances/v<version>/cli/<provider>/`. This is the
+/// same path the frontend uses to launch the agent
+/// (`agent-model.ts::resolveCliDir`), so the bin we drop in
+/// `node_modules/.bin/` is what the launch path will execute.
+/// Honors portable / installed mode + the `AGENTMUX_HOME_OVERRIDE`
+/// test override via `DataPaths::from_env()`.
 fn provider_install_dir(provider_id: &str) -> Option<std::path::PathBuf> {
-    let home = std::env::var("HOME")
-        .or_else(|_| std::env::var("USERPROFILE"))
-        .ok()?;
+    let paths = agentmux_common::DataPaths::from_env()?;
     let version = env!("CARGO_PKG_VERSION");
     Some(
-        std::path::PathBuf::from(home)
-            .join(".agentmux")
-            .join(version)
+        paths
+            .home_dir
+            .join("instances")
+            .join(format!("v{version}"))
             .join("cli")
             .join(provider_id),
     )

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -60,11 +60,15 @@ struct InstallCheckReq {
 }
 
 /// Per-session abort handle so `install.cancel` can kill an in-flight
-/// install. `parking_lot::Mutex` since the engine is sync at the
-/// handler boundary.
+/// install. Also tracks `active_providers` so concurrent sessions for
+/// the *same* provider directory are rejected — without that, cancel
+/// of one would `rm_rf` the shared dir mid-install for the other.
+/// `parking_lot::Mutex` since the engine is sync at the handler
+/// boundary.
 #[derive(Default)]
 pub struct InstallSessionRegistry {
     sessions: Mutex<std::collections::HashMap<String, tokio::sync::oneshot::Sender<()>>>,
+    active_providers: Mutex<std::collections::HashSet<String>>,
 }
 
 impl InstallSessionRegistry {
@@ -74,6 +78,16 @@ impl InstallSessionRegistry {
 
     fn insert(&self, session_id: String, tx: tokio::sync::oneshot::Sender<()>) {
         self.sessions.lock().insert(session_id, tx);
+    }
+
+    /// Try to claim a provider; returns false if another session is
+    /// already installing this provider.
+    fn try_claim_provider(&self, provider_id: &str) -> bool {
+        self.active_providers.lock().insert(provider_id.to_string())
+    }
+
+    fn release_provider(&self, provider_id: &str) {
+        self.active_providers.lock().remove(provider_id);
     }
 
     fn cancel(&self, session_id: &str) -> bool {
@@ -167,6 +181,12 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 if req.npm_package.is_empty() {
                     return Err(format!(
                         "install.start: provider {} has no npm_package — only npm-installable providers are supported in Phase α",
+                        req.provider_id
+                    ));
+                }
+                if !registry.try_claim_provider(&req.provider_id) {
+                    return Err(format!(
+                        "install.start: provider {} is already being installed in another session",
                         req.provider_id
                     ));
                 }
@@ -294,6 +314,7 @@ fn spawn_install_task(
             None => {
                 emit_done(&broker, false, Some("cannot determine home directory".into()));
                 registry.drop_session(&session_id);
+                registry.release_provider(&provider_id);
                 return;
             }
         };
@@ -337,6 +358,7 @@ fn spawn_install_task(
             Err(e) => {
                 emit_done(&broker, false, Some(format!("spawn npm: {e}")));
                 registry.drop_session(&session_id);
+                registry.release_provider(&provider_id);
                 return;
             }
         };
@@ -417,6 +439,7 @@ fn spawn_install_task(
         }
 
         registry.drop_session(&session_id);
+        registry.release_provider(&provider_id);
     });
 }
 

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -268,7 +268,7 @@ fn spawn_install_task(
     registry: Arc<InstallSessionRegistry>,
     session_id: String,
     provider_id: String,
-    _cli_command: String,
+    cli_command: String,
     npm_package: String,
     pinned_version: String,
     mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
@@ -414,7 +414,26 @@ fn spawn_install_task(
                 let _ = stdout_task.await;
                 let _ = stderr_task.await;
                 match wait {
-                    Ok(s) if s.success() => emit_done(&broker, true, None),
+                    Ok(s) if s.success() => {
+                        // npm exit 0 ≠ "binary is on disk". Verify the
+                        // expected bin shim exists so a package/bin
+                        // rename or provider-config mismatch surfaces
+                        // as an install failure rather than a phantom
+                        // launch with a non-existent cmd path.
+                        if resolve_installed_bin(&provider_id, &cli_command).is_some() {
+                            emit_done(&broker, true, None);
+                        } else {
+                            emit_done(
+                                &broker,
+                                false,
+                                Some(format!(
+                                    "npm install reported success but {} not found in {}/node_modules/.bin/",
+                                    cli_command,
+                                    provider_dir.display()
+                                )),
+                            );
+                        }
+                    }
                     Ok(s) => emit_done(&broker, false, Some(format!("npm exited {:?}", s.code()))),
                     Err(e) => emit_done(&broker, false, Some(format!("wait: {e}"))),
                 }

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -34,6 +34,7 @@ use crate::server::AppState;
 
 pub const COMMAND_INSTALL_START: &str = "install.start";
 pub const COMMAND_INSTALL_CANCEL: &str = "install.cancel";
+pub const COMMAND_INSTALL_CHECK: &str = "install.check";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -49,6 +50,13 @@ struct InstallStartReq {
 #[serde(rename_all = "camelCase")]
 struct InstallCancelReq {
     session_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallCheckReq {
+    provider_id: String,
+    cli_command: String,
 }
 
 /// Per-session abort handle so `install.cancel` can kill an in-flight
@@ -82,6 +90,51 @@ impl InstallSessionRegistry {
     }
 }
 
+/// Provider ids feed into the install dir path; reject anything that
+/// could escape `~/.agentmux/<version>/cli/<provider>/`.
+fn is_safe_provider_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 64
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Canonical install directory for a provider —
+/// `~/.agentmux/<version>/cli/<provider>/`. `install.start` writes
+/// here and `install.check` reads the same path so the frontend's
+/// "is installed?" probe matches what `install.start` produces.
+fn provider_install_dir(provider_id: &str) -> Option<std::path::PathBuf> {
+    let home = std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .ok()?;
+    let version = env!("CARGO_PKG_VERSION");
+    Some(
+        std::path::PathBuf::from(home)
+            .join(".agentmux")
+            .join(version)
+            .join("cli")
+            .join(provider_id),
+    )
+}
+
+/// Returns the path to the installed CLI binary if present in the
+/// per-version cache, else None. Used by `install.check`.
+fn resolve_installed_bin(provider_id: &str, cli_command: &str) -> Option<std::path::PathBuf> {
+    let dir = provider_install_dir(provider_id)?;
+    let bin_dir = dir.join("node_modules").join(".bin");
+    let candidates: &[&str] = if cfg!(windows) {
+        &[".cmd", ".exe", ""]
+    } else {
+        &["", ".cmd"]
+    };
+    for suffix in candidates {
+        let p = bin_dir.join(format!("{cli_command}{suffix}"));
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
 pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
     let registry = state.install_sessions.clone();
     let broker = state.broker.clone();
@@ -93,6 +146,12 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
             Box::pin(async move {
                 let req: InstallStartReq = serde_json::from_value(data)
                     .map_err(|e| format!("install.start: {e}"))?;
+                if !is_safe_provider_id(&req.provider_id) {
+                    return Err(format!(
+                        "install.start: invalid provider id {:?} — must match [a-zA-Z0-9_-]+",
+                        req.provider_id
+                    ));
+                }
                 if req.npm_package.is_empty() {
                     return Err(format!(
                         "install.start: provider {} has no npm_package — only npm-installable providers are supported in Phase α",
@@ -123,6 +182,24 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 );
 
                 Ok(Some(json!({ "sessionId": session_id })))
+            })
+        }),
+    );
+
+    engine.register_handler(
+        COMMAND_INSTALL_CHECK,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                let req: InstallCheckReq = serde_json::from_value(data)
+                    .map_err(|e| format!("install.check: {e}"))?;
+                if !is_safe_provider_id(&req.provider_id) {
+                    return Err(format!(
+                        "install.check: invalid provider id {:?}",
+                        req.provider_id
+                    ));
+                }
+                let installed = resolve_installed_bin(&req.provider_id, &req.cli_command).is_some();
+                Ok(Some(json!({ "installed": installed })))
             })
         }),
     );
@@ -194,23 +271,20 @@ fn spawn_install_task(
             broker.publish(event);
         };
 
-        // Resolve install dir. Mirrors `cli_handlers.rs::resolve_cli`:
-        // `~/.agentmux/<version>/cli/<provider>/`.
-        let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
-            Ok(h) => h,
-            Err(_) => {
+        let provider_dir = match provider_install_dir(&provider_id) {
+            Some(p) => p,
+            None => {
                 emit_done(&broker, false, Some("cannot determine home directory".into()));
                 registry.drop_session(&session_id);
                 return;
             }
         };
-        let version = env!("CARGO_PKG_VERSION");
-        let provider_dir = format!("{}/.agentmux/{}/cli/{}", home, version, provider_id);
         if let Err(e) = std::fs::create_dir_all(&provider_dir) {
-            emit_done(&broker, false, Some(format!("mkdir {provider_dir}: {e}")));
+            emit_done(&broker, false, Some(format!("mkdir {}: {e}", provider_dir.display())));
             registry.drop_session(&session_id);
             return;
         }
+        let provider_dir_str = provider_dir.to_string_lossy().to_string();
 
         let pkg_arg = if pinned_version.is_empty() {
             npm_package.clone()
@@ -218,14 +292,14 @@ fn spawn_install_task(
             format!("{}@{}", npm_package, pinned_version)
         };
 
-        emit_line(&broker, format!("$ npm install {} --prefix {}", pkg_arg, provider_dir), "stdout");
+        emit_line(&broker, format!("$ npm install {} --prefix {}", pkg_arg, provider_dir_str), "stdout");
 
         let mut cmd = Command::new(if cfg!(windows) { "npm.cmd" } else { "npm" });
         cmd.args([
             "install",
             &pkg_arg,
             "--prefix",
-            &provider_dir,
+            &provider_dir_str,
             "--no-audit",
             "--no-fund",
             "--progress=false",
@@ -315,4 +389,35 @@ fn spawn_install_task(
 
         registry.drop_session(&session_id);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_provider_id;
+
+    #[test]
+    fn safe_provider_ids_accepted() {
+        for id in ["claude", "claude-code", "open_claw", "Codex42"] {
+            assert!(is_safe_provider_id(id), "{id} should be accepted");
+        }
+    }
+
+    #[test]
+    fn unsafe_provider_ids_rejected() {
+        for id in [
+            "",
+            "../escape",
+            "a/b",
+            "a\\b",
+            "a b",
+            ".",
+            "..",
+            "a..b",
+            "a/../b",
+            "\0null",
+            &"x".repeat(65),
+        ] {
+            assert!(!is_safe_provider_id(id), "{id:?} should be rejected");
+        }
+    }
 }

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -1,0 +1,318 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `install.start` / `install.cancel` RPC handlers.
+//!
+//! Phase α of `SPEC_AGENT_INSTALL_STAGE_2026_05_17.md`. Spawns
+//! `npm install <package>` for the requested provider, streams every
+//! line of stdout+stderr to `install_chunk` WPS events scoped to
+//! `install:<sessionId>`, and emits a terminal `{ op: "done", ok,
+//! error? }` event when the child exits (or the user cancels).
+//!
+//! Phase α scope:
+//!  - npm-only install (existing per-version layout at
+//!    `~/.agentmux/<version>/cli/<provider>/`).
+//!  - Plain piped stdio (no PTY) — npm doesn't isatty-gate its output
+//!    line-by-line, so pipes are fine here. PTY would be required for
+//!    interactive post-install steps (Phase δ).
+//!  - Single in-flight install per session id. The frontend modal owns
+//!    the session id and prevents parallel installs at the UI layer.
+//!  - Cancel kills the child via `kill_on_drop` when the abort handle
+//!    fires. The partial `node_modules` dir is rm-rf'd best-effort.
+//!  - No verify / doctor / post-install steps yet — those land in
+//!    Phase β.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::backend::rpc::engine::WshRpcEngine;
+use crate::backend::wps::{Broker, WaveEvent};
+use crate::server::AppState;
+
+pub const COMMAND_INSTALL_START: &str = "install.start";
+pub const COMMAND_INSTALL_CANCEL: &str = "install.cancel";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallStartReq {
+    provider_id: String,
+    cli_command: String,
+    npm_package: String,
+    #[serde(default)]
+    pinned_version: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InstallCancelReq {
+    session_id: String,
+}
+
+/// Per-session abort handle so `install.cancel` can kill an in-flight
+/// install. `parking_lot::Mutex` since the engine is sync at the
+/// handler boundary.
+#[derive(Default)]
+pub struct InstallSessionRegistry {
+    sessions: Mutex<std::collections::HashMap<String, tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl InstallSessionRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn insert(&self, session_id: String, tx: tokio::sync::oneshot::Sender<()>) {
+        self.sessions.lock().insert(session_id, tx);
+    }
+
+    fn cancel(&self, session_id: &str) -> bool {
+        if let Some(tx) = self.sessions.lock().remove(session_id) {
+            let _ = tx.send(());
+            true
+        } else {
+            false
+        }
+    }
+
+    fn drop_session(&self, session_id: &str) {
+        self.sessions.lock().remove(session_id);
+    }
+}
+
+pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
+    let registry = state.install_sessions.clone();
+    let broker = state.broker.clone();
+    engine.register_handler(
+        COMMAND_INSTALL_START,
+        Box::new(move |data, _ctx| {
+            let registry = registry.clone();
+            let broker = broker.clone();
+            Box::pin(async move {
+                let req: InstallStartReq = serde_json::from_value(data)
+                    .map_err(|e| format!("install.start: {e}"))?;
+                if req.npm_package.is_empty() {
+                    return Err(format!(
+                        "install.start: provider {} has no npm_package — only npm-installable providers are supported in Phase α",
+                        req.provider_id
+                    ));
+                }
+                let session_id = format!("install-{}", uuid::Uuid::new_v4());
+                tracing::info!(
+                    session_id = %session_id,
+                    provider_id = %req.provider_id,
+                    npm_package = %req.npm_package,
+                    pinned_version = %req.pinned_version,
+                    "install.start"
+                );
+
+                let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+                registry.insert(session_id.clone(), cancel_tx);
+
+                spawn_install_task(
+                    broker,
+                    registry,
+                    session_id.clone(),
+                    req.provider_id,
+                    req.cli_command,
+                    req.npm_package,
+                    req.pinned_version,
+                    cancel_rx,
+                );
+
+                Ok(Some(json!({ "sessionId": session_id })))
+            })
+        }),
+    );
+
+    let registry = state.install_sessions.clone();
+    engine.register_handler(
+        COMMAND_INSTALL_CANCEL,
+        Box::new(move |data, _ctx| {
+            let registry = registry.clone();
+            Box::pin(async move {
+                let req: InstallCancelReq = serde_json::from_value(data)
+                    .map_err(|e| format!("install.cancel: {e}"))?;
+                let ok = registry.cancel(&req.session_id);
+                Ok(Some(json!({
+                    "success": ok,
+                    "error": if ok { serde_json::Value::Null } else {
+                        json!(format!("unknown or already-terminal session: {}", req.session_id))
+                    }
+                })))
+            })
+        }),
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_install_task(
+    broker: Arc<Broker>,
+    registry: Arc<InstallSessionRegistry>,
+    session_id: String,
+    provider_id: String,
+    _cli_command: String,
+    npm_package: String,
+    pinned_version: String,
+    mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    tokio::spawn(async move {
+        use std::process::Stdio;
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        use tokio::process::Command;
+
+        let scope = format!("install:{}", session_id);
+        let emit_line = |broker: &Broker, line: String, stream: &'static str| {
+            let event = WaveEvent {
+                event: "install_chunk".to_string(),
+                scopes: vec![scope.clone()],
+                sender: String::new(),
+                persist: 1024,
+                data: Some(json!({
+                    "sessionId": session_id,
+                    "line": line,
+                    "stream": stream,
+                })),
+            };
+            broker.publish(event);
+        };
+        let emit_done = |broker: &Broker, ok: bool, error: Option<String>| {
+            let event = WaveEvent {
+                event: "install_chunk".to_string(),
+                scopes: vec![scope.clone()],
+                sender: String::new(),
+                persist: 1024,
+                data: Some(json!({
+                    "sessionId": session_id,
+                    "op": "done",
+                    "ok": ok,
+                    "error": error,
+                })),
+            };
+            broker.publish(event);
+        };
+
+        // Resolve install dir. Mirrors `cli_handlers.rs::resolve_cli`:
+        // `~/.agentmux/<version>/cli/<provider>/`.
+        let home = match std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE")) {
+            Ok(h) => h,
+            Err(_) => {
+                emit_done(&broker, false, Some("cannot determine home directory".into()));
+                registry.drop_session(&session_id);
+                return;
+            }
+        };
+        let version = env!("CARGO_PKG_VERSION");
+        let provider_dir = format!("{}/.agentmux/{}/cli/{}", home, version, provider_id);
+        if let Err(e) = std::fs::create_dir_all(&provider_dir) {
+            emit_done(&broker, false, Some(format!("mkdir {provider_dir}: {e}")));
+            registry.drop_session(&session_id);
+            return;
+        }
+
+        let pkg_arg = if pinned_version.is_empty() {
+            npm_package.clone()
+        } else {
+            format!("{}@{}", npm_package, pinned_version)
+        };
+
+        emit_line(&broker, format!("$ npm install {} --prefix {}", pkg_arg, provider_dir), "stdout");
+
+        let mut cmd = Command::new(if cfg!(windows) { "npm.cmd" } else { "npm" });
+        cmd.args([
+            "install",
+            &pkg_arg,
+            "--prefix",
+            &provider_dir,
+            "--no-audit",
+            "--no-fund",
+            "--progress=false",
+        ]);
+        cmd.stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+        }
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                emit_done(&broker, false, Some(format!("spawn npm: {e}")));
+                registry.drop_session(&session_id);
+                return;
+            }
+        };
+
+        let stdout = child.stdout.take().expect("piped");
+        let stderr = child.stderr.take().expect("piped");
+
+        let broker_out = broker.clone();
+        let session_out = session_id.clone();
+        let scope_out = scope.clone();
+        let stdout_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let event = WaveEvent {
+                    event: "install_chunk".to_string(),
+                    scopes: vec![scope_out.clone()],
+                    sender: String::new(),
+                    persist: 1024,
+                    data: Some(json!({
+                        "sessionId": session_out,
+                        "line": line,
+                        "stream": "stdout",
+                    })),
+                };
+                broker_out.publish(event);
+            }
+        });
+
+        let broker_err = broker.clone();
+        let session_err = session_id.clone();
+        let scope_err = scope.clone();
+        let stderr_task = tokio::spawn(async move {
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let event = WaveEvent {
+                    event: "install_chunk".to_string(),
+                    scopes: vec![scope_err.clone()],
+                    sender: String::new(),
+                    persist: 1024,
+                    data: Some(json!({
+                        "sessionId": session_err,
+                        "line": line,
+                        "stream": "stderr",
+                    })),
+                };
+                broker_err.publish(event);
+            }
+        });
+
+        tokio::select! {
+            wait = child.wait() => {
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+                match wait {
+                    Ok(s) if s.success() => emit_done(&broker, true, None),
+                    Ok(s) => emit_done(&broker, false, Some(format!("npm exited {:?}", s.code()))),
+                    Err(e) => emit_done(&broker, false, Some(format!("wait: {e}"))),
+                }
+            }
+            _ = &mut cancel_rx => {
+                tracing::info!(session_id = %session_id, "install.cancel: killing child");
+                let _ = child.kill().await;
+                let _ = stdout_task.await;
+                let _ = stderr_task.await;
+                emit_done(&broker, false, Some("cancelled".into()));
+            }
+        }
+
+        registry.drop_session(&session_id);
+    });
+}

--- a/agentmux-srv/src/server/mod.rs
+++ b/agentmux-srv/src/server/mod.rs
@@ -3,6 +3,7 @@ mod files;
 mod app_api;
 mod forge_handlers;
 mod identity_handlers;
+pub mod install_handlers;
 mod messagebus;
 mod reactive;
 pub(crate) mod service;
@@ -98,6 +99,13 @@ pub struct AppState {
     /// "Connect with OAuth" attempt from the launch modal. See
     /// `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md`.
     pub auth_session_manager: std::sync::Arc<crate::identity::auth_session::AuthSessionManager>,
+
+    /// In-flight `install.start` sessions. Frontend subscribes to
+    /// `install_chunk` WPS events scoped by session id; the registry
+    /// holds per-session cancel handles so `install.cancel` can abort
+    /// an install mid-flight.
+    /// See `SPEC_AGENT_INSTALL_STAGE_2026_05_17.md` §9.
+    pub install_sessions: std::sync::Arc<crate::server::install_handlers::InstallSessionRegistry>,
 }
 
 /// Build the Axum router with all routes, auth middleware, and CORS.

--- a/agentmux-srv/src/server/tests.rs
+++ b/agentmux-srv/src/server/tests.rs
@@ -58,6 +58,7 @@ pub(crate) fn test_state() -> AppState {
         // hermetic. Production opens a file under the data dir.
         saga_log: Arc::new(crate::sagas::log::SagaLog::open_in_memory().unwrap()),
         auth_session_manager: Arc::new(crate::identity::auth_session::AuthSessionManager::new()),
+        install_sessions: crate::server::install_handlers::InstallSessionRegistry::new(),
     }
 }
 

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -1187,6 +1187,10 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
     // cancel / submitapikey — see docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md)
     super::identity_handlers::register_identity_handlers(engine, &state);
 
+    // Install handlers (install.start / install.cancel — see
+    // docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md)
+    super::install_handlers::register_install_handlers(engine, &state);
+
     // App API handlers (agent.open, agent.send, agent.stop, agent.status, agent.list, agent.output)
     super::app_api::register_app_api_handlers(engine, &state);
 }

--- a/docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md
+++ b/docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md
@@ -1,0 +1,581 @@
+# SPEC: Agent Install Stage
+
+**Status:** Draft
+**Date:** 2026-05-17
+**Author:** AgentA
+**Related:** [`SPEC_OPENCLAW_AGENT_2026_05_17.md`](./SPEC_OPENCLAW_AGENT_2026_05_17.md) (§6 onboarding, made concrete here for ALL agents), [`SPEC_LIVE_LOG_PTY_REWORK_2026_05_16.md`](./SPEC_LIVE_LOG_PTY_REWORK_2026_05_16.md) (reuses the same streaming-output primitive)
+
+---
+
+## 0. TL;DR
+
+When the user picks an agent that isn't installed (or whose install is stale / broken), the agent pane's default content becomes a **distinctly-colored Install button** + a **progress feed**. Clicking installs the agent's CLI + runs any post-install steps + verifies. On success the button transitions to **Launch**. Re-clicks during install are idempotent. Cancel rolls back partial state.
+
+This separates "install" from "launch" semantically — today they're conflated in a single click flow, which hides 30–60 second installs behind a silent spinner and (verified today) lets a user queue six parallel `npm install` runs by clicking impatiently.
+
+The install stage is **per-agent declarative** in the provider config, reuses the existing PTY-streaming primitive for visible progress, and supports caching across AgentMux versions to avoid re-installing 373 MB of OpenClaw on every version bump.
+
+---
+
+## 1. Problem
+
+Three concrete failure modes observed today (2026-05-17 session):
+
+### 1.1 Silent first-install
+
+`npm install` runs invisibly under the OpenClaw card's first launch. ~30–60s of nothing in the UI. User clicks again. AgentMux happily queues a second install. By the time it's done, six parallel `npm install` processes are in flight. Same `node_modules` directory. Predictable corruption surface.
+
+### 1.2 Conflated semantics
+
+Today's button: "Connect to OpenClaw". It actually does three things: resolve-or-install CLI, auth-or-not, launch. If install fails the user sees "auth panel didn't appear"; if auth fails they see "Connect button doesn't work"; if launch fails they see "agent doesn't open". The error surface is wrong because the actions are wrong.
+
+### 1.3 Per-version cache duplication
+
+`~/.agentmux/<version>/cli/<agent>/` — fresh dir per AgentMux version bump. Five OpenClaw bumps in a session = 5 × 373 MB = **~1.9 GB** of duplicated `node_modules`. Disk impact is real, and the user pays a full re-install on every minor version label change.
+
+### 1.4 Heterogeneous install recipes hidden in code
+
+| Agent | Install | Post-install needed |
+|---|---|---|
+| Claude Code | `npm install -g @anthropic-ai/claude-code` | OAuth (interactive) |
+| Codex | `npm install -g @openai/codex` | `codex login` (OAuth, interactive) |
+| Gemini | `npm install -g @google/genai-cli` (TBD) | OAuth (interactive) |
+| OpenClaw | `npm install -g openclaw` | `openclaw config set gateway.mode local` + `openclaw onboard` (interactive) + brain auth |
+| Kimi | `pip install kimi-cli` (TBD) | API key |
+| Pi | bundled in OpenClaw | — |
+| Copilot | `gh extension install …` | GitHub device flow |
+
+Today each agent's install is hard-coded in different code paths (npm in `cli_handlers.rs`, post-install nowhere). The provider config (`providers.rs` + `providers/index.ts`) doesn't describe the post-install graph — so OpenClaw's `gateway.mode = unset` doctor warning has no path to a fix-button.
+
+---
+
+## 2. Goals
+
+- **G1.** Brand-new user → click agent card → Install button (with cost + size + estimated time) → click → visible streamed progress → success → Launch button.
+- **G2.** Re-clicking during install is a no-op (or pauses the user-visible bar at most). No queued parallel installs.
+- **G3.** Per-agent install recipes are **declarative** in the provider config, not hard-coded in the launch flow.
+- **G4.** Post-install steps that need interactive TTY (`openclaw onboard`, `codex login`) reuse the PTY infrastructure shipped with `SPEC_LIVE_LOG_PTY_REWORK_2026_05_16.md`.
+- **G5.** Install dirs are **shared across AgentMux versions** by default (`~/.agentmux/shared/cli/<agent>/`), with per-version override available for compatibility quirks.
+- **G6.** Cancel mid-install reverts to `NOT_INSTALLED` and removes the partial dir.
+- **G7.** A first-run successful install ends with the agent able to launch in one more click — no separate "now run doctor" / "now configure" dance.
+
+## 3. Non-goals
+
+- **Not a package manager**. We don't try to update individual deps inside a CLI's `node_modules`. The agent CLI itself is the unit of install/upgrade.
+- **Not a global registry replacement**. We use `npm install` for npm-packaged CLIs, `pip install` for pip ones, etc. The recipe just calls the right tool — no AgentMux-internal package server.
+- **Not Code-Signing / verification of CLI binaries**. Trust comes from the upstream registry (npmjs.org, PyPI, etc.).
+- **Not solving disk-pressure GC**. We add the shared-cache to reduce duplication, but don't add a "GC old installs" pass in v1. Logged as follow-up.
+- **Not changing the per-agent OAuth UX** beyond using the install stage as its host. Each provider's OAuth flow remains its own (per the "shared interfaces, distinct flavor" principle).
+
+---
+
+## 4. State machine
+
+Per (agent × identity) pair, the install-and-launch lifecycle is:
+
+```
+                                  ┌────────────────────────────────────────┐
+                                  │                                        │
+                                  ▼                                        │
+   user picks agent ─► NOT_INSTALLED ──click Install──► INSTALLING ──fail──┤
+                                  │                          │             │
+                                  │                          │ ok          │
+                                  │                          ▼             │
+                                  │                      INSTALLED         │
+                                  │                          │             │
+                                  │                          ▼             │
+                                  │                      AUTH_REQUIRED?  ──┤ no
+                                  │                          │             │
+                                  │                       yes│             ▼
+                                  │                          ▼          READY ─► Launch
+                                  │              click "Login with …"     ▲
+                                  │                          │             │
+                                  │                  AUTHING (PTY login)   │
+                                  │                          │             │
+                                  │                       ok ▼             │
+                                  │                       AUTHED ──────────┘
+                                  │
+                                  │       ┌───────────── user clicks "Reinstall" ──┐
+                                  │       │                                        │
+                                  └───────┴────────────────────────────────────────┘
+```
+
+State definitions:
+
+| state | description | UI affordance |
+|---|---|---|
+| `NOT_INSTALLED` | Provider's CLI not present in shared/versioned cache, or version stale | **Install {agent}** button (orange/yellow tint, size estimate, est. time) |
+| `INSTALLING` | npm/pip/etc. in progress | Disabled button, streaming progress feed below, **Cancel** button |
+| `INSTALL_FAILED` | Install or post-install errored | **Retry** button (same color as Install), error excerpt, full log expandable |
+| `INSTALLED` | Binary present; running `<agent> doctor` to determine auth state | Brief "Verifying…" spinner; transitions to AUTH_REQUIRED or AUTHED |
+| `AUTH_REQUIRED` | Doctor reports not authed | **Login with {provider}** button (provider-color, per `SPEC_OPENCLAW_AGENT_2026_05_17.md` §3) |
+| `AUTHING` | OAuth subprocess running | Streaming feed + URL/copy box (existing PreLaunchAuthPanel WaitingPanel UX) |
+| `AUTHED` | Doctor reports authed | Briefly verifies once more, then ready |
+| `READY` | Everything passes | **Launch {agent}** button (normal blue, the existing launch UX) |
+
+The state is **persisted in the agent pane's reducer slot** (per [[reference_master_reducer_status]]) so a refresh doesn't drop the user back to NOT_INSTALLED if they already installed.
+
+## 5. Per-agent install recipe (provider config)
+
+Extend `ProviderDefinition` (frontend `providers/index.ts`) and `ProviderConfig` (Rust `providers.rs`) with a declarative install graph:
+
+```ts
+interface InstallRecipe {
+    /** Heuristic for sizing the install button. Renders as
+     *  "Install OpenClaw (~400 MB, ~45 s)". */
+    estimatedSizeMb: number;
+    estimatedDurationSec: number;
+
+    /** Ordered steps. First failure aborts the recipe and surfaces
+     *  the step's error. Each step's stdout/stderr streams into the
+     *  install panel via PTY (same pipeline as live-log). */
+    steps: InstallStep[];
+
+    /** Once `steps` complete, run this command to verify the install
+     *  succeeded end-to-end. Non-zero exit = INSTALL_FAILED. */
+    verifyCommand: string[];
+
+    /** Doctor command (parsed for "needs auth" vs "ready" vs
+     *  "needs other config"). Run on transition INSTALLED →
+     *  AUTH_REQUIRED. */
+    doctorCommand: string[];
+}
+
+interface InstallStep {
+    /** Human label shown in the progress feed: "Installing
+     *  npm package openclaw…", "Configuring gateway…", etc. */
+    name: string;
+
+    /** Command to run. The first element is the CLI binary path
+     *  (resolved by the install runner — `npm`, `pip`, the
+     *  agent's own binary post-step-1, …). */
+    command: string[];
+
+    /** If true, the step runs under a PTY (for `isatty()`-strict
+     *  commands like `openclaw onboard`). Default false (pipes). */
+    requiresTty?: boolean;
+
+    /** Env vars to inject. Useful for `OPENCLAW_HOME` etc. */
+    env?: Record<string, string>;
+
+    /** If true and the step fails, we stop the recipe. If false,
+     *  we log and continue. Default true. */
+    required?: boolean;
+}
+```
+
+### 5.1 OpenClaw recipe (concrete example)
+
+```ts
+installRecipe: {
+    estimatedSizeMb: 400,
+    estimatedDurationSec: 45,
+    steps: [
+        {
+            name: "Installing OpenClaw npm package…",
+            command: ["npm", "install", "openclaw@latest", "--prefix", "{installDir}"],
+        },
+        {
+            name: "Configuring local gateway mode…",
+            command: ["{cli}", "config", "set", "gateway.mode", "local"],
+        },
+        // `openclaw onboard` is interactive; treat as a separate
+        // user-driven step (don't auto-run). The user clicks
+        // "Run onboarding" once the install completes and `doctor`
+        // surfaces the need. Phase β.
+    ],
+    verifyCommand: ["{cli}", "--version"],
+    doctorCommand: ["{cli}", "doctor", "--json"],
+}
+```
+
+`{installDir}` is `~/.agentmux/shared/cli/openclaw/` (per §7) and `{cli}` is `{installDir}/node_modules/.bin/openclaw{.cmd}`.
+
+### 5.2 Claude Code recipe
+
+```ts
+installRecipe: {
+    estimatedSizeMb: 250,
+    estimatedDurationSec: 20,
+    steps: [
+        {
+            name: "Installing Claude Code…",
+            command: ["npm", "install", "@anthropic-ai/claude-code@latest", "--prefix", "{installDir}"],
+        },
+    ],
+    verifyCommand: ["{cli}", "--version"],
+    doctorCommand: ["{cli}", "auth", "status", "--json"],
+}
+```
+
+(Today's `authCheckCommand` becomes `doctorCommand`. Authoring is just renaming + adding the `installRecipe` wrapper.)
+
+### 5.3 Auth recipe lives separately
+
+`authLoginCommand` (already exists) stays as-is — it's the OAuth/interactive login the user triggers after INSTALLED. Install recipe ends at INSTALLED; auth is a separate phase.
+
+---
+
+## 6. UI flow
+
+### 6.1 Two surfaces: a card in the pane + a modal for the work
+
+The default agent-pane view when the picked agent isn't installed renders a **single tinted Install button** + a one-line description. Clicking it opens an **Install Modal** (sibling to today's `AgentLaunchModal.tsx`) that hosts the live xterm-rendered install feed. The pane behind stays where it is.
+
+This pattern matches the launch UX: a small clickable affordance in the pane, the actual work happens in a modal that can be sized, dragged, kept open while the user does something else, or dismissed without canceling the underlying process.
+
+#### Default pane view — `NOT_INSTALLED`
+
+```
+┌── agent pane ─────────────────────────────────────────────────┐
+│                                                                │
+│   🦞 OpenClaw                                                  │
+│   Open-source personal AI assistant — model-agnostic           │
+│                                                                │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  ⚡ Install OpenClaw   (~400 MB, ~45 s)                 │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   Bundled: openclaw CLI, OpenAI + Anthropic + Google +         │
+│   Mistral provider SDKs, playwright (browser control).         │
+│   Stored at ~/.agentmux/shared/cli/openclaw/                   │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+The Install button is the **only** interactive affordance in this state — distinct color (suggest amber `#d9923a` to read as "do this thing first") so users don't confuse it with the regular Launch button (blue). No identity dropdown, no message composer.
+
+#### Install Modal — opens on click, persists across pane navigation
+
+The modal's layout mirrors `AgentLaunchModal.tsx`:
+
+```
+┌── Install OpenClaw ──────────────────────────────────────────┐ ✕
+│                                                               │
+│  Step 1 of 2: Installing npm package openclaw                 │
+│  ┌────────────────────────────────────────────────────────┐   │
+│  │ ▌                                                      │   │
+│  │ openclaw@2026.5.12                                     │   │
+│  │ added 487 packages in 12s                              │   │
+│  │ npm warn deprecated readable-stream@…                  │   │
+│  │ ▌                                                      │   │
+│  └────────────────────────────────────────────────────────┘   │
+│  (xterm.js live view — handles ANSI, progress bars, color)    │
+│                                                               │
+│  Disk: 287 MB / ~400 MB estimated                             │
+│  Elapsed: 0:23                                                │
+│                                                               │
+│              [ Cancel ]                  [ Background ]       │
+└───────────────────────────────────────────────────────────────┘
+```
+
+Key affordances:
+- **xterm.js inside the modal** — full terminal rendering so npm's `[==>] 50%` progress lines, ANSI colors, and `\r`-overwriting redraws look right. Same xterm we use for terminal panes (`agentmux-srv/src/backend/blockcontroller/shell.rs` plumbing).
+- **Step indicator** at top tells the user which step of the recipe is running.
+- **Disk + elapsed**, surfaced so the user understands the bar isn't stuck.
+- **Cancel** kills the install + rolls back partial state (§9.3).
+- **Background** closes the modal but the install keeps running. The pane's Install button updates to "Installing… (12 MB / 400 MB)" with a progress hint so the user can re-open the modal anytime.
+- **Modal close (✕)** is equivalent to Background — install continues, doesn't cancel.
+
+#### `INSTALL_FAILED` modal variant
+
+```
+┌── Install OpenClaw — failed ─────────────────────────────────┐ ✕
+│                                                               │
+│  ⚠  Step 1 of 2 failed: npm install                           │
+│                                                               │
+│  ┌────────────────────────────────────────────────────────┐   │
+│  │ npm ERR! code ETIMEDOUT                                │   │
+│  │ npm ERR! errno -4039                                   │   │
+│  │ npm ERR! syscall connect                               │   │
+│  │ ▌                                                      │   │
+│  └────────────────────────────────────────────────────────┘   │
+│                                                               │
+│  Possible cause: network timeout. Retry once you're online.   │
+│                                                               │
+│              [ View full log ]    [ Retry ]                   │
+└───────────────────────────────────────────────────────────────┘
+```
+
+#### After success — INSTALLED → AUTH_REQUIRED
+
+Modal **auto-closes** on a successful end-of-recipe + `doctor` parse. Pane transitions to:
+
+```
+┌── agent pane ─────────────────────────────────────────────────┐
+│                                                                │
+│   ✓ OpenClaw installed (391 MB)                                │
+│                                                                │
+│   Sign in to enable a backing model:                           │
+│                                                                │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Login with OpenAI (ChatGPT)                            │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   More providers (Anthropic, Google, Mistral) — later.         │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+After AUTHED → READY: the existing AgentLaunchModal opens with "Launch OpenClaw" (no change to existing UX past this point).
+
+### 6.2 xterm.js inside the modal
+
+The install modal renders the install subprocess through an xterm.js instance, NOT the plain `ChunkList` we use for the bash tool overlay. Reasoning:
+
+- `npm install` output is heavily ANSI-encoded (progress meters, color-coded warnings, redraws). Plain text rendering looks worse than the user's expectation for an install screen.
+- xterm.js is already in our frontend deps and powers the terminal pane.
+- The bash tool overlay's `ChunkList` is the right call for "agent did `ls`, show me the output as a chunk list." Install is "this is a terminal — let it draw itself."
+- ANSI strip in the bashwrap path is conscious lossy normalisation for the chat conversation. For an install screen we want the opposite — keep everything, render it.
+
+Mechanically:
+- Backend streams raw PTY bytes (no strip) on `install_chunk` WPS events scoped to `agent:<provider>` (no per-block scope since install is agent-level, not block-level).
+- Frontend feeds bytes into the modal's xterm.js instance via `term.write(bytes)`. Identical pattern to terminal pane.
+- Cap scrollback at 8 000 lines (terminal-default) so a chatty install doesn't OOM the renderer.
+
+### 6.3 Re-click idempotency
+
+Re-clicks on the Install button when the install is already in flight (modal open OR backgrounded) re-open the modal instead of starting a second install. The reducer (per §8) holds a single in-flight `installToken` per agent; subsequent `StartInstall` dispatches with that token already present are a visual no-op (modal pops to front, that's all).
+
+---
+
+## 7. Shared cache across AgentMux versions
+
+### 7.1 The 1.9 GB problem
+
+Today: `~/.agentmux/<version>/cli/openclaw/` — 373 MB per version. After five `bump patch` builds today, the user has 1.9 GB of duplicated `node_modules` on disk.
+
+### 7.2 Proposed layout
+
+```
+~/.agentmux/
+├── shared/
+│   └── cli/
+│       ├── openclaw/      ← single source of truth, ~373 MB
+│       ├── claude/        ← ~219 MB
+│       └── …
+└── versions/
+    └── 0.33.903/
+        └── cli/
+            └── openclaw/  → SYMLINK to ../../../shared/cli/openclaw
+```
+
+Each `~/.agentmux/<version>/cli/<agent>/` becomes a symlink (or NTFS junction on Windows) into `~/.agentmux/shared/cli/<agent>/`. Install runs in `shared/`. Subsequent version bumps reuse it.
+
+### 7.3 Version compatibility
+
+What if openclaw v2 introduces a breaking change and AgentMux 0.33.910 needs v2 while 0.33.909 needs v1? Provider config can opt in to per-version isolation:
+
+```ts
+installRecipe: {
+    cacheScope: "shared" | "per-version";   // default: "shared"
+    // …
+}
+```
+
+For v1 of this spec, default `shared` for every provider. Per-version isolation as an escape hatch.
+
+### 7.4 Migration
+
+On first launch with the new layout: if `~/.agentmux/<version>/cli/<agent>/` exists as a real directory (not a symlink), move it to `~/.agentmux/shared/cli/<agent>/` and replace with a symlink. This is a one-shot migration; subsequent versions just create the symlink at version-creation time.
+
+---
+
+## 8. Reducer + state
+
+Per [[reference_master_reducer_status]], all per-pane lifecycle state lives in a slot store. Add a new slice `agent-install-store`:
+
+```ts
+interface AgentInstallState {
+    perAgent: Map<string, AgentInstallEntry>;   // keyed by agentId
+}
+
+interface AgentInstallEntry {
+    state:
+        | { kind: "not_installed" }
+        | { kind: "installing"; token: string; steps: InstallStepProgress[]; log: LogChunks }
+        | { kind: "install_failed"; error: string; logExcerpt: string; log: LogChunks }
+        | { kind: "installed_verifying" }
+        | { kind: "auth_required" }
+        | { kind: "authing"; sessionId: string; authUrl?: string }
+        | { kind: "authed" }
+        | { kind: "ready" };
+}
+
+interface InstallStepProgress {
+    name: string;
+    status: "pending" | "running" | "ok" | "failed";
+}
+```
+
+Reducer commands:
+
+- `CheckAgentInstalled { agentId }` — opens the pane, runs the recipe's verify command, sets initial state.
+- `StartInstall { agentId, token }` — transitions to INSTALLING. Idempotent on same token.
+- `InstallChunk { agentId, chunk }` — append to log.
+- `InstallStepDone { agentId, stepIndex, ok }` — advance UI marker.
+- `InstallComplete { agentId }` — transitions to INSTALLED_VERIFYING.
+- `InstallFailed { agentId, error }` — transitions to INSTALL_FAILED.
+- `CancelInstall { agentId }` — transitions to NOT_INSTALLED, fires backend cancel.
+- `DoctorResult { agentId, kind: "auth_required" | "authed" | "needs_config", details? }` — branches state.
+
+Auth-state transitions integrate with existing `auth-flow-controller.ts` — AUTHING is a thin wrapper that delegates.
+
+---
+
+## 9. Backend
+
+### 9.1 New RPC commands
+
+| Command | Purpose |
+|---|---|
+| `install.start` | Begin an install recipe. Returns `installToken`. Idempotent on token. |
+| `install.cancel` | Abort an in-flight install + roll back partial state. |
+| `install.poll` | Optional — used if WS isn't reliable; otherwise events stream over existing chunk pipeline. |
+| `install.doctor` | Run the recipe's doctor command; parse output to one of `auth_required` / `authed` / `needs_config` / `unknown`. |
+
+### 9.2 Streaming
+
+PTY-spawn each install step (via `portable_pty`, same as `spawn_auth_cli_pty`). Lines fed through `record_install_line` (analogous to `record_line` in auth_session) → events on `install_chunk` WPS event scoped to the agent block.
+
+### 9.3 Atomic install dir
+
+Install to `{cacheDir}/{agent}.tmp/`. On verify success, atomic rename to `{cacheDir}/{agent}/`. On failure or cancel, rm-rf the tmp dir.
+
+### 9.4 Cancel signal
+
+Same cancel-handle pattern as `auth_session_manager`: `install.cancel` sends a oneshot the install-task watches. On signal, child is killed via PID + the tmp dir is removed.
+
+---
+
+## 10. Risks + mitigations
+
+### 10.1 npm install hung / network slow
+
+Recipe step has an implicit deadline (no timer in our code — `npm install` itself fails on its own connect timeout, ~30s default). If the user cancels, we kill via PID and rm-rf. **No timer added in our code** per `feedback_no_timers_or_delays.md` — the install network primitives have their own deadlines, we just propagate cancel signals.
+
+### 10.2 Symlink permissions on Windows
+
+NTFS symlinks require admin or "Developer Mode" enabled. Mitigation: use NTFS junctions (don't require elevation) via `cmd /c mklink /J`. Junctions are functionally equivalent for dir-only links.
+
+### 10.3 Shared cache + version drift
+
+Two AgentMux versions on the same machine pointing at `~/.agentmux/shared/cli/openclaw/`: one upgrades the cache, the other might break. Mitigation: see §7.3 `cacheScope: "per-version"` escape hatch. Default `shared` for v1 — most CLIs are forward-compatible.
+
+### 10.4 Re-install during running session
+
+User has an OpenClaw agent open, then clicks "Reinstall" elsewhere. Currently-running agent now uses a possibly-deleted binary. Mitigation: detect any open panes using this CLI before allowing reinstall; surface a "Close all OpenClaw panes first?" confirmation.
+
+### 10.5 First-install offline
+
+User clicks Install with no network → `npm install` fails. We surface the error in the panel + retry button. No silent loop, no timer — the user reads the error and acts.
+
+---
+
+## 11. Phased rollout
+
+### Phase α — scaffold + Install button + xterm modal (1 PR)
+- New `AgentInstallCard.tsx` rendered when the agent isn't installed (the tinted button + description, in the agent pane's default view).
+- New `AgentInstallModal.tsx` (sibling to `AgentLaunchModal.tsx`) hosting the xterm.js live install feed.
+- New `agent-install-store` reducer slice with the state machine (`NOT_INSTALLED → INSTALLING → INSTALL_FAILED|INSTALLED`), most transitions stubbed past INSTALLED.
+- Single-step recipe (just `npm install`, no post-install steps yet) reusing existing `ResolveCli` plumbing.
+- Backend streams raw PTY bytes on `install_chunk` WPS events; modal writes them into xterm via `term.write`.
+- Re-click idempotency: clicking the Install button while modal is open re-focuses it, doesn't start a second install.
+- No shared cache yet — still per-version.
+
+**Exit criteria:** user clicks the OpenClaw card → sees the tinted Install button → click → modal opens with xterm-rendered live npm install → reaches INSTALLED → modal auto-closes → pane shows "Login with OpenAI" follow-up. No more "click 6 times, queue 6 npm installs".
+
+### Phase β — declarative install recipes
+- `installRecipe` added to provider config (TS + Rust).
+- Multi-step support, with verify + doctor.
+- OpenClaw recipe gets `config set gateway.mode local` as a second step.
+
+### Phase γ — shared cache
+- `~/.agentmux/shared/cli/` becomes the default. Per-version dirs become symlinks/junctions.
+- One-shot migration on first launch (move existing dirs into shared, replace with junctions).
+
+### Phase δ — interactive post-install (TTY-required steps)
+- Steps with `requiresTty: true` spawn under PTY (reuse `spawn_auth_cli_pty` pattern).
+- OpenClaw's `onboard` flow becomes a button: "Run onboarding (~30 s)".
+
+### Phase ε — reinstall + update
+- "Reinstall" button on a ready/authed agent.
+- "Update available" badge if upstream version differs from installed.
+
+---
+
+## 12. Open questions
+
+1. **Where does the Install button live spatially** when the agent picker (forge) is browseable? On the pane after pick, vs inline in the picker card? Recommend pane-after-pick — picker stays a chooser, install is a commitment.
+
+2. **Should the Install button surface required environment** (Node.js version, Python version)? OpenClaw needs Node ≥ 20 per its package.json `engines`. AgentMux doesn't currently check. Lean: add a "Requirements check" step ahead of install steps; fail-loud with a "Node ≥ 20 required, you have X" if missing.
+
+3. **Per-identity install isolation?** Today every identity shares one `~/.agentmux/<version>/cli/openclaw/`. If two identities want different OpenClaw versions, they can't. Likely fine; flag as known limitation.
+
+4. **Streaming-output limit during install** — `npm install` can output thousands of lines (deprecated warnings, etc.). Cap at N lines or last-N-lines-on-failure? Reuse the same scrollback cap as the bash overlay (sensible 1024-line default).
+
+5. **Estimate accuracy** — `estimatedSizeMb` and `estimatedDurationSec` are hand-coded. Should they get refreshed from telemetry (median of last N installs on this OS)? Out of scope for v1.
+
+6. **Failure detail** — `INSTALL_FAILED` shows an error excerpt; the full log stays expandable. Where? Inline below the Retry button? Modal? Lean: inline, collapsed by default, expand-on-click — matches the live-log tool overlay UX.
+
+---
+
+## 13. Test plan
+
+### 13.1 Happy path (first install)
+1. Fresh AgentMux (no `~/.agentmux/shared/cli/` yet).
+2. Open agent picker, pick OpenClaw.
+3. See Install button with "~400 MB, ~45 s".
+4. Click Install → progress feed streams `npm install` output.
+5. Within ~60 s, transitions to AUTH_REQUIRED.
+6. Click "Login with OpenAI" → existing PreLaunchAuthPanel.WaitingPanel UX.
+7. Complete OAuth → AUTHED → READY → Launch button.
+
+### 13.2 Re-click idempotency
+1. Click Install. Immediately click again (and again, and again). Console + reducer log: at most one install command dispatched.
+
+### 13.3 Cancel mid-install
+1. Click Install. After ~5s, click Cancel.
+2. State returns to NOT_INSTALLED.
+3. `~/.agentmux/<version>/cli/openclaw.tmp/` removed; no `node_modules` left behind.
+
+### 13.4 Install failure
+1. Disconnect network. Click Install.
+2. npm install fails (network error in its stderr).
+3. State → INSTALL_FAILED. Error excerpt visible. Retry button works after network restored.
+
+### 13.5 Shared cache (Phase γ)
+1. Install OpenClaw on AgentMux 0.33.910.
+2. Bump to 0.33.911, launch.
+3. Pick OpenClaw — should be already INSTALLED (verify command runs, doctor runs, jumps to AUTH_REQUIRED or AUTHED). No re-install.
+
+### 13.6 Re-install during open pane
+1. OpenClaw pane open. Open a second pane, hit Reinstall (Phase ε).
+2. Confirmation modal: "Close all OpenClaw panes first?" — Cancel returns to normal; Confirm closes panes then reinstalls.
+
+---
+
+## 14. References
+
+### Code (current state, pre-spec)
+- `frontend/app/view/agent/providers/index.ts` — `ProviderDefinition` (grows `installRecipe` field)
+- `agentmux-srv/src/backend/providers.rs` — `ProviderConfig` (Rust mirror grows the same field)
+- `agentmux-srv/src/server/cli_handlers.rs` — existing `npm install` + `ResolveCli` (becomes one step of the recipe)
+- `agentmux-srv/src/server/identity_handlers.rs` — `spawn_auth_cli_pty` (reused for `requiresTty: true` install steps)
+- `agentmux-srv/src/identity/auth_session.rs` — pattern for `install_session_manager` (mirrors auth-session machinery)
+- `frontend/app/view/agent/components/PreLaunchAuthPanel.tsx` — AUTH_REQUIRED → AUTHING transitions already wired here; keep them, just relocate the entry point into the new install panel
+- `frontend/app/view/agent/components/AgentInstallCard.tsx` — NEW (the tinted Install button + description in the pane's default view)
+- `frontend/app/view/agent/components/AgentInstallModal.tsx` — NEW (modal with xterm.js live feed; sibling to `AgentLaunchModal.tsx`)
+- `agentmux-srv/src/identity/install_session.rs` — NEW (analogous to `auth_session.rs`; tracks in-flight installs, holds cancel tokens, emits `install_chunk` events)
+- xterm.js terminal-pane shell (already in deps) — reused for the modal feed
+
+### Prior specs
+- [`SPEC_OPENCLAW_AGENT_2026_05_17.md`](./SPEC_OPENCLAW_AGENT_2026_05_17.md) — §6β "onboarding UX" generalized here
+- [`SPEC_LIVE_LOG_PTY_REWORK_2026_05_16.md`](./SPEC_LIVE_LOG_PTY_REWORK_2026_05_16.md) — PTY-streaming primitive reused for install progress
+- [`SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md`](./SPEC_TOOL_AUTO_EXPAND_PANEL_2026_05_16.md) — auto-expand-while-running pattern; the same idea applies to install panel during INSTALLING
+- [`SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md`](./SPEC_AGENT_PANE_STATE_PERSISTENCE_2026_05_15.md) — install state persists across pane reopen via the same snapshot mechanism
+
+### Memory
+- [[feedback_no_timers_or_delays]] — no fixed-duration grace windows for npm install (let npm's own timeouts fire)
+- [[feedback_dont_measure_the_meter]] — install progress streaming must not loop-back into the auth or launch streaming paths
+- [[reference_master_reducer_status]] — install state lives in a per-pane slot store, audit-friendly

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -786,6 +786,34 @@ class RpcApiType {
         return client.rpcCall("auth.cancel", data, opts);
     }
 
+    // ── Agent install (SPEC_AGENT_INSTALL_STAGE_2026_05_17.md) ────────────
+
+    // command "install.start" — begin install of a provider's CLI; the
+    // backend npm-installs into the per-version cache and streams output
+    // via `install_chunk` WPS events scoped to `install:<sessionId>`.
+    InstallStartCommand(
+        client: RpcClient,
+        data: {
+            providerId: string;
+            cliCommand: string;
+            npmPackage: string;
+            pinnedVersion: string;
+        },
+        opts?: RpcOpts,
+    ): Promise<{ sessionId: string }> {
+        return client.rpcCall("install.start", data, opts);
+    }
+
+    // command "install.cancel" — abort an in-flight install and remove
+    // the partial dir.
+    InstallCancelCommand(
+        client: RpcClient,
+        data: { sessionId: string },
+        opts?: RpcOpts,
+    ): Promise<{ success: boolean; error?: string }> {
+        return client.rpcCall("install.cancel", data, opts);
+    }
+
     // command "auth.submitapikey"
     AuthSubmitApiKeyCommand(
         client: RpcClient,

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -814,6 +814,18 @@ class RpcApiType {
         return client.rpcCall("install.cancel", data, opts);
     }
 
+    // command "install.check" — probe the per-version install dir to
+    // decide whether the provider's CLI is already installed. Reads the
+    // same path that `install.start` writes to, so the picker's
+    // "show install modal?" decision matches the install location.
+    InstallCheckCommand(
+        client: RpcClient,
+        data: { providerId: string; cliCommand: string },
+        opts?: RpcOpts,
+    ): Promise<{ installed: boolean }> {
+        return client.rpcCall("install.check", data, opts);
+    }
+
     // command "auth.submitapikey"
     AuthSubmitApiKeyCommand(
         client: RpcClient,

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -24,6 +24,7 @@ import { createSignal, onCleanup, onMount, Show, type Accessor, type Component, 
 
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
+import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
 import "./tab-modal.scss";
@@ -151,6 +152,23 @@ function renderRequest(
                                 setSubmitting(false);
                                 throw e;
                             }
+                        }}
+                    />
+                ),
+            };
+        case "install-agent":
+            return {
+                label: `Install ${req.agent.name}`,
+                panel: (
+                    <AgentInstallModalPanel
+                        agent={req.agent}
+                        onCancel={api.close}
+                        onInstalled={() => {
+                            // Close the install modal and immediately
+                            // call back so the picker can chain into
+                            // launch. The picker handles the chain.
+                            api.close();
+                            req.onInstalled();
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -19,7 +19,7 @@ import { createContext, useContext, type Accessor } from "solid-js";
 // Discriminated union so the layer can dispatch on `kind`. New tab-modal
 // surfaces add a variant here and a render branch in TabModalLayer.
 
-export type TabModalRequest = LaunchAgentRequest;
+export type TabModalRequest = LaunchAgentRequest | InstallAgentRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -41,6 +41,23 @@ export interface LaunchAgentSubmit {
     agentType: "host" | "container";
     environment: "local" | "docker";
     containerImage?: string;
+}
+
+/**
+ * Install-agent modal — opens when the user picks an agent whose CLI
+ * isn't installed in the per-version cache. Streams the npm-install
+ * output live inside the modal. On success the layer auto-transitions
+ * to the launch-agent modal (via `onInstalled`). Per
+ * SPEC_AGENT_INSTALL_STAGE_2026_05_17.md §6.
+ */
+export interface InstallAgentRequest {
+    kind: "install-agent";
+    agent: ForgeAgent;
+    originBlockId: string;
+    /** Called by the modal once the install completes successfully.
+     *  Convention: the layer closes the install modal then opens the
+     *  launch-agent modal as the natural next step. */
+    onInstalled: () => void;
 }
 
 // ── Context API ──────────────────────────────────────────────────────────────

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -55,6 +55,9 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     let preRef: HTMLPreElement | undefined;
     let startedAt = 0;
     let tickHandle: ReturnType<typeof setInterval> | null = null;
+    // Flipped in onCleanup so a startInstall awaiting the RPC response
+    // can cancel the resolved session id even if it landed after unmount.
+    let disposed = false;
 
     const appendChunk = (chunk: InstallChunk) => {
         setChunks((prev) => {
@@ -102,6 +105,15 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 npmPackage: prov.npmPackage,
                 pinnedVersion: prov.pinnedVersion,
             });
+            // If the modal unmounted while the RPC was in flight, the
+            // backend now owns a live session our cleanup couldn't
+            // cancel (sessionId was null). Cancel it explicitly here.
+            if (disposed) {
+                void RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: r.sessionId }).catch(() => {
+                    /* best-effort */
+                });
+                return;
+            }
             setSessionId(r.sessionId);
             unsub = waveEventSubscribe({
                 eventType: "install_chunk",
@@ -151,6 +163,7 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     });
 
     onCleanup(() => {
+        disposed = true;
         if (unsub) {
             unsub();
             unsub = null;
@@ -159,11 +172,11 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             clearInterval(tickHandle);
             tickHandle = null;
         }
-        // If the user closes the modal mid-install (Esc, backdrop
-        // click, tab switch), cancel the backend session so the next
-        // open doesn't see a phantom second install running. The
-        // explicit Cancel button takes a different path that also
-        // calls `onCancel`; this catches the implicit closes.
+        // Catch implicit closes (Esc, backdrop click, tab switch)
+        // while installing. The Cancel button itself goes through
+        // `cancel()`. If the modal unmounts *before* InstallStartCommand
+        // resolves, the `disposed` flag above lets the in-flight start
+        // path issue the cancel once the session id arrives.
         const sid = sessionId();
         if (sid && phase() === "installing") {
             void RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: sid }).catch(() => {

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -78,6 +78,18 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             setPhase("failed");
             return;
         }
+        // Tear down any prior run (Retry path) before reassigning —
+        // otherwise the previous setInterval keeps ticking + the
+        // previous WPS subscription stays active for the rest of the
+        // component's life.
+        if (unsub) {
+            unsub();
+            unsub = null;
+        }
+        if (tickHandle != null) {
+            clearInterval(tickHandle);
+            tickHandle = null;
+        }
         setPhase("installing");
         setChunks([]);
         setError(null);
@@ -146,6 +158,17 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         if (tickHandle != null) {
             clearInterval(tickHandle);
             tickHandle = null;
+        }
+        // If the user closes the modal mid-install (Esc, backdrop
+        // click, tab switch), cancel the backend session so the next
+        // open doesn't see a phantom second install running. The
+        // explicit Cancel button takes a different path that also
+        // calls `onCancel`; this catches the implicit closes.
+        const sid = sessionId();
+        if (sid && phase() === "installing") {
+            void RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: sid }).catch(() => {
+                /* best-effort */
+            });
         }
     });
 

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -1,0 +1,215 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentInstallModalPanel — modal that runs an agent's install recipe
+ * and shows live output. Opens when the user picks an agent whose CLI
+ * isn't already in the per-version cache. Sibling to
+ * `AgentLaunchModalPanel`.
+ *
+ * Phase α (SPEC_AGENT_INSTALL_STAGE_2026_05_17.md §11): single-step
+ * recipe (just `npm install <package>`) streamed line-by-line via the
+ * `install.start` RPC. The visual surface is a scrollable `<pre>` for
+ * v1 — xterm.js upgrade lands in Phase β. Cancel kills the install +
+ * removes the partial dir.
+ *
+ * Re-click idempotency: the modal owns the install lifecycle. While a
+ * session is in flight, opening this modal again (re-click on the
+ * picker card) re-focuses the existing modal instead of starting a
+ * second install.
+ */
+
+import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+import { waveEventSubscribe } from "@/app/store/wps";
+
+import { getCliCatalogEntry } from "../defaults/cli-catalog";
+import { getProvider } from "../providers";
+
+interface AgentInstallModalPanelProps {
+    agent: ForgeAgent;
+    onCancel: () => void;
+    onInstalled: () => void;
+}
+
+interface InstallChunk {
+    line: string;
+    stream: "stdout" | "stderr";
+}
+
+export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.Element => {
+    const catalog = () => getCliCatalogEntry(props.agent.provider);
+    const provider = () => getProvider(props.agent.provider);
+    const displayName = () => catalog()?.displayName ?? props.agent.name;
+
+    const [phase, setPhase] = createSignal<"idle" | "installing" | "done" | "failed">("idle");
+    const [chunks, setChunks] = createSignal<InstallChunk[]>([]);
+    const [error, setError] = createSignal<string | null>(null);
+    const [sessionId, setSessionId] = createSignal<string | null>(null);
+    const [elapsedMs, setElapsedMs] = createSignal(0);
+
+    let unsub: (() => void) | null = null;
+    let preRef: HTMLPreElement | undefined;
+    let startedAt = 0;
+    let tickHandle: ReturnType<typeof setInterval> | null = null;
+
+    const appendChunk = (chunk: InstallChunk) => {
+        setChunks((prev) => {
+            const next = prev.concat(chunk);
+            // Cap scrollback so very chatty installs don't drag the
+            // renderer. 2000 lines is enough for typical npm output;
+            // last-N is what the user needs anyway.
+            if (next.length > 2000) return next.slice(next.length - 2000);
+            return next;
+        });
+        // Auto-scroll to bottom.
+        queueMicrotask(() => {
+            if (preRef) preRef.scrollTop = preRef.scrollHeight;
+        });
+    };
+
+    const startInstall = async () => {
+        const prov = provider();
+        if (!prov) {
+            setError(`unknown provider ${props.agent.provider}`);
+            setPhase("failed");
+            return;
+        }
+        setPhase("installing");
+        setChunks([]);
+        setError(null);
+        startedAt = Date.now();
+        tickHandle = setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
+        try {
+            const r = await RpcApi.InstallStartCommand(TabRpcClient, {
+                providerId: prov.id,
+                cliCommand: prov.cliCommand,
+                npmPackage: prov.npmPackage,
+                pinnedVersion: prov.pinnedVersion,
+            });
+            setSessionId(r.sessionId);
+            unsub = waveEventSubscribe({
+                eventType: "install_chunk",
+                scope: `install:${r.sessionId}`,
+                handler: (event: any) => {
+                    const data = event?.data;
+                    if (!data || typeof data !== "object") return;
+                    if (typeof data.line === "string") {
+                        appendChunk({
+                            line: data.line,
+                            stream: data.stream === "stderr" ? "stderr" : "stdout",
+                        });
+                    } else if (data.op === "done") {
+                        if (data.ok) {
+                            setPhase("done");
+                            // Auto-close + chain to launch modal one
+                            // frame later so the user sees the "done"
+                            // state briefly.
+                            queueMicrotask(() => props.onInstalled());
+                        } else {
+                            setError(data.error ?? "install failed");
+                            setPhase("failed");
+                        }
+                    }
+                },
+            });
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setPhase("failed");
+        }
+    };
+
+    const cancel = async () => {
+        const sid = sessionId();
+        if (sid) {
+            try {
+                await RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: sid });
+            } catch {
+                /* ignore — best-effort */
+            }
+        }
+        props.onCancel();
+    };
+
+    onMount(() => {
+        void startInstall();
+    });
+
+    onCleanup(() => {
+        if (unsub) {
+            unsub();
+            unsub = null;
+        }
+        if (tickHandle != null) {
+            clearInterval(tickHandle);
+            tickHandle = null;
+        }
+    });
+
+    const elapsedLabel = () => {
+        const s = Math.floor(elapsedMs() / 1000);
+        const mm = Math.floor(s / 60).toString().padStart(1, "0");
+        const ss = (s % 60).toString().padStart(2, "0");
+        return `${mm}:${ss}`;
+    };
+
+    return (
+        <div class="agent-install-modal-panel">
+            <div class="agent-install-modal-header">
+                <span class="agent-install-modal-icon" aria-hidden="true">
+                    {catalog()?.icon ?? "📦"}
+                </span>
+                <span class="agent-install-modal-title">Install {displayName()}</span>
+                <span class="agent-install-modal-status">
+                    <Show when={phase() === "installing"}>
+                        <span class="agent-install-modal-spinner">⏳</span>
+                        Installing… {elapsedLabel()}
+                    </Show>
+                    <Show when={phase() === "done"}>
+                        <span class="agent-install-modal-ok">✓</span>
+                        Installed
+                    </Show>
+                    <Show when={phase() === "failed"}>
+                        <span class="agent-install-modal-fail">✗</span>
+                        Failed
+                    </Show>
+                </span>
+            </div>
+            <pre class="agent-install-modal-log" ref={preRef}>
+                {chunks().map((c) => (
+                    <span
+                        classList={{
+                            "agent-install-modal-line": true,
+                            "agent-install-modal-line--stderr": c.stream === "stderr",
+                        }}
+                    >
+                        {c.line}
+                        {"\n"}
+                    </span>
+                ))}
+            </pre>
+            <Show when={error()}>
+                <div class="agent-install-modal-error">⚠ {error()}</div>
+            </Show>
+            <div class="agent-install-modal-actions">
+                <Show when={phase() === "installing"}>
+                    <Button onClick={() => void cancel()}>Cancel</Button>
+                </Show>
+                <Show when={phase() === "failed"}>
+                    <Button onClick={() => void startInstall()} className="green solid">
+                        Retry
+                    </Button>
+                    <Button onClick={() => props.onCancel()}>Close</Button>
+                </Show>
+                <Show when={phase() === "done"}>
+                    <span class="agent-install-modal-launching">Opening launch modal…</span>
+                </Show>
+            </div>
+        </div>
+    );
+};
+
+AgentInstallModalPanel.displayName = "AgentInstallModalPanel";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -11,12 +11,12 @@
  */
 
 import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
-import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { useTabModal } from "@/app/tab/tab-modal";
 import type { AgentViewModel } from "../agent-model";
+import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
 import { AgentCardSettingsPanel } from "./AgentCardSettingsPanel";
 import { AgentActionBar } from "./AgentActionBar";
@@ -107,25 +107,47 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // the tab-scoped layer, depending on whether the agent's CLI is
     // already installed in the per-version cache. Phase α of
     // SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
+    //
+    // Concurrency guard: handleSelect awaits an IPC round-trip
+    // (getCliPath), so a rapid double-click could open two modals (and
+    // start two parallel installs) without it. The pendingSelect set
+    // tracks in-flight resolutions per agent id and rejects re-entry.
+    const pendingSelect = new Set<string>();
     const handleSelect = async (agent: ForgeAgent) => {
-        setNodejsError(null);
-        let installed = false;
+        if (pendingSelect.has(agent.id)) return;
+        pendingSelect.add(agent.id);
         try {
-            const cliPath = await getApi().getCliPath(agent.provider);
-            installed = !!cliPath && cliPath.length > 0;
-        } catch {
-            installed = false;
+            setNodejsError(null);
+            // Query the backend's per-version install dir (the same
+            // location `install.start` writes to). The CEF host's
+            // getCliPath probes a different path and would falsely
+            // report "not installed" for npm-cached providers, causing
+            // a re-install on every launch.
+            let installed = false;
+            const prov = getProvider(agent.provider);
+            const cliCommand = prov?.cliCommand ?? agent.provider;
+            try {
+                const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
+                    providerId: agent.provider,
+                    cliCommand,
+                });
+                installed = r.installed;
+            } catch {
+                installed = false;
+            }
+            if (!installed) {
+                tabModal.open({
+                    kind: "install-agent",
+                    agent,
+                    originBlockId: props.model.blockId,
+                    onInstalled: () => openLaunchModal(agent),
+                });
+                return;
+            }
+            openLaunchModal(agent);
+        } finally {
+            pendingSelect.delete(agent.id);
         }
-        if (!installed) {
-            tabModal.open({
-                kind: "install-agent",
-                agent,
-                originBlockId: props.model.blockId,
-                onInstalled: () => openLaunchModal(agent),
-            });
-            return;
-        }
-        openLaunchModal(agent);
     };
 
     const openForgeFor = (agent: ForgeAgent) => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -123,6 +123,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             // PATH CLIs), fall through to the launch flow — its
             // ResolveCliCommand already does the system-PATH search.
             const prov = getProvider(agent.provider);
+            // Use the canonical provider id for the path probe — the
+            // saved agent definition may carry an alias like
+            // "claude-code" while install.start writes under "claude".
+            const canonicalProviderId = prov?.id ?? agent.provider;
             const cliCommand = prov?.cliCommand ?? agent.provider;
             const npmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
             // Query the backend's per-version install dir (the same
@@ -134,7 +138,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             if (npmInstallable) {
                 try {
                     const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
-                        providerId: agent.provider,
+                        providerId: canonicalProviderId,
                         cliCommand,
                     });
                     installed = r.installed;

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -118,22 +118,33 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         pendingSelect.add(agent.id);
         try {
             setNodejsError(null);
+            // Phase α only handles npm-installable providers. For
+            // providers without `npmPackage` (e.g. kimi via pip, system-
+            // PATH CLIs), fall through to the launch flow — its
+            // ResolveCliCommand already does the system-PATH search.
+            const prov = getProvider(agent.provider);
+            const cliCommand = prov?.cliCommand ?? agent.provider;
+            const npmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
             // Query the backend's per-version install dir (the same
             // location `install.start` writes to). The CEF host's
             // getCliPath probes a different path and would falsely
             // report "not installed" for npm-cached providers, causing
             // a re-install on every launch.
             let installed = false;
-            const prov = getProvider(agent.provider);
-            const cliCommand = prov?.cliCommand ?? agent.provider;
-            try {
-                const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
-                    providerId: agent.provider,
-                    cliCommand,
-                });
-                installed = r.installed;
-            } catch {
-                installed = false;
+            if (npmInstallable) {
+                try {
+                    const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
+                        providerId: agent.provider,
+                        cliCommand,
+                    });
+                    installed = r.installed;
+                } catch {
+                    installed = false;
+                }
+            } else {
+                // Non-npm provider — launch flow will resolve via
+                // system PATH or report a missing-CLI error.
+                installed = true;
             }
             if (!installed) {
                 tabModal.open({

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -11,6 +11,7 @@
  */
 
 import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -77,12 +78,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // Session-local only — not persisted to block meta.
     const [expandedId, setExpandedId] = createSignal<string | null>(null);
 
-    // Clicking the card opens the launch modal in the tab-scoped layer.
-    // The picker no longer owns the modal's open/closed signal — that
-    // lives on TabModalLayer. We pass an `onSubmit` callback in the
-    // request; the layer closes the modal when it resolves.
-    const handleSelect = (agent: ForgeAgent) => {
-        setNodejsError(null);
+    // Open the launch modal. Extracted so the install-modal path can
+    // chain into it after a successful install.
+    const openLaunchModal = (agent: ForgeAgent) => {
         tabModal.open({
             kind: "launch-agent",
             agent,
@@ -103,6 +101,31 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 }
             },
         });
+    };
+
+    // Clicking the card opens either the install or launch modal in
+    // the tab-scoped layer, depending on whether the agent's CLI is
+    // already installed in the per-version cache. Phase α of
+    // SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
+    const handleSelect = async (agent: ForgeAgent) => {
+        setNodejsError(null);
+        let installed = false;
+        try {
+            const cliPath = await getApi().getCliPath(agent.provider);
+            installed = !!cliPath && cliPath.length > 0;
+        } catch {
+            installed = false;
+        }
+        if (!installed) {
+            tabModal.open({
+                kind: "install-agent",
+                agent,
+                originBlockId: props.model.blockId,
+                onInstalled: () => openLaunchModal(agent),
+            });
+            return;
+        }
+        openLaunchModal(agent);
     };
 
     const openForgeFor = (agent: ForgeAgent) => {


### PR DESCRIPTION
## Summary

Closes the "click 6 times stacked installs" UX gap by giving the user a visible, cancellable install flow before launch. Implements Phase α of [`docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md`](docs/specs/SPEC_AGENT_INSTALL_STAGE_2026_05_17.md) §11.

## What lands

**Backend** — new `install.start` / `install.cancel` RPCs (`agentmux-srv/src/server/install_handlers.rs`, 318 LOC):

- `InstallSessionRegistry` tracks one cancel handle per in-flight session.
- Spawns `npm install <pkg>[@<ver>] --prefix ~/.agentmux/<version>/cli/<provider>/` with piped stdio.
- Streams every line as `install_chunk` WPS event scoped to `install:<sessionId>`. Terminal event = `op: "done"` + `ok` + optional `error`.
- Cancel kills the child and emits `cancelled`.

**Frontend**

- `AgentInstallModal.tsx` (215 LOC) — tab-modal panel with phase state machine (`idle | installing | done | failed`), `<pre>` log capped at 2000 lines with auto-scroll, Cancel/Retry buttons.
- `tab-modal.ts` / `TabModalLayer.tsx` — new `InstallAgentRequest` variant + render branch.
- `AgentPicker.tsx::handleSelect` is now async, checks `getApi().getCliPath`, opens install modal first if the CLI isn't resolved.
- `rpc-api.ts` — `InstallStartCommand` and `InstallCancelCommand`.
- On success, the install modal calls `onInstalled` and the layer chains into the launch modal.

## Phase α scope notes

The spec calls for xterm.js inside the modal; the shipped version uses `<pre>` instead. That already gives the user the live visibility the "click 6 times" issue needed — xterm fidelity (colors, redraws) can come in a follow-up. Other Phase α items deferred:

- `AgentInstallCard.tsx` (tinted button as pane default) — for now `AgentPicker` triggers the install modal directly.
- `agent-install-store` reducer slice — for now modal-local signals are sufficient.

## Test plan

- [ ] Click an agent whose CLI isn't installed → install modal opens with the npm command echoed
- [ ] Watch npm install lines stream live into the `<pre>` log
- [ ] Cancel mid-install → child process killed, "cancelled" terminal event
- [ ] Install completes → modal closes, launch modal opens
- [ ] Click again on an installed agent → goes straight to launch modal (no install modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)