### PR TITLE
feat(voice): Phase 3 polish — tooltips, permission toast, settings toggle

### DIFF
--- a/.changesets/1779215297-feat-voice-phase-3-polish-tooltips-permission-toast-settings-g1wk.md
+++ b/.changesets/1779215297-feat-voice-phase-3-polish-tooltips-permission-toast-settings-g1wk.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(voice): Phase 3 polish — tooltips, permission toast, settings toggle

--- a/agentmux-srv/src/backend/wconfig/types.rs
+++ b/agentmux-srv/src/backend/wconfig/types.rs
@@ -206,6 +206,18 @@ pub struct SettingsType {
     #[serde(rename = "network:lan_discovery", default, skip_serializing_if = "is_false")]
     pub network_lan_discovery: bool,
 
+    // -- Voice settings --
+    //
+    // `voice:enabled` globally controls whether the per-pane microphone
+    // button is rendered. The default at the UX layer is "enabled" — the
+    // frontend treats `undefined`/absent as enabled, so we only need to
+    // model the explicit-disable case here. Users set this to `false` in
+    // `settings.json` to fully hide the buttons across all panes.
+    //
+    // Spec: docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md §7 Phase 3.
+    #[serde(rename = "voice:enabled", default, skip_serializing_if = "Option::is_none")]
+    pub voice_enabled: Option<bool>,
+
     /// Catch-all for unknown/dynamic keys (e.g. `widget:hidden@defwidget@sysinfo`).
     /// These pass through serde unchanged so the frontend can access them as flat settings keys.
     #[serde(flatten, default, skip_serializing_if = "HashMap::is_empty")]

--- a/frontend/app-init.ts
+++ b/frontend/app-init.ts
@@ -327,6 +327,14 @@ export async function initApp() {
     // Register context menu click handler now that window.api exists.
     ContextMenuModel.init();
 
+    // Phase 3 voice input — surface permission errors via the existing
+    // notification system. `useVoiceInput.ts` dispatches `voice-input-error`
+    // on the only fatal SpeechRecognition error codes ("not-allowed" /
+    // "service-not-allowed"); transient errors like "no-speech" and
+    // "aborted" are silently auto-restarted by `recognition.onend` and
+    // never reach this listener.
+    installVoiceInputErrorListener();
+
     const bareStart = performance.now();
     window.__startupPerfStart = bareStart;
     getApi().sendLog("Init Bare");
@@ -590,6 +598,35 @@ function installWindowTitleEffect(windowId: string): void {
         return disposeFn;
     });
     window.addEventListener("beforeunload", () => dispose(), { once: true });
+}
+
+/**
+ * One-time listener for the `voice-input-error` CustomEvent dispatched by
+ * `useVoiceInput.ts` when SpeechRecognition emits a fatal permission error.
+ * Surfaces a notification toast via the app's existing notification system
+ * (`pushNotification`, same path used by term.tsx for drop/copy failures).
+ *
+ * Spec: docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md §7 Phase 3.
+ */
+function installVoiceInputErrorListener(): void {
+    window.addEventListener("voice-input-error", (e: Event) => {
+        const detail = (e as CustomEvent<string>).detail;
+        let message: string | null = null;
+        if (detail === "not-allowed") {
+            message = "Microphone permission denied. Enable it in browser settings to use voice input.";
+        } else if (detail === "service-not-allowed") {
+            message = "Voice service unavailable. Check browser settings.";
+        }
+        if (message == null) return;
+        pushNotification({
+            icon: "fa-microphone-slash",
+            title: "Voice input unavailable",
+            message,
+            timestamp: new Date().toISOString(),
+            type: "error",
+            expiration: Date.now() + 10000,
+        });
+    });
 }
 
 function reloadAllWorkspaceTabs(ws: Workspace) {

--- a/frontend/app/block/blockframe.tsx
+++ b/frontend/app/block/blockframe.tsx
@@ -176,6 +176,9 @@ function EndIcons(props: {
     viewModel: ViewModel;
     nodeModel: NodeModel;
     onContextMenu: (e: MouseEvent) => void;
+    /** View key from `blockData.meta.view`, used to render a context-aware
+     *  tooltip on the per-pane mic button (e.g. "Speak into this terminal"). */
+    blockView?: string;
 }): JSX.Element {
     // createMemo so blockAtom reads inside endIconButtons() are tracked and
     // the button array re-evaluates when the agent loads/unloads.
@@ -202,6 +205,13 @@ function EndIcons(props: {
                 <MicButton
                     blockId={props.nodeModel.blockId}
                     handle={props.viewModel.voiceHandle!()}
+                    paneTitle={
+                        props.blockView === "term"
+                            ? "Speak into this terminal (Ctrl+Shift+V)"
+                            : props.blockView === "agent"
+                                ? "Speak into this agent (Ctrl+Shift+V)"
+                                : undefined
+                    }
                 />
             </Show>
             <Show when={ephemeral()} fallback={
@@ -408,7 +418,7 @@ function BlockFrame_Header(props: BlockFrameProps & { changeConnModalAtom: util.
             </Show>
             <div class="block-frame-textelems-wrapper">{headerTextElems}</div>
             <div class="block-frame-end-icons" onDblClick={(e) => e.stopPropagation()}>
-                <EndIcons viewModel={props.viewModel} nodeModel={props.nodeModel} onContextMenu={onContextMenu} />
+                <EndIcons viewModel={props.viewModel} nodeModel={props.nodeModel} onContextMenu={onContextMenu} blockView={blockData()?.meta?.view} />
             </div>
         </div>
     );

--- a/frontend/app/element/MicButton.tsx
+++ b/frontend/app/element/MicButton.tsx
@@ -3,16 +3,23 @@
 
 import { ToggleIconButton } from "@/app/element/iconbutton";
 import { getVoiceSession, type PaneVoiceHandle } from "@/app/hook/useVoiceInput";
+import { getSettingsKeyAtom } from "@/app/store/global";
 import { Show, type JSX } from "solid-js";
 import "./MicButton.scss";
 
 interface MicButtonProps {
     blockId: string;
     handle: PaneVoiceHandle;
+    /** Optional context-aware tooltip (e.g. "Speak into this terminal").
+     *  Falls back to a generic "Voice input" label when absent. */
+    paneTitle?: string;
 }
 
 export function MicButton(props: MicButtonProps): JSX.Element {
     const voice = getVoiceSession();
+    // `voice:enabled` is a global kill-switch (default true). Absent /
+    // undefined ⇒ enabled; only an explicit `false` hides the button.
+    const voiceEnabled = getSettingsKeyAtom("voice:enabled");
 
     // Active iff this pane owns the current voice session.
     const isActiveHere = () => voice.isListening() && voice.currentTargetId() === props.blockId;
@@ -44,13 +51,13 @@ export function MicButton(props: MicButtonProps): JSX.Element {
     });
 
     return (
-        <Show when={voice.isAvailable()}>
+        <Show when={voice.isAvailable() && voiceEnabled() !== false}>
             <div class="mic-button-wrap" classList={{ "mic-active": isActiveHere() }}>
                 <ToggleIconButton
                     decl={{
                         elemtype: "toggleiconbutton",
                         icon: "regular@microphone",
-                        title: "Voice input (Ctrl+Shift+V)",
+                        title: props.paneTitle ?? "Voice input (Ctrl+Shift+V)",
                         active: activeAtom,
                     }}
                 />

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -1293,6 +1293,7 @@ declare global {
         "telemetry:numpoints"?: number;
         "conn:*"?: boolean;
         "network:lan_discovery"?: boolean;
+        "voice:enabled"?: boolean;
     };
 
     // waveobj.StickerClickOptsType


### PR DESCRIPTION
## Summary

Phase 3 (polish) of the voice-input initiative — spec §7 of
`docs/specs/SPEC_VOICE_INPUT_PER_PANE_2026_05_19.md`. Phase 1 (#920)
and Phase 2 (#930) already merged.

Three polish items, all scoped narrowly:

- **Per-pane tooltips on the mic button.** `MicButton` now accepts an
  optional `paneTitle` prop. `BlockFrame_Header` threads
  `blockData.meta.view` into `EndIcons`, which renders the right copy:
  `"Speak into this terminal (Ctrl+Shift+V)"` for terminal panes,
  `"Speak into this agent (Ctrl+Shift+V)"` for agent panes, and falls
  back to the existing `"Voice input (Ctrl+Shift+V)"` for any future
  view that gains a voice handle.

- **Permission-denied toast.** Hooks the existing `voice-input-error`
  `CustomEvent` (dispatched by `useVoiceInput.ts` only on the fatal
  `not-allowed` / `service-not-allowed` cases) and surfaces it via the
  app's existing notification system (`pushNotification` from
  `app/store/global.ts` — the same path used by `term.tsx` for drop/
  copy failures). Listener is installed once in `app-init.ts`'s
  `initApp()`. No new toast framework introduced.

- **Settings toggle `voice:enabled`** (default `true`). Added to the
  Rust `SettingsType` and the TypeScript `SettingsType`. `MicButton`
  reads it via `getSettingsKeyAtom("voice:enabled")` and uses
  `!== false` so the absent/undefined case keeps the button enabled.
  Only an explicit `false` in `settings.json` hides the button across
  all panes.

## Test plan

- [ ] In a terminal pane, hover the mic button — tooltip reads
      "Speak into this terminal (Ctrl+Shift+V)".
- [ ] In an agent pane, hover the mic button — tooltip reads
      "Speak into this agent (Ctrl+Shift+V)".
- [ ] Click the mic button, deny the browser microphone permission —
      a "Microphone permission denied" toast appears.
- [ ] Add `"voice:enabled": false` to `settings.json`, reload — mic
      buttons vanish from every pane.
- [ ] Remove the setting (or set to `true`) — mic buttons reappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)