### PR TITLE
fix(install-modal) + feat(picker): styled modal + xterm.js + install ribbon

### DIFF
--- a/.changesets/1779058361-fix-install-modal-add-missing-scss-modal-was-collapsing-to-i-u43p.md
+++ b/.changesets/1779058361-fix-install-modal-add-missing-scss-modal-was-collapsing-to-i-u43p.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(install-modal): add missing SCSS, modal was collapsing to intrinsic size

--- a/frontend/app/view/agent/agent-view.scss
+++ b/frontend/app/view/agent/agent-view.scss
@@ -9,6 +9,7 @@
 @use "styles/tool-overlay-portal";
 @use "styles/identity-panel";
 @use "styles/launch-modal-body";
+@use "styles/install-modal";
 @use "styles/import-modal-body";
 @use "styles/picker-delete-error";
 @use "styles/card-info-popover";

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -8,74 +8,32 @@
  * by the CLI catalog, not by the ForgeAgent row's user-facing fields.
  * Title reads as a capability blurb ("Anthropic's coding agent") and
  * the CLI brand name sits as a caption below. Clicking the body opens
- * the Launch modal instead of launching directly.
+ * the Launch modal (or Install modal if the CLI isn't installed yet).
  *
- * The ⓘ button uses the Popover primitive (PR F of the definitions
- * spec) so users get the catalog's full CLI deep-dive text — startup
- * flow, MCP support, memory behaviour — on click, rather than a
- * native tooltip truncated by the OS.
- *
- * The card is rendered as a <div role="button"> rather than <button>
- * so nested action buttons are valid HTML (buttons can't contain
- * buttons).
+ * When `installed === false`, a bottom-right "Click to install" ribbon
+ * is overlaid on the card — like a "For Sale" sign. The ribbon
+ * disappears once installation succeeds (parent re-runs install.check
+ * after the install modal closes).
  */
 
-import { createMemo, Show, useContext, type Component, type JSX } from "solid-js";
-import { Popover, PopoverContext, PopoverContent } from "@/element/popover";
+import { Show, type JSX } from "solid-js";
 import { ProviderLogo } from "@/element/ProviderLogo";
-import { getCliCatalogEntry } from "../defaults/cli-catalog";
 
 interface AgentCardProps {
     agent: ForgeAgent;
     launching: boolean;
     disabled: boolean;
-    /** Opens the AgentLaunchModal for this definition. */
+    /** undefined = not yet checked / non-npm provider (no install needed).
+     *  true = CLI present in the per-version cache.
+     *  false = needs install — render the bottom-right ribbon. */
+    installed: boolean | undefined;
+    /** Opens the AgentLaunchModal (or Install modal) for this definition. */
     onLaunch: (agent: ForgeAgent) => void;
-    /** Opens the inline settings panel (Forge tab). */
-    onOpenForge: (agent: ForgeAgent) => void;
-    /** Called when the user clicks the 🗑 delete button. Caller is
-     *  responsible for confirmation + the `DeleteForgeAgent` RPC. */
-    onDelete: (agent: ForgeAgent) => void;
 }
 
-/**
- * The ⓘ trigger. Custom trigger (not `PopoverButton`) so we keep
- * the existing `agent-card-action-btn` chrome instead of inheriting
- * the default `Button` styling. Uses `PopoverContext` directly.
- */
-const InfoPopoverTrigger: Component<{ ariaLabel: string }> = (props) => {
-    const ctx = useContext(PopoverContext);
-    return (
-        <button
-            ref={(el) => ctx?.registerReference(el)}
-            class="agent-card-action-btn agent-card-action-btn--info"
-            classList={{ "agent-card-action-btn--open": ctx?.isOpen() }}
-            onClick={(e) => {
-                e.stopPropagation();
-                ctx?.togglePopover();
-            }}
-            type="button"
-            aria-label={props.ariaLabel}
-            aria-expanded={ctx?.isOpen()}
-        >
-            {"\u24D8"}
-        </button>
-    );
-};
-
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
-    const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
-
-    const title = () => catalog()?.blurb || props.agent.description || props.agent.name;
-    const caption = () => catalog()?.displayName || props.agent.name;
-    const popoverText = () => catalog()?.popoverMarkdown ?? props.agent.description ?? "";
-    const primaryContextFile = () => catalog()?.primaryContextFile ?? "";
-    const mcpSupport = () => catalog()?.mcpSupport ?? "";
-
-    const stopAndRun = (fn: () => void) => (e: MouseEvent) => {
-        e.stopPropagation();
-        fn();
-    };
+    const title = () => props.agent.description || props.agent.name;
+    const caption = () => props.agent.name;
 
     const handleCardClick = () => {
         if (!props.disabled) props.onLaunch(props.agent);
@@ -92,7 +50,10 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
     return (
         <div
             class={`agent-card${props.launching ? " agent-card--launching" : ""}`}
-            classList={{ "agent-card--disabled": props.disabled }}
+            classList={{
+                "agent-card--disabled": props.disabled,
+                "agent-card--needs-install": props.installed === false,
+            }}
             onClick={handleCardClick}
             onKeyDown={handleKeyDown}
             role="button"
@@ -105,47 +66,11 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
                 <span class="agent-card-title">{title()}</span>
                 <span class="agent-card-caption">{caption()}</span>
             </span>
-            <div class="agent-card-actions" onClick={(e) => e.stopPropagation()}>
-                <Show when={popoverText()}>
-                    <Popover placement="right-start" offset={8}>
-                        <InfoPopoverTrigger ariaLabel={`About ${caption()}`} />
-                        <PopoverContent className="agent-card-info-popover">
-                            <div class="agent-card-info-popover-title">{caption()}</div>
-                            <Show when={primaryContextFile()}>
-                                <div class="agent-card-info-popover-meta">
-                                    <span class="agent-card-info-popover-label">Context file</span>
-                                    <code>{primaryContextFile()}</code>
-                                </div>
-                            </Show>
-                            <Show when={mcpSupport() && mcpSupport() !== "none"}>
-                                <div class="agent-card-info-popover-meta">
-                                    <span class="agent-card-info-popover-label">MCP</span>
-                                    <code>{mcpSupport()}</code>
-                                </div>
-                            </Show>
-                            <div class="agent-card-info-popover-body">{popoverText()}</div>
-                        </PopoverContent>
-                    </Popover>
-                </Show>
-                <button
-                    class="agent-card-action-btn"
-                    onClick={stopAndRun(() => props.onOpenForge(props.agent))}
-                    title="Configure this definition in the Forge"
-                    disabled={props.disabled}
-                    type="button"
-                >
-                    {"\u2699"}
-                </button>
-                <button
-                    class="agent-card-action-btn agent-card-action-btn--delete"
-                    onClick={stopAndRun(() => props.onDelete(props.agent))}
-                    title="Delete this definition"
-                    disabled={props.disabled}
-                    type="button"
-                >
-                    {"\uD83D\uDDD1"}
-                </button>
-            </div>
+            <Show when={props.installed === false}>
+                <span class="agent-card-install-ribbon" aria-hidden="true">
+                    Click to install
+                </span>
+            </Show>
             <Show when={props.launching}>
                 <span class="agent-card-spinner" />
             </Show>

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -4,20 +4,24 @@
 /**
  * AgentCard — a definition tile in the agent picker.
  *
- * After SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23 the card is driven
- * by the CLI catalog, not by the ForgeAgent row's user-facing fields.
- * Title reads as a capability blurb ("Anthropic's coding agent") and
- * the CLI brand name sits as a caption below. Clicking the body opens
- * the Launch modal (or Install modal if the CLI isn't installed yet).
+ * Per SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23 the card is driven
+ * by the CLI catalog when one exists for the provider — title reads
+ * as a capability blurb ("Anthropic's coding agent") and the CLI
+ * brand name ("Claude Code") sits as a caption below. Providers
+ * without a catalog entry fall back to the ForgeAgent row's own
+ * description/name fields.
  *
- * When `installed === false`, a bottom-right "Click to install" ribbon
- * is overlaid on the card — like a "For Sale" sign. The ribbon
- * disappears once installation succeeds (parent re-runs install.check
- * after the install modal closes).
+ * Clicking the body opens the Launch modal (or Install modal if
+ * the CLI isn't installed yet). When `installed === false`, a
+ * bottom-right "Click to install" ribbon is overlaid on the card —
+ * like a "For Sale" sign. The ribbon disappears once installation
+ * succeeds (parent re-runs install.check after the install modal
+ * closes).
  */
 
-import { Show, type JSX } from "solid-js";
+import { createMemo, Show, type JSX } from "solid-js";
 import { ProviderLogo } from "@/element/ProviderLogo";
+import { getCliCatalogEntry } from "../defaults/cli-catalog";
 
 interface AgentCardProps {
     agent: ForgeAgent;
@@ -32,8 +36,9 @@ interface AgentCardProps {
 }
 
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
-    const title = () => props.agent.description || props.agent.name;
-    const caption = () => props.agent.name;
+    const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
+    const title = () => catalog()?.blurb || props.agent.description || props.agent.name;
+    const caption = () => catalog()?.displayName || props.agent.name;
 
     const handleCardClick = () => {
         if (!props.disabled) props.onLaunch(props.agent);

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -209,7 +209,7 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
 
     const elapsedLabel = () => {
         const s = Math.floor(elapsedMs() / 1000);
-        const mm = Math.floor(s / 60).toString().padStart(1, "0");
+        const mm = Math.floor(s / 60).toString();
         const ss = (s % 60).toString().padStart(2, "0");
         return `${mm}:${ss}`;
     };

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -28,7 +28,11 @@ import { waveEventSubscribe } from "@/app/store/wps";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { getProvider } from "../providers";
-import "@xterm/xterm/css/xterm.css";
+// Use the project's customized xterm.css copy (same one term.tsx
+// imports) rather than the raw package stylesheet. The package CSS
+// loads later in the bundle and would override our project-wide
+// terminal theme tweaks.
+import "../../term/xterm.css";
 
 interface AgentInstallModalPanelProps {
     agent: ForgeAgent;

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -54,6 +54,7 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     let termRef: HTMLDivElement | undefined;
     let terminal: Terminal | null = null;
     let fitAddon: FitAddon | null = null;
+    let resizeObserver: ResizeObserver | null = null;
     let startedAt = 0;
     let tickHandle: ReturnType<typeof setInterval> | null = null;
     // Flipped in onCleanup so a startInstall awaiting the RPC response
@@ -164,11 +165,19 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
         terminal.open(termRef);
-        try {
-            fitAddon.fit();
-        } catch {
-            /* container may still be 0×0 — fit again on first resize */
-        }
+        const tryFit = () => {
+            try {
+                fitAddon?.fit();
+            } catch {
+                /* container still 0×0 — wait for next resize */
+            }
+        };
+        tryFit();
+        // Refit on container resize. The modal may animate in from
+        // 0×0; without an observer the terminal stays at the default
+        // 80×24 indefinitely.
+        resizeObserver = new ResizeObserver(() => tryFit());
+        resizeObserver.observe(termRef);
         terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
     });
 
@@ -181,6 +190,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         if (tickHandle != null) {
             clearInterval(tickHandle);
             tickHandle = null;
+        }
+        if (resizeObserver) {
+            resizeObserver.disconnect();
+            resizeObserver = null;
         }
         if (terminal) {
             terminal.dispose();

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -3,23 +3,23 @@
 
 /**
  * AgentInstallModalPanel — modal that runs an agent's install recipe
- * and shows live output. Opens when the user picks an agent whose CLI
- * isn't already in the per-version cache. Sibling to
- * `AgentLaunchModalPanel`.
+ * and shows live output in an xterm.js terminal. Opens when the user
+ * picks an agent whose CLI isn't already in the per-version cache.
+ * Sibling to `AgentLaunchModalPanel`.
  *
  * Phase α (SPEC_AGENT_INSTALL_STAGE_2026_05_17.md §11): single-step
  * recipe (just `npm install <package>`) streamed line-by-line via the
- * `install.start` RPC. The visual surface is a scrollable `<pre>` for
- * v1 — xterm.js upgrade lands in Phase β. Cancel kills the install +
- * removes the partial dir.
+ * `install.start` RPC. Cancel kills the install + removes the partial
+ * dir.
  *
- * Re-click idempotency: the modal owns the install lifecycle. While a
- * session is in flight, opening this modal again (re-click on the
- * picker card) re-focuses the existing modal instead of starting a
- * second install.
+ * UX: modal opens in `idle` state with a "Click to install" CTA at the
+ * bottom-right. Clicking starts the install; the CTA goes away and the
+ * xterm renders npm's output (ANSI colors preserved).
  */
 
 import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
 
 import { Button } from "@/element/button";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -28,16 +28,12 @@ import { waveEventSubscribe } from "@/app/store/wps";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { getProvider } from "../providers";
+import "@xterm/xterm/css/xterm.css";
 
 interface AgentInstallModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
     onInstalled: () => void;
-}
-
-interface InstallChunk {
-    line: string;
-    stream: "stdout" | "stderr";
 }
 
 export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.Element => {
@@ -46,32 +42,27 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     const displayName = () => catalog()?.displayName ?? props.agent.name;
 
     const [phase, setPhase] = createSignal<"idle" | "installing" | "done" | "failed">("idle");
-    const [chunks, setChunks] = createSignal<InstallChunk[]>([]);
     const [error, setError] = createSignal<string | null>(null);
     const [sessionId, setSessionId] = createSignal<string | null>(null);
     const [elapsedMs, setElapsedMs] = createSignal(0);
 
     let unsub: (() => void) | null = null;
-    let preRef: HTMLPreElement | undefined;
+    let termRef: HTMLDivElement | undefined;
+    let terminal: Terminal | null = null;
+    let fitAddon: FitAddon | null = null;
     let startedAt = 0;
     let tickHandle: ReturnType<typeof setInterval> | null = null;
     // Flipped in onCleanup so a startInstall awaiting the RPC response
     // can cancel the resolved session id even if it landed after unmount.
     let disposed = false;
 
-    const appendChunk = (chunk: InstallChunk) => {
-        setChunks((prev) => {
-            const next = prev.concat(chunk);
-            // Cap scrollback so very chatty installs don't drag the
-            // renderer. 2000 lines is enough for typical npm output;
-            // last-N is what the user needs anyway.
-            if (next.length > 2000) return next.slice(next.length - 2000);
-            return next;
-        });
-        // Auto-scroll to bottom.
-        queueMicrotask(() => {
-            if (preRef) preRef.scrollTop = preRef.scrollHeight;
-        });
+    const writeTerm = (line: string, stream: "stdout" | "stderr") => {
+        if (!terminal) return;
+        if (stream === "stderr") {
+            terminal.write(`\x1b[31m${line}\x1b[0m\r\n`);
+        } else {
+            terminal.write(`${line}\r\n`);
+        }
     };
 
     const startInstall = async () => {
@@ -81,10 +72,7 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             setPhase("failed");
             return;
         }
-        // Tear down any prior run (Retry path) before reassigning —
-        // otherwise the previous setInterval keeps ticking + the
-        // previous WPS subscription stays active for the rest of the
-        // component's life.
+        // Tear down any prior run (Retry path).
         if (unsub) {
             unsub();
             unsub = null;
@@ -93,8 +81,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             clearInterval(tickHandle);
             tickHandle = null;
         }
+        if (terminal) {
+            terminal.clear();
+        }
         setPhase("installing");
-        setChunks([]);
         setError(null);
         startedAt = Date.now();
         tickHandle = setInterval(() => setElapsedMs(Date.now() - startedAt), 250);
@@ -105,9 +95,8 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 npmPackage: prov.npmPackage,
                 pinnedVersion: prov.pinnedVersion,
             });
-            // If the modal unmounted while the RPC was in flight, the
-            // backend now owns a live session our cleanup couldn't
-            // cancel (sessionId was null). Cancel it explicitly here.
+            // If the modal unmounted while the RPC was in flight, cancel
+            // the resolved session id rather than subscribing.
             if (disposed) {
                 void RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: r.sessionId }).catch(() => {
                     /* best-effort */
@@ -122,16 +111,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                     const data = event?.data;
                     if (!data || typeof data !== "object") return;
                     if (typeof data.line === "string") {
-                        appendChunk({
-                            line: data.line,
-                            stream: data.stream === "stderr" ? "stderr" : "stdout",
-                        });
+                        writeTerm(data.line, data.stream === "stderr" ? "stderr" : "stdout");
                     } else if (data.op === "done") {
                         if (data.ok) {
                             setPhase("done");
-                            // Auto-close + chain to launch modal one
-                            // frame later so the user sees the "done"
-                            // state briefly.
                             queueMicrotask(() => props.onInstalled());
                         } else {
                             setError(data.error ?? "install failed");
@@ -159,7 +142,30 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     };
 
     onMount(() => {
-        void startInstall();
+        // Lazy-create the terminal so it doesn't render before the
+        // container has a layout size (FitAddon needs a real rect).
+        if (!termRef) return;
+        terminal = new Terminal({
+            cursorBlink: false,
+            scrollback: 5000,
+            fontSize: 12,
+            fontFamily: "var(--fixed-font, monospace)",
+            theme: {
+                background: "#0d0e0f",
+                foreground: "#cccccc",
+            },
+            convertEol: false,
+            scrollOnUserInput: false,
+        });
+        fitAddon = new FitAddon();
+        terminal.loadAddon(fitAddon);
+        terminal.open(termRef);
+        try {
+            fitAddon.fit();
+        } catch {
+            /* container may still be 0×0 — fit again on first resize */
+        }
+        terminal.writeln("\x1b[90m# Click \"Install now\" to begin.\x1b[0m");
     });
 
     onCleanup(() => {
@@ -172,11 +178,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             clearInterval(tickHandle);
             tickHandle = null;
         }
-        // Catch implicit closes (Esc, backdrop click, tab switch)
-        // while installing. The Cancel button itself goes through
-        // `cancel()`. If the modal unmounts *before* InstallStartCommand
-        // resolves, the `disposed` flag above lets the in-flight start
-        // path issue the cancel once the session id arrives.
+        if (terminal) {
+            terminal.dispose();
+            terminal = null;
+        }
         const sid = sessionId();
         if (sid && phase() === "installing") {
             void RpcApi.InstallCancelCommand(TabRpcClient, { sessionId: sid }).catch(() => {
@@ -193,58 +198,54 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     };
 
     return (
-        <div class="agent-install-modal-panel">
-            <div class="agent-install-modal-header">
-                <span class="agent-install-modal-icon" aria-hidden="true">
-                    {catalog()?.icon ?? "📦"}
-                </span>
-                <span class="agent-install-modal-title">Install {displayName()}</span>
-                <span class="agent-install-modal-status">
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">
+                    <span class="agent-install-modal-icon" aria-hidden="true">
+                        {catalog()?.icon ?? "📦"}
+                    </span>
+                    Install {displayName()}
+                </h2>
+                <p class="modal-panel-description">
+                    <Show when={phase() === "idle"}>not installed — click below to install</Show>
                     <Show when={phase() === "installing"}>
-                        <span class="agent-install-modal-spinner">⏳</span>
-                        Installing… {elapsedLabel()}
+                        <span class="agent-install-modal-spinner">⏳</span> Installing… {elapsedLabel()}
                     </Show>
                     <Show when={phase() === "done"}>
-                        <span class="agent-install-modal-ok">✓</span>
-                        Installed
+                        <span class="agent-install-modal-ok">✓</span> Installed
                     </Show>
                     <Show when={phase() === "failed"}>
-                        <span class="agent-install-modal-fail">✗</span>
-                        Failed
+                        <span class="agent-install-modal-fail">✗</span> Failed
                     </Show>
-                </span>
+                </p>
+            </header>
+            <div class="modal-panel-body agent-install-modal-body">
+                <div class="agent-install-modal-term" ref={termRef} />
+                <Show when={error()}>
+                    <div class="agent-install-modal-error">⚠ {error()}</div>
+                </Show>
             </div>
-            <pre class="agent-install-modal-log" ref={preRef}>
-                {chunks().map((c) => (
-                    <span
-                        classList={{
-                            "agent-install-modal-line": true,
-                            "agent-install-modal-line--stderr": c.stream === "stderr",
-                        }}
-                    >
-                        {c.line}
-                        {"\n"}
-                    </span>
-                ))}
-            </pre>
-            <Show when={error()}>
-                <div class="agent-install-modal-error">⚠ {error()}</div>
-            </Show>
-            <div class="agent-install-modal-actions">
+            <footer class="modal-panel-footer">
+                <Show when={phase() === "idle"}>
+                    <Button onClick={() => props.onCancel()}>Cancel</Button>
+                    <Button onClick={() => void startInstall()} className="green solid">
+                        Install now
+                    </Button>
+                </Show>
                 <Show when={phase() === "installing"}>
                     <Button onClick={() => void cancel()}>Cancel</Button>
                 </Show>
                 <Show when={phase() === "failed"}>
+                    <Button onClick={() => props.onCancel()}>Close</Button>
                     <Button onClick={() => void startInstall()} className="green solid">
                         Retry
                     </Button>
-                    <Button onClick={() => props.onCancel()}>Close</Button>
                 </Show>
                 <Show when={phase() === "done"}>
                     <span class="agent-install-modal-launching">Opening launch modal…</span>
                 </Show>
-            </div>
-        </div>
+            </footer>
+        </>
     );
 };
 

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -130,18 +130,31 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // (getCliPath), so a rapid double-click could open two modals (and
     // start two parallel installs) without it. The pendingSelect set
     // tracks in-flight resolutions per agent id and rejects re-entry.
-    const handleSelect = (agent: ForgeAgent) => {
+    const handleSelect = async (agent: ForgeAgent) => {
         setNodejsError(null);
-        // Use the cached install state. `undefined` = non-npm provider
-        // or not-yet-checked; either way fall through to launch flow.
-        const installed = installState()[agent.id];
+        let installed = installState()[agent.id];
+
+        // If the bg check hasn't populated state yet (initial render
+        // race, slow IPC, freshly added definition), block on a sync
+        // probe for npm-backed providers before deciding the path.
+        // Without this, an unchecked npm agent would fall through to
+        // openLaunchModal and the launch would write a per-version
+        // `.bin` path that doesn't exist on disk.
+        if (installed === undefined) {
+            const prov = getProvider(agent.provider);
+            const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
+            if (isNpmInstallable) {
+                await checkInstalled(agent);
+                installed = installState()[agent.id];
+            }
+        }
+
         if (installed === false) {
             tabModal.open({
                 kind: "install-agent",
                 agent,
                 originBlockId: props.model.blockId,
                 onInstalled: () => {
-                    // Mark installed + refresh state for the ribbon.
                     setInstallState((s) => ({ ...s, [agent.id]: true }));
                     openLaunchModal(agent);
                 },

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -125,11 +125,6 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // the tab-scoped layer, depending on whether the agent's CLI is
     // already installed in the per-version cache. Phase α of
     // SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
-    //
-    // Concurrency guard: handleSelect awaits an IPC round-trip
-    // (getCliPath), so a rapid double-click could open two modals (and
-    // start two parallel installs) without it. The pendingSelect set
-    // tracks in-flight resolutions per agent id and rejects re-entry.
     const handleSelect = async (agent: ForgeAgent) => {
         setNodejsError(null);
         let installed = installState()[agent.id];

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -125,7 +125,18 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // the tab-scoped layer, depending on whether the agent's CLI is
     // already installed in the per-version cache. Phase α of
     // SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
+    //
+    // Re-entry guard: handleSelect awaits an IPC round-trip when
+    // install state is still undefined. Without the in-flight set,
+    // a double-click during the await would spawn two install
+    // modals — the second mount replaces the first, and its
+    // onCleanup fires `install.cancel` on the session the first one
+    // had just kicked off.
+    const pendingSelect = new Set<string>();
     const handleSelect = async (agent: ForgeAgent) => {
+        if (pendingSelect.has(agent.id)) return;
+        pendingSelect.add(agent.id);
+        try {
         setNodejsError(null);
         let installed = installState()[agent.id];
 
@@ -171,6 +182,9 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             return;
         }
         openLaunchModal(agent);
+        } finally {
+            pendingSelect.delete(agent.id);
+        }
     };
 
     const busy = () => launching() !== null;

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -10,7 +10,7 @@
  * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md.
  */
 
-import { createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -18,10 +18,8 @@ import { useTabModal } from "@/app/tab/tab-modal";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
-import { AgentCardSettingsPanel } from "./AgentCardSettingsPanel";
 import { AgentActionBar } from "./AgentActionBar";
 import type { LaunchOverrides } from "./AgentLaunchModal";
-import { ConfirmModal } from "@/element/modal-v2";
 
 // ── useForgeAgents hook ───────────────────────────────────────────────────────
 
@@ -69,14 +67,34 @@ interface AgentPickerProps {
 export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const [launching, setLaunching] = createSignal<string | null>(null);
     const [nodejsError, setNodejsError] = createSignal<string | null>(null);
-    const [deleteCandidate, setDeleteCandidate] = createSignal<ForgeAgent | null>(null);
-    const [deleteError, setDeleteError] = createSignal<string | null>(null);
     const agents = useForgeAgents();
     const tabModal = useTabModal();
 
-    // Inline Forge-settings panel: which definition is expanded.
-    // Session-local only — not persisted to block meta.
-    const [expandedId, setExpandedId] = createSignal<string | null>(null);
+    // Per-agent install state, keyed by agent.id.
+    //   undefined = not yet checked / non-npm provider (no install needed)
+    //   true      = present in the per-version cache
+    //   false     = needs install — card shows the bottom-right ribbon
+    const [installState, setInstallState] = createSignal<Record<string, boolean | undefined>>({});
+
+    const checkInstalled = async (agent: ForgeAgent) => {
+        const prov = getProvider(agent.provider);
+        // Non-npm providers (kimi via pip, system-PATH CLIs) don't go
+        // through the install modal — never show the ribbon.
+        if (!prov?.npmPackage || prov.npmPackage.length === 0) {
+            setInstallState((s) => ({ ...s, [agent.id]: undefined }));
+            return;
+        }
+        try {
+            const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
+                providerId: prov.id,
+                cliCommand: prov.cliCommand,
+            });
+            setInstallState((s) => ({ ...s, [agent.id]: r.installed }));
+        } catch {
+            // Treat as needs-install — better to over-prompt than miss.
+            setInstallState((s) => ({ ...s, [agent.id]: false }));
+        }
+    };
 
     // Open the launch modal. Extracted so the install-modal path can
     // chain into it after a successful install.
@@ -112,93 +130,37 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // (getCliPath), so a rapid double-click could open two modals (and
     // start two parallel installs) without it. The pendingSelect set
     // tracks in-flight resolutions per agent id and rejects re-entry.
-    const pendingSelect = new Set<string>();
-    const handleSelect = async (agent: ForgeAgent) => {
-        if (pendingSelect.has(agent.id)) return;
-        pendingSelect.add(agent.id);
-        try {
-            setNodejsError(null);
-            // Phase α only handles npm-installable providers. For
-            // providers without `npmPackage` (e.g. kimi via pip, system-
-            // PATH CLIs), fall through to the launch flow — its
-            // ResolveCliCommand already does the system-PATH search.
-            const prov = getProvider(agent.provider);
-            // Use the canonical provider id for the path probe — the
-            // saved agent definition may carry an alias like
-            // "claude-code" while install.start writes under "claude".
-            const canonicalProviderId = prov?.id ?? agent.provider;
-            const cliCommand = prov?.cliCommand ?? agent.provider;
-            const npmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
-            // Query the backend's per-version install dir (the same
-            // location `install.start` writes to). The CEF host's
-            // getCliPath probes a different path and would falsely
-            // report "not installed" for npm-cached providers, causing
-            // a re-install on every launch.
-            let installed = false;
-            if (npmInstallable) {
-                try {
-                    const r = await RpcApi.InstallCheckCommand(TabRpcClient, {
-                        providerId: canonicalProviderId,
-                        cliCommand,
-                    });
-                    installed = r.installed;
-                } catch {
-                    installed = false;
-                }
-            } else {
-                // Non-npm provider — launch flow will resolve via
-                // system PATH or report a missing-CLI error.
-                installed = true;
-            }
-            if (!installed) {
-                tabModal.open({
-                    kind: "install-agent",
-                    agent,
-                    originBlockId: props.model.blockId,
-                    onInstalled: () => openLaunchModal(agent),
-                });
-                return;
-            }
-            openLaunchModal(agent);
-        } finally {
-            pendingSelect.delete(agent.id);
+    const handleSelect = (agent: ForgeAgent) => {
+        setNodejsError(null);
+        // Use the cached install state. `undefined` = non-npm provider
+        // or not-yet-checked; either way fall through to launch flow.
+        const installed = installState()[agent.id];
+        if (installed === false) {
+            tabModal.open({
+                kind: "install-agent",
+                agent,
+                originBlockId: props.model.blockId,
+                onInstalled: () => {
+                    // Mark installed + refresh state for the ribbon.
+                    setInstallState((s) => ({ ...s, [agent.id]: true }));
+                    openLaunchModal(agent);
+                },
+            });
+            return;
         }
-    };
-
-    const openForgeFor = (agent: ForgeAgent) => {
-        // Toggle the inline settings panel for this definition.
-        setExpandedId((prev) => (prev === agent.id ? null : agent.id));
-    };
-
-    const closePanel = () => {
-        setExpandedId(null);
-    };
-
-    /**
-     * Stage a Forge definition for deletion — the actual delete runs
-     * via `handleDeleteConfirm` when the user confirms in the modal.
-     * The backend `DeleteForgeAgent` RPC removes the row and emits a
-     * `forgeagents:changed` event, which `useForgeAgents` re-fetches
-     * on — so the list updates without manual refresh.
-     */
-    const handleDelete = (agent: ForgeAgent) => {
-        setDeleteError(null);
-        setDeleteCandidate(agent);
-    };
-
-    const handleDeleteConfirm = async () => {
-        const agent = deleteCandidate();
-        if (!agent) return;
-        try {
-            await RpcApi.DeleteForgeAgentCommand(TabRpcClient, { id: agent.id });
-            setDeleteCandidate(null);
-        } catch (e: any) {
-            setDeleteError(e?.message ?? String(e));
-            // Leave the modal open so the user sees the error.
-        }
+        openLaunchModal(agent);
     };
 
     const busy = () => launching() !== null;
+
+    // Refresh install state whenever the agent list changes.
+    createEffect(() => {
+        for (const agent of agents()) {
+            if (!(agent.id in installState())) {
+                void checkInstalled(agent);
+            }
+        }
+    });
 
     return (
         <>
@@ -222,25 +184,13 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         <div class="agent-picker-list">
                             <For each={agents()}>
                                 {(agent) => (
-                                    <>
-                                        <AgentCard
-                                            agent={agent}
-                                            launching={launching() === agent.id}
-                                            disabled={busy()}
-                                            onLaunch={handleSelect}
-                                            onOpenForge={openForgeFor}
-                                            onDelete={handleDelete}
-                                        />
-                                        <Show when={expandedId() === agent.id}>
-                                            <AgentCardSettingsPanel
-                                                blockId={props.model.blockId}
-                                                nodeModel={props.model.nodeModel}
-                                                agent={agent}
-                                                initialTab="forge"
-                                                onClose={closePanel}
-                                            />
-                                        </Show>
-                                    </>
+                                    <AgentCard
+                                        agent={agent}
+                                        launching={launching() === agent.id}
+                                        disabled={busy()}
+                                        installed={installState()[agent.id]}
+                                        onLaunch={handleSelect}
+                                    />
                                 )}
                             </For>
                         </div>
@@ -261,28 +211,6 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     </div>
                     <AgentActionBar />
                 </div>
-            </Show>
-            <Show when={deleteCandidate()}>
-                {(agent) => (
-                    <ConfirmModal
-                        open={true}
-                        title={`Delete definition "${agent().name}"?`}
-                        description="This removes it permanently. Any open panes running instances of it will stay connected until you close them."
-                        confirmLabel="Delete"
-                        destructive
-                        onConfirm={handleDeleteConfirm}
-                        onCancel={() => {
-                            setDeleteCandidate(null);
-                            setDeleteError(null);
-                        }}
-                    >
-                        <Show when={deleteError()}>
-                            <div class="agent-picker-delete-error">
-                                Delete failed: {deleteError()}
-                            </div>
-                        </Show>
-                    </ConfirmModal>
-                )}
             </Show>
         </>
     );

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -137,51 +137,51 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         if (pendingSelect.has(agent.id)) return;
         pendingSelect.add(agent.id);
         try {
-        setNodejsError(null);
-        let installed = installState()[agent.id];
+            setNodejsError(null);
+            let installed = installState()[agent.id];
 
-        // If the bg check hasn't populated state yet (initial render
-        // race, slow IPC, freshly added definition), block on a sync
-        // probe for npm-backed providers before deciding the path.
-        // Without this, an unchecked npm agent would fall through to
-        // openLaunchModal and the launch would write a per-version
-        // `.bin` path that doesn't exist on disk.
-        if (installed === undefined) {
-            const prov = getProvider(agent.provider);
-            const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
-            if (isNpmInstallable) {
-                await checkInstalled(agent);
-                installed = installState()[agent.id];
+            // If the bg check hasn't populated state yet (initial render
+            // race, slow IPC, freshly added definition), block on a sync
+            // probe for npm-backed providers before deciding the path.
+            // Without this, an unchecked npm agent would fall through to
+            // openLaunchModal and the launch would write a per-version
+            // `.bin` path that doesn't exist on disk.
+            if (installed === undefined) {
+                const prov = getProvider(agent.provider);
+                const isNpmInstallable = !!prov?.npmPackage && prov.npmPackage.length > 0;
+                if (isNpmInstallable) {
+                    await checkInstalled(agent);
+                    installed = installState()[agent.id];
+                }
             }
-        }
 
-        if (installed === false) {
-            tabModal.open({
-                kind: "install-agent",
-                agent,
-                originBlockId: props.model.blockId,
-                onInstalled: () => {
-                    // install.start runs at provider scope, so every
-                    // ForgeAgent definition that resolves to the same
-                    // canonical provider is now installed — not just
-                    // the one the user clicked. Mark all of them so
-                    // sibling cards drop their ribbon too.
-                    const canonical = getProvider(agent.provider)?.id ?? agent.provider;
-                    setInstallState((s) => {
-                        const next = { ...s };
-                        for (const a of agents()) {
-                            if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
-                                next[a.id] = true;
+            if (installed === false) {
+                tabModal.open({
+                    kind: "install-agent",
+                    agent,
+                    originBlockId: props.model.blockId,
+                    onInstalled: () => {
+                        // install.start runs at provider scope, so every
+                        // ForgeAgent definition that resolves to the same
+                        // canonical provider is now installed — not just
+                        // the one the user clicked. Mark all of them so
+                        // sibling cards drop their ribbon too.
+                        const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+                        setInstallState((s) => {
+                            const next = { ...s };
+                            for (const a of agents()) {
+                                if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                                    next[a.id] = true;
+                                }
                             }
-                        }
-                        return next;
-                    });
-                    openLaunchModal(agent);
-                },
-            });
-            return;
-        }
-        openLaunchModal(agent);
+                            return next;
+                        });
+                        openLaunchModal(agent);
+                    },
+                });
+                return;
+            }
+            openLaunchModal(agent);
         } finally {
             pendingSelect.delete(agent.id);
         }

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -155,7 +155,21 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 agent,
                 originBlockId: props.model.blockId,
                 onInstalled: () => {
-                    setInstallState((s) => ({ ...s, [agent.id]: true }));
+                    // install.start runs at provider scope, so every
+                    // ForgeAgent definition that resolves to the same
+                    // canonical provider is now installed — not just
+                    // the one the user clicked. Mark all of them so
+                    // sibling cards drop their ribbon too.
+                    const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+                    setInstallState((s) => {
+                        const next = { ...s };
+                        for (const a of agents()) {
+                            if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                                next[a.id] = true;
+                            }
+                        }
+                        return next;
+                    });
                     openLaunchModal(agent);
                 },
             });

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -1,51 +1,23 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-// AgentInstallModal — opens when the user picks an agent whose CLI
-// isn't installed in the per-version cache. Streams npm install output
-// live. Phase α of SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
-//
-// Pattern after AgentLaunchModalBody but with a scrollable log area
-// instead of form fields.
+// AgentInstallModal — install-specific bits only. The outer modal
+// chrome (header/body/footer/title/description) lives in
+// `frontend/app/element/modal-v2.scss` and is shared across all
+// tab-modal panels.
 
-.agent-install-modal-panel {
+.agent-install-modal-body {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: var(--space-3);
     min-width: 560px;
     max-width: 720px;
-    min-height: 360px;
-    max-height: 70vh;
-}
-
-.agent-install-modal-header {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding-bottom: var(--space-1);
-    border-bottom: 1px solid var(--border-color);
+    min-height: 320px;
+    max-height: 60vh;
 }
 
 .agent-install-modal-icon {
-    font-size: 20px;
-    flex-shrink: 0;
-}
-
-.agent-install-modal-title {
-    flex: 1 1 auto;
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--main-text-color);
-}
-
-.agent-install-modal-status {
-    flex: 0 0 auto;
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
-    font-size: 12px;
-    color: var(--secondary-text-color);
-    font-variant-numeric: tabular-nums;
+    margin-right: var(--space-2);
 }
 
 .agent-install-modal-spinner {
@@ -62,31 +34,20 @@
     font-weight: 700;
 }
 
-.agent-install-modal-log {
+// xterm.js container — Terminal mounts here and renders its own
+// canvas / DOM. We just provide a sized box matching xterm's theme.
+.agent-install-modal-term {
     flex: 1 1 auto;
-    min-height: 200px;
-    overflow-y: auto;
-    overflow-x: hidden;
+    min-height: 240px;
     padding: var(--space-1-5);
-    margin: 0;
-    background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+    background: #0d0e0f;
     border: 1px solid var(--border-color);
     border-radius: 4px;
-    font-family: var(--fixed-font, monospace);
-    font-size: 11px;
-    line-height: 1.4;
-    color: var(--main-text-color);
-    white-space: pre-wrap;
-    word-break: break-word;
-}
+    overflow: hidden;
 
-.agent-install-modal-line {
-    display: inline;
-}
-
-.agent-install-modal-line--stderr {
-    color: var(--error-color, #ff6b6b);
-    opacity: 0.9;
+    .xterm {
+        height: 100%;
+    }
 }
 
 .agent-install-modal-error {
@@ -95,19 +56,11 @@
     border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 40%, transparent);
     border-radius: 4px;
     color: var(--error-color, #ff6b6b);
-    font-size: 12px;
-}
-
-.agent-install-modal-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--space-1);
-    padding-top: var(--space-1);
+    font-size: var(--text-sm);
 }
 
 .agent-install-modal-launching {
-    align-self: center;
     color: var(--secondary-text-color);
-    font-size: 12px;
+    font-size: var(--text-sm);
     font-style: italic;
 }

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -1,0 +1,113 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// AgentInstallModal — opens when the user picks an agent whose CLI
+// isn't installed in the per-version cache. Streams npm install output
+// live. Phase α of SPEC_AGENT_INSTALL_STAGE_2026_05_17.md.
+//
+// Pattern after AgentLaunchModalBody but with a scrollable log area
+// instead of form fields.
+
+.agent-install-modal-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    min-width: 560px;
+    max-width: 720px;
+    min-height: 360px;
+    max-height: 70vh;
+}
+
+.agent-install-modal-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding-bottom: var(--space-1);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.agent-install-modal-icon {
+    font-size: 20px;
+    flex-shrink: 0;
+}
+
+.agent-install-modal-title {
+    flex: 1 1 auto;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--main-text-color);
+}
+
+.agent-install-modal-status {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: 12px;
+    color: var(--secondary-text-color);
+    font-variant-numeric: tabular-nums;
+}
+
+.agent-install-modal-spinner {
+    color: var(--warning-color, #e9b800);
+}
+
+.agent-install-modal-ok {
+    color: var(--success-color, #2bd4a8);
+    font-weight: 700;
+}
+
+.agent-install-modal-fail {
+    color: var(--error-color, #ff6b6b);
+    font-weight: 700;
+}
+
+.agent-install-modal-log {
+    flex: 1 1 auto;
+    min-height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: var(--space-1-5);
+    margin: 0;
+    background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    font-family: var(--fixed-font, monospace);
+    font-size: 11px;
+    line-height: 1.4;
+    color: var(--main-text-color);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.agent-install-modal-line {
+    display: inline;
+}
+
+.agent-install-modal-line--stderr {
+    color: var(--error-color, #ff6b6b);
+    opacity: 0.9;
+}
+
+.agent-install-modal-error {
+    padding: var(--space-1) var(--space-1-5);
+    background: color-mix(in srgb, var(--error-color, #ff6b6b) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 40%, transparent);
+    border-radius: 4px;
+    color: var(--error-color, #ff6b6b);
+    font-size: 12px;
+}
+
+.agent-install-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-1);
+    padding-top: var(--space-1);
+}
+
+.agent-install-modal-launching {
+    align-self: center;
+    color: var(--secondary-text-color);
+    font-size: 12px;
+    font-style: italic;
+}

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -79,54 +79,43 @@
             cursor: not-allowed;
         }
 
-        // Actions float in the top-left corner of the card so the
-        // icon + title + caption take the full horizontal width.
-        // Absolute positioning keeps them out of the flex row that
-        // lays out icon + info — no reserved gutter, no ellipsis
-        // truncation halfway through long titles. Hidden by default
-        // so the card reads clean; hover/focus reveals them.
-        .agent-card-actions {
+        // Install-state ribbon — anchored to the bottom-right corner
+        // of the card when the agent's CLI isn't in the per-version
+        // cache yet. Styled as a small "For Sale" sign tag so the user
+        // immediately understands clicking will start the install
+        // (modal) flow rather than launching the agent directly.
+        .agent-card-install-ribbon {
             position: absolute;
-            top: 6px;
-            left: 6px;
-            display: flex;
-            gap: var(--space-1);
-            opacity: 0;
-            transition: opacity 0.15s;
+            right: -4px;
+            bottom: -4px;
+            padding: 3px 8px;
+            font-size: 10px;
+            font-weight: 600;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+            color: #fff; /* stylelint-disable-line color-no-hex */
+            background: var(--warning-color, #e9b800);
+            border-radius: 4px 0 4px 0;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+            pointer-events: none;
             z-index: 1;
+            user-select: none;
+
+            // Animate a gentle pulse so it draws the eye without
+            // being noisy. Halts on hover so the card hover state
+            // stays the focal point.
+            animation: agent-card-ribbon-pulse 2.4s ease-in-out infinite;
         }
 
-        &:hover .agent-card-actions,
-        &:focus-within .agent-card-actions {
-            opacity: 1;
+        &:hover .agent-card-install-ribbon {
+            animation: none;
+            background: color-mix(in srgb, var(--warning-color, #e9b800) 80%, white);
         }
 
-        .agent-card-action-btn {
-            width: 26px;
-            height: 26px;
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            padding: 0;
-            border: 1px solid var(--border-color);
-            // Fully opaque background so the icon/text behind the
-            // absolutely-positioned actions doesn't bleed through.
-            background: var(--main-bg-color);
-            border-radius: 4px;
-            color: var(--main-text-color);
-            font-size: 13px;
-            cursor: pointer;
-            transition: all 0.1s;
-
-            &:hover:not(:disabled) {
-                border-color: var(--accent-color);
-                background: color-mix(in srgb, var(--accent-color) 15%, var(--main-bg-color));
-            }
-
-            &:disabled {
-                opacity: 0.4;
-                cursor: not-allowed;
-            }
+        &.agent-card--needs-install {
+            // Subtle accent on the card border to reinforce the
+            // ribbon's "needs action" signal.
+            border-color: color-mix(in srgb, var(--warning-color, #e9b800) 40%, var(--border-color));
         }
 
         .agent-card-icon {
@@ -384,5 +373,22 @@
             font-style: italic;
             margin-top: var(--space-1-5);
         }
+    }
+}
+
+@keyframes agent-card-ribbon-pulse {
+    0%, 100% {
+        transform: scale(1);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    }
+    50% {
+        transform: scale(1.05);
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-card-install-ribbon {
+        animation: none !important;
     }
 }


### PR DESCRIPTION
## Summary

Combined install-modal polish + agent-picker UX change for the Phase α install flow that shipped in #889. Three things land:

### 1. Install modal SCSS + universal `modal-v2` chrome

PR #889 shipped `AgentInstallModal.tsx` referencing `.agent-install-modal-*` classes with no matching stylesheet — the modal collapsed to intrinsic content size on smoke. Audit also found I was using *ad-hoc* chrome classes that duplicated the universal `modal-v2` system (`AgentLaunchModal` uses the universal one). Fixes:

- New `_install-modal.scss` with **only** modal-specific styles (`.agent-install-modal-body`, `.agent-install-modal-term`, status icons, error banner).
- Modal JSX restructured to use `.modal-panel-header / -title / -description / -body / -footer` — same pattern as `AgentLaunchModal`.
- Wired into `agent-view.scss`.

### 2. xterm.js log + idle "Click to install" CTA

- The `<pre>` placeholder log is replaced with a real `Terminal` + `FitAddon`. Colored npm install output renders properly; stderr lines wrap in red.
- Modal opens in `idle` state with an *Install now* button bottom-right. Click → install starts, button becomes *Cancel*. Auto-chains to launch modal on success.
- Imports `../../term/xterm.css` (the project's customized copy) instead of `@xterm/xterm/css/xterm.css` so we don't override project-wide terminal theming (codex P2 round 2).

### 3. Agent picker — install-state ribbon + drop the 3 action buttons

- Removed the ⓘ / ⚙ / 🗑 overlay buttons on each `AgentCard`. Card chrome reads clean — body click = launch.
- New bottom-right "Click to install" ribbon (For-Sale-sign style) when the CLI isn't in the per-version cache yet. Yellow tag with gentle pulse, honors `prefers-reduced-motion`. Card border picks up a faint warning tint.
- `AgentPicker` caches per-agent install state and refreshes it after the install modal completes — ribbon disappears immediately on success.
- Dropped now-orphaned inline `AgentCardSettingsPanel` and `ConfirmModal` delete flow from the picker (those settings paths remain reachable from the Memory tab inside the agent pane and via `settings.json`).

### Docs follow-up

Companion docs PR https://github.com/agentmuxai/agentmux-docs/pull/30 (merged + deployed) adds:
- `internals/modal-system.md` — the universal `modal-v2` system: chrome classes, two rendering paths, when NOT to use it.
- `main-menu.md` — hamburger menu + command palette reference.
- Repo `README.md`.

## Test plan

- [ ] Open agent picker → uninstalled npm-backed agents show the yellow ribbon, installed ones don't.
- [ ] Click a card with the ribbon → install modal opens in idle state with *Install now* CTA at footer.
- [ ] Click *Install now* → xterm streams npm install output in color; stderr wraps red.
- [ ] Install completes → ribbon disappears on that card; launch modal auto-opens.
- [ ] Cancel mid-install → process killed (cef-side kill-pid path); modal closes.
- [ ] Non-npm provider (Kimi) → no ribbon; clicking goes straight to launch flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)