### PR TITLE
diag(browser-pane): per-instance vmId to detect stale viewmodel refs

### DIFF
--- a/.changesets/1779117353-diag-browser-pane-per-instance-vmid-to-detect-stale-viewmode-ky7a.md
+++ b/.changesets/1779117353-diag-browser-pane-per-instance-vmid-to-detect-stale-viewmode-ky7a.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+diag(browser-pane): per-instance vmId to detect stale viewmodel refs

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -297,7 +297,8 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
         // memo itself: it only re-fires when the dependent atom
         // changes, so this won't spam.
         if (blockData()?.meta?.view === "browser") {
-            console.log(`[browser-pane:diag][${(blockData()?.oid ?? "").slice(0, 7)}] header-render favUrl=${JSON.stringify(favUrl ?? "")}`);
+            const vmId = (props.viewModel as any)?.__diagVmId ?? "?";
+            console.log(`[browser-pane:diag][${(blockData()?.oid ?? "").slice(0, 7)} vm=${vmId}] header-render favUrl=${JSON.stringify(favUrl ?? "")}`);
         }
         if (favUrl) {
             return (

--- a/frontend/app/view/browser/browser-model.ts
+++ b/frontend/app/view/browser/browser-model.ts
@@ -197,12 +197,19 @@ export class BrowserViewModel implements ViewModel {
     /** Tag every diag log with the block prefix so multi-pane sessions
      *  are greppable per pane. See docs/specs/browser-pane-reducer-roadmap.md
      *  Phase 1. */
-    private get _diagTag(): string { return `[browser-pane:diag][${this.blockId.slice(0, 7)}]`; }
+    // Per-instance ID so we can tell when a stale viewModel reference
+    // is hanging around. Used in diag logs alongside blockId. If the
+    // setFavicon-side and the memo-read-side print different `vm`
+    // values for the same blockId, the bug is "two viewModels for the
+    // same blockId, blockframe holds the wrong one."
+    public readonly __diagVmId: string = Math.random().toString(36).slice(2, 8);
+    private get _diagTag(): string { return `[browser-pane:diag][${this.blockId.slice(0, 7)} vm=${this.__diagVmId}]`; }
     private diag(msg: string): void { console.log(`${this._diagTag} ${msg}`); }
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;
         this.nodeModel = nodeModel;
+        this.diag(`viewmodel-constructed`);
 
         this.blockAtom = getWaveObjectAtom<Block>(makeORef("block", blockId));
 
@@ -255,7 +262,11 @@ export class BrowserViewModel implements ViewModel {
         installEventSinkOnce();
 
         this.viewName = createMemo(() => this.titleAtom());
-        this.viewFaviconUrl = createMemo(() => this.faviconUrlAtom());
+        this.viewFaviconUrl = createMemo(() => {
+            const v = this.faviconUrlAtom();
+            this.diag(`vm-favicon-memo-eval value=${JSON.stringify(v)}`);
+            return v;
+        });
 
         // Subscribe to live title changes fired by CEF's on_title_change.
         // Diag note: log EVERY arrival (pre block-id filter) so a


### PR DESCRIPTION
Continuing diag from #902. Chain ends correctly at state-write but header-render reads stale value forever — suggests stale viewmodel ref. Adding per-instance `__diagVmId` to the BrowserViewModel + logging it from both the writer side (already prefixed in this.diag) and the reader side (blockframe's header-render log).

After this lands, smoke and check:
- If `state-write vm=ABC` and `header-render vm=XYZ` show different IDs for the same blockId, the bug is a stale viewmodel ref (blockframe holds an older instance).
- If they match, the bug is in reactivity (memo not subscribing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)