### PR TITLE
feat(launch-modal): New Memory bundle modal (Phase γ)

### DIFF
--- a/.changesets/1779163519-feat-launch-modal-new-memory-bundle-modal-phase.md
+++ b/.changesets/1779163519-feat-launch-modal-new-memory-bundle-modal-phase.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(launch-modal): New Memory bundle modal (Phase γ)

--- a/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
+++ b/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md
@@ -269,9 +269,9 @@ This phase ships immediately — visual surface only, no backend.
 
 ### Phase γ — Memory creation modal
 
-8. `AgentNewMemoryModal.tsx` with name + description + seed mode + conditional region.
-9. `memory.create_bundle` RPC supporting all three seed modes.
-10. File picker integration.
+8. `AgentNewMemoryModal.tsx` with name + description + seed mode radios.
+9. Reuses existing `upsertmemory` RPC — paste-text mode JSON-encodes `[{path: "notes.md", content}]` into `context_files`; empty mode ships `[]`.
+10. **File picker mode is deferred** to its own PR (radio disabled with "(coming soon)"). The drag-and-drop / OS file dialog integration is its own design concern; not blocking the rest of Phase γ.
 
 ### Phase δ (deferred) — Manage connections inline
 
@@ -293,7 +293,10 @@ A future "Connect AI provider" / "Connect GitHub" / "Connect AWS" flow could liv
 7. Cancel returns to Launch modal with the previously selected bundle still chosen.
 
 ### Phase γ
-8. Same for Memory, plus file picker integration + paste-text mode + empty mode.
+8. Click `+` next to Memory (in either state) → New Memory modal opens via `tabModal.replace` (no flicker; same modal chrome).
+9. Empty seed mode creates a bundle with `context_files = "[]"`; paste mode writes a single `notes.md` entry containing the pasted text.
+10. Submit returns Launch modal with the new memory id pre-selected; Cancel returns with the previous selection intact.
+11. Pick-files radio is disabled and labelled "(coming soon)" — file-picker integration is out of scope for this PR.
 
 ---
 

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -29,6 +29,7 @@ import { AgentLaunchModalPanel } from "@/app/view/agent/components/AgentLaunchMo
 import { AgentInstallModalPanel } from "@/app/view/agent/components/AgentInstallModal";
 import { AgentPrereqModalPanel } from "@/app/view/agent/components/AgentPrereqModal";
 import { AgentNewIdentityModalPanel } from "@/app/view/agent/components/AgentNewIdentityModal";
+import { AgentNewMemoryModalPanel } from "@/app/view/agent/components/AgentNewMemoryModal";
 import "@/app/view/agent/components/AgentPrereqModal.scss";
 import "@/app/view/agent/components/AgentNewBundleModal.scss";
 
@@ -298,6 +299,51 @@ function renderRequest(
                         // api.close() afterward would nullify that replace
                         // (both run synchronously, last write wins) and
                         // exit the launch flow — reagent P1 on PR #910.
+                        onCancel={req.onCancel}
+                    />
+                ),
+            };
+        case "new-memory":
+            return {
+                label: "New Memory",
+                panel: (
+                    <AgentNewMemoryModalPanel
+                        initialName={req.initialName}
+                        // Same lift-up pattern as new-identity above —
+                        // layer owns the UpsertMemory RPC so its
+                        // submitting() flag (gates safeClose) tracks
+                        // the in-flight call.
+                        onSubmit={async ({ name, description, contextFiles }) => {
+                            setSubmitting(true);
+                            try {
+                                const memory = await RpcApi.UpsertMemoryCommand(
+                                    TabRpcClient,
+                                    {
+                                        // Wire convention from
+                                        // memory-model.ts:draftToWire —
+                                        // empty id triggers server-side
+                                        // uuid; 0 timestamps trigger
+                                        // server-side now-stamping.
+                                        id: "",
+                                        name,
+                                        description,
+                                        provider: "",
+                                        model: "",
+                                        instructions: "",
+                                        context_files: contextFiles,
+                                        mcp_servers: "[]",
+                                        skills: "[]",
+                                        created_at: 0,
+                                        updated_at: 0,
+                                    },
+                                );
+                                setSubmitting(false);
+                                req.onCreated(memory.id, memory.name);
+                            } catch (e) {
+                                setSubmitting(false);
+                                throw e;
+                            }
+                        }}
                         onCancel={req.onCancel}
                     />
                 ),

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -23,7 +23,8 @@ export type TabModalRequest =
     | LaunchAgentRequest
     | InstallAgentRequest
     | AgentPrereqRequest
-    | NewIdentityBundleRequest;
+    | NewIdentityBundleRequest
+    | NewMemoryBundleRequest;
 
 export interface LaunchAgentRequest {
     kind: "launch-agent";
@@ -151,6 +152,29 @@ export interface NewIdentityBundleRequest {
      *  intact, OR `tabModal.close()` to exit. The layer does NOT
      *  close after this fires — running both replace + close
      *  synchronously nullified the replace, reagent P1 on PR #910. */
+    onCancel: () => void;
+}
+
+/**
+ * "+ New" affordance on the Launch modal's Memory row creates a new
+ * Memory bundle with an optional pasted-text seed (saved as a single
+ * `notes.md` context file).
+ *
+ * Same layer-owned-RPC contract as NewIdentityBundleRequest: the
+ * UpsertMemory call lives in TabModalLayer's dispatch so the layer's
+ * submitting() flag tracks the in-flight RPC; caller routes after
+ * success/cancel via tabModal.replace or tabModal.close.
+ *
+ * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+export interface NewMemoryBundleRequest {
+    kind: "new-memory";
+    originBlockId: string;
+    initialName?: string;
+    /** Caller should tabModal.replace(launchRequest) with the new id
+     *  preselected. Layer does NOT close. */
+    onCreated: (bundleId: string, bundleName: string) => void;
+    /** Caller routes (replace vs close). Layer does NOT close. */
     onCancel: () => void;
 }
 

--- a/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewMemoryModal.tsx
@@ -1,0 +1,194 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentNewMemoryModalPanel — creates a new Memory bundle from the
+ * Launch modal's "+ New" affordance.
+ *
+ * Memory bundles are organized text content (notes, instructions,
+ * project context files). The modal supports three seed modes:
+ *   - Empty: just create the bundle; user adds content later from
+ *     the Memory pane.
+ *   - Paste text: pastes go into a single `notes.md` context file.
+ *   - Pick files: deferred (file picker integration is its own work).
+ *
+ * The actual UpsertMemory RPC lives in TabModalLayer's new-memory
+ * dispatch (mirrors the Launch modal's onSubmit pattern) so the
+ * layer's `submitting()` flag — which gates safeClose — tracks the
+ * in-flight call. Reagent P1 on PR #911.
+ *
+ * Phase γ of SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md.
+ */
+
+import { Show, createSignal, type JSX } from "solid-js";
+
+import { Button } from "@/element/button";
+
+type SeedMode = "empty" | "paste" | "files";
+
+export interface NewMemoryFormData {
+    name: string;
+    description: string;
+    /** JSON-encoded array of `{ path, content }` — server stores this
+     *  verbatim in the Memory row's context_files column. Empty array
+     *  ("[]") for the empty / pick-files seed modes. */
+    contextFiles: string;
+}
+
+interface AgentNewMemoryModalPanelProps {
+    initialName?: string;
+    onCancel: () => void;
+    onSubmit: (formData: NewMemoryFormData) => Promise<void>;
+}
+
+export const AgentNewMemoryModalPanel = (
+    props: AgentNewMemoryModalPanelProps,
+): JSX.Element => {
+    const [name, setName] = createSignal(props.initialName ?? "");
+    const [description, setDescription] = createSignal("");
+    const [seedMode, setSeedMode] = createSignal<SeedMode>("empty");
+    const [pasteText, setPasteText] = createSignal("");
+    const [submitting, setSubmitting] = createSignal(false);
+    const [error, setError] = createSignal<string | null>(null);
+
+    const canSubmit = () => name().trim().length > 0 && !submitting();
+
+    const submit = async () => {
+        if (!canSubmit()) return;
+        setSubmitting(true);
+        setError(null);
+        try {
+            const contextFiles =
+                seedMode() === "paste" && pasteText().trim().length > 0
+                    ? JSON.stringify([
+                          { path: "notes.md", content: pasteText() },
+                      ])
+                    : "[]";
+            await props.onSubmit({
+                name: name().trim(),
+                description: description().trim(),
+                contextFiles,
+            });
+            setSubmitting(false);
+        } catch (e) {
+            setError((e as Error)?.message ?? String(e));
+            setSubmitting(false);
+        }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+        if (e.key === "Enter" && (e.ctrlKey || e.metaKey)) {
+            e.preventDefault();
+            void submit();
+        }
+        // Escape handled by the layer's overlay handler so the
+        // layer-level submitting() gate takes effect uniformly
+        // across all focusable elements — reagent P2 on PR #911.
+    };
+
+    return (
+        <>
+            <header class="modal-panel-header">
+                <h2 class="modal-panel-title">New Memory</h2>
+                <p class="modal-panel-description">
+                    A Memory holds text the agent reads at launch — notes,
+                    project context, style guides, instructions.
+                </p>
+            </header>
+            <div class="modal-panel-body agent-new-bundle-modal-body">
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Name</span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        autofocus
+                        placeholder="Project Apollo notes, Style guide, …"
+                        value={name()}
+                        onInput={(e) => setName(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <label class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">
+                        Description <span class="agent-new-bundle-modal-optional">(optional)</span>
+                    </span>
+                    <input
+                        type="text"
+                        class="agent-new-bundle-modal-input"
+                        placeholder="What's this Memory for?"
+                        value={description()}
+                        onInput={(e) => setDescription(e.currentTarget.value)}
+                        onKeyDown={onKeyDown}
+                        disabled={submitting()}
+                    />
+                </label>
+                <fieldset class="agent-new-bundle-modal-field">
+                    <span class="agent-new-bundle-modal-label">Seed content</span>
+                    <div class="agent-new-bundle-modal-radios">
+                        <label class="agent-new-bundle-modal-radio">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                checked={seedMode() === "empty"}
+                                onChange={() => setSeedMode("empty")}
+                                disabled={submitting()}
+                            />
+                            <span>Start empty — add files later from the Memory pane</span>
+                        </label>
+                        <label class="agent-new-bundle-modal-radio">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                checked={seedMode() === "paste"}
+                                onChange={() => setSeedMode("paste")}
+                                disabled={submitting()}
+                            />
+                            <span>Paste text now (saved as <code>notes.md</code>)</span>
+                        </label>
+                        <label class="agent-new-bundle-modal-radio" title="Coming soon">
+                            <input
+                                type="radio"
+                                name="seed-mode"
+                                disabled
+                            />
+                            <span style={{ "opacity": 0.6 }}>
+                                Pick files from disk <em>(coming soon)</em>
+                            </span>
+                        </label>
+                    </div>
+                </fieldset>
+                <Show when={seedMode() === "paste"}>
+                    <label class="agent-new-bundle-modal-field">
+                        <span class="agent-new-bundle-modal-label">Notes</span>
+                        <textarea
+                            class="agent-new-bundle-modal-textarea"
+                            rows={8}
+                            placeholder="Paste any text the agent should remember…"
+                            value={pasteText()}
+                            onInput={(e) => setPasteText(e.currentTarget.value)}
+                            disabled={submitting()}
+                        />
+                    </label>
+                </Show>
+                {error() && (
+                    <div class="agent-new-bundle-modal-error">{error()}</div>
+                )}
+            </div>
+            <footer class="modal-panel-footer">
+                <Button onClick={() => props.onCancel()} disabled={submitting()}>
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => void submit()}
+                    className="green solid"
+                    disabled={!canSubmit()}
+                >
+                    {submitting() ? "Creating…" : "Create"}
+                </Button>
+            </footer>
+        </>
+    );
+};
+
+AgentNewMemoryModalPanel.displayName = "AgentNewMemoryModalPanel";

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -150,10 +150,27 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                 },
             });
         },
-        // onRequestNewMemory deliberately omitted — Phase γ (#911)
-        // wires it. Leaving the prop undefined makes the Memory `+`
-        // buttons render disabled with a "Coming soon" tooltip, which
-        // is the behaviour reagent asked for on P2 of this PR.
+        onRequestNewMemory: (current: LaunchFormStateWire) => {
+            // Mirror of onRequestNewIdentity above — thread the live
+            // form snapshot through the new-memory round-trip so the
+            // user's other edits (name, runtime, image, identity)
+            // survive alongside the freshly-created memory id.
+            tabModal.replace({
+                kind: "new-memory" as const,
+                originBlockId: props.model.blockId,
+                onCreated: (id: string) => {
+                    tabModal.replace(
+                        buildLaunchRequest(agent, {
+                            ...current,
+                            memoryId: id,
+                        }),
+                    );
+                },
+                onCancel: () => {
+                    tabModal.replace(buildLaunchRequest(agent, current));
+                },
+            });
+        },
     });
 
     const openLaunchModal = (agent: ForgeAgent) => {


### PR DESCRIPTION
## Summary

Phase γ of [SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md](../blob/agenta/launch-modal-new-memory/docs/specs/SPEC_LAUNCH_MODAL_PROFILE_SECTION_2026_05_18.md) — adds the **+ New Memory** affordance on the Launch modal's Profile section, mirroring the Phase β Identity modal merged in #910.

**Re-opens** the prior #911 (auto-closed when its base branch was deleted on #910's merge). Same code, cleanly rebased onto main and integrated with #910's `LaunchFormStateWire` / `initialFormState` round-trip API so picking Memory before clicking "+ New Memory" preserves the user's other edits (name, runtime, image, identity).

- `AgentNewMemoryModalPanel`: name + description + seed-mode radios (Empty / Paste text / Pick files-disabled). Paste mode JSON-encodes `[{path: "notes.md", content}]` into `context_files`.
- Reuses existing `upsertmemory` RPC — **no backend changes**. Wire convention from `memory-model.ts:draftToWire` (id="", timestamps=0 → server-side).
- TabModalLayer owns the UpsertMemory RPC so the layer's `submitting()` gates safeClose during the in-flight call.
- AgentPicker.`onRequestNewMemory` threads `LaunchFormStateWire` through on both onCreated and onCancel.

## Out of scope

- **File-picker mode** — radio disabled with "(coming soon)" tooltip. Drag-and-drop / OS file dialog is its own design concern; tracked as a follow-up.

## Stack

- #909 Phase α — merged
- #910 Phase β (New Identity + OAuth-binding gate + LaunchFormState plumbing) — merged
- **This PR — Phase γ** (was #911 before auto-close)

## Test plan

- [ ] Launch agent with **zero memories** → only "+ New Memory" button visible.
- [ ] Click "+ New" → modal opens via `tabModal.replace` (crossfade, no flicker).
- [ ] Create with Empty mode → returns to Launch with new memory preselected; `context_files` in DB is `"[]"`.
- [ ] Create with Paste mode → context_files contains `[{path:"notes.md", content:"<text>"}]`.
- [ ] Cancel → returns to Launch with prior name + runtime + image + identity intact (not just Memory).
- [ ] Pick-files radio disabled and labelled "(coming soon)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)