### PR TITLE
feat(launch-modal): New Memory bundle modal (Phase γ)

### DIFF
--- a/.changesets/1779162692-feat-launch-modal-profile-section-new-buttons-phase-bprk.md
+++ b/.changesets/1779162692-feat-launch-modal-profile-section-new-buttons-phase-bprk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launch-modal): Profile section + New buttons (Phase α)

--- a/.changesets/1779163155-feat-launch-modal-new-identity-bundle-modal-phase-hs6q.md
+++ b/.changesets/1779163155-feat-launch-modal-new-identity-bundle-modal-phase-hs6q.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launch-modal): New Identity bundle modal (Phase β)

--- a/.changesets/1779163519-feat-launch-modal-new-memory-bundle-modal-phase.md
+++ b/.changesets/1779163519-feat-launch-modal-new-memory-bundle-modal-phase.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launch-modal): New Memory bundle modal (Phase γ)

--- a/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
+++ b/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
@@ -1,0 +1,305 @@
+# SPEC: Launch Modal — Profile Section + New Identity/Memory Modals
+
+**Status:** Draft
+**Date:** 2026-05-18
+**Author:** AgentA
+**Related:**
+- `frontend/app/view/agent/components/AgentLaunchModal.tsx` (current Identity+Memory section)
+- [`SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md`](./SPEC_OAUTH_IN_IDENTITY_BUNDLES_2026_05_13.md) (identity bundle storage)
+- `frontend/app/view/agent/identity/IdentityPaneViewModel.ts` (existing identity-pane manage-connectors UI)
+
+---
+
+## 0. TL;DR
+
+Three changes to the agent Launch modal:
+
+1. **Rename the wrapping section heading** from "Identity" to **"Profile"**. The two rows underneath — **Identity** and **Memory** — keep their existing labels. Today the section's `<legend>` is "Identity" which double-uses the same word as one of its rows, so users can't tell the section apart from its contents.
+
+2. **Add "+ New" buttons** beside each dropdown. On the empty state (no bundles of that type yet), show the New button as the only control. On the has-bundles state, show the dropdown plus the New button as a shortcut.
+
+3. **Two new tab-scoped modals** for bundle creation:
+   - **New Identity** — name + description, then opens the Identity pane focused on the new bundle for connector setup. Identity is a generic credential container (Claude / Codex / Gemini / OpenClaw OAuth + GitHub + AWS, etc.) — **not provider-scoped**.
+   - **New Memory** — name + description + seed content (files / paste / empty).
+
+---
+
+## 1. Problem
+
+### 1.1 Heading reads weird
+
+```
+Identity                       ← section legend
+  Identity   [dropdown]        ← row 1
+  Memory     [dropdown]        ← row 2
+```
+
+The legend repeats the row label. Reads as a typo. Visually unclear which level is which.
+
+### 1.2 No way to create from the Launch modal
+
+If the user opens the Launch modal and realizes they want a fresh Identity bundle (e.g. a "Client X" account separate from their default), they have to:
+1. Cancel the Launch modal
+2. Open an Agent pane
+3. Click the cog → Settings → Identity tab
+4. Create the bundle
+5. Re-open the Launch modal
+6. Pick the new bundle
+
+That's 6 steps for what should be a one-click "+ New" affordance.
+
+### 1.3 Empty state has no affordance
+
+If the user has no Identity bundles, the dropdown still renders with only "— Blank (no creds) —" as an option, which doesn't communicate "you can create one." First-time users assume the feature isn't usable.
+
+---
+
+## 2. Design
+
+### 2.1 Section heading: "Profile"
+
+Single-word swap in the `<legend>` of `AgentLaunchModal.tsx:364-365`:
+
+```diff
+- <legend class="agent-launch-modal-label">Identity</legend>
++ <legend class="agent-launch-modal-label">Profile</legend>
+```
+
+Profile reads as "the persona this agent runs as" — encompassing both the credentials it uses (Identity) AND the content it remembers (Memory).
+
+Alternative considered: "Context" — rejected because Context is overloaded in LLM-land (context window).
+
+### 2.2 Empty state vs has-bundles state
+
+Each row (Identity, Memory) has two render branches:
+
+**Empty state** — the bundle list is `[]` or only contains the implicit `blank` sentinel:
+
+```
+Identity
+┌─────────────────────────────────────────────────────┐
+│   +  New identity bundle...                         │
+└─────────────────────────────────────────────────────┘
+```
+
+Single full-width button. Tab-focusable. Click → opens the New Identity modal (§2.4).
+
+**Has-bundles state** — at least one user-created bundle exists:
+
+```
+Identity
+┌─────────────────────────────────────────┐  ┌──────┐
+│  Work account                       ▾  │  │  +   │
+└─────────────────────────────────────────┘  └──────┘
+```
+
+Dropdown plus inline `+` button. The `+` button is `~28×28px`, same height as the dropdown, with `aria-label="New identity bundle"`. Tooltip on hover: "New identity bundle...". Click → opens the New Identity modal.
+
+Same shape for the Memory row.
+
+### 2.3 Identity is generic (not provider-scoped)
+
+**Critical:** an Identity bundle holds connectors for many things, reusable across providers:
+
+- AI provider OAuths: Claude Code, Codex CLI, Gemini CLI, OpenClaw
+- External services: GitHub (PAT or OAuth), AWS (access keys or SSO), and future-proof for Linear, Vercel, etc.
+
+A user's "Work" identity might contain:
+```
+Work
+├── Claude Code (OAuth, asaf@employer.com)
+├── Codex CLI (OAuth, asaf@employer.com)
+├── GitHub (@asafebgi PAT)
+└── AWS (access key for employer's dev account)
+```
+
+The same Work bundle is selected when launching any agent — the spawn layer reads whichever connector the agent's provider needs.
+
+### 2.4 New Identity modal
+
+Lean — name + description only. Connector setup happens after creation in the Identity pane (which already exists per CLAUDE.md: "Tab inside an Agent pane (cog → settings panel → Identity tab)").
+
+```
+┌─ New Identity ─────────────────────────────────────────────────┐
+│                                                                │
+│   Name                                                         │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Work                                                   │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   Description (optional)                                       │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Employer-issued credentials for AI + cloud             │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   ─ You'll add connections (Claude, GitHub, AWS, …) in the     │
+│     Identity pane after creating this bundle. ─                │
+│                                                                │
+│                              [ Cancel ]   [ Create ]           │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Submit flow:**
+1. Create empty identity bundle on disk (`~/.agentmux/identity/<slug>/bundle.json`).
+2. Auto-select the new bundle in the Launch modal's Identity dropdown via `tabModal.replace(launchRequest)` (passing the new bundle id).
+3. Show a small toast: *"Created identity 'Work'. Add connections in the Identity pane (cog → Settings → Identity)."*
+
+**Why not embed connector-add inside the modal?** Two reasons: (a) connector setup spans many distinct flows (OAuth, paste-token, AWS keys) that already live in the Identity pane and have nontrivial UI; (b) keeps this modal small and predictable. The "Create then configure" two-step matches the OS-level "Add Account" flow.
+
+### 2.5 New Memory modal
+
+Memory bundles are directories of `.md`/`.txt` files. Three seed options.
+
+```
+┌─ New Memory ───────────────────────────────────────────────────┐
+│                                                                │
+│   Name                                                         │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Project Apollo notes                                   │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   Description (optional)                                       │
+│   ┌─────────────────────────────────────────────────────────┐  │
+│   │  Architecture decisions + style guide for Apollo        │  │
+│   └─────────────────────────────────────────────────────────┘  │
+│                                                                │
+│   Seed content                                                 │
+│     ◉  Start empty (add files later from the Memory pane)      │
+│     ○  Pick files from disk                                    │
+│     ○  Paste text now                                          │
+│                                                                │
+│   [ ─── conditional region — only shown for chosen mode ───   ]│
+│                                                                │
+│   Storage                                                      │
+│   ~/.agentmux/memory/project-apollo-notes/                     │
+│   ─ Slug auto-derived from name ─                              │
+│                                                                │
+│                              [ Cancel ]   [ Create ]           │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Conditional region** for each seed mode:
+
+- **Start empty** — no extra region. Submit creates the dir.
+- **Pick files from disk** — file-picker button + selected-files list:
+  ```
+  ┌─────────────────────────────┐
+  │  +  Add files...            │
+  └─────────────────────────────┘
+
+  Selected files (2)
+    • CLAUDE.md          12 KB    ✕
+    • architecture.md     8 KB    ✕
+  ```
+  Submit copies the files into the new bundle dir.
+- **Paste text now** — single multi-line textarea labeled "Notes":
+  ```
+  ┌─────────────────────────────────────────────────────────┐
+  │                                                         │
+  │  (textarea, 8 rows)                                     │
+  │                                                         │
+  └─────────────────────────────────────────────────────────┘
+  ```
+  Submit writes the pasted text to `notes.md` inside the new bundle dir.
+
+**Submit flow:**
+1. Create `~/.agentmux/memory/<slug>/` (slug from name, kebab-case).
+2. Write `bundle.json` with `{ name, description }`.
+3. Copy files / write `notes.md` based on seed mode.
+4. Auto-select via `tabModal.replace(launchRequest)`.
+5. Toast: *"Created memory 'Project Apollo notes' with 2 files."*
+
+---
+
+## 3. Architecture
+
+### 3.1 Frontend
+
+| File | Change |
+|---|---|
+| `AgentLaunchModal.tsx` | Rename legend "Identity" → "Profile". Add empty-state vs has-bundles rendering. Wire `+` buttons to open the new modals via `tabModal.replace`. |
+| `AgentNewIdentityModal.tsx` | New component. Modal-v2 chrome. Name + description fields. |
+| `AgentNewMemoryModal.tsx` | New component. Name + description + seed mode + conditional region. |
+| `tab-modal.ts` | New `kind` variants: `"new-identity"` and `"new-memory"`. Each carries `onSubmit(bundleId)` so the Launch modal can auto-select after creation. |
+| `TabModalLayer.tsx` | Render dispatch for the two new kinds. |
+
+### 3.2 Backend RPCs
+
+| Command | Args | Effect |
+|---|---|---|
+| `identity.create_bundle` | `{ name, description }` | Create `~/.agentmux/identity/<slug>/` with empty `bundle.json`. Return `{ id }`. |
+| `memory.create_bundle` | `{ name, description, seedMode: "empty"\|"files"\|"text", files?: Array<{path, content}>, text? }` | Create `~/.agentmux/memory/<slug>/` + seed. Return `{ id }`. |
+
+Both reuse the slug helpers + bundle-listing infra that already power `list_identity_bundles` and `list_memories`.
+
+For `seedMode: "files"`, the frontend uses the host's file picker (`getApi().showOpenDialog?.()` — if not yet present, fall back to a `<input type="file" multiple>` which CEF supports). File contents are read in the renderer (or via existing `read_file` IPC) and shipped to the backend in the RPC body — keeps the backend handler stateless and decoupled from the OS picker.
+
+### 3.3 Flow continuity
+
+After the New modal submits, the Launch modal must re-appear with the new bundle pre-selected. Use `tabModal.replace(buildLaunchRequest(agent, { preselectedIdentityId, preselectedMemoryId }))`:
+
+```ts
+// In AgentNewIdentityModal's onSubmit:
+const { id } = await RpcApi.IdentityCreateBundleCommand(...);
+tabModal.replace(buildLaunchRequest(agent, { preselectedIdentityId: id }));
+```
+
+`buildLaunchRequest` already exists in `AgentPicker.tsx` — extend it to accept preselect args that override the default `"blank"`.
+
+---
+
+## 4. Implementation phases
+
+### Phase α — UI rename + New buttons + empty state
+
+1. AgentLaunchModal: legend rename, empty/has-bundles branches, `+` buttons (placeholder click handlers).
+2. SCSS: tiny styling for the `+` button (28×28, primary-on-hover).
+3. New tab-modal kinds + render dispatch (panels stub to "Coming soon" body).
+
+This phase ships immediately — visual surface only, no backend.
+
+### Phase β — Identity creation modal
+
+4. `AgentNewIdentityModal.tsx` with name + description form.
+5. `identity.create_bundle` RPC.
+6. `+` button on Identity row routes here; submit chains back to Launch via `tabModal.replace` with `preselectedIdentityId`.
+7. Toast notification system reuse.
+
+### Phase γ — Memory creation modal
+
+8. `AgentNewMemoryModal.tsx` with name + description + seed mode + conditional region.
+9. `memory.create_bundle` RPC supporting all three seed modes.
+10. File picker integration.
+
+### Phase δ (deferred) — Manage connections inline
+
+A future "Connect AI provider" / "Connect GitHub" / "Connect AWS" flow could live inside the New Identity modal so the user adds connectors in one sitting. Out of scope here — the existing Identity pane handles it after creation.
+
+---
+
+## 5. Acceptance criteria
+
+### Phase α
+1. Section legend reads "Profile". Identity and Memory row labels unchanged.
+2. No identity bundles created → only the New Identity button is visible in that row (no empty dropdown).
+3. No memory bundles → only the New Memory button.
+4. At least one bundle of either type → dropdown + inline `+` button.
+
+### Phase β
+5. Click `+` next to Identity (in either state) → New Identity modal opens via `tabModal.replace` (no flicker; same modal chrome).
+6. Submit creates the bundle on disk and returns Launch modal with the new id pre-selected.
+7. Cancel returns to Launch modal with the previously selected bundle still chosen.
+
+### Phase γ
+8. Same for Memory, plus file picker integration + paste-text mode + empty mode.
+
+---
+
+## 6. Out of scope
+
+- **Edit / delete bundles** from the Launch modal. Stays in the Identity / Memory panes.
+- **Connector add inside the New Identity modal** (Phase δ).
+- **Bundle import / export.**
+- **Per-bundle settings** (avatar color, ordering).

--- a/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
+++ b/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
@@ -269,9 +269,9 @@ This phase ships immediately — visual surface only, no backend.
 
 ### Phase γ — Memory creation modal
 
-8. `AgentNewMemoryModal.tsx` with name + description + seed mode + conditional region.
-9. `memory.create_bundle` RPC supporting all three seed modes.
-10. File picker integration.
+8. `AgentNewMemoryModal.tsx` with name + description + seed mode radios.
+9. Reuses existing `upsertmemory` RPC — paste-text mode JSON-encodes `[{path: "notes.md", content}]` into `context_files`; empty mode ships `[]`.
+10. **File picker mode is deferred** to its own PR (radio disabled with "(coming soon)"). The drag-and-drop / OS file dialog integration is its own design concern; not blocking the rest of Phase γ.
 
 ### Phase δ (deferred) — Manage connections inline
 
@@ -293,7 +293,10 @@ A future "Connect AI provider" / "Connect GitHub" / "Connect AWS" flow could liv
 7. Cancel returns to Launch modal with the previously selected bundle still chosen.
 
 ### Phase γ
-8. Same for Memory, plus file picker integration + paste-text mode + empty mode.
+8. Click `+` next to Memory (in either state) → New Memory modal opens via `tabModal.replace` (no flicker; same modal chrome).
+9. Empty seed mode creates a bundle with `context_files = "[]"`; paste mode writes a single `notes.md` entry containing the pasted text.
+10. Submit returns Launch modal with the new memory id pre-selected; Cancel returns with the previous selection intact.
+11. Pick-files radio is disabled and labelled "(coming soon)" — file-picker integration is out of scope for this PR.
 
 ---
 

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -306,13 +306,44 @@ function renderRequest(
                 panel: (
                     <AgentNewMemoryModalPanel
                         initialName={req.initialName}
-                        onCreated={(id, name) => {
-                            req.onCreated(id, name);
+                        // Same lift-up pattern as new-identity above —
+                        // layer owns the UpsertMemory RPC so its
+                        // submitting() flag (gates safeClose) tracks
+                        // the in-flight call (reagent P1 on PR #911).
+                        onSubmit={async ({ name, description, contextFiles }) => {
+                            setSubmitting(true);
+                            try {
+                                const memory = await RpcApi.UpsertMemoryCommand(
+                                    TabRpcClient,
+                                    {
+                                        // Wire convention from
+                                        // memory-model.ts:draftToWire —
+                                        // empty id triggers server-side
+                                        // uuid; 0 timestamps trigger
+                                        // server-side now-stamping.
+                                        id: "",
+                                        name,
+                                        description,
+                                        provider: "",
+                                        model: "",
+                                        instructions: "",
+                                        context_files: contextFiles,
+                                        mcp_servers: "[]",
+                                        skills: "[]",
+                                        created_at: 0,
+                                        updated_at: 0,
+                                    },
+                                );
+                                setSubmitting(false);
+                                req.onCreated(memory.id, memory.name);
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
                         }}
-                        onCancel={() => {
-                            req.onCancel();
-                            api.close();
-                        }}
+                        // Caller routes (replace vs close); see the
+                        // new-identity case + reagent P1 on PR #910.
+                        onCancel={req.onCancel}
                     />
                 ),
             };

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -29,6 +29,7 @@ import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchMo
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
 import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
+import { AgentNewMemoryModalPanel } from "@/app/view/agent/components/AgentNewMemoryModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
 
@@ -296,6 +297,22 @@ function renderRequest(
                         // (both run synchronously, last write wins) and
                         // exit the launch flow — reagent P1 on PR #910.
                         onCancel={req.onCancel}
+                    />
+                ),
+            };
+        case "new-memory":
+            return {
+                label: "New Memory",
+                panel: (
+                    <AgentNewMemoryModalPanel
+                        initialName={req.initialName}
+                        onCreated={(id, name) => {
+                            req.onCreated(id, name);
+                        }}
+                        onCancel={() => {
+                            req.onCancel();
+                            api.close();
+                        }}
                     />
                 ),
             };

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -23,6 +23,8 @@
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show, type Accessor, type Component, type JSX } from "solid-js";
 
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
@@ -256,17 +258,44 @@ function renderRequest(
                 panel: (
                     <AgentNewIdentityModalPanel
                         initialName={req.initialName}
-                        onCreated={(id, name) => {
-                            req.onCreated(id, name);
-                            // Caller is responsible for chaining back
-                            // to the Launch modal via tabModal.replace —
-                            // we DON'T close here, since closing then
-                            // re-opening the Launch modal would flicker.
+                        // The layer owns the RPC + chaining so its
+                        // `submitting()` flag (which gates safeClose)
+                        // tracks the in-flight call. Mirrors the
+                        // launch-agent dispatch above — reagent P1 on
+                        // PR #911.
+                        onSubmit={async ({ name, description }) => {
+                            setSubmitting(true);
+                            try {
+                                const id = crypto.randomUUID();
+                                const now = Date.now();
+                                const bundle = await RpcApi.UpsertIdentityBundleCommand(
+                                    TabRpcClient,
+                                    {
+                                        id,
+                                        name,
+                                        description,
+                                        is_blank: false,
+                                        created_at: now,
+                                        updated_at: now,
+                                    },
+                                );
+                                setSubmitting(false);
+                                // Caller's onCreated does tabModal.replace
+                                // back to Launch with the new id
+                                // preselected — that's what unmounts this
+                                // panel. We don't `api.close()` here.
+                                req.onCreated(bundle.id, bundle.name);
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
                         }}
-                        onCancel={() => {
-                            req.onCancel();
-                            api.close();
-                        }}
+                        // Caller's onCancel does tabModal.replace back to
+                        // Launch with the prior selection intact. Running
+                        // api.close() afterward would nullify that replace
+                        // (both run synchronously, last write wins) and
+                        // exit the launch flow — reagent P1 on PR #910.
+                        onCancel={req.onCancel}
                     />
                 ),
             };

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -26,7 +26,9 @@ import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchModal";
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
+import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
+import "@/app/view/agent/components/AgentNewBundleModal.scss";
 
 import { TabModalContext, type TabModalApi, type TabModalRequest } from "./tab-modal";
 import "./tab-modal.scss";
@@ -240,6 +242,30 @@ function renderRequest(
                                 setSubmitting(false);
                                 throw e;
                             }
+                        }}
+                        preselectedIdentityId={req.preselectedIdentityId}
+                        preselectedMemoryId={req.preselectedMemoryId}
+                        onRequestNewIdentity={req.onRequestNewIdentity}
+                        onRequestNewMemory={req.onRequestNewMemory}
+                    />
+                ),
+            };
+        case "new-identity":
+            return {
+                label: "New Identity",
+                panel: (
+                    <AgentNewIdentityModalPanel
+                        initialName={req.initialName}
+                        onCreated={(id, name) => {
+                            req.onCreated(id, name);
+                            // Caller is responsible for chaining back
+                            // to the Launch modal via tabModal.replace —
+                            // we DON'T close here, since closing then
+                            // re-opening the Launch modal would flicker.
+                        }}
+                        onCancel={() => {
+                            req.onCancel();
+                            api.close();
                         }}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -148,13 +148,22 @@ export interface NewIdentityBundleRequest {
  * "+ New" affordance on the Launch modal's Memory row creates a new
  * Memory bundle with an optional pasted-text seed (saved as a single
  * `notes.md` context file).
+ *
+ * Same layer-owned-RPC contract as NewIdentityBundleRequest: the
+ * UpsertMemory call lives in TabModalLayer's dispatch so the layer's
+ * submitting() flag tracks the in-flight RPC; caller routes after
+ * success/cancel via tabModal.replace or tabModal.close.
+ *
  * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
  */
 export interface NewMemoryBundleRequest {
     kind: "new-memory";
     originBlockId: string;
     initialName?: string;
+    /** Caller should tabModal.replace(launchRequest) with the new id
+     *  preselected. Layer does NOT close. */
     onCreated: (bundleId: string, bundleName: string) => void;
+    /** Caller routes (replace vs close). Layer does NOT close. */
     onCancel: () => void;
 }
 

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -22,7 +22,8 @@ import { createContext, useContext, type Accessor } from "solid-js";
 export type TabModalRequest =
     | LaunchAgentRequest
     | InstallAgentRequest
-    | AgentPrereqRequest;
+    | AgentPrereqRequest
+    | NewIdentityBundleRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -37,6 +38,20 @@ export interface LaunchAgentRequest {
      * rejects, the modal stays open and surfaces the error.
      */
     onSubmit: (overrides: LaunchAgentSubmit) => Promise<void> | void;
+    /** If set, the launch modal initialises its Identity dropdown to
+     *  this bundle id instead of the default "blank". Used by the
+     *  "+ New" → create → replace-back flow so the new bundle is
+     *  auto-selected. Phase β of
+     *  SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md. */
+    preselectedIdentityId?: string;
+    /** Same idea for the Memory dropdown. Phase γ. */
+    preselectedMemoryId?: string;
+    /** Optional callback fired when the user clicks the "+ New
+     *  identity" button. Caller is expected to call
+     *  tabModal.replace(newIdentityRequest) — the picker does this. */
+    onRequestNewIdentity?: () => void;
+    /** Same for "+ New memory". */
+    onRequestNewMemory?: () => void;
 }
 
 export interface LaunchAgentSubmit {
@@ -96,6 +111,23 @@ export interface AgentPrereqRequest {
      *  tool. Useful when the tool is at a non-standard PATH. */
     onProceed: () => void;
     /** "Cancel" — close the modal, do not launch. */
+    onCancel: () => void;
+}
+
+/**
+ * "+ New" affordance on the Launch modal's Identity row creates an
+ * empty Identity bundle. Connector setup (Claude/Codex/GitHub/AWS)
+ * happens in the Identity pane afterward.
+ * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+export interface NewIdentityBundleRequest {
+    kind: "new-identity";
+    originBlockId: string;
+    /** Initial value for the name field. Usually empty. */
+    initialName?: string;
+    /** Called after the bundle is persisted on disk. The Launch
+     *  modal uses the id to auto-select on its next render. */
+    onCreated: (bundleId: string, bundleName: string) => void;
     onCancel: () => void;
 }
 

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -118,6 +118,12 @@ export interface AgentPrereqRequest {
  * "+ New" affordance on the Launch modal's Identity row creates an
  * empty Identity bundle. Connector setup (Claude/Codex/GitHub/AWS)
  * happens in the Identity pane afterward.
+ *
+ * The actual UpsertIdentityBundle RPC is owned by the layer so its
+ * `submitting()` flag (which gates safeClose) tracks the in-flight
+ * call — see reagent P1 on PR #911. Callers only supply the chain
+ * callbacks for after-success / on-cancel.
+ *
  * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
  */
 export interface NewIdentityBundleRequest {
@@ -125,9 +131,15 @@ export interface NewIdentityBundleRequest {
     originBlockId: string;
     /** Initial value for the name field. Usually empty. */
     initialName?: string;
-    /** Called after the bundle is persisted on disk. The Launch
-     *  modal uses the id to auto-select on its next render. */
+    /** Called after the bundle is persisted on disk. Caller should
+     *  `tabModal.replace(launchRequest)` with the new id preselected;
+     *  the layer does NOT close after this fires. */
     onCreated: (bundleId: string, bundleName: string) => void;
+    /** Called when the user clicks Cancel. Caller should
+     *  `tabModal.replace(launchRequest)` with the prior selection
+     *  intact, OR `tabModal.close()` to exit. The layer does NOT
+     *  close after this fires — running both replace + close
+     *  synchronously nullified the replace, reagent P1 on PR #910. */
     onCancel: () => void;
 }
 

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -23,7 +23,8 @@ export type TabModalRequest =
     | LaunchAgentRequest
     | InstallAgentRequest
     | AgentPrereqRequest
-    | NewIdentityBundleRequest;
+    | NewIdentityBundleRequest
+    | NewMemoryBundleRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -140,6 +141,20 @@ export interface NewIdentityBundleRequest {
      *  intact, OR `tabModal.close()` to exit. The layer does NOT
      *  close after this fires — running both replace + close
      *  synchronously nullified the replace, reagent P1 on PR #910. */
+    onCancel: () => void;
+}
+
+/**
+ * "+ New" affordance on the Launch modal's Memory row creates a new
+ * Memory bundle with an optional pasted-text seed (saved as a single
+ * `notes.md` context file).
+ * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+export interface NewMemoryBundleRequest {
+    kind: "new-memory";
+    originBlockId: string;
+    initialName?: string;
+    onCreated: (bundleId: string, bundleName: string) => void;
     onCancel: () => void;
 }
 

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -90,6 +90,29 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         }
     });
 
+    // Empty-state predicate — the backend always returns the implicit
+    // "blank" singleton, so an empty-of-user-bundles list still has
+    // length 1. Treat any list where every entry is `is_blank` as
+    // empty for the "show only New button" branch.
+    const hasUserIdentities = createMemo(() =>
+        (identities() ?? []).some((b) => !b.is_blank),
+    );
+    const hasUserMemories = createMemo(() =>
+        (memories() ?? []).some((m) => !m.is_blank),
+    );
+
+    // Phase β/γ stubs — wired to real modals in follow-up PRs. For
+    // now, log + alert so the buttons are testable without backend
+    // changes. SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+    const handleNewIdentity = () => {
+        console.log("[launch-modal] New identity clicked — modal Phase β");
+        // TODO Phase β: tabModal.replace({ kind: "new-identity", ... })
+    };
+    const handleNewMemory = () => {
+        console.log("[launch-modal] New memory clicked — modal Phase γ");
+        // TODO Phase γ: tabModal.replace({ kind: "new-memory", ... })
+    };
+
     // v8 — "Continue agent" dropdown. Filters to instances of the
     // CURRENT definition (server-side; a global cap would let older
     // rows of this definition fall off when users have many agents
@@ -362,34 +385,58 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                     </fieldset>
 
                     <fieldset class="agent-launch-modal-field agent-launch-modal-bundles">
-                        <legend class="agent-launch-modal-label">Identity</legend>
+                        <legend class="agent-launch-modal-label">Profile</legend>
                         <span class="agent-launch-modal-hint">
-                            Identity bundles credentials per provider. Pick a bundle to
-                            inject its accounts as env vars at launch (e.g. GITHUB_TOKEN,
-                            ANTHROPIC_API_KEY); pick blank to use whatever's already in
-                            your environment.
+                            A Profile groups the agent's <strong>Identity</strong> (credentials
+                            for Claude, Codex, GitHub, AWS, …) with its <strong>Memory</strong>
+                            (notes, instructions, project context). Blank uses whatever's
+                            already in your environment.
                         </span>
 
-                        <label class="agent-launch-modal-bundle-row">
+                        <div class="agent-launch-modal-bundle-row">
                             <span class="agent-launch-modal-bundle-row-label">Identity</span>
-                            <select
-                                class="agent-launch-modal-input"
-                                value={identityId()}
-                                onChange={(e) => setIdentityId(e.currentTarget.value)}
-                                disabled={submitting() || isContinue()}
-                                aria-label="Identity bundle"
+                            <Show
+                                when={hasUserIdentities()}
+                                fallback={
+                                    <button
+                                        type="button"
+                                        class="agent-launch-modal-bundle-empty-btn"
+                                        onClick={handleNewIdentity}
+                                        disabled={submitting() || isContinue()}
+                                    >
+                                        + New identity bundle...
+                                    </button>
+                                }
                             >
-                                <For each={identities() ?? []}>
-                                    {(bundle) => (
-                                        <option value={bundle.id}>
-                                            {bundle.is_blank
-                                                ? "— Blank (no creds) —"
-                                                : bundle.name}
-                                        </option>
-                                    )}
-                                </For>
-                            </select>
-                        </label>
+                                <select
+                                    class="agent-launch-modal-input"
+                                    value={identityId()}
+                                    onChange={(e) => setIdentityId(e.currentTarget.value)}
+                                    disabled={submitting() || isContinue()}
+                                    aria-label="Identity bundle"
+                                >
+                                    <For each={identities() ?? []}>
+                                        {(bundle) => (
+                                            <option value={bundle.id}>
+                                                {bundle.is_blank
+                                                    ? "— Blank (no creds) —"
+                                                    : bundle.name}
+                                            </option>
+                                        )}
+                                    </For>
+                                </select>
+                                <button
+                                    type="button"
+                                    class="agent-launch-modal-bundle-new-btn"
+                                    onClick={handleNewIdentity}
+                                    disabled={submitting() || isContinue()}
+                                    title="New identity bundle..."
+                                    aria-label="New identity bundle"
+                                >
+                                    +
+                                </button>
+                            </Show>
+                        </div>
 
                         {/*
                          * Memory dropdown — companion to Identity.
@@ -405,26 +452,50 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                          * behavior.
                          */}
 
-                        <label class="agent-launch-modal-bundle-row">
+                        <div class="agent-launch-modal-bundle-row">
                             <span class="agent-launch-modal-bundle-row-label">Memory</span>
-                            <select
-                                class="agent-launch-modal-input"
-                                value={memoryId()}
-                                onChange={(e) => setMemoryId(e.currentTarget.value)}
-                                disabled={submitting() || isContinue()}
-                                aria-label="Memory bundle"
+                            <Show
+                                when={hasUserMemories()}
+                                fallback={
+                                    <button
+                                        type="button"
+                                        class="agent-launch-modal-bundle-empty-btn"
+                                        onClick={handleNewMemory}
+                                        disabled={submitting() || isContinue()}
+                                    >
+                                        + New memory bundle...
+                                    </button>
+                                }
                             >
-                                <For each={memories() ?? []}>
-                                    {(memory) => (
-                                        <option value={memory.id}>
-                                            {memory.is_blank
-                                                ? "— Blank (vanilla CLI) —"
-                                                : memory.name}
-                                        </option>
-                                    )}
-                                </For>
-                            </select>
-                        </label>
+                                <select
+                                    class="agent-launch-modal-input"
+                                    value={memoryId()}
+                                    onChange={(e) => setMemoryId(e.currentTarget.value)}
+                                    disabled={submitting() || isContinue()}
+                                    aria-label="Memory bundle"
+                                >
+                                    <For each={memories() ?? []}>
+                                        {(memory) => (
+                                            <option value={memory.id}>
+                                                {memory.is_blank
+                                                    ? "— Blank (vanilla CLI) —"
+                                                    : memory.name}
+                                            </option>
+                                        )}
+                                    </For>
+                                </select>
+                                <button
+                                    type="button"
+                                    class="agent-launch-modal-bundle-new-btn"
+                                    onClick={handleNewMemory}
+                                    disabled={submitting() || isContinue()}
+                                    title="New memory bundle..."
+                                    aria-label="New memory bundle"
+                                >
+                                    +
+                                </button>
+                            </Show>
+                        </div>
                     </fieldset>
 
                     {/*

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -119,7 +119,10 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // "+ New ..." buttons delegate to picker-injected callbacks that
     // chain `tabModal.replace(newBundleRequest)`. The picker owns the
     // chain because it can rebuild the Launch request with
-    // preselectedIdentityId/preselectedMemoryId after creation.
+    // preselectedIdentityId/preselectedMemoryId after creation. A
+    // missing callback (Phase β ships Identity wiring only; Memory
+    // wiring lands in Phase γ) keeps the button visible but disabled
+    // with a "coming soon" hint — see reagent P2 on PR #910.
     const handleNewIdentity = () => props.onRequestNewIdentity?.();
     const handleNewMemory = () => props.onRequestNewMemory?.();
 
@@ -412,7 +415,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         type="button"
                                         class="agent-launch-modal-bundle-empty-btn"
                                         onClick={handleNewIdentity}
-                                        disabled={submitting() || isContinue()}
+                                        disabled={
+                                            submitting() ||
+                                            isContinue() ||
+                                            !props.onRequestNewIdentity
+                                        }
+                                        title={
+                                            props.onRequestNewIdentity
+                                                ? undefined
+                                                : "Coming soon"
+                                        }
                                     >
                                         + New identity bundle...
                                     </button>
@@ -439,8 +451,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     type="button"
                                     class="agent-launch-modal-bundle-new-btn"
                                     onClick={handleNewIdentity}
-                                    disabled={submitting() || isContinue()}
-                                    title="New identity bundle..."
+                                    disabled={
+                                        submitting() ||
+                                        isContinue() ||
+                                        !props.onRequestNewIdentity
+                                    }
+                                    title={
+                                        props.onRequestNewIdentity
+                                            ? "New identity bundle..."
+                                            : "Coming soon"
+                                    }
                                     aria-label="New identity bundle"
                                 >
                                     +
@@ -471,7 +491,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                         type="button"
                                         class="agent-launch-modal-bundle-empty-btn"
                                         onClick={handleNewMemory}
-                                        disabled={submitting() || isContinue()}
+                                        disabled={
+                                            submitting() ||
+                                            isContinue() ||
+                                            !props.onRequestNewMemory
+                                        }
+                                        title={
+                                            props.onRequestNewMemory
+                                                ? undefined
+                                                : "Coming soon"
+                                        }
                                     >
                                         + New memory bundle...
                                     </button>
@@ -498,8 +527,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                                     type="button"
                                     class="agent-launch-modal-bundle-new-btn"
                                     onClick={handleNewMemory}
-                                    disabled={submitting() || isContinue()}
-                                    title="New memory bundle..."
+                                    disabled={
+                                        submitting() ||
+                                        isContinue() ||
+                                        !props.onRequestNewMemory
+                                    }
+                                    title={
+                                        props.onRequestNewMemory
+                                            ? "New memory bundle..."
+                                            : "Coming soon"
+                                    }
                                     aria-label="New memory bundle"
                                 >
                                     +

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -55,6 +55,17 @@ interface AgentLaunchModalPanelProps {
     agent: ForgeAgent;
     onCancel: () => void;
     onSubmit: (overrides: LaunchOverrides) => Promise<void> | void;
+    /** Auto-select this Identity bundle on mount. Used by the
+     *  "+ New" → create → replace-back flow so the freshly-created
+     *  bundle shows up as the picker's choice. */
+    preselectedIdentityId?: string;
+    /** Same for Memory. Phase γ. */
+    preselectedMemoryId?: string;
+    /** Called when the "+" / empty-state New buttons fire. The picker
+     *  is expected to chain `tabModal.replace(newIdentityRequest)` —
+     *  this component doesn't know how to build that request. */
+    onRequestNewIdentity?: () => void;
+    onRequestNewMemory?: () => void;
 }
 
 export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.Element => {
@@ -72,8 +83,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // which the resolver short-circuits as "no override". Lists fetched
     // once at mount; the blank singleton is always present. See
     // docs/specs/identity-forge-integration-and-vault-2026-05-08.md.
-    const [identityId, setIdentityId] = createSignal<string>("blank");
-    const [memoryId, setMemoryId] = createSignal<string>("blank");
+    const [identityId, setIdentityId] = createSignal<string>(
+        props.preselectedIdentityId ?? "blank",
+    );
+    const [memoryId, setMemoryId] = createSignal<string>(
+        props.preselectedMemoryId ?? "blank",
+    );
 
     const [identities] = createResource<IdentityBundle[]>(async () => {
         try {
@@ -101,17 +116,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         (memories() ?? []).some((m) => !m.is_blank),
     );
 
-    // Phase β/γ stubs — wired to real modals in follow-up PRs. For
-    // now, log + alert so the buttons are testable without backend
-    // changes. SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
-    const handleNewIdentity = () => {
-        console.log("[launch-modal] New identity clicked — modal Phase β");
-        // TODO Phase β: tabModal.replace({ kind: "new-identity", ... })
-    };
-    const handleNewMemory = () => {
-        console.log("[launch-modal] New memory clicked — modal Phase γ");
-        // TODO Phase γ: tabModal.replace({ kind: "new-memory", ... })
-    };
+    // "+ New ..." buttons delegate to picker-injected callbacks that
+    // chain `tabModal.replace(newBundleRequest)`. The picker owns the
+    // chain because it can rebuild the Launch request with
+    // preselectedIdentityId/preselectedMemoryId after creation.
+    const handleNewIdentity = () => props.onRequestNewIdentity?.();
+    const handleNewMemory = () => props.onRequestNewMemory?.();
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
     // CURRENT definition (server-side; a global cap would let older

--- a/frontend/app/view/agent/components/AgentNewBundleModal.scss
+++ b/frontend/app/view/agent/components/AgentNewBundleModal.scss
@@ -1,0 +1,106 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared styles for AgentNewIdentityModalPanel and
+// AgentNewMemoryModalPanel. Modal-v2 chrome lives in modal-v2.scss;
+// this file styles the form bodies only.
+
+.agent-new-bundle-modal-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    min-width: 440px;
+    max-width: 560px;
+}
+
+.agent-new-bundle-modal-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    font-size: var(--text-sm);
+}
+
+.agent-new-bundle-modal-label {
+    color: var(--main-text-color);
+    font-weight: 500;
+    font-size: var(--text-sm);
+}
+
+.agent-new-bundle-modal-optional {
+    color: var(--secondary-text-color);
+    font-weight: 400;
+    font-size: var(--text-xs);
+}
+
+.agent-new-bundle-modal-input {
+    width: 100%;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    outline: none;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+
+    &::placeholder {
+        color: color-mix(in srgb, var(--secondary-text-color) 80%, transparent);
+    }
+}
+
+.agent-new-bundle-modal-textarea {
+    width: 100%;
+    min-height: 120px;
+    padding: var(--space-1-5) var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+    background: var(--main-bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    outline: none;
+    resize: vertical;
+    font-family: inherit;
+
+    &:focus {
+        border-color: var(--accent-color);
+        box-shadow: 0 0 0 1px var(--accent-color);
+    }
+}
+
+.agent-new-bundle-modal-hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--secondary-text-color);
+    line-height: 1.4;
+}
+
+.agent-new-bundle-modal-error {
+    padding: var(--space-1-5) var(--space-2);
+    background: color-mix(in srgb, var(--error-color, #ff6b6b) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--error-color, #ff6b6b) 30%, transparent);
+    border-radius: 4px;
+    color: var(--error-color, #ff6b6b);
+    font-size: var(--text-sm);
+}
+
+// Seed-mode radio group for the New Memory modal.
+.agent-new-bundle-modal-radios {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.agent-new-bundle-modal-radio {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1-5);
+    cursor: pointer;
+    font-size: var(--text-sm);
+    color: var(--main-text-color);
+
+    input { cursor: pointer; }
+}

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -53,6 +53,13 @@ export const AgentNewIdentityModalPanel = (
                 updated_at: now,
             });
             props.onCreated(bundle.id, bundle.name);
+            // Reset on success too. In practice the caller unmounts
+            // this panel via tabModal.replace, so the next render
+            // never observes the reset value — but leaving the flag
+            // stuck at true is a fragile invariant (reagent P2 on
+            // PR #910): a future caller that fails to replace the
+            // modal would strand the inputs disabled.
+            setSubmitting(false);
         } catch (e) {
             setError((e as Error)?.message ?? String(e));
             setSubmitting(false);

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -1,0 +1,134 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentNewIdentityModalPanel — creates an empty Identity bundle from
+ * the Launch modal's "+ New" affordance. Identity bundles are generic
+ * credential containers (Claude / Codex / Gemini / OpenClaw OAuth +
+ * GitHub + AWS + …), NOT provider-scoped — so the create form is
+ * deliberately small: just name + description. Connector setup
+ * happens later in the Identity pane.
+ *
+ * Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+
+import { createSignal, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+interface AgentNewIdentityModalPanelProps {
+    /** Suggested initial name (often empty). */
+    initialName?: string;
+    onCancel: () => void;
+    /** Fires after the bundle is persisted. Caller passes the new id
+     *  to the Launch modal so it auto-selects on next render. */
+    onCreated: (bundleId: string, bundleName: string) => void;
+}
+
+export const AgentNewIdentityModalPanel = (
+    props: AgentNewIdentityModalPanelProps,
+): JSX.Element => {
+    const [name, setName] = createSignal(props.initialName ?? "");
+    const [description, setDescription] = createSignal("");
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const canSubmit = () => name().trim().length > 0 && !submitting();
+
+    const submit = async () => {
+        if (!canSubmit()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            const id = crypto.randomUUID();
+            const now = Date.now();
+            const bundle = await RpcApi.UpsertIdentityBundleCommand(TabRpcClient, {
+                id,
+                name: name().trim(),
+                description: description().trim(),
+                is_blank: false,
+                created_at: now,
+                updated_at: now,
+            });
+            props.onCreated(bundle.id, bundle.name);
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setSubmitting(false);
+        }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            void submit();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            props.onCancel();
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">New Identity</h2>
+                <p class="modal-panel-description">
+                    An Identity holds credentials your agent uses — Claude /
+                    Codex / Gemini / OpenClaw OAuth + GitHub / AWS / etc.
+                    Same Identity works across providers.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-new-bundle-modal-body">
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Name</span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        autofocus
+                        placeholder="Work, Personal, Client X, …"
+                        value={name()}
+                        onInput={(e) => setName(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">
+                        Description <span class="agent-new-bundle-modal-optional">(optional)</span>
+                    </span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        placeholder="What's this Identity for?"
+                        value={description()}
+                        onInput={(e) => setDescription(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <p class="agent-new-bundle-modal-hint">
+                    You'll add connections (Claude, GitHub, AWS, …) in the
+                    Identity pane after creating this bundle.
+                </p>
+                {error() && (
+                    <div class="agent-new-bundle-modal-error">{error()}</div>
+                )}
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={submitting()}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => void submit()}
+                    className="green solid"
+                    disabled={!canSubmit()}
+                >
+                    {submitting() ? "Creating…" : "Create"}
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentNewIdentityModalPanel.displayName = "AgentNewIdentityModalPanel";

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -15,16 +15,23 @@
 import { createSignal, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
+
+export interface NewIdentityFormData {
+    name: string;
+    description: string;
+}
 
 interface AgentNewIdentityModalPanelProps {
     /** Suggested initial name (often empty). */
     initialName?: string;
     onCancel: () => void;
-    /** Fires after the bundle is persisted. Caller passes the new id
-     *  to the Launch modal so it auto-selects on next render. */
-    onCreated: (bundleId: string, bundleName: string) => void;
+    /** Runs the RPC + downstream chaining. Owned by the layer so its
+     *  `submitting()` signal correctly gates ESC / backdrop while the
+     *  RPC is in flight (mirrors the Launch modal pattern). Reagent
+     *  P1 on PR #911 — panel-local submitting wasn't visible to the
+     *  layer's safeClose, so users could ESC mid-RPC and the resolved
+     *  promise would re-open Launch unexpectedly. */
+    onSubmit: (formData: NewIdentityFormData) => Promise<void>;
 }
 
 export const AgentNewIdentityModalPanel = (
@@ -42,23 +49,13 @@ export const AgentNewIdentityModalPanel = (
         setSubmitting(true);
         setError(null);
         try {
-            const id = crypto.randomUUID();
-            const now = Date.now();
-            const bundle = await RpcApi.UpsertIdentityBundleCommand(TabRpcClient, {
-                id,
+            await props.onSubmit({
                 name: name().trim(),
                 description: description().trim(),
-                is_blank: false,
-                created_at: now,
-                updated_at: now,
             });
-            props.onCreated(bundle.id, bundle.name);
-            // Reset on success too. In practice the caller unmounts
-            // this panel via tabModal.replace, so the next render
-            // never observes the reset value — but leaving the flag
-            // stuck at true is a fragile invariant (reagent P2 on
-            // PR #910): a future caller that fails to replace the
-            // modal would strand the inputs disabled.
+            // On success the layer unmounts this panel via the
+            // request's chained tabModal.replace. The reset is for
+            // the fragile case where the caller's chain doesn't fire.
             setSubmitting(false);
         } catch (e) {
             setError((e as Error)?.message ?? String(e));
@@ -70,10 +67,9 @@ export const AgentNewIdentityModalPanel = (
         if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             void submit();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            props.onCancel();
         }
+        // Escape handled by the layer's overlay handler so the
+        // submitting() gate (layer-level) takes effect uniformly.
     };
 
     return (

--- a/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
@@ -1,0 +1,195 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentNewMemoryModalPanel — creates a new Memory bundle from the
+ * Launch modal's "+ New" affordance.
+ *
+ * Memory bundles are organized text content (notes, instructions,
+ * project context files). The modal supports three seed modes:
+ *   - Empty: just create the bundle; user adds content later from
+ *     the Memory pane.
+ *   - Paste text: pastes go into a single `notes.md` context file.
+ *   - Pick files: deferred (file picker integration is its own work).
+ *
+ * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+
+import { Show, createSignal, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+import { RpcApi } from "@/app/store/rpc-api";
+import { TabRpcClient } from "@/app/store/rpc-util";
+
+type SeedMode = "empty" | "paste" | "files";
+
+interface AgentNewMemoryModalPanelProps {
+    initialName?: string;
+    onCancel: () => void;
+    onCreated: (memoryId: string, memoryName: string) => void;
+}
+
+export const AgentNewMemoryModalPanel = (
+    props: AgentNewMemoryModalPanelProps,
+): JSX.Element => {
+    const [name, setName] = createSignal(props.initialName ?? "");
+    const [description, setDescription] = createSignal("");
+    const [seedMode, setSeedMode] = createSignal<SeedMode>("empty");
+    const [pasteText, setPasteText] = createSignal("");
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const canSubmit = () => name().trim().length > 0 && !submitting();
+
+    const submit = async () => {
+        if (!canSubmit()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            // Wire convention from memory-model.ts:draftToWire — empty
+            // id triggers server-side uuid generation; 0 timestamps
+            // trigger server-side now-stamping (codex P1 on PR #749).
+            // context_files is a JSON-encoded array of {path, content};
+            // paste mode writes a single notes.md, empty mode ships [].
+            const contextFiles =
+                seedMode() === "paste" && pasteText().trim().length > 0
+                    ? JSON.stringify([
+                          { path: "notes.md", content: pasteText() },
+                      ])
+                    : "[]";
+            const memory = await RpcApi.UpsertMemoryCommand(TabRpcClient, {
+                id: "",
+                name: name().trim(),
+                description: description().trim(),
+                provider: "",
+                model: "",
+                instructions: "",
+                context_files: contextFiles,
+                mcp_servers: "[]",
+                skills: "[]",
+                created_at: 0,
+                updated_at: 0,
+            });
+            props.onCreated(memory.id, memory.name);
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setSubmitting(false);
+        }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            void submit();
+        } else if (e.key === "Escape") {
+            e.preventDefault();
+            props.onCancel();
+        }
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">New Memory</h2>
+                <p class="modal-panel-description">
+                    A Memory holds text the agent reads at launch — notes,
+                    project context, style guides, instructions.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-new-bundle-modal-body">
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Name</span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        autofocus
+                        placeholder="Project Apollo notes, Style guide, …"
+                        value={name()}
+                        onInput={(e) => setName(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">
+                        Description <span class="agent-new-bundle-modal-optional">(optional)</span>
+                    </span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        placeholder="What's this Memory for?"
+                        value={description()}
+                        onInput={(e) => setDescription(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <fieldset class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Seed content</span>
+                    <div class="agent-new-bundle-modal-radios">
+                        <label class="agent-new-bundle-modal-radio">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                checked={seedMode() === "empty"}
+                                onChange={() => setSeedMode("empty")}
+                                disabled={submitting()}
+                            />
+                            <span>Start empty — add files later from the Memory pane</span>
+                        </label>
+                        <label class="agent-new-bundle-modal-radio">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                checked={seedMode() === "paste"}
+                                onChange={() => setSeedMode("paste")}
+                                disabled={submitting()}
+                            />
+                            <span>Paste text now (saved as <code>notes.md</code>)</span>
+                        </label>
+                        <label class="agent-new-bundle-modal-radio" title="Coming soon">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                disabled
+                            />
+                            <span style={{ "opacity": 0.6 }}>
+                                Pick files from disk <em>(coming soon)</em>
+                            </span>
+                        </label>
+                    </div>
+                </fieldset>
+                <Show when={seedMode() === "paste"}>
+                    <label class="agent-new-bundle-modal-field">
+                        <span class="agent-new-bundle-modal-label">Notes</span>
+                        <textarea
+                            class="agent-new-bundle-modal-textarea"
+                            rows={8}
+                            placeholder="Paste any text the agent should remember…"
+                            value={pasteText()}
+                            onInput={(e) => setPasteText(e.currentTarget.value)}
+                            disabled={submitting()}
+                        />
+                    </label>
+                </Show>
+                {error() && (
+                    <div class="agent-new-bundle-modal-error">{error()}</div>
+                )}
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={submitting()}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => void submit()}
+                    className="green solid"
+                    disabled={!canSubmit()}
+                >
+                    {submitting() ? "Creating…" : "Create"}
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentNewMemoryModalPanel.displayName = "AgentNewMemoryModalPanel";

--- a/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
@@ -12,21 +12,33 @@
  *   - Paste text: pastes go into a single `notes.md` context file.
  *   - Pick files: deferred (file picker integration is its own work).
  *
+ * The actual UpsertMemory RPC lives in TabModalLayer's new-memory
+ * dispatch (mirrors the Launch modal's onSubmit pattern) so the
+ * layer's `submitting()` flag — which gates safeClose — tracks the
+ * in-flight call. Reagent P1 on PR #911.
+ *
  * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
  */
 
 import { Show, createSignal, type JSX } from "solid-js";
 
 import { Button } from "@/element/button";
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
 
 type SeedMode = "empty" | "paste" | "files";
+
+export interface NewMemoryFormData {
+    name: string;
+    description: string;
+    /** JSON-encoded array of `{ path, content }` — server stores this
+     *  verbatim in the Memory row's context_files column. Empty array
+     *  ("[]") for the empty / pick-files seed modes. */
+    contextFiles: string;
+}
 
 interface AgentNewMemoryModalPanelProps {
     initialName?: string;
     onCancel: () => void;
-    onCreated: (memoryId: string, memoryName: string) => void;
+    onSubmit: (formData: NewMemoryFormData) => Promise<void>;
 }
 
 export const AgentNewMemoryModalPanel = (
@@ -46,31 +58,18 @@ export const AgentNewMemoryModalPanel = (
         setSubmitting(true);
         setError(null);
         try {
-            // Wire convention from memory-model.ts:draftToWire — empty
-            // id triggers server-side uuid generation; 0 timestamps
-            // trigger server-side now-stamping (codex P1 on PR #749).
-            // context_files is a JSON-encoded array of {path, content};
-            // paste mode writes a single notes.md, empty mode ships [].
             const contextFiles =
                 seedMode() === "paste" && pasteText().trim().length > 0
                     ? JSON.stringify([
                           { path: "notes.md", content: pasteText() },
                       ])
                     : "[]";
-            const memory = await RpcApi.UpsertMemoryCommand(TabRpcClient, {
-                id: "",
+            await props.onSubmit({
                 name: name().trim(),
                 description: description().trim(),
-                provider: "",
-                model: "",
-                instructions: "",
-                context_files: contextFiles,
-                mcp_servers: "[]",
-                skills: "[]",
-                created_at: 0,
-                updated_at: 0,
+                contextFiles,
             });
-            props.onCreated(memory.id, memory.name);
+            setSubmitting(false);
         } catch (e) {
             setError((e as Error)?.message ?? String(e));
             setSubmitting(false);
@@ -81,10 +80,10 @@ export const AgentNewMemoryModalPanel = (
         if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault();
             void submit();
-        } else if (e.key === "Escape") {
-            e.preventDefault();
-            props.onCancel();
         }
+        // Escape handled by the layer's overlay handler so the
+        // layer-level submitting() gate takes effect uniformly
+        // across all focusable elements — reagent P2 on PR #911.
     };
 
     return (

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -155,10 +155,23 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 },
             });
         },
-        // onRequestNewMemory deliberately omitted — Phase γ (#911)
-        // wires it. Leaving the prop undefined makes the Memory `+`
-        // buttons render disabled with a "Coming soon" tooltip, which
-        // is the behaviour reagent asked for on P2 of this PR.
+        onRequestNewMemory: () => {
+            tabModal.replace({
+                kind: "new-memory" as const,
+                originBlockId: props.model.blockId,
+                onCreated: (id: string) => {
+                    tabModal.replace(
+                        buildLaunchRequest(agent, {
+                            preselectedIdentityId: preselect.preselectedIdentityId,
+                            preselectedMemoryId: id,
+                        }),
+                    );
+                },
+                onCancel: () => {
+                    tabModal.replace(buildLaunchRequest(agent, preselect));
+                },
+            });
+        },
     });
 
     const openLaunchModal = (agent: ForgeAgent) => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -155,10 +155,10 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 },
             });
         },
-        // Phase γ stub — replaced in #911 when new-memory lands.
-        onRequestNewMemory: () => {
-            console.log("[launch-modal] New memory clicked — Phase γ pending");
-        },
+        // onRequestNewMemory deliberately omitted — Phase γ (#911)
+        // wires it. Leaving the prop undefined makes the Memory `+`
+        // buttons render disabled with a "Coming soon" tooltip, which
+        // is the behaviour reagent asked for on P2 of this PR.
     });
 
     const openLaunchModal = (agent: ForgeAgent) => {

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -100,7 +100,20 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     // Build the launch-agent request descriptor. Separated from the
     // open call so the install→launch chain can hand the same shape
     // to `tabModal.replace()` for a crossfade (no shell teardown).
-    const buildLaunchRequest = (agent: ForgeAgent) => ({
+    //
+    // Optional preselect args drive the "+ New" → create → replace-
+    // back-with-new-id flow: the new-identity / new-memory modal's
+    // onCreated calls this with `preselectedIdentityId: newId` (or
+    // memory equivalent) so the rebuilt Launch modal auto-selects
+    // the freshly-created bundle.
+    // Phase β of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+    const buildLaunchRequest = (
+        agent: ForgeAgent,
+        preselect: {
+            preselectedIdentityId?: string;
+            preselectedMemoryId?: string;
+        } = {},
+    ) => ({
         kind: "launch-agent" as const,
         agent,
         originBlockId: props.model.blockId,
@@ -118,6 +131,33 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             } finally {
                 setLaunching(null);
             }
+        },
+        preselectedIdentityId: preselect.preselectedIdentityId,
+        preselectedMemoryId: preselect.preselectedMemoryId,
+        onRequestNewIdentity: () => {
+            tabModal.replace({
+                kind: "new-identity" as const,
+                originBlockId: props.model.blockId,
+                onCreated: (id: string) => {
+                    // Chain back to the launch modal with the new
+                    // bundle preselected.
+                    tabModal.replace(
+                        buildLaunchRequest(agent, {
+                            preselectedIdentityId: id,
+                            preselectedMemoryId: preselect.preselectedMemoryId,
+                        }),
+                    );
+                },
+                onCancel: () => {
+                    // User backed out — go back to the launch modal
+                    // with whatever preselection was in flight.
+                    tabModal.replace(buildLaunchRequest(agent, preselect));
+                },
+            });
+        },
+        // Phase γ stub — replaced in #911 when new-memory lands.
+        onRequestNewMemory: () => {
+            console.log("[launch-modal] New memory clicked — Phase γ pending");
         },
     });
 

--- a/frontend/app/view/agent/styles/_launch-modal-body.scss
+++ b/frontend/app/view/agent/styles/_launch-modal-body.scss
@@ -210,8 +210,12 @@
 }
 
 .agent-launch-modal-bundle-row {
+    // Grid: [label, dropdown, +new-btn]. The third column collapses
+    // to 0 when only a label + full-width Empty button render (the
+    // empty button spans both content columns via grid-column).
+    // SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
     display: grid;
-    grid-template-columns: 80px 1fr;
+    grid-template-columns: 80px 1fr auto;
     align-items: center;
     gap: var(--space-2);
 }
@@ -220,5 +224,63 @@
     font-size: 12px;
     color: var(--main-text-color);
     font-weight: 500;
+}
+
+// Empty-state button — spans the dropdown column AND the +-btn slot
+// so it reads as a single full-width affordance.
+.agent-launch-modal-bundle-empty-btn {
+    grid-column: 2 / span 2;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-1-5) var(--space-2);
+    border: 1px dashed var(--border-color);
+    background: transparent;
+    border-radius: 4px;
+    color: var(--main-text-color);
+    font-size: var(--text-sm);
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s, background 0.12s;
+
+    &:hover:not(:disabled) {
+        border-color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 8%, transparent);
+        color: var(--accent-color);
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+// Inline "+" button next to the dropdown when bundles exist.
+.agent-launch-modal-bundle-new-btn {
+    width: 28px;
+    height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: 1px solid var(--border-color);
+    background: color-mix(in srgb, var(--main-text-color) 4%, transparent);
+    border-radius: 4px;
+    color: var(--main-text-color);
+    font-size: 16px;
+    font-weight: 500;
+    line-height: 1;
+    cursor: pointer;
+    transition: border-color 0.12s, color 0.12s, background 0.12s;
+
+    &:hover:not(:disabled) {
+        border-color: var(--accent-color);
+        background: color-mix(in srgb, var(--accent-color) 12%, transparent);
+        color: var(--accent-color);
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
 }
 


### PR DESCRIPTION
## Summary

Phase γ of [SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md](../blob/agenta/launch-modal-new-memory/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md) — adds the **+ New Memory** affordance on the Launch modal's Profile section. Stacks on #910 (Phase β).

- New `AgentNewMemoryModalPanel` with name + description + seed-mode radios (Empty / Paste text / Pick files-disabled).
- Paste mode JSON-encodes `[{path: "notes.md", content: text}]` into `context_files`; Empty mode ships `"[]"`.
- Reuses the existing `upsertmemory` RPC — **no backend changes**.
- Wire shape follows `memory-model.ts:draftToWire`: `id=""` so server generates uuid, timestamps `0` so server stamps now (codex P1 on PR #749).
- `AgentPicker.onRequestNewMemory` now actually fires `tabModal.replace` (was a Phase β stub).

## Out of scope

- **File-picker mode** — radio is disabled with "(coming soon)". Drag-and-drop / OS file dialog is its own design concern; tracked as a follow-up.

## Stack

- #909 Phase α (Profile section + New buttons) — merged
- #910 Phase β (New Identity modal) — open
- **#911 Phase γ (this PR)** — stacks on #910

## Test plan

- [ ] Launch agent with **zero memories** → only "+ New Memory" button visible.
- [ ] Click "+ New" → modal opens via `tabModal.replace` (crossfade, no flicker).
- [ ] Create with Empty mode → returns to Launch modal with new memory preselected; `context_files` in DB is `"[]"`.
- [ ] Create with Paste mode → context_files contains `[{path:"notes.md", content:"<text>"}]`; launching the agent surfaces notes.md.
- [ ] Cancel → returns to Launch modal with prior selection intact.
- [ ] Pick-files radio disabled and labelled "(coming soon)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)