### PR TITLE
diag(browser-pane): instrument title/favicon flow end-to-end

### DIFF
--- a/.changesets/1779115599-diag-browser-pane-instrument-title-favicon-flow-end-to-end-n433.md
+++ b/.changesets/1779115599-diag-browser-pane-instrument-title-favicon-flow-end-to-end-n433.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(browser-pane): instrument title/favicon flow end-to-end

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -291,6 +291,14 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
     const viewFaviconUrl = createMemo(() => util.useAtomValueSafe(props.viewModel?.viewFaviconUrl));
     const viewIconElem = createMemo(() => {
         const favUrl = viewFaviconUrl();
+        // Diag for the favicon path — log every recomputation of this
+        // memo for browser-view blocks so muxlog shows whether the
+        // atom is being read with a non-empty value. Throttle is the
+        // memo itself: it only re-fires when the dependent atom
+        // changes, so this won't spam.
+        if (blockData()?.meta?.view === "browser") {
+            console.log(`[browser-pane:diag][${(blockData()?.oid ?? "").slice(0, 7)}] header-render favUrl=${JSON.stringify(favUrl ?? "")}`);
+        }
         if (favUrl) {
             return (
                 <div class="block-frame-view-icon">
@@ -308,9 +316,11 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
                             // all subsequent valid favicons. Reset on every
                             // successful load.
                             (e.currentTarget as HTMLImageElement).style.display = "";
+                            console.log(`[browser-pane:diag][${(blockData()?.oid ?? "").slice(0, 7)}] favicon-load ok src=${JSON.stringify(favUrl)}`);
                         }}
                         onError={(e) => {
                             (e.currentTarget as HTMLImageElement).style.display = "none";
+                            console.log(`[browser-pane:diag][${(blockData()?.oid ?? "").slice(0, 7)}] favicon-load fail src=${JSON.stringify(favUrl)}`);
                         }}
                     />
                 </div>

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -258,15 +258,20 @@ export class BrowserViewModel implements ViewModel {
         this.viewFaviconUrl = createMemo(() => this.faviconUrlAtom());
 
         // Subscribe to live title changes fired by CEF's on_title_change.
+        // Diag note: log EVERY arrival (pre block-id filter) so a
+        // mismatched block_id is observable in muxlog — silent drops
+        // were the main blind spot when chasing the favicon/title
+        // regression on 2026-05-18.
         void listenEvent<{ block_id: string; title: string }>(
             "browser-pane-title-change",
             (payload) => {
+                const matched = payload.block_id === this.blockId;
+                this.diag(`title-change arrive payload-block=${(payload.block_id ?? "").slice(0, 7)} match=${matched} title=${JSON.stringify(payload.title)}`);
                 if (this.closed) {
                     this.diag(`post-close-event-dropped name=browser-pane-title-change`);
                     return;
                 }
-                if (payload.block_id !== this.blockId) return;
-                this.diag(`title-change recv title=${JSON.stringify(payload.title)}`);
+                if (!matched) return;
                 this._dispatch({ type: "TitleChanged", title: payload.title }, "title-change");
             },
         ).then((unsub) => {
@@ -279,12 +284,13 @@ export class BrowserViewModel implements ViewModel {
         void listenEvent<{ block_id: string; urls: string[] }>(
             "browser-pane-favicon-urls",
             (payload) => {
+                const matched = payload.block_id === this.blockId;
+                this.diag(`favicon-urls arrive payload-block=${(payload.block_id ?? "").slice(0, 7)} match=${matched} count=${payload.urls?.length ?? 0} first=${JSON.stringify(payload.urls?.[0])}`);
                 if (this.closed) {
                     this.diag(`post-close-event-dropped name=browser-pane-favicon-urls`);
                     return;
                 }
-                if (payload.block_id !== this.blockId) return;
-                this.diag(`favicon-urls recv count=${payload.urls.length}`);
+                if (!matched) return;
                 this._dispatch({ type: "FaviconUrlsReceived", urls: payload.urls }, "favicon-urls");
             },
         ).then((unsub) => {


### PR DESCRIPTION
## Summary

Browser pane favicon + page title appear stuck at the static fallback in v0.33.899 (likely regression from PR #876). Adding diagnostic logging at the two unobserved layers — renderer-side wire receipt (pre block-id filter) and blockframe render — so every step of the chain is visible in \`muxlog srv '[browser-pane'\`.

After this lands, smoke flow:

\`\`\`
muxlog srv '[browser-pane' &
# open browser pane, navigate to github.com
\`\`\`

Expected sequence per navigation:

1. \`emit-title-change\` / \`emit-favicon-urls\` — CEF host
2. \`title-change arrive\` / \`favicon-urls arrive\` — renderer wire (new)
3. \`dispatch type=TitleChanged|FaviconUrlsReceived\` — reducer entry
4. \`state-write key=title|faviconUrl\` — projection setter
5. \`header-render favUrl=...\` — blockframe memo recompute (new)
6. \`favicon-load ok|fail\` — \`<img>\` mount (new)

First silent step or stale value identifies the bug.

## Test plan

- [ ] Build portable, open browser pane → navigate to https://github.com
- [ ] \`muxlog srv '[browser-pane' | head\` shows the 6-step chain
- [ ] If chain incomplete: report the last log line we see — that's the boundary where the bug lives
- [ ] If chain complete but header still shows globe + "Browser": separate UI memo issue, blockframe diff needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)