### PR TITLE
fix(install-modal): copy/paste + unified clipboard spec (Phase α)

### DIFF
--- a/.changesets/1779109995-fix-install-modal-copy-paste-wiring-unified-clipboard-spec-vf6o.md
+++ b/.changesets/1779109995-fix-install-modal-copy-paste-wiring-unified-clipboard-spec-vf6o.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(install-modal): copy/paste wiring + unified clipboard spec

--- a/docs/specs/SPEC_UNIFIED_CLIPBOARD_2026_05_18.md
+++ b/docs/specs/SPEC_UNIFIED_CLIPBOARD_2026_05_18.md
@@ -9,10 +9,11 @@
 
 ## 0. TL;DR
 
-The user reports they can't copy text from the install modal's xterm.js terminal. They want **copy/paste to work from anywhere in the app**, plus two adjacent actions:
+The user reports they can't copy text from the install modal's xterm.js terminal. They want **copy/paste to work from anywhere in the app**, plus one adjacent action for long-output regions:
 
-- **Save selection / pane content to a file** (e.g. `~/.agentmux/clips/install-2026-05-18.log`).
-- **Open in editor** (VS Code, or the user's configured external editor).
+- **Save selection / pane content to a file** (e.g. `~/.agentmux/clips/install-2026-05-18.log`) — useful when the output is too long to paste comfortably.
+
+> **Open-in-editor was originally scoped here but cut after design review (2026-05-18).** It belongs in a separate spec — selecting text for copy/paste doesn't imply moving the whole buffer into an editor. If that capability is needed later, it can live on top of Save Selection As… by chaining `OpenExternal(path)` after the write.
 
 Today: clipboard works only in *some* surfaces (regular terminal pane, code blocks, context menu actions), and even then via four different paths. The install modal terminal has **zero** clipboard wiring — the audit found no `onSelectionChange`, no `term:copyonselect` read, no paste handler, no keyboard binding. xterm.js's `getSelection()` is never queried, and the container has `user-select: none` from the shared `xterm.css`, so browser-native selection-copy is blocked too.
 
@@ -116,7 +117,7 @@ export function getActiveSelectionProvider(): SelectionProvider | null;
 
 Activation follows DOM focus. The pane's container wires `onFocusIn` / `onFocusOut` to `register` / `unregister`. Multiple panes can be mounted; only the focused one is active.
 
-### 3.2 The four global commands
+### 3.2 The three global commands
 
 Wired once at app root (`frontend/app/app.tsx`), keyed off the active provider:
 
@@ -125,9 +126,8 @@ Wired once at app root (`frontend/app/app.tsx`), keyed off the active provider:
 | Copy | `Ctrl+C` (or `Ctrl+Shift+C` in terminal context) | `clipboardWriteText(provider.getSelection() || provider.getAll())` |
 | Copy All | `Ctrl+Shift+A` | `clipboardWriteText(provider.getAll())` |
 | Save Selection As… | `Ctrl+S` (when focus is in a non-editor pane) | `RpcApi.WriteFile({ path: dialogPick, content: provider.getSelection() || provider.getAll() })` |
-| Open in Editor | `Ctrl+Shift+E` | Write to a temp file in `~/.agentmux/clips/`, then `RpcApi.OpenExternal(tempPath)` which routes to the user's configured editor (default: VS Code's `code <path>` if on PATH; fallback: OS default for `.txt`). |
 
-All four also appear in the right-click context menu (`buildPaneContextMenu` extension) and as buttons in a hover-revealed action bar (Phase β).
+All three also appear in the right-click context menu (`buildPaneContextMenu` extension) and as buttons in a hover-revealed action bar (Phase β).
 
 ### 3.3 Clipboard write path
 
@@ -181,15 +181,9 @@ Path resolution: relative paths are resolved against `~/.agentmux/clips/`. Absol
 
 For the OS file picker, use `getApi().showSaveDialog({ defaultPath, filters })` — CEF exposes the native Chromium save dialog. If we don't have that bridge yet, the v1 implementation can drop content into `~/.agentmux/clips/<timestamp>-<label>.txt` and surface a toast with the path (good enough for "open in editor" follow-up).
 
-### 3.7 Open in Editor
+### 3.7 Open in Editor — cut from this spec
 
-Two-step:
-
-1. Write content to `~/.agentmux/clips/<timestamp>-<label>.txt` via the same path as 3.6.
-2. Resolve the user's editor: setting `editor:external` (default: `"code"` on Windows/Linux, `"open -a 'Visual Studio Code'"` on macOS, fallback to OS default `open` / `xdg-open` / `start`).
-3. Spawn editor via `RpcApi.OpenExternalCommand(path)` — already exists at `agentmux-cef/src/commands/platform.rs::open_external`.
-
-The cleanup story: clips older than 7 days get pruned on startup. Capped at 1 MB / file to keep disk usage bounded.
+Cut after design review (2026-05-18). Selecting text for copy/paste doesn't imply moving the whole buffer into an editor — those are separate user goals. If "open this output in VS Code" becomes a frequent ask, it can live on top of 3.6: after the file is written, optionally chain `RpcApi.OpenExternalCommand(path)` (which already exists at `agentmux-cef/src/commands/platform.rs::open_external`). That's a small extension, not a foundational piece of the unified clipboard.
 
 ---
 
@@ -209,18 +203,17 @@ That's ~30 lines. Spec + Phase α implementation ship as one PR. Internals doc p
 ### Phase β — Selection-provider registry + global commands
 
 1. New file `frontend/util/selection-registry.ts` per §3.1.
-2. App-root keyboard listener registers Ctrl+C / Ctrl+Shift+A / Ctrl+S / Ctrl+Shift+E → dispatches to active provider.
+2. App-root keyboard listener registers Ctrl+C / Ctrl+Shift+A / Ctrl+S → dispatches to active provider.
 3. Both xterm consumers + agent doc view + markdown blocks register providers.
-4. Extend `buildPaneContextMenu` with Copy / Copy All / Save As… / Open in Editor entries.
+4. Extend `buildPaneContextMenu` with Copy / Copy All / Save As… entries.
 
 Separate PR after Phase α stabilizes.
 
-### Phase γ — Write to file + Open in editor
+### Phase γ — Write to file
 
 1. New `RpcApi.WriteFile` backend handler.
 2. `~/.agentmux/clips/` directory + 7-day pruning.
-3. `editor:external` setting wired through to `open_external`.
-4. Toast on save with click-to-open.
+3. Toast on save with path.
 
 Separate PR.
 
@@ -242,10 +235,9 @@ Hover-revealed "[ Copy | Save | Open ]" bar on the install-modal terminal and ot
 
 ### Phase γ
 1. `Ctrl+S` in any focused pane opens a save dialog (or writes to `~/.agentmux/clips/` with a toast).
-2. `Ctrl+Shift+E` opens the saved file in the user's configured editor.
 
 ### Phase δ
-1. Hovering an exportable output region shows the [Copy | Save | Open] bar.
+1. Hovering an exportable output region shows the `[ Copy | Save ]` bar.
 
 ---
 

--- a/docs/specs/SPEC_UNIFIED_CLIPBOARD_2026_05_18.md
+++ b/docs/specs/SPEC_UNIFIED_CLIPBOARD_2026_05_18.md
@@ -1,0 +1,263 @@
+# SPEC: Unified Copy/Paste + Export
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:** [`SPEC_AGENT_INSTALL_STAGE_2026_05_17.md`](./SPEC_AGENT_INSTALL_STAGE_2026_05_17.md) (the install modal that surfaced this gap), `frontend/util/clipboard.ts` (existing CEF clipboard bridge).
+
+---
+
+## 0. TL;DR
+
+The user reports they can't copy text from the install modal's xterm.js terminal. They want **copy/paste to work from anywhere in the app**, plus two adjacent actions:
+
+- **Save selection / pane content to a file** (e.g. `~/.agentmux/clips/install-2026-05-18.log`).
+- **Open in editor** (VS Code, or the user's configured external editor).
+
+Today: clipboard works only in *some* surfaces (regular terminal pane, code blocks, context menu actions), and even then via four different paths. The install modal terminal has **zero** clipboard wiring — the audit found no `onSelectionChange`, no `term:copyonselect` read, no paste handler, no keyboard binding. xterm.js's `getSelection()` is never queried, and the container has `user-select: none` from the shared `xterm.css`, so browser-native selection-copy is blocked too.
+
+Fix: introduce a **selection-provider** abstraction at the pane level + **global keyboard / context-menu / action-bar** plumbing on top. Every selectable surface registers a provider; global commands (Copy / Copy All / Save As… / Open in Editor) query the focused provider. Single source of truth for clipboard writes (the existing `frontend/util/clipboard.ts` CEF wrapper); single source of truth for write-to-file and open-in-editor (new `RpcApi.WriteFile` + `RpcApi.OpenExternal` wiring).
+
+---
+
+## 1. Problem
+
+### 1.1 What the user reports (2026-05-18)
+
+> "I tried copying the npm log in the install modal and it was unsuccessful."
+
+Open install modal → install → try to select the log → either no selection visible (xterm.js's selection didn't register) or selection visible but Ctrl+C does nothing.
+
+### 1.2 Audit findings (2026-05-18)
+
+| Surface | Copy on selection | Ctrl+Shift+C | Paste | Context menu Copy | Notes |
+|---|---|---|---|---|---|
+| Regular terminal pane (`term.tsx`) | ✅ via `term:copyonselect` setting | ✅ xterm.js default | ✅ wired | ✅ | Reference implementation |
+| **Install modal terminal** | ❌ | ❌ | ❌ | ❌ | Zero clipboard wiring |
+| Code blocks (`markdown.tsx`, `streamdown.tsx`, `table-block.tsx`) | n/a | ✅ button | n/a | ❌ | Dedicated copy button |
+| Agent pane (chat/doc view) | n/a | partial | ❌ | ❌ | `window.getSelection()` only |
+| Browser pane | n/a | depends on CEF | depends on CEF | ❌ | Out of scope (uses CEF native) |
+| PreLaunchAuth OAuth URL copy | n/a | ✅ button | n/a | n/a | Uses `navigator.clipboard.writeText` *directly*, bypassing the wrapper |
+
+### 1.3 Root cause: no unifying contract
+
+Four different clipboard paths exist:
+
+1. `frontend/util/clipboard.ts` — CEF IPC wrapper (`read_clipboard` / `write_clipboard`). The "right" path.
+2. xterm.js's built-in selection model (used by the terminal pane but the API isn't exposed to anyone else).
+3. `window.getSelection()` (used by agent doc view).
+4. `navigator.clipboard.writeText` directly (used in `PreLaunchAuthPanel.tsx:366`).
+
+Path 4 only works by accident: Chromium's permission policy normally blocks `navigator.clipboard.readText()`. The write side works without permission today, but this is fragile.
+
+Each path has its own context menu wiring (or none). Adding a new pane means re-implementing the four actions (Copy, Copy All, Save As…, Open in Editor) from scratch — which is why the install modal launched with none.
+
+---
+
+## 2. Best practices research
+
+### 2.1 VS Code
+
+- Single global Copy/Paste command. Every editor/output view registers a "text contribution" so the command knows what to grab.
+- "Reveal in Editor" pattern: any output buffer (terminal, problems panel, output channel) has a single click that opens its contents in a real editor tab.
+- "Save Selection As…" and "Save Output As…" use a single OS file dialog; the resolved path goes to either `fs.writeFile` or a "tail this file" pseudo-watch.
+
+### 2.2 Slack / Discord / Linear
+
+- Hover-revealed action bar on selectable content blocks (messages, log lines): Copy, Copy Link, Save, Share. Lower discoverability than a context menu but no right-click required.
+- Slack additionally exposes a "copy link to this message" — selection-aware, not just text.
+
+### 2.3 Chrome DevTools
+
+- Right-click anywhere → context menu with "Copy", "Copy all as cURL" (action-specific), "Save as…". The console terminal supports both `window.getSelection()` (native) AND a custom selection model.
+- Lesson: the right unit is "this view's current selection" — let each view decide what counts.
+
+### 2.4 Common rules across all three
+
+1. **One global command per action** (Copy, Save, Open in Editor). No per-pane reinvention.
+2. **Each view tells the global command what's selected** via a thin provider interface — never asks each view to handle the command itself.
+3. **Keyboard shortcut + context menu + (optional) action bar** are three views of the same command. Pick a command; surface it three ways.
+4. **External writes use the OS's save dialog or a known directory**. Never paste data into a random path without user awareness.
+
+---
+
+## 3. Proposed architecture
+
+### 3.1 The contract: `SelectionProvider`
+
+A pane that has selectable content implements:
+
+```ts
+interface SelectionProvider {
+    /** Best-effort current selection. Returns the empty string when nothing
+     *  is selected (so callers can branch on truthiness). */
+    getSelection(): string;
+    /** Full content of the view, regardless of selection. Used by
+     *  "Copy All", "Save As…", "Open in Editor". For long-running
+     *  panes (terminal scrollback), bounded by the existing scrollback
+     *  cap. */
+    getAll(): string;
+    /** Optional label for export filenames — e.g. `install-${agent}` so
+     *  the suggested file is named meaningfully. Defaults to the pane's
+     *  view type if omitted. */
+    exportLabel?(): string;
+}
+```
+
+Providers register themselves with the focused-pane registry on mount, unregister on unmount. The global commands query the registry for the focused pane's provider and act on what they get back.
+
+```ts
+// frontend/util/selection-registry.ts (new)
+let active: SelectionProvider | null = null;
+
+export function registerSelectionProvider(p: SelectionProvider): () => void;
+export function getActiveSelectionProvider(): SelectionProvider | null;
+```
+
+Activation follows DOM focus. The pane's container wires `onFocusIn` / `onFocusOut` to `register` / `unregister`. Multiple panes can be mounted; only the focused one is active.
+
+### 3.2 The four global commands
+
+Wired once at app root (`frontend/app/app.tsx`), keyed off the active provider:
+
+| Command | Key | Action |
+|---|---|---|
+| Copy | `Ctrl+C` (or `Ctrl+Shift+C` in terminal context) | `clipboardWriteText(provider.getSelection() || provider.getAll())` |
+| Copy All | `Ctrl+Shift+A` | `clipboardWriteText(provider.getAll())` |
+| Save Selection As… | `Ctrl+S` (when focus is in a non-editor pane) | `RpcApi.WriteFile({ path: dialogPick, content: provider.getSelection() || provider.getAll() })` |
+| Open in Editor | `Ctrl+Shift+E` | Write to a temp file in `~/.agentmux/clips/`, then `RpcApi.OpenExternal(tempPath)` which routes to the user's configured editor (default: VS Code's `code <path>` if on PATH; fallback: OS default for `.txt`). |
+
+All four also appear in the right-click context menu (`buildPaneContextMenu` extension) and as buttons in a hover-revealed action bar (Phase β).
+
+### 3.3 Clipboard write path
+
+All clipboard writes go through `frontend/util/clipboard.ts` → CEF IPC `write_clipboard` → `agentmux-cef/src/commands/clipboard.rs`. This is the existing path; the gap is enforcing it. Concretely:
+
+- Audit + replace the one `navigator.clipboard.writeText` direct call in `PreLaunchAuthPanel.tsx:366`.
+- Add an ESLint rule (or comment-noted code review checkpoint) forbidding direct `navigator.clipboard` use outside `frontend/util/clipboard.ts`.
+
+### 3.4 xterm.js providers
+
+The two xterm consumers (`termwrap.ts`, `AgentInstallModal.tsx`) wrap a tiny adapter:
+
+```ts
+function xtermSelectionProvider(term: Terminal, scrollback: () => string): SelectionProvider {
+    return {
+        getSelection: () => term.getSelection() || "",
+        getAll: scrollback,
+        exportLabel: () => "terminal",
+    };
+}
+```
+
+For the install modal specifically: `scrollback` is the full buffer (xterm.js's `serializeAddon` if loaded, else the live `buffer.active.getLine(i)` walk).
+
+The xterm's existing `onSelectionChange` hook also gets wired in the install modal (it's already wired in `termwrap.ts:200-214`), respecting the global `term:copyonselect` setting. With this one change, **selecting text in the install modal copies it to the clipboard immediately** — covering the user's reported regression in two lines.
+
+### 3.5 Non-xterm providers
+
+| Pane | `getSelection` | `getAll` |
+|---|---|---|
+| Agent doc view | `window.getSelection().toString()` | Full markdown content of the view |
+| Code blocks (markdown.tsx) | `window.getSelection().toString()` if inside block, else "" | The block's source text |
+| Error banner / log viewers | `window.getSelection().toString()` | Concatenated lines |
+| Forms (LaunchModal, etc.) | input/textarea native selection | n/a (not a logical "all" — skip Copy All) |
+
+### 3.6 Write-to-file
+
+Backend already has `RpcApi.FileAppendCommand`. Add a sibling `RpcApi.WriteFile` (overwrite) or piggyback on AgentMuxError-style error wrapping. For "Save As…" specifically:
+
+```rust
+// agentmux-srv/src/server/file_handlers.rs (new or extend existing)
+#[derive(Deserialize)]
+struct WriteFileReq {
+    path: String,        // absolute, must be under user's home unless `unrestricted`
+    content: String,
+    overwrite: bool,
+}
+```
+
+Path resolution: relative paths are resolved against `~/.agentmux/clips/`. Absolute paths under the user's home are allowed; outside the home requires `unrestricted: true` (future).
+
+For the OS file picker, use `getApi().showSaveDialog({ defaultPath, filters })` — CEF exposes the native Chromium save dialog. If we don't have that bridge yet, the v1 implementation can drop content into `~/.agentmux/clips/<timestamp>-<label>.txt` and surface a toast with the path (good enough for "open in editor" follow-up).
+
+### 3.7 Open in Editor
+
+Two-step:
+
+1. Write content to `~/.agentmux/clips/<timestamp>-<label>.txt` via the same path as 3.6.
+2. Resolve the user's editor: setting `editor:external` (default: `"code"` on Windows/Linux, `"open -a 'Visual Studio Code'"` on macOS, fallback to OS default `open` / `xdg-open` / `start`).
+3. Spawn editor via `RpcApi.OpenExternalCommand(path)` — already exists at `agentmux-cef/src/commands/platform.rs::open_external`.
+
+The cleanup story: clips older than 7 days get pruned on startup. Capped at 1 MB / file to keep disk usage bounded.
+
+---
+
+## 4. Implementation phases
+
+### Phase α — Install modal copy works (this PR)
+
+Smallest viable fix the user can feel immediately:
+
+1. Wire `onSelectionChange` in `AgentInstallModal.tsx` to call `clipboardWriteText(terminal.getSelection())` when `term:copyonselect` is true.
+2. Wire `terminal.attachCustomKeyEventHandler` to intercept Ctrl+Shift+C → manual copy of current selection.
+3. Add a right-click context menu (single item: "Copy") on the install modal terminal.
+4. Replace the one `navigator.clipboard.writeText` in `PreLaunchAuthPanel.tsx:366` with `clipboardWriteText` from the wrapper.
+
+That's ~30 lines. Spec + Phase α implementation ship as one PR. Internals doc page added.
+
+### Phase β — Selection-provider registry + global commands
+
+1. New file `frontend/util/selection-registry.ts` per §3.1.
+2. App-root keyboard listener registers Ctrl+C / Ctrl+Shift+A / Ctrl+S / Ctrl+Shift+E → dispatches to active provider.
+3. Both xterm consumers + agent doc view + markdown blocks register providers.
+4. Extend `buildPaneContextMenu` with Copy / Copy All / Save As… / Open in Editor entries.
+
+Separate PR after Phase α stabilizes.
+
+### Phase γ — Write to file + Open in editor
+
+1. New `RpcApi.WriteFile` backend handler.
+2. `~/.agentmux/clips/` directory + 7-day pruning.
+3. `editor:external` setting wired through to `open_external`.
+4. Toast on save with click-to-open.
+
+Separate PR.
+
+### Phase δ — Action bar (optional, low priority)
+
+Hover-revealed "[ Copy | Save | Open ]" bar on the install-modal terminal and other long-output surfaces. Nice-to-have; defer until the keyboard + context-menu surfaces have stabilized.
+
+---
+
+## 5. Acceptance criteria
+
+### Phase α
+1. Select text in install modal terminal → clipboard receives it (if `term:copyonselect` is on, or via Ctrl+Shift+C / right-click → Copy).
+2. `grep -nE 'navigator\.clipboard' frontend/` returns 0 results.
+
+### Phase β
+1. `Ctrl+C` in any focused pane copies the pane's selection (or its full content, if nothing is selected).
+2. New pane types add clipboard support by implementing `SelectionProvider` + calling `registerSelectionProvider` in `onMount`.
+
+### Phase γ
+1. `Ctrl+S` in any focused pane opens a save dialog (or writes to `~/.agentmux/clips/` with a toast).
+2. `Ctrl+Shift+E` opens the saved file in the user's configured editor.
+
+### Phase δ
+1. Hovering an exportable output region shows the [Copy | Save | Open] bar.
+
+---
+
+## 6. Out of scope
+
+- **Rich content copy** (HTML, images, MIME types). The wrapper is plain-text only; lifting this is a separate spec.
+- **Browser pane** clipboard. CEF's browser child handles its own clipboard via Chromium internals; the host app shouldn't intercept.
+- **Cross-app drag-and-drop** of files / panes. Different problem.
+- **History / clipboard manager**. The user's OS handles this.
+
+---
+
+## 7. Internals doc
+
+A new page at `agentmux-docs/src/content/docs/internals/clipboard.md` documents the contract, the wrapper, the keyboard/context surfaces, and the provider registration pattern. Linked from the Architecture sidebar entry. Lands alongside the Phase α PR.

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -348,13 +348,24 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                         // right-click + dismiss (reagent P2). For
                         // long install logs this is non-trivial work.
                         const collectAll = (): string => {
+                            // Reassemble logical lines from xterm's visual
+                            // rows. `isWrapped` on row N+1 means row N's
+                            // logical line continues onto N+1, so emit a
+                            // newline only when the next row starts a fresh
+                            // logical line. Codex P2 on PR #899 v3 — naive
+                            // join inserted artificial breaks into long
+                            // URLs / stack traces / npm command echoes.
                             const buf = terminal?.buffer?.active;
                             if (!buf) return "";
-                            const lines: string[] = [];
+                            let out = "";
                             for (let i = 0; i < buf.length; i++) {
-                                lines.push(buf.getLine(i)?.translateToString(true) ?? "");
+                                const line = buf.getLine(i);
+                                if (!line) continue;
+                                out += line.translateToString(true);
+                                const next = buf.getLine(i + 1);
+                                if (!next?.isWrapped) out += "\n";
                             }
-                            return lines.join("\n");
+                            return out;
                         };
                         ContextMenuModel.showContextMenu(
                             [

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -23,11 +23,13 @@ import { FitAddon } from "@xterm/addon-fit";
 
 import { Button } from "@/element/button";
 import { ErrorBanner } from "@/app/errors/ErrorBanner";
-import { atoms } from "@/app/store/global";
+import { atoms, getSettingsKeyAtom } from "@/app/store/global";
+import { ContextMenuModel } from "@/app/store/contextmenu";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { computeTermThemeFromSettings } from "@/app/view/term/termutil";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 import { getProvider } from "../providers";
@@ -205,6 +207,31 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             const [t] = computeTermThemeFromSettings(atoms.fullConfigAtom());
             if (terminal) terminal.options.theme = t;
         });
+        // Clipboard wiring — phase α of SPEC_UNIFIED_CLIPBOARD_2026_05_18.md.
+        // Mirrors the regular term pane's three paths (copy-on-select,
+        // Ctrl+Shift+C, context menu Copy) so users can pull npm output
+        // out of the install log.
+        const copyOnSelect = getSettingsKeyAtom("term:copyonselect");
+        terminal.onSelectionChange(() => {
+            if (!copyOnSelect()) return;
+            const sel = terminal?.getSelection() ?? "";
+            if (sel.length > 0) {
+                clipboardWriteText(sel).catch(() => { /* best-effort */ });
+            }
+        });
+        terminal.attachCustomKeyEventHandler((ev) => {
+            // Ctrl+Shift+C → manual copy. Return false stops xterm from
+            // also routing the keystroke as input.
+            if (ev.type === "keydown" && ev.ctrlKey && ev.shiftKey && ev.key === "C") {
+                const sel = terminal?.getSelection() ?? "";
+                if (sel.length > 0) {
+                    clipboardWriteText(sel).catch(() => { /* best-effort */ });
+                }
+                return false;
+            }
+            return true;
+        });
+
         fitAddon = new FitAddon();
         terminal.loadAddon(fitAddon);
         terminal.open(termRef);
@@ -287,7 +314,36 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 </p>
             </header>
             <div class="modal-panel-body agent-install-modal-body">
-                <div class="agent-install-modal-term" ref={termRef} />
+                <div
+                    class="agent-install-modal-term"
+                    ref={termRef}
+                    onContextMenu={(e) => {
+                        // Right-click → Copy (selection) / Copy All. Mirrors
+                        // the regular term pane's menu. Phase α of
+                        // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md.
+                        const sel = terminal?.getSelection() ?? "";
+                        const all = terminal?.buffer?.active
+                            ? Array.from({ length: terminal.buffer.active.length }, (_, i) =>
+                                terminal.buffer.active.getLine(i)?.translateToString(true) ?? ""
+                              ).join("\n")
+                            : "";
+                        ContextMenuModel.showContextMenu(
+                            [
+                                {
+                                    label: "Copy",
+                                    enabled: sel.length > 0,
+                                    click: () => void clipboardWriteText(sel).catch(() => {}),
+                                },
+                                {
+                                    label: "Copy All",
+                                    enabled: all.length > 0,
+                                    click: () => void clipboardWriteText(all).catch(() => {}),
+                                },
+                            ],
+                            e,
+                        );
+                    }}
+                />
                 <Show when={error()}>
                     <ErrorBanner error={error()} />
                 </Show>

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -212,12 +212,20 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         // Ctrl+Shift+C, context menu Copy) so users can pull npm output
         // out of the install log.
         const copyOnSelect = getSettingsKeyAtom("term:copyonselect");
+        // Debounce matches termwrap.ts:205 — fires once per drag burst
+        // instead of once per tick.
+        let selectionDebounce: ReturnType<typeof setTimeout> | null = null;
         terminal.onSelectionChange(() => {
             if (!copyOnSelect()) return;
-            const sel = terminal?.getSelection() ?? "";
-            if (sel.length > 0) {
-                clipboardWriteText(sel).catch(() => { /* best-effort */ });
-            }
+            if (selectionDebounce != null) clearTimeout(selectionDebounce);
+            selectionDebounce = setTimeout(() => {
+                const sel = terminal?.getSelection() ?? "";
+                if (sel.length > 0) {
+                    clipboardWriteText(sel).catch((e) =>
+                        console.log("clipboard write failed", e),
+                    );
+                }
+            }, 50);
         });
         terminal.attachCustomKeyEventHandler((ev) => {
             // Ctrl+Shift+C → manual copy. Return false stops xterm from
@@ -225,7 +233,9 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             if (ev.type === "keydown" && ev.ctrlKey && ev.shiftKey && ev.key === "C") {
                 const sel = terminal?.getSelection() ?? "";
                 if (sel.length > 0) {
-                    clipboardWriteText(sel).catch(() => { /* best-effort */ });
+                    clipboardWriteText(sel).catch((e) =>
+                        console.log("clipboard write failed", e),
+                    );
                 }
                 return false;
             }
@@ -321,6 +331,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                         // Right-click → Copy (selection) / Copy All. Mirrors
                         // the regular term pane's menu. Phase α of
                         // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md.
+                        // preventDefault stops Chromium's native right-click
+                        // menu from firing alongside our custom one
+                        // (reagent P1 + codex P2 on PR #899).
+                        e.preventDefault();
                         const sel = terminal?.getSelection() ?? "";
                         const all = terminal?.buffer?.active
                             ? Array.from({ length: terminal.buffer.active.length }, (_, i) =>
@@ -332,12 +346,14 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                                 {
                                     label: "Copy",
                                     enabled: sel.length > 0,
-                                    click: () => void clipboardWriteText(sel).catch(() => {}),
+                                    click: () => void clipboardWriteText(sel).catch((err) =>
+                                        console.log("clipboard write failed", err)),
                                 },
                                 {
                                     label: "Copy All",
                                     enabled: all.length > 0,
-                                    click: () => void clipboardWriteText(all).catch(() => {}),
+                                    click: () => void clipboardWriteText(all).catch((err) =>
+                                        console.log("clipboard write failed", err)),
                                 },
                             ],
                             e,

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -77,6 +77,9 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     let resizeObserver: ResizeObserver | null = null;
     let startedAt = 0;
     let tickHandle: ReturnType<typeof setInterval> | null = null;
+    // Hoisted so onCleanup can cancel the pending copy-on-select
+    // timer when the modal unmounts (reagent P2 on PR #899 v2).
+    let selectionDebounce: ReturnType<typeof setTimeout> | null = null;
     // Flipped in onCleanup so a startInstall awaiting the RPC response
     // can cancel the resolved session id even if it landed after unmount.
     let disposed = false;
@@ -213,8 +216,8 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         // out of the install log.
         const copyOnSelect = getSettingsKeyAtom("term:copyonselect");
         // Debounce matches termwrap.ts:205 — fires once per drag burst
-        // instead of once per tick.
-        let selectionDebounce: ReturnType<typeof setTimeout> | null = null;
+        // instead of once per tick. `selectionDebounce` is hoisted to
+        // component scope so onCleanup can cancel it.
         terminal.onSelectionChange(() => {
             if (!copyOnSelect()) return;
             if (selectionDebounce != null) clearTimeout(selectionDebounce);
@@ -270,6 +273,10 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
         if (tickHandle != null) {
             clearInterval(tickHandle);
             tickHandle = null;
+        }
+        if (selectionDebounce != null) {
+            clearTimeout(selectionDebounce);
+            selectionDebounce = null;
         }
         if (resizeObserver) {
             resizeObserver.disconnect();
@@ -336,11 +343,19 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                         // (reagent P1 + codex P2 on PR #899).
                         e.preventDefault();
                         const sel = terminal?.getSelection() ?? "";
-                        const all = terminal?.buffer?.active
-                            ? Array.from({ length: terminal.buffer.active.length }, (_, i) =>
-                                terminal.buffer.active.getLine(i)?.translateToString(true) ?? ""
-                              ).join("\n")
-                            : "";
+                        // Lazy-walk the scrollback inside the click
+                        // handler so we don't pay for it on every
+                        // right-click + dismiss (reagent P2). For
+                        // long install logs this is non-trivial work.
+                        const collectAll = (): string => {
+                            const buf = terminal?.buffer?.active;
+                            if (!buf) return "";
+                            const lines: string[] = [];
+                            for (let i = 0; i < buf.length; i++) {
+                                lines.push(buf.getLine(i)?.translateToString(true) ?? "");
+                            }
+                            return lines.join("\n");
+                        };
                         ContextMenuModel.showContextMenu(
                             [
                                 {
@@ -351,9 +366,13 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                                 },
                                 {
                                     label: "Copy All",
-                                    enabled: all.length > 0,
-                                    click: () => void clipboardWriteText(all).catch((err) =>
-                                        console.log("clipboard write failed", err)),
+                                    enabled: !!terminal?.buffer?.active?.length,
+                                    click: () => {
+                                        const all = collectAll();
+                                        if (all.length === 0) return;
+                                        void clipboardWriteText(all).catch((err) =>
+                                            console.log("clipboard write failed", err));
+                                    },
                                 },
                             ],
                             e,

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -23,6 +23,7 @@ import { translateError } from "@/app/errors/translate";
 import { getApi } from "@/app/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
+import { writeText as clipboardWriteText } from "@/util/clipboard";
 import {
     createEffect,
     createSignal,
@@ -363,7 +364,11 @@ const WaitingPanel = (p: {
                     <Button
                         className="grey solid"
                         onClick={() => {
-                            void navigator.clipboard.writeText(p.state.authUrl);
+                            // Route through the CEF clipboard wrapper —
+                            // navigator.clipboard.* is fragile under CEF's
+                            // permission policy. See
+                            // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
+                            void clipboardWriteText(p.state.authUrl).catch(() => {});
                         }}
                     >
                         Copy

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -368,7 +368,9 @@ const WaitingPanel = (p: {
                             // navigator.clipboard.* is fragile under CEF's
                             // permission policy. See
                             // SPEC_UNIFIED_CLIPBOARD_2026_05_18.md §3.3.
-                            void clipboardWriteText(p.state.authUrl).catch(() => {});
+                            void clipboardWriteText(p.state.authUrl).catch((err) =>
+                                console.log("clipboard write failed", err),
+                            );
                         }}
                     >
                         Copy


### PR DESCRIPTION
## Summary

User report: "I tried copying the npm log in the install modal and it was unsuccessful." The audit found **zero clipboard wiring** on AgentInstallModal's xterm.js terminal — no `onSelectionChange`, no `Ctrl+Shift+C` handler, no context menu.

### Phase α (this PR)

Wires the install modal to match the regular term pane:

1. **`onSelectionChange`** → respects `term:copyonselect` setting, copies xterm's current selection on every change.
2. **`attachCustomKeyEventHandler` for Ctrl+Shift+C** → manual copy of the current selection.
3. **`onContextMenu`** → right-click menu with **Copy** / **Copy All** (full scrollback walk).

All routed through `frontend/util/clipboard.ts` → CEF IPC → host's `write_clipboard`.

Also replaces the one direct `navigator.clipboard.writeText` call in `PreLaunchAuthPanel.tsx:366` (OAuth URL copy) with the wrapper. After this: `grep -nE 'navigator\.clipboard' frontend/` returns 0 hits.

### Roadmap (separate PRs)

Spec lays out the full unified system:

- **Phase β** — `SelectionProvider` registry: every pane registers what it considers "selected" and "all content"; global Ctrl+C / Ctrl+Shift+A / context menu route through the registry.
- **Phase γ** — Save Selection As… + Open in Editor: writes to `~/.agentmux/clips/<timestamp>-<label>.txt`, spawns user's configured editor (default `code`).
- **Phase δ** — Hover action bar on long-output regions.

Spec: [`SPEC_UNIFIED_CLIPBOARD_2026_05_18.md`](docs/specs/SPEC_UNIFIED_CLIPBOARD_2026_05_18.md)
Docs: companion agentmux-docs PR #34 adds the **Clipboard & export** internals page.

## Test plan

- [ ] Open install modal → install → select text in the npm log → if `term:copyonselect` is on, clipboard has it. Verify via paste in a notepad.
- [ ] Same modal, Ctrl+Shift+C with selection → clipboard updated.
- [ ] Right-click the term area → Copy / Copy All menu items appear; Copy is disabled with no selection.
- [ ] OAuth Copy button still works (now via wrapper).
- [ ] `grep -nE 'navigator\.clipboard' frontend/` returns 0 hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)