### PR TITLE
feat(browser-pane): HTTP Basic/Digest auth prompt (Phase α)

### DIFF
--- a/.changesets/1779126812-feat-browser-pane-http-basic-digest-auth-prompt-phase-259z.md
+++ b/.changesets/1779126812-feat-browser-pane-http-basic-digest-auth-prompt-phase-259z.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(browser-pane): HTTP Basic/Digest auth prompt (Phase α)

--- a/agentmux-cef/src/browser_pane/auth.rs
+++ b/agentmux-cef/src/browser_pane/auth.rs
@@ -1,0 +1,168 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP Basic / Digest auth callback registry.
+//!
+//! When CEF fires `RequestHandler::get_auth_credentials` for a browser
+//! pane, the host returns `1` (will-async-respond), parks the
+//! `AuthCallback` in this registry keyed by a generated `request_id`,
+//! and broadcasts a `browser-pane-auth-required` event to the renderer.
+//! The renderer prompts the user and replies via the
+//! `browser_pane_auth_submit` / `browser_pane_auth_cancel` IPC
+//! commands, which resolve the callback here and complete the CEF
+//! flow.
+//!
+//! Phase α of SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+
+use cef::{AuthCallback, ImplAuthCallback};
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::runtime::Handle;
+
+/// One parked auth challenge — the CEF callback plus the block_id
+/// owning it (so pane-close can clean up just its entries) and a
+/// monotonically-increasing arming epoch (so a delayed timeout task
+/// can detect "this request was already resolved + re-registered
+/// under the same id" and bail). The epoch is a defensive guard;
+/// uuid request_ids shouldn't collide.
+struct Entry {
+    block_id: String,
+    callback: AuthCallback,
+    epoch: u64,
+}
+
+/// std OnceLock + lazy init (HashMap::new is not const-fn, and our
+/// Cargo.toml has no once_cell dep). Reagent P1 on PR #906 round 2 —
+/// the original `once_cell::sync::Lazy` import didn't resolve.
+fn pending() -> &'static Mutex<HashMap<String, Entry>> {
+    static CELL: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
+    CELL.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+static NEXT_EPOCH: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Tokio runtime Handle captured from `main.rs` so `register()` can
+/// schedule the TTL timer from any thread — CEF invokes
+/// `get_auth_credentials` on its IO thread, which has no
+/// `Handle::current()`, so a bare `tokio::spawn(...)` would panic
+/// with "there is no reactor running". Reagent + codex P1 on PR
+/// #906 round 2.
+static TOKIO_HANDLE: OnceLock<Handle> = OnceLock::new();
+
+/// Install the Tokio runtime Handle. Called once from `main.rs` after
+/// `Runtime::new()` and before CEF starts dispatching callbacks.
+pub fn set_runtime_handle(h: Handle) {
+    let _ = TOKIO_HANDLE.set(h);
+}
+
+/// Maximum time a callback can sit parked before we cancel it
+/// automatically. Bounds the leak if the renderer never replies
+/// (background tab + suspended JS, hung modal). 5 minutes is well
+/// above any realistic credential-entry time and well below "user
+/// noticed and wondered what happened."
+pub const PARKED_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Park a CEF auth callback under `request_id`. The renderer will
+/// resolve it shortly via `submit` / `cancel`. A 5-minute timeout
+/// task is armed alongside so the entry can't leak indefinitely if
+/// the renderer never replies. Replaces any prior entry for the same
+/// id (shouldn't happen — ids are uuid4).
+pub fn register(request_id: String, block_id: String, cb: AuthCallback) {
+    use std::sync::atomic::Ordering;
+    let epoch = NEXT_EPOCH.fetch_add(1, Ordering::Relaxed);
+    {
+        let mut g = pending().lock();
+        if g.insert(
+            request_id.clone(),
+            Entry { block_id, callback: cb, epoch },
+        ).is_some() {
+            tracing::warn!(
+                "[browser-pane-auth] duplicate request_id {} — overwriting",
+                request_id
+            );
+        }
+    }
+    // Arm the TTL. A delayed task that runs `cancel + remove` if the
+    // entry's epoch still matches when the timeout fires. If the
+    // renderer resolved the request before the timeout, the epoch
+    // check fails and the task is a no-op.
+    //
+    // Spawn via the stored Handle — `tokio::spawn` would panic here
+    // because CEF calls this from its IO thread, which has no
+    // current runtime. If the handle isn't installed (init order
+    // bug), log and skip the TTL rather than crash the host.
+    let rid = request_id;
+    match TOKIO_HANDLE.get() {
+        Some(handle) => {
+            handle.spawn(async move {
+                tokio::time::sleep(PARKED_TTL).await;
+                let to_cancel: Option<AuthCallback> = {
+                    let mut g = pending().lock();
+                    match g.get(&rid) {
+                        Some(entry) if entry.epoch == epoch => g.remove(&rid).map(|e| e.callback),
+                        _ => None,
+                    }
+                };
+                if let Some(cb) = to_cancel {
+                    tracing::warn!(
+                        "[browser-pane-auth] request_id {} timed out after {:?} — auto-cancel",
+                        rid, PARKED_TTL
+                    );
+                    cb.cancel();
+                }
+            });
+        }
+        None => {
+            tracing::error!(
+                "[browser-pane-auth] tokio handle not installed; TTL timer skipped for request_id {} \
+                 — callback will leak if the renderer never replies. Did main.rs call set_runtime_handle?",
+                rid
+            );
+        }
+    }
+}
+
+/// Pop the callback for `request_id`. Returns None if it was already
+/// resolved (e.g. submit + cancel race) or never existed.
+pub fn take(request_id: &str) -> Option<AuthCallback> {
+    pending().lock().remove(request_id).map(|e| e.callback)
+}
+
+/// Cancel every callback parked for `block_id` — called from
+/// `browser_pane_close` so closing a pane mid-prompt doesn't leak
+/// CEF refcounts. Returns the number cancelled.
+pub fn cancel_for_block(block_id: &str) -> usize {
+    let to_cancel: Vec<AuthCallback> = {
+        let mut g = pending().lock();
+        let ids: Vec<String> = g
+            .iter()
+            .filter(|(_, e)| e.block_id == block_id)
+            .map(|(k, _)| k.clone())
+            .collect();
+        ids.into_iter()
+            .filter_map(|id| g.remove(&id))
+            .map(|e| e.callback)
+            .collect()
+    };
+    let n = to_cancel.len();
+    for cb in to_cancel {
+        cb.cancel();
+    }
+    if n > 0 {
+        tracing::info!(
+            "[browser-pane-auth] cancelled {} pending auth(s) for block {}",
+            n,
+            block_id.chars().take(7).collect::<String>(),
+        );
+    }
+    n
+}
+
+/// Pending request count. Useful for diagnostics and leak checks in
+/// tests.
+pub fn pending_count() -> usize {
+    pending().lock().len()
+}

--- a/agentmux-cef/src/browser_pane/auth.rs
+++ b/agentmux-cef/src/browser_pane/auth.rs
@@ -33,9 +33,7 @@ struct Entry {
     epoch: u64,
 }
 
-/// std OnceLock + lazy init (HashMap::new is not const-fn, and our
-/// Cargo.toml has no once_cell dep). Reagent P1 on PR #906 round 2 —
-/// the original `once_cell::sync::Lazy` import didn't resolve.
+/// HashMap::new is not const-fn so the static needs lazy init.
 fn pending() -> &'static Mutex<HashMap<String, Entry>> {
     static CELL: OnceLock<Mutex<HashMap<String, Entry>>> = OnceLock::new();
     CELL.get_or_init(|| Mutex::new(HashMap::new()))
@@ -48,8 +46,7 @@ static NEXT_EPOCH: std::sync::atomic::AtomicU64 =
 /// schedule the TTL timer from any thread — CEF invokes
 /// `get_auth_credentials` on its IO thread, which has no
 /// `Handle::current()`, so a bare `tokio::spawn(...)` would panic
-/// with "there is no reactor running". Reagent + codex P1 on PR
-/// #906 round 2.
+/// with "there is no reactor running".
 static TOKIO_HANDLE: OnceLock<Handle> = OnceLock::new();
 
 /// Install the Tokio runtime Handle. Called once from `main.rs` after

--- a/agentmux-cef/src/browser_pane/auth.rs
+++ b/agentmux-cef/src/browser_pane/auth.rs
@@ -60,7 +60,7 @@ pub fn set_runtime_handle(h: Handle) {
 /// (background tab + suspended JS, hung modal). 5 minutes is well
 /// above any realistic credential-entry time and well below "user
 /// noticed and wondered what happened."
-pub const PARKED_TTL: Duration = Duration::from_secs(5 * 60);
+const PARKED_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Park a CEF auth callback under `request_id`. The renderer will
 /// resolve it shortly via `submit` / `cancel`. A 5-minute timeout

--- a/agentmux-cef/src/browser_pane/mod.rs
+++ b/agentmux-cef/src/browser_pane/mod.rs
@@ -7,6 +7,7 @@
 //! lifecycle now lives only in the host reducer (`HostState.browser_panes`).
 //! `RegisterResult` moved to `crate::reducer`.
 
+pub mod auth;
 pub mod callbacks;
 pub mod creation;
 #[cfg(target_os = "windows")]

--- a/agentmux-cef/src/client/handlers.rs
+++ b/agentmux-cef/src/client/handlers.rs
@@ -328,5 +328,26 @@ wrap_request_handler! {
             let mut inner = self.inner.lock();
             inner.on_render_process_terminated(browser, status, error_code, error_string);
         }
+
+        // HTTP Basic / Digest auth challenge. Phase α of
+        // SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md. Returns 1
+        // (async) so CEF holds the request open while we surface the
+        // credential prompt to the user.
+        fn auth_credentials(
+            &self,
+            browser: Option<&mut Browser>,
+            origin_url: Option<&CefString>,
+            is_proxy: ::std::os::raw::c_int,
+            host: Option<&CefString>,
+            port: ::std::os::raw::c_int,
+            realm: Option<&CefString>,
+            scheme: Option<&CefString>,
+            callback: Option<&mut AuthCallback>,
+        ) -> ::std::os::raw::c_int {
+            let mut inner = self.inner.lock();
+            inner.on_auth_credentials(
+                browser, origin_url, is_proxy, host, port, realm, scheme, callback,
+            )
+        }
     }
 }

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1485,7 +1485,14 @@ impl AgentMuxHandler {
             cb.clone(),
         );
 
-        crate::events::emit_event_from_state(
+        // Broadcast to ALL windows — `emit_event_from_state` only
+        // dispatches to the "main" browser, so panes hosted in a
+        // tear-off / secondary window never see the event and the
+        // CEF callback would wait until TTL/cancel. The renderer
+        // filters on `payload.block_id` (browser-view.tsx:182) so
+        // broadcasting is safe: only the window that owns this
+        // block_id reacts. Codex P2 on PR #906.
+        crate::events::emit_event_all_windows(
             &self.state,
             "browser-pane-auth-required",
             &serde_json::json!({

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1418,8 +1418,89 @@ impl AgentMuxHandler {
             }
         }
     }
+
+    /// CEF asks the embedder for HTTP Basic / Digest credentials on a
+    /// 401/407. Browser-pane requests get surfaced to the renderer via
+    /// `browser-pane-auth-required` so the user can type credentials;
+    /// non-browser-pane requests (the main host window's frontend
+    /// load) are declined — those shouldn't hit auth-challenged
+    /// resources, and silently failing matches the prior behavior.
+    ///
+    /// Returns 1 (async — we'll resolve the callback via
+    /// `browser_pane_auth_submit` / `browser_pane_auth_cancel`) or 0
+    /// (sync no — CEF aborts the request).
+    ///
+    /// Phase α of SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+    fn on_auth_credentials(
+        &mut self,
+        browser: Option<&mut Browser>,
+        origin_url: Option<&CefString>,
+        is_proxy: ::std::os::raw::c_int,
+        host: Option<&CefString>,
+        port: ::std::os::raw::c_int,
+        realm: Option<&CefString>,
+        _scheme: Option<&CefString>,
+        callback: Option<&mut AuthCallback>,
+    ) -> ::std::os::raw::c_int {
+        // Resolve the pane block_id from the browser ref. If this isn't
+        // a browser-pane browser (i.e. it's the host frontend's browser),
+        // we have no UI to prompt — decline and let CEF fail the
+        // request. The host frontend should never hit auth challenges.
+        let Some(b) = browser.as_deref() else {
+            tracing::warn!("[browser-pane-auth] no browser ref — declining");
+            return 0;
+        };
+        let Some(block_id) =
+            crate::browser_pane::callbacks::resolve_pane_block_id(&self.state, b)
+        else {
+            tracing::info!(
+                "[browser-pane-auth] not a browser pane (host frontend?) — declining"
+            );
+            return 0;
+        };
+        let Some(cb) = callback else {
+            return 0;
+        };
+
+        let request_id = uuid::Uuid::new_v4().to_string();
+        let origin = origin_url.map(CefString::to_string).unwrap_or_default();
+        let host_str = host.map(CefString::to_string).unwrap_or_default();
+        let realm_str = realm.map(CefString::to_string).unwrap_or_default();
+        let is_proxy_bool = is_proxy != 0;
+
+        let block_id_short: String = block_id.chars().take(7).collect();
+        tracing::info!(
+            "[browser-pane-auth][{}] auth-required origin={:?} host={:?}:{} realm={:?} is_proxy={} request_id={}",
+            block_id_short, origin, host_str, port, realm_str, is_proxy_bool, request_id,
+        );
+
+        // Park the callback so the renderer's submit/cancel IPC can
+        // resolve it. The callback IS reference-counted internally
+        // (RefGuard) — `cb.clone()` bumps the refcount so the registry
+        // can hold it after CEF's invocation returns. Pass block_id so
+        // `cancel_for_block` can clean up when the pane closes.
+        crate::browser_pane::auth::register(
+            request_id.clone(),
+            block_id.clone(),
+            cb.clone(),
+        );
+
+        crate::events::emit_event_from_state(
+            &self.state,
+            "browser-pane-auth-required",
+            &serde_json::json!({
+                "block_id": block_id,
+                "request_id": request_id,
+                "origin": origin,
+                "host": host_str,
+                "port": port,
+                "realm": realm_str,
+                "is_proxy": is_proxy_bool,
+            }),
+        );
+
+        1
+    }
 }
-
-
 
 

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1485,14 +1485,17 @@ impl AgentMuxHandler {
             cb.clone(),
         );
 
-        // Broadcast to ALL windows — `emit_event_from_state` only
-        // dispatches to the "main" browser, so panes hosted in a
+        // Broadcast to every TOP-LEVEL window — `emit_event_from_state`
+        // only dispatches to the "main" browser, so panes hosted in a
         // tear-off / secondary window would never see the event and
-        // the CEF callback would wait until TTL/cancel. The renderer
-        // filters on `payload.block_id` (browser-view.tsx) so
-        // broadcasting is safe: only the window that owns this
-        // block_id reacts.
-        crate::events::emit_event_all_windows(
+        // the CEF callback would wait until TTL/cancel. Filtering to
+        // top-level is critical: the payload carries origin/host/realm
+        // plus block_id correlation, which must not be visible to
+        // remote content loaded inside a sibling pane (whose main
+        // frame is an arbitrary URL). The host renderer filters on
+        // `payload.block_id` so only the window owning this pane
+        // surfaces the prompt.
+        crate::events::emit_event_to_top_level_windows(
             &self.state,
             "browser-pane-auth-required",
             &serde_json::json!({

--- a/agentmux-cef/src/client/mod.rs
+++ b/agentmux-cef/src/client/mod.rs
@@ -1487,11 +1487,11 @@ impl AgentMuxHandler {
 
         // Broadcast to ALL windows — `emit_event_from_state` only
         // dispatches to the "main" browser, so panes hosted in a
-        // tear-off / secondary window never see the event and the
-        // CEF callback would wait until TTL/cancel. The renderer
-        // filters on `payload.block_id` (browser-view.tsx:182) so
+        // tear-off / secondary window would never see the event and
+        // the CEF callback would wait until TTL/cancel. The renderer
+        // filters on `payload.block_id` (browser-view.tsx) so
         // broadcasting is safe: only the window that owns this
-        // block_id reacts. Codex P2 on PR #906.
+        // block_id reacts.
         crate::events::emit_event_all_windows(
             &self.state,
             "browser-pane-auth-required",

--- a/agentmux-cef/src/events.rs
+++ b/agentmux-cef/src/events.rs
@@ -57,6 +57,27 @@ pub fn emit_event_all_windows(state: &crate::state::AppState, event: &str, paylo
     }
 }
 
+/// Emit an event to every TOP-LEVEL window — i.e. the host frontend
+/// renderers, excluding pane child browsers. Use this instead of
+/// `emit_event_all_windows` when the payload carries metadata that
+/// shouldn't be visible to untrusted remote content loaded inside a
+/// browser pane. The host frontend's `listenEvent` lives in the
+/// top-level renderer; pane main frames load arbitrary URLs.
+pub fn emit_event_to_top_level_windows(
+    state: &crate::state::AppState,
+    event: &str,
+    payload: &serde_json::Value,
+) {
+    let all = state.list_top_level_browsers();
+    if all.is_empty() {
+        tracing::warn!("Cannot broadcast event '{}': no top-level browsers", event);
+        return;
+    }
+    for (_label, browser) in all {
+        emit_event(&browser, event, payload);
+    }
+}
+
 /// Emit an event to a specific browser window by label.
 /// Used by the tear-off Phase 4 hook to push merge-candidate
 /// changes to the destination renderer.

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -365,9 +365,9 @@ async fn route_command(
         "browser_pane_close" => {
             let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
             // Cancel any pending HTTP-auth callbacks parked for this
-            // pane before tearing it down — reagent + codex P1 on #906.
-            // Without this, closing a pane mid-auth-prompt leaks the
-            // CEF AuthCallback refcount until the 5-minute TTL fires.
+            // pane before tearing it down. Without this, closing a
+            // pane mid-auth-prompt leaks the CEF AuthCallback refcount
+            // until the 5-minute TTL fires.
             crate::browser_pane::auth::cancel_for_block(block_id);
             state.browser_panes.close(block_id, state);
             Ok(serde_json::json!(true))
@@ -400,10 +400,10 @@ async fn route_command(
             let request_id = args.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
             let username = args.get("username").and_then(|v| v.as_str()).unwrap_or("");
             let password = args.get("password").and_then(|v| v.as_str()).unwrap_or("");
-            // Reagent P2 on #906: don't log username/password length —
-            // host logs are retained 7 days per CLAUDE.md and the
-            // length is sensitive metadata that could narrow a brute
-            // force window. request_id alone is enough to trace flow.
+            // Don't log username/password length — host logs are
+            // retained 7 days per CLAUDE.md and the length is sensitive
+            // metadata that could narrow a brute-force window.
+            // request_id alone is enough to trace flow.
             tracing::info!(
                 "[browser-pane-auth] submit request_id={}",
                 request_id,

--- a/agentmux-cef/src/ipc.rs
+++ b/agentmux-cef/src/ipc.rs
@@ -364,6 +364,11 @@ async fn route_command(
         }
         "browser_pane_close" => {
             let block_id = args.get("block_id").and_then(|v| v.as_str()).unwrap_or("");
+            // Cancel any pending HTTP-auth callbacks parked for this
+            // pane before tearing it down — reagent + codex P1 on #906.
+            // Without this, closing a pane mid-auth-prompt leaks the
+            // CEF AuthCallback refcount until the 5-minute TTL fires.
+            crate::browser_pane::auth::cancel_for_block(block_id);
             state.browser_panes.close(block_id, state);
             Ok(serde_json::json!(true))
         }
@@ -387,6 +392,46 @@ async fn route_command(
             tracing::info!("[ipc] browser_pane_focus block_id={}", block_id);
             state.browser_panes.focus(block_id, state);
             Ok(serde_json::json!(true))
+        }
+        "browser_pane_auth_submit" => {
+            // Renderer collected credentials from the modal. Resolve the
+            // CEF AuthCallback parked under request_id and continue.
+            // Phase α of SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+            let request_id = args.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
+            let username = args.get("username").and_then(|v| v.as_str()).unwrap_or("");
+            let password = args.get("password").and_then(|v| v.as_str()).unwrap_or("");
+            // Reagent P2 on #906: don't log username/password length —
+            // host logs are retained 7 days per CLAUDE.md and the
+            // length is sensitive metadata that could narrow a brute
+            // force window. request_id alone is enough to trace flow.
+            tracing::info!(
+                "[browser-pane-auth] submit request_id={}",
+                request_id,
+            );
+            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                use cef::ImplAuthCallback;
+                let u = cef::CefString::from(username);
+                let p = cef::CefString::from(password);
+                cb.cont(Some(&u), Some(&p));
+                Ok(serde_json::json!(true))
+            } else {
+                tracing::warn!(
+                    "[browser-pane-auth] submit for unknown request_id {} — already resolved?",
+                    request_id
+                );
+                Ok(serde_json::json!(false))
+            }
+        }
+        "browser_pane_auth_cancel" => {
+            let request_id = args.get("request_id").and_then(|v| v.as_str()).unwrap_or("");
+            tracing::info!("[browser-pane-auth] cancel request_id={}", request_id);
+            if let Some(cb) = crate::browser_pane::auth::take(request_id) {
+                use cef::ImplAuthCallback;
+                cb.cancel();
+                Ok(serde_json::json!(true))
+            } else {
+                Ok(serde_json::json!(false))
+            }
         }
         "browser_panes_set_overlay_clip" => {
             // Apply a clip region to every pane HWND that excludes the given

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -279,7 +279,6 @@ fn main() {
     // thread) can spawn the parked-auth TTL timer. A bare
     // `tokio::spawn` there would panic with "there is no reactor
     // running" because that thread has no `Handle::current()`.
-    // Reagent + codex P1 on PR #906.
     browser_pane::auth::set_runtime_handle(runtime.handle().clone());
 
     // Start the IPC HTTP server and get the assigned port.

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -274,6 +274,14 @@ fn main() {
     // Start tokio runtime for async operations (IPC server, sidecar management).
     let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
 
+    // Install the runtime Handle into browser_pane::auth so the
+    // CEF `get_auth_credentials` callback (which runs on CEF's IO
+    // thread) can spawn the parked-auth TTL timer. A bare
+    // `tokio::spawn` there would panic with "there is no reactor
+    // running" because that thread has no `Handle::current()`.
+    // Reagent + codex P1 on PR #906.
+    browser_pane::auth::set_runtime_handle(runtime.handle().clone());
+
     // Start the IPC HTTP server and get the assigned port.
     let ipc_port = runtime.block_on(ipc::start_ipc_server(app_state.clone()));
     *app_state.ipc_port.lock() = ipc_port;

--- a/agentmux-cef/src/state.rs
+++ b/agentmux-cef/src/state.rs
@@ -844,6 +844,21 @@ impl AppState {
             .collect()
     }
 
+    /// Snapshot of TOP-LEVEL browsers only — excludes `BrowserKind::Pane`
+    /// child browsers whose main frame is loading untrusted remote
+    /// content. Callers emitting JS-injected host events must use this
+    /// (or `emit_event_to_window`) so a hostile page in one pane can't
+    /// observe events meant for the host frontend.
+    pub fn list_top_level_browsers(&self) -> Vec<(String, Browser)> {
+        self.host_state
+            .lock()
+            .browsers
+            .iter()
+            .filter(|(_, h)| matches!(h.kind, BrowserKind::TopLevel { .. }))
+            .map(|(k, h)| (k.clone(), h.browser.clone()))
+            .collect()
+    }
+
     /// First registered browser (for "any browser" callers like command
     /// palette routing). Returns the label + Browser pair, or None if
     /// the registry is empty.

--- a/docs/specs/SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md
+++ b/docs/specs/SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md
@@ -1,0 +1,214 @@
+# SPEC: Browser Pane HTTP Basic / Digest Auth
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:**
+- `agentmux-cef/src/client/handlers.rs` (CEF `RequestHandler` host-side hook)
+- `SPEC_MODAL_TRANSITIONS_2026_05_18.md` / modal-v2 chrome (the credential prompt UI)
+- CEF API: [`CefRequestHandler::GetAuthCredentials`](https://cef-builds.spotifycdn.com/docs/stable.html?Doxygen/classCefRequestHandler.html#a)
+
+---
+
+## 0. TL;DR
+
+Loading a site that returns `401 WWW-Authenticate: Basic ...` in the browser pane currently fails with `ERR_INVALID_AUTH_CREDENTIALS (-338)` because the host never implements CEF's `GetAuthCredentials` callback. CEF asks the embedder for credentials, the embedder is silent, the request fails.
+
+Fix: wire `get_auth_credentials` on `AgentMuxRequestHandler` to surface a modal prompt (modal-v2 chrome via `TabModalLayer`), collect username + password from the user, and call the CEF callback. In-memory per-pane credential cache so a page that triggers multiple subresource auth challenges only prompts once.
+
+Supports HTTP **Basic** and **Digest** auth (CEF handles both via the same callback). No proxy auth, no NTLM, no client-cert auth in v1.
+
+---
+
+## 1. Problem
+
+User report 2026-05-18: opened `https://pulse.asaf.cc/` in the browser pane → page failed to load → host's error overlay showed `ERR_INVALID_AUTH_CREDENTIALS (-338)`. The site requires HTTP Basic auth.
+
+CEF's `RequestHandler::get_auth_credentials` is the only hook by which the embedder can supply credentials in response to a `401`. Today our `AgentMuxRequestHandler` (`handlers.rs:316`) only implements `on_render_process_terminated`. The default behavior of an unimplemented `get_auth_credentials` is "no credentials available" → CEF treats the 401 as a fatal error.
+
+---
+
+## 2. Best practices
+
+### Chrome's model
+- Modal dialog at the top of the tab content with username + password fields, a "Remember me on this site" checkbox, OK / Cancel.
+- Cached in the OS keyring (`chrome.passwords.sync`) when remembered; in-memory otherwise.
+- Cancel → page loads the 401 response body (typically a server-provided "Auth required" page).
+
+### Firefox / Safari
+- Same shape. Slight UI differences. Same callback model.
+
+### Cancel UX
+- Important: a cancel must call `callback.cont(...)` with empty strings OR `callback.cancel()` so CEF doesn't hang waiting forever. CEF's API allows either path; we'll use `cancel()` to be explicit.
+
+### Proxy vs. server auth
+- CEF's same `get_auth_credentials` callback also fires for HTTP proxy auth (407). The `is_proxy` argument distinguishes. v1 spec covers server auth only; proxy auth out of scope (most users don't run through an authenticated proxy; if it becomes an ask, the same modal UI applies).
+
+---
+
+## 3. Architecture
+
+### 3.1 Host side (Rust)
+
+`AgentMuxRequestHandler::get_auth_credentials`:
+
+```rust
+fn get_auth_credentials(
+    &self,
+    browser: Option<&mut Browser>,
+    origin_url: Option<&CefString>,
+    is_proxy: bool,
+    host: Option<&CefString>,
+    port: i32,
+    realm: Option<&CefString>,
+    scheme: Option<&CefString>,
+    callback: Option<AuthCallback>,
+) -> bool {
+    // Returning true tells CEF we'll provide credentials asynchronously
+    // via the callback; returning false tells CEF to abort and surface
+    // ERR_INVALID_AUTH_CREDENTIALS. Always return true so we can drive
+    // the prompt UI.
+    let Some(cb) = callback else { return false; };
+    let block_id = /* resolve from browser */;
+    let req = AuthRequest { origin: ..., realm: ..., is_proxy };
+
+    // Send IPC event to renderer for that pane: "browser-pane-auth-required"
+    // with { block_id, request_id, origin, realm, is_proxy }.
+    // Store the callback in a registry keyed by request_id so the
+    // renderer's reply can resolve it.
+    register_auth_callback(request_id, cb);
+    emit_event(...);
+    true   // async — we'll callback.cont() / .cancel() later
+}
+```
+
+Add a global registry in `agentmux-cef/src/browser_pane/auth.rs`:
+
+```rust
+static AUTH_CALLBACKS: Lazy<Mutex<HashMap<String, AuthCallback>>> = ...;
+```
+
+New IPC handlers (in `commands/`):
+
+| Command | Args | Effect |
+|---|---|---|
+| `browser_pane_auth_submit` | `{ request_id, username, password }` | Look up callback, call `cb.cont(username, password)`, drop entry |
+| `browser_pane_auth_cancel` | `{ request_id }` | Look up callback, call `cb.cancel()`, drop entry |
+
+Timeouts: if the renderer doesn't reply within (say) 5 minutes, the host should drop the callback and cancel — preserves CEF state cleanliness. Implemented via a `tokio::time::sleep` task per registered callback.
+
+### 3.2 Renderer side (TypeScript)
+
+`BrowserViewModel` subscribes to `browser-pane-auth-required` (alongside the existing nav-state / title-change / favicon-urls listeners). On arrival:
+
+1. Open a `tabModal.open({ kind: "browser-auth", ... })` modal request with the origin + realm.
+2. User submits → call `RpcApi.BrowserPaneAuthSubmitCommand({ request_id, username, password })` (or the renderer-side `invokeCommand` equivalent).
+3. User cancels → call the cancel command.
+4. Modal closes.
+
+New `TabModalRequest` variant in `frontend/app/tab/tab-modal.ts`:
+
+```ts
+export interface BrowserAuthRequest {
+    kind: "browser-auth";
+    blockId: string;
+    requestId: string;
+    origin: string;
+    realm: string;
+    isProxy: boolean;
+    onSubmit: (username: string, password: string) => void;
+    onCancel: () => void;
+}
+```
+
+`TabModalLayer.tsx` dispatches this `kind` to a new `<BrowserAuthModalPanel>` component (`frontend/app/view/browser/components/BrowserAuthModal.tsx`).
+
+### 3.3 UI
+
+Modal-v2 chrome (header + body + footer per `internals/modal-system.md`). Body has:
+- Title row: `"Authentication required"`
+- Subtitle: `"<origin> says: <realm>"` (familiar to users from Chrome's prompt)
+- Username input (autofocus)
+- Password input (type=password)
+- "Remember for this session" checkbox (deferred to v2; v1 always remembers per session)
+
+Footer: Cancel + Sign in (Sign in is the green primary action; Enter inside the password field submits).
+
+### 3.4 In-memory credential cache
+
+Keyed by `${origin}#${realm}`. Per-pane (not global) — different panes might want different credentials for the same realm. Lives in the renderer's `BrowserViewModel` instance. Reset on pane close. Not persisted to disk in v1.
+
+When CEF asks again for the same realm (subresource fetches, follow-ups), the renderer checks the cache and replies immediately without prompting. New realm → prompt.
+
+### 3.5 Cancel path
+
+User clicks Cancel:
+1. Modal closes
+2. `browser_pane_auth_cancel` IPC fires
+3. Host calls `callback.cancel()`
+4. CEF aborts the request → renders the 401 response body (typically server-rendered "Unauthorized" page) in the pane
+
+That matches Chrome's behavior — the user gets a chance to see the server's error page.
+
+### 3.6 Failure path (wrong password)
+
+User enters wrong creds → CEF gets the 401 again → fires `get_auth_credentials` again → renderer prompts again. We can show a "Incorrect username or password" inline message in the modal on the second+ prompt for the same realm. Track per-realm attempt count.
+
+---
+
+## 4. Implementation order
+
+### Phase α — Wire the callback + minimal prompt
+
+1. `agentmux-cef/src/client/handlers.rs`: implement `get_auth_credentials`. Register the callback in a global mutex registry keyed by a generated request_id.
+2. `agentmux-cef/src/browser_pane/auth.rs` (new): `register_auth_callback`, `resolve_auth_callback`, 5-min timeout.
+3. `agentmux-cef/src/commands/`: `browser_pane_auth_submit` + `browser_pane_auth_cancel` IPC commands.
+4. `frontend/app/tab/tab-modal.ts`: `BrowserAuthRequest` variant.
+5. `frontend/app/tab/TabModalLayer.tsx`: dispatch case for `kind: "browser-auth"`.
+6. `frontend/app/view/browser/components/BrowserAuthModal.tsx`: the modal panel (modal-v2 chrome).
+7. `BrowserViewModel`: subscribe to `browser-pane-auth-required`, open modal, route submit/cancel.
+
+### Phase β — Per-pane in-memory cache
+
+8. Pane-scoped `Map<realmKey, {username, password}>` in `BrowserViewModel`.
+9. When the IPC arrives, check cache before prompting; if hit, immediately reply with cached credentials.
+10. On failed attempt (second `browser-pane-auth-required` for the same realmKey within ~10s), invalidate cache + re-prompt with "Incorrect password" inline.
+
+### Phase γ — Polish (defer)
+
+- Persisted credential store (OS keyring).
+- Proxy auth (`is_proxy=true`).
+- Client-cert auth (`OnCertificateError` + `SelectClientCertificate`).
+- NTLM / Negotiate (`is_proxy=false` but mechanism != Basic/Digest — CEF mostly handles these internally on Windows via SSPI; verify before scoping).
+
+---
+
+## 5. Test plan
+
+- [ ] `https://httpbin.org/basic-auth/user/pass` — prompt appears, submitting `user`/`pass` loads the success page.
+- [ ] Wrong credentials → re-prompt with inline error.
+- [ ] Cancel → server's 401 body renders (typically "Authorization required").
+- [ ] Subresource auth on the same realm (page with images behind same auth) — only one prompt.
+- [ ] Cross-realm subresources → two prompts.
+- [ ] Two browser panes both pointed at `pulse.asaf.cc` — each prompts independently (no global cache).
+- [ ] Close pane mid-prompt → no host-side memory leak, callback released within timeout.
+
+---
+
+## 6. Acceptance criteria
+
+1. `ERR_INVALID_AUTH_CREDENTIALS (-338)` no longer surfaces for sites that return `401 WWW-Authenticate: Basic` — instead, the modal prompts.
+2. Submit with correct credentials → page loads.
+3. Cancel → 401 response body renders.
+4. Per-pane cache: same realm asks once per pane per session.
+5. Modal uses modal-v2 chrome — Cancel + Sign in footer, Enter submits.
+
+---
+
+## 7. Out of scope
+
+- Persisted credential storage (OS keyring integration). v2.
+- Proxy auth.
+- Client certificates.
+- "Remember me on this site" checkbox UI (v1 always remembers per session; v2 adds the toggle + persistence).
+- Auto-population from a system password manager (1Password, etc.).

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -30,8 +30,10 @@ import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstall
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
 import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
 import { AgentNewMemoryModalPanel } from "@/app/view/agent/components/AgentNewMemoryModal";
+import { BrowserAuthModalPanel } from "@/app/view/browser/components/BrowserAuthModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
+import "@/app/view/browser/components/BrowserAuthModal.scss";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
 import "./tab-modal.scss";
@@ -380,6 +382,25 @@ function renderRequest(
                             // install→launch crossfade for the chain
                             // path. SPEC_MODAL_TRANSITIONS_2026_05_18.md.
                             req.onInstalled(continueToLaunch);
+                        }}
+                    />
+                ),
+            };
+        case "browser-auth":
+            return {
+                label: req.isProxy ? "Proxy authentication required" : "Authentication required",
+                panel: (
+                    <BrowserAuthModalPanel
+                        origin={req.origin}
+                        realm={req.realm}
+                        isProxy={req.isProxy}
+                        onCancel={() => {
+                            req.onCancel();
+                            api.close();
+                        }}
+                        onSubmit={(username, password) => {
+                            req.onSubmit(username, password);
+                            api.close();
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -24,7 +24,8 @@ export type TabModalRequest =
     | InstallAgentRequest
     | AgentPrereqRequest
     | NewIdentityBundleRequest
-    | NewMemoryBundleRequest;
+    | NewMemoryBundleRequest
+    | BrowserAuthRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -175,6 +176,36 @@ export interface NewMemoryBundleRequest {
      *  preselected. Layer does NOT close. */
     onCreated: (bundleId: string, bundleName: string) => void;
     /** Caller routes (replace vs close). Layer does NOT close. */
+    onCancel: () => void;
+}
+
+/**
+ * Browser-pane HTTP Basic / Digest auth challenge. Opened by the
+ * BrowserViewModel when CEF fires `browser-pane-auth-required`.
+ * Phase α of SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+ */
+export interface BrowserAuthRequest {
+    kind: "browser-auth";
+    /** Pane that the request belongs to (used as the modal origin). */
+    blockId: string;
+    /** Opaque id correlating this prompt with the parked CEF callback
+     *  on the host side. The submit/cancel IPC echoes it back. */
+    requestId: string;
+    /** Origin of the challenge (e.g. `https://pulse.asaf.cc`). Shown
+     *  to the user so they know who's asking. */
+    origin: string;
+    /** Realm header value (e.g. `Restricted area`). Shown as the
+     *  prompt subtitle. Empty when the server didn't supply one. */
+    realm: string;
+    /** True for HTTP 407 proxy auth; false for 401 server auth.
+     *  v1 surfaces both with the same UI; future spec may diverge. */
+    isProxy: boolean;
+    /** User submitted credentials. The layer routes them to the host
+     *  via `browser_pane_auth_submit`. */
+    onSubmit: (username: string, password: string) => void;
+    /** User cancelled. The layer routes to `browser_pane_auth_cancel`,
+     *  which calls `AuthCallback.cancel()` so CEF aborts the request
+     *  and renders the 401 response body. */
     onCancel: () => void;
 }
 

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -160,6 +160,66 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     // so we cancel exactly the ones that didn't resolve through
     // the submit/cancel buttons.
     const pendingAuthIds = new Set<string>();
+    // FIFO queue for concurrent auth challenges. Two protected
+    // subresources on the same page (or two panes in the same tab)
+    // can challenge before the user resolves the first prompt;
+    // unconditional tabModal.open would replace the visible modal,
+    // and the unmounted panel's onCleanup would cancel the earlier
+    // challenge — so authenticating the survivor still fails the
+    // earlier requests. Queue new arrivals; open the next after the
+    // active one resolves.
+    type AuthChallenge = {
+        request_id: string;
+        origin: string;
+        host: string;
+        port: number;
+        realm: string;
+        is_proxy: boolean;
+    };
+    const authQueue: AuthChallenge[] = [];
+    let authActive = false;
+
+    const openAuthPrompt = (c: AuthChallenge) => {
+        authActive = true;
+        tabModal.open({
+            kind: "browser-auth",
+            blockId: model.blockId,
+            requestId: c.request_id,
+            origin: c.origin || `${c.host}:${c.port}`,
+            realm: c.realm,
+            isProxy: c.is_proxy,
+            onSubmit: (username, password) => {
+                pendingAuthIds.delete(c.request_id);
+                diag(`auth-submit request_id=${c.request_id}`);
+                void invokeCommand("browser_pane_auth_submit", {
+                    request_id: c.request_id,
+                    username,
+                    password,
+                }).catch((e) => diag(`auth-submit-failed err=${String(e)}`));
+                authActive = false;
+                drainAuthQueue();
+            },
+            onCancel: () => {
+                pendingAuthIds.delete(c.request_id);
+                diag(`auth-cancel request_id=${c.request_id}`);
+                void invokeCommand("browser_pane_auth_cancel", {
+                    request_id: c.request_id,
+                }).catch(() => {});
+                authActive = false;
+                drainAuthQueue();
+            },
+        });
+    };
+    const drainAuthQueue = () => {
+        if (authActive || authQueue.length === 0) return;
+        const next = authQueue.shift()!;
+        // Defer to a microtask so the prior modal's onCleanup has
+        // run before we mount the next one — replacing synchronously
+        // would re-trigger the cleanup-cancel path the queue exists
+        // to prevent.
+        queueMicrotask(() => openAuthPrompt(next));
+    };
+
     onMount(() => {
         if (placeholderRef) {
             resizeObserver = new ResizeObserver(syncPosition);
@@ -184,30 +244,20 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             // are enough to trace the prompt without logging credentials.
             diag(`auth-required request_id=${payload.request_id} origin=${JSON.stringify(payload.origin)} realm=${JSON.stringify(payload.realm)}`);
             pendingAuthIds.add(payload.request_id);
-            tabModal.open({
-                kind: "browser-auth",
-                blockId: model.blockId,
-                requestId: payload.request_id,
-                origin: payload.origin || `${payload.host}:${payload.port}`,
+            const challenge: AuthChallenge = {
+                request_id: payload.request_id,
+                origin: payload.origin,
+                host: payload.host,
+                port: payload.port,
                 realm: payload.realm,
-                isProxy: payload.is_proxy,
-                onSubmit: (username, password) => {
-                    pendingAuthIds.delete(payload.request_id);
-                    diag(`auth-submit request_id=${payload.request_id}`);
-                    void invokeCommand("browser_pane_auth_submit", {
-                        request_id: payload.request_id,
-                        username,
-                        password,
-                    }).catch((e) => diag(`auth-submit-failed err=${String(e)}`));
-                },
-                onCancel: () => {
-                    pendingAuthIds.delete(payload.request_id);
-                    diag(`auth-cancel request_id=${payload.request_id}`);
-                    void invokeCommand("browser_pane_auth_cancel", {
-                        request_id: payload.request_id,
-                    }).catch(() => {});
-                },
-            });
+                is_proxy: payload.is_proxy,
+            };
+            if (authActive) {
+                diag(`auth-queue request_id=${payload.request_id} depth=${authQueue.length + 1}`);
+                authQueue.push(challenge);
+            } else {
+                openAuthPrompt(challenge);
+            }
         }).then((unsub) => {
             // listenEvent's promise can resolve AFTER onCleanup has
             // already run (pane closed before subscription completed).
@@ -240,15 +290,17 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             authUnsub();
             authUnsub = null;
         }
-        // Cancel any auth prompts still parked on the host. The
-        // backend also fires `cancel_for_block` from `browser_pane_close`
-        // as a safety net, but firing them here ensures each cancel
-        // logs against the correct request_id.
+        // Cancel any auth prompts still parked on the host (active
+        // + queued). The backend also fires `cancel_for_block` from
+        // `browser_pane_close` as a safety net, but firing them here
+        // ensures each cancel logs against the correct request_id.
         for (const requestId of pendingAuthIds) {
             invokeCommand("browser_pane_auth_cancel", { request_id: requestId })
                 .catch(() => {});
         }
         pendingAuthIds.clear();
+        authQueue.length = 0;
+        authActive = false;
     });
 
     return (

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createEffect, createSignal, onCleanup, onMount, Show, type JSX } from "solid-js";
-import { invokeCommand } from "@/app/platform/ipc";
+import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+import { useTabModal } from "@/app/tab/tab-modal";
 import type { BrowserViewModel } from "./browser-model";
 import "./browser-view.scss";
 
@@ -19,6 +20,7 @@ function tagElement(el: Element | null): string {
 
 export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>): JSX.Element {
     const model = props.model;
+    const tabModal = useTabModal();
     const _diagTag = `[browser-pane:diag][${model.blockId.slice(0, 7)}]`;
     const diag = (msg: string): void => { console.log(`${_diagTag} ${msg}`); };
     // Captured once at mount — same window_label that createPane uses
@@ -149,12 +151,70 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
         }
     };
 
+    let authUnsub: (() => void) | null = null;
+    let authDisposed = false;
+    // Per-pane set of in-flight auth requests. ESC/backdrop dismiss
+    // tears down the modal via `safeClose()` without firing the
+    // browser-auth onCancel, so any remaining ids in this set need
+    // explicit cancel on pane unmount AND on resolution. Tracks ids
+    // so we cancel exactly the ones that didn't resolve through
+    // submit/cancel buttons (codex P2 on #906).
+    const pendingAuthIds = new Set<string>();
     onMount(() => {
         if (placeholderRef) {
             resizeObserver = new ResizeObserver(syncPosition);
             resizeObserver.observe(placeholderRef);
             positionInterval = setInterval(syncPosition, 200);
         }
+        // Subscribe to CEF's HTTP Basic/Digest auth challenges. Lives
+        // in the view (not the model) because it needs `useTabModal()`
+        // context, which is a SolidJS hook. Phase α of
+        // SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+        void listenEvent<{
+            block_id: string;
+            request_id: string;
+            origin: string;
+            host: string;
+            port: number;
+            realm: string;
+            is_proxy: boolean;
+        }>("browser-pane-auth-required", (payload) => {
+            if (payload.block_id !== model.blockId) return;
+            // Don't log username-length on submit — reagent P2 on #906.
+            diag(`auth-required request_id=${payload.request_id} origin=${JSON.stringify(payload.origin)} realm=${JSON.stringify(payload.realm)}`);
+            pendingAuthIds.add(payload.request_id);
+            tabModal.open({
+                kind: "browser-auth",
+                blockId: model.blockId,
+                requestId: payload.request_id,
+                origin: payload.origin || `${payload.host}:${payload.port}`,
+                realm: payload.realm,
+                isProxy: payload.is_proxy,
+                onSubmit: (username, password) => {
+                    pendingAuthIds.delete(payload.request_id);
+                    diag(`auth-submit request_id=${payload.request_id}`);
+                    void invokeCommand("browser_pane_auth_submit", {
+                        request_id: payload.request_id,
+                        username,
+                        password,
+                    }).catch((e) => diag(`auth-submit-failed err=${String(e)}`));
+                },
+                onCancel: () => {
+                    pendingAuthIds.delete(payload.request_id);
+                    diag(`auth-cancel request_id=${payload.request_id}`);
+                    void invokeCommand("browser_pane_auth_cancel", {
+                        request_id: payload.request_id,
+                    }).catch(() => {});
+                },
+            });
+        }).then((unsub) => {
+            // Race guard (reagent P1 on #906): listenEvent's promise
+            // can resolve AFTER onCleanup runs. Without this check,
+            // authUnsub gets set post-cleanup and never invoked,
+            // leaking the listener until renderer teardown.
+            if (authDisposed) unsub();
+            else authUnsub = unsub;
+        });
         const url = model.urlAtom();
         if (url) createPane(url);
     });
@@ -173,6 +233,20 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             clearInterval(positionInterval);
             positionInterval = null;
         }
+        authDisposed = true;
+        if (authUnsub) {
+            authUnsub();
+            authUnsub = null;
+        }
+        // Cancel any auth prompts still parked on the host. Pane
+        // close also fires `cancel_for_block` on the backend as a
+        // safety net (codex P2 on #906), but firing them here ensures
+        // each cancel logs against the correct request_id.
+        for (const requestId of pendingAuthIds) {
+            invokeCommand("browser_pane_auth_cancel", { request_id: requestId })
+                .catch(() => {});
+        }
+        pendingAuthIds.clear();
     });
 
     return (

--- a/frontend/app/view/browser/browser-view.tsx
+++ b/frontend/app/view/browser/browser-view.tsx
@@ -158,7 +158,7 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
     // browser-auth onCancel, so any remaining ids in this set need
     // explicit cancel on pane unmount AND on resolution. Tracks ids
     // so we cancel exactly the ones that didn't resolve through
-    // submit/cancel buttons (codex P2 on #906).
+    // the submit/cancel buttons.
     const pendingAuthIds = new Set<string>();
     onMount(() => {
         if (placeholderRef) {
@@ -180,7 +180,8 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             is_proxy: boolean;
         }>("browser-pane-auth-required", (payload) => {
             if (payload.block_id !== model.blockId) return;
-            // Don't log username-length on submit — reagent P2 on #906.
+            // Diagnostic stays high-signal: request_id + origin + realm
+            // are enough to trace the prompt without logging credentials.
             diag(`auth-required request_id=${payload.request_id} origin=${JSON.stringify(payload.origin)} realm=${JSON.stringify(payload.realm)}`);
             pendingAuthIds.add(payload.request_id);
             tabModal.open({
@@ -208,10 +209,11 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
                 },
             });
         }).then((unsub) => {
-            // Race guard (reagent P1 on #906): listenEvent's promise
-            // can resolve AFTER onCleanup runs. Without this check,
-            // authUnsub gets set post-cleanup and never invoked,
-            // leaking the listener until renderer teardown.
+            // listenEvent's promise can resolve AFTER onCleanup has
+            // already run (pane closed before subscription completed).
+            // Without this check, the unsub closure is captured post-
+            // cleanup and never invoked, leaking the listener until
+            // renderer teardown.
             if (authDisposed) unsub();
             else authUnsub = unsub;
         });
@@ -238,10 +240,10 @@ export function BrowserViewComponent(props: ViewComponentProps<BrowserViewModel>
             authUnsub();
             authUnsub = null;
         }
-        // Cancel any auth prompts still parked on the host. Pane
-        // close also fires `cancel_for_block` on the backend as a
-        // safety net (codex P2 on #906), but firing them here ensures
-        // each cancel logs against the correct request_id.
+        // Cancel any auth prompts still parked on the host. The
+        // backend also fires `cancel_for_block` from `browser_pane_close`
+        // as a safety net, but firing them here ensures each cancel
+        // logs against the correct request_id.
         for (const requestId of pendingAuthIds) {
             invokeCommand("browser_pane_auth_cancel", { request_id: requestId })
                 .catch(() => {});

--- a/frontend/app/view/browser/components/BrowserAuthModal.scss
+++ b/frontend/app/view/browser/components/BrowserAuthModal.scss
@@ -1,0 +1,39 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// BrowserAuthModal — modal-panel chrome lives in modal-v2.scss; this
+// file only styles the form body. SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+
+.browser-auth-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 380px;
+    max-width: 480px;
+}
+
+.browser-auth-modal-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+
+    span { user-select: none; }
+}
+
+.browser-auth-modal-input {
+    width: 100%;
+    padding: var(--space-1) var(--space-1-5);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}

--- a/frontend/app/view/browser/components/BrowserAuthModal.tsx
+++ b/frontend/app/view/browser/components/BrowserAuthModal.tsx
@@ -28,8 +28,8 @@ export const BrowserAuthModalPanel = (props: BrowserAuthModalPanelProps): JSX.El
     // True once either footer button fired its handler. onCleanup
     // uses this to detect "modal was unmounted via ESC / backdrop
     // click / pane close / replace" and fire onCancel exactly once
-    // so the parked CEF AuthCallback gets resolved (codex P2 on #906
-    // — TabModalLayer's safeClose() bypasses footer handlers).
+    // so the parked CEF AuthCallback gets resolved — the layer's
+    // safeClose() unmounts without routing through onCancel.
     let resolved = false;
 
     const submit = () => {

--- a/frontend/app/view/browser/components/BrowserAuthModal.tsx
+++ b/frontend/app/view/browser/components/BrowserAuthModal.tsx
@@ -1,0 +1,102 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * BrowserAuthModalPanel — prompts for HTTP Basic / Digest credentials
+ * when CEF fires `browser-pane-auth-required` for a browser pane.
+ *
+ * Phase α of SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md.
+ * Sibling to `AgentLaunchModalPanel` / `AgentInstallModalPanel` —
+ * mounts inside `TabModalLayer` via the `browser-auth` request kind.
+ */
+
+import { createSignal, onCleanup, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+
+interface BrowserAuthModalPanelProps {
+    origin: string;
+    realm: string;
+    isProxy: boolean;
+    onCancel: () => void;
+    onSubmit: (username: string, password: string) => void;
+}
+
+export const BrowserAuthModalPanel = (props: BrowserAuthModalPanelProps): JSX.Element => {
+    const [username, setUsername] = createSignal("");
+    const [password, setPassword] = createSignal("");
+    // True once either footer button fired its handler. onCleanup
+    // uses this to detect "modal was unmounted via ESC / backdrop
+    // click / pane close / replace" and fire onCancel exactly once
+    // so the parked CEF AuthCallback gets resolved (codex P2 on #906
+    // — TabModalLayer's safeClose() bypasses footer handlers).
+    let resolved = false;
+
+    const submit = () => {
+        resolved = true;
+        props.onSubmit(username(), password());
+    };
+    const cancel = () => {
+        resolved = true;
+        props.onCancel();
+    };
+
+    onCleanup(() => {
+        if (!resolved) props.onCancel();
+    });
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submit();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            cancel();
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">
+                    {props.isProxy ? "Proxy authentication required" : "Authentication required"}
+                </h2>
+                <p class="modal-panel-description">
+                    <strong>{props.origin || "This site"}</strong>
+                    {props.realm ? <> says: <em>{props.realm}</em></> : null}
+                </p>
+            </header>
+            <div class="modal-panel-body browser-auth-modal-body">
+                <label class="browser-auth-modal-field">
+                    <span>Username</span>
+                    <input
+                        type="text"
+                        class="browser-auth-modal-input"
+                        autocomplete="username"
+                        autofocus
+                        value={username()}
+                        onInput={(e) => setUsername(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                    />
+                </label>
+                <label class="browser-auth-modal-field">
+                    <span>Password</span>
+                    <input
+                        type="password"
+                        class="browser-auth-modal-input"
+                        autocomplete="current-password"
+                        value={password()}
+                        onInput={(e) => setPassword(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                    />
+                </label>
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={cancel}>Cancel</Button>
+                <Button onClick={submit} className="green solid">Sign in</Button>
+            </footer>
+        </>
+    );
+};
+
+BrowserAuthModalPanel.displayName = "BrowserAuthModalPanel";


### PR DESCRIPTION
## Summary

Sites that return 401 WWW-Authenticate: Basic / Digest were failing with \`ERR_INVALID_AUTH_CREDENTIALS (-338)\` because CEF's \`RequestHandler::get_auth_credentials\` wasn't wired (only \`on_render_process_terminated\` is implemented today). The host was silent, CEF treated the 401 as a fatal error, the pane showed a blank error page.

Phase α wires the full chain:

**Host (Rust)**
- New \`agentmux-cef/src/browser_pane/auth.rs\` — global registry parking CEF \`AuthCallback\`s keyed by uuid request_id (Mutex<HashMap>, with helpers \`register\` / \`take\` / \`pending_count\`).
- \`AgentMuxRequestHandler::auth_credentials\` returns 1 (async), registers the callback, broadcasts \`browser-pane-auth-required\` IPC event with origin/host/port/realm/is_proxy.
- IPC handlers \`browser_pane_auth_submit\` / \`browser_pane_auth_cancel\` pop the callback and call \`cb.cont(user, pass)\` / \`cb.cancel()\`.
- Non-browser-pane requests (the main host frontend) decline (return 0) — host frontend shouldn't hit auth challenges.

**Frontend (TS)**
- New \`BrowserAuthRequest\` variant on \`TabModalRequest\`.
- New \`BrowserAuthModalPanel\` (modal-v2 chrome) with username + password inputs. Username autofocuses, Enter submits, Escape cancels.
- \`browser-view.tsx\` subscribes to \`browser-pane-auth-required\` in onMount (lives in the view so \`useTabModal()\` SolidJS hook is in context) and opens the modal. Subscription cleanup in onCleanup.

**Spec**: [\`SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md\`](docs/specs/SPEC_BROWSER_PANE_HTTP_BASIC_AUTH_2026_05_18.md)

Phase β (per-pane in-memory realm cache so subresource auth doesn't re-prompt) and Phase γ (OS keyring persistence, proxy auth, client certs) deferred.

## Test plan

- [ ] Open browser pane → navigate to https://pulse.asaf.cc/ (or any 401 site) → modal opens with origin + realm
- [ ] Enter correct credentials → page loads
- [ ] Cancel → 401 response body renders
- [ ] Enter wrong credentials → CEF re-fires get_auth_credentials → modal re-opens (no built-in "wrong password" feedback yet — Phase β)
- [ ] Two browser panes both pointed at the same auth-required site — each prompts independently
- [ ] Close pane mid-prompt — \`pending_count()\` returns to 0 within the cleanup window

🤖 Generated with [Claude Code](https://claude.com/claude-code)