### PR TITLE
feat(errors): migrate auth paths to typed catalog — PR 3 of 3

### DIFF
--- a/.changesets/1779076322-feat-errors-migrate-auth-paths-to-typed-catalog-pr-3-of-3-yc3u.md
+++ b/.changesets/1779076322-feat-errors-migrate-auth-paths-to-typed-catalog-pr-3-of-3-yc3u.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(errors): migrate auth paths to typed catalog — PR 3 of 3

--- a/agentmux-srv/src/server/identity_handlers.rs
+++ b/agentmux-srv/src/server/identity_handlers.rs
@@ -520,8 +520,22 @@ fn spawn_auth_cli_pty(
     }) {
         Ok(p) => p,
         Err(e) => {
-            tracing::error!(session_id = %session_id, error = %e, "auth.spawn (PTY): openpty failed");
-            mgr.finish_failure(&session_id, format!("openpty failed: {e}"));
+            // PTY allocation failure means the provider's auth
+            // subprocess can't get the interactive TTY it requires
+            // (openclaw `models auth login`). Surface as the typed
+            // `AMX-AUTH-001` so the FailedBanner shows the friendly
+            // recovery hint instead of "openpty failed: <e>".
+            let mux = agentmux_common::AgentMuxError::AuthRequiresTty {
+                provider: provider_id.clone(),
+            };
+            tracing::error!(
+                target: "amx::error",
+                session_id = %session_id,
+                amx_code = %mux.code(),
+                error = %e,
+                "auth.spawn (PTY): openpty failed"
+            );
+            mgr.finish_failure(&session_id, mux.to_wire().to_string());
             mgr.detach_process(&session_id);
             return;
         }

--- a/frontend/app/view/agent/flows/launch-flow.ts
+++ b/frontend/app/view/agent/flows/launch-flow.ts
@@ -245,8 +245,17 @@ export async function runLaunchFlow(opts: LaunchFlowOptions): Promise<LaunchFlow
             }
 
             if (!authenticated) {
-                log("auth", "login timed out after 5 minutes", "error");
-                log("auth", `retry: click the button below, or run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`, "warn");
+                // Synthesize an AMX-AUTH-002 wire payload so the log
+                // entry renders with the catalog's friendly title +
+                // retry hint, matching the typed-error pattern used
+                // elsewhere. Same retry-first / error-last ordering
+                // so ActivityLogPanel keeps failed-state styling.
+                const t = translateError({
+                    code: "AMX-AUTH-002",
+                    details: { provider: provider.id, seconds: 300 },
+                });
+                log("auth", `retry: ${t.retry ?? `run '${provider.cliCommand} ${provider.authLoginCommand.join(" ")}' manually`}`, "warn");
+                log("auth", `${t.title}: ${t.message}`, "error");
                 return "auth_failed";
             }
         } catch (err: any) {


### PR DESCRIPTION
Final PR in the series from [`docs/specs/SPEC_ERROR_CATALOG_2026_05_17.md`](docs/specs/SPEC_ERROR_CATALOG_2026_05_17.md). PR 1 (#892) shipped the scaffold + install IO. PR 2 (#893) migrated the CLI resolve path. PR 3 covers the auth category.

## Migrated sites

- **`identity_handlers.rs:519`** — PTY allocation failure in `spawn_auth_cli_pty`. Previously surfaced as `"openpty failed: <e>"`. Now routes to `AMX-AUTH-001 AuthRequiresTty` so the FailedBanner renders the catalog's friendly title + retry hint ("Use the Connect button in the launch modal — that wires up a PTY"). Tracing log gains the `amx_code` field.
- **`launch-flow.ts:248`** — 5-minute auth poll timeout. Synthesizes an `AMX-AUTH-002` wire payload locally so the activity log entry uses the catalog's friendly text + retry hint. Retry-first / error-last ordering matches PR 2's fixed pattern.

## Deferred

Network (`AMX-NET-001`) and remaining lifecycle (`AMX-LIFECYCLE-001/002`) categories — no current sites exercise these at the RPC boundary in a way that benefits from typed wire. The variants exist in `agentmux-common::errors` for future migration when actual sites need them.

## Series summary

| PR | Scope | Status |
|---|---|---|
| #892 | Scaffold (enum + frontend banner) + install IO mkdir | ✅ Merged |
| #893 | CLI resolve (AMX-CLI-001/002/003/004) + ResolveCli frontend routing | ✅ Merged |
| **#894** | Auth (AMX-AUTH-001/002) | This PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)