### PR TITLE
feat(agent-picker): pre-launch system prereq check (git for Claude Code/OpenClaw)

### DIFF
--- a/.changesets/1779160182-feat-agent-picker-pre-launch-system-prereq-check-git-for-cla-sutg.md
+++ b/.changesets/1779160182-feat-agent-picker-pre-launch-system-prereq-check-git-for-cla-sutg.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent-picker): pre-launch system prereq check (git for Claude Code/OpenClaw)

--- a/agentmux-srv/src/server/install_handlers.rs
+++ b/agentmux-srv/src/server/install_handlers.rs
@@ -35,6 +35,7 @@ use crate::server::AppState;
 pub const COMMAND_INSTALL_START: &str = "install.start";
 pub const COMMAND_INSTALL_CANCEL: &str = "install.cancel";
 pub const COMMAND_INSTALL_CHECK: &str = "install.check";
+pub const COMMAND_RESOLVE_PREREQS: &str = "resolve.prereqs";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -144,6 +145,30 @@ fn provider_install_dir(provider_id: &str) -> Option<std::path::PathBuf> {
 
 /// Returns the path to the installed CLI binary if present in the
 /// per-version cache, else None. Used by `install.check`.
+/// Locate a system tool (e.g. `git`, `gh`) on PATH. Uses the platform
+/// equivalent of `which` and returns the resolved absolute path. None
+/// when the tool isn't on PATH or the lookup itself failed.
+///
+/// Used by `resolve.prereqs` to pre-launch-check whether a provider's
+/// system dependencies are installed. The probe is path-only — never
+/// executes the tool — so it's safe to call without side effects.
+/// See SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+async fn resolve_tool_path(tool: &str) -> Option<String> {
+    let cmd = if cfg!(windows) { "where" } else { "which" };
+    let output = tokio::process::Command::new(cmd)
+        .arg(tool)
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    // `where` on Windows can return multiple lines; first is canonical.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    stdout.lines().next().map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 fn resolve_installed_bin(provider_id: &str, cli_command: &str) -> Option<std::path::PathBuf> {
     let dir = provider_install_dir(provider_id)?;
     let bin_dir = dir.join("node_modules").join(".bin");
@@ -244,6 +269,35 @@ pub fn register_install_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 }
                 let installed = resolve_installed_bin(&req.provider_id, &req.cli_command).is_some();
                 Ok(Some(json!({ "installed": installed })))
+            })
+        }),
+    );
+
+    engine.register_handler(
+        COMMAND_RESOLVE_PREREQS,
+        Box::new(move |data, _ctx| {
+            Box::pin(async move {
+                #[derive(serde::Deserialize)]
+                #[serde(rename_all = "camelCase")]
+                struct Req { tools: Vec<String> }
+                let req: Req = serde_json::from_value(data)
+                    .map_err(|e| format!("resolve.prereqs: {e}"))?;
+                let mut results = Vec::with_capacity(req.tools.len());
+                for tool in &req.tools {
+                    if !is_safe_cli_command(tool) {
+                        return Err(format!(
+                            "resolve.prereqs: invalid tool name {:?}",
+                            tool
+                        ));
+                    }
+                    let path = resolve_tool_path(tool).await;
+                    results.push(json!({
+                        "tool": tool,
+                        "found": path.is_some(),
+                        "path": path,
+                    }));
+                }
+                Ok(Some(json!({ "results": results })))
             })
         }),
     );

--- a/docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md
+++ b/docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md
@@ -1,0 +1,229 @@
+# SPEC: Provider System-Tool Prerequisites
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:**
+- `frontend/app/view/agent/providers/index.ts` (provider definitions)
+- `agentmux-cef/src/commands/providers.rs::check_nodejs_available` (existing single-tool check)
+- Anthropic Claude Code issue [#29898](https://github.com/anthropics/claude-code/issues/29898) (the runtime error this spec eliminates)
+
+---
+
+## 0. TL;DR
+
+Some CLI providers AgentMux supports require system tools beyond Node.js to actually run. Claude Code, for instance, errors at session start with:
+
+> `Error: Git is required but was not found. Install git and try again.`
+
+We don't check for git today, so the user sees this stderr from Claude Code itself rather than an AgentMux notice. Same gap exists in principle for any future provider that depends on `gh`, `python`, etc.
+
+Fix: declare each provider's `systemPrereqs` as part of `ProviderDefinition`. Probe the system at install / launch time via a new `resolve_prereqs` RPC. Show a friendly pre-launch banner listing any missing tools with their official download URLs as clickable links.
+
+---
+
+## 1. Problem
+
+Today's flow with Claude Code on a machine without git:
+
+1. User clicks the Claude Code card in the agent picker.
+2. Install modal runs `npm install @anthropic-ai/claude-code` — succeeds (no git dep at install time).
+3. User clicks Continue to Launch.
+4. Agent pane spawns `claude` CLI.
+5. Claude Code starts a local session, calls git, and prints to stderr:
+   > `Error: Git is required but was not found. Install git and try again.`
+6. User sees that error in the agent terminal — no AgentMux UI explaining what to do.
+
+Same shape for any provider that internally relies on a non-bundled system tool.
+
+---
+
+## 2. Best-practices comparison
+
+- **VS Code extensions** with system-tool deps surface a notification on activation: "This extension requires `<tool>`. Install from `<url>`." Click → opens the URL in browser. Most check on activation rather than at every command.
+- **Tauri's auto-updater** does platform-specific tool probes during init.
+- **Homebrew** declares formula `depends_on` and refuses to install if missing — too rigid for our case (we want to inform, not block install).
+
+The pattern that fits AgentMux: check at **install / launch time** and surface a banner with install URLs. Don't hard-block the launch — the user may have the tool under a non-standard path that `where`/`which` can't find. Allow override with "Launch anyway."
+
+---
+
+## 3. Proposed architecture
+
+### 3.1 Declare prereqs on the provider
+
+Add to `ProviderDefinition` (`frontend/app/view/agent/providers/index.ts`):
+
+```ts
+export interface SystemPrereq {
+    /** Binary name to look up via `where` (Windows) / `which` (Unix). */
+    tool: string;
+    /** Human-readable display name shown in the banner.
+     *  Defaults to `tool` if omitted. */
+    label?: string;
+    /** Per-platform install URLs. Each one is a curated landing page,
+     *  not the raw downloads index — so the link feels intentional. */
+    installUrls: {
+        windows: string;
+        macos: string;
+        linux: string;
+    };
+    /** When true, mark the prereq as launch-blocking in the UI.
+     *  When false, show as a warning (user can Launch anyway).
+     *  Defaults to true — most prereqs are hard reqs at runtime. */
+    blocking?: boolean;
+}
+
+export interface ProviderDefinition {
+    // ...existing fields...
+    /** System tools the provider needs at runtime (beyond Node, which
+     *  is checked separately by `check_nodejs_available`). */
+    systemPrereqs?: SystemPrereq[];
+}
+```
+
+Initial population:
+
+| Provider | Prereqs |
+|---|---|
+| `claude` | `git` (issue #29898) |
+| `codex` | none (OpenAI Codex CLI doesn't shell out to system tools) |
+| `gemini` | none |
+| `openclaw` | `git` (built on the Codex harness which doesn't need it, but openclaw model auth + project context use git) |
+| `kimi` | none |
+| `copilot` | `gh` (GitHub Copilot CLI wraps `gh`) |
+| `pi` | none |
+
+This list is conservative — if a provider doesn't *consistently* fail without a tool, leave it off. False-positive banners are worse than no banner.
+
+### 3.2 Probe RPC
+
+New `RpcApi.ResolvePrereqsCommand` backed by `agentmux-srv/src/server/cli_handlers.rs::resolve_prereqs`:
+
+```rust
+#[derive(Deserialize)]
+struct ResolvePrereqsReq {
+    tools: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct ResolvePrereqsRsp {
+    /// One entry per requested tool, preserving order. `path` is the
+    /// resolved absolute path (Some) or None if not found.
+    results: Vec<PrereqResult>,
+}
+
+#[derive(Serialize)]
+struct PrereqResult {
+    tool: String,
+    found: bool,
+    path: Option<String>,
+}
+```
+
+Probe via `where {tool}` (Windows) / `which {tool}` (Unix). Use the **path-only** form so we don't accidentally execute the tool. Cache per-renderer-process for the session (PATH doesn't change while AgentMux is running).
+
+### 3.3 UI: pre-launch prereq banner
+
+When the user clicks an agent card whose provider has `systemPrereqs`:
+
+1. AgentPicker calls `resolve_prereqs(provider.systemPrereqs.map(p => p.tool))` BEFORE opening the install or launch modal.
+2. If any required tools are missing → open a new "Prerequisites" modal kind in the existing `TabModalLayer` showing a list:
+
+   ```
+   Claude Code needs some tools that aren't installed.
+
+   ⚠ Git — not found
+        Install Git for Windows ↗  (https://git-scm.com/download/win)
+
+   [ Launch anyway ]   [ Cancel ]
+   ```
+
+3. "Cancel" → close.
+4. "Launch anyway" → proceed to the install modal (or directly to launch if already installed).
+
+If all prereqs present → fall through to the existing install/launch flow with no extra step.
+
+The banner links use `getApi().openExternal(url)` (existing CEF IPC for opening URLs in the system browser) so the user lands on the official downloads page in their default browser.
+
+### 3.4 Platform detection for the URL
+
+The `useSystemPlatform()` hook already exists in `frontend/app/store/global.ts` (returns `"win32" | "darwin" | "linux"`). The banner picks the matching URL from `installUrls.{windows,macos,linux}`.
+
+### 3.5 Banner copy
+
+```
+Title:    "Install required tools to use {displayName}"
+Subtitle: "{displayName} needs the following tools. Install them and restart AgentMux."
+
+Per-tool row:
+   ⚠ <label> — not found
+   ↗ <Install link> (anchor text is platform-specific, e.g. "Install Git for Windows")
+
+Footer:
+   [ Cancel ]   [ Launch anyway ]   [ Refresh ] (re-probe after user installs)
+```
+
+A "Refresh" button re-runs the RPC so a user who installs git in another terminal can re-check without re-opening AgentMux.
+
+---
+
+## 4. Implementation plan
+
+### Phase α — claude + openclaw only
+
+1. `frontend/app/view/agent/providers/index.ts` — add `SystemPrereq` interface + `systemPrereqs` field; populate for `claude` and `openclaw`.
+2. `agentmux-srv/src/server/cli_handlers.rs` — new `resolve_prereqs` RPC handler.
+3. Auto-generated RPC bindings — re-run codegen (`task generate-ts`?).
+4. `frontend/app/view/agent/components/AgentPrereqModal.tsx` — new component using modal-v2 chrome. Reuses the same `useTabModal` pattern as install/launch.
+5. `frontend/app/tab/tab-modal.ts` — new `kind: "agent-prereqs"` request shape.
+6. `frontend/app/view/agent/components/AgentPicker.tsx` — between card click and install-modal open, call `resolve_prereqs`; if anything missing + blocking, route to the prereq modal first.
+
+### Phase β — extend
+
+7. Refresh-button wiring.
+8. Add `copilot` → `gh` once we ship that provider.
+
+---
+
+## 5. Curated install URLs
+
+Per the user's "good looking links to proper locations":
+
+| Tool | Windows | macOS | Linux |
+|---|---|---|---|
+| `git` | https://git-scm.com/download/win | https://git-scm.com/download/mac | https://git-scm.com/download/linux |
+| `gh` | https://cli.github.com/ | https://cli.github.com/ | https://cli.github.com/ |
+
+These are the official landing pages each project maintains. The Windows git page in particular leads with the prominent download button — best signal for our users.
+
+---
+
+## 6. Test plan
+
+- [ ] On a machine without git installed: click Claude Code → prereq modal opens listing Git → click "Install Git for Windows" → opens https://git-scm.com/download/win in default browser → user installs → clicks Refresh → modal updates to "all prereqs satisfied" → can launch.
+- [ ] On a machine WITH git: click Claude Code → prereq modal does NOT open; flow proceeds straight to install/launch.
+- [ ] Click "Launch anyway" with git missing → install/launch proceeds → user sees Claude Code's `Git is required` stderr in the agent pane (best we can do — the agent itself owns that flow now).
+- [ ] Provider with no `systemPrereqs` → no extra modal, no extra RPC call (skip the probe).
+- [ ] Cancel from prereq modal → returns to picker, no install attempted.
+
+---
+
+## 7. Acceptance criteria
+
+1. New `SystemPrereq` field on `ProviderDefinition`, populated for `claude` and `openclaw` with `git`.
+2. `resolve_prereqs` RPC returns accurate found/path for each tool on Windows, macOS, Linux.
+3. Pre-launch prereq modal opens only when prereqs are missing AND blocking.
+4. Install links open the platform-appropriate URL in the user's default browser.
+5. "Launch anyway" overrides the modal and proceeds.
+6. "Refresh" re-probes without closing.
+7. No extra latency on launch for providers without prereqs (RPC skipped).
+
+---
+
+## 8. Out of scope
+
+- **Bundled tools** in the portable (e.g. shipping our own `git.exe`). Adds ~50MB and creates an upgrade-skew problem (users may run a different system git in terminals). Separate spec if requested.
+- **Auto-install** of missing tools via package managers (winget, brew, apt). Cross-platform package-manager invocation is its own can of worms.
+- **Per-provider prereqs configurable by the user** (e.g. "I know my git is at `D:\portable\git\bin\git.exe`"). Could add `prereqOverrides: { tool: path }` to settings later.
+- **Probing during AgentMux startup** to surface a global "missing tools" notice. Not a launcher concern; per-provider lazy probe is enough.

--- a/frontend/app/store/rpc-api.ts
+++ b/frontend/app/store/rpc-api.ts
@@ -830,6 +830,18 @@ class RpcApiType {
         return client.rpcCall("install.check", data, opts);
     }
 
+    // command "resolve.prereqs" — probe the system PATH for each
+    // requested tool via where/which. Returns one PrereqResult per
+    // input tool preserving order. Path-only — never executes the
+    // tools. See SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+    ResolvePrereqsCommand(
+        client: RpcClient,
+        data: { tools: string[] },
+        opts?: RpcOpts,
+    ): Promise<{ results: Array<{ tool: string; found: boolean; path: string | null }> }> {
+        return client.rpcCall("resolve.prereqs", data, opts);
+    }
+
     // command "auth.submitapikey"
     AuthSubmitApiKeyCommand(
         client: RpcClient,

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -25,6 +25,8 @@ import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type 
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
+import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
+import "@/app/view/agent/components/AgentPrereqModal.scss";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
 import "./tab-modal.scss";
@@ -238,6 +240,22 @@ function renderRequest(
                                 setSubmitting(false);
                                 throw e;
                             }
+                        }}
+                    />
+                ),
+            };
+        case "agent-prereqs":
+            return {
+                label: `Install required tools for ${req.agent.name}`,
+                panel: (
+                    <AgentPrereqModalPanel
+                        agent={req.agent}
+                        missing={req.missing}
+                        onRefresh={() => req.onRefresh()}
+                        onProceed={() => req.onProceed()}
+                        onCancel={() => {
+                            req.onCancel();
+                            api.close();
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -19,7 +19,10 @@ import { createContext, useContext, type Accessor } from "solid-js";
 // Discriminated union so the layer can dispatch on `kind`. New tab-modal
 // surfaces add a variant here and a render branch in TabModalLayer.
 
-export type TabModalRequest = LaunchAgentRequest | InstallAgentRequest;
+export type TabModalRequest =
+    | LaunchAgentRequest
+    | InstallAgentRequest
+    | AgentPrereqRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -66,6 +69,34 @@ export interface InstallAgentRequest {
      * flip and stranded users on a stale ribbon.
      */
     onInstalled: (continueToLaunch: boolean) => void;
+}
+
+/**
+ * Pre-launch system prerequisite check. Opened when one or more of
+ * the provider's `systemPrereqs` are missing from PATH (e.g. Claude
+ * Code requires `git` to start a session — anthropics/claude-code#29898).
+ * See docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+ */
+export interface AgentPrereqRequest {
+    kind: "agent-prereqs";
+    agent: ForgeAgent;
+    originBlockId: string;
+    /** Missing prereqs to display. Each row is rendered with its
+     *  platform-appropriate install link. */
+    missing: Array<{
+        tool: string;
+        label: string;
+        installUrl: string;
+        installLinkText: string;
+    }>;
+    /** User clicked "Refresh" — caller re-probes and either closes
+     *  this modal (no missing) or replaces it with an updated list. */
+    onRefresh: () => void;
+    /** "Launch anyway" — proceed to install/launch despite the missing
+     *  tool. Useful when the tool is at a non-standard PATH. */
+    onProceed: () => void;
+    /** "Cancel" — close the modal, do not launch. */
+    onCancel: () => void;
 }
 
 // ── Context API ──────────────────────────────────────────────────────────────

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -124,6 +124,32 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         tabModal.open(buildLaunchRequest(agent));
     };
 
+    // Extracted from the install branch of handleSelect so the
+    // prereq modal's "Launch anyway" path can route to install when
+    // needed. Same shape as the existing inline install request.
+    const buildInstallRequest = (agent: ForgeAgent) => ({
+        kind: "install-agent" as const,
+        agent,
+        originBlockId: props.model.blockId,
+        onInstalled: (continueToLaunch: boolean) => {
+            const canonical = getProvider(agent.provider)?.id ?? agent.provider;
+            setInstallState((s) => {
+                const next = { ...s };
+                for (const a of agents()) {
+                    if ((getProvider(a.provider)?.id ?? a.provider) === canonical) {
+                        next[a.id] = true;
+                    }
+                }
+                return next;
+            });
+            if (continueToLaunch) {
+                tabModal.replace(buildLaunchRequest(agent));
+            } else {
+                tabModal.close();
+            }
+        },
+    });
+
     // Clicking the card opens either the install or launch modal in
     // the tab-scoped layer, depending on whether the agent's CLI is
     // already installed in the per-version cache. Phase α of
@@ -135,6 +161,48 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // modals — the second mount replaces the first, and its
     // onCleanup fires `install.cancel` on the session the first one
     // had just kicked off.
+    // System-tool prereq probe + modal. Phase α of
+    // SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md. Caches per-tool
+    // probe results for the session (PATH doesn't change mid-session
+    // unless the user installs a new tool — `Refresh` clears).
+    const prereqCache = new Map<string, boolean>();
+    const platformKey = (): "windows" | "macos" | "linux" => {
+        const p = (window.navigator?.platform ?? "").toLowerCase();
+        if (p.includes("win")) return "windows";
+        if (p.includes("mac")) return "macos";
+        return "linux";
+    };
+    const probeMissingPrereqs = async (agent: ForgeAgent) => {
+        const prov = getProvider(agent.provider);
+        const reqs = prov?.systemPrereqs ?? [];
+        if (reqs.length === 0) return [];
+        const uncached = reqs.filter((r) => !prereqCache.has(r.tool));
+        if (uncached.length > 0) {
+            try {
+                const r = await RpcApi.ResolvePrereqsCommand(TabRpcClient, {
+                    tools: uncached.map((u) => u.tool),
+                });
+                for (const result of r.results) {
+                    prereqCache.set(result.tool, result.found);
+                }
+            } catch {
+                // If the probe fails (e.g. backend not ready), treat
+                // all as found — don't block launch on probe failure.
+                for (const u of uncached) prereqCache.set(u.tool, true);
+            }
+        }
+        const platform = platformKey();
+        return reqs
+            .filter((r) => prereqCache.get(r.tool) === false)
+            .map((r) => ({
+                tool: r.tool,
+                label: r.label ?? r.tool,
+                installUrl: r.installUrls[platform],
+                installLinkText:
+                    r.installLinkText?.[platform] ?? `Install ${r.label ?? r.tool}`,
+            }));
+    };
+
     const pendingSelect = new Set<string>();
     const handleSelect = async (agent: ForgeAgent) => {
         if (pendingSelect.has(agent.id)) return;
@@ -156,6 +224,49 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     await checkInstalled(agent);
                     installed = installState()[agent.id];
                 }
+            }
+
+            // System-tool prereq check (e.g. Claude Code requires git
+            // — anthropics/claude-code#29898). If any are missing, open
+            // the prereq modal first; user can install + refresh or
+            // override via Launch anyway.
+            const missing = await probeMissingPrereqs(agent);
+            if (missing.length > 0) {
+                const proceedWithFlow = () => {
+                    if (installed === false) {
+                        tabModal.replace(buildInstallRequest(agent));
+                    } else {
+                        tabModal.replace(buildLaunchRequest(agent));
+                    }
+                };
+                tabModal.open({
+                    kind: "agent-prereqs",
+                    agent,
+                    originBlockId: props.model.blockId,
+                    missing,
+                    onRefresh: async () => {
+                        // Clear cache, re-probe, replace modal with
+                        // fresh result.
+                        for (const m of missing) prereqCache.delete(m.tool);
+                        const fresh = await probeMissingPrereqs(agent);
+                        if (fresh.length === 0) {
+                            proceedWithFlow();
+                        } else {
+                            tabModal.replace({
+                                kind: "agent-prereqs",
+                                agent,
+                                originBlockId: props.model.blockId,
+                                missing: fresh,
+                                onRefresh: () => { /* will be re-bound by next replace */ },
+                                onProceed: proceedWithFlow,
+                                onCancel: () => { /* layer closes */ },
+                            });
+                        }
+                    },
+                    onProceed: proceedWithFlow,
+                    onCancel: () => { /* layer closes */ },
+                });
+                return;
             }
 
             if (installed === false) {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -15,6 +15,7 @@ import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { useTabModal } from "@/app/tab/tab-modal";
+import { getPlatform } from "@/util/platformutil";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
 import { AgentCard } from "./AgentCard";
@@ -167,10 +168,14 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // unless the user installs a new tool — `Refresh` clears).
     const prereqCache = new Map<string, boolean>();
     const platformKey = (): "windows" | "macos" | "linux" => {
-        const p = (window.navigator?.platform ?? "").toLowerCase();
-        if (p.includes("win")) return "windows";
-        if (p.includes("mac")) return "macos";
-        return "linux";
+        // Read from the CEF host's authoritative `getPlatform()` IPC
+        // rather than the deprecated `window.navigator.platform` —
+        // reagent P2 on PR #908.
+        switch (getPlatform()) {
+            case "win32": return "windows";
+            case "darwin": return "macos";
+            default: return "linux";
+        }
     };
     const probeMissingPrereqs = async (agent: ForgeAgent) => {
         const prov = getProvider(agent.provider);
@@ -239,33 +244,36 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                         tabModal.replace(buildLaunchRequest(agent));
                     }
                 };
-                tabModal.open({
-                    kind: "agent-prereqs",
-                    agent,
-                    originBlockId: props.model.blockId,
-                    missing,
-                    onRefresh: async () => {
-                        // Clear cache, re-probe, replace modal with
-                        // fresh result.
-                        for (const m of missing) prereqCache.delete(m.tool);
+                // Recursive opener so the Refresh handler on every
+                // rendered modal (including the replacement after a
+                // failed re-probe) gets a working re-probe wired up.
+                // Reagent + codex P1/P2 on PR #908.
+                const openPrereqModal = (
+                    currentMissing: typeof missing,
+                    op: "open" | "replace",
+                ): void => {
+                    const refresh = async () => {
+                        for (const m of currentMissing) prereqCache.delete(m.tool);
                         const fresh = await probeMissingPrereqs(agent);
                         if (fresh.length === 0) {
                             proceedWithFlow();
                         } else {
-                            tabModal.replace({
-                                kind: "agent-prereqs",
-                                agent,
-                                originBlockId: props.model.blockId,
-                                missing: fresh,
-                                onRefresh: () => { /* will be re-bound by next replace */ },
-                                onProceed: proceedWithFlow,
-                                onCancel: () => { /* layer closes */ },
-                            });
+                            openPrereqModal(fresh, "replace");
                         }
-                    },
-                    onProceed: proceedWithFlow,
-                    onCancel: () => { /* layer closes */ },
-                });
+                    };
+                    const req = {
+                        kind: "agent-prereqs" as const,
+                        agent,
+                        originBlockId: props.model.blockId,
+                        missing: currentMissing,
+                        onRefresh: () => void refresh(),
+                        onProceed: proceedWithFlow,
+                        onCancel: () => { /* layer closes */ },
+                    };
+                    if (op === "open") tabModal.open(req);
+                    else tabModal.replace(req);
+                };
+                openPrereqModal(missing, "open");
                 return;
             }
 

--- a/frontend/app/view/agent/components/AgentPrereqModal.scss
+++ b/frontend/app/view/agent/components/AgentPrereqModal.scss
@@ -1,0 +1,90 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Modal-panel chrome lives in modal-v2.scss; this file only styles
+// the prereq list body. SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+
+.agent-prereq-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 440px;
+    max-width: 540px;
+}
+
+.agent-prereq-modal-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.agent-prereq-modal-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-2-5);
+    background: color-mix(in srgb, var(--warning-color, #e9b800) 6%, transparent);
+    border: 1px solid color-mix(in srgb, var(--warning-color, #e9b800) 30%, transparent);
+    border-radius: 6px;
+}
+
+.agent-prereq-modal-icon {
+    flex-shrink: 0;
+    color: var(--warning-color, #e9b800);
+    font-size: 18px;
+    line-height: 1;
+    padding-top: 2px;
+}
+
+.agent-prereq-modal-info {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-0-5);
+}
+
+.agent-prereq-modal-tool {
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--main-text-color);
+}
+
+.agent-prereq-modal-tool-status {
+    font-weight: 400;
+    color: var(--secondary-text-color);
+}
+
+.agent-prereq-modal-link {
+    font-size: var(--text-sm);
+    color: var(--accent-color);
+    text-decoration: none;
+    cursor: pointer;
+    width: fit-content;
+
+    &:hover {
+        text-decoration: underline;
+    }
+}
+
+.agent-prereq-modal-link-arrow {
+    color: color-mix(in srgb, var(--accent-color) 70%, transparent);
+    font-size: 0.9em;
+}
+
+.agent-prereq-modal-hint {
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.4;
+    margin: 0;
+
+    code {
+        padding: 1px 4px;
+        background: color-mix(in srgb, var(--main-text-color) 6%, transparent);
+        border-radius: 3px;
+        font-size: 0.9em;
+    }
+}

--- a/frontend/app/view/agent/components/AgentPrereqModal.tsx
+++ b/frontend/app/view/agent/components/AgentPrereqModal.tsx
@@ -1,0 +1,97 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentPrereqModalPanel — pre-launch modal listing missing system
+ * tools the provider's CLI needs at runtime. Opens when any of the
+ * provider's `systemPrereqs` aren't on PATH.
+ *
+ * SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+ */
+
+import { For, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { getApi } from "@/app/store/global";
+
+interface MissingPrereq {
+    tool: string;
+    label: string;
+    installUrl: string;
+    installLinkText: string;
+}
+
+interface AgentPrereqModalPanelProps {
+    agent: ForgeAgent;
+    missing: MissingPrereq[];
+    onRefresh: () => void;
+    onProceed: () => void;
+    onCancel: () => void;
+}
+
+export const AgentPrereqModalPanel = (props: AgentPrereqModalPanelProps): JSX.Element => {
+    const open = (url: string): void => {
+        try {
+            getApi().openExternal(url);
+        } catch {
+            // Fall through — if external-open fails, the link is at
+            // least visible in the modal as text the user can copy.
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">
+                    Install required tools to use {props.agent.name}
+                </h2>
+                <p class="modal-panel-description">
+                    {props.agent.name} depends on tools that aren't on your
+                    PATH. Install them, then click <em>Refresh</em>.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-prereq-modal-body">
+                <ul class="agent-prereq-modal-list">
+                    <For each={props.missing}>
+                        {(req) => (
+                            <li class="agent-prereq-modal-row">
+                                <span class="agent-prereq-modal-icon" aria-hidden="true">⚠</span>
+                                <div class="agent-prereq-modal-info">
+                                    <div class="agent-prereq-modal-tool">
+                                        {req.label}
+                                        <span class="agent-prereq-modal-tool-status"> — not found</span>
+                                    </div>
+                                    <a
+                                        class="agent-prereq-modal-link"
+                                        href={req.installUrl}
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            open(req.installUrl);
+                                        }}
+                                    >
+                                        {req.installLinkText}
+                                        <span class="agent-prereq-modal-link-arrow" aria-hidden="true"> ↗</span>
+                                    </a>
+                                </div>
+                            </li>
+                        )}
+                    </For>
+                </ul>
+                <p class="agent-prereq-modal-hint">
+                    Already installed under a non-standard path? Click <em>Launch
+                    anyway</em> — AgentMux can't see it from <code>PATH</code> but
+                    your CLI might pick it up.
+                </p>
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()}>Cancel</Button>
+                <Button onClick={() => props.onRefresh()}>Refresh</Button>
+                <Button onClick={() => props.onProceed()} className="green solid">
+                    Launch anyway
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentPrereqModalPanel.displayName = "AgentPrereqModalPanel";

--- a/frontend/app/view/agent/providers/index.ts
+++ b/frontend/app/view/agent/providers/index.ts
@@ -1,6 +1,37 @@
 // Copyright 2025, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * A system tool the provider's CLI needs at runtime — beyond Node
+ * itself, which is checked separately by `check_nodejs_available`.
+ * Examples: Claude Code calls `git` from inside session-start; the
+ * GitHub Copilot CLI wraps `gh`.
+ *
+ * Probed pre-launch via the `resolve_prereqs` RPC. Missing prereqs
+ * open the `AgentPrereqModal` with platform-aware install links.
+ * See docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md.
+ */
+export interface SystemPrereq {
+    /** Binary name to look up via `where` (Windows) / `which` (Unix). */
+    tool: string;
+    /** Display label in the banner. Defaults to `tool` if omitted. */
+    label?: string;
+    /** Per-platform official install URLs. Curated landing pages so
+     *  the link reads as intentional, not a generic Google search. */
+    installUrls: {
+        windows: string;
+        macos: string;
+        linux: string;
+    };
+    /** Anchor text shown for the install link, per platform. Falls
+     *  back to "Install {label}" when omitted. */
+    installLinkText?: {
+        windows?: string;
+        macos?: string;
+        linux?: string;
+    };
+}
+
 export interface ProviderDefinition {
     id: string;
     displayName: string;
@@ -44,7 +75,29 @@ export interface ProviderDefinition {
     // `openclaw models auth login --provider <id>`. The host's
     // `run_cli_login` reads this flag and chooses the PTY branch.
     requiresLoginTty?: boolean;
+    /** System tools the provider's CLI needs at runtime. Probed before
+     *  the user launches the agent so we can show install links
+     *  instead of letting the CLI fail with cryptic stderr. */
+    systemPrereqs?: SystemPrereq[];
 }
+
+/** Shared git prereq — claude-code calls `git` from session-start
+ *  (issue anthropics/claude-code#29898), and openclaw uses git for
+ *  project context. Curated install URLs per platform. */
+const GIT_PREREQ: SystemPrereq = {
+    tool: "git",
+    label: "Git",
+    installUrls: {
+        windows: "https://git-scm.com/download/win",
+        macos: "https://git-scm.com/download/mac",
+        linux: "https://git-scm.com/download/linux",
+    },
+    installLinkText: {
+        windows: "Install Git for Windows",
+        macos: "Install Git for macOS",
+        linux: "Install Git",
+    },
+};
 
 export const PROVIDERS: Record<string, ProviderDefinition> = {
     claude: {
@@ -72,6 +125,10 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "session_id",
         controllerType: "subprocess",
         persistentLaunchArgs: ["--input-format", "stream-json", "--output-format", "stream-json", "--verbose", "--include-partial-messages", "--dangerously-skip-permissions"],
+        // Claude Code calls `git` at session-start (issue
+        // anthropics/claude-code#29898). Without git the CLI fails
+        // with `Error: Git is required but was not found.`.
+        systemPrereqs: [GIT_PREREQ],
     },
     codex: {
         id: "codex",
@@ -180,6 +237,9 @@ export const PROVIDERS: Record<string, ProviderDefinition> = {
         sessionIdField: "sessionId",
         controllerType: "acp",
         requiresLoginTty: true,
+        // Same git dependency as Claude Code — OpenClaw uses git for
+        // project-context features when invoking the Codex harness.
+        systemPrereqs: [GIT_PREREQ],
     },
     // Kimi Code CLI — Moonshot AI's coding agent.
     // Python-based CLI (not npm). Supports stream-json output and OpenAI-style tool calls.


### PR DESCRIPTION
## Summary

Some CLI providers depend on system tools beyond Node (e.g. Claude Code calls \`git\` at session-start — [anthropics/claude-code#29898](https://github.com/anthropics/claude-code/issues/29898)). Without those tools the CLI crashes with confusing stderr inside the agent pane.

Phase α adds declarative prereqs on \`ProviderDefinition\` + a pre-launch probe + a friendly modal showing missing tools with platform-aware install links that open in the user's default browser.

| Provider | Prereqs |
|---|---|
| \`claude\` | \`git\` |
| \`openclaw\` | \`git\` |
| others | (none today; extend as we discover) |

The modal offers Cancel / Refresh (re-probe after install) / Launch anyway (override).

Spec: [\`SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md\`](docs/specs/SPEC_PROVIDER_SYSTEM_PREREQS_2026_05_18.md)

## Test plan

- [ ] Machine without git: click Claude Code → prereq modal opens with "Git — not found" + clickable "Install Git for Windows" link → click link → browser opens https://git-scm.com/download/win → install git → click Refresh in modal → modal closes / install flow proceeds.
- [ ] Machine with git: click Claude Code → no prereq modal, flow goes straight to install/launch.
- [ ] Provider with no \`systemPrereqs\` (codex, gemini, kimi, copilot, pi): no extra modal, no extra RPC.
- [ ] Click Launch anyway with git missing: install/launch proceeds; user sees Claude Code's own \`Git is required\` error in the agent pane (we did our part).
- [ ] Cancel: returns to picker, no install attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)