### PR TITLE
feat(voice): per-pane mic button in frame header (Phase 2)

### DIFF
--- a/.changesets/1779209427-feat-voice-per-pane-mic-button-in-frame-header-phase-2-zi04.md
+++ b/.changesets/1779209427-feat-voice-per-pane-mic-button-in-frame-header-phase-2-zi04.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(voice): per-pane mic button in frame header (Phase 2)

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -22,6 +22,7 @@ import { IconButton, ToggleIconButton } from "@/element/iconbutton";
 import { BlockStatsBadge } from "@/element/blockstats";
 import { MagnifyIcon } from "@/element/magnify";
 import { MenuButton } from "@/element/menubutton";
+import { MicButton } from "@/app/element/MicButton";
 import { NodeModel } from "@/layout/index";
 import * as util from "@/util/util";
 import { computeBgStyleFromMeta } from "@/util/waveutil";
@@ -196,6 +197,12 @@ function EndIcons(props: {
                 <For each={endIconButtons()}>
                     {(button) => <IconButton decl={button} />}
                 </For>
+            </Show>
+            <Show when={props.viewModel?.voiceHandle}>
+                <MicButton
+                    blockId={props.nodeModel.blockId}
+                    handle={props.viewModel.voiceHandle!()}
+                />
             </Show>
             <Show when={ephemeral()} fallback={
                 <OptMagnifyButton

--- a/frontend/app/element/MicButton.tsx
+++ b/frontend/app/element/MicButton.tsx
@@ -2,22 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ToggleIconButton } from "@/app/element/iconbutton";
-import { getVoiceSession } from "@/app/hook/useVoiceInput";
+import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { Show, type JSX } from "solid-js";
 import "./MicButton.scss";
 
-export function MicButton(): JSX.Element {
+interface MicButtonProps {
+    blockId: string;
+    handle: PaneVoiceHandle;
+}
+
+export function MicButton(props: MicButtonProps): JSX.Element {
     const voice = getVoiceSession();
 
-    // Wrap toggleListening into the SignalAtom._set slot so ToggleIconButton
-    // can call _set(!active()) to trigger the toggle.
-    const activeAtom = Object.assign(() => voice.isListening(), {
-        _set: (_v: boolean) => voice.toggleListening(),
+    // Active iff this pane owns the current voice session.
+    const isActiveHere = () => voice.isListening() && voice.currentTargetId() === props.blockId;
+
+    const handleClick = () => {
+        // Snapshot pre-click state — registerPane below will overwrite
+        // currentTargetId, so we need to know whether THIS pane already
+        // owned the session before retargeting.
+        const wasListening = voice.isListening();
+        const wasMine = wasListening && voice.currentTargetId() === props.blockId;
+        // Always bind this pane as the target; the session reads
+        // `activeHandle` on every recognition event, so a click on
+        // another pane's mic instantly retargets.
+        voice.registerPane(props.blockId, props.handle);
+        if (!wasListening) {
+            voice.toggleListening(); // start
+        } else if (wasMine) {
+            voice.toggleListening(); // stop (same pane)
+        }
+        // else: was listening to another pane → registerPane already
+        //       retargeted; do NOT toggle (would stop the session).
+    };
+
+    // Wrap our click handler into the SignalAtom._set slot so
+    // ToggleIconButton can call _set(!active()) to dispatch the click.
+    // We ignore the boolean it passes — we drive state ourselves.
+    const activeAtom = Object.assign(() => isActiveHere(), {
+        _set: (_v: boolean) => handleClick(),
     });
 
     return (
         <Show when={voice.isAvailable()}>
-            <div class="mic-button-wrap" classList={{ "mic-active": voice.isListening() }}>
+            <div class="mic-button-wrap" classList={{ "mic-active": isActiveHere() }}>
                 <ToggleIconButton
                     decl={{
                         elemtype: "toggleiconbutton",

--- a/frontend/app/hook/useVoiceInput.ts
+++ b/frontend/app/hook/useVoiceInput.ts
@@ -10,9 +10,13 @@ export interface PaneVoiceHandle {
 
 export interface VoiceSession {
     isListening: SignalAtom<boolean>;
+    /** blockId of the pane currently receiving voice output (null when no
+     *  pane is targeted). Each pane's mic button reads this to determine
+     *  whether *it* owns the active session — multi-pane safe. */
+    currentTargetId: SignalAtom<string | null>;
     isAvailable: () => boolean;
     toggleListening: () => void;
-    registerPane: (handle: PaneVoiceHandle) => void;
+    registerPane: (blockId: string, handle: PaneVoiceHandle) => void;
 }
 
 const RESTART_DELAY_MS = 100;
@@ -20,10 +24,12 @@ const RESTART_DELAY_MS = 100;
 function createVoiceSession(): VoiceSession {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
     const isListening = createSignalAtom(false);
+    const currentTargetId = createSignalAtom<string | null>(null);
 
     if (!SR) {
         return {
             isListening,
+            currentTargetId,
             isAvailable: () => false,
             toggleListening: () => {},
             registerPane: () => {},
@@ -92,6 +98,10 @@ function createVoiceSession(): VoiceSession {
                 interimActive = false;
             }
             isListening._set(false);
+            // Clear target so per-pane mic buttons reflect "no active
+            // session" instead of leaving the previous target's button
+            // stuck in active state.
+            currentTargetId._set(null);
         } else {
             try {
                 recognition.start();
@@ -104,9 +114,13 @@ function createVoiceSession(): VoiceSession {
 
     return {
         isListening,
+        currentTargetId,
         isAvailable: () => true,
         toggleListening,
-        registerPane: (handle) => { activeHandle = handle; },
+        registerPane: (blockId, handle) => {
+            activeHandle = handle;
+            currentTargetId._set(blockId);
+        },
     };
 }
 

--- a/frontend/app/store/keymodel.ts
+++ b/frontend/app/store/keymodel.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { focusManager } from "@/app/store/focusManager";
+import { getVoiceSession } from "@/app/hook/useVoiceInput";
 import {
     atoms,
     createBlock,
@@ -556,6 +557,33 @@ function registerGlobalKeys() {
             return true;
         }
         setIsTermMultiInput(!curMI);
+        return true;
+    });
+    // Ctrl+Shift+V — toggle voice input on the currently focused pane.
+    // Mirrors MicButton click semantics: bind target first, then start
+    // OR stop OR retarget. No-op on panes whose ViewModel doesn't
+    // expose voiceHandle (e.g. browser, editor). Spec:
+    // docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md §6.
+    globalKeyMap.set("Ctrl:Shift:v", () => {
+        const blockId = getFocusedBlockInStaticTab();
+        if (!blockId) return true;
+        const bcm = getBlockComponentModel(blockId);
+        const vm: any = bcm?.viewModel;
+        if (!vm?.voiceHandle) {
+            // No-op on non-supporting panes. (Could surface a toast in Phase 3.)
+            return true;
+        }
+        const voice = getVoiceSession();
+        if (!voice.isAvailable()) return true;
+        const wasListening = voice.isListening();
+        const wasMine = wasListening && voice.currentTargetId() === blockId;
+        voice.registerPane(blockId, vm.voiceHandle());
+        if (!wasListening) {
+            voice.toggleListening();
+        } else if (wasMine) {
+            voice.toggleListening();
+        }
+        // else: retarget without toggle (same logic as MicButton click)
         return true;
     });
     for (let idx = 1; idx <= 9; idx++) {

--- a/frontend/app/view/agent/agent-model.ts
+++ b/frontend/app/view/agent/agent-model.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { atoms, getApi, WOS } from "@/app/store/global";
@@ -36,6 +37,17 @@ export class AgentViewModel implements ViewModel {
     _setOverlayTab: ((tab: OverlayTab | null) => void) | null = null;
     // Last-used overlay tab — gear re-opens to whichever tab was active last.
     _lastOverlayTab: OverlayTab = "forge";
+
+    // Voice-input target ref. AgentFooter populates this on mount with a
+    // textarea-backed handle (and clears it on unmount). The exposed
+    // `voiceHandle` accessor below delegates to whatever's current —
+    // before AgentFooter mounts (or after it unmounts) it's a no-op.
+    voiceTargetRef: { current: PaneVoiceHandle | null } = { current: null };
+
+    voiceHandle = (): PaneVoiceHandle => ({
+        appendFinal: (text: string) => this.voiceTargetRef.current?.appendFinal(text),
+        setInterim: (text: string) => this.voiceTargetRef.current?.setInterim(text),
+    });
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.blockId = blockId;

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -748,6 +748,7 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                     onTyping={() => scrollToBottomFn?.()}
                     onStopAgent={commands.stopAgent}
                     getCompletions={commands.completions}
+                    viewModel={model}
                 />
             </div>
             {/* AgentActionBar (Add / Import / Export) lives in the

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -5,7 +5,9 @@
  * AgentFooter - Minimal Claude Code-style input
  */
 
-import { Show, createEffect, createMemo, createSignal, onCleanup, type JSX } from "solid-js";
+import { Show, createEffect, createMemo, createSignal, onCleanup, onMount, type JSX } from "solid-js";
+import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import type { AgentViewModel } from "../agent-model";
 import type { SlashCommand } from "../commands/types";
 import type { SessionStats, TurnTokens } from "../types";
 import { SlashAutocomplete } from "./SlashAutocomplete";
@@ -208,6 +210,13 @@ interface AgentFooterProps {
      * If absent, autocomplete is disabled.
      */
     getCompletions?: (prefix: string) => SlashCommand[];
+    /**
+     * AgentViewModel — used to register a textarea-backed
+     * PaneVoiceHandle so the frame-header mic button can write
+     * transcripts into the composer. Optional so tests / older
+     * callers that haven't been updated still type-check.
+     */
+    viewModel?: AgentViewModel;
 }
 
 export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
@@ -287,6 +296,49 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
             cb();
         });
     };
+
+    // ── Voice input handle ───────────────────────────────────────────
+    // Registers a textarea-backed PaneVoiceHandle on the AgentViewModel
+    // so the frame-header mic button can write voice transcripts into
+    // the composer. `baseValue` is the prefix the user typed (or the
+    // last appended-final state) — interim updates render *after* it
+    // without committing, final updates fold in and become the new
+    // base. Cleared on unmount.
+    onMount(() => {
+        const vm = props.viewModel;
+        if (!vm) return;
+        let baseValue = textareaRef?.value ?? "";
+        const handle: PaneVoiceHandle = {
+            appendFinal: (text) => {
+                const ta = textareaRef;
+                if (!ta) return;
+                // Re-snapshot in case the user typed between voice
+                // events — voice should append to current text, not
+                // overwrite what they manually added.
+                if (ta.value !== baseValue && !ta.value.startsWith(baseValue)) {
+                    baseValue = ta.value;
+                }
+                ta.value = baseValue + text + " ";
+                ta.dispatchEvent(new Event("input", { bubbles: true }));
+                baseValue = ta.value;
+            },
+            setInterim: (text) => {
+                const ta = textareaRef;
+                if (!ta) return;
+                if (ta.value !== baseValue && !ta.value.startsWith(baseValue)) {
+                    baseValue = ta.value;
+                }
+                ta.value = baseValue + text;
+                ta.dispatchEvent(new Event("input", { bubbles: true }));
+            },
+        };
+        vm.voiceTargetRef.current = handle;
+        onCleanup(() => {
+            if (vm.voiceTargetRef.current === handle) {
+                vm.voiceTargetRef.current = null;
+            }
+        });
+    });
 
     const handleSend = () => {
         if (!textareaRef) return;

--- a/frontend/app/view/agent/components/AgentFooter.tsx
+++ b/frontend/app/view/agent/components/AgentFooter.tsx
@@ -307,29 +307,41 @@ export const AgentFooter = (props: AgentFooterProps): JSX.Element => {
     onMount(() => {
         const vm = props.viewModel;
         if (!vm) return;
+        // Two pieces of state interleave with the user's manual typing:
+        //   * baseValue — the textarea content as of the last user-or-
+        //     final-voice event. Interim updates render AFTER it but
+        //     don't promote into it.
+        //   * lastVoiceWrite — the exact string we last wrote to the
+        //     textarea. If ta.value diverges from this between events,
+        //     the user typed something manually and we re-snapshot
+        //     baseValue from ta.value so the next voice event preserves
+        //     what they added.
+        //
+        // Earlier guard (`!startsWith(baseValue)`) never fired for the
+        // common case where the user APPENDED to existing content —
+        // their additions were silently clobbered by the next voice
+        // append. (reagent P1 on PR #930.)
         let baseValue = textareaRef?.value ?? "";
+        let lastVoiceWrite = baseValue;
         const handle: PaneVoiceHandle = {
             appendFinal: (text) => {
                 const ta = textareaRef;
                 if (!ta) return;
-                // Re-snapshot in case the user typed between voice
-                // events — voice should append to current text, not
-                // overwrite what they manually added.
-                if (ta.value !== baseValue && !ta.value.startsWith(baseValue)) {
-                    baseValue = ta.value;
-                }
-                ta.value = baseValue + text + " ";
+                if (ta.value !== lastVoiceWrite) baseValue = ta.value;
+                const next = baseValue + text + " ";
+                ta.value = next;
                 ta.dispatchEvent(new Event("input", { bubbles: true }));
-                baseValue = ta.value;
+                baseValue = next;
+                lastVoiceWrite = next;
             },
             setInterim: (text) => {
                 const ta = textareaRef;
                 if (!ta) return;
-                if (ta.value !== baseValue && !ta.value.startsWith(baseValue)) {
-                    baseValue = ta.value;
-                }
-                ta.value = baseValue + text;
+                if (ta.value !== lastVoiceWrite) baseValue = ta.value;
+                const next = baseValue + text;
+                ta.value = next;
                 ta.dispatchEvent(new Event("input", { bubbles: true }));
+                lastVoiceWrite = next;
             },
         };
         vm.voiceTargetRef.current = handle;

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -3,6 +3,7 @@
 
 import { Block } from "@/app/block/block";
 import { BlockNodeModel } from "@/app/block/blocktypes";
+import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { appHandleKeyDown } from "@/app/store/keymodel";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { RpcApi } from "@/app/store/rpc-api";
@@ -70,6 +71,7 @@ class TermViewModel implements ViewModel {
     isRestarting: SignalAtom<boolean>;
     agentRuntimeLabel: () => string | null;
     searchAtoms?: SearchAtoms;
+    voiceHandle: () => PaneVoiceHandle;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.viewType = "term";
@@ -286,6 +288,23 @@ class TermViewModel implements ViewModel {
                 title: title,
             };
             return [buttonDecl];
+        });
+
+        // Voice input handle — streams transcript characters into the
+        // PTY via the same controllerinput RPC that keystrokes use, so
+        // xterm input modes (echo, line-buffered, etc.) are honored.
+        // No interim preview: the terminal has no affordance for it.
+        this.voiceHandle = () => ({
+            appendFinal: (text: string) => {
+                const inputdata64 = stringToBase64(text);
+                RpcApi.ControllerInputCommand(TabRpcClient, {
+                    blockid: this.blockId,
+                    inputdata64,
+                    signame: "",
+                    termsize: undefined,
+                });
+            },
+            setInterim: () => { /* terminal has no preview affordance */ },
         });
 
         const initialShellProcStatus = services.BlockService.GetControllerStatus(blockId);

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -6,6 +6,7 @@
 import type { Placement } from "@floating-ui/dom";
 import type { Accessor, JSX } from "solid-js";
 import type { SignalAtom } from "@/util/util";
+import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import type * as rxjs from "rxjs";
 
 declare global {
@@ -455,6 +456,10 @@ declare global {
         giveFocus?: () => boolean;
         keyDownHandler?: (e: WaveKeyboardEvent) => boolean;
         dispose?: () => void;
+        /** Views that support voice input expose a handle accessor. Called
+         *  by BlockFrame_Header (to render the mic button) and by the
+         *  Ctrl+Shift+V global hotkey to retarget the voice session. */
+        voiceHandle?: () => PaneVoiceHandle;
     }
 
     type UpdaterStatus = "up-to-date" | "checking" | "available" | "downloading" | "ready" | "error" | "installing";


### PR DESCRIPTION
## Summary

Phase 2 of the voice-input initiative — wires the Phase 1 building blocks (#920) into actual pane chrome and adds per-view `voiceHandle` implementations for Terminal and Agent. Spec: [`docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md`](docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md).

### Changes

- **`useVoiceInput.ts`** — adds `currentTargetId: SignalAtom<string | null>` so each pane's mic button reflects ONLY its own active state. `registerPane` now takes `(blockId, handle)`; stopping the session clears the target.
- **`MicButton.tsx`** — accepts `{ blockId, handle }` props. Click logic: bind target, then start / stop (same pane) / retarget (other pane).
- **`BlockFrame_Header`** (`blockframe.tsx`) — renders `<MicButton>` in `EndIcons` between the view's `endIconButtons` and the max/close pair, gated on `props.viewModel?.voiceHandle`.
- **`TermViewModel`** — exposes `voiceHandle` that streams transcript chars into the PTY via `ControllerInputCommand` (no interim preview — terminal has no affordance for it).
- **`AgentViewModel` + `AgentFooter`** — `AgentViewModel.voiceTargetRef` holds the current handle; `AgentFooter.onMount` populates it with a textarea-backed handle that appends finals and previews interims, clears on cleanup.
- **`keymodel.ts`** — `Ctrl+Shift+V` toggles voice on the currently focused pane. No-op on panes whose ViewModel doesn't expose `voiceHandle` (browser, editor, etc.).
- **`custom.d.ts`** — adds optional `voiceHandle?: () => PaneVoiceHandle` to the `ViewModel` interface.

### Architectural notes

- The `ViewModel` interface lives in `frontend/types/custom.d.ts` as an ambient global; imported `PaneVoiceHandle` from the hook for the new optional field.
- AgentFooter wires the handle on mount using `onMount` + `onCleanup` rather than threading the textarea ref out — keeps the existing local `let textareaRef` scoping intact while still publishing the handle to the ViewModel via `voiceTargetRef`.
- `baseValue` is re-snapshotted before each voice append if the textarea diverges, so manual typing between voice events doesn't get clobbered.

### Test plan

- [ ] `npm run build` passes (verified locally)
- [ ] Open a Terminal pane → mic button appears top-right next to max/close; click → starts listening; speak → text appears at PTY prompt
- [ ] Open an Agent pane → mic button appears; click → starts listening; speak → text appears in composer (with interim preview)
- [ ] Open two terminal panes → click mic on pane A → speak → text lands in A; click mic on pane B → text retargets to B; pane A's pulse stops, pane B's starts
- [ ] Focus a terminal pane, press `Ctrl+Shift+V` → toggles voice; press again → stops
- [ ] Focus a browser/editor pane (no voiceHandle), press `Ctrl+Shift+V` → silent no-op

References: spec at `docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md`; Phase 1 in #920.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>