### PR TITLE
feat(openclaw): OAuth login via Codex harness + PTY-backed auth subprocess

### DIFF
--- a/.changesets/1779031647-feat-openclaw-oauth-login-via-codex-harness-pty-backed-auth--f6i0.md
+++ b/.changesets/1779031647-feat-openclaw-oauth-login-via-codex-harness-pty-backed-auth--f6i0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(openclaw): OAuth login via Codex harness + PTY-backed auth subprocess

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
  "futures-util",
  "json_comments",
  "parking_lot",
+ "portable-pty",
  "proptest",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "json_comments",
+ "libc",
  "parking_lot",
  "portable-pty",
  "proptest",

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,7 +14,6 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
-| 0.33.899 | 2026-05-17 | 164.6 MiB | 345.5 MiB | |
 | 0.33.835 | 2026-05-13 | 164.2 MiB | 344.3 MiB | |
 | 0.33.831 | 2026-05-13 | 164.1 MiB | 344.1 MiB | |
 | 0.33.827 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,6 +14,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.33.899 | 2026-05-17 | 164.6 MiB | 345.5 MiB | |
 | 0.33.835 | 2026-05-13 | 164.2 MiB | 344.3 MiB | |
 | 0.33.831 | 2026-05-13 | 164.1 MiB | 344.1 MiB | |
 | 0.33.827 | 2026-05-12 | 164.1 MiB | 344.0 MiB | |

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -82,6 +82,12 @@ windows-sys = { version = "0.59", features = [
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winres = "0.1"
 
+[target.'cfg(unix)'.dependencies]
+# Used by `cancel_cli_login` to send SIGTERM to a PTY child by PID
+# when `auth.cancel` fires (the portable_pty child sits inside a
+# `spawn_blocking` task that doesn't unwind on outer-task abort).
+libc = "0.2"
+
 [dev-dependencies]
 # Property tests for the shadow projection (master spec §8.14
 # subscriber idempotency contract). Mirrors agentmux-launcher's

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -38,6 +38,12 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["cors", "fs"] }
 tokio = { version = "1", features = ["full"] }
 whoami = "1"
+# PTY-backed CLI login flow — needed for providers that strictly require
+# an interactive TTY for their OAuth subcommand (currently OpenClaw's
+# `openclaw models auth login --provider <id>`). Other providers (Claude,
+# Codex, Gemini, etc.) still go through the plain-pipes path inside
+# run_cli_login. See SPEC_OPENCLAW_AGENT_2026_05_17.md §6.
+portable-pty = "0.9"
 json_comments = "0.2"
 # Browser DOM API (SPEC_BROWSER_DOM_API.md): CDP WebSocket client + /json probe
 tokio-tungstenite = "0.24"

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -272,6 +272,42 @@ pub fn ensure_settings_file(state: &Arc<AppState>) -> Result<serde_json::Value, 
     Ok(serde_json::json!(settings_path.to_string_lossy()))
 }
 
+/// Stdin handle for an in-progress CLI login, regardless of whether
+/// it was spawned via plain pipes or via a PTY. `set_provider_auth`
+/// writes the OAuth code / pasted token here.
+pub enum CliLoginStdin {
+    /// Plain pipe — `tokio::process::Command` with `Stdio::piped()`.
+    /// AsyncWrite via tokio. Used by Claude, Codex, Gemini, Copilot,
+    /// Kimi — anything that doesn't strictly require a TTY for its
+    /// auth subcommand.
+    Pipe(tokio::process::ChildStdin),
+    /// PTY writer — `portable_pty` master writer. Sync `std::io::Write`.
+    /// Used by providers whose auth subcommand bails on `isatty()==0`
+    /// (currently OpenClaw's `openclaw models auth login`).
+    Pty(Box<dyn std::io::Write + Send>),
+}
+
+impl CliLoginStdin {
+    /// Write a line (terminated with `\n`) to the child's stdin. Used
+    /// by `set_provider_auth` to deliver an OAuth code.
+    pub async fn write_line(&mut self, line: &str) -> std::io::Result<()> {
+        let payload = format!("{}\n", line);
+        match self {
+            CliLoginStdin::Pipe(s) => {
+                use tokio::io::AsyncWriteExt;
+                s.write_all(payload.as_bytes()).await?;
+                s.flush().await?;
+                Ok(())
+            }
+            CliLoginStdin::Pty(w) => {
+                use std::io::Write;
+                w.write_all(payload.as_bytes())?;
+                w.flush()
+            }
+        }
+    }
+}
+
 /// Spawn a CLI auth login flow.
 pub async fn run_cli_login(
     state: Arc<AppState>,
@@ -306,6 +342,21 @@ pub async fn run_cli_login(
         })
         .unwrap_or_default();
 
+    // `requires_tty` (passed by the frontend from the provider config)
+    // selects the PTY-spawn branch below. Providers like OpenClaw
+    // strictly require an interactive TTY for their auth subcommand —
+    // plain piped stdio causes the CLI to exit with
+    // "requires an interactive TTY" before printing the OAuth URL.
+    let requires_tty = args
+        .get("requires_tty")
+        .or_else(|| args.get("requiresTty"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if requires_tty {
+        return run_cli_login_pty(state, cli_path, login_args, auth_env).await;
+    }
+
     let mut cmd = make_cli_cmd(&cli_path);
     cmd.args(&login_args)
         .envs(&auth_env)
@@ -322,12 +373,12 @@ pub async fn run_cli_login(
         .spawn()
         .map_err(|e| format!("failed to spawn {cli_path}: {e}"))?;
 
-    tracing::info!(cli = %cli_path, "run_cli_login: spawned, browser should open");
+    tracing::info!(cli = %cli_path, "run_cli_login: spawned (pipes), browser should open");
 
     // Store the stdin handle so set_provider_auth can deliver the OAuth code.
     {
         let mut stored_stdin = state.cli_login_stdin.lock();
-        *stored_stdin = child.stdin.take();
+        *stored_stdin = child.stdin.take().map(CliLoginStdin::Pipe);
     }
 
     // Capture the OAuth URL from stdout/stderr. The CLI prints it within the
@@ -398,6 +449,144 @@ pub async fn run_cli_login(
             }
         }
         // Clear the stored stdin handle once the process is done.
+        *state_for_cleanup.cli_login_stdin.lock() = None;
+    });
+
+    Ok(serde_json::json!({ "auth_url": auth_url }))
+}
+
+/// PTY-backed variant of run_cli_login. Used for providers whose auth
+/// subcommand requires an interactive TTY (currently OpenClaw —
+/// `openclaw models auth login --provider <id>` exits immediately with
+/// "requires an interactive TTY" when stdin is a pipe).
+///
+/// Same return shape as run_cli_login: `{ auth_url: <url or null> }`.
+/// Writes the master writer into `state.cli_login_stdin` so
+/// `set_provider_auth` can deliver an OAuth code if the CLI prompts
+/// for one.
+///
+/// CRITICAL ConPTY lifetime contract on Windows: the PtyPair (master +
+/// slave) MUST stay alive across child.wait(). Same hazard pattern
+/// agentmux-bashwrap navigates. The blocking wait task takes ownership
+/// of the pair so the destructor runs after the child reaps.
+async fn run_cli_login_pty(
+    state: Arc<AppState>,
+    cli_path: String,
+    login_args: Vec<String>,
+    auth_env: std::collections::HashMap<String, String>,
+) -> Result<serde_json::Value, String> {
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .map_err(|e| format!("openpty for {cli_path}: {e}"))?;
+
+    let mut cmd = CommandBuilder::new(&cli_path);
+    for a in &login_args {
+        cmd.arg(a);
+    }
+    for (k, v) in &auth_env {
+        cmd.env(k, v);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+
+    let child = pair
+        .slave
+        .spawn_command(cmd)
+        .map_err(|e| format!("PTY spawn of {cli_path}: {e}"))?;
+
+    let reader = pair
+        .master
+        .try_clone_reader()
+        .map_err(|e| format!("PTY try_clone_reader: {e}"))?;
+    let writer = pair
+        .master
+        .take_writer()
+        .map_err(|e| format!("PTY take_writer: {e}"))?;
+
+    tracing::info!(cli = %cli_path, "run_cli_login: spawned (PTY), waiting for OAuth URL");
+
+    // Store the PTY writer so set_provider_auth can deliver an OAuth
+    // code via stdin (some flows prompt the user to paste a code).
+    {
+        let mut stored = state.cli_login_stdin.lock();
+        *stored = Some(CliLoginStdin::Pty(writer));
+    }
+
+    // Synchronously read from the master in a blocking task, scanning
+    // each line for an OAuth URL. portable_pty's reader is sync.
+    // 15 s timeout — login subprocesses can take a couple seconds to
+    // initialise (network probe, plugin load, browser handshake) and
+    // 2 s was empirically too tight for OpenClaw's `models auth login`.
+    let (url_tx, url_rx) = tokio::sync::oneshot::channel::<Option<String>>();
+    tokio::task::spawn_blocking(move || {
+        use std::io::BufRead;
+        let mut reader = std::io::BufReader::new(reader);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut found: Option<String> = None;
+        let mut line = String::new();
+        while std::time::Instant::now() < deadline {
+            line.clear();
+            // BufRead::read_line blocks; the deadline above is a
+            // best-effort cap that's checked only between reads.
+            match reader.read_line(&mut line) {
+                Ok(0) => break,                          // EOF
+                Ok(_) => {
+                    if let Some(u) = extract_url(&line) {
+                        found = Some(u);
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "run_cli_login_pty: read error");
+                    break;
+                }
+            }
+        }
+        let _ = url_tx.send(found);
+        // Reader is dropped here. Master keeps living in the wait task
+        // below.
+    });
+
+    let auth_url: Option<String> = url_rx.await.unwrap_or(None);
+    if let Some(ref url) = auth_url {
+        tracing::info!(url = %url, "run_cli_login_pty: captured auth URL");
+    } else {
+        tracing::warn!("run_cli_login_pty: no auth URL captured within 15s");
+    }
+
+    // Reap the child in a blocking task. The PtyPair (master + slave)
+    // moves into the closure so its destructor runs AFTER child.wait()
+    // — necessary for ConPTY on Windows (see retro
+    // 2026-05-11-live-log-streaming-wrapper-failures.md §4.2).
+    //
+    // Cancel handling: the pipes path stores a cancel sender for the
+    // user-clicks-cancel flow; the PTY path skips that for now because
+    // portable_pty::Child::kill() needs &mut access and is awkward to
+    // share across the wait task. v2 can wire it via PID + taskkill.
+    let state_for_cleanup = state.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut child = child;
+        match child.wait() {
+            Ok(status) => tracing::info!(
+                exit_code = ?status.exit_code(),
+                "run_cli_login_pty: child exited"
+            ),
+            Err(e) => tracing::warn!(
+                error = %e,
+                "run_cli_login_pty: child wait error"
+            ),
+        }
+        // pair drops here, after child.wait() returns
+        drop(pair);
         *state_for_cleanup.cli_login_stdin.lock() = None;
     });
 

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -509,6 +509,15 @@ async fn run_cli_login_pty(
         .spawn_command(cmd)
         .map_err(|e| format!("PTY spawn of {cli_path}: {e}"))?;
 
+    // Capture the child PID before moving the child into the wait
+    // task — cancel_cli_login needs it to kill the subprocess
+    // platform-side, since aborting the spawn_blocking wait does not
+    // propagate to the child.
+    let child_pid = child.process_id();
+    if let Some(pid) = child_pid {
+        *state.cli_login_pty_pid.lock() = Some(pid);
+    }
+
     let reader = pair
         .master
         .try_clone_reader()
@@ -518,7 +527,7 @@ async fn run_cli_login_pty(
         .take_writer()
         .map_err(|e| format!("PTY take_writer: {e}"))?;
 
-    tracing::info!(cli = %cli_path, "run_cli_login: spawned (PTY), waiting for OAuth URL");
+    tracing::info!(cli = %cli_path, pid = ?child_pid, "run_cli_login: spawned (PTY), waiting for OAuth URL");
 
     // Store the PTY writer so set_provider_auth can deliver an OAuth
     // code via stdin (some flows prompt the user to paste a code).
@@ -583,10 +592,9 @@ async fn run_cli_login_pty(
     // — necessary for ConPTY on Windows (see retro
     // 2026-05-11-live-log-streaming-wrapper-failures.md §4.2).
     //
-    // Cancel handling: the pipes path stores a cancel sender for the
-    // user-clicks-cancel flow; the PTY path skips that for now because
-    // portable_pty::Child::kill() needs &mut access and is awkward to
-    // share across the wait task. v2 can wire it via PID + taskkill.
+    // Cancel handling: `cancel_cli_login` reads `cli_login_pty_pid`
+    // and kills the subprocess by PID; once the child dies, this
+    // wait task observes the exit and clears the PID slot.
     let state_for_cleanup = state.clone();
     tokio::task::spawn_blocking(move || {
         let mut child = child;
@@ -603,6 +611,7 @@ async fn run_cli_login_pty(
         // pair drops here, after child.wait() returns
         drop(pair);
         *state_for_cleanup.cli_login_stdin.lock() = None;
+        *state_for_cleanup.cli_login_pty_pid.lock() = None;
     });
 
     Ok(serde_json::json!({ "auth_url": auth_url }))
@@ -645,17 +654,62 @@ fn extract_url(line: &str) -> Option<String> {
     None
 }
 
-/// Kill the in-progress CLI login process.
+/// Kill the in-progress CLI login process. Covers both transports:
+/// the pipe path uses a oneshot to drop the Tokio Child (kill_on_drop
+/// terminates the subprocess); the PTY path uses platform-specific
+/// kill-by-PID because the `portable_pty::Child` lives inside a
+/// `spawn_blocking` task that doesn't react to outer-task abort.
 pub fn cancel_cli_login(state: &Arc<AppState>) -> Result<serde_json::Value, String> {
+    // Pipe path.
     let sender = {
         let mut stored = state.cli_login_cancel.lock();
         stored.take()
     };
     if let Some(tx) = sender {
         let _ = tx.send(());
-        tracing::info!("cancel_cli_login: cancel signal sent");
+        tracing::info!("cancel_cli_login: pipe-path cancel signal sent");
+    }
+    // PTY path.
+    let pid = {
+        let mut stored = state.cli_login_pty_pid.lock();
+        stored.take()
+    };
+    if let Some(pid) = pid {
+        if let Err(e) = kill_pid(pid) {
+            tracing::warn!(pid, error = %e, "cancel_cli_login: kill_pid failed");
+        } else {
+            tracing::info!(pid, "cancel_cli_login: PTY child killed");
+        }
     }
     Ok(serde_json::Value::Null)
+}
+
+/// Platform-specific best-effort kill of a child process by PID.
+#[cfg(windows)]
+fn kill_pid(pid: u32) -> std::io::Result<()> {
+    // Use taskkill /F /T so the whole tree dies — `openclaw models
+    // auth login` typically spawns a child that opens the browser.
+    let status = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("taskkill exit {:?}", status.code())))
+    }
+}
+
+#[cfg(unix)]
+fn kill_pid(pid: u32) -> std::io::Result<()> {
+    // SIGTERM first; an aborting subprocess gets a chance to clean up.
+    let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 // --- CLI command helpers ---

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -301,8 +301,14 @@ impl CliLoginStdin {
             }
             CliLoginStdin::Pty(w) => {
                 use std::io::Write;
-                w.write_all(payload.as_bytes())?;
-                w.flush()
+                // portable_pty's master writer is sync. Run it via
+                // `block_in_place` so the brief sync write doesn't
+                // starve the tokio reactor on the current worker
+                // thread if the PTY input buffer is full.
+                tokio::task::block_in_place(|| {
+                    w.write_all(payload.as_bytes())?;
+                    w.flush()
+                })
             }
         }
     }
@@ -523,22 +529,23 @@ async fn run_cli_login_pty(
 
     // Synchronously read from the master in a blocking task, scanning
     // each line for an OAuth URL. portable_pty's reader is sync.
-    // 15 s timeout — login subprocesses can take a couple seconds to
-    // initialise (network probe, plugin load, browser handshake) and
-    // 2 s was empirically too tight for OpenClaw's `models auth login`.
+    // The 15 s cap is enforced async-side via tokio::time::timeout —
+    // BufRead::read_line itself blocks indefinitely without per-read
+    // timeout support, so a child that pauses before its first line
+    // (or sits at a prompt with no newline) would wedge `url_rx.await`
+    // without it. When the timeout fires we return auth_url=None to
+    // the frontend and let the wait task below reap the child whenever
+    // it finishes naturally.
     let (url_tx, url_rx) = tokio::sync::oneshot::channel::<Option<String>>();
     tokio::task::spawn_blocking(move || {
         use std::io::BufRead;
         let mut reader = std::io::BufReader::new(reader);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
         let mut found: Option<String> = None;
         let mut line = String::new();
-        while std::time::Instant::now() < deadline {
+        loop {
             line.clear();
-            // BufRead::read_line blocks; the deadline above is a
-            // best-effort cap that's checked only between reads.
             match reader.read_line(&mut line) {
-                Ok(0) => break,                          // EOF
+                Ok(0) => break, // EOF
                 Ok(_) => {
                     if let Some(u) = extract_url(&line) {
                         found = Some(u);
@@ -556,7 +563,15 @@ async fn run_cli_login_pty(
         // below.
     });
 
-    let auth_url: Option<String> = url_rx.await.unwrap_or(None);
+    let auth_url: Option<String> = match tokio::time::timeout(
+        std::time::Duration::from_secs(15),
+        url_rx,
+    )
+    .await
+    {
+        Ok(Ok(u)) => u,
+        Ok(Err(_)) | Err(_) => None,
+    };
     if let Some(ref url) = auth_url {
         tracing::info!(url = %url, "run_cli_login_pty: captured auth URL");
     } else {

--- a/agentmux-cef/src/commands/providers.rs
+++ b/agentmux-cef/src/commands/providers.rs
@@ -324,20 +324,18 @@ pub async fn set_provider_auth(state: &Arc<AppState>, args: &serde_json::Value) 
         .ok_or_else(|| "Missing token".to_string())?;
 
     // For Claude (and any CLI-based provider), deliver the auth code directly
-    // to the running login process via its piped stdin. The CLI prints the
+    // to the running login process via its stdin. The CLI prints the
     // OAuth URL, then waits for the user to paste the device code on stdin.
-    // Without this, the code went to our own config file (wrong) and the CLI
-    // never received it, so the polling loop ran forever.
+    // The stdin is either a piped tokio::process::ChildStdin (typical) or a
+    // portable_pty master writer (for TTY-required providers like OpenClaw)
+    // — `CliLoginStdin::write_line` dispatches on the variant.
     let maybe_stdin = state.cli_login_stdin.lock().take();
     if let Some(mut child_stdin) = maybe_stdin {
         tracing::info!(provider = %provider, "set_provider_auth: delivering code to CLI stdin");
-        use tokio::io::AsyncWriteExt;
-        let payload = format!("{}\n", token);
-        if let Err(e) = child_stdin.write_all(payload.as_bytes()).await {
+        if let Err(e) = child_stdin.write_line(&token).await {
             tracing::warn!(error = %e, "set_provider_auth: failed to write to CLI stdin");
             return Err(format!("Failed to deliver auth code to CLI: {e}"));
         }
-        let _ = child_stdin.flush().await;
         // Don't put stdin back — it's single-use (one code per login flow).
         return Ok(serde_json::Value::Null);
     }

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -469,6 +469,15 @@ pub struct AppState {
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 
+    /// PID of an in-progress PTY-backed CLI login child. The pipe
+    /// path uses `cli_login_cancel` + `tokio::select!` + Tokio's
+    /// `kill_on_drop` Child to terminate, but the PTY path moves
+    /// the `portable_pty` child into a `spawn_blocking` task that
+    /// outlives the outer abort — so cancel needs a PID + platform
+    /// kill to actually stop the subprocess. Populated by
+    /// `run_cli_login_pty`, cleared when the child exits naturally.
+    pub cli_login_pty_pid: Mutex<Option<u32>>,
+
     /// Stdin handle for the running CLI login child process. Two
     /// variants because some providers (OpenClaw) require an
     /// interactive TTY for their auth subcommand and we spawn them via
@@ -708,6 +717,7 @@ impl Default for AppState {
                 m
             }),
             cli_login_cancel: Mutex::new(None),
+            cli_login_pty_pid: Mutex::new(None),
             cli_login_stdin: Mutex::new(None),
             ipc_port: Mutex::new(0),
             ipc_token: uuid::Uuid::new_v4().to_string(),

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -469,9 +469,13 @@ pub struct AppState {
     /// Cancellation channel for an in-progress CLI login process
     pub cli_login_cancel: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 
-    /// Stdin handle for the running CLI login child process.
-    /// Written to by `set_provider_auth` to deliver the OAuth device code.
-    pub cli_login_stdin: Mutex<Option<tokio::process::ChildStdin>>,
+    /// Stdin handle for the running CLI login child process. Two
+    /// variants because some providers (OpenClaw) require an
+    /// interactive TTY for their auth subcommand and we spawn them via
+    /// `portable_pty` instead of `tokio::process::Command`. Written to
+    /// by `set_provider_auth` to deliver an OAuth device code or
+    /// pasted token. See `commands::platform::CliLoginStdin`.
+    pub cli_login_stdin: Mutex<Option<crate::commands::platform::CliLoginStdin>>,
 
     /// IPC HTTP server port
     pub ipc_port: Mutex<u16>,

--- a/agentmux-srv/forge-seed.json
+++ b/agentmux-srv/forge-seed.json
@@ -127,7 +127,7 @@
       "icon": "◎",
       "provider": "openclaw",
       "agent_type": "host",
-      "description": "ACP orchestration platform",
+      "description": "Open-source personal AI assistant (model-agnostic, local-first)",
       "working_directory": "",
       "shell": "pwsh",
       "agent_bus_id": "openclaw",

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -8,7 +8,7 @@
 //! protocol for session management, prompting, and streaming events.
 //!
 //! Lifecycle:
-//!   1. Spawn the ACP agent process (e.g., `gemini --acp`, `acpx --agent openclaw`)
+//!   1. Spawn the ACP agent process (e.g., `gemini --acp`, `openclaw acp`)
 //!   2. Send `initialize` request, receive capabilities
 //!   3. Send `initialized` notification
 //!   4. Create a session via `session/create`

--- a/agentmux-srv/src/backend/providers.rs
+++ b/agentmux-srv/src/backend/providers.rs
@@ -207,9 +207,20 @@ static KIMI: ProviderConfig = ProviderConfig {
 static OPENCLAW: ProviderConfig = ProviderConfig {
     id: "openclaw",
     display_name: "OpenClaw",
-    cli_command: "acpx",
+    // `openclaw acp` runs OpenClaw's ACP bridge — speaks ACP over stdio
+    // for IDE/tool clients (us) and forwards turns to the local
+    // OpenClaw Gateway over WebSocket. The Gateway is OpenClaw's own
+    // daemon (`openclaw gateway`) and MUST be running before this
+    // bridge can establish a session — surfaced to the user as an
+    // onboarding requirement in SPEC_OPENCLAW_AGENT_2026_05_17.md §6β.
+    //
+    // The previous scaffold pointed at `acpx` / `@openclaw/acpx`,
+    // which is not a real package. The canonical binary is `openclaw`
+    // (npm: `openclaw`) and the ACP subcommand is `openclaw acp`.
+    // Verified against docs.openclaw.ai/cli/acp + GitHub README.
+    cli_command: "openclaw",
     controller_type: ControllerType::Acp,
-    launch_args: &["--agent", "openclaw"],
+    launch_args: &["acp"],
     persistent_launch_args: None,
     // ACP handles sessions natively — no resume flag or session ID parsing needed
     resume_flag: None,
@@ -219,7 +230,7 @@ static OPENCLAW: ProviderConfig = ProviderConfig {
     auth_dir_name: "openclaw",
     auth_extra_env: &[],
     unset_env: &[],
-    npm_package: "@openclaw/acpx",
+    npm_package: "openclaw",
     pinned_version: "latest",
     icon: "lobster",
     docs_url: "https://docs.openclaw.ai",

--- a/agentmux-srv/src/identity/auth_patterns.rs
+++ b/agentmux-srv/src/identity/auth_patterns.rs
@@ -54,7 +54,12 @@ pub fn match_line(provider_id: &str, line: &str) -> Option<AuthPatternMatch> {
 }
 
 fn is_api_key_provider(provider_id: &str) -> bool {
-    matches!(provider_id, "openclaw" | "kimi" | "pi")
+    // OpenClaw moved out: as of SPEC_OPENCLAW_AGENT_2026_05_17.md Phase
+    // α + the "Login with OpenAI" addition, OpenClaw's launch flow runs
+    // `openclaw models auth login --provider openai-codex` which emits
+    // an OpenAI OAuth URL (auth.openai.com). The same `match_codex_url`
+    // we use for Codex matches it.
+    matches!(provider_id, "kimi" | "pi")
 }
 
 type LineMatcher = fn(&str) -> Option<AuthPatternMatch>;
@@ -63,12 +68,17 @@ fn patterns_for(provider_id: &str) -> &'static [LineMatcher] {
     match provider_id {
         "claude" => &[match_claude_url, match_logged_in_as],
         "codex" => &[match_codex_url, match_logged_in_as],
+        // OpenClaw onboards into OpenAI via the Codex harness; the OAuth
+        // URL OpenClaw emits is the same shape Codex CLI emits, so reuse
+        // the same matcher. When OpenClaw later supports Login-with-
+        // Claude / Gemini / etc., this list can grow.
+        "openclaw" => &[match_codex_url, match_logged_in_as],
         "gemini" => &[match_gemini_url, match_logged_in_as],
         "copilot" => &[match_copilot_device_code, match_logged_in_as],
         // API-key providers don't OAuth — these patterns never match.
         // Listed here so the dispatch is exhaustive and adding a new
         // provider always lands a code edit in this table.
-        "openclaw" | "kimi" | "pi" => &[],
+        "kimi" | "pi" => &[],
         _ => &[],
     }
 }
@@ -349,13 +359,23 @@ mod tests {
 
     #[test]
     fn api_key_providers_match_nothing() {
-        // openclaw / kimi / pi don't have OAuth flow. Even if their
-        // output includes an https URL during onboarding, we don't
-        // want to misinterpret it as OAuth.
-        for provider in ["openclaw", "kimi", "pi"] {
+        // kimi / pi don't have OAuth flow. Even if their output includes
+        // an https URL during onboarding, we don't want to misinterpret
+        // it as OAuth.
+        for provider in ["kimi", "pi"] {
             let m = match_line(provider, "Get your API key at https://example.com/keys");
             assert!(m.is_none(), "provider {provider} unexpectedly matched");
         }
+    }
+
+    #[test]
+    fn openclaw_matches_openai_oauth_url() {
+        // OpenClaw's `models auth login --provider openai-codex` emits
+        // the same OpenAI OAuth URL Codex CLI emits. We reuse codex's
+        // matcher for it.
+        let line = "Open this URL to sign in: https://auth.openai.com/oauth/authorize?...";
+        let m = match_line("openclaw", line);
+        assert!(matches!(m, Some(AuthPatternMatch::OAuthUrl(_))));
     }
 
     #[test]
@@ -391,8 +411,10 @@ mod tests {
         // used to run for API-key providers. Their onboarding output
         // ("get your key at https://.../auth") would mis-classify
         // as OAuth and drive the wrong UI branch. Now: no fallback
-        // for openclaw/kimi/pi at all.
-        for provider in ["openclaw", "kimi", "pi"] {
+        // for kimi/pi at all. (OpenClaw moved out — see
+        // openclaw_matches_openai_oauth_url; its `models auth login
+        // --provider openai-codex` emits a real OAuth URL.)
+        for provider in ["kimi", "pi"] {
             let line = "Get your API key at https://example.com/auth/keys";
             assert!(match_line(provider, line).is_none(), "{provider} matched");
         }

--- a/agentmux-srv/src/identity/auth_session.rs
+++ b/agentmux-srv/src/identity/auth_session.rs
@@ -135,6 +135,10 @@ pub struct PollSessionResult {
 struct ProcessRefs {
     drain_tasks: HashMap<String, tokio::task::JoinHandle<()>>,
     stdin_senders: HashMap<String, tokio::sync::mpsc::Sender<String>>,
+    /// PID of a PTY-backed auth subprocess. Aborting `drain_tasks`
+    /// can't reach into a `spawn_blocking` wait task, so cancel_session
+    /// kills the child by PID for PTY transports.
+    pty_pids: HashMap<String, u32>,
 }
 
 #[derive(Default)]
@@ -284,7 +288,25 @@ impl AuthSessionManager {
             handle.abort();
         }
         refs.stdin_senders.remove(session_id);
+        // PTY transport: abort() doesn't reach the spawn_blocking
+        // wait task, so kill the child by PID. Pipes path doesn't
+        // need this — its tokio Child uses kill_on_drop.
+        if let Some(pid) = refs.pty_pids.remove(session_id) {
+            if let Err(e) = kill_pid(pid) {
+                tracing::warn!(pid, session_id, error = %e, "cancel_session: kill_pid failed");
+            } else {
+                tracing::info!(pid, session_id, "cancel_session: PTY child killed");
+            }
+        }
         transitioned
+    }
+
+    /// Register the PID of a PTY-backed auth subprocess so
+    /// `cancel_session` can terminate it. Called by `auth.start`
+    /// after spawning a PTY login (in addition to `attach_process`).
+    pub fn attach_pty_pid(&self, session_id: &str, pid: u32) {
+        let mut refs = self.process_refs.lock().unwrap();
+        refs.pty_pids.insert(session_id.to_string(), pid);
     }
 
     /// Register the drain task + stdin sender for a session. Called
@@ -322,6 +344,7 @@ impl AuthSessionManager {
         let mut refs = self.process_refs.lock().unwrap();
         refs.drain_tasks.remove(session_id);
         refs.stdin_senders.remove(session_id);
+        refs.pty_pids.remove(session_id);
     }
 
     /// Remove a session from the map. Caller should only invoke this
@@ -354,6 +377,32 @@ impl AuthSessionManager {
             s.started_at = Instant::now() - Duration::from_secs(SESSION_TIMEOUT_SECS + 1);
         }
     }
+}
+
+/// Platform-specific best-effort kill of a child process by PID.
+/// Mirror of the cef-side helper in `agentmux-cef::commands::platform`.
+#[cfg(windows)]
+fn kill_pid(pid: u32) -> std::io::Result<()> {
+    let status = std::process::Command::new("taskkill")
+        .args(["/F", "/T", "/PID", &pid.to_string()])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!("taskkill exit {:?}", status.code())))
+    }
+}
+
+#[cfg(unix)]
+fn kill_pid(pid: u32) -> std::io::Result<()> {
+    let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -552,6 +552,14 @@ fn spawn_auth_cli_pty(
             }
         };
 
+        // Register the child PID with the session manager so
+        // `cancel_session` can kill it — aborting drain_handle below
+        // can't reach into the spawn_blocking wait task that owns
+        // the portable_pty::Child.
+        if let Some(pid) = child.process_id() {
+            mgr_for_task.attach_pty_pid(&session_id_for_task, pid);
+        }
+
         let reader = match pair.master.try_clone_reader() {
             Ok(r) => r,
             Err(e) => {

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -496,94 +496,86 @@ fn spawn_auth_cli_pty(
     let auth_check_args_for_check = auth_check_args.clone();
     let auth_env_for_check = auth_env.clone();
 
+    tracing::info!(
+        session_id = %session_id,
+        provider_id = %provider_id,
+        cli_path = %cli_path,
+        auth_login_args = ?auth_login_args,
+        "auth.spawn (PTY): launching provider CLI"
+    );
+
+    // Allocate the PTY, build the command, spawn the child, and
+    // register the PID — all synchronously, BEFORE the async drain/
+    // wait task and BEFORE `attach_process`. That way no
+    // `cancel_session` racing with the spawn can find a registered
+    // handle but a missing PID; either the PID is registered first
+    // (cancel can kill), or the early-return path fired and there
+    // is no child to kill.
+    let pty_system = native_pty_system();
+    let pair = match pty_system.openpty(PtySize {
+        rows: 24,
+        cols: 80,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(session_id = %session_id, error = %e, "auth.spawn (PTY): openpty failed");
+            mgr.finish_failure(&session_id, format!("openpty failed: {e}"));
+            mgr.detach_process(&session_id);
+            return;
+        }
+    };
+
+    let mut cmd = CommandBuilder::new(&cli_path);
+    for a in &auth_login_args {
+        cmd.arg(a);
+    }
+    for (k, v) in &auth_env {
+        cmd.env(k, v);
+    }
+    if let Ok(cwd) = std::env::current_dir() {
+        cmd.cwd(cwd);
+    }
+
+    let child = match pair.slave.spawn_command(cmd) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                session_id = %session_id,
+                error = %e,
+                "auth.spawn (PTY): spawn_command failed"
+            );
+            mgr.finish_failure(&session_id, format!("PTY spawn `{cli_path}` failed: {e}"));
+            mgr.detach_process(&session_id);
+            return;
+        }
+    };
+
+    if let Some(pid) = child.process_id() {
+        mgr.attach_pty_pid(&session_id, pid);
+    }
+
+    let reader = match pair.master.try_clone_reader() {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::error!(session_id = %session_id, error = %e, "auth.spawn (PTY): try_clone_reader failed");
+            mgr.finish_failure(&session_id, format!("PTY reader: {e}"));
+            mgr.detach_process(&session_id);
+            return;
+        }
+    };
+    let writer = match pair.master.take_writer() {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::error!(session_id = %session_id, error = %e, "auth.spawn (PTY): take_writer failed");
+            mgr.finish_failure(&session_id, format!("PTY writer: {e}"));
+            mgr.detach_process(&session_id);
+            return;
+        }
+    };
+
     let handle = tokio::spawn(async move {
-        tracing::info!(
-            session_id = %session_id_for_task,
-            provider_id = %provider_id,
-            cli_path = %cli_path,
-            auth_login_args = ?auth_login_args,
-            "auth.spawn (PTY): launching provider CLI"
-        );
-
-        let pty_system = native_pty_system();
-        let pair = match pty_system.openpty(PtySize {
-            rows: 24,
-            cols: 80,
-            pixel_width: 0,
-            pixel_height: 0,
-        }) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): openpty failed");
-                mgr_for_task.finish_failure(
-                    &session_id_for_task,
-                    format!("openpty failed: {e}"),
-                );
-                mgr_for_task.detach_process(&session_id_for_task);
-                return;
-            }
-        };
-
-        let mut cmd = CommandBuilder::new(&cli_path);
-        for a in &auth_login_args {
-            cmd.arg(a);
-        }
-        for (k, v) in &auth_env {
-            cmd.env(k, v);
-        }
-        if let Ok(cwd) = std::env::current_dir() {
-            cmd.cwd(cwd);
-        }
-
-        let child = match pair.slave.spawn_command(cmd) {
-            Ok(c) => c,
-            Err(e) => {
-                tracing::error!(
-                    session_id = %session_id_for_task,
-                    error = %e,
-                    "auth.spawn (PTY): spawn_command failed"
-                );
-                mgr_for_task.finish_failure(
-                    &session_id_for_task,
-                    format!("PTY spawn `{cli_path}` failed: {e}"),
-                );
-                mgr_for_task.detach_process(&session_id_for_task);
-                return;
-            }
-        };
-
-        // Register the child PID with the session manager so
-        // `cancel_session` can kill it — aborting drain_handle below
-        // can't reach into the spawn_blocking wait task that owns
-        // the portable_pty::Child.
-        if let Some(pid) = child.process_id() {
-            mgr_for_task.attach_pty_pid(&session_id_for_task, pid);
-        }
-
-        let reader = match pair.master.try_clone_reader() {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): try_clone_reader failed");
-                mgr_for_task.finish_failure(
-                    &session_id_for_task,
-                    format!("PTY reader: {e}"),
-                );
-                mgr_for_task.detach_process(&session_id_for_task);
-                return;
-            }
-        };
-        let writer = match pair.master.take_writer() {
-            Ok(w) => w,
-            Err(e) => {
-                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): take_writer failed");
-                mgr_for_task.finish_failure(
-                    &session_id_for_task,
-                    format!("PTY writer: {e}"),
-                );
-                mgr_for_task.detach_process(&session_id_for_task);
-                return;
-            }
-        };
 
         // Stdin writer: forward callback URLs from the manager into
         // the child's PTY input. portable_pty's master writer is sync;

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -57,6 +57,14 @@ struct StartProviderAuthReq {
     /// GEMINI_CLI_HOME, etc.).
     #[serde(default)]
     auth_env: std::collections::HashMap<String, String>,
+    /// Spawn the auth login subprocess under a PTY (instead of plain
+    /// piped stdio). Required by providers whose auth subcommand
+    /// checks `isatty()` and refuses to run otherwise (currently
+    /// OpenClaw's `models auth login --provider <id>`). The flag is
+    /// forwarded down to the CEF host's `run_cli_login` which picks
+    /// the PTY branch when set.
+    #[serde(default)]
+    requires_tty: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -127,6 +135,7 @@ pub fn register_identity_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) 
                     req.auth_login_args,
                     req.auth_check_args,
                     req.auth_env,
+                    req.requires_tty,
                 );
                 Ok(Some(serde_json::to_value(&r).unwrap_or_default()))
             })
@@ -239,6 +248,7 @@ fn spawn_auth_cli(
     auth_login_args: Vec<String>,
     auth_check_args: Vec<String>,
     auth_env: std::collections::HashMap<String, String>,
+    requires_tty: bool,
 ) {
     use std::process::Stdio;
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -248,6 +258,27 @@ fn spawn_auth_cli(
     // Channel for SubmitAuthCallback → CLI stdin forwarding.
     // Buffer of 4 is enough — only one URL per session in normal use.
     let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(4);
+
+    // PTY branch: providers like OpenClaw whose auth subcommand
+    // refuses to run when `isatty()==0`. Spawn via portable_pty so the
+    // child sees an interactive terminal, feed PTY output through the
+    // same record_line matcher the pipes path uses. Stdout/stderr are
+    // merged into the single PTY stream — record_line handles both as
+    // identical input.
+    if requires_tty {
+        spawn_auth_cli_pty(
+            mgr,
+            session_id,
+            provider_id,
+            cli_path,
+            auth_login_args,
+            auth_check_args,
+            auth_env,
+            stdin_tx,
+            stdin_rx,
+        );
+        return;
+    }
 
     let mgr_for_task = mgr.clone();
     let session_id_for_task = session_id.clone();
@@ -431,6 +462,240 @@ fn spawn_auth_cli(
                 mgr_for_task.finish_failure(
                     &session_id_for_task,
                     format!("wait error: {e}"),
+                );
+            }
+        }
+
+        mgr_for_task.detach_process(&session_id_for_task);
+    });
+
+    mgr.attach_process(&session_id, handle, stdin_tx);
+}
+
+/// PTY-backed variant of spawn_auth_cli. Used for providers whose auth
+/// subcommand bails on `isatty()==0` (currently OpenClaw). Mirrors the
+/// pipes path's lifecycle: spawn → drain → confirm → finish_success or
+/// finish_failure → detach. Stdout+stderr are merged on the PTY side;
+/// `record_line` doesn't care which stream a line came from.
+fn spawn_auth_cli_pty(
+    mgr: Arc<crate::identity::auth_session::AuthSessionManager>,
+    session_id: String,
+    provider_id: String,
+    cli_path: String,
+    auth_login_args: Vec<String>,
+    auth_check_args: Vec<String>,
+    auth_env: std::collections::HashMap<String, String>,
+    stdin_tx: tokio::sync::mpsc::Sender<String>,
+    mut stdin_rx: tokio::sync::mpsc::Receiver<String>,
+) {
+    use portable_pty::{native_pty_system, CommandBuilder, PtySize};
+
+    let mgr_for_task = mgr.clone();
+    let session_id_for_task = session_id.clone();
+    let cli_path_for_check = cli_path.clone();
+    let auth_check_args_for_check = auth_check_args.clone();
+    let auth_env_for_check = auth_env.clone();
+
+    let handle = tokio::spawn(async move {
+        tracing::info!(
+            session_id = %session_id_for_task,
+            provider_id = %provider_id,
+            cli_path = %cli_path,
+            auth_login_args = ?auth_login_args,
+            "auth.spawn (PTY): launching provider CLI"
+        );
+
+        let pty_system = native_pty_system();
+        let pair = match pty_system.openpty(PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        }) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): openpty failed");
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("openpty failed: {e}"),
+                );
+                mgr_for_task.detach_process(&session_id_for_task);
+                return;
+            }
+        };
+
+        let mut cmd = CommandBuilder::new(&cli_path);
+        for a in &auth_login_args {
+            cmd.arg(a);
+        }
+        for (k, v) in &auth_env {
+            cmd.env(k, v);
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            cmd.cwd(cwd);
+        }
+
+        let child = match pair.slave.spawn_command(cmd) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::error!(
+                    session_id = %session_id_for_task,
+                    error = %e,
+                    "auth.spawn (PTY): spawn_command failed"
+                );
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("PTY spawn `{cli_path}` failed: {e}"),
+                );
+                mgr_for_task.detach_process(&session_id_for_task);
+                return;
+            }
+        };
+
+        let reader = match pair.master.try_clone_reader() {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): try_clone_reader failed");
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("PTY reader: {e}"),
+                );
+                mgr_for_task.detach_process(&session_id_for_task);
+                return;
+            }
+        };
+        let writer = match pair.master.take_writer() {
+            Ok(w) => w,
+            Err(e) => {
+                tracing::error!(session_id = %session_id_for_task, error = %e, "auth.spawn (PTY): take_writer failed");
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("PTY writer: {e}"),
+                );
+                mgr_for_task.detach_process(&session_id_for_task);
+                return;
+            }
+        };
+
+        // Stdin writer: forward callback URLs from the manager into
+        // the child's PTY input. PTY writer is sync; wrap calls in a
+        // blocking task.
+        let stdin_writer_handle = tokio::spawn(async move {
+            let mut writer = writer;
+            while let Some(line) = stdin_rx.recv().await {
+                use std::io::Write;
+                if writer.write_all(line.as_bytes()).is_err() {
+                    break;
+                }
+                if writer.write_all(b"\n").is_err() {
+                    break;
+                }
+                let _ = writer.flush();
+            }
+        });
+
+        // Drain: synchronous line reader from PTY master, feeds into
+        // the same record_line matcher the pipes path uses. Runs in a
+        // blocking thread; sends parsed events through a oneshot when
+        // we hit a login-success pattern (so the async task can run
+        // confirm_authenticated without crossing the blocking thread).
+        let mgr_drain = mgr_for_task.clone();
+        let sid_drain = session_id_for_task.clone();
+        let cli_path_drain = cli_path_for_check.clone();
+        let check_args_drain = auth_check_args_for_check.clone();
+        let check_env_drain = auth_env_for_check.clone();
+        let drain_handle = tokio::task::spawn_blocking(move || {
+            use std::io::BufRead;
+            let mut reader = std::io::BufReader::new(reader);
+            let mut success_transitioned = false;
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break, // EOF
+                    Ok(_) => {
+                        // Same redaction policy as the pipes path —
+                        // OAuth URLs / codes can be in here.
+                        tracing::debug!(session_id = %sid_drain, bytes = line.len(), "auth.spawn (PTY): line");
+                        let m = mgr_drain.record_line(&sid_drain, &line);
+                        if !success_transitioned
+                            && matches!(
+                                m,
+                                Some(crate::identity::auth_patterns::AuthPatternMatch::LoginSuccess { .. })
+                            )
+                        {
+                            // Hand off to async to call confirm_authenticated.
+                            let cli = cli_path_drain.clone();
+                            let args = check_args_drain.clone();
+                            let env = check_env_drain.clone();
+                            let mgr2 = mgr_drain.clone();
+                            let sid2 = sid_drain.clone();
+                            tokio::runtime::Handle::current().spawn(async move {
+                                if confirm_authenticated(&cli, &args, &env).await {
+                                    let bundle_id = format!("pending-bundle-for-{}", sid2);
+                                    mgr2.finish_success(&sid2, bundle_id);
+                                }
+                            });
+                            success_transitioned = true;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        // Wait for the child in a blocking task. pair (master + slave)
+        // moves into the closure so its destructor runs AFTER
+        // child.wait() — ConPTY contract on Windows.
+        let wait_handle = tokio::task::spawn_blocking(move || {
+            let mut child = child;
+            let exit = child.wait();
+            drop(pair);
+            exit
+        });
+
+        let exit = wait_handle.await;
+        tracing::info!(session_id = %session_id_for_task, exit = ?exit, "auth.spawn (PTY): child exited");
+
+        let _ = drain_handle.await;
+        stdin_writer_handle.abort();
+
+        // Final transition fallback — some CLIs exit cleanly without
+        // emitting a login-success line that record_line recognizes.
+        match exit {
+            Ok(Ok(s)) if s.success() => {
+                if confirm_authenticated(
+                    &cli_path_for_check,
+                    &auth_check_args_for_check,
+                    &auth_env_for_check,
+                )
+                .await
+                {
+                    let bundle_id = format!("pending-bundle-for-{}", session_id_for_task);
+                    mgr_for_task.finish_success(&session_id_for_task, bundle_id);
+                } else {
+                    mgr_for_task.finish_failure(
+                        &session_id_for_task,
+                        "CLI exited cleanly but auth-check still failed".to_string(),
+                    );
+                }
+            }
+            Ok(Ok(s)) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("CLI exited with code {:?}", s.exit_code()),
+                );
+            }
+            Ok(Err(e)) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("PTY wait error: {e}"),
+                );
+            }
+            Err(e) => {
+                mgr_for_task.finish_failure(
+                    &session_id_for_task,
+                    format!("PTY wait task join error: {e}"),
                 );
             }
         }

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -578,19 +578,23 @@ fn spawn_auth_cli_pty(
         };
 
         // Stdin writer: forward callback URLs from the manager into
-        // the child's PTY input. PTY writer is sync; wrap calls in a
-        // blocking task.
+        // the child's PTY input. portable_pty's master writer is sync;
+        // wrap each write in `block_in_place` so the blocking IO
+        // doesn't starve the tokio reactor when the PTY input buffer
+        // is full.
         let stdin_writer_handle = tokio::spawn(async move {
             let mut writer = writer;
             while let Some(line) = stdin_rx.recv().await {
-                use std::io::Write;
-                if writer.write_all(line.as_bytes()).is_err() {
+                let res = tokio::task::block_in_place(|| {
+                    use std::io::Write;
+                    writer
+                        .write_all(line.as_bytes())
+                        .and_then(|_| writer.write_all(b"\n"))
+                        .and_then(|_| writer.flush())
+                });
+                if res.is_err() {
                     break;
                 }
-                if writer.write_all(b"\n").is_err() {
-                    break;
-                }
-                let _ = writer.flush();
             }
         });
 

--- a/docs/specs/SPEC_OPENCLAW_AGENT_2026_05_17.md
+++ b/docs/specs/SPEC_OPENCLAW_AGENT_2026_05_17.md
@@ -1,0 +1,530 @@
+# SPEC: OpenClaw integration — shared interfaces, distinct flavor
+
+**Date:** 2026-05-17 (revised)
+**Author:** AgentA (research pass)
+**Status:** Draft for discussion — pre-implementation
+**Discussion thread:** TBD (open one when this lands)
+
+> Revision note: the prior draft of this file framed OpenClaw as an internal,
+> OpenAI-powered Claude-Code clone built by extending the `codex` provider with
+> a translator skin. That framing was wrong. OpenClaw is a real, third-party,
+> open-source product from **openclaw.ai** that AgentMux already scaffolds as a
+> first-class provider. This rewrite reframes the work around the user's
+> "shared interfaces, distinct flavor" principle and the existing scaffold.
+
+---
+
+## 0. TL;DR
+
+OpenClaw is its own product. AgentMux already has the scaffold to launch it as
+a peer of Claude, Codex, Gemini, and Copilot — see `agentmux-srv/src/backend/
+providers.rs:207-226` (`acpx --agent openclaw`, ACP controller, `OPENCLAW_HOME`
+auth dir). The work is **not** to make OpenClaw look like Claude Code; it is
+to (a) verify the scaffold actually spawns and renders, (b) route OpenClaw's
+own onboarding through AgentMux's launch flow without "jamming" it, and (c)
+make sure the **shared interfaces** AgentMux exposes — the agent-pane
+DocumentNode model, the tool overlay, the identity/memory tabs — render
+OpenClaw's events cleanly.
+
+The OpenAI-as-backing-model question (the user's "verify OpenAI OAuth can be
+used") is a **configuration matter inside OpenClaw**, not an AgentMux OAuth
+flow. Section 4 dissects what that means concretely.
+
+---
+
+## 1. What OpenClaw actually is
+
+From [openclaw.ai](https://openclaw.ai) and [docs.openclaw.ai](https://docs.openclaw.ai):
+
+- **Open-source personal AI assistant.** GitHub-hosted. Apache or similar OSS
+  license. Single-user, on-device — Mac, Windows, Linux.
+- **Two surfaces:** a CLI (`openclaw onboard`, `openclaw tui`, `openclaw acp …`,
+  `openclaw doctor`) and a daemon (`openclaw gateway`) that runs on
+  `localhost:18789` and hosts sessions, agent identities, and channel routing.
+- **Model-agnostic.** Supports Anthropic Claude (default), OpenAI GPT, and
+  local models (e.g. MiniMax 2.5). Bring-your-own-key per backend.
+- **Chat-app multiplexing.** Routes the same agent through WhatsApp, Telegram,
+  Discord, Slack, Signal, iMessage in DMs and group chats.
+- **Full system access** with sandboxing options — file IO, browser control,
+  shell execution. Skill / plugin system.
+- **Onboarding via `openclaw onboard`** — described in docs as a "guided setup
+  with pairing flows." Specifics (interactive vs scripted, browser-required vs
+  not) are not fully documented; see §8 open questions.
+- **No central OAuth.** OpenClaw onboards into the user's own environment.
+  Provider credentials (Anthropic API key, OpenAI API key, etc.) are entered
+  during onboarding and stored under `~/.openclaw/`.
+
+OpenClaw's relationship to AgentMux: **OpenClaw is one CLI agent among many
+that AgentMux can host in an agent pane.** It is not an AgentMux subsystem,
+not a clone target, and not something to graft Claude-Code semantics onto.
+
+---
+
+## 2. What AgentMux already has scaffolded
+
+| File | Line | What it does |
+|---|---|---|
+| `agentmux-srv/src/backend/providers.rs` | 207-226 | `OPENCLAW` `ProviderConfig` — `cli_command: "acpx"`, `controller_type: Acp`, `launch_args: ["--agent", "openclaw"]`, `auth_config_dir_env_var: "OPENCLAW_HOME"`, `npm_package: "@openclaw/acpx"`. |
+| `agentmux-srv/src/backend/blockcontroller/acp.rs` | 11 | Doc-comment lists `acpx --agent openclaw` as a canonical example of an ACP-protocol agent the controller drives. Same JSON-RPC lifecycle as `gemini --acp` and `copilot --acp`. |
+| `agentmux-srv/src/identity/auth_patterns.rs` | 57, 71 | `openclaw` listed in `is_api_key_provider()` and in the empty-matcher branch of `patterns_for()`. No OAuth URL extraction — credentials come from OpenClaw's own onboarding. |
+| `frontend/app/view/agent/providers/index.ts` | 127-150 | `PROVIDERS.openclaw` entry — `cliCommand: "acpx"`, `authType: "api-key"`, `authCheckCommand: ["openclaw", "doctor"]`, `authLoginCommand: ["openclaw", "onboard"]`, `controllerType: "acp"`. |
+| `frontend/app/view/forge/forge-constants.ts` | 115-126 | Agent-card metadata: blurb "ACP orchestration platform" + popover describing OpenClaw as a coordinator that runs other agents. |
+| `agentmux-srv/forge-seed.json` | 124-147 | Seed agent persona for `openclaw` with startup skill. |
+| `docs/specs/openclaw-agent-runtime.md` | — | Earlier spec describing `openclaw tui` (interactive TUI backed by the gateway) and `openclaw acp client` (sub-agent protocol bridge) as the two integration surfaces. |
+| `docs/specs/openclaw-widget.md` | — | Companion spec for embedding OpenClaw's web dashboard at `localhost:18789` as an AgentMux widget. |
+
+**Status of the scaffold:** wired but unverified end-to-end. The
+`cli_command: "acpx"` value is an early guess at the binary name; current
+[docs.openclaw.ai](https://docs.openclaw.ai) references `openclaw acp` as a
+first-party subcommand, not a separate `acpx` binary, and the
+`@openclaw/acpx` npm package isn't visible in the documented CLI reference.
+Verifying the actual binary/subcommand is Phase α work.
+
+---
+
+## 3. The shared-interface principle
+
+The user's framing — *"we don't want to jam anything, each should keep their
+own unique flavor, but we encourage shared interfaces"* — maps onto a small
+number of seams that AgentMux already owns. The integration question for any
+new provider is **which seams it plugs into vs which it routes around**.
+
+### 3.1 The seams
+
+| Seam | What it is | Where it lives | What it normalizes |
+|---|---|---|---|
+| **DocumentNode model** | The renderable tree the agent pane displays — assistant text blocks, tool-call blocks, tool-result blocks, markdown sections, thinking sections, cost banner. | `frontend/app/view/agent/types.ts`, `virtualization/state.ts`, `virtualization/renderers.ts`, `components/ToolBlock.tsx` | What appears on screen and how it's structured / collapsible / styled. |
+| **StreamEvent union** | The provider-agnostic event shape translators emit. Variants: `text`, `tool_call`, `tool_result`, `thinking`, `cost`, `error`, `done`. | `frontend/app/view/agent/stream-parser.ts` + `state.ts` | What translators must produce. ACP, claude-stream-json, codex-json, gemini-json all funnel through here. |
+| **Translator interface** | Per-provider parser that consumes the CLI's wire format and emits `StreamEvent`s. | `frontend/app/view/agent/providers/translator.ts` + `*-translator.ts` files | The boundary between provider-specific wire formats and the shared event model. |
+| **Launch flow** | 3-phase modal: resolve binary → check/run auth → register controller. | `frontend/app/view/agent/flows/launch-flow.ts` + `components/PreLaunchAuthPanel.tsx` + `auth/auth-flow-controller.ts` | When and how the user authenticates and what the modal shows during onboarding. |
+| **Auth-URL pattern matchers** | Per-provider regex pack that pulls OAuth URLs or device codes from CLI stdout. | `agentmux-srv/src/identity/auth_patterns.rs` | The seam between "CLI prints stuff" and "AgentMux opens a browser." |
+| **Identity / Memory tabs** | Per-agent identity bundle dropdown + persistent memory tab inside the agent pane. | `frontend/app/view/agent/` settings panel; `db_identities`, `db_memories` schema. | Multi-account hygiene and conversation persistence — provider-independent. |
+| **Bash-stream overlay** | `agentmux-bashwrap` hook + the streaming output viewer that shows partial stdout while a tool runs. | `.claude/settings.json` PreToolUse hook → `agentmux-bashwrap` crate; `BashOutputViewer.tsx`. | Mid-tool-execution streaming UX — only fires if the provider routes its shell tool through a hookable boundary. |
+| **Container path** | Per-agent containerized run inside `agentmux/<provider>:latest`. | `cli-catalog.ts` `containerSupported` flag + container build configs. | Sandboxed execution (defer for openclaw v1). |
+
+### 3.2 Provider matrix — what plugs into what
+
+| Provider | DocumentNode | StreamEvent | Translator | Launch flow | Auth-URL matcher | Identity/Memory | Bash overlay | Container |
+|---|---|---|---|---|---|---|---|---|
+| **Claude** | shared | shared | `claude-translator.ts` (stream-json) | shared | shared (`match_claude_url`) | shared | **yes** — `agentmux-bashwrap` via `.claude/settings.json` PreToolUse | yes |
+| **Codex** | shared | shared | `codex-translator.ts` (codex-json) | shared | shared (`match_codex_url`) | shared | no — Codex's internal tool dispatch has no hook surface | yes |
+| **Gemini** | shared | shared | `gemini-translator.ts` (stream-json) | shared | shared (`match_gemini_url`) | shared | no — same reason as Codex | yes |
+| **Copilot** | shared | shared | ACP translator (JSON-RPC 2.0) | shared | shared (`match_copilot_device_code`) | shared | no | no |
+| **OpenClaw** *(this spec)* | shared | shared | ACP translator | shared *(but defers to openclaw onboard for credentials)* | none — `is_api_key_provider` | shared | **defer** — needs investigation (§7) | no (v1) |
+| **Kimi** | shared | shared | `kimi-translator.ts` (stream-json) | shared | none — `is_api_key_provider` | shared | no | yes |
+| **Pi** | shared | shared | ACP translator | shared | none — `is_api_key_provider` | shared | no | no |
+
+The horizontal sameness is the point. OpenClaw "keeps its own flavor" by (a)
+running its own binary, (b) using its own onboarding flow, (c) speaking ACP
+on its own terms, (d) routing through its own gateway when active. AgentMux
+"shares interfaces" by giving OpenClaw the same agent-pane render path, the
+same identity/memory tabs, and the same launch modal shell every other
+provider gets.
+
+What is **explicitly not** shared and shouldn't be forced:
+
+- OpenClaw's onboarding is interactive and conversational — that flavor stays.
+  AgentMux does not impersonate it with a different UI.
+- OpenClaw's model selection is internal (config + onboard wizard). AgentMux
+  does not expose a `--model` dropdown for openclaw the way it does for Claude.
+- OpenClaw's gateway-multi-channel-routing (WhatsApp / Telegram / Discord)
+  has no analog in AgentMux's agent pane; we don't try to render it.
+
+---
+
+## 4. The OpenAI-as-backing-model question
+
+**Confirmed via openclaw.ai docs + community guides (2026-05-17 research):**
+OpenClaw ships a **bundled `codex-harness` plugin** that runs embedded OpenAI
+agent turns through Codex's own app-server, in place of OpenClaw's default
+Pi harness. **ChatGPT-subscription OAuth credentials work as the auth
+source** — the OAuth profile that Codex CLI writes during `codex login` is
+the same shape OpenClaw's `openai-codex:*` auth profile expects.
+
+### 4.1 How OpenClaw uses Codex as its brain
+
+Three OpenClaw-side ingredients (verified from `docs.openclaw.ai/plugins/codex-harness`):
+
+1. **Plugin enabled:** `plugins.entries.codex.enabled = true` in OpenClaw's
+   config. The `codex-harness` plugin ships bundled — no separate install.
+2. **Model selected:** `agents.defaults.model = openai/gpt-5.5` (or any
+   `openai/gpt-*` ref). The `openai/` prefix routes the agent's turn through
+   the Codex harness instead of Pi.
+3. **Auth profile registered:** an `openai-codex:*` profile under
+   `auth.profiles`, with `auth.order.openai` listing it first (or a
+   subscription-first / API-key-fallback ordering).
+
+The OpenClaw-native command to enroll a ChatGPT-subscription identity is:
+
+```
+openclaw models auth login --provider openai-codex
+```
+
+This walks the user through the same "Sign in with ChatGPT" OAuth flow
+that Codex CLI's `codex login` does, then writes the resulting credentials
+into OpenClaw's auth store. **When OpenClaw subsequently launches the
+Codex app-server as the agent's brain, it strips `CODEX_API_KEY` and
+`OPENAI_API_KEY` from the spawned child's env** so the OAuth profile takes
+precedence — no risk of an ambient API key silently overriding the
+subscription auth.
+
+### 4.2 Auth resolution order (for the local stdio Codex launch)
+
+When OpenClaw spawns the Codex app-server to handle an `openai/*` turn,
+auth is selected in this order:
+
+1. Ordered OpenAI auth profiles (`auth.order.openai`) — subscription
+   profile first if present, API-key profile second.
+2. The app-server's existing account in that agent's per-identity Codex
+   home directory (lets a previously-authed `codex login` in the agent's
+   sandbox survive).
+3. Env-var fallback (`CODEX_API_KEY` → `OPENAI_API_KEY`) — only used if 1
+   and 2 are absent.
+
+The user's question — "can the codex brain be gotten for openclaw's use
+via the openai oauth auth?" — answer: **yes, via `openclaw models auth
+login --provider openai-codex` which performs the ChatGPT-subscription
+OAuth flow and writes a profile OpenClaw uses as the Codex harness's auth
+source.** No API key needed.
+
+### 4.3 What's split between OpenClaw and Codex when this is configured
+
+| Layer | Owner |
+|---|---|
+| Routing, channels, sessions, cron jobs, memory files | **OpenClaw** |
+| Persistent agent identity, dynamic-tool layer, approvals | **OpenClaw** |
+| Visible transcript / channel mirror | **OpenClaw** |
+| Low-level agent session (turn, thread resume) | **Codex app-server** |
+| Native tool continuation, compaction | **Codex app-server** |
+| Model API call, OAuth token refresh | **Codex app-server** |
+
+So even with the Codex harness enabled, OpenClaw still owns the user-facing
+agent surface — the brain is Codex but the agent is still OpenClaw.
+
+### 4.4 What AgentMux should do
+
+For Phase β (§6 below): surface OpenClaw's model selection as **informational
+only** in the launch panel — a read-only "configured model: openai/gpt-5.5"
+pill sourced from `openclaw doctor` (or whatever subcommand exposes that
+config in the bundled version). No dropdown that mutates the model — that
+would jam OpenClaw's config.
+
+If we later want a "switch backing model" UX, the right pattern is a
+**launch into `openclaw models auth login --provider <provider>`** action
+that hands control back to OpenClaw's own enrollment wizard. AgentMux's
+launch flow already supports deferring to a CLI's own subcommand (that's
+what `authLoginCommand` does for Kimi — runs `kimi login` inline in the
+pane). Re-use that mechanism rather than reimplementing OpenClaw's auth
+wizard inside the launch modal.
+
+**Sources for §4** (added 2026-05-17 after the user's clarification):
+
+- [Codex harness — docs.openclaw.ai](https://docs.openclaw.ai/plugins/codex-harness)
+- [openai.md — github.com/openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/docs/providers/openai.md)
+- [model-providers.md — github.com/openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/docs/concepts/model-providers.md)
+- ["I Switched My Agent Stack from Claude to OpenAI Codex" — mager.co](https://www.mager.co/blog/2026-04-11-openclaw-openai-codex/) (community write-up of the exact path above)
+
+---
+
+## 5. The hardcoded-to-Claude runner in `agents/runner.rs`
+
+The prior draft flagged this and it's still real. `agentmux-srv/src/agents/
+runner.rs:82-117` hard-codes `claude --print --output-format=stream-json` and
+the Claude translator. The runner is the **workflow Agent block** path
+(`SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` §4.2) — one-shot, headless agent
+spawns from inside a workflow.
+
+**Impact on OpenClaw:** the interactive agent-pane path goes through
+`blockcontroller/acp.rs`, not `runner.rs`. OpenClaw users launching from the
+agent picker hit the ACP controller; that path is unaffected by the runner
+hardcoding. The hardcoding only blocks workflow Agent blocks from running
+OpenClaw as the executor — a real limitation but not a v1 blocker for
+"OpenClaw works in the agent pane."
+
+Keep this as a Phase ε cleanup, scoped under the unified-agent-types Phase B
+work, not as a prerequisite for shipping OpenClaw to the agent picker.
+
+---
+
+## 6. Integration plan
+
+### Phase α — verify the scaffold (1-2 PRs)
+
+**Goal:** OpenClaw spawns from the agent picker, ACP handshake completes,
+output renders in the agent pane.
+
+1. **Verify the binary.** Confirm whether `acpx` or `openclaw acp client`
+   (or `openclaw acp serve`) is the canonical AgentMux launch invocation in
+   today's openclaw release. Update `agentmux-srv/src/backend/providers.rs`
+   lines 210, 212, 222 if the answer is `openclaw acp …` instead of `acpx`.
+   Mirror in `frontend/app/view/agent/providers/index.ts` lines 130-149.
+
+2. **Verify ACP handshake.** Spawn `openclaw acp …` (or `acpx`) by hand from
+   a shell, send the `initialize` / `initialized` / `session/create` /
+   `session/prompt` sequence `blockcontroller/acp.rs:480-502` will send, and
+   confirm OpenClaw responds correctly. Document any field-shape differences
+   (e.g. does OpenClaw expect `cwd` in `session/create` params? does it
+   support our `workspaceRoots` array?).
+
+3. **Verify output renders.** Drive a one-turn prompt and confirm the
+   agent-pane DocumentNode renderer accepts OpenClaw's `session/update`
+   notifications without translator changes. If OpenClaw emits an ACP variant
+   that doesn't map cleanly, scope a small OpenClaw-flavored ACP translator
+   in `frontend/app/view/agent/providers/`.
+
+4. **Forge card copy.** Update `frontend/app/view/forge/forge-constants.ts`
+   lines 116-126 — the "ACP orchestration platform" blurb is technically
+   accurate but undersells the product. Suggested:
+   - blurb: `"Open-source personal AI assistant"`
+   - popover: brief mention that OpenClaw is model-agnostic, runs locally,
+     and onboards via its own `openclaw onboard` wizard. Encourage users to
+     run onboarding before launching from AgentMux.
+
+**Exit criteria:** user clicks the OpenClaw card → AgentMux runs
+`openclaw doctor` to verify install + onboard state → if not onboarded,
+modal explains "run `openclaw onboard` first" with a one-click "open
+terminal here" affordance → otherwise spawn → ACP session live → user types
+prompt → response streams in the agent pane.
+
+### Phase β — onboarding UX inside the launch flow (1 PR)
+
+**Goal:** first-time OpenClaw users have a clear path through `openclaw
+onboard` without leaving AgentMux.
+
+Open question §8.2 gates the implementation choice:
+
+- **(β.A) Defer to OpenClaw's own wizard.** Launch panel detects "not
+  onboarded" via `openclaw doctor` exit code, surfaces a single CTA that
+  spawns `openclaw onboard` in a regular Terminal pane (not the Agent pane,
+  because onboarding may be interactive in ways that don't fit the
+  StreamEvent model). When the user is done, they re-click the OpenClaw
+  agent card and AgentMux retries `openclaw doctor`.
+
+- **(β.B) Embed the wizard.** Spawn `openclaw onboard` inside the launch
+  modal itself, capture stdout/stdin, render its interactive prompts. Larger
+  surface, fragile if openclaw changes the wizard shape, but slicker UX.
+
+**Recommendation:** β.A. It respects OpenClaw's flavor (its onboarding is its
+own product surface), it's smaller to ship, and it generalizes to any
+future provider whose login flow doesn't fit a streaming event model. Track
+β.B as a "polish if users complain" follow-up.
+
+`authLoginCommand: ["openclaw", "onboard"]` is already wired in
+`providers/index.ts` line 137; the launch flow already knows how to run a
+provider's login command. Phase β work is mostly UX copy — explain to the
+user that OpenClaw's onboarding is its own product surface and they're
+about to leave the launch modal briefly.
+
+### Phase γ — model selection inside OpenClaw (1 PR — informational only)
+
+**Goal:** user can see which model OpenClaw is configured to use, without
+AgentMux mutating that config.
+
+Scope:
+
+- Parse `openclaw doctor` output (or whatever subcommand reports current
+  config — `openclaw config show`?) to extract the currently-selected
+  backing model. **Open question §8.3** — what command and what shape?
+- Render that as a read-only pill in the agent pane's settings panel:
+  `Backing model: gpt-4o (via OpenClaw)`. Click → opens
+  `https://docs.openclaw.ai` configuration section in browser.
+- "Reconfigure backing model" action button — runs `openclaw onboard
+  --reconfigure` in a Terminal pane (same pattern as β.A).
+
+**Non-goal:** AgentMux does not provide a model dropdown for OpenClaw. Each
+provider keeps its own flavor of model-selection UX. Claude has a flag-driven
+dropdown because Claude's CLI supports `--model`; OpenClaw has an internal
+config because that's OpenClaw's idiom.
+
+### Phase δ — identity / memory persistence (1 PR)
+
+**Goal:** OpenClaw participates in the shared identity-bundle and memory-tab
+plumbing without leaking state across AgentMux identities.
+
+Scope:
+
+- Verify `OPENCLAW_HOME` redirect actually points `~/.openclaw/` somewhere
+  inside `{dataDir}/auth/openclaw/<bundle>/` per
+  `docs/specs/provider-auth-isolation.md`. Test: switch identity bundles in
+  the launcher, confirm each bundle has its own `~/.openclaw/`-shaped tree.
+- Confirm the agent-pane Memory tab (cog → settings → Memory) reads/writes
+  to a `db_memories` row keyed by OpenClaw's identity bundle. The seed row
+  in `forge-seed.json:124-147` (`id: openclaw`) is the migration target.
+- Named-agent continuation: typing a previously-used OpenClaw agent name
+  re-uses the prior working directory. ACP `session_id` resumption is not
+  needed — `blockcontroller/acp.rs` re-initializes a fresh session per pane
+  open, and OpenClaw's gateway persists conversation state independently.
+
+**Exit criteria:** two AgentMux identity bundles each onboarded into
+separate `~/.openclaw/`-shaped trees, conversations persist across pane
+close/reopen, no credential leakage across bundles.
+
+### Phase ε — `agentmux-bashwrap` integration (deferred — needs empirical data)
+
+**Goal:** match Claude's mid-tool-execution streaming bash output UX.
+
+OpenClaw executes shell commands as part of its skills. Whether
+`agentmux-bashwrap` can intercept those depends on:
+
+- Does OpenClaw spawn shell commands via a hookable boundary (PreToolUse
+  hook, MCP hook, plugin)?
+- Does the spawn inherit the AgentMux-injected `PATH` so a bashwrap shim
+  could intercept generically?
+
+Both are unknown from the public docs. Defer until Phase α produces
+empirical data on what OpenClaw's shell-tool flow looks like in
+`session/update` notifications. If shell calls arrive as opaque "ran X,
+output Y" pairs (no mid-execution stream), the v1 UX is "tool block shows
+command + final result, no streaming partial" — matching the current Codex
+and Gemini UX.
+
+### Phase ζ — workflow Agent block support (deferred)
+
+Decouple `agents/runner.rs` from `claude` so OpenClaw (and Codex, Gemini)
+can run as a workflow Agent block executor. Tracked under Phase B
+unified-runner work, not a v1 OpenClaw blocker.
+
+---
+
+## 7. Files that change (by phase)
+
+| Phase | File | Action |
+|---|---|---|
+| α | `agentmux-srv/src/backend/providers.rs` | Verify + correct `cli_command`, `npm_package`, `launch_args` for openclaw if `acpx` is not the right value. |
+| α | `frontend/app/view/agent/providers/index.ts` | Mirror the providers.rs correction. |
+| α | `frontend/app/view/forge/forge-constants.ts` | Rewrite OpenClaw blurb + popover (lines 115-126). |
+| α | `agentmux-srv/forge-seed.json` | Refresh OpenClaw seed description (line 130) to match new blurb. |
+| α | `frontend/app/view/agent/providers/openclaw-translator.ts` | NEW *(only if OpenClaw's ACP variant differs from Gemini/Copilot ACP enough to need provider-specific shaping)*. |
+| β | `frontend/app/view/agent/components/PreLaunchAuthPanel.tsx` | "Onboard with OpenClaw" copy + handoff CTA for the `openclaw onboard` flow (β.A path). |
+| β | `frontend/app/view/agent/auth/auth-state.ts` | New `awaiting_openclaw_onboard` sub-state if β.A's "open a Terminal pane and poll doctor" requires explicit FSM step. |
+| γ | `frontend/app/view/agent/agent-view.tsx` (settings panel) | Read-only "backing model" pill + "reconfigure" action. |
+| δ | (no new files — exercises existing identity/memory plumbing) | |
+
+Estimated **+1 file (translator, contingent)**, **5 modified**, **~300 LoC**
+for Phases α-δ.
+
+---
+
+## 8. Open questions
+
+1. ~~**Does OpenClaw natively support OpenAI ChatGPT-subscription OAuth?**~~
+   **Resolved 2026-05-17 (see §4):** Yes, via the bundled `codex-harness`
+   plugin. `openclaw models auth login --provider openai-codex` performs
+   the ChatGPT-subscription OAuth flow and writes an `openai-codex:*`
+   profile under `auth.profiles`. With `plugins.entries.codex.enabled =
+   true` + `agents.defaults.model = openai/gpt-*` + a subscription-first
+   `auth.order.openai` ordering, OpenClaw spawns Codex's app-server as the
+   agent's brain using that OAuth profile. `CODEX_API_KEY` / `OPENAI_API_KEY`
+   are stripped from the spawned child's env so the OAuth takes precedence.
+   No API key required.
+
+2. **β.A vs β.B for the onboarding UX.** Defer to OpenClaw's own wizard (β.A)
+   keeps the flavor distinct; embedding it (β.B) is slicker but jammier.
+   Recommend β.A — confirm with user.
+
+3. **What command reports OpenClaw's current backing model?** `openclaw
+   doctor`? `openclaw config show`? `openclaw status --json`? Phase γ
+   depends on this; needs Phase α exploratory work to find out.
+
+4. **`acpx` vs `openclaw acp …`.** The scaffolded `cli_command: "acpx"` in
+   `providers.rs:210` doesn't match what current `docs.openclaw.ai` documents.
+   Phase α verifies which one is right. If both exist, prefer the
+   first-party `openclaw acp` subcommand for reliability.
+
+5. **Does OpenClaw's ACP emit tool calls in a shape our DocumentNode renderer
+   already handles?** ACP is a protocol; the *content* of `session/update`
+   notifications varies by agent. The Gemini and Copilot ACP paths might have
+   already normalized this; Phase α confirms whether OpenClaw fits the same
+   shape or needs a small `openclaw-translator.ts`.
+
+6. **`agentmux-bashwrap` applicability** (Phase ε). Does OpenClaw expose a
+   PreToolUse-style hook surface, or is its shell execution opaque to
+   external interception? Defer until empirical data exists.
+
+7. **Container path.** Currently `containerSupported: false` for openclaw.
+   Containerizing OpenClaw is complex — its gateway, channel integrations,
+   and `~/.openclaw/` state would all need to map into the container. Defer
+   beyond v1 unless a specific use case drives it.
+
+8. **Gateway lifecycle.** OpenClaw runs a daemon (`openclaw gateway`) that
+   AgentMux currently doesn't manage. Does AgentMux start the gateway on
+   first launch? Detect-and-warn-if-not-running? The earlier
+   `openclaw-agent-runtime.md` spec assumed the user runs `openclaw gateway
+   --detach` themselves. Confirm that's still the right model — or whether
+   `openclaw acp` runs without needing the gateway up.
+
+9. **Skills / plugin discovery.** OpenClaw's skill system is rich; should
+   AgentMux surface installed skills anywhere (status pane, settings tab),
+   or is that purely OpenClaw's own UI concern? Recommend: out of scope for
+   v1. Each provider's "what tools / skills are available" UX stays inside
+   the provider's own surface.
+
+---
+
+## 9. Verification plan
+
+After Phase α:
+
+- [ ] `openclaw doctor` exits 0 on the test machine — confirm install + onboard prior to launching from AgentMux.
+- [ ] Click the OpenClaw agent card → ACP controller spawns the process → `session/create` succeeds → first prompt renders streaming text in the agent pane.
+- [ ] Close pane, reopen → fresh ACP session; OpenClaw gateway state persists user's conversation if the user opted into that during onboard.
+- [ ] `muxlog srv` shows the openclaw spawn with `OPENCLAW_HOME` env pointing inside `{dataDir}/auth/openclaw/`.
+- [ ] OpenClaw and Claude can run side-by-side in two agent panes without credential collision (Claude reads `{dataDir}/auth/claude/`, OpenClaw reads `{dataDir}/auth/openclaw/`).
+
+After Phase β:
+
+- [ ] Fresh install, no prior onboard: clicking OpenClaw surfaces a clear "onboard first" CTA, the CTA opens a Terminal pane with `openclaw onboard` running, finishing the wizard returns the user to AgentMux, retry succeeds.
+
+After Phase γ:
+
+- [ ] The OpenClaw agent pane shows the currently-configured backing model.
+- [ ] Changing the backing model via OpenClaw's own reconfigure flow is reflected in the pill on next launch.
+
+After Phase δ:
+
+- [ ] Switching identity bundles isolates OpenClaw conversations + credentials.
+- [ ] Memory tab persists per-bundle.
+
+---
+
+## 10. Non-goals (v1)
+
+- AgentMux brokering Anthropic / OpenAI / local-model credentials on
+  OpenClaw's behalf. OpenClaw onboards into the user's environment.
+- A model dropdown for OpenClaw inside AgentMux. Model selection stays in
+  OpenClaw's own config.
+- Embedding `openclaw onboard` inside the launch modal (β.B). Defer until
+  empirical UX feedback demands it.
+- Replacing OpenClaw's TUI or web dashboard. Those are OpenClaw's own
+  surfaces; AgentMux composes alongside them, not on top of them.
+- `agentmux-bashwrap` integration for OpenClaw shell tools. Phase ε,
+  needs empirical data first.
+- Containerized OpenClaw. Phase ζ at earliest.
+- Workflow-Agent-block execution via OpenClaw. Phase ζ, gated on
+  `agents/runner.rs` decoupling from Claude.
+
+---
+
+## References
+
+- External: [openclaw.ai](https://openclaw.ai) — landing page
+- External: [docs.openclaw.ai](https://docs.openclaw.ai) — CLI reference
+- `agentmux-srv/src/backend/providers.rs` — provider registry (OPENCLAW at 207-226)
+- `agentmux-srv/src/backend/blockcontroller/acp.rs` — ACP controller (mentions `acpx --agent openclaw` at line 11)
+- `agentmux-srv/src/identity/auth_patterns.rs` — `is_api_key_provider` list (line 57), `patterns_for` dispatch (line 62-74)
+- `agentmux-srv/src/agents/runner.rs` — workflow Agent block runner, hardcoded to `claude` (lines 82-117). Phase ε decoupling target, not v1 blocker.
+- `frontend/app/view/agent/providers/index.ts` — frontend provider metadata (openclaw at 127-150)
+- `frontend/app/view/agent/providers/translator.ts` + `*-translator.ts` — translator interface and per-provider implementations
+- `frontend/app/view/agent/stream-parser.ts` — StreamEvent model
+- `frontend/app/view/agent/virtualization/state.ts` + `renderers.ts` + `DocumentRow.tsx` — DocumentNode rendering
+- `frontend/app/view/agent/components/ToolBlock.tsx` — tool overlay
+- `frontend/app/view/agent/components/PreLaunchAuthPanel.tsx` — launch modal
+- `frontend/app/view/agent/flows/launch-flow.ts` — 3-phase launch flow
+- `frontend/app/view/forge/forge-constants.ts` — agent-card metadata (openclaw at 115-126)
+- `agentmux-srv/forge-seed.json` — seed personas (openclaw at 124-147)
+- `docs/specs/openclaw-agent-runtime.md` — earlier `openclaw tui` integration spec; useful gateway-lifecycle context
+- `docs/specs/openclaw-widget.md` — openclaw web dashboard widget spec (companion, not in scope here)
+- `docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md` — Phase B unified-runner plan (governs §5 / Phase ζ)
+- `docs/specs/SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md` — launch flow + auth pattern reference
+- `docs/specs/provider-auth-isolation.md` — per-provider `{dataDir}/auth/<provider>/` model
+- `docs/specs/SPEC_ACP_CONTROLLER_2026_04_16.md` — ACP controller design

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -753,6 +753,10 @@ class RpcApiType {
             authLoginArgs: string[];
             authCheckArgs: string[];
             authEnv?: Record<string, string>;
+            /** Spawn the login subprocess under a PTY (run_cli_login's
+             *  PTY branch). Required for providers whose auth subcommand
+             *  refuses to run without an interactive TTY (OpenClaw). */
+            requiresTty?: boolean;
         },
         opts?: RpcOpts,
     ): Promise<{ sessionId: string; authUrl?: string }> {

--- a/frontend/app/view/agent/auth/auth-flow-controller.ts
+++ b/frontend/app/view/agent/auth/auth-flow-controller.ts
@@ -41,6 +41,7 @@ export interface AuthRpc {
         authLoginArgs: string[];
         authCheckArgs: string[];
         authEnv?: Record<string, string>;
+        requiresTty?: boolean;
     }): Promise<{ sessionId: string; authUrl?: string }>;
     poll(sessionId: string): Promise<AuthSessionStatusWire>;
     submitCallback(sessionId: string, callbackUrl: string): Promise<void>;
@@ -108,6 +109,11 @@ export interface ProviderCliMeta {
     authLoginArgs: string[];
     authCheckArgs: string[];
     authEnv?: Record<string, string>;
+    /** Spawn the auth login subprocess under a PTY (instead of plain
+     *  piped stdio). Required by providers whose auth subcommand
+     *  refuses to run when `isatty()==0` — currently OpenClaw's
+     *  `models auth login`. Default false for backwards compat. */
+    requiresTty?: boolean;
 }
 
 export interface AuthFlowOptions {
@@ -222,6 +228,7 @@ export class AuthFlowController {
                 authLoginArgs: cli.authLoginArgs,
                 authCheckArgs: cli.authCheckArgs,
                 authEnv: cli.authEnv,
+                requiresTty: cli.requiresTty,
             });
             if (this.actionToken !== myToken) {
                 // The user did something else (selected/cancelled/

--- a/frontend/app/view/agent/commands/global/login.ts
+++ b/frontend/app/view/agent/commands/global/login.ts
@@ -38,7 +38,7 @@ export const loginCommand: SlashCommand = {
                     if (typeof v === "string") authEnv[k] = v;
                 }
             }
-            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv);
+            const url = await getApi().runCliLogin(cliPath, prov.authLoginCommand, authEnv, prov.requiresLoginTty ?? false);
             if (url) {
                 ctx.setAuthUrl(url);
                 ctx.log("auth", "OAuth URL captured — browser should open automatically");

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -180,15 +180,25 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // the blank singleton selected.
     //
     // - `isContinue` bypasses: prior launch already produced creds.
-    // - API-key providers (openclaw/kimi/pi) bypass: until the backend
+    // - API-key providers (kimi/pi) bypass: until the backend
     //   `auth.submitapikey` persists bundles (PR C-2), the gate would
     //   deadlock — the user can't reach `ready` because save is a
     //   stub. Their existing `launch-flow.ts` Phase 2 prompts for the
     //   key in-line. Reagent + codex P1 on #847.
+    // - OpenClaw: even with a non-blank identity selected, no identity
+    //   has been openclaw-authed yet (Phase α addition, 2026-05-17).
+    //   Until identity bundles include openclaw auth profiles, gate
+    //   ALWAYS — the user needs to run the OpenAI OAuth flow before
+    //   `openclaw acp` will spawn. Lifts once identity-bundles-include-
+    //   openclaw lands (planned with Phase δ persistence work).
     const authRequired = () =>
         !isContinue()
         && provider()?.authType === "oauth"
-        && (identityId() === "blank" || identityId() === "");
+        && (
+            identityId() === "blank"
+            || identityId() === ""
+            || provider()?.id === "openclaw"
+        );
     const authReady = () => !authRequired() || authStateKind() === "ready";
     const canSubmit = () =>
         !submitting() && slugifyInstanceName(name()).length > 0 && authReady();

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -80,7 +80,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         const url = s.authUrl;
         if (url && url !== lastOpenedUrl) {
             lastOpenedUrl = url;
-            console.log(`[auth-diag] opening auth URL in browser: ${url}`);
+            console.log(`[auth-diag] opening auth URL in browser (host=${(() => { try { return new URL(url).host; } catch { return "?"; } })()})`);
             try {
                 getApi().openExternal(url);
             } catch (e) {

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -132,7 +132,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         // (= "create new bundle") rather than `"blank"` (= "attach
         // to bundle named blank", which doesn't exist in wstore).
         const bundleArg = id === "blank" ? "" : id;
-        untrack(() => controller.selected(prov.id, bundleArg, outcomeFor(id)));
+        untrack(() => controller.selected(prov.id, bundleArg, outcomeFor(id, prov.id)));
     });
 
     onCleanup(() => {
@@ -201,7 +201,13 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
  *  is deferred to PR B-4 / PR D — for MVP we treat:
  *   - blank singleton → `needs-bundle` (Connect creates new)
  *   - non-blank bundle → `ready` (trust prior auth — old behavior). */
-function outcomeFor(identityId: string): SelectionOutcome {
+function outcomeFor(identityId: string, providerId?: string): SelectionOutcome {
+    // Phase α for openclaw: bundle persistence isn't wired yet, so an
+    // already-selected identity can't be trusted as authenticated. Force
+    // a fresh OAuth on every launch so AgentLaunchModal's openclaw
+    // override actually gates Launch. Lift once Phase δ wires real
+    // bundle storage.
+    if (providerId === "openclaw") return "needs-bundle";
     if (!identityId || identityId === "blank") return "needs-bundle";
     return "ready";
 }

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -67,6 +67,28 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         props.onStateChange(controller.state());
     });
 
+    // Auto-open the OAuth URL in the user's default browser as soon as
+    // the auth controller surfaces it. Same effect as the legacy
+    // launch-flow.ts inline path. The URL also stays visible in the
+    // WaitingPanel below with a Copy button — that's the manual
+    // fallback when the OS doesn't route the open (browser closed,
+    // protocol handler missing, etc.). Fires once per URL (the guard
+    // tracks the last URL we opened so re-renders don't re-fire).
+    let lastOpenedUrl: string | null = null;
+    createEffect(() => {
+        const s = controller.state();
+        const url = s.authUrl;
+        if (url && url !== lastOpenedUrl) {
+            lastOpenedUrl = url;
+            console.log(`[auth-diag] opening auth URL in browser: ${url}`);
+            try {
+                getApi().openExternal(url);
+            } catch (e) {
+                console.warn(`[auth-diag] openExternal failed: ${(e as Error)?.message ?? String(e)}`);
+            }
+        }
+    });
+
     // Forward `succeeded` / `api-key-accepted` to bundle-creation
     // callback so the modal can refresh the bundle list.
     //
@@ -188,7 +210,11 @@ async function startConnect(
     controller: AuthFlowController,
     provider: ProviderDefinition | undefined,
 ): Promise<void> {
-    if (!provider) return;
+    console.log(`[auth-diag] startConnect entry: provider=${provider?.id ?? "(undefined)"} requiresLoginTty=${provider?.requiresLoginTty}`);
+    if (!provider) {
+        console.warn("[auth-diag] startConnect: provider undefined, bailing");
+        return;
+    }
     // Resolve the CLI path via the same RPC `launch-flow.ts` uses.
     // The backend handles "not installed → npm install" so the
     // call returns a valid path or an error.
@@ -207,7 +233,9 @@ async function startConnect(
             { timeout: 120000 },
         );
         cliPath = r.cli_path;
+        console.log(`[auth-diag] ResolveCli ok: cliPath=${cliPath}`);
     } catch (e) {
+        console.error(`[auth-diag] ResolveCli FAILED: ${(e as Error)?.message ?? String(e)}`);
         // Surface the real ResolveCli error in the FailedBanner —
         // reagent P1 on #847: previously this discarded `e` and
         // called connect with an empty cliPath, producing a
@@ -226,7 +254,9 @@ async function startConnect(
         try {
             const authDir = await getApi().ensureAuthDir(provider.id);
             authEnv[provider.authConfigDirEnvVar] = authDir;
+            console.log(`[auth-diag] ensureAuthDir ok: ${provider.authConfigDirEnvVar}=${authDir}`);
         } catch (e) {
+            console.error(`[auth-diag] ensureAuthDir FAILED: ${(e as Error)?.message ?? String(e)}`);
             controller.failConnect(e);
             return;
         }
@@ -237,13 +267,19 @@ async function startConnect(
     // Codex P2 on #854 round 4: bail before connect() if the modal
     // closed mid-prep. The controller itself also gates on `closed`,
     // but skipping the call avoids the extra RPC bookkeeping.
-    if (controller.state().closed) return;
+    if (controller.state().closed) {
+        console.warn("[auth-diag] startConnect: controller closed mid-prep, bailing");
+        return;
+    }
+    console.log(`[auth-diag] calling controller.connect(); kind=${controller.state().kind}`);
     await controller.connect({
         cliPath,
         authLoginArgs: provider.authLoginCommand,
         authCheckArgs: provider.authCheckCommand,
         authEnv,
+        requiresTty: provider.requiresLoginTty ?? false,
     });
+    console.log(`[auth-diag] controller.connect returned; kind=${controller.state().kind}`);
 }
 
 // ── Sub-panels ─────────────────────────────────────────────────────

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -184,6 +184,7 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
                 cliResult.cli_path,
                 provider.authLoginCommand,
                 authEnv ?? {},
+                provider.requiresLoginTty ?? false,
             );
             if (loginUrl) {
                 setAuthUrl(loginUrl);

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -158,7 +158,12 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         // "Login with Gemini", ...) and let the user pick which brain
         // before the OAuth subcommand runs.
         authType: "oauth",
-        authCheckCommand: ["doctor"],
+        // `doctor` is a health/repair command — exits 0 even when no
+        // openai-codex auth profile is registered, which would let
+        // AgentMux skip the OAuth login and launch `openclaw acp`
+        // unauthenticated. List the profiles for the specific provider
+        // instead; exits non-zero when none are configured.
+        authCheckCommand: ["models", "auth", "list", "--provider", "openai-codex"],
         // `cliCommand: "openclaw"` is prefixed by the spawn layer — keep
         // only the args here. Kimi's `["login"]` is the convention.
         authLoginCommand: ["models", "auth", "login", "--provider", "openai-codex"],

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -38,6 +38,12 @@ export interface ProviderDefinition {
     // Launch args for persistent mode (--input-format stream-json, no -p).
     // Only used when controllerType is "persistent".
     persistentLaunchArgs?: string[];
+    // Spawn the auth login subprocess under a PTY (instead of plain
+    // piped stdio). Required by providers whose auth subcommand checks
+    // `isatty()` and refuses to run otherwise — currently OpenClaw's
+    // `openclaw models auth login --provider <id>`. The host's
+    // `run_cli_login` reads this flag and chooses the PTY branch.
+    requiresLoginTty?: boolean;
 }
 
 export const PROVIDERS: Record<string, ProviderDefinition> = {
@@ -121,32 +127,54 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
     },
-    // OpenClaw via gateway daemon (detected if `openclaw` is installed and gateway is running).
-    // Uses acpx as the ACP bridge to the running OpenClaw gateway.
-    // Full OpenClaw features: skills, external messaging channels, memory, multi-agent.
+    // OpenClaw — model-agnostic personal AI assistant from openclaw.ai.
+    // We launch its `openclaw acp` bridge: speaks ACP over stdio (our
+    // side) and forwards turns to OpenClaw's local Gateway daemon over
+    // WebSocket (its side). The Gateway is OpenClaw's own daemon
+    // (`openclaw gateway --port 18789`) and MUST be running before
+    // the bridge can establish a session — onboarding via
+    // `openclaw onboard` covers that on first install.
+    //
+    // OpenClaw is model-agnostic — the backing LLM brain is selected
+    // by the user inside OpenClaw's own config (defaults to Pi; users
+    // can wire Claude, Codex/OpenAI, Gemini, or local models via
+    // `openclaw models auth login --provider <provider>`).
     openclaw: {
         id: "openclaw",
         displayName: "OpenClaw",
-        cliCommand: "acpx",
+        cliCommand: "openclaw",
         defaultArgs: [],
-        styledArgs: ["--agent", "openclaw"],
+        styledArgs: [],
         outputFormat: "acp",
         styledOutputFormat: "acp",
-        authType: "api-key",
-        authCheckCommand: ["openclaw", "doctor"],
-        authLoginCommand: ["openclaw", "onboard"],
-        npmPackage: "@openclaw/acpx",
+        // OAuth-via-subcommand. `openclaw models auth login --provider
+        // openai-codex` runs OpenAI's "Sign in with ChatGPT" flow and
+        // writes the resulting profile under ~/.openclaw/. OpenClaw then
+        // uses that profile to spawn Codex's app-server as the agent's
+        // backing brain (per docs.openclaw.ai/plugins/codex-harness +
+        // SPEC_OPENCLAW_AGENT_2026_05_17.md §4).
+        //
+        // Future Phase: add more provider options ("Login with Claude",
+        // "Login with Gemini", ...) and let the user pick which brain
+        // before the OAuth subcommand runs.
+        authType: "oauth",
+        authCheckCommand: ["doctor"],
+        // `cliCommand: "openclaw"` is prefixed by the spawn layer — keep
+        // only the args here. Kimi's `["login"]` is the convention.
+        authLoginCommand: ["models", "auth", "login", "--provider", "openai-codex"],
+        npmPackage: "openclaw",
         pinnedVersion: "latest",
         docsUrl: "https://docs.openclaw.ai",
-        windowsInstallCommand: "npm install -g @openclaw/acpx",
-        unixInstallCommand: "npm install -g @openclaw/acpx",
+        windowsInstallCommand: "npm install -g openclaw",
+        unixInstallCommand: "npm install -g openclaw",
         icon: "lobster",
         authConfigDirEnvVar: "OPENCLAW_HOME",
         authDirName: "openclaw",
-        launchArgs: ["--agent", "openclaw"],
+        launchArgs: ["acp"],
         resumeFlag: null,
         sessionIdField: "sessionId",
         controllerType: "acp",
+        requiresLoginTty: true,
     },
     // Kimi Code CLI — Moonshot AI's coding agent.
     // Python-based CLI (not npm). Supports stream-json output and OpenAI-style tool calls.

--- a/frontend/app/view/forge/forge-constants.ts
+++ b/frontend/app/view/forge/forge-constants.ts
@@ -6,6 +6,6 @@ export const PROVIDERS = [
     { id: "codex", label: "Codex CLI", cmd: "codex --full-auto" },
     { id: "gemini", label: "Gemini CLI", cmd: "gemini --yolo" },
     { id: "kimi", label: "Kimi Code CLI", cmd: "kimi --print --output-format stream-json" },
-    { id: "openclaw", label: "OpenClaw", cmd: "acpx --agent openclaw" },
+    { id: "openclaw", label: "OpenClaw", cmd: "openclaw acp" },
     { id: "pi", label: "Pi", cmd: "pi --json" },
 ] as const;

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -170,7 +170,7 @@ declare global {
         getCliPath: (provider: string) => Promise<string | null>;
         checkNodejsAvailable: () => Promise<NodejsStatus>;
         ensureAuthDir: (providerId: string) => Promise<string>;
-        runCliLogin: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>) => Promise<string | null>;
+        runCliLogin: (cliPath: string, loginArgs: string[], authEnv: Record<string, string>, requiresTty?: boolean) => Promise<string | null>;
         cancelCliLogin: () => Promise<void>;
         listen: (event: string, callback: (event: any) => void) => Promise<() => void>;
         startCrossDrag: (

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -537,8 +537,8 @@ export function buildCefApi(): AppApi {
         ensureAuthDir: async (providerId: string) => {
             return await invokeCommand<string>("ensure_auth_dir", { providerId });
         },
-        runCliLogin: async (cliPath: string, loginArgs: string[], authEnv: Record<string, string>) => {
-            const result = await invokeCommand<{ auth_url: string | null } | string | null>("run_cli_login", { cliPath, loginArgs, authEnv });
+        runCliLogin: async (cliPath: string, loginArgs: string[], authEnv: Record<string, string>, requiresTty?: boolean) => {
+            const result = await invokeCommand<{ auth_url: string | null } | string | null>("run_cli_login", { cliPath, loginArgs, authEnv, requiresTty: requiresTty ?? false });
             // Backend now returns { auth_url } — extract for callers expecting just a URL
             if (result && typeof result === "object" && "auth_url" in result) {
                 return result.auth_url;


### PR DESCRIPTION
## Summary

OpenClaw's \`models auth login --provider openai-codex\` refuses to run without an interactive TTY, so the existing pipe-based auth subprocess can't drive it. This PR adds a PTY auth code path plus the surrounding wiring needed to actually launch OpenClaw from the agent picker — provider config fix, OAuth-URL detection patterns, browser auto-open, and a \`requiresLoginTty\` flag that threads through the auth-flow plumbing.

## What lands

**Backend**

- \`agentmux-srv/src/backend/providers.rs\` — OpenClaw provider entry: \`cli_command: \"openclaw\"\`, \`launch_args: [\"acp\"]\`, \`npm_package: \"openclaw\"\` (was pointing at non-existent \`acpx\`).
- \`agentmux-srv/src/identity/auth_patterns.rs\` — openclaw is OAuth, not API-key. OAuth-URL + \"Logged in as\" detection patterns + one new unit test.
- \`agentmux-srv/src/server/identity_handlers.rs\` (+265 LOC) — \`spawn_auth_cli_pty\` mirrors the pipe-based spawn but allocates a \`portable_pty\` PTY when the request carries \`requires_tty: true\`. ANSI-stripped output through the same channel.
- \`agentmux-srv/src/backend/blockcontroller/acp.rs\` — comment update for the openclaw=ACP-over-stdio bridge.

**Host (agentmux-cef)**

- New \`portable-pty\` dep.
- \`state.rs::cli_login_stdin\` becomes \`Option<CliLoginStdin>\` (enum \`Pipe(ChildStdin) | Pty(Box<dyn Write + Send>)\`) so callers drive either transport from one field.
- \`commands/platform.rs::run_cli_login_pty\` — PTY-backed login spawn with the same OAuth-URL capture + AUTH_PROMPT detection as the pipe path.
- \`commands/providers.rs::set_provider_auth\` — \`write_line\` over either transport.

**Frontend**

- \`view/agent/providers/index.ts\` — OpenClaw entry: \`requiresLoginTty: true\`, \`authLoginCommand: [\"models\", \"auth\", \"login\", \"--provider\", \"openai-codex\"]\`, \`authCheckCommand: [\"doctor\"]\`, \`launchArgs: [\"acp\"]\`.
- \`AgentLaunchModal.tsx\` — \`authRequired\` always fires for openclaw on first launch.
- \`PreLaunchAuthPanel.tsx\` — auto-open browser via \`getApi().openExternal(authUrl)\` once per URL; URL stays in the panel with a Copy button for the fallback.
- \`auth-flow-controller.ts\` / \`cef-api.ts\` / \`custom.d.ts\` — \`requiresTty\` flag threads through.

## Diag logging (intentional)

\`PreLaunchAuthPanel.tsx\` keeps 11 \`[auth-diag]\` console logs around the connect path. **These are intentional for the in-flight smoke** — once we've verified the OpenClaw OAuth round-trip works on a real build, a follow-up PR will strip them.

## Spec

\`docs/specs/SPEC_OPENCLAW_AGENT_2026_05_17.md\` — design doc covering the codex-harness OAuth flow, ACP bridge wiring, and the deferred Phase β polish.

## Test plan

- [ ] OpenClaw appears in the agent picker with correct icon/description
- [ ] Click the card on a fresh install → install modal runs npm install of \`openclaw\`
- [ ] Post-install → launch modal opens with \`Login with OpenAI\` CTA
- [ ] Click Connect → browser auto-opens to the Codex OAuth URL; the URL also renders in the panel with Copy
- [ ] Complete OAuth in browser → panel transitions to \`Connected as <email>\`
- [ ] Launch → \`openclaw acp\` spawns, ACP controller takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)