### PR TITLE
feat(install-modal): default verbose output to true

### DIFF
--- a/.changesets/1779109538-feat-install-modal-default-verbose-output-to-true-zgqs.md
+++ b/.changesets/1779109538-feat-install-modal-default-verbose-output-to-true-zgqs.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(install-modal): default verbose output to true

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -62,9 +62,11 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     const [error, setError] = createSignal<unknown>(null);
     const [sessionId, setSessionId] = createSignal<string | null>(null);
     const [elapsedMs, setElapsedMs] = createSignal(0);
-    // When true, install runs with `npm --loglevel=verbose` + progress
-    // bar enabled. Off by default — keeps the install log scannable.
-    const [verbose, setVerbose] = createSignal(false);
+    // When true, install runs with `npm --loglevel=verbose`. On by
+    // default — surface per-package fetch/extract lines so the user
+    // can see what's happening during long installs. Toggle off for
+    // a terse log.
+    const [verbose, setVerbose] = createSignal(true);
 
     let unsub: (() => void) | null = null;
     let termRef: HTMLDivElement | undefined;


### PR DESCRIPTION
Per user feedback after #897: terse mode hides the per-package activity that makes long installs feel responsive. Default the toggle ON. User can still flip off for a terser log.

## Test plan

- [ ] Open install modal — `Verbose output` checkbox is checked by default.
- [ ] Install runs with `npm install <pkg> --loglevel=verbose`.
- [ ] Untoggle + install → falls back to terse `notice` tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)