### PR TITLE
feat(launch-modal): New Identity bundle modal (Phase β)

### DIFF
--- a/.changesets/1779163155-feat-launch-modal-new-identity-bundle-modal-phase-hs6q.md
+++ b/.changesets/1779163155-feat-launch-modal-new-identity-bundle-modal-phase-hs6q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launch-modal): New Identity bundle modal (Phase β)

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -266,17 +266,21 @@ function renderRequest(
                         onSubmit={async ({ name, description }) => {
                             setSubmitting(true);
                             try {
-                                const id = crypto.randomUUID();
-                                const now = Date.now();
+                                // Wire convention from identity-pane-
+                                // model.ts:bundleDraftToWire — empty id
+                                // triggers server-side uuid; 0 timestamps
+                                // trigger server-side now-stamping. Keeps
+                                // id/timestamp handling in one place
+                                // (codex P2 on PR #910 round 3).
                                 const bundle = await RpcApi.UpsertIdentityBundleCommand(
                                     TabRpcClient,
                                     {
-                                        id,
+                                        id: "",
                                         name,
                                         description,
                                         is_blank: false,
-                                        created_at: now,
-                                        updated_at: now,
+                                        created_at: 0,
+                                        updated_at: 0,
                                     },
                                 );
                                 setSubmitting(false);

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -245,8 +245,7 @@ function renderRequest(
                                 throw e;
                             }
                         }}
-                        preselectedIdentityId={req.preselectedIdentityId}
-                        preselectedMemoryId={req.preselectedMemoryId}
+                        initialFormState={req.initialFormState}
                         onRequestNewIdentity={req.onRequestNewIdentity}
                         onRequestNewMemory={req.onRequestNewMemory}
                     />

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -23,6 +23,8 @@
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type Accessor, type Component, type JSX } from "solid-js";
 
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
@@ -256,17 +258,44 @@ function renderRequest(
                 panel: (
                     <AgentNewIdentityModalPanel
                         initialName={req.initialName}
-                        onCreated={(id, name) => {
-                            req.onCreated(id, name);
-                            // Caller is responsible for chaining back
-                            // to the Launch modal via tabModal.replace —
-                            // we DON'T close here, since closing then
-                            // re-opening the Launch modal would flicker.
+                        // The layer owns the RPC + chaining so its
+                        // `submitting()` flag (which gates safeClose)
+                        // tracks the in-flight call. Mirrors the
+                        // launch-agent dispatch above — reagent P1 on
+                        // PR #911.
+                        onSubmit={async ({ name, description }) => {
+                            setSubmitting(true);
+                            try {
+                                const id = crypto.randomUUID();
+                                const now = Date.now();
+                                const bundle = await RpcApi.UpsertIdentityBundleCommand(
+                                    TabRpcClient,
+                                    {
+                                        id,
+                                        name,
+                                        description,
+                                        is_blank: false,
+                                        created_at: now,
+                                        updated_at: now,
+                                    },
+                                );
+                                setSubmitting(false);
+                                // Caller's onCreated does tabModal.replace
+                                // back to Launch with the new id
+                                // preselected — that's what unmounts this
+                                // panel. We don't `api.close()` here.
+                                req.onCreated(bundle.id, bundle.name);
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
                         }}
-                        onCancel={() => {
-                            req.onCancel();
-                            api.close();
-                        }}
+                        // Caller's onCancel does tabModal.replace back to
+                        // Launch with the prior selection intact. Running
+                        // api.close() afterward would nullify that replace
+                        // (both run synchronously, last write wins) and
+                        // exit the launch flow — reagent P1 on PR #910.
+                        onCancel={req.onCancel}
                     />
                 ),
             };

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -26,7 +26,9 @@ import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
+import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
+import "@/app/view/agent/components/AgentNewBundleModal.scss";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
 import "./tab-modal.scss";
@@ -240,6 +242,30 @@ function renderRequest(
                                 setSubmitting(false);
                                 throw e;
                             }
+                        }}
+                        preselectedIdentityId={req.preselectedIdentityId}
+                        preselectedMemoryId={req.preselectedMemoryId}
+                        onRequestNewIdentity={req.onRequestNewIdentity}
+                        onRequestNewMemory={req.onRequestNewMemory}
+                    />
+                ),
+            };
+        case "new-identity":
+            return {
+                label: "New Identity",
+                panel: (
+                    <AgentNewIdentityModalPanel
+                        initialName={req.initialName}
+                        onCreated={(id, name) => {
+                            req.onCreated(id, name);
+                            // Caller is responsible for chaining back
+                            // to the Launch modal via tabModal.replace —
+                            // we DON'T close here, since closing then
+                            // re-opening the Launch modal would flicker.
+                        }}
+                        onCancel={() => {
+                            req.onCancel();
+                            api.close();
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -48,10 +48,15 @@ export interface LaunchAgentRequest {
     preselectedMemoryId?: string;
     /** Optional callback fired when the user clicks the "+ New
      *  identity" button. Caller is expected to call
-     *  tabModal.replace(newIdentityRequest) — the picker does this. */
-    onRequestNewIdentity?: () => void;
+     *  tabModal.replace(newIdentityRequest) — the picker does this.
+     *  The `current` arg carries the modal's live Identity + Memory
+     *  selections so the picker can preserve them across the
+     *  new-bundle round-trip (codex P2 on PR #910 round 6 — without
+     *  this, picking a Memory before clicking "+ New Identity"
+     *  silently reset to blank on return). */
+    onRequestNewIdentity?: (current: { identityId: string; memoryId: string }) => void;
     /** Same for "+ New memory". */
-    onRequestNewMemory?: () => void;
+    onRequestNewMemory?: (current: { identityId: string; memoryId: string }) => void;
 }
 
 export interface LaunchAgentSubmit {

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -22,7 +22,8 @@ import { createContext, useContext, type Accessor } from "solid-js";
 export type TabModalRequest =
     | LaunchAgentRequest
     | InstallAgentRequest
-    | AgentPrereqRequest;
+    | AgentPrereqRequest
+    | NewIdentityBundleRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -37,6 +38,20 @@ export interface LaunchAgentRequest {
      * rejects, the modal stays open and surfaces the error.
      */
     onSubmit: (overrides: LaunchAgentSubmit) => Promise<void> | void;
+    /** If set, the launch modal initialises its Identity dropdown to
+     *  this bundle id instead of the default "blank". Used by the
+     *  "+ New" → create → replace-back flow so the new bundle is
+     *  auto-selected. Phase β of
+     *  SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md. */
+    preselectedIdentityId?: string;
+    /** Same idea for the Memory dropdown. Phase γ. */
+    preselectedMemoryId?: string;
+    /** Optional callback fired when the user clicks the "+ New
+     *  identity" button. Caller is expected to call
+     *  tabModal.replace(newIdentityRequest) — the picker does this. */
+    onRequestNewIdentity?: () => void;
+    /** Same for "+ New memory". */
+    onRequestNewMemory?: () => void;
 }
 
 export interface LaunchAgentSubmit {
@@ -96,6 +111,23 @@ export interface AgentPrereqRequest {
      *  tool. Useful when the tool is at a non-standard PATH. */
     onProceed: () => void;
     /** "Cancel" — close the modal, do not launch. */
+    onCancel: () => void;
+}
+
+/**
+ * "+ New" affordance on the Launch modal's Identity row creates an
+ * empty Identity bundle. Connector setup (Claude/Codex/GitHub/AWS)
+ * happens in the Identity pane afterward.
+ * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+export interface NewIdentityBundleRequest {
+    kind: "new-identity";
+    originBlockId: string;
+    /** Initial value for the name field. Usually empty. */
+    initialName?: string;
+    /** Called after the bundle is persisted on disk. The Launch
+     *  modal uses the id to auto-select on its next render. */
+    onCreated: (bundleId: string, bundleName: string) => void;
     onCancel: () => void;
 }
 

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -38,25 +38,31 @@ export interface LaunchAgentRequest {
      * rejects, the modal stays open and surfaces the error.
      */
     onSubmit: (overrides: LaunchAgentSubmit) => Promise<void> | void;
-    /** If set, the launch modal initialises its Identity dropdown to
-     *  this bundle id instead of the default "blank". Used by the
-     *  "+ New" → create → replace-back flow so the new bundle is
-     *  auto-selected. Phase β of
-     *  SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md. */
-    preselectedIdentityId?: string;
-    /** Same idea for the Memory dropdown. Phase γ. */
-    preselectedMemoryId?: string;
+    /** Initial form state for the launch modal — used by the
+     *  "+ New" → create → replace-back flow to restore the user's
+     *  in-progress edits (name, runtime, image, identity, memory)
+     *  across the new-bundle round-trip. Codex P2 on PR #910
+     *  rounds 6 + 7. */
+    initialFormState?: Partial<LaunchFormStateWire>;
     /** Optional callback fired when the user clicks the "+ New
      *  identity" button. Caller is expected to call
      *  tabModal.replace(newIdentityRequest) — the picker does this.
-     *  The `current` arg carries the modal's live Identity + Memory
-     *  selections so the picker can preserve them across the
-     *  new-bundle round-trip (codex P2 on PR #910 round 6 — without
-     *  this, picking a Memory before clicking "+ New Identity"
-     *  silently reset to blank on return). */
-    onRequestNewIdentity?: (current: { identityId: string; memoryId: string }) => void;
+     *  The `current` snapshot carries the modal's live form state so
+     *  the picker can preserve it across the new-bundle round-trip. */
+    onRequestNewIdentity?: (current: LaunchFormStateWire) => void;
     /** Same for "+ New memory". */
-    onRequestNewMemory?: (current: { identityId: string; memoryId: string }) => void;
+    onRequestNewMemory?: (current: LaunchFormStateWire) => void;
+}
+
+/** Snapshot of the editable Launch form. Kept here (not imported from
+ *  AgentLaunchModal) so tab-modal.ts stays a leaf type module with no
+ *  imports into the view layer. */
+export interface LaunchFormStateWire {
+    name: string;
+    runtime: "host" | "container";
+    image: string;
+    identityId: string;
+    memoryId: string;
 }
 
 export interface LaunchAgentSubmit {

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -118,6 +118,12 @@ export interface AgentPrereqRequest {
  * "+ New" affordance on the Launch modal's Identity row creates an
  * empty Identity bundle. Connector setup (Claude/Codex/GitHub/AWS)
  * happens in the Identity pane afterward.
+ *
+ * The actual UpsertIdentityBundle RPC is owned by the layer so its
+ * `submitting()` flag (which gates safeClose) tracks the in-flight
+ * call — see reagent P1 on PR #911. Callers only supply the chain
+ * callbacks for after-success / on-cancel.
+ *
  * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
  */
 export interface NewIdentityBundleRequest {
@@ -125,9 +131,15 @@ export interface NewIdentityBundleRequest {
     originBlockId: string;
     /** Initial value for the name field. Usually empty. */
     initialName?: string;
-    /** Called after the bundle is persisted on disk. The Launch
-     *  modal uses the id to auto-select on its next render. */
+    /** Called after the bundle is persisted on disk. Caller should
+     *  `tabModal.replace(launchRequest)` with the new id preselected;
+     *  the layer does NOT close after this fires. */
     onCreated: (bundleId: string, bundleName: string) => void;
+    /** Called when the user clicks Cancel. Caller should
+     *  `tabModal.replace(launchRequest)` with the prior selection
+     *  intact, OR `tabModal.close()` to exit. The layer does NOT
+     *  close after this fires — running both replace + close
+     *  synchronously nullified the replace, reagent P1 on PR #910. */
     onCancel: () => void;
 }
 

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -55,6 +55,17 @@ interface AgentLaunchModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
     onSubmit: (overrides: LaunchOverrides) => Promise<void> | void;
+    /** Auto-select this Identity bundle on mount. Used by the
+     *  "+ New" → create → replace-back flow so the freshly-created
+     *  bundle shows up as the picker's choice. */
+    preselectedIdentityId?: string;
+    /** Same for Memory. Phase γ. */
+    preselectedMemoryId?: string;
+    /** Called when the "+" / empty-state New buttons fire. The picker
+     *  is expected to chain `tabModal.replace(newIdentityRequest)` —
+     *  this component doesn't know how to build that request. */
+    onRequestNewIdentity?: () => void;
+    onRequestNewMemory?: () => void;
 }
 
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
@@ -72,8 +83,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // which the resolver short-circuits as "no override". Lists fetched
     // once at mount; the blank singleton is always present. See
     // docs/specs/identity-forge-integration-and-vault-2026-05-08.md.
-    const [identityId, setIdentityId] = createSignal<string>("blank");
-    const [memoryId, setMemoryId] = createSignal<string>("blank");
+    const [identityId, setIdentityId] = createSignal<string>(
+        props.preselectedIdentityId ?? "blank",
+    );
+    const [memoryId, setMemoryId] = createSignal<string>(
+        props.preselectedMemoryId ?? "blank",
+    );
 
     const [identities] = createResource<IdentityBundle[]>(async () => {
         try {
@@ -101,16 +116,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         (memories() ?? []).some((m) => !m.is_blank),
     );
 
-    // Phase β/γ stubs — only console.log so the click paths are
-    // observable in dev. The real handlers (which fire
-    // tabModal.replace) land in Phase β (identity) and Phase γ
-    // (memory). SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
-    const handleNewIdentity = () => {
-        console.log("[launch-modal] New identity clicked — modal Phase β");
-    };
-    const handleNewMemory = () => {
-        console.log("[launch-modal] New memory clicked — modal Phase γ");
-    };
+    // "+ New ..." buttons delegate to picker-injected callbacks that
+    // chain `tabModal.replace(newBundleRequest)`. The picker owns the
+    // chain because it can rebuild the Launch request with
+    // preselectedIdentityId/preselectedMemoryId after creation.
+    const handleNewIdentity = () => props.onRequestNewIdentity?.();
+    const handleNewMemory = () => props.onRequestNewMemory?.();
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
     // CURRENT definition (server-side; a global cap would let older

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -119,7 +119,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // "+ New ..." buttons delegate to picker-injected callbacks that
     // chain `tabModal.replace(newBundleRequest)`. The picker owns the
     // chain because it can rebuild the Launch request with
-    // preselectedIdentityId/preselectedMemoryId after creation.
+    // preselectedIdentityId/preselectedMemoryId after creation. A
+    // missing callback (Phase β ships Identity wiring only; Memory
+    // wiring lands in Phase γ) keeps the button visible but disabled
+    // with a "coming soon" hint — see reagent P2 on PR #910.
     const handleNewIdentity = () => props.onRequestNewIdentity?.();
     const handleNewMemory = () => props.onRequestNewMemory?.();
 
@@ -419,7 +422,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         type="button"
                                         class="agent-launch-modal-bundle-empty-btn"
                                         onClick={handleNewIdentity}
-                                        disabled={submitting() || isContinue()}
+                                        disabled={
+                                            submitting() ||
+                                            isContinue() ||
+                                            !props.onRequestNewIdentity
+                                        }
+                                        title={
+                                            props.onRequestNewIdentity
+                                                ? undefined
+                                                : "Coming soon"
+                                        }
                                     >
                                         + New identity bundle...
                                     </button>
@@ -446,8 +458,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     type="button"
                                     class="agent-launch-modal-bundle-new-btn"
                                     onClick={handleNewIdentity}
-                                    disabled={submitting() || isContinue()}
-                                    title="New identity bundle..."
+                                    disabled={
+                                        submitting() ||
+                                        isContinue() ||
+                                        !props.onRequestNewIdentity
+                                    }
+                                    title={
+                                        props.onRequestNewIdentity
+                                            ? "New identity bundle..."
+                                            : "Coming soon"
+                                    }
                                     aria-label="New identity bundle"
                                 >
                                     +
@@ -478,7 +498,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         type="button"
                                         class="agent-launch-modal-bundle-empty-btn"
                                         onClick={handleNewMemory}
-                                        disabled={submitting() || isContinue()}
+                                        disabled={
+                                            submitting() ||
+                                            isContinue() ||
+                                            !props.onRequestNewMemory
+                                        }
+                                        title={
+                                            props.onRequestNewMemory
+                                                ? undefined
+                                                : "Coming soon"
+                                        }
                                     >
                                         + New memory bundle...
                                     </button>
@@ -505,8 +534,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     type="button"
                                     class="agent-launch-modal-bundle-new-btn"
                                     onClick={handleNewMemory}
-                                    disabled={submitting() || isContinue()}
-                                    title="New memory bundle..."
+                                    disabled={
+                                        submitting() ||
+                                        isContinue() ||
+                                        !props.onRequestNewMemory
+                                    }
+                                    title={
+                                        props.onRequestNewMemory
+                                            ? "New memory bundle..."
+                                            : "Coming soon"
+                                    }
                                     aria-label="New memory bundle"
                                 >
                                     +

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -212,21 +212,61 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         setIdentityId(bundleId);
     };
     const provider = createMemo(() => getProvider(props.agent.provider));
-    // Auth gate applies ONLY to fresh launches of OAuth providers with
-    // the blank singleton selected.
+
+    // Bindings for the currently selected identity bundle — used by
+    // authRequired() to detect non-blank bundles that have no
+    // credential binding for the agent's provider (e.g. a "Work"
+    // identity created via "+ New" but never connected to Claude/Codex
+    // yet). Reagent + codex P1 on PR #910 round 3 — without this
+    // check, "+ New" could bypass the OAuth gate entirely.
+    const [selectedBundleBindings] = createResource(
+        () => identityId(),
+        async (id) => {
+            if (!id || id === "blank" || id.startsWith("pending-bundle-for-")) {
+                return [] as IdentityBinding[];
+            }
+            try {
+                return await RpcApi.ListIdentityBindingsCommand(TabRpcClient, {
+                    identity_id: id,
+                });
+            } catch {
+                return [] as IdentityBinding[];
+            }
+        },
+    );
+
+    const bundleHasMatchingBinding = () => {
+        const id = identityId();
+        if (!id || id === "blank") return false;
+        // Treat the loading state as "no binding" so a fast-launch
+        // race can't slip through the gate while bindings refetch.
+        if (selectedBundleBindings.loading) return false;
+        const providerId = provider()?.id;
+        if (!providerId) return false;
+        return (selectedBundleBindings() ?? []).some(
+            (b) => b.provider === providerId,
+        );
+    };
+
+    // Auth gate applies to fresh launches of OAuth providers when the
+    // selected identity can't supply credentials for the agent's
+    // provider. That's true when:
     //
-    // - `isContinue` bypasses: prior launch already produced creds.
-    // - API-key providers (kimi/pi) bypass: until the backend
+    // - `blank`/empty is selected — ambient creds, OAuth flow runs once.
+    // - OpenClaw provider — until identity bundles include openclaw
+    //   auth profiles, gate ALWAYS (Phase α addition, 2026-05-17).
+    //   Lifts once identity-bundles-include-openclaw lands (planned
+    //   with Phase δ persistence work).
+    // - A non-blank bundle without a matching provider binding —
+    //   e.g. "+ New" just created an empty "Work" bundle. Reagent +
+    //   codex P1 on PR #910 round 3.
+    //
+    // Bypasses:
+    // - `isContinue` — prior launch already produced creds.
+    // - API-key providers (kimi/pi) — until the backend
     //   `auth.submitapikey` persists bundles (PR C-2), the gate would
-    //   deadlock — the user can't reach `ready` because save is a
-    //   stub. Their existing `launch-flow.ts` Phase 2 prompts for the
-    //   key in-line. Reagent + codex P1 on #847.
-    // - OpenClaw: even with a non-blank identity selected, no identity
-    //   has been openclaw-authed yet (Phase α addition, 2026-05-17).
-    //   Until identity bundles include openclaw auth profiles, gate
-    //   ALWAYS — the user needs to run the OpenAI OAuth flow before
-    //   `openclaw acp` will spawn. Lifts once identity-bundles-include-
-    //   openclaw lands (planned with Phase δ persistence work).
+    //   deadlock. Their existing `launch-flow.ts` Phase 2 prompts for
+    //   the key in-line. Reagent + codex P1 on #847.
     const authRequired = () =>
         !isContinue()
         && provider()?.authType === "oauth"
@@ -234,6 +274,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
             identityId() === "blank"
             || identityId() === ""
             || provider()?.id === "openclaw"
+            || !bundleHasMatchingBinding()
         );
     const authReady = () => !authRequired() || authStateKind() === "ready";
     const canSubmit = () =>

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -596,15 +596,20 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                     {/*
                      * Pre-launch OAuth panel (spec:
                      * SPEC_PRE_LAUNCH_OAUTH_FLOW_2026_05_14.md).
-                     * Shows the Connect CTA when the user has the
-                     * blank singleton picked. Non-blank bundles are
-                     * trusted (PR B-4 / D will tighten this with a
-                     * per-bundle binding lookup).
+                     * Shows the Connect CTA whenever the selected
+                     * identity can't supply creds for this provider —
+                     * blank singleton, openclaw, or a non-blank bundle
+                     * without a matching binding (e.g. "+ New" just
+                     * created an empty bundle). The panel uses
+                     * `hasMatchingBinding` to compute its own outcome
+                     * so non-blank-but-empty bundles don't shortcut
+                     * to `ready`.
                      */}
                     <Show when={authRequired()}>
                         <PreLaunchAuthPanel
                             provider={provider()}
                             identityId={identityId}
+                            hasMatchingBinding={bundleHasMatchingBinding}
                             onStateChange={onAuthStateChange}
                             onBundleCreated={onBundleCreated}
                             disabled={submitting()}

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -63,9 +63,20 @@ interface AgentLaunchModalPanelProps {
     preselectedMemoryId?: string;
     /** Called when the "+" / empty-state New buttons fire. The picker
      *  is expected to chain `tabModal.replace(newIdentityRequest)` —
-     *  this component doesn't know how to build that request. */
-    onRequestNewIdentity?: () => void;
-    onRequestNewMemory?: () => void;
+     *  this component doesn't know how to build that request.
+     *
+     *  The current Identity + Memory selections are passed through so
+     *  the picker can preserve them across the new-bundle round-trip
+     *  (codex P2 on PR #910 round 6 — without this, picking a Memory
+     *  before clicking "+ New Identity" silently reset to blank on
+     *  return). */
+    onRequestNewIdentity?: (current: CurrentSelection) => void;
+    onRequestNewMemory?: (current: CurrentSelection) => void;
+}
+
+export interface CurrentSelection {
+    identityId: string;
+    memoryId: string;
 }
 
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
@@ -123,8 +134,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // missing callback (Phase β ships Identity wiring only; Memory
     // wiring lands in Phase γ) keeps the button visible but disabled
     // with a "coming soon" hint — see reagent P2 on PR #910.
-    const handleNewIdentity = () => props.onRequestNewIdentity?.();
-    const handleNewMemory = () => props.onRequestNewMemory?.();
+    const handleNewIdentity = () =>
+        props.onRequestNewIdentity?.({ identityId: identityId(), memoryId: memoryId() });
+    const handleNewMemory = () =>
+        props.onRequestNewMemory?.({ identityId: identityId(), memoryId: memoryId() });
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
     // CURRENT definition (server-side; a global cap would let older

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -235,7 +235,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         },
     );
 
-    const bundleHasMatchingBinding = () => {
+    // Wrapped in createMemo (not a bare accessor) so downstream
+    // effects only re-fire on actual boolean transitions. Codex P2
+    // on PR #910 round 5: without the memo, when bindings finish
+    // loading the value stays false (no binding yet) but the
+    // underlying resource read changes, which re-ran
+    // PreLaunchAuthPanel's createEffect — which calls
+    // controller.selected, which cancels any in-flight `waiting`
+    // OAuth session. Memo's === dedupe makes the loading→loaded
+    // false→false transition a no-op.
+    const bundleHasMatchingBinding = createMemo(() => {
         const id = identityId();
         if (!id || id === "blank") return false;
         // Treat the loading state as "no binding" so a fast-launch
@@ -246,7 +255,7 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         return (selectedBundleBindings() ?? []).some(
             (b) => b.provider === providerId,
         );
-    };
+    });
 
     // Auth gate applies to fresh launches of OAuth providers when the
     // selected identity can't supply credentials for the agent's

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -55,26 +55,30 @@ interface AgentLaunchModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
     onSubmit: (overrides: LaunchOverrides) => Promise<void> | void;
-    /** Auto-select this Identity bundle on mount. Used by the
-     *  "+ New" → create → replace-back flow so the freshly-created
-     *  bundle shows up as the picker's choice. */
-    preselectedIdentityId?: string;
-    /** Same for Memory. Phase γ. */
-    preselectedMemoryId?: string;
+    /** Initial form state — used by the "+ New" → create → replace-
+     *  back flow so the user's in-progress edits (name, runtime,
+     *  image, identity, memory) survive the round-trip. All fields
+     *  default to the modal's normal initial values when omitted.
+     *  Codex P2 on PR #910 rounds 6 + 7: rounds 1-6 only restored
+     *  identity/memory selection; round 7 added the rest of the form. */
+    initialFormState?: Partial<LaunchFormState>;
     /** Called when the "+" / empty-state New buttons fire. The picker
      *  is expected to chain `tabModal.replace(newIdentityRequest)` —
      *  this component doesn't know how to build that request.
      *
-     *  The current Identity + Memory selections are passed through so
-     *  the picker can preserve them across the new-bundle round-trip
-     *  (codex P2 on PR #910 round 6 — without this, picking a Memory
-     *  before clicking "+ New Identity" silently reset to blank on
-     *  return). */
-    onRequestNewIdentity?: (current: CurrentSelection) => void;
-    onRequestNewMemory?: (current: CurrentSelection) => void;
+     *  The current launch form state is passed through so the picker
+     *  can preserve it across the new-bundle round-trip. */
+    onRequestNewIdentity?: (current: LaunchFormState) => void;
+    onRequestNewMemory?: (current: LaunchFormState) => void;
 }
 
-export interface CurrentSelection {
+/** Snapshot of the editable Launch form. Used to thread the user's
+ *  in-progress edits through the new-identity / new-memory modal so
+ *  returning to Launch doesn't reset typed-but-unsubmitted values. */
+export interface LaunchFormState {
+    name: string;
+    runtime: "host" | "container";
+    image: string;
     identityId: string;
     memoryId: string;
 }
@@ -83,22 +87,33 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
     const displayName = () => catalog()?.displayName ?? props.agent.name;
 
-    const [name, setName] = createSignal("");
-    const [runtime, setRuntime] = createSignal<"host" | "container">("host");
-    const [image, setImage] = createSignal<string>("");
+    // Initial form values — `initialFormState` carries the user's
+    // in-progress edits through the "+ New" round-trip.
+    const initial = props.initialFormState ?? {};
+    const [name, setName] = createSignal(initial.name ?? "");
+    const [runtime, setRuntime] = createSignal<"host" | "container">(
+        initial.runtime ?? "host",
+    );
+    const [image, setImage] = createSignal<string>(initial.image ?? "");
     const [submitting, setSubmitting] = createSignal(false);
     const [error, setError] = createSignal<string | null>(null);
-    const [showAdvanced, setShowAdvanced] = createSignal(false);
+    // Advanced section auto-expands when restored state has a non-
+    // default runtime/image — otherwise the user would see "host" /
+    // empty image in the dropdown row and not realize their advanced
+    // edits round-tripped.
+    const [showAdvanced, setShowAdvanced] = createSignal(
+        (initial.runtime ?? "host") !== "host" || (initial.image ?? "") !== "",
+    );
 
     // v7 — Identity + Memory bundle pickers. Both default to "blank"
     // which the resolver short-circuits as "no override". Lists fetched
     // once at mount; the blank singleton is always present. See
     // docs/specs/identity-forge-integration-and-vault-2026-05-08.md.
     const [identityId, setIdentityId] = createSignal<string>(
-        props.preselectedIdentityId ?? "blank",
+        initial.identityId ?? "blank",
     );
     const [memoryId, setMemoryId] = createSignal<string>(
-        props.preselectedMemoryId ?? "blank",
+        initial.memoryId ?? "blank",
     );
 
     const [identities] = createResource<IdentityBundle[]>(async () => {
@@ -134,10 +149,15 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // missing callback (Phase β ships Identity wiring only; Memory
     // wiring lands in Phase γ) keeps the button visible but disabled
     // with a "coming soon" hint — see reagent P2 on PR #910.
-    const handleNewIdentity = () =>
-        props.onRequestNewIdentity?.({ identityId: identityId(), memoryId: memoryId() });
-    const handleNewMemory = () =>
-        props.onRequestNewMemory?.({ identityId: identityId(), memoryId: memoryId() });
+    const snapshot = (): LaunchFormState => ({
+        name: name(),
+        runtime: runtime(),
+        image: image(),
+        identityId: identityId(),
+        memoryId: memoryId(),
+    });
+    const handleNewIdentity = () => props.onRequestNewIdentity?.(snapshot());
+    const handleNewMemory = () => props.onRequestNewMemory?.(snapshot());
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
     // CURRENT definition (server-side; a global cap would let older

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared styles for AgentNewIdentityModalPanel and
+// AgentNewMemoryModalPanel. Modal-v2 chrome lives in modal-v2.scss;
+// this file styles the form bodies only.
+
+.agent-new-bundle-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 440px;
+    max-width: 560px;
+}
+
+.agent-new-bundle-modal-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+}
+
+.agent-new-bundle-modal-label {
+    color: var(--main-text-color);
+    font-weight: 500;
+    font-size: var(--text-sm);
+}
+
+.agent-new-bundle-modal-optional {
+    color: var(--secondary-text-color);
+    font-weight: 400;
+    font-size: var(--text-xs);
+}
+
+.agent-new-bundle-modal-input {
+    width: 100%;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+
+    &::placeholder {
+        color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+    }
+}
+
+.agent-new-bundle-modal-textarea {
+    width: 100%;
+    min-height: 120px;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    outline: none;
+    resize: vertical;
+    font-family: inherit;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.agent-new-bundle-modal-hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.4;
+}
+
+.agent-new-bundle-modal-error {
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color, #ff6b6b) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 30%, transparent);
+    border-radius: 4px;
+    color: var(--error-color, #ff6b6b);
+    font-size: var(--text-sm);
+}
+
+// Seed-mode radio group for the New Memory modal.
+.agent-new-bundle-modal-radios {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.agent-new-bundle-modal-radio {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    cursor: pointer;
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+
+    input { cursor: pointer; }
+}

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -53,6 +53,13 @@ export const AgentNewIdentityModalPanel = (
                 updated_at: now,
             });
             props.onCreated(bundle.id, bundle.name);
+            // Reset on success too. In practice the caller unmounts
+            // this panel via tabModal.replace, so the next render
+            // never observes the reset value — but leaving the flag
+            // stuck at true is a fragile invariant (reagent P2 on
+            // PR #910): a future caller that fails to replace the
+            // modal would strand the inputs disabled.
+            setSubmitting(false);
         } catch (e) {
             setError((e as Error)?.message ?? String(e));
             setSubmitting(false);

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -1,0 +1,134 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentNewIdentityModalPanel — creates an empty Identity bundle from
+ * the Launch modal's "+ New" affordance. Identity bundles are generic
+ * credential containers (Claude / Codex / Gemini / OpenClaw OAuth +
+ * GitHub + AWS + …), NOT provider-scoped — so the create form is
+ * deliberately small: just name + description. Connector setup
+ * happens later in the Identity pane.
+ *
+ * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+
+import { createSignal, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+interface AgentNewIdentityModalPanelProps {
+    /** Suggested initial name (often empty). */
+    initialName?: string;
+    onCancel: () => void;
+    /** Fires after the bundle is persisted. Caller passes the new id
+     *  to the Launch modal so it auto-selects on next render. */
+    onCreated: (bundleId: string, bundleName: string) => void;
+}
+
+export const AgentNewIdentityModalPanel = (
+    props: AgentNewIdentityModalPanelProps,
+): JSX.Element => {
+    const [name, setName] = createSignal(props.initialName ?? "");
+    const [description, setDescription] = createSignal("");
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const canSubmit = () => name().trim().length > 0 && !submitting();
+
+    const submit = async () => {
+        if (!canSubmit()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            const id = crypto.randomUUID();
+            const now = Date.now();
+            const bundle = await RpcApi.UpsertIdentityBundleCommand(TabRpcClient, {
+                id,
+                name: name().trim(),
+                description: description().trim(),
+                is_blank: false,
+                created_at: now,
+                updated_at: now,
+            });
+            props.onCreated(bundle.id, bundle.name);
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setSubmitting(false);
+        }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            void submit();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            props.onCancel();
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">New Identity</h2>
+                <p class="modal-panel-description">
+                    An Identity holds credentials your agent uses — Claude /
+                    Codex / Gemini / OpenClaw OAuth + GitHub / AWS / etc.
+                    Same Identity works across providers.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-new-bundle-modal-body">
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Name</span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        autofocus
+                        placeholder="Work, Personal, Client X, …"
+                        value={name()}
+                        onInput={(e) => setName(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">
+                        Description <span class="agent-new-bundle-modal-optional">(optional)</span>
+                    </span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        placeholder="What's this Identity for?"
+                        value={description()}
+                        onInput={(e) => setDescription(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <p class="agent-new-bundle-modal-hint">
+                    You'll add connections (Claude, GitHub, AWS, …) in the
+                    Identity pane after creating this bundle.
+                </p>
+                {error() && (
+                    <div class="agent-new-bundle-modal-error">{error()}</div>
+                )}
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={submitting()}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => void submit()}
+                    className="green solid"
+                    disabled={!canSubmit()}
+                >
+                    {submitting() ? "Creating…" : "Create"}
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentNewIdentityModalPanel.displayName = "AgentNewIdentityModalPanel";

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -15,16 +15,23 @@
 import { createSignal, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface NewIdentityFormData {
+    name: string;
+    description: string;
+}
 
 interface AgentNewIdentityModalPanelProps {
     /** Suggested initial name (often empty). */
     initialName?: string;
     onCancel: () => void;
-    /** Fires after the bundle is persisted. Caller passes the new id
-     *  to the Launch modal so it auto-selects on next render. */
-    onCreated: (bundleId: string, bundleName: string) => void;
+    /** Runs the RPC + downstream chaining. Owned by the layer so its
+     *  `submitting()` signal correctly gates ESC / backdrop while the
+     *  RPC is in flight (mirrors the Launch modal pattern). Reagent
+     *  P1 on PR #911 — panel-local submitting wasn't visible to the
+     *  layer's safeClose, so users could ESC mid-RPC and the resolved
+     *  promise would re-open Launch unexpectedly. */
+    onSubmit: (formData: NewIdentityFormData) => Promise<void>;
 }
 
 export const AgentNewIdentityModalPanel = (
@@ -42,23 +49,13 @@ export const AgentNewIdentityModalPanel = (
         setSubmitting(true);
         setError(null);
         try {
-            const id = crypto.randomUUID();
-            const now = Date.now();
-            const bundle = await RpcApi.UpsertIdentityBundleCommand(TabRpcClient, {
-                id,
+            await props.onSubmit({
                 name: name().trim(),
                 description: description().trim(),
-                is_blank: false,
-                created_at: now,
-                updated_at: now,
             });
-            props.onCreated(bundle.id, bundle.name);
-            // Reset on success too. In practice the caller unmounts
-            // this panel via tabModal.replace, so the next render
-            // never observes the reset value — but leaving the flag
-            // stuck at true is a fragile invariant (reagent P2 on
-            // PR #910): a future caller that fails to replace the
-            // modal would strand the inputs disabled.
+            // On success the layer unmounts this panel via the
+            // request's chained tabModal.replace. The reset is for
+            // the fragile case where the caller's chain doesn't fire.
             setSubmitting(false);
         } catch (e) {
             setError((e as Error)?.message ?? String(e));
@@ -70,10 +67,9 @@ export const AgentNewIdentityModalPanel = (
         if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             void submit();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            props.onCancel();
         }
+        // Escape handled by the layer's overlay handler so the
+        // submitting() gate (layer-level) takes effect uniformly.
     };
 
     return (

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -14,7 +14,7 @@ import { createEffect, createMemo, createSignal, For, onCleanup, onMount, Show, 
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { waveEventSubscribe } from "@/app/store/wps";
-import { useTabModal } from "@/app/tab/tab-modal";
+import { useTabModal, type LaunchFormStateWire } from "@/app/tab/tab-modal";
 import { getPlatform } from "@/util/platformutil";
 import type { AgentViewModel } from "../agent-model";
 import { getProvider } from "../providers";
@@ -101,18 +101,15 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // open call so the install→launch chain can hand the same shape
     // to `tabModal.replace()` for a crossfade (no shell teardown).
     //
-    // Optional preselect args drive the "+ New" → create → replace-
-    // back-with-new-id flow: the new-identity / new-memory modal's
-    // onCreated calls this with `preselectedIdentityId: newId` (or
-    // memory equivalent) so the rebuilt Launch modal auto-selects
-    // the freshly-created bundle.
-    // Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+    // `initialFormState` carries the user's in-progress launch-form
+    // edits through the "+ New identity/memory" round-trip — name,
+    // runtime, image, identity, memory. Spec: Phase β of
+    // SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md; codex P2 on
+    // round 7 expanded preservation from identity+memory only to the
+    // full form.
     const buildLaunchRequest = (
         agent: ForgeAgent,
-        preselect: {
-            preselectedIdentityId?: string;
-            preselectedMemoryId?: string;
-        } = {},
+        initialFormState?: Partial<LaunchFormStateWire>,
     ) => ({
         kind: "launch-agent" as const,
         agent,
@@ -132,31 +129,24 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 setLaunching(null);
             }
         },
-        preselectedIdentityId: preselect.preselectedIdentityId,
-        preselectedMemoryId: preselect.preselectedMemoryId,
-        onRequestNewIdentity: (current) => {
-            // Use the modal's LIVE selections (passed via `current`)
-            // rather than the request's frozen `preselect` — the user
-            // may have changed Memory before clicking "+ New Identity".
-            // Codex P2 on PR #910 round 6.
+        initialFormState,
+        onRequestNewIdentity: (current: LaunchFormStateWire) => {
+            // Thread the user's whole live form snapshot through the
+            // new-identity round-trip so name/runtime/image/memory
+            // survive alongside the freshly-created identity id.
             tabModal.replace({
                 kind: "new-identity" as const,
                 originBlockId: props.model.blockId,
                 onCreated: (id: string) => {
                     tabModal.replace(
                         buildLaunchRequest(agent, {
-                            preselectedIdentityId: id,
-                            preselectedMemoryId: current.memoryId,
+                            ...current,
+                            identityId: id,
                         }),
                     );
                 },
                 onCancel: () => {
-                    tabModal.replace(
-                        buildLaunchRequest(agent, {
-                            preselectedIdentityId: current.identityId,
-                            preselectedMemoryId: current.memoryId,
-                        }),
-                    );
+                    tabModal.replace(buildLaunchRequest(agent, current));
                 },
             });
         },

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -155,10 +155,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 },
             });
         },
-        // Phase γ stub — replaced in #911 when new-memory lands.
-        onRequestNewMemory: () => {
-            console.log("[launch-modal] New memory clicked — Phase γ pending");
-        },
+        // onRequestNewMemory deliberately omitted — Phase γ (#911)
+        // wires it. Leaving the prop undefined makes the Memory `+`
+        // buttons render disabled with a "Coming soon" tooltip, which
+        // is the behaviour reagent asked for on P2 of this PR.
     });
 
     const openLaunchModal = (agent: ForgeAgent) => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -134,24 +134,29 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
         },
         preselectedIdentityId: preselect.preselectedIdentityId,
         preselectedMemoryId: preselect.preselectedMemoryId,
-        onRequestNewIdentity: () => {
+        onRequestNewIdentity: (current) => {
+            // Use the modal's LIVE selections (passed via `current`)
+            // rather than the request's frozen `preselect` — the user
+            // may have changed Memory before clicking "+ New Identity".
+            // Codex P2 on PR #910 round 6.
             tabModal.replace({
                 kind: "new-identity" as const,
                 originBlockId: props.model.blockId,
                 onCreated: (id: string) => {
-                    // Chain back to the launch modal with the new
-                    // bundle preselected.
                     tabModal.replace(
                         buildLaunchRequest(agent, {
                             preselectedIdentityId: id,
-                            preselectedMemoryId: preselect.preselectedMemoryId,
+                            preselectedMemoryId: current.memoryId,
                         }),
                     );
                 },
                 onCancel: () => {
-                    // User backed out — go back to the launch modal
-                    // with whatever preselection was in flight.
-                    tabModal.replace(buildLaunchRequest(agent, preselect));
+                    tabModal.replace(
+                        buildLaunchRequest(agent, {
+                            preselectedIdentityId: current.identityId,
+                            preselectedMemoryId: current.memoryId,
+                        }),
+                    );
                 },
             });
         },

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -100,7 +100,20 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // Build the launch-agent request descriptor. Separated from the
     // open call so the install→launch chain can hand the same shape
     // to `tabModal.replace()` for a crossfade (no shell teardown).
-    const buildLaunchRequest = (agent: ForgeAgent) => ({
+    //
+    // Optional preselect args drive the "+ New" → create → replace-
+    // back-with-new-id flow: the new-identity / new-memory modal's
+    // onCreated calls this with `preselectedIdentityId: newId` (or
+    // memory equivalent) so the rebuilt Launch modal auto-selects
+    // the freshly-created bundle.
+    // Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+    const buildLaunchRequest = (
+        agent: ForgeAgent,
+        preselect: {
+            preselectedIdentityId?: string;
+            preselectedMemoryId?: string;
+        } = {},
+    ) => ({
         kind: "launch-agent" as const,
         agent,
         originBlockId: props.model.blockId,
@@ -118,6 +131,33 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             } finally {
                 setLaunching(null);
             }
+        },
+        preselectedIdentityId: preselect.preselectedIdentityId,
+        preselectedMemoryId: preselect.preselectedMemoryId,
+        onRequestNewIdentity: () => {
+            tabModal.replace({
+                kind: "new-identity" as const,
+                originBlockId: props.model.blockId,
+                onCreated: (id: string) => {
+                    // Chain back to the launch modal with the new
+                    // bundle preselected.
+                    tabModal.replace(
+                        buildLaunchRequest(agent, {
+                            preselectedIdentityId: id,
+                            preselectedMemoryId: preselect.preselectedMemoryId,
+                        }),
+                    );
+                },
+                onCancel: () => {
+                    // User backed out — go back to the launch modal
+                    // with whatever preselection was in flight.
+                    tabModal.replace(buildLaunchRequest(agent, preselect));
+                },
+            });
+        },
+        // Phase γ stub — replaced in #911 when new-memory lands.
+        onRequestNewMemory: () => {
+            console.log("[launch-modal] New memory clicked — Phase γ pending");
         },
     });
 

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -232,9 +232,11 @@ function outcomeFor(
     // Reagent + codex P1 on PR #910 round 3 — a non-blank bundle
     // without a binding for the agent's provider can't supply creds
     // (e.g. "+ New identity" created an empty "Work" bundle that the
-    // user hasn't connected yet). Treat as `needs-bundle` so OAuth
-    // runs and the binding lands on this bundle.
-    if (!hasMatchingBinding) return "needs-bundle";
+    // user hasn't connected yet). Use `needs-account` (NOT
+    // `needs-bundle`) so the reducer preserves `intoBundleId` and
+    // OAuth lands on THIS bundle instead of creating a fresh one
+    // (codex P1 round 4 — `needs-bundle` clears the bundle id).
+    if (!hasMatchingBinding) return "needs-account";
     return "ready";
 }
 

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -50,6 +50,14 @@ export interface PreLaunchAuthPanelProps {
     provider: ProviderDefinition | undefined;
     /** Currently-selected identity bundle id. "blank" = singleton. */
     identityId: Accessor<string>;
+    /** True when the selected non-blank bundle has a binding for the
+     *  agent's provider. Required because `outcomeFor` used to treat
+     *  any non-blank as "ready" — which let the "+ New identity" flow
+     *  bypass OAuth entirely (reagent + codex P1 on PR #910 round 3).
+     *  When false (or while bindings are still loading), the panel
+     *  routes to `needs-bundle` so the user goes through the OAuth
+     *  flow before Launch enables. */
+    hasMatchingBinding: Accessor<boolean>;
     /** Notify parent when auth state changes — used to gate Launch. */
     onStateChange: (state: AuthState) => void;
     /** Called when a new bundle is created via OAuth or API-key
@@ -126,6 +134,12 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     createEffect(() => {
         const id = props.identityId();
         const prov = props.provider;
+        // Track hasMatchingBinding so the effect re-fires when
+        // bindings finish loading — without this, a freshly created
+        // "+ New" bundle that initially reports `hasMatchingBinding=
+        // false` would never re-dispatch to `ready` once the user
+        // connects an account.
+        const hasBinding = props.hasMatchingBinding();
         if (!prov) return;
         // Codex P2 on #847 round 8: "blank" is a UI sentinel meaning
         // "no bundle selected", not a real bundleId. Normalize it to
@@ -134,7 +148,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         // (= "create new bundle") rather than `"blank"` (= "attach
         // to bundle named blank", which doesn't exist in wstore).
         const bundleArg = id === "blank" ? "" : id;
-        untrack(() => controller.selected(prov.id, bundleArg, outcomeFor(id, prov.id)));
+        untrack(() => controller.selected(prov.id, bundleArg, outcomeFor(id, prov.id, hasBinding)));
     });
 
     onCleanup(() => {
@@ -198,12 +212,16 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
     );
 };
 
-/** Compute the SelectionOutcome from the bundle id. The richer
- *  expired / needs-account computation (per-bundle binding lookup)
- *  is deferred to PR B-4 / PR D — for MVP we treat:
- *   - blank singleton → `needs-bundle` (Connect creates new)
- *   - non-blank bundle → `ready` (trust prior auth — old behavior). */
-function outcomeFor(identityId: string, providerId?: string): SelectionOutcome {
+/** Compute the SelectionOutcome from the bundle id and its binding
+ *  state. Treat:
+ *   - blank singleton or "+ New"-just-created (no matching binding)
+ *     → `needs-bundle` (Connect creates new or attaches a binding).
+ *   - non-blank bundle WITH a binding for this provider → `ready`. */
+function outcomeFor(
+    identityId: string,
+    providerId: string | undefined,
+    hasMatchingBinding: boolean,
+): SelectionOutcome {
     // Phase α for openclaw: bundle persistence isn't wired yet, so an
     // already-selected identity can't be trusted as authenticated. Force
     // a fresh OAuth on every launch so AgentLaunchModal's openclaw
@@ -211,6 +229,12 @@ function outcomeFor(identityId: string, providerId?: string): SelectionOutcome {
     // bundle storage.
     if (providerId === "openclaw") return "needs-bundle";
     if (!identityId || identityId === "blank") return "needs-bundle";
+    // Reagent + codex P1 on PR #910 round 3 — a non-blank bundle
+    // without a binding for the agent's provider can't supply creds
+    // (e.g. "+ New identity" created an empty "Work" bundle that the
+    // user hasn't connected yet). Treat as `needs-bundle` so OAuth
+    // runs and the binding lands on this bundle.
+    if (!hasMatchingBinding) return "needs-bundle";
     return "ready";
 }
 


### PR DESCRIPTION
## Summary

Phase β of [`SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md`](docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md). Stacks on top of Phase α (#909).

Wires the "+ New" / empty-state buttons on the Launch modal's Identity row to a creation modal. Lean form — name + description — submits via the existing `upsertidentitybundle` RPC. After creation, the Launch modal re-mounts with the new bundle auto-selected.

## Identity is generic, not per-provider

The modal copy explicitly states "Same Identity works across providers" — Claude / Codex / GitHub / AWS connectors all live in one bundle. Connector setup happens in the Identity pane after creation.

## Test plan

- [ ] Open Launch modal with no identity bundles → empty-state "+ New identity bundle..." button visible.
- [ ] Click it → New Identity modal opens (modal-v2 chrome, name + description fields).
- [ ] Submit with empty name → button disabled.
- [ ] Submit with "Work" → bundle persists → Launch modal re-renders with dropdown showing "Work" pre-selected.
- [ ] Cancel from New Identity → returns to Launch modal with previous preselection intact.

## Depends on

- #909 (Phase α — Profile section + New buttons). Will rebase if #909 needs adjustments before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)