### PR TITLE
feat(launch-modal): route auth state through the slice (Stage 2d.2, closes spec §6.7)

### DIFF
--- a/.changesets/1779207561-feat-launch-modal-route-auth-state-through-slice-stage-2d-2.md
+++ b/.changesets/1779207561-feat-launch-modal-route-auth-state-through-slice-stage-2d-2.md
@@ -1,0 +1,13 @@
+---
+type: patch
+---
+
+feat(launch-modal): route auth state through the slice (Stage 2d.2)
+
+AuthFlowController accepts optional `externalGetState` +
+`externalDispatch` hooks. AgentLaunchModal wires them so the
+controller reads + writes auth state via the launch-flow-state
+slice. `flow.state.auth` is now the single source of truth;
+internal signal stays as a fallback for tests + standalone use.
+
+§6.7 satisfied: all Launch modal state is owned by the slice.

--- a/frontend/app/view/agent/auth/auth-flow-controller.ts
+++ b/frontend/app/view/agent/auth/auth-flow-controller.ts
@@ -128,11 +128,25 @@ export interface AuthFlowOptions {
         setTimeout: (fn: () => void, ms: number) => unknown;
         clearTimeout: (handle: unknown) => void;
     };
+    /** Externalize state ownership. When provided, the controller
+     *  reads `state()` from `externalGetState` and writes via
+     *  `externalDispatch` (which is expected to run the same
+     *  pure `update()` reducer the controller would use internally).
+     *  Used by AgentLaunchModal to fold auth state into the
+     *  launch-flow-state slice (Stage 2d of
+     *  SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md). When omitted
+     *  (the default — preserves test/standalone use), the controller
+     *  uses an internal Solid signal. */
+    externalGetState?: () => AuthState;
+    externalDispatch?: (cmd: AuthCommand) => void;
 }
 
 export class AuthFlowController {
+    /** Internal Solid signal — fallback state holder for tests and
+     *  any caller that doesn't externalize state via `opts.externalGetState`.
+     *  Untouched when externalization is wired. */
     private _state = createSignal<AuthState>(initialState());
-    state: Accessor<AuthState> = this._state[0];
+    state: Accessor<AuthState>;
 
     private rpc: AuthRpc;
     private pollIntervalMs: number;
@@ -145,6 +159,7 @@ export class AuthFlowController {
      *  `auth.submitapikey` completion from landing after the user
      *  swapped to a different bundle and submitted again. */
     private actionToken = 0;
+    private externalDispatch: ((cmd: AuthCommand) => void) | null;
 
     constructor(opts: AuthFlowOptions = {}) {
         this.rpc = opts.rpc ?? defaultAuthRpc;
@@ -153,6 +168,16 @@ export class AuthFlowController {
             setTimeout: (fn, ms) => setTimeout(fn, ms) as unknown,
             clearTimeout: (h) => clearTimeout(h as ReturnType<typeof setTimeout>),
         };
+        // State accessor + dispatch path. If the caller injected
+        // externalGetState + externalDispatch, route through them so
+        // the launch-flow-state slice can be the single source of
+        // truth. Otherwise keep the internal signal for back-compat.
+        if (opts.externalGetState) {
+            this.state = opts.externalGetState;
+        } else {
+            this.state = this._state[0];
+        }
+        this.externalDispatch = opts.externalDispatch ?? null;
     }
 
     /** Dispatch a command into the reducer, project state.
@@ -163,6 +188,13 @@ export class AuthFlowController {
      *  dispatch and silently invalidate any session the caller
      *  had just started. */
     dispatch(command: AuthCommand): void {
+        if (this.externalDispatch) {
+            // External dispatch (e.g. through launch-flow-state) is
+            // responsible for running the same pure `update()` reducer.
+            // We don't touch `_state` in this path.
+            this.externalDispatch(command);
+            return;
+        }
         untrack(() => {
             const prev = this._state[0]();
             const result = update(prev, command);

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -302,9 +302,17 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
     // controller's lifetime spans the whole modal mount, so a brief
     // re-render that unmounts the conditionally-rendered Connect
     // panel no longer destroys in-flight auth state.
-    const authController = new AuthFlowController();
+    // Auth state is owned by the slice (Stage 2d.2). The controller
+    // continues to orchestrate side-effects (OAuth start, polling,
+    // openExternal) but reads + writes state through the slice via
+    // the externalGetState / externalDispatch hooks. So
+    // `flow.state.auth` is the single source of truth.
+    const authController = new AuthFlowController({
+        externalGetState: () => flow.state.auth,
+        externalDispatch: (cmd) => flow.dispatch({ type: "Auth", cmd }),
+    });
     onCleanup(() => authController.dispose());
-    const authStateKind = () => authController.state().kind;
+    const authStateKind = () => flow.state.auth.kind;
     const onBundleCreated = (bundleId: string) => {
         // The new bundle was just persisted backend-side. Switch the
         // dropdown to it AND refetch the identities list so the new


### PR DESCRIPTION
## Summary

Closes [§6.7](../blob/agenta/launch-modal-state-machine-stage-2d-2/docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md) — all Launch modal state is now owned by `useLaunchFlowStore`. `flow.state.auth` is the single source of truth; the controller reads + writes through it via the new `externalGetState`/`externalDispatch` injection.

- 64 existing AuthFlowController tests pass (no signature break — the internal signal is the back-compat fallback).
- 59 launch-flow-state tests pass.
- tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)