### PR TITLE
feat(launch-flow-state): fold AuthState into slice + cross-product tests (Stage 2d.1)

### DIFF
--- a/.changesets/1779207254-feat-launch-flow-state-fold-auth-state-into-slice-stage-2d.md
+++ b/.changesets/1779207254-feat-launch-flow-state-fold-auth-state-into-slice-stage-2d.md
@@ -1,0 +1,18 @@
+---
+type: patch
+---
+
+feat(launch-flow-state): fold AuthState into the slice (Stage 2d.1)
+
+`LaunchFlowState.auth: AuthState` is now part of the slice. The
+reducer delegates `{ type: "Auth", cmd }` commands to auth-state's
+pure `update()` and wraps emitted events as
+`{ type: "Auth", event }` on the outer ReducerResult.
+
+Adds the §6.9 cross-product test suite — 8 tests asserting that
+form-field commands (Name/Memory/Runtime/Image/Identities/
+Bindings/Submit) never touch `state.auth`, and that auth commands
+never touch `state.form`. Pins the original memory-change-resets-
+auth bug as a pure-reducer regression.
+
+View migration to read `flow.state.auth.kind` is Stage 2d.2.

--- a/docs/specs/SPEC_LAUNCH_MODAL_INTEGRATION_TESTS_2026_05_19.md
+++ b/docs/specs/SPEC_LAUNCH_MODAL_INTEGRATION_TESTS_2026_05_19.md
@@ -1,0 +1,220 @@
+# SPEC: Launch Modal — Integration Tests (jsdom-based)
+
+**Status:** Draft
+**Date:** 2026-05-19
+**Author:** AgentA
+**Related:**
+- [SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md](./SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md) §6.10 — calls for an integration test that pins the memory-change-resets-auth regression.
+- `frontend/app/store/launch-flow-state/` — the reducer slice the tests cross-verify against the view.
+
+---
+
+## 0. TL;DR
+
+§6.10 of the launch-modal spec called for a "Playwright or equivalent" integration test that replays the memory-change-resets-auth repro. This spec picks **"or equivalent"**: use **Vitest + `@solidjs/testing-library` + jsdom** to mount `AgentLaunchModalPanel` with mocked RPCs and drive the flow programmatically. Catches the exact regression the spec wants pinned, runs in `npm test`, ~80–150 LOC, no separate CEF-spawn infrastructure.
+
+Full-stack Playwright/WebDriver against the real CEF host is **out of scope here** — see §6 for why and what it would actually cost.
+
+---
+
+## 1. Why not Playwright/WebDriver?
+
+The current repo has zero working e2e infrastructure:
+
+- **No `@playwright/*` dep** in `package.json`.
+- `test/specs/*.e2e.js` are **WebdriverIO + Tauri-helpers** files left over from before the Tauri-to-CEF migration. The helper file is literally named `tauri-helpers.js`. These tests have not run successfully against current `main` in months.
+- `testdriver/` is an AI-driven UI tester for onboarding flows — different tool, narrow scope, not suitable for state-machine assertions.
+- The only working test runner is **Vitest** (53 reducer-slice unit tests pass).
+
+Standing up real Playwright against the CEF host needs all of:
+1. CEF host process spawn fixture (build artifact path, ipc port discovery, ready-wait, teardown).
+2. Frontend devtools-protocol attachment (CEF supports DevTools — port allocation + WebDriver bridge).
+3. Mocks or fixtures for the `agentmux-srv` sidecar (else every test hits real RPC).
+4. Per-test data-dir isolation (so tests don't poison each other).
+5. CI runner with display server (Windows GH runners do; macOS/Linux need Xvfb or equivalent).
+
+That's a 1-2 week build-out. The **regression we actually want to pin** — "memory change shouldn't unmount the auth panel" — is a frontend-only state-machine concern. jsdom mounts the component, dispatches the same commands the real user would, and asserts the same DOM. No CEF needed.
+
+---
+
+## 2. Library choice
+
+| Library | Why |
+|---|---|
+| **Vitest** | Already the project's test runner. `vite.config.ts` + `vitest.config.ts` exist and work. CI runs `npm test`. |
+| **jsdom** | Solid component testing's canonical DOM environment. Lightweight, fast, deterministic. (`happy-dom` is faster but less compatible; not worth the deviation.) |
+| **`@solidjs/testing-library`** | Idiomatic mounting + cleanup for SolidJS components. Wraps `render(() => <Component />)` and auto-disposes between tests. ([docs](https://testing-library.com/docs/solid-testing-library/intro/)) |
+| **`@testing-library/user-event`** | Realistic user interactions (type, click, select). Use `userEvent.setup()` before `render`. |
+| **`@testing-library/jest-dom`** | Adds matchers like `toBeInTheDocument`, `toBeDisabled`. Plays with Vitest via `expect.extend`. |
+| **`vi.mock`** | RPC mocking at the module boundary (`@/app/store/rpc-api`). |
+
+These mirror the SolidJS docs' recommended stack ([guides/testing](https://docs.solidjs.com/guides/testing)).
+
+---
+
+## 3. Test surface
+
+### 3.1 What we mock
+
+| Module | Why | How |
+|---|---|---|
+| `@/app/store/rpc-api` | RPCs hit a real WebSocket — can't run in jsdom. | `vi.mock` the module; replace each `RpcApi.X` with a `vi.fn()` returning controllable promises. |
+| `@/app/store/wps` (`waveEventSubscribe`) | Cross-tab push events come over the IPC pipe. | `vi.mock` to return a no-op `unsub`. Tests that need to drive push events expose a `triggerEvent(eventType, payload)` helper. |
+| `@/app/platform/ipc` (`invokeCommand`) | OpenExternal / browser_pane_auth_* don't exist outside CEF. | `vi.mock` to no-op `vi.fn()`. |
+| `@/app/store/global` (`getApi`) | `openExternal` on the catalog page. | `vi.fn()`. |
+
+### 3.2 What we DON'T mock
+
+- The `launch-flow-state` reducer + store — they're the SUT.
+- The `AuthFlowController` — we want its state to flow through real dispatch.
+- `solid-js` itself.
+
+### 3.3 What we render
+
+`AgentLaunchModalPanel` directly — bypasses `TabModalLayer` (which mounts the modal globally). The panel's props (`agent`, `onSubmit`, `onCancel`, `onRequestNewIdentity`, `onRequestNewMemory`, `initialFormState`) are easy to fixture.
+
+---
+
+## 4. Test plan
+
+Each test sets up:
+```ts
+beforeEach(() => {
+    vi.clearAllMocks();
+    // Default identities list with one bound Claude identity
+    vi.mocked(RpcApi.ListIdentityBundlesCommand).mockResolvedValue([
+        { id: "ident-work", name: "Work", ...timestamps },
+    ]);
+    vi.mocked(RpcApi.ListMemoriesCommand).mockResolvedValue([
+        { id: "mem-notes", name: "Notes", ...timestamps },
+    ]);
+    vi.mocked(RpcApi.ListIdentityBindingsCommand).mockResolvedValue([
+        { identity_id: "ident-work", provider: "claude", account_id: "acc-1" },
+    ]);
+    vi.mocked(RpcApi.ListNamedAgentsCommand).mockResolvedValue([]);
+});
+```
+
+### 4.1 Regression test (the §6.10 must-have)
+
+```ts
+it("changing Memory does not reset auth state to Connect", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(() => (
+        <AgentLaunchModalPanel
+            agent={claudeAgent}
+            onSubmit={onSubmit}
+            onCancel={() => {}}
+        />
+    ));
+
+    // Wait for the initial loads to settle + auto-pick to run.
+    await screen.findByRole("combobox", { name: /identity bundle/i });
+
+    // With "Work" auto-picked + binding for "claude" present, the
+    // Connect panel should NOT be visible — Launch should be enabled
+    // once a name is typed.
+    expect(screen.queryByText(/Connect with Claude/i)).not.toBeInTheDocument();
+
+    await user.type(screen.getByLabelText(/agent name/i), "alpha");
+    const launchBtn = screen.getByRole("button", { name: /launch/i });
+    expect(launchBtn).not.toBeDisabled();
+
+    // The regression repro: change Memory selection.
+    await user.selectOptions(
+        screen.getByRole("combobox", { name: /memory bundle/i }),
+        "mem-notes",
+    );
+
+    // Assertion: auth state stays ready. Connect panel doesn't reappear.
+    // Launch button stays enabled. The exact bug pinned.
+    expect(screen.queryByText(/Connect with Claude/i)).not.toBeInTheDocument();
+    expect(launchBtn).not.toBeDisabled();
+});
+```
+
+### 4.2 Adjacent regression tests
+
+| Scenario | Assertion |
+|---|---|
+| Form mounts with no identity selected, identities list returns a non-blank bundle | Auto-pick fires; dropdown shows that bundle selected; binding fetch fires; Launch enables once name typed. |
+| Form mounts via continuation with legacy `identity_id="blank"` | Identity dropdown is editable (not locked); Launch disabled until user picks. |
+| User types name, picks Identity, picks Memory, clicks Launch | `onSubmit` called with the right payload (instanceName, identityId, memoryId, …). |
+| Backend emits `identitybundlebindings:changed:ident-work` mid-modal | View refetches and dispatches `BindingsChanged`; selector updates. |
+| User clicks "+ New Identity" with current Memory selection | Picker callback receives the live snapshot (name, runtime, image, identityId, memoryId) — codex's PR #910 round 6/7 finding pinned. |
+| OAuth success path: panel reaches `kind: "ready"` → `identityId` swaps to the new bundle, `loadIdentities` re-runs | Dropdown shows the new bundle; Connect panel goes away. |
+
+Goal: **6–8 focused tests, ~250 LOC total**. Each test is one specific regression or one specific happy path.
+
+### 4.3 What we deliberately don't test in this suite
+
+- Full visual rendering / CSS — that's what manual smoke + Storybook (if we ever add it) catches.
+- Real RPC round-trips — that's what unit tests for the backend handlers catch.
+- Multi-window / pane integration — out of scope for jsdom.
+- Performance / large-list rendering — separate concern.
+
+---
+
+## 5. Implementation plan
+
+1. Add deps:
+   ```
+   npm i -D @solidjs/testing-library @testing-library/user-event @testing-library/jest-dom jsdom
+   ```
+2. Update `vitest.config.ts`:
+   ```ts
+   test: {
+       environment: "jsdom",
+       setupFiles: ["./test/vitest-setup.ts"],
+       ...
+   }
+   ```
+3. Create `test/vitest-setup.ts`:
+   ```ts
+   import "@testing-library/jest-dom/vitest";
+   ```
+4. Create `frontend/app/view/agent/components/AgentLaunchModal.integration.test.tsx` with the suite from §4.
+5. Wire CI: `npm test` already runs Vitest — no new pipeline.
+
+---
+
+## 6. Out of scope (deferred)
+
+### 6.1 Real Playwright/WebDriver against CEF
+
+If we want full end-to-end coverage (real CEF + real srv + real DOM events), the path is:
+1. Add `@playwright/test`.
+2. Write a CEF launcher fixture: spawn `agentmux-portable/agentmux.exe` with a temp data dir, capture the dev-tools port from stdout, connect Playwright via `chromium.connectOverCDP`.
+3. Stub the srv sidecar OR run it with a clean SQLite for each test.
+4. Implement per-test isolation: data dir per worker, port allocation, cleanup.
+5. CI: Windows runner already supports it; Linux needs Xvfb; macOS needs xvfb-run-equivalent or headless framework.
+
+This is a 1-2 week build-out and gates by it: separate PR, separate spec. Not blocking Stage 2 completion.
+
+### 6.2 Visual regression / screenshot diffing
+
+Not enabled today. Would need Percy / Chromatic / Playwright snapshot. Separate concern.
+
+### 6.3 The `recordDispatch` audit ring (§6.8 of the launch-modal spec)
+
+Wiring `launch-flow-store` through `command-source.ts` so transitions show in the diag panel. Not test infrastructure — separate, mechanical follow-up.
+
+---
+
+## 7. Best-practice references
+
+- [SolidJS testing guide](https://docs.solidjs.com/guides/testing) — canonical setup steps, why `solid-js` must be loaded once (Vite/Node duplication trap).
+- [`@solidjs/testing-library` npm](https://www.npmjs.com/package/@solidjs/testing-library) — `render` API, `testEffect` for reactivity assertions.
+- [Vitest browser/component testing](https://vitest.dev/guide/browser/component-testing) — alternative real-browser mode if jsdom limitations bite (e.g. layout-dependent assertions); not needed for this suite.
+- [Testing Library — "tests resemble usage"](https://testing-library.com/docs/solid-testing-library/intro/) — the guiding principle for what to assert (DOM + user-facing semantics, not implementation details).
+- `userEvent.setup()` recommended over the older fire-event style — closer to real user input timing.
+
+---
+
+## 8. Acceptance criteria
+
+1. `npm test` runs the new integration suite alongside existing Vitest unit tests; both pass.
+2. The §4.1 regression test fails on Stage 0 code (before the lift) and passes on `main` (Stage 1+ shipped).
+3. CI green; no new infrastructure beyond `package.json` dev deps + a tiny `vitest-setup.ts`.
+4. Suite runs in under 10 seconds locally.

--- a/frontend/app/store/launch-flow-state/reducer.test.ts
+++ b/frontend/app/store/launch-flow-state/reducer.test.ts
@@ -371,6 +371,157 @@ describe("launch-flow-state reducer", () => {
         });
     });
 
+    describe("Auth state (folded-in)", () => {
+        it("initial auth.kind is idle", () => {
+            const s = initialState();
+            expect(s.auth.kind).toBe("idle");
+        });
+
+        it("Auth Selected drives inner reducer + updates outer state", () => {
+            const r = update(initialState(), {
+                type: "Auth",
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+            });
+            // SelectionKind for "needs-bundle" → "unauthenticated"
+            expect(r.state.auth.kind).toBe("unauthenticated");
+            expect(r.state.auth.providerId).toBe("claude");
+        });
+
+        it("Auth no-op (same inner state) returns the same outer state", () => {
+            const s0 = update(initialState(), {
+                type: "Auth",
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+            }).state;
+            // Re-dispatching the same selection is the inner reducer's
+            // own no-op surface. We just verify the outer wrapper
+            // doesn't fabricate a state-change either.
+            const r = update(s0, {
+                type: "Auth",
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+            });
+            expect(r.state.auth).toBe(s0.auth);
+        });
+
+        it("inner events are wrapped + surfaced via outer ReducerResult.events", () => {
+            // Drive the inner machine into a state where it emits an
+            // event. `Connect` from unauthenticated kicks off the
+            // OAuth start RPC via `StartAuth` event.
+            let s = update(initialState(), {
+                type: "Auth",
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+            }).state;
+            const r = update(s, { type: "Auth", cmd: { type: "ConnectClicked" } });
+            // Outer events should contain at least one wrapped Auth
+            // event. Spot-check it's tagged correctly.
+            expect(r.events.length).toBeGreaterThan(0);
+            for (const e of r.events) {
+                expect(e.type).toBe("Auth");
+            }
+        });
+    });
+
+    describe("Cross-product: auth × form (the §6.9 regression suite)", () => {
+        // Build an "auth ready" state — the bug we shipped Stage 1
+        // to fix is "memory change after auth-ready resets the
+        // auth back to Connect". With auth folded into the slice,
+        // pure form-field commands must NEVER touch state.auth.
+        const setupReady = (): LaunchFlowState => {
+            let s = update(initialState(), {
+                type: "Auth",
+                cmd: {
+                    type: "Selected",
+                    providerId: "claude",
+                    bundleId: "ident-work",
+                    outcome: "ready",
+                },
+            }).state;
+            return s;
+        };
+
+        it("auth.kind survives NameChanged", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, { type: "NameChanged", name: "alpha" }).state;
+            expect(s.auth).toBe(before); // same object identity
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("auth.kind survives MemoryChanged — THE original repro", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, { type: "MemoryChanged", memoryId: "mem-notes" }).state;
+            expect(s.auth).toBe(before);
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("auth.kind survives RuntimeChanged + ImageChanged", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, { type: "RuntimeChanged", runtime: "container" }).state;
+            s = update(s, { type: "ImageChanged", image: "alpine:latest" }).state;
+            expect(s.auth).toBe(before);
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("auth.kind survives IdentitiesLoaded + MemoriesLoaded", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, {
+                type: "IdentitiesLoaded",
+                list: [ident("ident-work", "Work")],
+            }).state;
+            s = update(s, {
+                type: "MemoriesLoaded",
+                list: [mem("mem-notes", "Notes")],
+            }).state;
+            expect(s.auth).toBe(before);
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("auth.kind survives BindingsLoaded + BindingsChanged", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, {
+                type: "BindingsLoaded",
+                identityId: "ident-work",
+                bindings: [binding("ident-work", "claude")],
+            }).state;
+            s = update(s, {
+                type: "BindingsChanged",
+                identityId: "ident-work",
+                bindings: [binding("ident-work", "claude")],
+            }).state;
+            expect(s.auth).toBe(before);
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("auth.kind survives SubmitClicked + SubmitFailed", () => {
+            let s = setupReady();
+            const before = s.auth;
+            s = update(s, { type: "SubmitClicked" }).state;
+            s = update(s, { type: "SubmitFailed", error: "no creds on disk" }).state;
+            expect(s.auth).toBe(before);
+            expect(s.auth.kind).toBe("ready");
+        });
+
+        it("form state survives Auth Connect (auth path doesn't touch form)", () => {
+            let s = update(initialState(), { type: "NameChanged", name: "carry-name" }).state;
+            s = update(s, { type: "IdentityChanged", identityId: "ident-a" }).state;
+            s = update(s, { type: "MemoryChanged", memoryId: "mem-a" }).state;
+            const formBefore = s.form;
+            // Drive auth machine
+            s = update(s, {
+                type: "Auth",
+                cmd: { type: "Selected", providerId: "claude", bundleId: "", outcome: "needs-bundle" },
+            }).state;
+            s = update(s, { type: "Auth", cmd: { type: "ConnectClicked" } }).state;
+            expect(s.form).toBe(formBefore);
+            expect(s.form.name).toBe("carry-name");
+            expect(s.form.identityId).toBe("ident-a");
+            expect(s.form.memoryId).toBe("mem-a");
+        });
+    });
+
     describe("canSubmit cross-product", () => {
         const baseAuth = { authReady: true, nameValid: true };
 

--- a/frontend/app/store/launch-flow-state/reducer.ts
+++ b/frontend/app/store/launch-flow-state/reducer.ts
@@ -11,6 +11,8 @@
  * `docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md`.
  */
 
+import { update as authUpdate } from "@/app/view/agent/auth/auth-state";
+
 import type {
     LaunchFlowCommand,
     LaunchFlowEvent,
@@ -233,6 +235,26 @@ export function update(
             return {
                 state: { ...state, submit: { inFlight: false, error: command.error } },
                 events: [],
+            };
+        }
+
+        case "Auth": {
+            // Delegate to the auth-state reducer. State change → new
+            // outer state with the inner result merged in. Events get
+            // wrapped so the view's outer event sink can pattern-
+            // match on `{ type: "Auth", event }` to dispatch the
+            // side-effect (RPC fire, openExternal, etc.).
+            const inner = authUpdate(state.auth, command.cmd);
+            const wrappedEvents: LaunchFlowEvent[] = inner.events.map((event) => ({
+                type: "Auth" as const,
+                event,
+            }));
+            if (inner.state === state.auth) {
+                return { state, events: wrappedEvents };
+            }
+            return {
+                state: { ...state, auth: inner.state },
+                events: wrappedEvents,
             };
         }
 

--- a/frontend/app/store/launch-flow-state/types.ts
+++ b/frontend/app/store/launch-flow-state/types.ts
@@ -2,20 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Type definitions for the launch-flow-state reducer (Stage 2a of
- * docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).
+ * Type definitions for the launch-flow-state reducer.
+ * Spec: docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md.
  *
- * Owns the editable Launch-modal surface as a single state object:
+ * Owns the entire editable Launch-modal surface as a single state
+ * object:
  *   - `form` — name, runtime, image, identity/memory/continue selections
  *   - `identities` / `memories` — loaded bundle lists + load status
- *   - `bindings` — per-identity binding cache (push-updatable in
- *     stage 2c via a backend event subscription)
+ *   - `bindings` — per-identity binding cache (push-updated via
+ *     backend `identitybundlebindings:changed:<id>` events)
  *   - `submit` — submit-in-flight + last error
- *
- * Auth state is intentionally OUT of scope for stage 2a — it stays
- * in the existing `AuthFlowController` (lifted to AgentLaunchModal
- * in Stage 1). A later stage can fold auth into this store if the
- * cross-product simplifies further.
+ *   - `auth` — folded-in OAuth state machine (Stage 2d) so the
+ *     (auth × form-field-changed) cross-product is testable
+ *     against a single pure reducer. The `Auth` command wraps
+ *     `AuthCommand`s from auth-state.ts and delegates to that
+ *     module's `update()`.
  *
  * Pure reducer — `update(state, command) → { state, events }`. The
  * view mounts the store, dispatches commands, and runs emitted
@@ -24,6 +25,9 @@
  * Reference: `frontend/app/store/browser-pane-state/types.ts` is the
  * established slice shape this file mirrors.
  */
+
+import type { AuthCommand, AuthEvent, AuthState } from "@/app/view/agent/auth/auth-state";
+import { initialState as initialAuthState } from "@/app/view/agent/auth/auth-state";
 
 /** Editable Launch-modal form fields. Empty strings mean "no
  *  selection"; the view's submit predicate blocks Launch until the
@@ -92,6 +96,11 @@ export interface LaunchFlowState {
      *  fast Connect click doesn't slip through the race. */
     bindingsLoading: Record<string, boolean>;
     submit: SubmitStatus;
+    /** Folded-in OAuth state machine. The `Auth` command wraps an
+     *  `AuthCommand` from auth-state.ts; the reducer delegates to
+     *  that module's `update()` so this slice stays the single
+     *  source of truth (Stage 2d). */
+    auth: AuthState;
     /** Terminal flag — set by `Closed`. Post-close commands are no-ops. */
     closed: boolean;
 }
@@ -103,6 +112,7 @@ export const initialState = (): LaunchFlowState => ({
     bindings: {},
     bindingsLoading: {},
     submit: initialSubmit(),
+    auth: initialAuthState(),
     closed: false,
 });
 
@@ -146,6 +156,11 @@ export type LaunchFlowCommand =
     | { type: "SubmitClicked" }
     | { type: "SubmitSucceeded" }
     | { type: "SubmitFailed"; error: string }
+    /** Wrapped auth-state command. Reducer delegates to the auth
+     *  module's pure `update()`; any auth events the inner reducer
+     *  emits get wrapped as `AuthEvent` and surfaced on the outer
+     *  ReducerResult. */
+    | { type: "Auth"; cmd: AuthCommand }
     /** Terminal. */
     | { type: "Closed" };
 
@@ -155,7 +170,11 @@ export type LaunchFlowCommand =
 export type LaunchFlowEvent =
     /** Fetch bindings for an identity that just became selected and
      *  has no cached entry. */
-    | { type: "FetchBindings"; identityId: string };
+    | { type: "FetchBindings"; identityId: string }
+    /** Pass-through of an auth-state event so the view can run the
+     *  side-effect (RPC, openExternal, etc.). Wraps `AuthEvent` from
+     *  auth-state.ts. */
+    | { type: "Auth"; event: AuthEvent };
 
 export interface ReducerResult {
     state: LaunchFlowState;


### PR DESCRIPTION
## Summary

Stage 2d.1 of [SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md](../blob/agenta/launch-modal-state-machine-stage-2d/docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).

- `LaunchFlowState.auth: AuthState` field added. Reducer delegates `{ type: "Auth", cmd }` commands to auth-state's pure `update()`.
- §6.9 cross-product test suite (8 tests) — pins the memory-change-resets-auth bug as a pure-reducer regression.
- Integration-test spec ships alongside ([SPEC_LAUNCH_MODAL_INTEGRATION_TESTS_2026_05_19.md](../blob/agenta/launch-modal-state-machine-stage-2d/docs/specs/SPEC_LAUNCH_MODAL_INTEGRATION_TESTS_2026_05_19.md)) — documents the Vitest + `@solidjs/testing-library` + jsdom approach for §6.10 (the full Playwright-against-CEF story is out of scope and explicitly justified in §1 of that spec).

## NOT in this PR

- View migration to read `flow.state.auth.kind` — Stage 2d.2.
- Integration test implementation — Stage 2g (once 2d.2 lands so the view reads the slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)