### PR TITLE
docs(drone): annotate pre-rename specs with rename-pointer headers

### DIFF
--- a/.changesets/1779185409-docs-drone-annotate-pre-rename-specs-with-rename-pointer-hea-q7nd.md
+++ b/.changesets/1779185409-docs-drone-annotate-pre-rename-specs-with-rename-pointer-hea-q7nd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(drone): annotate pre-rename specs with rename-pointer headers

--- a/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
+++ b/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
@@ -76,7 +76,7 @@ private dispatchIfAlive(command, source) {
 }
 ```
 
-Every async path (`await RpcApi.RunWorkflowCommand()`, `.then(async () => …)` continuations, the WPS subscription handler) routes through this one method. There is no way for a caller to forget the guard. New dispatches default-safe.
+Every async path (`await RpcApi.RunDroneCommand()`, `.then(async () => …)` continuations, the WPS subscription handler) routes through this one method. There is no way for a caller to forget the guard. New dispatches default-safe.
 
 Compared to the mounted-flag pattern (which requires the caller to remember to `if (!mounted) return` before each dispatch), the helper-method pattern is strictly stronger — it is impossible to forget unless someone bypasses the helper entirely.
 

--- a/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
+++ b/docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md
@@ -65,14 +65,14 @@ Four distinct guard patterns exist in the codebase. They are *not* equally effec
 | **Mounted-flag** (`let mounted = true; onCleanup(() => mounted = false; if (!mounted) return)`) | `useHistoryPagination.ts:126-129` and 6 dispatch guards | Async (await) continuations after the owner disposed. **Does not** defend against mid-callback cascade unless checked between *every* dispatch. |
 | **Subscription lifecycle** (subscribe in `onMount`, unsubscribe in `onCleanup`) | `useAgentStream.ts:519-521` `fileSubject.subscribe`, `blockChunkUnsub`, `acceptedUnsub` | Future emissions after `onCleanup` — but emissions *already in flight on the JS stack* still fire. |
 | **`if (this.closed) return`** model flag, checked at every dispatch | `browser-model.ts:261, 282, 311, 361` (uniform pattern across IPC handlers) | Both async continuations *and* mid-handler cascades, **provided the check is at every dispatch site, not just the function entry.** |
-| **`dispatchIfAlive(...)` model helper** | `workflows-model.ts:509-515`, used at all 10 dispatch sites | The strongest variant — encapsulates the closed-check so callers can't forget. |
+| **`dispatchIfAlive(...)` model helper** | `drone-model.ts:509-515` (formerly `workflows-model.ts`, renamed in #912), used at all 10 dispatch sites | The strongest variant — encapsulates the closed-check so callers can't forget. |
 
-### 3.1 The `workflows-model.ts` pattern is the right answer
+### 3.1 The `drone-model.ts` pattern is the right answer
 
 ```ts
 private dispatchIfAlive(command, source) {
     if (this.disposed) return;
-    dispatchWorkflowRun(this.blockId, command, source);
+    dispatchDroneRun(this.blockId, command, source);
 }
 ```
 
@@ -164,7 +164,7 @@ Today the latency of the failing RPC effectively covers the race. *But*: a synch
 
 `frontend/app/view/agent/hooks/useHistoryPagination.ts` — six dispatch sites, all preceded by `if (!mounted) return;` after every `await`. **Safe today** *for the dispatch-after-await scenario*. **Not safe** against the mid-callback cascade — if a `dispatchDoc(HistoryRestored)` cascade-disposes the pane, the immediately-following `dispatchPane(InitReady)` would still throw. (No evidence this happens in practice, but the pattern is fragile.)
 
-### 4.6 SAFE — `workflows-model.ts`
+### 4.6 SAFE — `drone-model.ts`
 
 All 10 dispatch sites route through `dispatchIfAlive()`. Even if the helper runs inside a cascade-disposed state, the `this.disposed` check fires first and the dispatch is silently dropped.
 

--- a/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
+++ b/docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md
@@ -1,5 +1,7 @@
 # SPEC: Unified agent type system (Workflows Phase 1.5)
 
+> **ℹ Naming note (2026-05-19):** This spec predates the Workflows → Drone rename in [#912](https://github.com/agentmuxai/agentmux/pull/912). References to the "Workflows" pane, `workflows-model.ts`, `view/workflows/`, `src/workflows/`, `workflowrun:<id>`, and "workflow Agent block" correspond to today's Drone equivalents (`drone-model.ts`, `view/drone/`, `src/drone/`, `dronerun:<id>`, "drone Agent block"). The technical design below shipped as-described; only the user-facing name changed. See [`SPEC_RENAME_WORKFLOWS_TO_DRONE_2026_05_18.md`](SPEC_RENAME_WORKFLOWS_TO_DRONE_2026_05_18.md) for the rename rationale.
+
 **Date:** 2026-05-13
 **Status:** Draft — lands after PR #755 (Workflows Phase 1) merges
 **Author:** AgentA


### PR DESCRIPTION
## Summary

Follow-up to #912 (the Workflows → Drone rename). Two docs predate that rename and reference file paths / identifiers that no longer exist.

## Changes

| File | Treatment |
|---|---|
| \`docs/analysis/LIFECYCLE_DISPATCH_LEAK_2026_05_15.md\` | Updated 4 inline references from \`workflows-model.ts\` → \`drone-model.ts\` and \`dispatchWorkflowRun\` → \`dispatchDroneRun\`. The cascade-leak analysis stands as-written; only the example file moved. |
| \`docs/specs/SPEC_UNIFIED_AGENT_TYPES_2026_05_13.md\` | Added a header \"Naming note\" mapping the old surface vocabulary to today's drone equivalents (\`workflows-model.ts\` → \`drone-model.ts\`, \`view/workflows/\` → \`view/drone/\`, \`workflowrun:<id>\` → \`dronerun:<id>\`, \"workflow Agent block\" → \"drone Agent block\"). Body left intact for historical accuracy. |

## Not touched (per [SPEC §3](https://github.com/agentmuxai/agentmux/blob/main/docs/specs/SPEC_RENAME_WORKFLOWS_TO_DRONE_2026_05_18.md#3-what-not-to-rename-critical))

Other doc hits on \"workflow\" are generic usage and stay:
- README.md: \"CI/CD workflows\"
- VERSION_HISTORY.md: \"release workflow\"
- Various retros/specs: \"agent workflows\", \"automation workflows\", \"GitHub Actions workflows\", etc.
- The historical [\`REPORT_DRONE_VS_WORKFLOW_ENGINE_2026_05_08.md\`](https://github.com/agentmuxai/agentmux/blob/main/specs/REPORT_DRONE_VS_WORKFLOW_ENGINE_2026_05_08.md) — already annotated in #912.

## Test plan

Docs-only change. Nothing to validate beyond reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)