### PR TITLE
feat(launch-flow-state): wire recordDispatch audit ring (closes spec §6.8)

### DIFF
--- a/.changesets/1779209066-feat-launch-flow-state-record-dispatch-audit-ring-closes-6-8.md
+++ b/.changesets/1779209066-feat-launch-flow-state-record-dispatch-audit-ring-closes-6-8.md
@@ -1,0 +1,14 @@
+---
+type: patch
+---
+
+feat(launch-flow-state): wire recordDispatch audit ring (closes §6.8)
+
+createLaunchFlowStore now appends every dispatch to the global
+audit ring (frontend/app/store/command-source.ts). Each entry tags:
+`slice: "launch-flow-state"`, `key: null`, the command + emitted
+events + source ("user" default, "system" override). The diag panel
+gets transition history for free.
+
+Closes the final unchecked acceptance criterion of
+docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md.

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -187,6 +187,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.36.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.35.0 | 2026-05-19 | 164.6 MiB | 345.6 MiB | |
 | 0.33.835 | 2026-05-13 | 164.2 MiB | 344.3 MiB | |
 | 0.33.831 | 2026-05-13 | 164.1 MiB | 344.1 MiB | |

--- a/frontend/app/store/launch-flow-state/launch-flow-store.test.ts
+++ b/frontend/app/store/launch-flow-state/launch-flow-store.test.ts
@@ -1,9 +1,14 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __resetDispatchLog, getRecentDispatches } from "../command-source";
 import { createLaunchFlowStore } from "./launch-flow-store";
 import type { LaunchFlowEvent } from "./types";
+
+beforeEach(() => {
+    __resetDispatchLog();
+});
 
 describe("createLaunchFlowStore", () => {
     it("starts in initial state", () => {
@@ -45,5 +50,46 @@ describe("createLaunchFlowStore", () => {
         dispatch({ type: "NameChanged", name: "x" });
         dispatch({ type: "NameChanged", name: "x" }); // same → no-op
         expect(sink).not.toHaveBeenCalled();
+    });
+
+    describe("recordDispatch audit ring (§6.8)", () => {
+        it("appends every dispatch to the global ring", () => {
+            const { dispatch } = createLaunchFlowStore();
+            dispatch({ type: "NameChanged", name: "alpha" });
+            dispatch({ type: "RuntimeChanged", runtime: "container" });
+            const records = getRecentDispatches();
+            expect(records).toHaveLength(2);
+            expect(records[0].slice).toBe("launch-flow-state");
+            expect(records[0].key).toBeNull();
+            expect((records[0].command as { type: string }).type).toBe("NameChanged");
+            expect((records[1].command as { type: string }).type).toBe("RuntimeChanged");
+        });
+
+        it("captures emitted events alongside the command", () => {
+            const { dispatch } = createLaunchFlowStore();
+            dispatch({ type: "IdentityChanged", identityId: "ident-a" });
+            const records = getRecentDispatches();
+            expect(records[0].events).toEqual([
+                { type: "FetchBindings", identityId: "ident-a" },
+            ]);
+        });
+
+        it("tags source — defaults to 'user', honors explicit override", () => {
+            const { dispatch } = createLaunchFlowStore();
+            dispatch({ type: "NameChanged", name: "alpha" });
+            dispatch({ type: "IdentitiesLoading" }, "system");
+            const records = getRecentDispatches();
+            expect(records[0].source).toBe("user");
+            expect(records[1].source).toBe("system");
+        });
+
+        it("records no-op dispatches too (audit-completeness)", () => {
+            const { dispatch } = createLaunchFlowStore();
+            dispatch({ type: "NameChanged", name: "x" });
+            dispatch({ type: "NameChanged", name: "x" }); // same → no-op
+            // Audit ring records all dispatches, including no-ops, so
+            // diag-panel users can see attempted-but-rejected transitions.
+            expect(getRecentDispatches()).toHaveLength(2);
+        });
     });
 });

--- a/frontend/app/store/launch-flow-state/launch-flow-store.ts
+++ b/frontend/app/store/launch-flow-state/launch-flow-store.ts
@@ -11,11 +11,15 @@
  * no register/unregister, just `createLaunchFlowStore()` returning
  * `{ state, dispatch }`.
  *
- * Stage 2b of `docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md`.
+ * Every dispatch is recorded into the global audit ring (§6.8 of
+ * SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md) so the diag panel
+ * + tests can replay transitions. The ring stores command + emitted
+ * events; state diffs are reconstructable by replaying.
  */
 
 import { createStore, reconcile, unwrap, type Store } from "solid-js/store";
 
+import { type CommandSource, recordDispatch } from "../command-source";
 import { update } from "./reducer";
 import { initialState, type LaunchFlowCommand, type LaunchFlowEvent, type LaunchFlowState } from "./types";
 
@@ -27,8 +31,12 @@ export interface LaunchFlowStore {
     /** Run a command through the reducer. Diffs old→new via Solid's
      *  `reconcile` so unchanged subtrees keep the same proxy
      *  identity (no spurious re-renders for fields the command
-     *  didn't touch). Emitted events are forwarded to `eventSink`. */
-    dispatch: (cmd: LaunchFlowCommand) => void;
+     *  didn't touch). Emitted events are forwarded to `eventSink`.
+     *  Optional `source` tags the recordDispatch entry; defaults to
+     *  `"user"` since most dispatches come from form interactions.
+     *  System-driven dispatches (initial resource loads, event-sink
+     *  followups) should pass `"system"`. */
+    dispatch: (cmd: LaunchFlowCommand, source?: CommandSource) => void;
 }
 
 export interface LaunchFlowStoreOptions {
@@ -41,12 +49,20 @@ export function createLaunchFlowStore(
 ): LaunchFlowStore {
     const [state, setState] = createStore<LaunchFlowState>(initialState());
     const sink = opts.eventSink ?? (() => {});
-    const dispatch = (cmd: LaunchFlowCommand): void => {
+    const dispatch = (cmd: LaunchFlowCommand, source: CommandSource = "user"): void => {
         const snapshot = unwrap(state);
         const result = update(snapshot, cmd);
         if (result.state !== snapshot) {
             setState(reconcile(result.state));
         }
+        recordDispatch({
+            slice: "launch-flow-state",
+            key: null,
+            command: cmd,
+            events: result.events,
+            source,
+            at: Date.now(),
+        });
         for (const event of result.events) {
             sink(event);
         }


### PR DESCRIPTION
## Summary

Closes the last §6 acceptance criterion of [SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md](../blob/agenta/launch-flow-state-record-dispatch/docs/specs/SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md).

Every dispatch through `createLaunchFlowStore` now lands in the global audit ring (`frontend/app/store/command-source.ts`). Same pattern as `browser-pane-state-store`. The diag panel + tests get transition history for free.

- Source tag defaults to `"user"`, overridable to `"system"` for system-driven dispatches.
- +4 audit-ring unit tests; 63/63 slice tests pass.

Spec is now 100% complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)