### PR TITLE
fix(install-modal): always verbose, drop checkbox

### DIFF
--- a/.changesets/1779114344-fix-install-modal-always-verbose-drop-checkbox-i8ji.md
+++ b/.changesets/1779114344-fix-install-modal-always-verbose-drop-checkbox-i8ji.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(install-modal): always verbose, drop checkbox

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -44,11 +44,6 @@ struct InstallStartReq {
     npm_package: String,
     #[serde(default)]
     pinned_version: String,
-    /// When true, run npm with `--loglevel=verbose` and re-enable the
-    /// install progress bar. Default false → terse "notice" loglevel
-    /// matching the pre-toggle behavior.
-    #[serde(default)]
-    verbose: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -221,7 +216,6 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     req.cli_command,
                     req.npm_package,
                     req.pinned_version,
-                    req.verbose,
                     cancel_rx,
                 );
 
@@ -283,7 +277,6 @@ fn spawn_install_task(
     cli_command: String,
     npm_package: String,
     pinned_version: String,
-    verbose: bool,
     mut cancel_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
     tokio::spawn(async move {
@@ -372,15 +365,14 @@ fn spawn_install_task(
             format!("{}@{}", npm_package, pinned_version)
         };
 
-        // Build the arg list once so the echoed command line matches
-        // what we actually exec — easier to copy/paste for debugging.
         // `--progress=false` is unconditional: npm only renders the
         // progress bar when both stdout and stderr are TTYs, and this
         // task pipes both, so leaving progress at the default would
-        // produce no visible spinner anyway (codex P3 on PR #897).
-        // The verbose toggle still earns its keep via per-package
-        // fetch/extract lines from `--loglevel=verbose`.
-        let mut npm_args: Vec<String> = vec![
+        // produce no visible spinner anyway. `--loglevel=verbose` is
+        // also unconditional: the user's only signal of progress
+        // during long installs is the per-package fetch/extract
+        // chatter, so we always pay for the noise to gain the signal.
+        let npm_args: Vec<String> = vec![
             "install".to_string(),
             pkg_arg.clone(),
             "--prefix".to_string(),
@@ -388,10 +380,8 @@ fn spawn_install_task(
             "--no-audit".to_string(),
             "--no-fund".to_string(),
             "--progress=false".to_string(),
+            "--loglevel=verbose".to_string(),
         ];
-        if verbose {
-            npm_args.push("--loglevel=verbose".to_string());
-        }
 
         emit_line(
             &broker,

--- a/frontend/app/view/agent/components/AgentInstallModal.tsx
+++ b/frontend/app/view/agent/components/AgentInstallModal.tsx
@@ -64,11 +64,6 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
     const [error, setError] = createSignal<unknown>(null);
     const [sessionId, setSessionId] = createSignal<string | null>(null);
     const [elapsedMs, setElapsedMs] = createSignal(0);
-    // When true, install runs with `npm --loglevel=verbose`. On by
-    // default — surface per-package fetch/extract lines so the user
-    // can see what's happening during long installs. Toggle off for
-    // a terse log.
-    const [verbose, setVerbose] = createSignal(true);
 
     let unsub: (() => void) | null = null;
     let termRef: HTMLDivElement | undefined;
@@ -128,7 +123,6 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
                 cliCommand: prov.cliCommand,
                 npmPackage: prov.npmPackage,
                 pinnedVersion: prov.pinnedVersion,
-                verbose: verbose(),
             });
             // If the modal unmounted while the RPC was in flight, cancel
             // the resolved session id rather than subscribing.
@@ -396,14 +390,6 @@ export const AgentInstallModalPanel = (props: AgentInstallModalPanelProps): JSX.
             </div>
             <footer class="modal-panel-footer">
                 <Show when={phase() === "idle"}>
-                    <label class="agent-install-modal-verbose">
-                        <input
-                            type="checkbox"
-                            checked={verbose()}
-                            onChange={(e) => setVerbose(e.currentTarget.checked)}
-                        />
-                        <span>Verbose output</span>
-                    </label>
                     <Button onClick={() => props.onCancel()}>Cancel</Button>
                     <Button onClick={() => void startInstall()} className="green solid">
                         Install now

--- a/frontend/app/view/agent/styles/_install-modal.scss
+++ b/frontend/app/view/agent/styles/_install-modal.scss
@@ -82,22 +82,3 @@
     font-size: var(--text-sm);
     font-style: italic;
 }
-
-// Verbose toggle — sits at the left of the idle-phase footer next to
-// Cancel/Install. `margin-right: auto` pushes the buttons to the right
-// edge so the toggle reads as an opt-in detail rather than a primary
-// action.
-.agent-install-modal-verbose {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    margin-right: auto;
-    color: var(--secondary-text-color);
-    font-size: var(--text-sm);
-    cursor: pointer;
-    user-select: none;
-
-    input {
-        cursor: pointer;
-    }
-}


### PR DESCRIPTION
Per user request — verbose output is always wanted, drop the toggle entirely. Idle-phase footer is back to Cancel + Install now.

Backend always passes `--loglevel=verbose --progress=false` to npm.

## Test plan

- [ ] Install modal opens — no Verbose checkbox.
- [ ] Install runs — log shows per-package fetch/extract chatter (npm verbose tier, many lines).
- [ ] Echoed command line at the top of the log reads `$ npm install ... --loglevel=verbose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)