### PR TITLE
feat(launch-flow-state): additive reducer slice + tests (Stage 2a)

### DIFF
--- a/.changesets/1779195185-feat-launch-flow-state-reducer-slice-stage-2a.md
+++ b/.changesets/1779195185-feat-launch-flow-state-reducer-slice-stage-2a.md
@@ -1,0 +1,13 @@
+---
+type: patch
+---
+
+feat(launch-flow-state): additive reducer slice + tests (Stage 2a)
+
+Adds `frontend/app/store/launch-flow-state/` — types + pure reducer
++ selectors + 37 unit tests covering the form/identity/memory/
+bindings/submit cross-product. Modeled on browser-pane-state.
+
+Purely additive — no view migration yet. AgentLaunchModal still uses
+its existing local signals; Stage 2b migrates it. Spec:
+docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md

--- a/frontend/app/store/launch-flow-state/index.ts
+++ b/frontend/app/store/launch-flow-state/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+export { update } from "./reducer";
+export {
+    canSubmit,
+    continueLocksIdentity,
+    continueLocksMemory,
+    hasMatchingBinding,
+    initialForm,
+    initialResourceList,
+    initialState,
+    initialSubmit,
+    isContinue,
+    realIdentities,
+    realMemories,
+} from "./types";
+export type {
+    LaunchFlowCommand,
+    LaunchFlowEvent,
+    LaunchFlowState,
+    LaunchForm,
+    ResourceList,
+    ReducerResult,
+    SubmitStatus,
+} from "./types";

--- a/frontend/app/store/launch-flow-state/reducer.test.ts
+++ b/frontend/app/store/launch-flow-state/reducer.test.ts
@@ -193,6 +193,42 @@ describe("launch-flow-state reducer", () => {
             expect(continueLocksMemory(s)).toBe(false);
         });
 
+        it("emits FetchBindings for uncached real carry-over identity", () => {
+            const r = update(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-1",
+                carry: { name: "prev", identityId: "a", memoryId: "m" },
+            });
+            expect(r.events).toEqual([{ type: "FetchBindings", identityId: "a" }]);
+        });
+
+        it("does NOT emit FetchBindings for empty carry-over identity (legacy)", () => {
+            const r = update(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-legacy",
+                carry: { name: "old", identityId: "", memoryId: "" },
+            });
+            expect(r.events).toEqual([]);
+        });
+
+        it("re-dispatch with same continueOfId is a no-op (preserves edits)", () => {
+            let s = dispatch(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-1",
+                carry: { name: "prev", identityId: "a", memoryId: "m" },
+            }).state;
+            // User edits name mid-flow
+            s = dispatch(s, { type: "NameChanged", name: "edited" }).state;
+            // Stray repeat from the view shouldn't overwrite the edit
+            const r = update(s, {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-1",
+                carry: { name: "prev", identityId: "a", memoryId: "m" },
+            });
+            expect(r.state).toBe(s);
+            expect(r.state.form.name).toBe("edited");
+        });
+
         it("clears form on `— New agent —` (null)", () => {
             let s = dispatch(initialState(), {
                 type: "ContinueOfChanged",

--- a/frontend/app/store/launch-flow-state/reducer.test.ts
+++ b/frontend/app/store/launch-flow-state/reducer.test.ts
@@ -1,0 +1,345 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+
+import { update } from "./reducer";
+import {
+    canSubmit,
+    continueLocksIdentity,
+    continueLocksMemory,
+    hasMatchingBinding,
+    initialState,
+    isContinue,
+    realIdentities,
+    realMemories,
+    type LaunchFlowCommand,
+    type LaunchFlowState,
+} from "./types";
+
+// Test fixtures. Match the wire shapes in frontend/types/gotypes.d.ts.
+const ident = (id: string, name: string, is_blank = false): IdentityBundle => ({
+    id,
+    name,
+    is_blank,
+    created_at: 0,
+    updated_at: 0,
+});
+
+const mem = (id: string, name: string, is_blank = false): Memory => ({
+    id,
+    name,
+    is_blank,
+    created_at: 0,
+    updated_at: 0,
+});
+
+const binding = (identityId: string, provider: string): IdentityBinding => ({
+    identity_id: identityId,
+    provider,
+    account_id: "acc-1",
+});
+
+const dispatch = (state: LaunchFlowState, cmd: LaunchFlowCommand) => update(state, cmd);
+
+// ── Reducer transitions ────────────────────────────────────────────
+
+describe("launch-flow-state reducer", () => {
+    describe("initial state", () => {
+        it("starts with empty form + no bundles + not closed", () => {
+            const s = initialState();
+            expect(s.form.name).toBe("");
+            expect(s.form.identityId).toBe("");
+            expect(s.form.memoryId).toBe("");
+            expect(s.form.continueOfId).toBe(null);
+            expect(s.identities.list).toEqual([]);
+            expect(s.memories.list).toEqual([]);
+            expect(s.bindings).toEqual({});
+            expect(s.bindingsLoading).toEqual({});
+            expect(s.submit.inFlight).toBe(false);
+            expect(s.closed).toBe(false);
+        });
+    });
+
+    describe("Opened", () => {
+        it("resets form to defaults when no initial supplied", () => {
+            let s = initialState();
+            s = dispatch(s, { type: "NameChanged", name: "stale" }).state;
+            s = dispatch(s, { type: "Opened" }).state;
+            expect(s.form.name).toBe("");
+        });
+
+        it("applies initial form overrides", () => {
+            const s = dispatch(initialState(), {
+                type: "Opened",
+                initial: { name: "carry", runtime: "container", identityId: "a" },
+            }).state;
+            expect(s.form.name).toBe("carry");
+            expect(s.form.runtime).toBe("container");
+            expect(s.form.identityId).toBe("a");
+        });
+
+        it("clears the closed flag (reopen)", () => {
+            let s = dispatch(initialState(), { type: "Closed" }).state;
+            expect(s.closed).toBe(true);
+            s = dispatch(s, { type: "Opened" }).state;
+            expect(s.closed).toBe(false);
+        });
+    });
+
+    describe("form fields", () => {
+        it("NameChanged updates name", () => {
+            const s = dispatch(initialState(), { type: "NameChanged", name: "n" }).state;
+            expect(s.form.name).toBe("n");
+        });
+
+        it("set-to-current is a no-op (same state identity)", () => {
+            const s0 = dispatch(initialState(), { type: "NameChanged", name: "x" }).state;
+            const r = update(s0, { type: "NameChanged", name: "x" });
+            expect(r.state).toBe(s0);
+        });
+
+        it("RuntimeChanged + ImageChanged update independently", () => {
+            let s = dispatch(initialState(), { type: "RuntimeChanged", runtime: "container" }).state;
+            s = dispatch(s, { type: "ImageChanged", image: "alpine" }).state;
+            expect(s.form.runtime).toBe("container");
+            expect(s.form.image).toBe("alpine");
+        });
+    });
+
+    describe("IdentityChanged", () => {
+        it("updates identityId", () => {
+            const s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            expect(s.form.identityId).toBe("a");
+        });
+
+        it("emits FetchBindings on selection of an uncached real id", () => {
+            const r = update(initialState(), { type: "IdentityChanged", identityId: "a" });
+            expect(r.events).toEqual([{ type: "FetchBindings", identityId: "a" }]);
+        });
+
+        it("does NOT emit FetchBindings when selecting the empty id", () => {
+            const r = update(initialState(), { type: "IdentityChanged", identityId: "" });
+            expect(r.events).toEqual([]);
+        });
+
+        it("does NOT emit FetchBindings when bindings already cached", () => {
+            let s = initialState();
+            s = dispatch(s, { type: "BindingsLoaded", identityId: "a", bindings: [] }).state;
+            const r = update(s, { type: "IdentityChanged", identityId: "a" });
+            expect(r.events).toEqual([]);
+        });
+
+        it("does NOT emit FetchBindings when bindings query is already in flight", () => {
+            let s = initialState();
+            s = dispatch(s, { type: "BindingsLoading", identityId: "a" }).state;
+            const r = update(s, { type: "IdentityChanged", identityId: "a" });
+            expect(r.events).toEqual([]);
+        });
+    });
+
+    describe("ContinueOfChanged", () => {
+        it("locks identity + memory when carry-over is real", () => {
+            const s = dispatch(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-1",
+                carry: { name: "prev", identityId: "a", memoryId: "m" },
+            }).state;
+            expect(s.form.continueOfId).toBe("inst-1");
+            expect(s.form.name).toBe("prev");
+            expect(s.form.identityId).toBe("a");
+            expect(s.form.memoryId).toBe("m");
+            expect(continueLocksIdentity(s)).toBe(true);
+            expect(continueLocksMemory(s)).toBe(true);
+        });
+
+        it("does NOT lock when continued row carries empty values (legacy)", () => {
+            const s = dispatch(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-legacy",
+                carry: { name: "old", identityId: "", memoryId: "" },
+            }).state;
+            expect(isContinue(s)).toBe(true);
+            // Legacy continuation — user must pick replacements
+            expect(continueLocksIdentity(s)).toBe(false);
+            expect(continueLocksMemory(s)).toBe(false);
+        });
+
+        it("clears form on `— New agent —` (null)", () => {
+            let s = dispatch(initialState(), {
+                type: "ContinueOfChanged",
+                continueOfId: "inst-1",
+                carry: { name: "prev", identityId: "a", memoryId: "m" },
+            }).state;
+            s = dispatch(s, { type: "ContinueOfChanged", continueOfId: null }).state;
+            expect(s.form.continueOfId).toBe(null);
+            expect(s.form.name).toBe("");
+            expect(s.form.identityId).toBe("");
+            expect(s.form.memoryId).toBe("");
+            expect(isContinue(s)).toBe(false);
+        });
+    });
+
+    describe("identities resource", () => {
+        it("IdentitiesLoading sets loading + clears error", () => {
+            let s = dispatch(initialState(), { type: "IdentitiesFailed", error: "old" }).state;
+            s = dispatch(s, { type: "IdentitiesLoading" }).state;
+            expect(s.identities.loading).toBe(true);
+            expect(s.identities.error).toBe(null);
+        });
+
+        it("IdentitiesLoaded sets list + clears loading", () => {
+            const a = ident("a", "A");
+            const s = dispatch(initialState(), { type: "IdentitiesLoaded", list: [a] }).state;
+            expect(s.identities.list).toEqual([a]);
+            expect(s.identities.loading).toBe(false);
+        });
+
+        it("realIdentities selector filters is_blank", () => {
+            const a = ident("a", "A");
+            const b = ident("blank", "Blank", true);
+            const s = dispatch(initialState(), { type: "IdentitiesLoaded", list: [b, a] }).state;
+            expect(realIdentities(s)).toEqual([a]);
+        });
+
+        it("realMemories selector filters is_blank", () => {
+            const m = mem("m", "M");
+            const b = mem("blank", "Blank", true);
+            const s = dispatch(initialState(), { type: "MemoriesLoaded", list: [b, m] }).state;
+            expect(realMemories(s)).toEqual([m]);
+        });
+    });
+
+    describe("bindings", () => {
+        it("BindingsLoading sets per-id loading flag", () => {
+            const s = dispatch(initialState(), { type: "BindingsLoading", identityId: "a" }).state;
+            expect(s.bindingsLoading.a).toBe(true);
+        });
+
+        it("BindingsLoaded sets list + clears loading", () => {
+            let s = dispatch(initialState(), { type: "BindingsLoading", identityId: "a" }).state;
+            const bs = [binding("a", "claude")];
+            s = dispatch(s, { type: "BindingsLoaded", identityId: "a", bindings: bs }).state;
+            expect(s.bindings.a).toEqual(bs);
+            expect(s.bindingsLoading.a).toBeUndefined();
+        });
+
+        it("BindingsChanged updates list without touching loading flag", () => {
+            // Simulates a backend push event arriving after the resource settled.
+            let s = dispatch(initialState(), {
+                type: "BindingsLoaded",
+                identityId: "a",
+                bindings: [],
+            }).state;
+            const bs = [binding("a", "claude")];
+            s = dispatch(s, { type: "BindingsChanged", identityId: "a", bindings: bs }).state;
+            expect(s.bindings.a).toEqual(bs);
+            expect(s.bindingsLoading.a).toBeUndefined();
+        });
+
+        it("hasMatchingBinding selector — provider match", () => {
+            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            s = dispatch(s, {
+                type: "BindingsLoaded",
+                identityId: "a",
+                bindings: [binding("a", "claude")],
+            }).state;
+            expect(hasMatchingBinding(s, "claude")).toBe(true);
+            expect(hasMatchingBinding(s, "codex")).toBe(false);
+        });
+
+        it("hasMatchingBinding returns false while bindings loading", () => {
+            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            s = dispatch(s, { type: "BindingsLoading", identityId: "a" }).state;
+            // Even if cache has stale data from a prior selection, the
+            // in-flight load is treated as "no match" — the gate stays on.
+            // (anti-vacuity guard for the race fixed in #910 round 5).
+            expect(hasMatchingBinding(s, "claude")).toBe(false);
+        });
+
+        it("hasMatchingBinding returns false on empty identityId", () => {
+            const s = initialState();
+            expect(hasMatchingBinding(s, "claude")).toBe(false);
+        });
+    });
+
+    describe("submit lifecycle", () => {
+        it("SubmitClicked sets inFlight + clears prior error", () => {
+            let s = dispatch(initialState(), { type: "SubmitFailed", error: "x" }).state;
+            s = dispatch(s, { type: "SubmitClicked" }).state;
+            expect(s.submit.inFlight).toBe(true);
+            expect(s.submit.error).toBe(null);
+        });
+
+        it("second SubmitClicked while in-flight is a no-op", () => {
+            const s1 = dispatch(initialState(), { type: "SubmitClicked" }).state;
+            const r = update(s1, { type: "SubmitClicked" });
+            expect(r.state).toBe(s1);
+        });
+
+        it("SubmitSucceeded clears in-flight", () => {
+            let s = dispatch(initialState(), { type: "SubmitClicked" }).state;
+            s = dispatch(s, { type: "SubmitSucceeded" }).state;
+            expect(s.submit.inFlight).toBe(false);
+        });
+
+        it("SubmitFailed records the error", () => {
+            let s = dispatch(initialState(), { type: "SubmitClicked" }).state;
+            s = dispatch(s, { type: "SubmitFailed", error: "boom" }).state;
+            expect(s.submit.error).toBe("boom");
+            expect(s.submit.inFlight).toBe(false);
+        });
+    });
+
+    describe("Closed terminal", () => {
+        it("subsequent non-Closed commands are no-ops", () => {
+            const closed = dispatch(initialState(), { type: "Closed" }).state;
+            const r = update(closed, { type: "NameChanged", name: "x" });
+            expect(r.state).toBe(closed);
+            expect(r.events).toEqual([]);
+        });
+
+        it("Opened re-arms the slice", () => {
+            let s = dispatch(initialState(), { type: "Closed" }).state;
+            s = dispatch(s, { type: "Opened", initial: { name: "fresh" } }).state;
+            expect(s.closed).toBe(false);
+            expect(s.form.name).toBe("fresh");
+        });
+    });
+
+    describe("canSubmit cross-product", () => {
+        const baseAuth = { authReady: true, nameValid: true };
+
+        it("blocks when in-flight", () => {
+            const s = dispatch(initialState(), { type: "SubmitClicked" }).state;
+            expect(canSubmit(s, baseAuth)).toBe(false);
+        });
+
+        it("blocks when name invalid", () => {
+            const s = initialState();
+            expect(canSubmit(s, { ...baseAuth, nameValid: false })).toBe(false);
+        });
+
+        it("blocks when identityId empty", () => {
+            const s = initialState();
+            expect(canSubmit(s, baseAuth)).toBe(false);
+        });
+
+        it("blocks when memoryId empty", () => {
+            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            expect(canSubmit(s, baseAuth)).toBe(false);
+        });
+
+        it("blocks when authReady false", () => {
+            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            s = dispatch(s, { type: "MemoryChanged", memoryId: "m" }).state;
+            expect(canSubmit(s, { ...baseAuth, authReady: false })).toBe(false);
+        });
+
+        it("passes when name + identity + memory + auth are all good", () => {
+            let s = dispatch(initialState(), { type: "IdentityChanged", identityId: "a" }).state;
+            s = dispatch(s, { type: "MemoryChanged", memoryId: "m" }).state;
+            expect(canSubmit(s, baseAuth)).toBe(true);
+        });
+    });
+});

--- a/frontend/app/store/launch-flow-state/reducer.test.ts
+++ b/frontend/app/store/launch-flow-state/reducer.test.ts
@@ -85,6 +85,34 @@ describe("launch-flow-state reducer", () => {
             s = dispatch(s, { type: "Opened" }).state;
             expect(s.closed).toBe(false);
         });
+
+        it("emits FetchBindings for an uncached preselected identityId", () => {
+            const r = update(initialState(), {
+                type: "Opened",
+                initial: { identityId: "preselect-a" },
+            });
+            expect(r.events).toEqual([
+                { type: "FetchBindings", identityId: "preselect-a" },
+            ]);
+        });
+
+        it("does NOT emit FetchBindings when preselected identity already cached", () => {
+            let s = dispatch(initialState(), {
+                type: "BindingsLoaded",
+                identityId: "preselect-a",
+                bindings: [],
+            }).state;
+            const r = update(s, {
+                type: "Opened",
+                initial: { identityId: "preselect-a" },
+            });
+            expect(r.events).toEqual([]);
+        });
+
+        it("does NOT emit FetchBindings when initial identityId is empty", () => {
+            const r = update(initialState(), { type: "Opened", initial: { identityId: "" } });
+            expect(r.events).toEqual([]);
+        });
     });
 
     describe("form fields", () => {

--- a/frontend/app/store/launch-flow-state/reducer.ts
+++ b/frontend/app/store/launch-flow-state/reducer.ts
@@ -38,7 +38,17 @@ export function update(
                 form: { ...initialForm(), ...command.initial },
                 closed: false,
             };
-            return { state: next, events: [] };
+            // If Opened carries a preselected identityId we haven't
+            // seen bindings for, emit a fetch — otherwise the cache
+            // stays empty and hasMatchingBinding keeps reading false
+            // for an already-bound bundle, holding Launch behind the
+            // Connect gate (codex P2 on PR #917).
+            const events: LaunchFlowEvent[] = [];
+            const id = next.form.identityId;
+            if (id !== "" && state.bindings[id] === undefined && !state.bindingsLoading[id]) {
+                events.push({ type: "FetchBindings", identityId: id });
+            }
+            return { state: next, events };
         }
 
         case "NameChanged": {

--- a/frontend/app/store/launch-flow-state/reducer.ts
+++ b/frontend/app/store/launch-flow-state/reducer.ts
@@ -1,0 +1,221 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure reducer for the launch-flow-state slice. Mirrors the
+ * `update(state, command) → { state, events }` shape used by
+ * `frontend/app/store/browser-pane-state/reducer.ts`.
+ *
+ * Stage 2a — additive. The view migration (AgentLaunchModal swap to
+ * `useLaunchFlowStore()`) is Stage 2b. See spec
+ * `docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md`.
+ */
+
+import type {
+    LaunchFlowCommand,
+    LaunchFlowEvent,
+    LaunchFlowState,
+    ReducerResult,
+} from "./types";
+import { initialForm } from "./types";
+
+export function update(
+    state: LaunchFlowState,
+    command: LaunchFlowCommand,
+): ReducerResult {
+    // Closed terminal — every command after Closed is a no-op so
+    // late events from a torn-down modal don't poke the state.
+    // `Opened` is the explicit re-arm path (reopen the modal) and
+    // bypasses the guard.
+    if (state.closed && command.type !== "Closed" && command.type !== "Opened") {
+        return { state, events: [] };
+    }
+
+    switch (command.type) {
+        case "Opened": {
+            const next: LaunchFlowState = {
+                ...state,
+                form: { ...initialForm(), ...command.initial },
+                closed: false,
+            };
+            return { state: next, events: [] };
+        }
+
+        case "NameChanged": {
+            if (state.form.name === command.name) return { state, events: [] };
+            return {
+                state: { ...state, form: { ...state.form, name: command.name } },
+                events: [],
+            };
+        }
+
+        case "RuntimeChanged": {
+            if (state.form.runtime === command.runtime) return { state, events: [] };
+            return {
+                state: { ...state, form: { ...state.form, runtime: command.runtime } },
+                events: [],
+            };
+        }
+
+        case "ImageChanged": {
+            if (state.form.image === command.image) return { state, events: [] };
+            return {
+                state: { ...state, form: { ...state.form, image: command.image } },
+                events: [],
+            };
+        }
+
+        case "IdentityChanged": {
+            if (state.form.identityId === command.identityId) {
+                return { state, events: [] };
+            }
+            const events: LaunchFlowEvent[] = [];
+            // Emit FetchBindings on selection of a real identity we
+            // haven't seen yet. The view runs the RPC and dispatches
+            // BindingsLoading + BindingsLoaded.
+            const id = command.identityId;
+            if (id !== "" && state.bindings[id] === undefined && !state.bindingsLoading[id]) {
+                events.push({ type: "FetchBindings", identityId: id });
+            }
+            return {
+                state: { ...state, form: { ...state.form, identityId: id } },
+                events,
+            };
+        }
+
+        case "MemoryChanged": {
+            if (state.form.memoryId === command.memoryId) return { state, events: [] };
+            return {
+                state: { ...state, form: { ...state.form, memoryId: command.memoryId } },
+                events: [],
+            };
+        }
+
+        case "ContinueOfChanged": {
+            const next: LaunchFlowState = {
+                ...state,
+                form: {
+                    ...state.form,
+                    continueOfId: command.continueOfId,
+                    // Carry-over (or clear) the form fields when the
+                    // user picks a row. `carry` is supplied by the
+                    // caller because the row's instance_name /
+                    // identity_id / memory_id translation (legacy
+                    // "" or "blank" → "") is a view concern.
+                    name: command.carry?.name ?? "",
+                    identityId: command.carry?.identityId ?? "",
+                    memoryId: command.carry?.memoryId ?? "",
+                },
+            };
+            return { state: next, events: [] };
+        }
+
+        case "IdentitiesLoading": {
+            return {
+                state: {
+                    ...state,
+                    identities: { ...state.identities, loading: true, error: null },
+                },
+                events: [],
+            };
+        }
+
+        case "IdentitiesLoaded": {
+            return {
+                state: {
+                    ...state,
+                    identities: { list: command.list, loading: false, error: null },
+                },
+                events: [],
+            };
+        }
+
+        case "IdentitiesFailed": {
+            return {
+                state: {
+                    ...state,
+                    identities: { ...state.identities, loading: false, error: command.error },
+                },
+                events: [],
+            };
+        }
+
+        case "MemoriesLoading": {
+            return {
+                state: { ...state, memories: { ...state.memories, loading: true, error: null } },
+                events: [],
+            };
+        }
+
+        case "MemoriesLoaded": {
+            return {
+                state: { ...state, memories: { list: command.list, loading: false, error: null } },
+                events: [],
+            };
+        }
+
+        case "MemoriesFailed": {
+            return {
+                state: { ...state, memories: { ...state.memories, loading: false, error: command.error } },
+                events: [],
+            };
+        }
+
+        case "BindingsLoading": {
+            return {
+                state: {
+                    ...state,
+                    bindingsLoading: { ...state.bindingsLoading, [command.identityId]: true },
+                },
+                events: [],
+            };
+        }
+
+        case "BindingsLoaded":
+        case "BindingsChanged": {
+            // BindingsLoaded settles the initial fetch (clears loading);
+            // BindingsChanged is the push event from the backend and
+            // doesn't toggle loading at all. Same state shape otherwise.
+            const nextLoading = { ...state.bindingsLoading };
+            if (command.type === "BindingsLoaded") {
+                delete nextLoading[command.identityId];
+            }
+            return {
+                state: {
+                    ...state,
+                    bindings: { ...state.bindings, [command.identityId]: command.bindings },
+                    bindingsLoading: nextLoading,
+                },
+                events: [],
+            };
+        }
+
+        case "SubmitClicked": {
+            // Idempotent under in-flight — second click is a no-op.
+            if (state.submit.inFlight) return { state, events: [] };
+            return {
+                state: { ...state, submit: { inFlight: true, error: null } },
+                events: [],
+            };
+        }
+
+        case "SubmitSucceeded": {
+            return {
+                state: { ...state, submit: { inFlight: false, error: null } },
+                events: [],
+            };
+        }
+
+        case "SubmitFailed": {
+            return {
+                state: { ...state, submit: { inFlight: false, error: command.error } },
+                events: [],
+            };
+        }
+
+        case "Closed": {
+            if (state.closed) return { state, events: [] };
+            return { state: { ...state, closed: true }, events: [] };
+        }
+    }
+}

--- a/frontend/app/store/launch-flow-state/reducer.ts
+++ b/frontend/app/store/launch-flow-state/reducer.ts
@@ -19,6 +19,21 @@ import type {
 } from "./types";
 import { initialForm } from "./types";
 
+/** Helper: emit `FetchBindings` exactly when an identityId is real
+ *  (non-empty), not yet cached, and not already in flight. Three
+ *  commands trigger this fetch (Opened with preselect,
+ *  IdentityChanged, ContinueOfChanged with carry-over), so the
+ *  predicate lives here to keep the rule in one place. */
+function maybeFetchBindings(
+    state: LaunchFlowState,
+    identityId: string,
+): LaunchFlowEvent[] {
+    if (identityId === "") return [];
+    if (state.bindings[identityId] !== undefined) return [];
+    if (state.bindingsLoading[identityId]) return [];
+    return [{ type: "FetchBindings", identityId }];
+}
+
 export function update(
     state: LaunchFlowState,
     command: LaunchFlowCommand,
@@ -38,17 +53,7 @@ export function update(
                 form: { ...initialForm(), ...command.initial },
                 closed: false,
             };
-            // If Opened carries a preselected identityId we haven't
-            // seen bindings for, emit a fetch — otherwise the cache
-            // stays empty and hasMatchingBinding keeps reading false
-            // for an already-bound bundle, holding Launch behind the
-            // Connect gate (codex P2 on PR #917).
-            const events: LaunchFlowEvent[] = [];
-            const id = next.form.identityId;
-            if (id !== "" && state.bindings[id] === undefined && !state.bindingsLoading[id]) {
-                events.push({ type: "FetchBindings", identityId: id });
-            }
-            return { state: next, events };
+            return { state: next, events: maybeFetchBindings(state, next.form.identityId) };
         }
 
         case "NameChanged": {
@@ -79,17 +84,9 @@ export function update(
             if (state.form.identityId === command.identityId) {
                 return { state, events: [] };
             }
-            const events: LaunchFlowEvent[] = [];
-            // Emit FetchBindings on selection of a real identity we
-            // haven't seen yet. The view runs the RPC and dispatches
-            // BindingsLoading + BindingsLoaded.
-            const id = command.identityId;
-            if (id !== "" && state.bindings[id] === undefined && !state.bindingsLoading[id]) {
-                events.push({ type: "FetchBindings", identityId: id });
-            }
             return {
-                state: { ...state, form: { ...state.form, identityId: id } },
-                events,
+                state: { ...state, form: { ...state.form, identityId: command.identityId } },
+                events: maybeFetchBindings(state, command.identityId),
             };
         }
 
@@ -102,6 +99,15 @@ export function update(
         }
 
         case "ContinueOfChanged": {
+            // Idempotency: re-dispatching with the same continueOfId
+            // is a no-op so a stray repeat from the view doesn't
+            // overwrite mid-form edits with the original carry-over.
+            // Compare on continueOfId; the carry values are a
+            // deterministic projection of the row, so if the id is
+            // unchanged the carry is too.
+            if (state.form.continueOfId === command.continueOfId) {
+                return { state, events: [] };
+            }
             const next: LaunchFlowState = {
                 ...state,
                 form: {
@@ -117,7 +123,10 @@ export function update(
                     memoryId: command.carry?.memoryId ?? "",
                 },
             };
-            return { state: next, events: [] };
+            return {
+                state: next,
+                events: maybeFetchBindings(state, next.form.identityId),
+            };
         }
 
         case "IdentitiesLoading": {
@@ -183,9 +192,13 @@ export function update(
 
         case "BindingsLoaded":
         case "BindingsChanged": {
-            // BindingsLoaded settles the initial fetch (clears loading);
-            // BindingsChanged is the push event from the backend and
-            // doesn't toggle loading at all. Same state shape otherwise.
+            // Both commands write the new bindings array. They differ
+            // only in what they do to the per-id loading flag:
+            //   - BindingsLoaded settles a fetch the reducer asked
+            //     for via FetchBindings → clears the loading flag.
+            //   - BindingsChanged is a backend push event arriving
+            //     unsolicited (no in-flight fetch) → leaves the
+            //     loading flag alone (likely already absent).
             const nextLoading = { ...state.bindingsLoading };
             if (command.type === "BindingsLoaded") {
                 delete nextLoading[command.identityId];

--- a/frontend/app/store/launch-flow-state/types.ts
+++ b/frontend/app/store/launch-flow-state/types.ts
@@ -1,0 +1,227 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Type definitions for the launch-flow-state reducer (Stage 2a of
+ * docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).
+ *
+ * Owns the editable Launch-modal surface as a single state object:
+ *   - `form` — name, runtime, image, identity/memory/continue selections
+ *   - `identities` / `memories` — loaded bundle lists + load status
+ *   - `bindings` — per-identity binding cache (push-updatable in
+ *     stage 2c via a backend event subscription)
+ *   - `submit` — submit-in-flight + last error
+ *
+ * Auth state is intentionally OUT of scope for stage 2a — it stays
+ * in the existing `AuthFlowController` (lifted to AgentLaunchModal
+ * in Stage 1). A later stage can fold auth into this store if the
+ * cross-product simplifies further.
+ *
+ * Pure reducer — `update(state, command) → { state, events }`. The
+ * view mounts the store, dispatches commands, and runs emitted
+ * events (RPC calls etc.) outside the reducer.
+ *
+ * Reference: `frontend/app/store/browser-pane-state/types.ts` is the
+ * established slice shape this file mirrors.
+ */
+
+/** Editable Launch-modal form fields. Empty strings mean "no
+ *  selection"; the view's submit predicate blocks Launch until the
+ *  user picks or creates a real bundle. */
+export interface LaunchForm {
+    name: string;
+    runtime: "host" | "container";
+    image: string;
+    /** Selected Identity bundle id. `""` = unselected. */
+    identityId: string;
+    /** Selected Memory bundle id. `""` = unselected. */
+    memoryId: string;
+    /** When set, this launch is a continuation of a prior named
+     *  agent — pulled from the user's "Continue agent" dropdown.
+     *  Drives the per-row lock semantics in §3.2.2 of the spec. */
+    continueOfId: string | null;
+}
+
+export const initialForm = (): LaunchForm => ({
+    name: "",
+    runtime: "host",
+    image: "",
+    identityId: "",
+    memoryId: "",
+    continueOfId: null,
+});
+
+/** Wrapper for an asynchronous resource the reducer tracks. The
+ *  view shows a loading state while `loading` is true; `error` is
+ *  set on fetch failure and cleared on the next successful load. */
+export interface ResourceList<T> {
+    list: T[];
+    loading: boolean;
+    error: string | null;
+}
+
+export const initialResourceList = <T>(): ResourceList<T> => ({
+    list: [],
+    loading: false,
+    error: null,
+});
+
+export interface SubmitStatus {
+    inFlight: boolean;
+    error: string | null;
+}
+
+export const initialSubmit = (): SubmitStatus => ({
+    inFlight: false,
+    error: null,
+});
+
+/** Top-level reducer state. */
+export interface LaunchFlowState {
+    form: LaunchForm;
+    identities: ResourceList<IdentityBundle>;
+    memories: ResourceList<Memory>;
+    /** Per-identity binding cache. Keyed on `identityId`. Push-
+     *  updated via `BindingsLoaded` (initial load) and `BindingsChanged`
+     *  (subsequent backend events). Empty value means "no bindings yet
+     *  / hasn't been queried"; the view distinguishes via the loading
+     *  side-channel below. */
+    bindings: Record<string, IdentityBinding[]>;
+    /** Identity ids whose bindings query is currently in flight.
+     *  Used by the view to render the auth gate as "loading" so a
+     *  fast Connect click doesn't slip through the race. */
+    bindingsLoading: Record<string, boolean>;
+    submit: SubmitStatus;
+    /** Terminal flag — set by `Closed`. Post-close commands are no-ops. */
+    closed: boolean;
+}
+
+export const initialState = (): LaunchFlowState => ({
+    form: initialForm(),
+    identities: initialResourceList<IdentityBundle>(),
+    memories: initialResourceList<Memory>(),
+    bindings: {},
+    bindingsLoading: {},
+    submit: initialSubmit(),
+    closed: false,
+});
+
+/** All transitions the view can dispatch. */
+export type LaunchFlowCommand =
+    /** Modal opened — initial form values (preselect / continuation
+     *  carry-over from the picker). */
+    | { type: "Opened"; initial?: Partial<LaunchForm> }
+    /** Form field commands. Each is idempotent (set-to-current is a
+     *  no-op the reducer's identity check filters out). */
+    | { type: "NameChanged"; name: string }
+    | { type: "RuntimeChanged"; runtime: "host" | "container" }
+    | { type: "ImageChanged"; image: string }
+    /** Setting identity to `""` clears it (e.g. on legacy
+     *  continuation with no carry-over). The view auto-picks the
+     *  first non-blank bundle elsewhere. */
+    | { type: "IdentityChanged"; identityId: string }
+    | { type: "MemoryChanged"; memoryId: string }
+    /** Continue dropdown — `null` = "— New agent —". Setting to a
+     *  real instance id locks per-row selectors with the carry-over
+     *  values. */
+    | {
+          type: "ContinueOfChanged";
+          continueOfId: string | null;
+          carry?: { name: string; identityId: string; memoryId: string };
+      }
+    /** Resource lifecycle commands. */
+    | { type: "IdentitiesLoading" }
+    | { type: "IdentitiesLoaded"; list: IdentityBundle[] }
+    | { type: "IdentitiesFailed"; error: string }
+    | { type: "MemoriesLoading" }
+    | { type: "MemoriesLoaded"; list: Memory[] }
+    | { type: "MemoriesFailed"; error: string }
+    /** Bindings push events. `BindingsChanged` is the wire shape the
+     *  backend will emit in Stage 2c; until then it's only used by
+     *  unit tests. */
+    | { type: "BindingsLoading"; identityId: string }
+    | { type: "BindingsLoaded"; identityId: string; bindings: IdentityBinding[] }
+    | { type: "BindingsChanged"; identityId: string; bindings: IdentityBinding[] }
+    /** Submit lifecycle. */
+    | { type: "SubmitClicked" }
+    | { type: "SubmitSucceeded" }
+    | { type: "SubmitFailed"; error: string }
+    /** Terminal. */
+    | { type: "Closed" };
+
+/** Side-effects the view runs in response to commands. The reducer
+ *  stays pure; emits these for the view to dispatch onto the wire.
+ *  Each event is keyed/tagged so the view can dedupe in-flight RPCs. */
+export type LaunchFlowEvent =
+    /** Fetch bindings for an identity that just became selected and
+     *  has no cached entry. */
+    | { type: "FetchBindings"; identityId: string };
+
+export interface ReducerResult {
+    state: LaunchFlowState;
+    events: LaunchFlowEvent[];
+}
+
+// ── Selectors ───────────────────────────────────────────────────────────────
+//
+// Pure read-only derivations over state. The view calls these instead
+// of repeating logic — keeps the cross-product testable in one place.
+
+/** Real (non-blank) identity bundles, filtering out any
+ *  back-compat `is_blank` singleton the backend may still return. */
+export function realIdentities(state: LaunchFlowState): IdentityBundle[] {
+    return state.identities.list.filter((b) => !b.is_blank);
+}
+
+/** Real (non-blank) memory bundles. */
+export function realMemories(state: LaunchFlowState): Memory[] {
+    return state.memories.list.filter((m) => !m.is_blank);
+}
+
+/** True when the form is a continuation of a prior named agent
+ *  (Continue dropdown set to a real instance id). */
+export function isContinue(state: LaunchFlowState): boolean {
+    return state.form.continueOfId !== null;
+}
+
+/** Per-row continuation lock. Identity selector locks ONLY when
+ *  the continued row carried a real (non-empty, non-legacy-"blank")
+ *  identity_id. Legacy carry-overs leave the selector editable so
+ *  the user can pick a replacement (codex P1 on PR #916). */
+export function continueLocksIdentity(state: LaunchFlowState): boolean {
+    return isContinue(state) && state.form.identityId !== "";
+}
+
+export function continueLocksMemory(state: LaunchFlowState): boolean {
+    return isContinue(state) && state.form.memoryId !== "";
+}
+
+/** Whether the selected identity bundle has a binding for the given
+ *  provider. Used by the auth-gate predicate. While bindings are
+ *  loading, returns false (safe — the gate stays on). */
+export function hasMatchingBinding(
+    state: LaunchFlowState,
+    providerId: string,
+): boolean {
+    const id = state.form.identityId;
+    if (!id) return false;
+    if (state.bindingsLoading[id]) return false;
+    const bindings = state.bindings[id] ?? [];
+    return bindings.some((b) => b.provider === providerId);
+}
+
+/** Whether Launch can fire. Combines form completeness with the
+ *  caller-supplied auth-ready check (the auth state machine still
+ *  lives in AuthFlowController for now; the view supplies its
+ *  `authStateKind === "ready"` boolean). */
+export function canSubmit(
+    state: LaunchFlowState,
+    opts: { authReady: boolean; nameValid: boolean },
+): boolean {
+    if (state.submit.inFlight) return false;
+    if (!opts.nameValid) return false;
+    if (state.form.identityId === "") return false;
+    if (state.form.memoryId === "") return false;
+    if (!opts.authReady) return false;
+    return true;
+}


### PR DESCRIPTION
## Summary

Stage 2a of [SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md](../blob/agenta/launch-modal-state-machine-stage-2a/docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).

**Purely additive.** Adds `frontend/app/store/launch-flow-state/` — types + pure reducer + selectors + 37 unit tests. No view code touched; AgentLaunchModal still uses its existing local signals. Stage 2b migrates the view.

## What's in the slice

- **State**: form (name/runtime/image/identity/memory/continueOf), identities + memories resource lists, per-identity bindings cache (with separate loading map), submit status, closed flag.
- **Commands**: form fields, resource lifecycle (Loading/Loaded/Failed), bindings (Loading/Loaded/Changed for push-events), submit lifecycle (Clicked/Succeeded/Failed), Opened/Closed.
- **Events**: `FetchBindings` — emitted on identity selection of an uncached real id.
- **Selectors**: `realIdentities`, `realMemories`, `isContinue`, `continueLocksIdentity`, `continueLocksMemory`, `hasMatchingBinding(state, providerId)`, `canSubmit(state, { authReady, nameValid })`.

## Cross-product covered in tests (37/37 pass)

- Initial state
- `Opened` with/without overrides + post-Closed re-arm
- Form-field commands incl. set-to-current idempotency
- `IdentityChanged` event emission gated on uncached / not-already-loading
- `ContinueOfChanged` lock semantics — real carry-over vs legacy `""`
- Resource lifecycles for identities, memories, bindings
- `BindingsChanged` push doesn't touch loading flag
- `hasMatchingBinding` race guard (returns false while bindings loading)
- Submit lifecycle (in-flight idempotency)
- `canSubmit` 5 blocking paths + happy path

## Out of scope (Stage 2b / 2c)

- Migrating `AgentLaunchModal` to call `useLaunchFlowStore()` — Stage 2b
- Backend `identity-bindings-changed` event + frontend subscription — Stage 2c
- Folding `AuthState` into this store — possible later refinement

## Test plan

- [ ] `npx vitest run frontend/app/store/launch-flow-state/` passes 37/37
- [ ] `npx tsc --noEmit` clean for the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)