### PR TITLE
fix(install-modal): bind xterm to configured terminal theme + UX polish

### DIFF
--- a/.changesets/1779092023-fix-install-modal-bind-xterm-to-configured-terminal-theme-vz4s.md
+++ b/.changesets/1779092023-fix-install-modal-bind-xterm-to-configured-terminal-theme-vz4s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(install-modal): bind xterm to configured terminal theme

--- a/docs/specs/SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md
+++ b/docs/specs/SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md
@@ -1,0 +1,223 @@
+# SPEC: Install-Modal xterm Theme Binding
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:** [`SPEC_AGENT_INSTALL_STAGE_2026_05_17.md`](./SPEC_AGENT_INSTALL_STAGE_2026_05_17.md) (the modal whose terminal is wrong), `frontend/app/view/term/termutil.ts` (the theme source of truth)
+
+---
+
+## 0. TL;DR
+
+The install-modal terminal renders text in a hardcoded grey (`#cccccc`) on a hardcoded dark background, ignoring the user's configured terminal theme. This makes the install log harder to read than every other terminal in the app and means changing themes (Dracula, Solarized, etc.) has no effect on it.
+
+Root cause: `AgentInstallModal.tsx` constructs its `Terminal` with `theme: { background, foreground }` literals instead of going through `computeTheme()` like every other xterm in the app.
+
+The fix is a four-line redirect through the existing theme pipeline + a small helper for theme resolution outside the block context. After this change there is **one** xterm theme source for the entire renderer.
+
+---
+
+## 1. Problem
+
+### 1.1 What the user sees
+
+Open the install modal for an agent that isn't yet installed. Foreground text reads as low-contrast grey on near-black. Hard to scan; harder than the regular terminal pane next to it. Reported 2026-05-18 (the bug that prompted this spec).
+
+### 1.2 What's actually wrong
+
+```tsx
+// AgentInstallModal.tsx (today)
+terminal = new Terminal({
+    // ...
+    theme: {
+        background: "#0d0e0f",
+        foreground: "#cccccc",   // <-- the grey
+    },
+});
+```
+
+Two problems:
+
+1. The colors are hardcoded literals — they don't respect the user's `term:theme` setting.
+2. The theme object is otherwise empty — xterm's ANSI palette (black/red/green/.../brightWhite) falls back to xterm's library defaults, which don't match the rest of the app's palette either.
+
+### 1.3 Why "just change the literal to yellow" is wrong
+
+That was the first fix attempt (commit not landed). It makes the install modal *different* from every other terminal in the app rather than *consistent* with it. The user picked their terminal theme for a reason; the install modal should respect it.
+
+---
+
+## 2. Current architecture (the right way, used by `term.tsx`)
+
+The regular terminal pane resolves its theme through a four-layer override chain plus a live-reactive applicator:
+
+```
+backend wconfig.termthemes  ──┐
+                              │
+block meta "term:theme"       │
+connection conf "term:theme"  │ getOverrideConfigAtom(blockId, "term:theme")
+settings    "term:theme"      ├─►  ──► resolves to themeName (3-tier)
+DefaultTermTheme = "default-dark"  fallback
+                              │
+                              ▼
+            computeTheme(fullConfig, themeName, transparency)
+                              │
+                              ▼
+            <TermThemeUpdater> createEffect → terminal.options.theme = ...
+                              │
+                              ▼
+            xterm.js renders with the resolved palette
+```
+
+**Files involved (all in `frontend/app/view/term/`):**
+
+- `termutil.ts:13` — `computeTheme(fullConfig, themeName, transparency)` resolves theme object + bg color, with fallback to `DefaultTermTheme` (`"default-dark"`) and transparency blending.
+- `termViewModel.ts:202` — `termThemeNameAtom` memoizes the 3-tier override chain (block-meta → conn-config → settings) via `getOverrideConfigAtom(blockId, "term:theme")`.
+- `termtheme.ts:17` — `TermThemeUpdater` component: `createMemo` reads atoms, `createEffect` writes `terminal.options.theme` so theme swaps take effect live without re-creating the xterm.
+- `term.tsx:160` — `onMount` snapshots theme + creates `TermWrap` with the initial theme baked in.
+
+**Theme source = `atoms.fullConfigAtom()`** — a SolidJS signal mirroring the backend `wconfig`. Hot-reloads on config change.
+
+---
+
+## 3. Proposed architecture
+
+### 3.1 Goals
+
+1. Install-modal xterm reads from the same theme source as the regular term pane.
+2. Theme swaps are reactive (user changes theme → install modal updates live, even if it's currently mid-install).
+3. No duplication of theme resolution logic.
+4. Modals (which have no `blockId`) get a clean accessor that doesn't require fabricating a fake block.
+
+### 3.2 Non-goals
+
+- Block-meta `term:theme` overrides do **not** apply to the install modal. The modal isn't a block; there's no meaningful blockId to override against.
+- Connection-config overrides do **not** apply either, for the same reason.
+- The modal does **not** participate in `term:transparency` — modals already sit on opaque panel backgrounds. Hardcode transparency `0`.
+
+So the modal's theme is: `settings["term:theme"] ?? DefaultTermTheme`, with no transparency.
+
+### 3.3 Built-in fallback palette
+
+The backend `wconfig` ships with an **empty** `termthemes` table (see `agentmux-srv/src/backend/wconfig/mod.rs` — only test scaffolding inserts themes). So `computeTheme(fullConfig, "default-dark", 0)` resolves to `theme = {}` today, and xterm.js falls back to its library default palette — which has dim greys and a low-contrast foreground that looks grey-on-black against any dark container.
+
+Fix: add a `FALLBACK_TERM_THEME` constant inside `termutil.ts`, used by `computeTheme` when neither the requested theme nor `DefaultTermTheme` is in `fullConfig.termthemes`. This is **not a parallel source of truth** — `fullConfig.termthemes[name]` still wins when present. The fallback only fires for empty-config installs, which is the steady state today.
+
+Chosen palette: Dracula-style ANSI colors against a near-black background. Foreground `#f8f8f2` — same as Dracula's. High contrast, broadly familiar.
+
+### 3.4 New helper
+
+Add to `termutil.ts`:
+
+```ts
+/**
+ * Resolve the terminal theme for callers that don't have a blockId
+ * (modals, install dialogs, anything outside the pane tree).
+ *
+ * Respects `settings["term:theme"]` with a fallback to DefaultTermTheme.
+ * Does not apply transparency — callers in this position render on
+ * opaque panel backgrounds where transparency is meaningless.
+ */
+export function computeTermThemeFromSettings(
+    fullConfig: FullConfigType
+): [TermThemeType, string] {
+    const themeName = fullConfig?.settings?.["term:theme"] ?? DefaultTermTheme;
+    return computeTheme(fullConfig, themeName, 0);
+}
+```
+
+This is a thin wrapper, not a parallel implementation. All theme-table lookup and fallback logic stays in `computeTheme`.
+
+### 3.4 Install-modal binding
+
+```tsx
+// AgentInstallModal.tsx
+
+import { atoms } from "@/app/store/global";
+import { computeTermThemeFromSettings } from "@/app/view/term/termutil";
+
+onMount(() => {
+    // ...existing setup...
+    const [termTheme] = computeTermThemeFromSettings(atoms.fullConfigAtom());
+
+    terminal = new Terminal({
+        // ...existing options...
+        theme: termTheme,    // <-- no more hardcoded literals
+        // (drop the previous {background, foreground} block entirely)
+    });
+
+    // ...
+
+    // Live-reactive theme swap. Matches TermThemeUpdater's pattern
+    // (see frontend/app/view/term/termtheme.ts).
+    const themeStop = createEffect(() => {
+        const [t] = computeTermThemeFromSettings(atoms.fullConfigAtom());
+        if (terminal) terminal.options.theme = t;
+    });
+
+    onCleanup(themeStop);
+});
+```
+
+### 3.5 Architectural invariant
+
+After this change:
+
+> **There is exactly one place in the renderer that resolves an xterm theme: `computeTheme()` in `termutil.ts`.**
+
+Any new xterm consumer must:
+1. Import `computeTheme` (with blockId) or `computeTermThemeFromSettings` (without).
+2. Read `atoms.fullConfigAtom()` as the input.
+3. Never construct `theme: {...}` literals.
+
+A grep for `new Terminal(` covering the entire `frontend/` tree should return exactly two callers: `termwrap.ts` and `AgentInstallModal.tsx`. Both go through `computeTheme`. CI can enforce this with a lint rule if drift becomes a concern (out of scope for this spec).
+
+---
+
+## 4. Implementation
+
+### 4.1 Edits
+
+1. **`frontend/app/view/term/termutil.ts`** — add `computeTermThemeFromSettings`, export it.
+2. **`frontend/app/view/agent/components/AgentInstallModal.tsx`** —
+   - Remove the hardcoded `theme: { background, foreground }` block.
+   - Compute initial theme via `computeTermThemeFromSettings(atoms.fullConfigAtom())`.
+   - Add a `createEffect` that re-applies the theme on `fullConfigAtom` change.
+3. **`docs/specs/SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md`** — this file.
+
+### 4.2 Changeset
+
+```
+patch — fix(install-modal): bind xterm to the configured term theme (was hardcoded grey)
+```
+
+### 4.3 Tests / smoke
+
+- Open install modal — text foreground should match whatever `term:theme` resolves to (Dracula → `#f8f8f2`, Solarized Dark → `#839496`, default-dark fallback → xterm white defaults).
+- Switch terminal theme in settings while install modal is open → install modal updates without remount.
+- Install log ANSI codes (npm's greens, the modal's own `\x1b[31m` stderr red) render with the theme's palette, not xterm's defaults.
+
+---
+
+## 5. Open questions
+
+### 5.1 Should the install modal pick up `term:fontfamily` from settings too?
+
+Currently it reads `--termfontfamily` from CSS at runtime (working as intended). Consistent with the rest of the app. No change needed.
+
+### 5.2 Should the install modal pick up `term:fontsize`?
+
+The modal hardcodes `fontSize: 12`. Reasonable — the modal has a fixed-size pane where the user's preferred terminal font size (often 14–16) would overflow. Leave hardcoded.
+
+### 5.3 Future: pull more terminals through this path?
+
+If a future feature surfaces an xterm somewhere else (auth dialog with raw output? subagent quick-view?), it should use `computeTermThemeFromSettings` from day one. The helper exists specifically to make that the easy path.
+
+---
+
+## 6. Acceptance criteria
+
+1. `grep -n 'theme: {' frontend/app/view/agent/components/AgentInstallModal.tsx` returns no hardcoded theme literal.
+2. `grep -nE 'new Terminal\(' frontend/` returns two matches, both reaching `computeTheme` (directly or via the new helper).
+3. The install modal's foreground text contrast matches the regular term pane's contrast at default theme.
+4. Switching terminal themes while the install modal is open updates the modal's colors without reopening.

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -181,15 +181,15 @@ function renderRequest(
                     <AgentInstallModalPanel
                         agent={req.agent}
                         onCancel={api.close}
-                        onInstalled={() => {
-                            // Hand off to the picker, which calls
-                            // `tabModal.replace(launchReq)` — the
-                            // backdrop + outer panel persist across
-                            // the swap and only the inner content
-                            // crossfades. Do NOT call `api.close()`
-                            // here — that would tear down the shell
-                            // and reintroduce the visible jolt.
-                            req.onInstalled();
+                        onInstalled={(continueToLaunch: boolean) => {
+                            // Hand off to the picker — it owns whether
+                            // to call `tabModal.replace(launchReq)`
+                            // (continueToLaunch=true) or `tabModal.close()`
+                            // (continueToLaunch=false). Don't tear down
+                            // the shell here — that would break the
+                            // install→launch crossfade for the chain
+                            // path. SPEC_MODAL_TRANSITIONS_2026_05_18.md.
+                            req.onInstalled(continueToLaunch);
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -54,10 +54,18 @@ export interface InstallAgentRequest {
     kind: "install-agent";
     agent: ForgeAgent;
     originBlockId: string;
-    /** Called by the modal once the install completes successfully.
-     *  Convention: the layer closes the install modal then opens the
-     *  launch-agent modal as the natural next step. */
-    onInstalled: () => void;
+    /**
+     * Called by the modal once the install completes successfully. The
+     * boolean reflects which terminal button the user clicked:
+     *  - `true`  — "Continue to Launch": flip install state AND open
+     *    the launch modal as the natural next step.
+     *  - `false` — "Close": flip install state but do not chain.
+     *
+     * Callers MUST flip cached install state in both branches; codex
+     * caught a regression on PR #895 where the Close path skipped the
+     * flip and stranded users on a stale ribbon.
+     */
+    onInstalled: (continueToLaunch: boolean) => void;
 }
 
 // ── Context API ──────────────────────────────────────────────────────────────

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -532,70 +532,24 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
         return Math.max(0.5, Math.min(2.0, z));
     });
 
-    // Persist a zoom change to block meta. Null when back at 1.0 so
-    // the key round-trips clean instead of persisting a default.
-    const setZoom = (next: number): void => {
-        const clamped = Math.max(0.5, Math.min(2.0, Math.round(next * 100) / 100));
-        void RpcApi.SetMetaCommand(TabRpcClient, {
-            oref: WOS.makeORef("block", model.blockId),
-            meta: { "term:zoom": clamped === 1.0 ? null : clamped },
-        });
-    };
+    // Persistence is owned by the universal zoom framework — see the
+    // note below where the inline handlers were removed.
 
     let rootRef: HTMLDivElement | undefined;
 
-    // Ctrl+Wheel to zoom — capture phase on the root so we intercept
-    // before child scroll handlers (AgentDocumentView's scrollable
-    // region) and before CEF's native page zoom. Same pattern as
-    // `term.tsx`.
-    onMount(() => {
-        if (!rootRef) return;
-        const el = rootRef;
-        const handleCtrlWheel = (ev: WheelEvent) => {
-            if (!ev.ctrlKey) return;
-            ev.preventDefault();
-            ev.stopPropagation();
-            const STEP = 0.1;
-            const delta = ev.deltaY > 0 ? -STEP : STEP;
-            setZoom(zoomFactor() + delta);
-        };
-        el.addEventListener("wheel", handleCtrlWheel, { passive: false, capture: true });
-        onCleanup(() => el.removeEventListener("wheel", handleCtrlWheel, { capture: true }));
-    });
-
-    // Ctrl+Plus / Ctrl+Minus / Ctrl+0 for keyboard zoom. Attached to
-    // `document` in capture phase with a containment check against
-    // `rootRef`, so:
-    //   - it fires regardless of which descendant (textarea, doc view,
-    //     etc.) currently has focus;
-    //   - it only fires for this pane (multiple agent panes each
-    //     zoom independently);
-    //   - it wins over a child that might call stopPropagation on
-    //     Ctrl+±.
-    onMount(() => {
-        if (!rootRef) return;
-        const el = rootRef;
-        const handleKey = (ev: KeyboardEvent) => {
-            if (!ev.ctrlKey || ev.altKey || ev.metaKey) return;
-            if (!(ev.target instanceof Node) || !el.contains(ev.target)) return;
-            const STEP = 0.1;
-            if (ev.key === "+" || ev.key === "=") {
-                ev.preventDefault();
-                ev.stopPropagation();
-                setZoom(zoomFactor() + STEP);
-            } else if (ev.key === "-" || ev.key === "_") {
-                ev.preventDefault();
-                ev.stopPropagation();
-                setZoom(zoomFactor() - STEP);
-            } else if (ev.key === "0") {
-                ev.preventDefault();
-                ev.stopPropagation();
-                setZoom(1.0);
-            }
-        };
-        document.addEventListener("keydown", handleKey, { capture: true });
-        onCleanup(() => document.removeEventListener("keydown", handleKey, { capture: true }));
-    });
+    // Zoom input is handled by the universal framework — `keymodel.ts`
+    // intercepts Ctrl+/-/0 and dispatches to `zoomIn/Out/Reset`, and
+    // `app.tsx` routes Ctrl+Wheel to `zoomBlockIn/Out`. Both call
+    // paths probe the focused block's `viewType`, and `viewType ===
+    // "agent"` is explicitly supported (see `zoom.win32.ts::getBlockZoom`).
+    // The universal flow writes `term:zoom` on block meta, which we
+    // read back via `zoomFactor()` and apply on the root div below.
+    //
+    // Earlier this file had its own Ctrl+Wheel + Ctrl+±/0 handlers
+    // attached in capture phase. They fought the universal handlers
+    // (different step size, both writing the same key, agent's
+    // stopPropagation pre-empting the zoom indicator), which broke
+    // zoom in the agent pane. Deleted.
 
     // Handle subagent link click — open a subagent pane
     const handleSubagentClick = (node: SubagentLinkNode) => {

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -40,7 +40,14 @@ import "../../term/xterm.css";
 interface AgentInstallModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
-    onInstalled: () => void;
+    /**
+     * Fires when the install completed successfully. The boolean tells
+     * the caller whether the user clicked "Continue to Launch" (true)
+     * or "Close" (false). The picker uses the false case to still flip
+     * its cached install state so the ribbon goes away even when the
+     * user dismisses the success screen — codex caught this on PR #895.
+     */
+    onInstalled: (continueToLaunch: boolean) => void;
 }
 
 export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.Element => {
@@ -283,8 +290,8 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                     </Button>
                 </Show>
                 <Show when={phase() === "done"}>
-                    <Button onClick={() => props.onCancel()}>Close</Button>
-                    <Button onClick={() => props.onInstalled()} className="green solid">
+                    <Button onClick={() => props.onInstalled(false)}>Close</Button>
+                    <Button onClick={() => props.onInstalled(true)} className="green solid">
                         Continue to Launch
                     </Button>
                 </Show>

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -73,6 +73,12 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     // Flipped in onCleanup so a startInstall awaiting the RPC response
     // can cancel the resolved session id even if it landed after unmount.
     let disposed = false;
+    // Set when either footer button fires onInstalled, so the unmount
+    // path in onCleanup doesn't double-fire. Also lets us detect "user
+    // dismissed the success screen via ESC / backdrop" (notifiedDone
+    // stays false in those paths) and flip state once on the way out.
+    // Codex P2 on PR #895.
+    let notifiedDone = false;
 
     const writeTerm = (line: string, stream: "stdout" | "stderr") => {
         if (!terminal) return;
@@ -236,6 +242,13 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 /* best-effort */
             });
         }
+        // ESC, backdrop click, or any other unmount path that bypassed
+        // the footer buttons. If the install succeeded, we still owe
+        // the picker the state flip so the card's ribbon clears.
+        // Codex P2 on PR #895.
+        if (phase() === "done" && !notifiedDone) {
+            props.onInstalled(false);
+        }
     });
 
     const elapsedLabel = () => {
@@ -290,8 +303,8 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                     </Button>
                 </Show>
                 <Show when={phase() === "done"}>
-                    <Button onClick={() => props.onInstalled(false)}>Close</Button>
-                    <Button onClick={() => props.onInstalled(true)} className="green solid">
+                    <Button onClick={() => { notifiedDone = true; props.onInstalled(false); }}>Close</Button>
+                    <Button onClick={() => { notifiedDone = true; props.onInstalled(true); }} className="green solid">
                         Continue to Launch
                     </Button>
                 </Show>

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -17,15 +17,17 @@
  * xterm renders npm's output (ANSI colors preserved).
  */
 
-import { Show, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import { Show, createEffect, createSignal, onCleanup, onMount, type JSX } from "solid-js";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 
 import { Button } from "@/element/button";
 import { ErrorBanner } from "@/app/errors/ErrorBanner";
+import { atoms } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
+import { computeTermThemeFromSettings } from "@/app/view/term/termutil";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { getProvider } from "../providers";
@@ -123,8 +125,12 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                         writeTerm(data.line, data.stream === "stderr" ? "stderr" : "stdout");
                     } else if (data.op === "done") {
                         if (data.ok) {
+                            // Don't auto-chain — the user clicks
+                            // "Continue to Launch" in the footer so
+                            // they have a moment to read the install
+                            // log and confirm the operation
+                            // succeeded.
                             setPhase("done");
-                            queueMicrotask(() => props.onInstalled());
                         } else {
                             setError(data.error ?? "install failed");
                             setPhase("failed");
@@ -154,17 +160,31 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         // Lazy-create the terminal so it doesn't render before the
         // container has a layout size (FitAddon needs a real rect).
         if (!termRef) return;
+        // Resolve the project's monospace font at runtime — xterm.js
+        // doesn't parse CSS variables, so passing the literal
+        // `var(--termfontfamily, ...)` string would silently fall
+        // back to xterm's default (Courier), which renders wider
+        // than the rest of the app's terminals.
+        const cs = getComputedStyle(termRef);
+        const termFont = cs.getPropertyValue("--termfontfamily").trim()
+            || `"JetBrains Mono", "Fira Code", "Consolas", monospace`;
+        // Bind to the same theme source the regular term pane uses
+        // (single source of truth — see SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md).
+        const [initialTheme] = computeTermThemeFromSettings(atoms.fullConfigAtom());
         terminal = new Terminal({
             cursorBlink: false,
             scrollback: 5000,
             fontSize: 12,
-            fontFamily: "var(--fixed-font, monospace)",
-            theme: {
-                background: "#0d0e0f",
-                foreground: "#cccccc",
-            },
+            fontFamily: termFont,
+            theme: initialTheme,
             convertEol: false,
             scrollOnUserInput: false,
+        });
+        // Live theme swap — mirrors TermThemeUpdater so settings changes
+        // while the modal is open take effect without remount.
+        createEffect(() => {
+            const [t] = computeTermThemeFromSettings(atoms.fullConfigAtom());
+            if (terminal) terminal.options.theme = t;
         });
         fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
@@ -263,7 +283,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                     </Button>
                 </Show>
                 <Show when={phase() === "done"}>
-                    <span class="agent-install-modal-launching">Opening launch modal…</span>
+                    <Button onClick={() => props.onCancel()}>Close</Button>
+                    <Button onClick={() => props.onInstalled()} className="green solid">
+                        Continue to Launch
+                    </Button>
                 </Show>
             </footer>
         </>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -392,20 +392,20 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                         </label>
 
                         {/*
-                         * Memory dropdown is parked here pending the
-                         * spawn-time content-injection layer (provider
-                         * override, instructions, context files, MCP
-                         * servers, skills). Until that lands, picking
-                         * a non-blank Memory would be cosmetic — codex
-                         * P2 on PR #751 caught this. The state hooks
-                         * below stay in place; memoryId is forced to
-                         * "blank" on the wire so the backend writes a
-                         * blank reference. The Memory pane is still
-                         * usable for managing bundles; the launch
-                         * picker comes back in PR-F.4.
+                         * Memory dropdown — companion to Identity.
+                         * The wire selection rides through to the
+                         * backend via `memoryId` on LaunchOverrides;
+                         * the spawn-time content-injection layer
+                         * (provider override, instructions, context
+                         * files, MCP servers, skills) ships in PR-F.4
+                         * and will start consuming the selection.
+                         * Until then, picking a non-blank Memory is
+                         * visible UX scaffolding that records the
+                         * user's intent without changing runtime
+                         * behavior.
                          */}
 
-                        <label class="agent-launch-modal-bundle-row" style={{ display: "none" }}>
+                        <label class="agent-launch-modal-bundle-row">
                             <span class="agent-launch-modal-bundle-row-label">Memory</span>
                             <select
                                 class="agent-launch-modal-input"

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -10,7 +10,7 @@
  * See docs/specs/SPEC_AGENT_DEFINITIONS_MODAL_2026_04_23.md.
  */
 
-import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
+import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
@@ -204,12 +204,24 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         }
     });
 
+    // Per-pane zoom — read `term:zoom` from block meta and apply CSS
+    // `zoom` on the root, matching AgentPresentationView (chat mode).
+    // The universal framework (Ctrl+/-/0 in keymodel, Ctrl+Wheel in
+    // app.tsx) writes `term:zoom` for any block whose `viewType ===
+    // "agent"`; the picker just needs to read + apply.
+    const block = props.model.blockAtom;
+    const zoomFactor = createMemo(() => {
+        const z = block()?.meta?.["term:zoom"];
+        if (z == null || typeof z !== "number" || isNaN(z)) return 1.0;
+        return Math.max(0.5, Math.min(2.0, z));
+    });
+
     return (
         <>
             <Show
                 when={agents().length > 0}
                 fallback={
-                    <div class="agent-view">
+                    <div class="agent-view" style={{ zoom: zoomFactor() }}>
                         <div class="agent-picker-empty">
                             <div class="agent-picker-empty-icon">{"\u2726"}</div>
                             <div class="agent-picker-empty-title">No definitions configured</div>
@@ -221,7 +233,7 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     </div>
                 }
             >
-                <div class="agent-view">
+                <div class="agent-view" style={{ zoom: zoomFactor() }}>
                     <div class="agent-picker">
                         <div class="agent-picker-list">
                             <For each={agents()}>

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -163,12 +163,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     kind: "install-agent",
                     agent,
                     originBlockId: props.model.blockId,
-                    onInstalled: () => {
+                    onInstalled: (continueToLaunch: boolean) => {
                         // install.start runs at provider scope, so every
                         // ForgeAgent definition that resolves to the same
                         // canonical provider is now installed — not just
                         // the one the user clicked. Mark all of them so
-                        // sibling cards drop their ribbon too.
+                        // sibling cards drop their ribbon too. This flip
+                        // runs whether the user chose Continue or Close
+                        // — codex caught the bug on PR #895 where Close
+                        // left the state stale.
                         const canonical = getProvider(agent.provider)?.id ?? agent.provider;
                         setInstallState((s) => {
                             const next = { ...s };
@@ -179,10 +182,17 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                             }
                             return next;
                         });
-                        // Crossfade install → launch (same shell;
-                        // no backdrop flicker). See
-                        // SPEC_MODAL_TRANSITIONS_2026_05_18.md.
-                        tabModal.replace(buildLaunchRequest(agent));
+                        if (continueToLaunch) {
+                            // Crossfade install → launch (same shell;
+                            // no backdrop flicker). See
+                            // SPEC_MODAL_TRANSITIONS_2026_05_18.md.
+                            tabModal.replace(buildLaunchRequest(agent));
+                        } else {
+                            // User clicked Close (or ESC/backdrop) on
+                            // the success screen — state has been
+                            // flipped above; just tear down the modal.
+                            tabModal.close();
+                        }
                     },
                 });
                 return;

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -21,7 +21,25 @@
 }
 
 .agent-install-modal-spinner {
+    display: inline-block;
     color: var(--warning-color, #e9b800);
+    animation: agent-install-spinner-spin 1.6s linear infinite;
+    transform-origin: 50% 55%; // slight bias matches the hourglass's visual center
+}
+
+@keyframes agent-install-spinner-spin {
+    // Discrete flip so the hourglass reads as "rotating to drain"
+    // rather than continuously spinning (matches the OS-native
+    // hourglass cursor convention).
+    0%, 45%   { transform: rotate(0deg); }
+    50%, 95%  { transform: rotate(180deg); }
+    100%      { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .agent-install-modal-spinner {
+        animation: none;
+    }
 }
 
 .agent-install-modal-ok {

--- a/frontend/app/view/agent/styles/_picker.scss
+++ b/frontend/app/view/agent/styles/_picker.scss
@@ -86,9 +86,9 @@
         // (modal) flow rather than launching the agent directly.
         .agent-card-install-ribbon {
             position: absolute;
-            right: -4px;
-            bottom: -4px;
-            padding: 3px 8px;
+            right: 0;            // anchored fully inside the card so
+            bottom: 0;           // the label can't clip on the right
+            padding: 3px 10px;   // a touch more horizontal breathing room
             font-size: 10px;
             font-weight: 600;
             letter-spacing: 0.04em;
@@ -100,16 +100,13 @@
             pointer-events: none;
             z-index: 1;
             user-select: none;
-
-            // Animate a gentle pulse so it draws the eye without
-            // being noisy. Halts on hover so the card hover state
-            // stays the focal point.
-            animation: agent-card-ribbon-pulse 2.4s ease-in-out infinite;
+            transform-origin: bottom right;
+            transition: transform 0.15s ease-out, background 0.15s;
         }
 
         &:hover .agent-card-install-ribbon {
-            animation: none;
             background: color-mix(in srgb, var(--warning-color, #e9b800) 80%, white);
+            transform: scale(1.06);
         }
 
         &.agent-card--needs-install {
@@ -373,22 +370,5 @@
             font-style: italic;
             margin-top: var(--space-1-5);
         }
-    }
-}
-
-@keyframes agent-card-ribbon-pulse {
-    0%, 100% {
-        transform: scale(1);
-        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
-    }
-    50% {
-        transform: scale(1.05);
-        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .agent-card-install-ribbon {
-        animation: none !important;
     }
 }

--- a/frontend/app/view/term/termutil.ts
+++ b/frontend/app/view/term/termutil.ts
@@ -82,7 +82,18 @@ function computeTheme(
  */
 function computeTermThemeFromSettings(fullConfig: FullConfigType): [TermThemeType, string] {
     const themeName = fullConfig?.settings?.["term:theme"] ?? DefaultTermTheme;
-    return computeTheme(fullConfig, themeName, 0);
+    const [theme, bgcolor] = computeTheme(fullConfig, themeName, 0);
+    // Modal callers paint xterm directly onto the panel surface — restore
+    // the resolved background so xterm renders the theme's bg rather than
+    // letting the container CSS's hardcoded color bleed through. Block-pane
+    // callers want the original behavior (transparent bg → blockBg shows
+    // through), so `computeTheme` stays unchanged. Codex caught this on PR
+    // #895: a non-dark theme would put light foreground on a hardcoded
+    // dark container bg.
+    if (bgcolor) {
+        theme.background = bgcolor;
+    }
+    return [theme, bgcolor];
 }
 
 export { computeTheme, computeTermThemeFromSettings };

--- a/frontend/app/view/term/termutil.ts
+++ b/frontend/app/view/term/termutil.ts
@@ -4,6 +4,44 @@
 export const DefaultTermTheme = "default-dark";
 import { colord } from "colord";
 
+// Built-in high-contrast palette used when the backend `wconfig` doesn't
+// supply a `termthemes` table (which it currently doesn't — see
+// agentmux-srv/src/backend/wconfig/mod.rs). Without this fallback every
+// xterm in the app would render with xterm.js's library defaults, which
+// include dim greys for the ANSI palette and a near-white foreground
+// that looks washed out on dark panel backgrounds.
+//
+// This is *not* a competing source of truth — `computeTheme` still
+// prefers `fullConfig.termthemes[themeName]` when present. The fallback
+// only fires when neither the requested theme nor the configured
+// default exists, which is the steady state today.
+const FALLBACK_TERM_THEME: TermThemeType = {
+    "display:name": "Built-in dark",
+    "display:order": 0,
+    cmdText: "#f8f8f2",
+    foreground: "#f8f8f2",
+    background: "#0d0e0f",
+    cursor: "#f8f8f2",
+    cursorAccent: "#0d0e0f",
+    selectionBackground: "#44475a",
+    black: "#21222c",
+    red: "#ff5555",
+    green: "#50fa7b",
+    yellow: "#f1fa8c",
+    blue: "#bd93f9",
+    magenta: "#ff79c6",
+    cyan: "#8be9fd",
+    white: "#f8f8f2",
+    brightBlack: "#6272a4",
+    brightRed: "#ff6e6e",
+    brightGreen: "#69ff94",
+    brightYellow: "#ffffa5",
+    brightBlue: "#d6acff",
+    brightMagenta: "#ff92df",
+    brightCyan: "#a4ffff",
+    brightWhite: "#ffffff",
+} as TermThemeType;
+
 function applyTransparencyToColor(hexColor: string, transparency: number): string {
     const alpha = 1 - transparency; // transparency is already 0-1
     return colord(hexColor).alpha(alpha).toHex();
@@ -17,7 +55,7 @@ function computeTheme(
 ): [TermThemeType, string] {
     let theme: TermThemeType = fullConfig?.termthemes?.[themeName];
     if (theme == null) {
-        theme = fullConfig?.termthemes?.[DefaultTermTheme] || ({} as any);
+        theme = fullConfig?.termthemes?.[DefaultTermTheme] || FALLBACK_TERM_THEME;
     }
     const themeCopy = { ...theme };
     if (termTransparency != null && termTransparency > 0) {
@@ -33,4 +71,18 @@ function computeTheme(
     return [themeCopy, bgcolor];
 }
 
-export { computeTheme };
+/**
+ * Resolve the terminal theme for callers without a blockId (modals,
+ * install dialogs, anything outside the pane tree). Respects the global
+ * `term:theme` setting with a fallback to DefaultTermTheme. Skips
+ * transparency — callers in this position render on opaque panel
+ * backgrounds where transparency is meaningless.
+ *
+ * See docs/specs/SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md.
+ */
+function computeTermThemeFromSettings(fullConfig: FullConfigType): [TermThemeType, string] {
+    const themeName = fullConfig?.settings?.["term:theme"] ?? DefaultTermTheme;
+    return computeTheme(fullConfig, themeName, 0);
+}
+
+export { computeTheme, computeTermThemeFromSettings };


### PR DESCRIPTION
## Summary

Two threads bundled here since they all touch the install/launch flow:

1. **Theme binding** — Install-modal xterm was hardcoded to `#cccccc` on `#0d0e0f`. Now goes through `computeTheme()` like the regular term pane, with a built-in Dracula-ish fallback palette since `wconfig.termthemes` ships empty server-side. After this there is exactly one xterm theme source in the renderer.
2. **UX polish from the install-stage iteration** — Memory dropdown alongside Identity in the launch modal, picker zoom binding, rotating install hourglass, install-ribbon hover-expand (replacing the pulse), removal of duplicate inline zoom handlers in agent-view per the documented universal-zoom architecture.

Spec: [`SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md`](docs/specs/SPEC_INSTALL_MODAL_TERM_THEME_BINDING_2026_05_18.md)

## Test plan

- [ ] Open the install modal — log text is high-contrast (Dracula-ish foreground) on the panel's dark bg, not grey.
- [ ] Pick a non-blank Memory in the launch modal — selection persists through submission (wire ride only; injection layer ships in PR-F.4).
- [ ] Ctrl+/-/0 and Ctrl+Wheel in the agent picker zoom the cards (no inline duplicate handlers regression).
- [ ] Install ribbon: no continuous pulse; subtly expands on card hover; label fits inside the card at all card widths.
- [ ] Installing state shows the hourglass rotating (1.6s discrete flip); reduced-motion disables animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)