### PR TITLE
fix(launcher): relocate launcher-sagas.db into <data-dir>/db/ (audit cleanup §8.3)

### DIFF
--- a/.changesets/1779215851-fix-launcher-relocate-launcher-sagas-db-into-data-dir-db.md
+++ b/.changesets/1779215851-fix-launcher-relocate-launcher-sagas-db-into-data-dir-db.md
@@ -1,0 +1,17 @@
+---
+type: patch
+---
+
+fix(launcher): relocate launcher-sagas.db into `<data-dir>/db/`
+
+Closes audit item §8.3. The launcher saga log previously lived
+directly in `<data-dir>/launcher-sagas.db` while srv put all its
+SQLite files under `<data-dir>/db/`. The new
+`data_dir::launcher_saga_log_path()` returns the canonical
+`<data-dir>/db/launcher-sagas.db` and performs a one-shot back-
+compat rename from the legacy location on first launch.
+
+Idempotent + safe to call repeatedly; +4 unit tests cover fresh
+install, legacy migration, both-files-present, repeated calls.
+Audit doc also corrected: §8.2 (duplicate saga tables) was a
+false alarm — retracted.

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -200,7 +200,6 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
-| 0.37.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.36.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.35.0 | 2026-05-19 | 164.6 MiB | 345.6 MiB | |
 | 0.33.835 | 2026-05-13 | 164.2 MiB | 344.3 MiB | |

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -200,6 +200,7 @@ Auto-appended by `scripts/package-cef-portable.sh`. Newest first.
 
 | Version | Date | ZIP (compressed) | Folder (uncompressed) | Note |
 |---------|------|------------------|-----------------------|------|
+| 0.37.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.36.0 | 2026-05-19 | 164.6 MiB | 345.7 MiB | |
 | 0.35.0 | 2026-05-19 | 164.6 MiB | 345.6 MiB | |
 | 0.33.835 | 2026-05-13 | 164.2 MiB | 344.3 MiB | |

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -85,8 +85,108 @@ pub fn resolve_paths(launcher_exe_dir: &Path, version: &str) -> Result<DataPaths
     })
 }
 
+/// Canonical path for the launcher saga log
+/// (`<data-dir>/db/launcher-sagas.db`). Performs a one-shot back-
+/// compat migration: launcher releases prior to this change wrote
+/// the saga log directly under `<data-dir>/launcher-sagas.db` (with
+/// srv DBs alongside in `<data-dir>/db/`, an inconsistency flagged
+/// by AUDIT_SQLITE_SYSTEMS §8.3). If only the legacy path exists,
+/// move it into `db/`.
+///
+/// Idempotent + safe to call repeatedly. Returns the canonical
+/// (post-migration) path the caller should open.
+pub fn launcher_saga_log_path(data_dir: &Path) -> PathBuf {
+    let db_dir = data_dir.join("db");
+    let new_path = db_dir.join("launcher-sagas.db");
+    let legacy_path = data_dir.join("launcher-sagas.db");
+
+    // Migrate iff only the legacy file is present. Don't overwrite a
+    // non-empty new file even if both exist — that would be a
+    // surprising data loss and likely indicates a multi-process race
+    // we'd want to investigate.
+    if legacy_path.exists() && !new_path.exists() {
+        // Best-effort `mkdir -p`. If this fails the rename will fail
+        // and we'll log + fall back to the legacy path below.
+        let _ = std::fs::create_dir_all(&db_dir);
+        if let Err(e) = std::fs::rename(&legacy_path, &new_path) {
+            // Migration failed — keep using the legacy path so we
+            // don't drop saga state. The next launch retries.
+            eprintln!(
+                "[launcher-saga-log] migration of {} → {} failed: {} \
+                 (continuing with legacy path)",
+                legacy_path.display(),
+                new_path.display(),
+                e
+            );
+            return legacy_path;
+        }
+    }
+    new_path
+}
+
 /// Create every directory the launcher + srv expect to exist.
 /// Idempotent. Delegates to the common implementation.
 pub fn ensure_dirs(paths: &DataPaths) -> Result<(), String> {
     paths.common.ensure_dirs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn launcher_saga_log_path_returns_db_subdir_on_fresh_install() {
+        let tmp = tempdir().unwrap();
+        let p = launcher_saga_log_path(tmp.path());
+        assert_eq!(p, tmp.path().join("db").join("launcher-sagas.db"));
+        // No legacy file → no rename attempt; new path simply returned.
+        assert!(!tmp.path().join("launcher-sagas.db").exists());
+    }
+
+    #[test]
+    fn launcher_saga_log_path_migrates_legacy_file() {
+        let tmp = tempdir().unwrap();
+        let legacy = tmp.path().join("launcher-sagas.db");
+        std::fs::write(&legacy, b"legacy bytes").unwrap();
+
+        let p = launcher_saga_log_path(tmp.path());
+
+        assert_eq!(p, tmp.path().join("db").join("launcher-sagas.db"));
+        assert!(p.exists());
+        assert_eq!(std::fs::read(&p).unwrap(), b"legacy bytes");
+        assert!(!legacy.exists(), "legacy path should be removed by rename");
+    }
+
+    #[test]
+    fn launcher_saga_log_path_does_not_overwrite_existing_new_file() {
+        // Both files exist (theoretical race / aborted migration).
+        // Keep the new file untouched and leave the legacy alone.
+        let tmp = tempdir().unwrap();
+        let legacy = tmp.path().join("launcher-sagas.db");
+        let new_dir = tmp.path().join("db");
+        std::fs::create_dir_all(&new_dir).unwrap();
+        let new_path = new_dir.join("launcher-sagas.db");
+        std::fs::write(&legacy, b"legacy").unwrap();
+        std::fs::write(&new_path, b"newer").unwrap();
+
+        let p = launcher_saga_log_path(tmp.path());
+
+        assert_eq!(p, new_path);
+        assert_eq!(std::fs::read(&p).unwrap(), b"newer");
+        // Legacy stays (user can clean up manually); we don't trash it.
+        assert!(legacy.exists());
+    }
+
+    #[test]
+    fn launcher_saga_log_path_is_idempotent() {
+        let tmp = tempdir().unwrap();
+        let legacy = tmp.path().join("launcher-sagas.db");
+        std::fs::write(&legacy, b"data").unwrap();
+
+        let first = launcher_saga_log_path(tmp.path());
+        let second = launcher_saga_log_path(tmp.path());
+        assert_eq!(first, second);
+        assert!(first.exists());
+    }
 }

--- a/agentmux-launcher/src/data_dir.rs
+++ b/agentmux-launcher/src/data_dir.rs
@@ -85,6 +85,26 @@ pub fn resolve_paths(launcher_exe_dir: &Path, version: &str) -> Result<DataPaths
     })
 }
 
+/// Read-only resolver for the launcher saga log path. Returns
+/// whichever location actually holds the data: the canonical
+/// `<data-dir>/db/launcher-sagas.db` if present, otherwise the
+/// legacy `<data-dir>/launcher-sagas.db` if THAT exists, otherwise
+/// the canonical path (for the fresh-install case).
+///
+/// Does NOT touch the filesystem — safe for read-only callers like
+/// `--diag sagas` which document themselves as passive.
+pub fn launcher_saga_log_path_read_only(data_dir: &Path) -> PathBuf {
+    let new_path = data_dir.join("db").join("launcher-sagas.db");
+    if new_path.exists() {
+        return new_path;
+    }
+    let legacy_path = data_dir.join("launcher-sagas.db");
+    if legacy_path.exists() {
+        return legacy_path;
+    }
+    new_path
+}
+
 /// Canonical path for the launcher saga log
 /// (`<data-dir>/db/launcher-sagas.db`). Performs a one-shot back-
 /// compat migration: launcher releases prior to this change wrote
@@ -92,6 +112,12 @@ pub fn resolve_paths(launcher_exe_dir: &Path, version: &str) -> Result<DataPaths
 /// srv DBs alongside in `<data-dir>/db/`, an inconsistency flagged
 /// by AUDIT_SQLITE_SYSTEMS §8.3). If only the legacy path exists,
 /// move it into `db/`.
+///
+/// This variant has WRITE side effects (rename + mkdir). Callers
+/// that must stay read-only (e.g. `--diag sagas` is documented as
+/// a passive on-disk inspector) should use
+/// `launcher_saga_log_path_read_only` instead. The launcher's own
+/// startup path uses this one — the rename is welcome there.
 ///
 /// Idempotent + safe to call repeatedly. Returns the canonical
 /// (post-migration) path the caller should open.
@@ -176,6 +202,40 @@ mod tests {
         assert_eq!(std::fs::read(&p).unwrap(), b"newer");
         // Legacy stays (user can clean up manually); we don't trash it.
         assert!(legacy.exists());
+    }
+
+    #[test]
+    fn read_only_resolver_returns_canonical_when_neither_file_exists() {
+        let tmp = tempdir().unwrap();
+        let p = launcher_saga_log_path_read_only(tmp.path());
+        assert_eq!(p, tmp.path().join("db").join("launcher-sagas.db"));
+        // Crucially, no side effects — no `db/` dir created.
+        assert!(!tmp.path().join("db").exists());
+    }
+
+    #[test]
+    fn read_only_resolver_returns_legacy_path_when_only_legacy_exists() {
+        let tmp = tempdir().unwrap();
+        let legacy = tmp.path().join("launcher-sagas.db");
+        std::fs::write(&legacy, b"legacy").unwrap();
+
+        let p = launcher_saga_log_path_read_only(tmp.path());
+
+        assert_eq!(p, legacy);
+        assert!(legacy.exists(), "read-only resolver must not migrate");
+        assert!(!tmp.path().join("db").exists());
+    }
+
+    #[test]
+    fn read_only_resolver_returns_canonical_when_canonical_exists() {
+        let tmp = tempdir().unwrap();
+        let db_dir = tmp.path().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let new_path = db_dir.join("launcher-sagas.db");
+        std::fs::write(&new_path, b"current").unwrap();
+
+        let p = launcher_saga_log_path_read_only(tmp.path());
+        assert_eq!(p, new_path);
     }
 
     #[test]

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -690,7 +690,7 @@ fn format_event(e: &Event) -> String {
 // LSD-3 — `agentmux.exe --diag sagas`
 //
 // Operator visibility into the launcher saga log
-// (`<data-dir>/launcher-sagas.db`). Unlike `--diag wrr` and
+// (`<data-dir>/db/launcher-sagas.db`). Unlike `--diag wrr` and
 // `--diag srv`, this command does NOT need a running launcher: the
 // SQLite log is a passive on-disk artefact. We open it read-only via
 // `LauncherSagaLog::open_read_only` and call `snapshot_recent(50)`. Useful when
@@ -725,7 +725,7 @@ async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), S
 
     let paths = crate::data_dir::resolve_paths(launcher_exe_dir, version)
         .map_err(|e| format!("path resolution failed: {}", e))?;
-    let saga_log_path = paths.data_dir.join("launcher-sagas.db");
+    let saga_log_path = crate::data_dir::launcher_saga_log_path(&paths.data_dir);
 
     println!("AgentMux launcher saga diagnostic");
     println!("Data dir: {}", paths.data_dir.display());

--- a/agentmux-launcher/src/diag.rs
+++ b/agentmux-launcher/src/diag.rs
@@ -725,7 +725,10 @@ async fn run_sagas_diag_impl(launcher_exe_dir: &std::path::Path) -> Result<(), S
 
     let paths = crate::data_dir::resolve_paths(launcher_exe_dir, version)
         .map_err(|e| format!("path resolution failed: {}", e))?;
-    let saga_log_path = crate::data_dir::launcher_saga_log_path(&paths.data_dir);
+    // `--diag sagas` is a passive on-disk inspector (see the doc
+    // comment for this function); use the read-only resolver so we
+    // don't trigger the legacy-file rename here. Reagent P2 on PR #932.
+    let saga_log_path = crate::data_dir::launcher_saga_log_path_read_only(&paths.data_dir);
 
     println!("AgentMux launcher saga diagnostic");
     println!("Data dir: {}", paths.data_dir.display());

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -344,14 +344,19 @@ async fn run_windows(
     let state = std::sync::Arc::new(tokio::sync::Mutex::new(state::State::default()));
 
     // LSD-2 — open the durable launcher saga log at
-    // `<data-dir>/launcher-sagas.db` (separate file from
+    // `<data-dir>/db/launcher-sagas.db` (separate file from
     // `launcher-events.log`; the saga log is structured SQLite, the
     // event log is append-only JSONL). Failure to open is a launcher
     // startup error — without the log, sagas have no crash-recovery
     // story (LSD-3 walks `unresolved_sagas` to mark interrupted
     // sagas `failed_compensation`). Spec
     // `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md` §3.1.
-    let saga_log_path = paths.data_dir.join("launcher-sagas.db");
+    //
+    // `launcher_saga_log_path` performs the back-compat move from
+    // the pre-AUDIT_SQLITE_SYSTEMS_2026_05_19.md location
+    // (`<data-dir>/launcher-sagas.db` — outside `db/`) into the
+    // canonical `db/` subdir alongside srv's SQLite files.
+    let saga_log_path = data_dir::launcher_saga_log_path(&paths.data_dir);
     let saga_log = match saga::LauncherSagaLog::open(&saga_log_path) {
         Ok(l) => std::sync::Arc::new(l),
         Err(e) => {

--- a/agentmux-launcher/src/reducer/tests.rs
+++ b/agentmux-launcher/src/reducer/tests.rs
@@ -220,6 +220,7 @@ fn extract_version(e: &Event) -> u64 {
         | Event::LayoutSplitVerticalApplied { version, .. }
         | Event::LayoutCleared { version, .. }
         | Event::LayoutTreeReplaced { version, .. }
+        | Event::WindowMetaUpdated { version, .. }
         | Event::Error { version, .. } => *version,
     }
 }

--- a/agentmux-launcher/src/saga/log/mod.rs
+++ b/agentmux-launcher/src/saga/log/mod.rs
@@ -5,8 +5,12 @@
 //
 // Spec: `docs/specs/SPEC_LAUNCHER_SAGA_DURABILITY_2026-05-01.md`
 //   - §3.1 storage (separate SQLite file at
-//     `~/.agentmux/launcher-sagas.db`, WAL + 5s busy timeout +
-//     foreign_keys=ON; same configuration as srv saga log)
+//     `<data-dir>/db/launcher-sagas.db`, WAL + 5s busy timeout +
+//     foreign_keys=ON; same configuration as srv saga log. Pre-
+//     AUDIT_SQLITE_SYSTEMS_2026_05_19.md the file lived directly
+//     in `<data-dir>/`; a back-compat migration in
+//     `data_dir::launcher_saga_log_path` moves the legacy file
+//     into `db/` on first launch.)
 //   - §3.2 schema (see `schema.rs`)
 //   - §3.3 API surface (this module)
 //   - §4 PR1 scope: log exists in isolation, NO coordinator wiring

--- a/agentmux-launcher/src/saga/mod.rs
+++ b/agentmux-launcher/src/saga/mod.rs
@@ -297,7 +297,7 @@ impl SagaCoordinator {
     }
 
     /// LSD-2 — install the durable saga log so saga lifecycle
-    /// transitions are persisted to `~/.agentmux/launcher-sagas.db`.
+    /// transitions are persisted to `<data-dir>/db/launcher-sagas.db`.
     /// Builder-style setter rather than a constructor parameter so
     /// existing tests + the `next_id_is_monotonic` smoke don't have
     /// to construct an in-memory log. Production wiring (in

--- a/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
+++ b/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
@@ -1,0 +1,300 @@
+# AUDIT: SQLite Systems in AgentMux
+
+**Status:** Reference document, current as of `main` 2026-05-19
+**Author:** AgentA
+**Companion specs:**
+- [`SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md`](./SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md) — proposes moving durable content to `~/.agentmux/shared/`. Read this audit first; the spec assumes its inventory.
+- agentmux-docs internals: [`data-layout.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/data-layout.md), [`persistence.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/persistence.md). Both are partially stale (see §10).
+
+---
+
+## 0. TL;DR
+
+AgentMux today opens **four physical SQLite files + a fifth cross-version "registry" file + an unbounded number of `:memory:` instances in tests**. They split across two processes (srv + launcher) and three persistence categories (durable user content, runtime saga state, ephemeral test fixtures). One additional store, `shared/store.db`, is proposed by SPEC_SHARED_BUNDLES.
+
+This document inventories every SQLite touchpoint: writer, schema, lifecycle, who opens it, where the path is resolved.
+
+---
+
+## 1. Files at a glance
+
+| File | Writer | Holds | Path | Lifecycle |
+|---|---|---|---|---|
+| `objects.db` | `agentmux-srv` | App-domain state + bundles + agents (mixed durable + runtime) | `<version-data-dir>/db/objects.db` | Lifetime of the user's install per version |
+| `filestore.db` | `agentmux-srv` | Per-block content blobs (forge configs, snapshots, file-pane content) | `<version-data-dir>/db/filestore.db` | Same; rebuildable but referenced by `objects.db` |
+| `sagas.db` | `agentmux-srv` | srv-side saga coordinator durability | `<version-data-dir>/db/sagas.db` | Per-version; truncated on saga completion |
+| `launcher-sagas.db` | `agentmux-launcher` | Launcher-side saga state (LSD spec) | `<version-data-dir>/db/launcher-sagas.db` (legacy installs migrate from the pre-2026-05-19 root location on first launch) | Per-version |
+| `registry/store` (NB: filesystem, not SQLite — flat file registry) | `agentmux-srv` migrator + `agentmux-launcher` reader | Cross-version named-agent history (Continue dropdown) | `~/.agentmux/shared/registry/` | One-shot migrated from per-version `objects.db` snapshots |
+| `shared/store.db` (proposed) | `agentmux-srv` | Cross-version bundles + accounts + memories + agent definitions | `~/.agentmux/shared/store.db` | One-shot migrated from per-version `objects.db` snapshots (mirrors registry pattern) |
+
+`registry/` is **filesystem-backed**, not SQLite — clarified in §5. SPEC_SHARED_BUNDLES proposes a real SQLite file in the same `shared/` tree.
+
+---
+
+## 2. `objects.db` — the kitchen sink
+
+### 2.1 Opening + configuration
+
+- Opened in `agentmux-srv/src/main.rs:316` via `WaveStore::open(&db_dir.join("objects.db"))`.
+- `db_dir = get_wave_data_dir().join("db")` per `agentmux-srv/src/backend/base.rs:132`.
+- `get_wave_data_dir()` reads `AGENTMUX_DATA_DIR` env var (launcher-injected) and falls back to `~/.agentmux`.
+- PRAGMAs applied per-connection in `WaveStore::configure_and_migrate` (`wstore.rs:56-72`):
+  - `journal_mode=WAL`
+  - `busy_timeout=5000`
+  - `foreign_keys=ON` (required — `db_agent_instances` cascades on `db_identities` deletion; missed cascades caused issues pre-v6)
+  - `synchronous=NORMAL`
+  - `cache_size=-8000`
+  - `mmap_size=268435456`
+  - `temp_store=MEMORY`
+
+### 2.2 Schema (current, after `run_forge_migrations` v1 → v10)
+
+Migrations are **additive, idempotent**, chained linearly in `run_forge_migrations` (`migrations.rs:111-132`). No `PRAGMA user_version` discipline — relies on `CREATE TABLE IF NOT EXISTS` + `ALTER TABLE … duplicate-column` swallowing.
+
+#### 2.2.a Generic object tables (run_wstore_migrations)
+
+One row-per-otype with `(oid, version, data TEXT)`:
+
+```
+db_client, db_window, db_workspace, db_tab, db_layout, db_block, db_temp
+```
+
+These are the reducer's app-domain state. JSON blobs in `data`. Writes funnel through `wcore` from HTTP/WS RPC; reads are `SELECT * FROM db_<otype> WHERE oid = ?`.
+
+#### 2.2.b Saga durability — NOT in objects.db
+
+The `saga` + `saga_step` schema lives in `sagas.db`, owned by `SagaLog` (`sagas/log.rs`). The initial draft of this audit incorrectly claimed `run_saga_log_migrations` also runs inside `WaveStore::configure_and_migrate`; verification on `main` (2026-05-19) confirms it does **not**. `objects.db` has no saga tables; `sagas.db` is the only home. The launcher's `launcher-sagas.db` is unambiguously its own file. See §4 for both schemas.
+
+#### 2.2.c Forge agent definitions (run_forge_v1 → v2)
+
+| Table | Purpose |
+|---|---|
+| `db_forge_agents` | Agent CLI definitions (slug, provider, working_directory, shell, …) — seeded from defaults on first launch |
+| `db_forge_content` | Generated config blobs per agent (soul/agentmd/mcp/env/memory) |
+| `db_forge_skills` | Skill catalog per agent |
+| `db_forge_history` | Per-agent launch history (legacy; named-agent registry now owns this) |
+
+#### 2.2.d Identity + bundle system (v5 → v8)
+
+| Table | Purpose |
+|---|---|
+| `db_identity_accounts` | Provider OAuth/API-key accounts (one row per attached account) |
+| `db_forge_agent_identities` | Junction: agent ↔ account (legacy v6) |
+| `db_agent_instances` | Per-instance launch rows (block_id, identity_id, memory_id, working_directory, parent_instance_id) |
+| `db_identities` | User-named identity bundles (Work, Personal, …) — Note: type uses `db_identities` in schema but `db_identity_bundles` in some references. **Inconsistency worth fixing.** |
+| `db_identity_bindings` | Junction: identity ↔ account ↔ provider |
+| `db_memories` | User-named memory bundles (notes/instructions) |
+
+#### 2.2.e Workflow / Drone (v9 → v10)
+
+| Table | Purpose |
+|---|---|
+| `db_workflow_definitions` (v9) | Pre-rename — kept for back-compat |
+| `db_workflow_runs` (v9) | Pre-rename — kept for back-compat |
+| `db_drone_definitions` (v10) | Renamed from workflow; user-defined drone graphs |
+| `db_drone_runs` (v10) | Drone execution history |
+
+### 2.3 Indexes summary
+
+Identity / agent path indexes:
+```
+idx_identity_accounts_provider
+idx_forge_agent_identities_account
+idx_agent_instances_definition
+idx_agent_instances_block
+idx_agent_instances_status
+idx_agent_instances_parent
+idx_agent_instances_name_recent
+idx_identities_is_blank
+idx_identity_bindings_account
+idx_memories_is_blank
+```
+
+Drone / workflow:
+```
+idx_drone_definitions_updated
+idx_drone_runs_drone_started
+idx_drone_runs_status
+idx_workflow_definitions_updated
+idx_workflow_runs_workflow_started
+idx_workflow_runs_status
+```
+
+---
+
+## 3. `filestore.db` — content blobs
+
+### 3.1 Opening
+
+- `agentmux-srv/src/main.rs:393`: `FileStore::open(&db_dir.join("filestore.db"))`.
+- Same PRAGMA discipline as `objects.db` (`filestore/core.rs:67`):
+  - `journal_mode=WAL`
+  - `busy_timeout=5000`
+- Same `db_dir` resolution.
+
+### 3.2 Schema (`run_filestore_migrations`)
+
+```sql
+db_wave_file  (zoneid, name, size, createdts, modts, opts, meta)   -- meta
+db_file_data  (zoneid, name, partidx, data BLOB)                    -- bytes
+```
+
+Composite primary keys on `(zoneid, name)` + `(zoneid, name, partidx)`. Chunked storage; partidx allows large files split across rows. In-memory LRU cache layer (`filestore/cache.rs`) sits on top.
+
+### 3.3 Lifecycle
+
+- Referenced by hash from `objects.db`.
+- Deleting `filestore.db` without `objects.db` → dangling references (file pane reports missing blobs).
+- Recoverable: `filestore.db` can be deleted independently if user accepts lost snapshots.
+
+---
+
+## 4. `sagas.db` and `launcher-sagas.db`
+
+### 4.1 srv `sagas.db`
+
+- Opened at `agentmux-srv/src/main.rs:403`: `SagaLog::open(&db_dir.join("sagas.db"))`.
+- `SagaLog::configure_and_migrate` (`sagas/log.rs:138`) is the only caller of `run_saga_log_migrations`. So the DDL lives exclusively in `sagas.db` — `objects.db` has no `saga` / `saga_step` tables.
+
+### 4.2 launcher `launcher-sagas.db`
+
+- Opened at `agentmux-launcher/src/main.rs:354`: `LauncherSagaLog::open(&saga_log_path)`.
+- Diag-cli reads from `agentmux-launcher/src/diag.rs:728`.
+- Path: `paths.data_dir.join("launcher-sagas.db")` — `data_dir` here is the **launcher's resolved data dir**, which is the same `~/.agentmux/versions/<v>/` tree as srv. Note this file lives at the **root of the version data dir**, not inside `db/` (cf. srv's `objects.db` etc.).
+
+#### Schema (`launcher/src/saga/log/schema.rs`)
+
+```sql
+launcher_saga (saga_id, name, state, started_at, ended_at, input_json, failure_reason)
+launcher_saga_step (saga_id, step_index, name, state, cmd_json, target, started_at, ended_at, output_json, failure_reason)
+
+idx_launcher_saga_state ON launcher_saga(state)
+idx_launcher_saga_step_state ON launcher_saga_step(saga_id, state)
+```
+
+Two deltas vs srv's `saga` table:
+
+1. **`target` column** on `launcher_saga_step` — launcher sagas dispatch to multiple peers (self / host / srv); srv sagas always target srv.
+2. **`failed_compensation` saga state** — launcher doesn't auto-compensate; recovery marks unresolved sagas as `failed_compensation` for operator review. srv has `compensated` terminal state instead.
+
+Timestamps are **RFC3339 TEXT** in the launcher (vs INTEGER epoch ms in srv) — easier to grep in shells.
+
+Schema lifecycle policy (per LSD spec §5 risk #2): only additive `ALTER TABLE` in future migration versions. No in-place rewrites.
+
+---
+
+## 5. `shared/registry/` — cross-version named-agent history
+
+**Not SQLite.** Despite living alongside the DBs and being called "the registry," `agentmux-srv/src/registry/store.rs` implements this as a **flat file store** in `~/.agentmux/shared/registry/`. Migration from per-version `objects.db` is a one-shot read-only scan (`registry/migrate.rs:85` enumerates every `versions/*/data/db/objects.db`).
+
+What gets shared via the registry today:
+
+| Source table in per-version `objects.db` | Shared via registry | Purpose |
+|---|---|---|
+| `db_agent_instances` (named rows only) | Yes — `NamedAgentRecord` | Continue-agent dropdown population. Cross-version dedup on `instance_id` with latest `started_at` winning. |
+
+Marker file: `~/.agentmux/shared/registry/.migrated_from_sqlite`. Idempotent: present → skip migration.
+
+---
+
+## 6. In-memory SQLite (tests + identity resolver)
+
+Roughly 20+ test files open `WaveStore::open_in_memory()` or `Connection::open_in_memory()`. Notable:
+
+| Site | Purpose |
+|---|---|
+| `agentmux-srv/src/backend/storage/migrations.rs:905-1612` | Unit tests for every migration version |
+| `agentmux-srv/src/backend/storage/wstore.rs:2238-3060` | Multiple test fixtures |
+| `agentmux-srv/src/identity/resolver.rs:242` | Stub for non-binding-coverage code paths |
+| `agentmux-srv/src/backend/blockcontroller/session_recovery.rs:134` | Session-recovery test fixture |
+| `agentmux-srv/src/backend/session_archive.rs:479` | Session archive test fixture |
+| `agentmux-srv/src/backend/wcore/mod.rs:215` | wcore-internal test fixture |
+
+These don't touch disk; they're safe to ignore for cross-version migration concerns.
+
+---
+
+## 7. Cargo dependency posture
+
+Both `agentmux-srv` and `agentmux-launcher` use **`rusqlite = "0.31"` with `bundled` feature** — locked in lockstep so the saga log schema stays compatible. Pinning comment in `agentmux-launcher/Cargo.toml` reminds future bumpers to upgrade both.
+
+No `sqlx`, no `diesel`, no async DB layer. All SQLite access is synchronous behind `Mutex<Connection>` wrappers (`WaveStore.conn: Mutex<Connection>`, `FileStore.conn: Mutex<Connection>`).
+
+---
+
+## 8. Open inconsistencies + clean-up items
+
+1. **Schema naming drift.** v7 creates a table called `db_identities` (`migrations.rs:470`), but the rest of the code and docs call it `db_identity_bundles`. Decide on one; either rename via migration or correct the references. Today readers compose `SELECT … FROM db_identities` so the table name is the canonical one — comments + docs should follow.
+
+2. ~~`saga` tables in two files.~~ **Retracted** — the initial audit miscounted; `run_saga_log_migrations` is only invoked from `SagaLog::configure_and_migrate`, so `objects.db` has no saga tables. See §2.2.b.
+
+3. **`launcher-sagas.db` lives in the wrong directory.** ~~Srv puts its DBs in `<data-dir>/db/`; launcher puts `launcher-sagas.db` directly in `<data-dir>/`.~~ **Fixed** in PR #930-ish — `agentmux-launcher::data_dir::launcher_saga_log_path` performs a one-shot rename of any pre-existing file from `<data-dir>/launcher-sagas.db` into `<data-dir>/db/launcher-sagas.db`. Idempotent + safe to call repeatedly. Both `main.rs` and `diag.rs` route through it.
+
+4. **`db_workflow_*` vs `db_drone_*` after the rename.** Both exist on v10. Eventually drop the v9 workflow tables (and the migration step) once we're confident no rows reference them.
+
+5. **No `PRAGMA user_version` discipline.** All migrations rely on idempotent DDL + `ALTER TABLE ... duplicate-column` error-swallow. Works, but is fragile. A real `user_version` ladder with explicit per-version "ran" markers would catch a partially-applied migration. Lower priority unless we hit a real bug.
+
+6. **Foreign keys ON only set in `WaveStore`.** `FileStore`'s connection doesn't set `foreign_keys=ON` (it has no FKs to enforce so probably fine, but worth documenting the gap).
+
+---
+
+## 9. Path resolution summary
+
+```
+~/.agentmux/
+├── versions/<version>/      ← installed + portable, resolved via DataPaths::resolve(version, mode)
+│   ├── data/
+│   │   ├── db/
+│   │   │   ├── objects.db          ← srv (mixed durable + runtime)
+│   │   │   ├── filestore.db        ← srv
+│   │   │   ├── sagas.db            ← srv (saga + saga_step only)
+│   │   │   └── launcher-sagas.db   ← launcher (auto-migrated from <data-dir>/launcher-sagas.db on first launch ≥2026-05-19)
+│   │   └── launcher-events.log     ← launcher JSONL (Layer-1 reducer log)
+│   ├── logs/
+│   ├── cef-cache/
+│   ├── agents/
+│   ├── config/
+│   └── runtime/
+├── dev/<branch>/            ← `task dev` only — same shape under here
+└── shared/
+    ├── registry/            ← cross-version named-agent registry (flat files; NOT SQLite)
+    └── store.db             ← proposed by SPEC_SHARED_BUNDLES (does NOT exist yet)
+```
+
+Notes:
+- `DataPaths` in `agentmux-common` is the single resolver. Host + srv + launcher all read paths from launcher-injected env vars (`AGENTMUX_DATA_DIR`, `AGENTMUX_LOG_DIR`, etc.).
+- Two same-version instances share the same `versions/<v>/` tree — that's the multi-instance isolation model documented in CLAUDE.md and `docs/internals/data-layout.md`.
+
+---
+
+## 10. Doc accuracy
+
+agentmux-docs internals currently has:
+
+- [`internals/data-layout.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/data-layout.md) — accurate on the per-version tree structure. Missing: registry layout under `shared/`, the planned `shared/store.db`, the `launcher-sagas.db` filename quirk.
+- [`internals/persistence.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/persistence.md) — accurate on the four-file model. Missing:
+  - The full bundle table catalog (`db_identities`, `db_identity_bindings`, `db_memories`, `db_identity_accounts`)
+  - `db_forge_*` table family
+  - `db_drone_*` (workflows → drone rename)
+  - The dual-DB `saga` table presence
+  - The named-agent registry sharing layer
+
+**Recommended docs follow-up PR** (separate from any spec implementation):
+
+1. Refresh `persistence.md` with a complete table catalog mirroring §2.2 of this audit.
+2. Add a new page `internals/cross-version-sharing.md` documenting the registry pattern and (once shipped) the `shared/store.db` model.
+3. Update `data-layout.md` to call out `shared/` more prominently.
+4. Cross-link from the user-facing `multi-instance.md` page so users understand what's shared vs not.
+
+Per `feedback_docs_refresh_after_features.md`: docs go in their own repo PR after the implementation lands, not bundled with the code change.
+
+---
+
+## 11. Next-step audit work
+
+Items worth a deeper look once this initial pass is in:
+
+1. **Concurrent access discipline.** All connections are `Mutex<Connection>`-wrapped. With multiple workers calling `wstore.bundle_*`, contention is the bottleneck. Measure latencies under load.
+2. **WAL checkpoint policy.** None set explicitly. WAL files can grow unbounded under heavy write. SQLite default auto-checkpoint at 1000 pages is acceptable but worth confirming nothing has overridden it.
+3. **Backup story.** No mention of `sqlite3_backup_init()` use. Crash-consistent backups today are "stop srv, copy files." Worth specifying a hot-backup approach if support tickets surface around it.
+4. **Cross-version saga compensation.** If launcher v0.36 starts a saga and srv v0.37 reads `launcher-sagas.db`, schema compat is asserted only by lockstep `rusqlite = 0.31` — not by an actual user_version check. Could surface as silent drift on a future bump.

--- a/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
+++ b/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
@@ -228,7 +228,7 @@ No `sqlx`, no `diesel`, no async DB layer. All SQLite access is synchronous behi
 
 2. ~~`saga` tables in two files.~~ **Retracted** — the initial audit miscounted; `run_saga_log_migrations` is only invoked from `SagaLog::configure_and_migrate`, so `objects.db` has no saga tables. See §2.2.b.
 
-3. **`launcher-sagas.db` lives in the wrong directory.** ~~Srv puts its DBs in `<data-dir>/db/`; launcher puts `launcher-sagas.db` directly in `<data-dir>/`.~~ **Fixed** in PR #930-ish — `agentmux-launcher::data_dir::launcher_saga_log_path` performs a one-shot rename of any pre-existing file from `<data-dir>/launcher-sagas.db` into `<data-dir>/db/launcher-sagas.db`. Idempotent + safe to call repeatedly. Both `main.rs` and `diag.rs` route through it.
+3. **`launcher-sagas.db` lives in the wrong directory.** ~~Srv puts its DBs in `<data-dir>/db/`; launcher puts `launcher-sagas.db` directly in `<data-dir>/`.~~ **Fixed** in PR #932 — `agentmux-launcher::data_dir::launcher_saga_log_path` performs a one-shot rename of any pre-existing file from `<data-dir>/launcher-sagas.db` into `<data-dir>/db/launcher-sagas.db`. Idempotent + safe to call repeatedly. `main.rs` uses this writing variant; `diag.rs` uses the read-only sibling `launcher_saga_log_path_read_only` so `--diag sagas` stays passive.
 
 4. **`db_workflow_*` vs `db_drone_*` after the rename.** Both exist on v10. Eventually drop the v9 workflow tables (and the migration step) once we're confident no rows reference them.
 

--- a/docs/specs/SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md
+++ b/docs/specs/SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md
@@ -1,0 +1,234 @@
+# SPEC: Cross-Version Sharing — Identity / Memory / Forge Definitions
+
+**Status:** Draft
+**Date:** 2026-05-19
+**Author:** AgentA
+**Related:**
+- `agentmux-common/src/data_paths.rs` — current per-version layout (`~/.agentmux/versions/<v>/`)
+- `agentmux-srv/src/registry/` — established cross-version registry pattern (named-agent history) with one-shot migration from per-version SQLite
+- `agentmux-srv/src/backend/storage/migrations.rs` — current `objects.db` schema (bundles, memories, forge defs, accounts, bindings)
+
+---
+
+## 0. TL;DR
+
+Today **all user content lives in per-version SQLite**: identity bundles, identity accounts (OAuth tokens), bindings, memory bundles, forge agent definitions. Install v0.37.0 alongside v0.36.0 and your "Work" identity, "Project Notes" memory, and saved Claude OAuth do not follow you.
+
+That's a UX bug. Bundles + agent definitions are durable user content; users expect them to persist across releases the way browser bookmarks persist across browser versions. Only **per-version runtime state** (in-progress sessions, CEF cache, working directories, logs) should be siloed.
+
+This spec proposes:
+
+1. **Move durable content to `~/.agentmux/shared/store.db`** — identity bundles + accounts + bindings + memory bundles + forge agent definitions.
+2. **Keep per-version state per-version** — agent instance rows, working directories, sagas, CEF cache, logs.
+3. **One-shot migration** modeled on `registry/migrate.rs` — scan per-version `objects.db`s, dedup, write to shared store, record a marker so it runs once.
+4. **Schema evolution discipline** — shared store has its own monotonic version. Forward-compat: newer field readers ignore unknown columns; older version warns + skips unparseable rows.
+
+---
+
+## 1. Current state (what's where today)
+
+### 1.1 Layout
+
+```
+~/.agentmux/
+├── versions/<v>/
+│   ├── data/db/
+│   │   ├── objects.db        ← ALL durable content + per-version instance rows
+│   │   ├── filestore.db
+│   │   ├── sagas.db
+│   │   └── launcher-sagas.db
+│   ├── cef-cache/
+│   ├── logs/
+│   ├── config/
+│   └── agents/<instance>/    ← per-instance working dirs
+└── shared/
+    └── registry/             ← shared named-agent history only
+```
+
+### 1.2 What's in `objects.db` today
+
+| Table | What | Should-share? |
+|---|---|---|
+| `db_identity_bundles` | User-named identity containers (Work, Personal, …) | **Yes** — durable user content. |
+| `db_identity_accounts` | Provider OAuth/API-key creds (one row per attached account) | **Yes** — re-prompting OAuth on every install is hostile. |
+| `db_identity_bindings` | Junction `bundle_id ↔ account_id ↔ provider` | **Yes** — meaningless without bundles+accounts being shared too. |
+| `db_memories` | User-named memory bundles (notes/instructions) | **Yes** — durable user content. |
+| `db_forge_agents` | Agent CLI definitions (Claude, Codex, OpenClaw…) | **Yes** — definitions are content; today reseeded per version on first launch. |
+| `db_agent_instances` | Per-instance launch rows (block_id, identity_id, memory_id, working_directory, …) | **No** — these reference per-version paths + block_ids. Keep per-version; `Continue agent` already federates via the named-agent registry. |
+| `db_oauth_sessions` | Transient OAuth-in-flight | **No** — runtime state. |
+| `db_skills`, `db_mcp_servers` (if present) | TBD — depend on whether they're user content or per-version | Probably yes. |
+
+The registry already shares **named-agent history** (Continue-agent dropdown). That stays unchanged.
+
+### 1.3 Why this matters now
+
+- Spec §3.1 of the launch-modal hardening (just shipped) made Identity + Memory **required at launch**. Users with zero bundles must create them. Doing that once per install is friction the spec did not anticipate.
+- Phase β/γ added the "+ New" affordance specifically to make creation cheap — that helps first-time-per-version creation, but doesn't help "I already have my Work identity in v0.36.0; let me just use it in v0.37.0."
+- The Stage 2 reducer refactor + 124 tests make the wire shape stable enough to safely bolt sharing underneath.
+
+---
+
+## 2. Design
+
+### 2.1 New layout
+
+```
+~/.agentmux/
+├── versions/<v>/data/db/objects.db   ← `db_agent_instances` only (per-version runtime state)
+├── versions/<v>/...                  ← unchanged: cef-cache, logs, sagas, agents/
+└── shared/
+    ├── registry/                     ← existing named-agent history (unchanged)
+    ├── store.db                      ← NEW: shared SQLite for durable content
+    └── secrets/                      ← OAuth tokens (existing OS-keychain path stays)
+        └── …
+```
+
+Notes:
+- `store.db` is the new home for `db_identity_*`, `db_memories`, `db_forge_agents`.
+- OS-keychain references (`SecretRef`) stay where they are — those already aren't IN `objects.db`; only the indirection (`SecretRef` ID strings) live in DB. So sharing the DB shares the indirection, which resolves to the same OS keychain entry from any version. ✓
+- `versions/<v>/data/db/objects.db` keeps just `db_agent_instances` (and any other per-version-only tables). Migration drops the shared tables from per-version DBs at the end.
+
+### 2.2 Schema versioning
+
+`shared/store.db` has its own `PRAGMA user_version`. Migrations live in a new `agentmux-srv/src/shared/migrations.rs`. The schema is initially **a copy of the relevant tables from `agentmux-srv/src/backend/storage/migrations.rs`** at the time this spec ships.
+
+Forward-compat rules:
+- Newer version reads older `store.db`: missing columns get defaults during read; new columns are added by migration on first launch of the newer version.
+- Older version reads newer `store.db`: unknown columns are ignored (`SELECT id, name, …` enumerates expected columns explicitly). Unknown TABLES are ignored.
+- Breaking schema changes go through the same RFC #857-style changeset workflow and are flagged in `VERSION_HISTORY.md` — users see a release note about a forced migration.
+
+### 2.3 RPC + reducer impact
+
+- Backend RPCs that read/write these tables (`upsertmemory`, `upsertidentitybundle`, `bundle_identity_bind`, `listidentitybundles`, …) target `store.db` instead of `objects.db`. Wrap `WaveStore::open` with a path resolver that picks `store.db` for shared tables vs `objects.db` for the instance table.
+- Frontend reducer slice (`launch-flow-state`) is **unchanged**. The view doesn't care what backing file the data comes from.
+- The `identitybundlebindings:changed:<id>` event (already cross-tab-broadcasted via WPS) gains a free win — it now also broadcasts across versions IF they share the same WPS process. They don't (each version has its own srv on a dynamic port), so cross-version reactivity needs a different mechanism.
+
+### 2.4 Cross-version reactivity
+
+Each version runs its own `agentmux-srv` sidecar. They can't subscribe to each other's WPS broker. Options:
+
+1. **SQLite WAL polling** — each srv polls `store.db`'s WAL frames for changes and broadcasts to its own clients. Cheap, ~1s lag, no coordination needed. Recommended for v1.
+2. **File watcher on `store.db`** — works but less precise (full-file mtime is the only signal in pure-fs mode).
+3. **Named-pipe IPC between sidecars** — overkill; introduces a discovery problem.
+
+V1 ships with **option 1**. Each srv runs a 1-second poll on `store.db`'s SQLite `data_version` PRAGMA; on change, refresh the in-memory cache and emit the relevant `identitybundlebindings:changed:*` / `bundles:changed` events to its renderer.
+
+### 2.5 One-shot migration
+
+Modeled on `registry/migrate.rs`:
+
+1. On srv startup, check `~/.agentmux/shared/.migrated_from_per_version` marker. If present, skip.
+2. Otherwise, enumerate `~/.agentmux/versions/*/data/db/objects.db`.
+3. For each file, read-only-open and extract: `db_identity_bundles`, `db_identity_accounts`, `db_identity_bindings`, `db_memories`, `db_forge_agents`.
+4. For each row, insert into `shared/store.db` with conflict resolution (§2.6).
+5. Write the marker.
+6. Per-version `objects.db` rows are **not deleted** in v1 — kept as a fallback in case migration is buggy. A follow-up release (e.g. v0.40.0) drops the per-version columns.
+
+Migration is **idempotent + read-only on the source DBs** — same discipline as the named-agent registry migration.
+
+### 2.6 Conflict resolution
+
+Same name, different `id` in two versions (the common case — user created "Work" identity independently in 0.34.0 and 0.37.0):
+
+| Strategy | Pro | Con | v1 choice |
+|---|---|---|---|
+| Latest `updated_at` wins | Simple | Loses the other's bindings | **No** |
+| Merge bundles by name | Preserves both versions' work | Requires deduping bindings underneath | **No** in v1 (complexity) |
+| Keep both as `Work` and `Work (0.34.0)` | Lossless | Clutters the dropdown | **Yes** in v1 |
+
+V1 ships the rename-on-conflict strategy. A future "merge identical bundles" UI lives in the Identity pane.
+
+For `db_forge_agents` (seeded agent definitions), name conflicts are common but rows are content-identical — keep the seeded version with the lower `created_at` (oldest install wins; later seeds skipped via `INSERT OR IGNORE` on `(slug, parent_id)`).
+
+### 2.7 Per-version opt-out
+
+Some users may want to test feature-branch builds without polluting their shared bundles. Add `AGENTMUX_USE_LOCAL_STORE=1` env var: when set, the srv falls back to per-version `objects.db` for ALL tables (legacy behavior). Document for developers; not a user-facing setting.
+
+### 2.8 Backward compatibility
+
+Older versions launched after this ships (e.g. user pins 0.35.0 to compare):
+- They read `~/.agentmux/versions/0.35.0/data/db/objects.db` — which after migration STILL contains the original rows (we didn't delete them in v1, §2.5).
+- So 0.35.0 sees the snapshot from its install date. New bundles created in 0.37.0+ are invisible to 0.35.0. Acceptable.
+- Once v0.40.0 drops per-version columns, older versions can't read anything; flagged as a release-notes breaking change.
+
+---
+
+## 3. Implementation phases
+
+### Phase 1 — read path (no migration yet)
+
+1. Add `agentmux-srv/src/shared/store.rs` — opens `~/.agentmux/shared/store.db`, runs migrations.
+2. Add `SharedStore` type alongside existing `WaveStore`.
+3. Adapt the relevant RPC handlers (`listidentitybundles`, `listmemories`, `listforgeagents`, `listidentitybindings`, …) to read from `SharedStore`.
+4. **Without writing yet** — write paths still target `WaveStore` so we can compare in dev.
+
+Wire this behind `AGENTMUX_SHARED_STORE_READS=1` for canary testing.
+
+### Phase 2 — migration
+
+5. Implement `migrate_from_per_version()` in `shared/migrate.rs`. Same shape as `registry/migrate.rs`.
+6. Wire into srv startup with the marker file gate.
+7. Document in release notes.
+
+### Phase 3 — write path
+
+8. Switch upsert/bind/unbind/upsertmemory/upsertforgeagent RPCs to write to `SharedStore`.
+9. Drop the `AGENTMUX_SHARED_STORE_READS` gate (always on).
+
+### Phase 4 — cross-version reactivity
+
+10. SQLite `data_version` polling per §2.4.
+11. Emit `identitybundlebindings:changed:*` / `bundles:changed` / `memories:changed` events when poll detects mutation.
+12. Frontend launch-flow-state already subscribes — gets cross-version reactivity for free.
+
+### Phase 5 — per-version cleanup (separate release)
+
+13. v0.40.0+ drops the shared tables from per-version `objects.db`. Release-notes-flagged.
+
+---
+
+## 4. Risks + open questions
+
+### 4.1 Risks
+
+- **Lock contention.** Multiple srv processes hitting the same `store.db` need WAL mode + `busy_timeout`. SQLite handles this well in practice but worth a stress test.
+- **Account secrets in OS keychain.** Sharing `SecretRef` IDs across versions means each version resolves the same keychain entry. Verify on macOS (Keychain Services) + Linux (libsecret / Secret Service) + Windows (Credential Manager).
+- **Migration data loss.** A buggy migration is hostile — non-recoverable. Mitigation: per-version `objects.db` rows are not deleted in v1 (§2.5). Plus a backup of `store.db` is written next to the marker file: `~/.agentmux/shared/store.db.pre-migrate-<v>.backup`.
+- **Forge agent re-seeding.** Each new install seeds default agents into its `objects.db`. With sharing, the seed should happen against `store.db` exactly once (gated by `INSERT OR IGNORE` on `slug` + a release-version watermark).
+
+### 4.2 Open questions
+
+1. **Renaming sensitivity.** If user renames a shared identity in 0.37.0, the 0.36.0 instance shows the old name until it polls + reloads. UX-acceptable in v1 (~1s).
+2. **Delete semantics.** Deleting a shared bundle removes it from all versions. Add a confirmation dialog noting "this affects all your AgentMux installs". V1 keeps the existing single-confirmation; revisit if support tickets surface.
+3. **Multi-user.** This spec assumes one OS user. Multi-user (e.g. company shared workstation) is out of scope.
+4. **`db_skills` / `db_mcp_servers` / future content tables.** Need to be classified the same way (durable vs runtime) as they're added. Add to §1.2 table on each new table.
+
+---
+
+## 5. Acceptance criteria
+
+1. After upgrading from 0.37.0 (per-version) to a release shipping Phase 3, identity bundles + memories + accounts created in 0.37.0 appear in the new version without user action.
+2. Old per-version `objects.db` rows remain readable by older versions (until Phase 5).
+3. Binding an account in version A, reopening version B → version B sees the new binding within 1s.
+4. SQLite stress test: two srvs hammering `store.db` for 60s show no lock contention errors.
+5. `AGENTMUX_USE_LOCAL_STORE=1` opt-out preserves legacy behavior.
+6. Migration marker file is present + correctly idempotent (re-running srv doesn't re-migrate).
+7. Backup file (`store.db.pre-migrate-*.backup`) exists after Phase 2 ships.
+
+---
+
+## 6. Out of scope
+
+- **Cloud sync.** Some users want bundles synced across machines. This spec only addresses cross-version on the same machine. Cloud sync is a separate, larger effort with auth + encryption concerns.
+- **Encryption at rest** for `store.db`. OAuth tokens live in OS keychain (already encrypted by the OS); the SQLite has only `SecretRef` IDs. If full-DB encryption is wanted later, that's a separate spec.
+- **Merge-identical-bundles UI.** The rename-on-conflict (§2.6) is the v1 shipping strategy. A merge UI is a follow-up.
+- **Per-tab / per-pane bundle scoping.** Bundles are user-scoped. Per-pane overrides are out of scope.
+
+---
+
+## 7. References
+
+- [`agentmux-common/src/data_paths.rs`](../../agentmux-common/src/data_paths.rs) — current layout
+- [`agentmux-srv/src/registry/migrate.rs`](../../agentmux-srv/src/registry/migrate.rs) — model for §2.5
+- [`agentmux-srv/src/backend/storage/migrations.rs`](../../agentmux-srv/src/backend/storage/migrations.rs) — schema this spec moves
+- SPEC_LAUNCH_MODAL_STATE_MACHINE_2026_05_19.md — the reducer slice this spec sits underneath


### PR DESCRIPTION
## Summary

Closes §8.3 of [AUDIT_SQLITE_SYSTEMS_2026_05_19.md](../blob/agenta/sqlite-cleanup-launcher-sagas-relocation/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md).

`launcher-sagas.db` now lives at `<data-dir>/db/launcher-sagas.db` alongside `objects.db`, `filestore.db`, `sagas.db`. New `launcher_saga_log_path()` helper performs a one-shot back-compat rename from the legacy location on first launch. Idempotent + 4 unit tests cover the cases.

Also ships:
- The audit itself (full SQLite inventory across all binaries).
- The cross-version sharing spec ([SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md](../blob/agenta/sqlite-cleanup-launcher-sagas-relocation/docs/specs/SPEC_SHARED_BUNDLES_AND_DEFINITIONS_2026_05_19.md)) for context — not implemented here.
- Audit §8.2 retraction (duplicate saga tables was a false alarm — verified).

## Test plan

- [ ] `cargo test -p agentmux-launcher data_dir::tests` → 4/4 pass.
- [ ] Fresh portable: `db/launcher-sagas.db` created on first launch; no file at `<data-dir>/launcher-sagas.db`.
- [ ] Upgrade smoke: launch a build with a legacy file present; first launch moves it; second launch is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)