### PR TITLE
fix(browser-pane): reset favicon override on cross-origin navigation

### DIFF
--- a/.changesets/1779124557-fix-browser-pane-reset-favicon-override-on-cross-origin-navi-hfiv.md
+++ b/.changesets/1779124557-fix-browser-pane-reset-favicon-override-on-cross-origin-navi-hfiv.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(browser-pane): reset favicon override on cross-origin navigation

--- a/docs/specs/SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md
+++ b/docs/specs/SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md
@@ -82,3 +82,13 @@ Wire it into two reducer cases:
 2. Cross-origin nav from CEF nav-state (in-page clicks) also resets the title placeholder.
 3. Same-origin redirects/hash-changes preserve the real title (no flash).
 4. `TitleChanged` still wins once CEF emits.
+
+## 6. Known trade-off — title race
+
+Unlike the favicon (whose URL encodes its origin and lets the reducer disambiguate "real favicon for new page beat UrlConfirmed" from "stale favicon from old page"), titles carry no origin signal. So `UrlConfirmed` cross-origin always resets to the hostname placeholder — even if `TitleChanged` already applied the real title in a race.
+
+Worst case: TitleChanged for the new page fires BEFORE UrlConfirmed, leaving `state.title = newReal, state.url = oldPage, titleOverridden = true`. UrlConfirmed arrives, origin changed → resets title to hostname placeholder. CEF doesn't re-emit TitleChanged for the same page → user is stuck on the placeholder until the next navigation.
+
+This is rare in practice (IPC subscription ordering in `BrowserViewModel` consistently sees nav-state ahead of title-change in the smoke logs) and produces a less-bad outcome than the alternative — which would be the real title of the PREVIOUS page sticking forever (the original bug §2 was filed to fix).
+
+A future PR could introduce a per-nav token (dispatch on `on_loading_state_change(is_loading=true)`) to disambiguate. Out of scope for this fix.

--- a/docs/specs/SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md
+++ b/docs/specs/SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md
@@ -1,0 +1,84 @@
+# SPEC: Optimistic Browser-Pane Header on Navigation
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:** `SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md` (the live-update plumbing), `frontend/app/store/browser-pane-state/reducer.ts`
+
+---
+
+## 0. TL;DR
+
+When the user clicks a link or navigates to a new URL, the browser pane header shows the **previous page's title** for 500ms–3s while CEF loads the new page and eventually emits `title-change`. The favicon is already optimistic (derived from the URL at `Navigate` time, t=0); the title isn't.
+
+Fix: in the `Navigate` and `UrlConfirmed` reducer cases, also set `state.title = deriveTitlePlaceholder(url)` so the header shows the URL's hostname (e.g. `"x.com"`) immediately on click. CEF's real title replaces it later. Mirrors how Chrome shows a tab title during navigation.
+
+---
+
+## 1. Problem
+
+Trace from the 2026-05-18 self-smoke:
+
+| t | event | header state |
+|---|---|---|
+| 0 | user click → `Navigate` → reducer: `url=x.com, faviconUrl=derive(x.com), loading=true` | favicon ✓ x.com derived, **title still says "Google"** |
+| ~100ms | CEF nav-state → `UrlConfirmed` | — |
+| ~500ms–3s | CEF title-change → `TitleChanged` | title finally "X / Twitter" |
+
+So the favicon and title are out of sync for the first ~1 second of every navigation. The favicon updates instantly; the title lags. Visible UX bug.
+
+---
+
+## 2. Fix
+
+Add a `deriveTitlePlaceholder(url): string` helper in `types.ts` alongside `deriveFaviconUrl`. Returns the URL's hostname stripped of `www.` prefix; empty for unparseable URLs.
+
+```ts
+export function deriveTitlePlaceholder(url: string): string {
+    if (url === "") return "";
+    try {
+        const u = new URL(url);
+        if (u.origin === "null" || u.origin === "") return "";
+        return u.hostname.replace(/^www\./, "");
+    } catch {
+        return "";
+    }
+}
+```
+
+Wire it into two reducer cases:
+
+1. **`Navigate`** — explicit navigation from the address bar or `model.navigate(url)`. Set `title = deriveTitlePlaceholder(command.url)` alongside the existing URL + faviconUrl + faviconOverridden reset.
+
+2. **`UrlConfirmed`** — CEF's nav-state event (covers in-page link clicks). Only update title when `originChanged`, mirroring the favicon-override logic from PR #905. Same-origin redirects/hash-changes keep the real title.
+
+`TitleChanged` already overrides whatever the placeholder set. No change needed there.
+
+### 2.1 Empty / null-origin URLs
+
+`about:blank`, `file://`, etc. → `deriveTitlePlaceholder` returns `""`. Reducer falls back through `TITLE_FALLBACK` ("Browser") via the existing `TitleChanged` empty-check path. Net: those URLs show "Browser" optimistically, same as today.
+
+---
+
+## 3. Test plan
+
+- [ ] Type `x.com` → press Enter. Header instantly reads "x.com" (was "Google" or whatever previous page). Real title "X / Twitter" replaces it ~1s later.
+- [ ] Click an in-page link to a same-origin path (e.g. `x.com/home`). Title stays at the real "X / Twitter" — no flash to "x.com" placeholder.
+- [ ] Click an in-page link to a different origin (e.g. opens `t.co/...`). Title flashes to "t.co" then upgrades to real title.
+- [ ] `about:blank` shows "Browser".
+
+---
+
+## 4. Out of scope
+
+- **Spinner / loading indicator on the title.** Could prefix with `"⏳ "` during `state.loading=true` — separate UX call, not in this spec.
+- **Address-bar visual feedback for invalid URLs.** Outside header.
+
+---
+
+## 5. Acceptance criteria
+
+1. `Navigate` dispatch produces a header that's immediately self-consistent (favicon + title both derived from the target URL).
+2. Cross-origin nav from CEF nav-state (in-page clicks) also resets the title placeholder.
+3. Same-origin redirects/hash-changes preserve the real title (no flash).
+4. `TitleChanged` still wins once CEF emits.

--- a/frontend/app/store/browser-pane-state/reducer.test.ts
+++ b/frontend/app/store/browser-pane-state/reducer.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import { update } from "./reducer";
-import { deriveFaviconUrl, initialState, TITLE_FALLBACK } from "./types";
+import { deriveFaviconUrl, initialState, TITLE_FALLBACK, type BrowserPaneState } from "./types";
 
 // Pure-function tests for the URL→favicon helper. Kept separate from
 // the reducer suite because the helper is reused by future consumers
@@ -638,6 +638,134 @@ describe("browser-pane-state reducer (slice #9, Phases 3a + 3b + 3c + 3d + 3e co
                     expect(r.state.loading && r.state.error !== null).toBe(false);
                 }
             }
+        });
+    });
+
+    // SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md +
+    // SPEC_BROWSER_PANE_FAVICON_TITLE_2026-05-15.md cross-origin
+    // reset logic introduced on PR #905.
+    describe("UrlConfirmed cross-origin handling", () => {
+        const setupRealFavicon = (origin: string): BrowserPaneState => {
+            // After Navigate + FaviconUrlsReceived for a given origin,
+            // state should hold the real CEF favicon with override=true.
+            const s1 = update(initialState(), {
+                type: "Navigate",
+                url: `${origin}/`,
+            }).state;
+            return update(s1, {
+                type: "FaviconUrlsReceived",
+                urls: [`${origin}/real.ico`],
+            }).state;
+        };
+
+        it("cross-origin URL change resets favicon override + derives fresh favicon", () => {
+            const s0 = setupRealFavicon("https://wikipedia.org");
+            expect(s0.faviconUrl).toBe("https://wikipedia.org/real.ico");
+            expect(s0.faviconOverridden).toBe(true);
+
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://google.com/",
+            });
+            expect(r.state.faviconUrl).toBe("https://google.com/favicon.ico");
+            expect(r.state.faviconOverridden).toBe(false);
+        });
+
+        it("same-origin URL change preserves favicon override (PR #876 P2)", () => {
+            const s0 = setupRealFavicon("https://wikipedia.org");
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://wikipedia.org/wiki/Foo",
+            });
+            expect(r.state.faviconUrl).toBe("https://wikipedia.org/real.ico");
+            expect(r.state.faviconOverridden).toBe(true);
+        });
+
+        it("preserves real favicon when FaviconUrlsReceived beat UrlConfirmed (race)", () => {
+            // Race: FaviconUrlsReceived for the new page arrived
+            // before UrlConfirmed updated state.url. So state.url is
+            // still old (wikipedia) but state.faviconUrl is from the
+            // new origin (google). Cross-origin UrlConfirmed should
+            // detect that and keep the real favicon.
+            const s0: BrowserPaneState = {
+                ...initialState(),
+                url: "https://wikipedia.org/",
+                faviconUrl: "https://google.com/real.ico",
+                faviconOverridden: true,
+            };
+            const r = update(s0, {
+                type: "UrlConfirmed",
+                url: "https://google.com/",
+            });
+            expect(r.state.faviconUrl).toBe("https://google.com/real.ico");
+            expect(r.state.faviconOverridden).toBe(true);
+        });
+
+        it("cross-origin resets title to hostname placeholder", () => {
+            const s0 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Wikipedia, the free encyclopedia",
+            });
+            const s1: BrowserPaneState = {
+                ...s0.state,
+                url: "https://wikipedia.org/",
+            };
+            const r = update(s1, {
+                type: "UrlConfirmed",
+                url: "https://google.com/",
+            });
+            expect(r.state.title).toBe("google.com");
+            expect(r.state.titleOverridden).toBe(false);
+        });
+
+        it("same-origin preserves real title (no flash)", () => {
+            const s0 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Wikipedia, the free encyclopedia",
+            });
+            const s1: BrowserPaneState = {
+                ...s0.state,
+                url: "https://wikipedia.org/wiki/Cat",
+            };
+            const r = update(s1, {
+                type: "UrlConfirmed",
+                url: "https://wikipedia.org/wiki/Dog",
+            });
+            expect(r.state.title).toBe("Wikipedia, the free encyclopedia");
+            expect(r.state.titleOverridden).toBe(true);
+        });
+    });
+
+    describe("TitleChanged sets titleOverridden flag", () => {
+        it("non-empty title sets titleOverridden=true", () => {
+            const r = update(initialState(), {
+                type: "TitleChanged",
+                title: "Hello",
+            });
+            expect(r.state.titleOverridden).toBe(true);
+        });
+
+        it("empty/whitespace folds to TITLE_FALLBACK with titleOverridden=false", () => {
+            const s1 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Hello",
+            }).state;
+            const r = update(s1, { type: "TitleChanged", title: "  " });
+            expect(r.state.title).toBe(TITLE_FALLBACK);
+            expect(r.state.titleOverridden).toBe(false);
+        });
+
+        it("Navigate clears titleOverridden", () => {
+            const s1 = update(initialState(), {
+                type: "TitleChanged",
+                title: "Hello",
+            }).state;
+            const r = update(s1, {
+                type: "Navigate",
+                url: "https://example.com/",
+            });
+            expect(r.state.titleOverridden).toBe(false);
+            expect(r.state.title).toBe("example.com");
         });
     });
 });

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -53,6 +53,7 @@ import {
     ReducerResult,
     TITLE_FALLBACK,
     deriveFaviconUrl,
+    sameOriginUrl,
 } from "./types";
 
 export function update(
@@ -143,18 +144,34 @@ export function update(
 
         case "UrlConfirmed": {
             if (state.url === command.url) return { state, events: [] };
-            // Reagent P2 on #876: preserve a CEF-reported favicon across
-            // redirects + hash-changes. Only re-derive the heuristic favicon
-            // if no real favicon has overridden it. Otherwise the user sees
-            // the real favicon flash to the heuristic on every nav event.
-            const faviconUrl = state.faviconOverridden
+            // Origin-aware favicon preservation:
+            //
+            // - Same-origin URL change (in-page redirect, hash change,
+            //   querystring update) keeps the CEF-reported favicon to
+            //   avoid the real favicon flashing back to the heuristic
+            //   on every nav event (reagent P2 on #876).
+            // - Cross-origin navigation resets the override so a stale
+            //   favicon from the previous site doesn't carry over —
+            //   bug found 2026-05-18, the old code preserved
+            //   faviconOverridden across all URL changes, so
+            //   navigating from agentmux.ai → bing.com → x.com would
+            //   keep bing's favicon when CEF was silent about x.com.
+            //   The new derived favicon may still flash briefly, but a
+            //   subsequent FaviconUrlsReceived from CEF will replace
+            //   it. That's a better default than retaining a foreign
+            //   favicon indefinitely.
+            const originChanged = sameOriginUrl(state.url, command.url) === false;
+            const keepOverride = state.faviconOverridden && !originChanged;
+            const faviconUrl = keepOverride
                 ? state.faviconUrl
                 : deriveFaviconUrl(command.url);
+            const faviconOverridden = keepOverride ? state.faviconOverridden : false;
             return {
                 state: {
                     ...state,
                     url: command.url,
                     faviconUrl,
+                    faviconOverridden,
                 },
                 events: [{ type: "url-confirmed", url: command.url }],
             };

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -188,24 +188,31 @@ export function update(
                 ? state.faviconUrl
                 : deriveFaviconUrl(command.url);
             const faviconOverridden = keepOverride ? state.faviconOverridden : false;
-            // Same logic for the title placeholder: cross-origin nav
-            // (in-page link click to a new domain) resets the title
-            // to the hostname so the user sees instant feedback. CEF
-            // will eventually emit the real title via TitleChanged.
+            // Title placeholder for cross-origin transitions. Simpler
+            // than favicon because title carries no origin information
+            // to disambiguate "real-title-from-new-page beat
+            // UrlConfirmed" vs "stale-real-title-from-old-page".
             //
-            // Race guard mirroring the favicon side (reagent P2 on
-            // #905 v2): if `TitleChanged` already applied the real
-            // destination title before `UrlConfirmed` arrived, we
-            // should NOT overwrite it with a hostname placeholder.
-            // `titleOverridden` is set true by TitleChanged and
-            // false by Navigate; cleared by an explicit reset here.
-            const keepTitle = state.titleOverridden && originChanged
-                ? true   // race case — real title already arrived
-                : !originChanged;  // same-origin → keep real title too
-            const title = keepTitle
-                ? state.title
-                : (deriveTitlePlaceholder(command.url) || TITLE_FALLBACK);
-            const titleOverridden = keepTitle ? state.titleOverridden : false;
+            //   - Same-origin: keep state.title (real title for this
+            //     page; no flash to placeholder).
+            //   - Cross-origin: reset to hostname placeholder so the
+            //     header shows instant feedback for in-page link
+            //     clicks to new domains (the primary win).
+            //
+            // Trade-off (reagent + codex P2 on #905 v2): if CEF's
+            // TitleChanged for the new page beat UrlConfirmed in a
+            // race, state.title already holds the real title with
+            // titleOverridden=true — we overwrite it with the
+            // placeholder here and never recover (CEF doesn't
+            // re-emit TitleChanged for the same page). Accepted
+            // because the common path (in-page link → new domain
+            // with no race) dominates, and the rare race produces a
+            // less-bad outcome than the original bug (real-title-of-
+            // PREVIOUS-page sticking forever).
+            const title = originChanged
+                ? (deriveTitlePlaceholder(command.url) || TITLE_FALLBACK)
+                : state.title;
+            const titleOverridden = originChanged ? false : state.titleOverridden;
             return {
                 state: {
                     ...state,

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -170,7 +170,19 @@ export function update(
             //   it. That's a better default than retaining a foreign
             //   favicon indefinitely.
             const originChanged = sameOriginUrl(state.url, command.url) === false;
-            const keepOverride = state.faviconOverridden && !originChanged;
+            // Race guard (reagent + codex P2 on #905 v1): if
+            // `FaviconUrlsReceived` for the destination page beat
+            // `UrlConfirmed` here, `state.faviconUrl` is already from
+            // the new origin even though `state.url` still points at
+            // the previous page. Resetting based purely on
+            // `originChanged` would overwrite that real favicon with
+            // the derived one. So: also keep the override when the
+            // current favicon's origin already matches the incoming
+            // URL's origin.
+            const faviconAlreadyForNewOrigin = state.faviconOverridden
+                && sameOriginUrl(state.faviconUrl, command.url);
+            const keepOverride = state.faviconOverridden
+                && (!originChanged || faviconAlreadyForNewOrigin);
             const faviconUrl = keepOverride
                 ? state.faviconUrl
                 : deriveFaviconUrl(command.url);

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -53,6 +53,7 @@ import {
     ReducerResult,
     TITLE_FALLBACK,
     deriveFaviconUrl,
+    deriveTitlePlaceholder,
     sameOriginUrl,
 } from "./types";
 
@@ -74,6 +75,13 @@ export function update(
 
     switch (command.type) {
         case "Navigate": {
+            // Optimistic header (SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18):
+            // also seed the title with a hostname-based placeholder so
+            // the header doesn't show the previous page's title for
+            // the 500ms–3s before CEF emits `TitleChanged`. The real
+            // title overrides this when it arrives.
+            const placeholder = deriveTitlePlaceholder(command.url);
+            const title = placeholder !== "" ? placeholder : TITLE_FALLBACK;
             return {
                 state: {
                     ...state,
@@ -82,6 +90,7 @@ export function update(
                     url: command.url,
                     faviconUrl: deriveFaviconUrl(command.url),
                     faviconOverridden: false,
+                    title,
                 },
                 events: [{ type: "navigate", url: command.url }],
             };
@@ -166,12 +175,22 @@ export function update(
                 ? state.faviconUrl
                 : deriveFaviconUrl(command.url);
             const faviconOverridden = keepOverride ? state.faviconOverridden : false;
+            // Same logic for the title placeholder: cross-origin nav
+            // (in-page link click to a new domain) resets the title
+            // to the hostname so the user sees instant feedback. CEF
+            // will eventually emit the real title via TitleChanged.
+            // Same-origin redirects keep the existing real title to
+            // avoid a flash to hostname.
+            const title = originChanged
+                ? (deriveTitlePlaceholder(command.url) || TITLE_FALLBACK)
+                : state.title;
             return {
                 state: {
                     ...state,
                     url: command.url,
                     faviconUrl,
                     faviconOverridden,
+                    title,
                 },
                 events: [{ type: "url-confirmed", url: command.url }],
             };

--- a/frontend/app/store/browser-pane-state/reducer.ts
+++ b/frontend/app/store/browser-pane-state/reducer.ts
@@ -91,6 +91,7 @@ export function update(
                     faviconUrl: deriveFaviconUrl(command.url),
                     faviconOverridden: false,
                     title,
+                    titleOverridden: false,
                 },
                 events: [{ type: "navigate", url: command.url }],
             };
@@ -191,11 +192,20 @@ export function update(
             // (in-page link click to a new domain) resets the title
             // to the hostname so the user sees instant feedback. CEF
             // will eventually emit the real title via TitleChanged.
-            // Same-origin redirects keep the existing real title to
-            // avoid a flash to hostname.
-            const title = originChanged
-                ? (deriveTitlePlaceholder(command.url) || TITLE_FALLBACK)
-                : state.title;
+            //
+            // Race guard mirroring the favicon side (reagent P2 on
+            // #905 v2): if `TitleChanged` already applied the real
+            // destination title before `UrlConfirmed` arrived, we
+            // should NOT overwrite it with a hostname placeholder.
+            // `titleOverridden` is set true by TitleChanged and
+            // false by Navigate; cleared by an explicit reset here.
+            const keepTitle = state.titleOverridden && originChanged
+                ? true   // race case — real title already arrived
+                : !originChanged;  // same-origin → keep real title too
+            const title = keepTitle
+                ? state.title
+                : (deriveTitlePlaceholder(command.url) || TITLE_FALLBACK);
+            const titleOverridden = keepTitle ? state.titleOverridden : false;
             return {
                 state: {
                     ...state,
@@ -203,6 +213,7 @@ export function update(
                     faviconUrl,
                     faviconOverridden,
                     title,
+                    titleOverridden,
                 },
                 events: [{ type: "url-confirmed", url: command.url }],
             };
@@ -226,10 +237,18 @@ export function update(
         }
 
         case "TitleChanged": {
-            const next = command.title.trim() === "" ? TITLE_FALLBACK : command.title;
-            if (next === state.title) return { state, events: [] };
+            // CEF emitted a real <title>. Empty / whitespace folds to
+            // TITLE_FALLBACK and is treated as NOT-overridden (no real
+            // title yet) so a subsequent UrlConfirmed cross-origin
+            // can still replace it with a hostname placeholder.
+            const trimmed = command.title.trim();
+            const next = trimmed === "" ? TITLE_FALLBACK : command.title;
+            const overridden = trimmed !== "";
+            if (next === state.title && overridden === state.titleOverridden) {
+                return { state, events: [] };
+            }
             return {
-                state: { ...state, title: next },
+                state: { ...state, title: next, titleOverridden: overridden },
                 events: [{ type: "title-changed", title: next }],
             };
         }

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -114,6 +114,29 @@ export function deriveFaviconUrl(url: string): string {
 }
 
 /**
+ * Hostname-based placeholder for the page title while CEF is loading.
+ * Returns the URL's hostname with a leading `www.` stripped (so
+ * `https://www.x.com/foo` → `"x.com"`). Empty for unparseable URLs or
+ * `null`-origin schemes (about:blank, file://) so the existing
+ * `TITLE_FALLBACK` ("Browser") rule takes over.
+ *
+ * Used by the reducer's `Navigate` + `UrlConfirmed` cases to give the
+ * header an instant title at navigation time, replaced by the real
+ * `<title>` once CEF emits `TitleChanged`. See
+ * SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md.
+ */
+export function deriveTitlePlaceholder(url: string): string {
+    if (url === "") return "";
+    try {
+        const u = new URL(url);
+        if (u.origin === "null" || u.origin === "") return "";
+        return u.hostname.replace(/^www\./, "");
+    } catch {
+        return "";
+    }
+}
+
+/**
  * True iff `a` and `b` resolve to the same `URL.origin`. Empty strings,
  * unparseable URLs, and `null`-origin schemes (about:blank, file://)
  * compare as same-origin only with themselves. Used by the reducer to

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -150,9 +150,11 @@ export function sameOriginUrl(a: string, b: string): boolean {
     let originB: string | null = null;
     try { originA = new URL(a).origin; } catch { originA = null; }
     try { originB = new URL(b).origin; } catch { originB = null; }
-    // Both unparseable → fall back to literal-equality (handled above)
-    // → treat as different. Otherwise compare origins.
+    // Unparseable or null-origin schemes (about:blank, file:, data:)
+    // are only same-origin with their own literal URL, never with
+    // each other or with regular http(s) origins — codex P3 on #905.
     if (originA == null || originB == null) return false;
+    if (originA === "null" || originB === "null") return false;
     return originA === originB;
 }
 

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -113,6 +113,26 @@ export function deriveFaviconUrl(url: string): string {
     }
 }
 
+/**
+ * True iff `a` and `b` resolve to the same `URL.origin`. Empty strings,
+ * unparseable URLs, and `null`-origin schemes (about:blank, file://)
+ * compare as same-origin only with themselves. Used by the reducer to
+ * decide whether a URL change is an in-page redirect (preserve the
+ * real favicon) vs. a cross-origin navigation (reset the override and
+ * fall back to the derived favicon for the new origin).
+ */
+export function sameOriginUrl(a: string, b: string): boolean {
+    if (a === b) return true;
+    let originA: string | null = null;
+    let originB: string | null = null;
+    try { originA = new URL(a).origin; } catch { originA = null; }
+    try { originB = new URL(b).origin; } catch { originB = null; }
+    // Both unparseable → fall back to literal-equality (handled above)
+    // → treat as different. Otherwise compare origins.
+    if (originA == null || originB == null) return false;
+    return originA === originB;
+}
+
 /** The string the reducer projects when `TitleChanged` arrives with
  *  empty or whitespace-only content. The view binds to `state.title`
  *  directly, so the fallback is enforced at write time, not at read

--- a/frontend/app/store/browser-pane-state/types.ts
+++ b/frontend/app/store/browser-pane-state/types.ts
@@ -71,6 +71,13 @@ export interface BrowserPaneState {
      *  `TitleChanged` is folded to `TITLE_FALLBACK` so the view
      *  never has to know about the empty case. */
     title: string;
+    /** True once a `TitleChanged` command has applied a non-fallback
+     *  title — used by `UrlConfirmed` to avoid overwriting the real
+     *  title with a hostname placeholder during the race where CEF's
+     *  title-change beats its nav-state event. Cleared by `Navigate`
+     *  so each new page starts fresh. Parallel to `faviconOverridden`.
+     *  See SPEC_BROWSER_PANE_OPTIMISTIC_HEADER_2026_05_18.md §3. */
+    titleOverridden: boolean;
     /** Committed/loading URL. Distinct from the address-bar `<input>`
      *  typing buffer (which stays in `browser-view.tsx` per the
      *  catalog — DOM is the source of truth for live-typing UX).
@@ -172,6 +179,7 @@ export const initialState = (): BrowserPaneState => ({
     canGoBack: false,
     canGoForward: false,
     title: TITLE_FALLBACK,
+    titleOverridden: false,
     url: "",
     faviconUrl: "",
     faviconOverridden: false,


### PR DESCRIPTION
## Summary

Bug found in self-smoke after #904 (the createRoot fix that made the memos live again). The viewModel now correctly re-fires the memo on every state-write, but the **reducer itself** holds the favicon across cross-origin navigation, which produces the user-visible "favicon retains between pages" behavior.

`UrlConfirmed` preserved `faviconOverridden` across ALL URL changes. So agentmux.ai → bing.com → x.com (with CEF silent about x.com) kept bing's favicon indefinitely.

Fix: keep the CEF favicon only when origin is unchanged (preserves the original intent — no flash on redirects/hash changes). Cross-origin nav resets the override + falls back to the new origin's derived favicon, and a later CEF emit replaces it.

New `sameOriginUrl(a, b)` helper in types.ts.

## Test plan

- [ ] Open browser pane → navigate to https://bing.com → header shows bing favicon
- [ ] Navigate to https://x.com → header updates to x.com favicon (no longer stuck on bing)
- [ ] Navigate to https://x.com/some/path → header still shows x.com favicon (same-origin, no flash to derived)
- [ ] Hash navigation https://github.com#header → favicon stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)