### PR TITLE
refactor(storage): rename db_identities → db_identity_bundles (v11)

### DIFF
--- a/.changesets/1779218334-refactor-storage-rename-db-identities-db-identity-bundles-an-txww.md
+++ b/.changesets/1779218334-refactor-storage-rename-db-identities-db-identity-bundles-an-txww.md
@@ -1,0 +1,26 @@
+---
+type: patch
+---
+
+refactor(storage): rename `db_identities` → `db_identity_bundles` and `db_memories` → `db_memory_bundles` (v11)
+
+Closes AUDIT_SQLITE_SYSTEMS §8.1 — the schema-naming drift where v7 created
+tables under the bare names but the rest of the codebase + UI vocabulary used
+"identity bundle" / "memory bundle." The "bundle" suffix conveys that each row
+carries multiple facets (provider bindings + display name for identities;
+instructions + context_files + mcp_servers + skills for memories).
+
+- New `run_forge_v11_migrations`: idempotent `ALTER TABLE … RENAME` for both
+  tables, plus DROP+CREATE on the `is_blank` indexes. SQLite ≥ 3.25
+  auto-updates the FK reference in `db_identity_bindings`, so the binding
+  cascade-delete still works through the rename (covered by a new test).
+- v7 now guards its legacy-name DDL/seed/shadow-migrate block on
+  `db_identity_bundles` not yet existing — prevents re-creating empty old
+  tables alongside the renamed ones on every subsequent startup.
+- v1 (the base `db_forge_agents` CREATE) extracted into its own
+  `run_forge_v1_migrations` so tests can stage a pre-v7 schema and exercise
+  the legacy path independently.
+- All `wstore.rs` queries + doc comments updated to the bundle names.
+- `db_identity_bindings` is intentionally NOT renamed — its name was already
+  bundle-consistent (a binding binds an identity bundle to a provider
+  account; the surrounding object IS the binding, not the bundle).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ These views exist in the codebase but are **not** widget-bar entries — do not 
 | Surface | How it's reached |
 |---|---|
 | **Identity** | Tab inside an Agent pane (cog → settings panel → Identity tab). The `view: "identity"` registration and `IdentityPaneViewModel` exist for `pane.open` RPC and right-click menu paths; no widget-bar entry. |
-| **Memory** | Tab inside an Agent pane (cog → settings panel → Memory tab). Same shape as Identity — view registered for programmatic access only. Replaces the old Forge concept; `db_forge_agents` rows migrated into `db_memories` in the v7 schema. The `block.tsx` migration shim still redirects `view: "forge"` blocks to `view: "agent"` for backward compatibility. |
+| **Memory** | Tab inside an Agent pane (cog → settings panel → Memory tab). Same shape as Identity — view registered for programmatic access only. Replaces the old Forge concept; `db_forge_agents` rows migrated into the bundle table in the v7 schema (renamed `db_memories` → `db_memory_bundles` by v11). The `block.tsx` migration shim still redirects `view: "forge"` blocks to `view: "agent"` for backward compatibility. |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in the user's default editor. |
 | **Subagent** | Spawned by clicking a sub-agent in the Swarm pane's overview. Not a top-level pane type the user opens directly. |
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The widget bar shows pinned widgets directly; the rest live in a **More** dropdo
 | Surface | How to reach it |
 |---|---|
 | **Identity** | Tab inside an Agent pane (cog → settings → Identity). Manage the credential bundle assigned to this instance. |
-| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle (provider, model, instructions, MCP, skills). Replaces the old Forge concept — `db_forge_agents` rows migrated into `db_memories` in the v7 schema. |
+| **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle (provider, model, instructions, MCP, skills). Replaces the old Forge concept — `db_forge_agents` rows migrated into the bundle table in the v7 schema (renamed `db_memory_bundles` by v11). |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in your default editor. |
 
 ## Agents

--- a/agentmux-srv/src/agents/types.rs
+++ b/agentmux-srv/src/agents/types.rs
@@ -19,11 +19,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentRef {
-    /// FK to `db_identities.id`. Empty = blank singleton (ambient
+    /// FK to `db_identity_bundles.id`. Empty = blank singleton (ambient
     /// creds, no env-var injection at spawn).
     #[serde(default)]
     pub identity_id: String,
-    /// FK to `db_memories.id`. Empty = blank singleton (vanilla CLI,
+    /// FK to `db_memory_bundles.id`. Empty = blank singleton (vanilla CLI,
     /// no system instructions injected).
     #[serde(default)]
     pub memory_id: String,

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -1663,12 +1663,12 @@ pub struct CommandCreateAgentInstanceData {
     pub block_id: String,
     #[serde(default)]
     pub parent_instance_id: String,
-    /// FK to db_identities. Empty = blank singleton (no env-var
+    /// FK to db_identity_bundles. Empty = blank singleton (no env-var
     /// injection; agent inherits ambient creds). Set by the launch
     /// modal's Identity dropdown.
     #[serde(default)]
     pub identity_id: String,
-    /// FK to db_memories. Empty = blank singleton. Set by the launch
+    /// FK to db_memory_bundles. Empty = blank singleton. Set by the launch
     /// modal's Memory dropdown.
     #[serde(default)]
     pub memory_id: String,
@@ -1704,8 +1704,8 @@ pub struct CommandListNamedAgentsData {
 
 /// One row of the launch modal's "Continue agent" dropdown. Joins
 /// `db_agent_instances` with `db_forge_agents` (for the definition's
-/// display name + provider) and `db_identities` / `db_memories` (for
-/// bundle names) so the frontend renders without further lookups.
+/// display name + provider) and `db_identity_bundles` / `db_memory_bundles`
+/// (for bundle names) so the frontend renders without further lookups.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NamedAgentRow {
     pub instance_id: String,

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -944,60 +944,105 @@ pub fn run_forge_v10_migrations(conn: &Connection) -> Result<(), StoreError> {
 ///
 /// Closes AUDIT_SQLITE_SYSTEMS §8.1.
 ///
-/// Idempotent: skips when the new names already exist. SQLite ≥ 3.25
-/// auto-updates the FK reference in `db_identity_bindings` when its
-/// parent table is renamed, so no separate touch of the binding table
-/// is required.
+/// Idempotent. Three cases per pair:
+///
+/// 1. Only the legacy table exists (first upgrade from pre-v11): ALTER
+///    TABLE RENAME. SQLite ≥ 3.25 auto-updates the FK reference in
+///    `db_identity_bindings` when its parent table is renamed.
+/// 2. Only the bundle table exists (already-migrated or fresh install):
+///    no-op.
+/// 3. **Both exist** (downgrade-then-re-upgrade — a user upgraded to a
+///    v11-aware build, then ran an older build that re-created empty
+///    `db_identities`/`db_memories` and possibly wrote new rows, then
+///    re-upgraded). Merge orphaned legacy rows into the bundle table
+///    via INSERT OR IGNORE (preserves existing bundle rows on id/name
+///    collision), then DROP the legacy table. The downgrade-era
+///    `db_identity_bindings` rows kept their `FK → db_identity_bundles`
+///    constraint across the round-trip (SQLite stores the CREATE
+///    statement, IF NOT EXISTS does not rewrite it), so the binding
+///    cascade stays intact.
+///
+/// Codex P1 on #933 (2026-05-19): without the case-3 merge, rows
+/// written during a downgrade are stranded silently. Reproduced + fixed.
 ///
 /// `db_identity_bindings` itself is NOT renamed — its name was already
 /// suffix-consistent with the bundle vocabulary (a binding binds an
 /// identity bundle to a provider account; the surrounding object is the
 /// binding, not the bundle).
 pub fn run_forge_v11_migrations(conn: &Connection) -> Result<(), StoreError> {
-    let identities_exists: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master
-         WHERE type='table' AND name='db_identities'",
-        [],
+    reconcile_legacy_into_bundle(
+        conn,
+        "db_identities",
+        "db_identity_bundles",
+        "idx_identities_is_blank",
+        "idx_identity_bundles_is_blank",
+        // Identity table columns — must match v7 DDL exactly.
+        "id, name, description, is_blank, created_at, updated_at",
+    )?;
+    reconcile_legacy_into_bundle(
+        conn,
+        "db_memories",
+        "db_memory_bundles",
+        "idx_memories_is_blank",
+        "idx_memory_bundles_is_blank",
+        // Memory table columns — must match v7 DDL exactly.
+        "id, name, description, is_blank, provider, model, instructions, \
+         context_files, mcp_servers, skills, created_at, updated_at",
+    )?;
+    Ok(())
+}
+
+/// Idempotent rename + merge helper for v11. See `run_forge_v11_migrations`
+/// for the three cases this handles and the downgrade-roundtrip scenario
+/// that motivated case 3.
+fn reconcile_legacy_into_bundle(
+    conn: &Connection,
+    legacy: &str,
+    bundle: &str,
+    legacy_index: &str,
+    bundle_index: &str,
+    columns: &str,
+) -> Result<(), StoreError> {
+    let legacy_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+        [legacy],
         |row| row.get(0),
     )?;
-    let identity_bundles_exists: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master
-         WHERE type='table' AND name='db_identity_bundles'",
-        [],
+    let bundle_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name=?1",
+        [bundle],
         |row| row.get(0),
     )?;
 
-    if identities_exists == 1 && identity_bundles_exists == 0 {
-        conn.execute_batch(
-            "ALTER TABLE db_identities RENAME TO db_identity_bundles;
-             DROP INDEX IF EXISTS idx_identities_is_blank;
-             CREATE INDEX IF NOT EXISTS idx_identity_bundles_is_blank
-                 ON db_identity_bundles(is_blank);",
-        )?;
+    match (legacy_exists == 1, bundle_exists == 1) {
+        (false, _) => {
+            // Case 2: legacy gone, nothing to do.
+        }
+        (true, false) => {
+            // Case 1: first upgrade — rename + reindex.
+            conn.execute_batch(&format!(
+                "ALTER TABLE {legacy} RENAME TO {bundle};
+                 DROP INDEX IF EXISTS {legacy_index};
+                 CREATE INDEX IF NOT EXISTS {bundle_index}
+                     ON {bundle}(is_blank);"
+            ))?;
+        }
+        (true, true) => {
+            // Case 3: downgrade-roundtrip — merge then drop. INSERT OR
+            // IGNORE protects existing bundle rows from being clobbered;
+            // any id/name collisions silently keep the bundle copy
+            // (which reflects the user's current-build writes). Rows
+            // unique to the legacy table get rescued.
+            conn.execute_batch(&format!(
+                "INSERT OR IGNORE INTO {bundle} ({columns})
+                     SELECT {columns} FROM {legacy};
+                 DROP TABLE {legacy};
+                 DROP INDEX IF EXISTS {legacy_index};
+                 CREATE INDEX IF NOT EXISTS {bundle_index}
+                     ON {bundle}(is_blank);"
+            ))?;
+        }
     }
-
-    let memories_exists: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master
-         WHERE type='table' AND name='db_memories'",
-        [],
-        |row| row.get(0),
-    )?;
-    let memory_bundles_exists: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master
-         WHERE type='table' AND name='db_memory_bundles'",
-        [],
-        |row| row.get(0),
-    )?;
-
-    if memories_exists == 1 && memory_bundles_exists == 0 {
-        conn.execute_batch(
-            "ALTER TABLE db_memories RENAME TO db_memory_bundles;
-             DROP INDEX IF EXISTS idx_memories_is_blank;
-             CREATE INDEX IF NOT EXISTS idx_memory_bundles_is_blank
-                 ON db_memory_bundles(is_blank);",
-        )?;
-    }
-
     Ok(())
 }
 
@@ -1668,6 +1713,153 @@ mod tests {
                 .unwrap();
             assert_eq!(count, 0, "v11 must not resurrect {legacy}");
         }
+    }
+
+    #[test]
+    fn test_forge_v11_merges_legacy_into_bundle_when_both_exist() {
+        // Codex P1 on #933 (2026-05-19): the downgrade-then-re-upgrade
+        // scenario. User upgrades to v11 (legacy → bundle rename), runs an
+        // older build that recreates empty `db_identities`/`db_memories`
+        // via v7's CREATE IF NOT EXISTS and possibly writes rows, then
+        // re-upgrades. v11 must merge orphan legacy rows into the bundle
+        // and drop the legacy table — without this, downgrade-era writes
+        // are silently stranded.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Simulate the post-upgrade-then-downgrade state: v7 has just been
+        // run for legacy creation, then v11 renames, then we manually
+        // re-create the legacy tables (= what old code would do on
+        // downgrade) and seed orphan + colliding rows.
+        migrate_through_v7(&conn).unwrap();
+        run_forge_v11_migrations(&conn).unwrap();
+
+        // Seed a row that exists ONLY in the bundle (current-build write).
+        conn.execute_batch(
+            "INSERT INTO db_identity_bundles
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES ('bundle-only', 'BundleOnly', '', 0, 100, 100);
+
+             INSERT INTO db_memory_bundles
+                (id, name, description, is_blank, provider, model, instructions,
+                 context_files, mcp_servers, skills, created_at, updated_at)
+             VALUES ('bundle-only', 'BundleOnly', '', 0, '', '', '',
+                     '[]', '[]', '[]', 100, 100);",
+        )
+        .unwrap();
+
+        // Simulate downgrade re-creating empty legacy tables, then writing
+        // orphan rows + an id collision with the bundle.
+        conn.execute_batch(
+            "CREATE TABLE db_identities (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL DEFAULT '',
+                is_blank INTEGER NOT NULL DEFAULT 0,
+                created_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE db_memories (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT NOT NULL DEFAULT '',
+                is_blank INTEGER NOT NULL DEFAULT 0,
+                provider TEXT NOT NULL DEFAULT '',
+                model TEXT NOT NULL DEFAULT '',
+                instructions TEXT NOT NULL DEFAULT '',
+                context_files TEXT NOT NULL DEFAULT '[]',
+                mcp_servers TEXT NOT NULL DEFAULT '[]',
+                skills TEXT NOT NULL DEFAULT '[]',
+                created_at INTEGER NOT NULL DEFAULT 0,
+                updated_at INTEGER NOT NULL DEFAULT 0
+             );
+
+             -- Rescuable orphans (id NOT in the bundle):
+             INSERT INTO db_identities
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES ('legacy-orphan', 'LegacyOrphan', 'from downgrade',
+                     0, 200, 200);
+             INSERT INTO db_memories
+                (id, name, description, is_blank, provider, model, instructions,
+                 context_files, mcp_servers, skills, created_at, updated_at)
+             VALUES ('legacy-orphan', 'LegacyOrphan', 'from downgrade',
+                     0, '', '', '', '[]', '[]', '[]', 200, 200);
+
+             -- Colliding id with the bundle row: OR IGNORE must keep the
+             -- bundle copy (current build's truth).
+             INSERT INTO db_identities
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES ('bundle-only', 'BundleOnly-LegacyOverride', 'stale', 0,
+                     50, 50);",
+        )
+        .unwrap();
+
+        // Re-upgrade: v11 must merge + drop legacy.
+        run_forge_v11_migrations(&conn).unwrap();
+
+        // Legacy tables gone after merge.
+        for legacy in &["db_identities", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [legacy],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "{legacy} should be dropped after merge");
+        }
+
+        // Orphan rescued into the bundle.
+        let orphan_desc: String = conn
+            .query_row(
+                "SELECT description FROM db_identity_bundles WHERE id='legacy-orphan'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphan_desc, "from downgrade");
+        let orphan_mem: String = conn
+            .query_row(
+                "SELECT description FROM db_memory_bundles WHERE id='legacy-orphan'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphan_mem, "from downgrade");
+
+        // Colliding id: bundle copy wins (INSERT OR IGNORE preserves it).
+        let bundle_name: String = conn
+            .query_row(
+                "SELECT name FROM db_identity_bundles WHERE id='bundle-only'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            bundle_name, "BundleOnly",
+            "bundle row must survive an id collision with a legacy row"
+        );
+
+        // Index renamed; legacy index dropped.
+        let new_idx: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='index' \
+                 AND name='idx_identity_bundles_is_blank'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(new_idx, 1);
+        let old_idx: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='index' \
+                 AND name='idx_identities_is_blank'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(old_idx, 0);
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -109,6 +109,24 @@ pub fn run_filestore_migrations(conn: &Connection) -> Result<(), StoreError> {
 /// Initialize the Forge schema.
 /// Creates the db_forge_agents table for user-defined AI agents.
 pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
+    run_forge_v1_migrations(conn)?;
+    run_forge_v2_migrations(conn)?;
+    run_forge_v3_migrations(conn)?;
+    run_forge_v4_migrations(conn)?;
+    run_forge_v5_migrations(conn)?;
+    run_forge_v6_migrations(conn)?;
+    run_forge_v7_migrations(conn)?;
+    run_forge_v8_migrations(conn)?;
+    run_forge_v9_migrations(conn)?;
+    run_forge_v10_migrations(conn)?;
+    run_forge_v11_migrations(conn)?;
+    Ok(())
+}
+
+/// Forge v1: original `db_forge_agents` base table. Kept as a separate
+/// step so tests can stage a pre-v7 state by composing v1..v6 without
+/// pulling later migrations (notably v11's rename to bundle tables).
+pub fn run_forge_v1_migrations(conn: &Connection) -> Result<(), StoreError> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS db_forge_agents (
             id TEXT PRIMARY KEY,
@@ -119,15 +137,6 @@ pub fn run_forge_migrations(conn: &Connection) -> Result<(), StoreError> {
             created_at INTEGER NOT NULL DEFAULT 0
         );",
     )?;
-    run_forge_v2_migrations(conn)?;
-    run_forge_v3_migrations(conn)?;
-    run_forge_v4_migrations(conn)?;
-    run_forge_v5_migrations(conn)?;
-    run_forge_v6_migrations(conn)?;
-    run_forge_v7_migrations(conn)?;
-    run_forge_v8_migrations(conn)?;
-    run_forge_v9_migrations(conn)?;
-    run_forge_v10_migrations(conn)?;
     Ok(())
 }
 
@@ -443,18 +452,20 @@ pub fn run_forge_v6_migrations(conn: &Connection) -> Result<(), StoreError> {
 ///
 /// Schema changes:
 ///
-/// - `db_identities` (new): named Identity bundles. Each row has a unique
-///   `name` (e.g. "Work", "Personal"). The `is_blank` flag tags the seeded
-///   singleton row that the launch UI defaults to.
+/// - `db_identities` (new — later renamed to `db_identity_bundles` by v11):
+///   named Identity bundles. Each row has a unique `name` (e.g. "Work",
+///   "Personal"). The `is_blank` flag tags the seeded singleton row that the
+///   launch UI defaults to.
 /// - `db_identity_bindings` (new): junction `(identity_id, provider) →
 ///   account_id`. Replaces the per-agent semantics of v6's
 ///   `db_forge_agent_identities` (which is left in place as legacy fallback;
 ///   a future v8 may drop it once all readers are migrated).
-/// - `db_memories` (new): named Memory bundles holding the agent's
-///   personality / capability stack — provider, model, instructions, context
-///   files, MCP servers, skills. Forge agents (`db_forge_agents`) get
-///   shadow-migrated into Memory rows so existing definitions remain
-///   accessible from the new code paths without data loss.
+/// - `db_memories` (new — later renamed to `db_memory_bundles` by v11): named
+///   Memory bundles holding the agent's personality / capability stack —
+///   provider, model, instructions, context files, MCP servers, skills.
+///   Forge agents (`db_forge_agents`) get shadow-migrated into Memory rows so
+///   existing definitions remain accessible from the new code paths without
+///   data loss.
 /// - `db_agent_instances.identity_id` / `db_agent_instances.memory_id` (new
 ///   columns): the launch composition. NULL means "use the blank
 ///   singleton".
@@ -465,6 +476,56 @@ pub fn run_forge_v6_migrations(conn: &Connection) -> Result<(), StoreError> {
 /// ignore them, but they remain on disk so a downgrade path stays open until
 /// v8.
 pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
+    // ---- Add identity_id / memory_id columns to db_agent_instances ----
+    // Always runs (idempotent: duplicate-column errors swallowed).
+    // Unaffected by v11's bundle-table rename — these are columns on
+    // db_agent_instances, not on the renamed tables.
+    let alter_statements = [
+        "ALTER TABLE db_agent_instances ADD COLUMN identity_id TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE db_agent_instances ADD COLUMN memory_id TEXT NOT NULL DEFAULT ''",
+    ];
+    for stmt in &alter_statements {
+        match conn.execute_batch(stmt) {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("duplicate column") {
+                    return Err(StoreError::Sqlite(match e {
+                        rusqlite::Error::SqliteFailure(code, _) => {
+                            rusqlite::Error::SqliteFailure(code, Some(msg))
+                        }
+                        other => other,
+                    }));
+                }
+            }
+        }
+    }
+
+    // Guard: once v11 has renamed `db_identities` → `db_identity_bundles`
+    // and `db_memories` → `db_memory_bundles`, the legacy-named CREATE +
+    // singleton seed + shadow-migrate block below would either re-create
+    // empty old-named tables alongside the renamed ones, or write to old
+    // names that no longer exist. Skip the legacy block in that case —
+    // the data is safe under the new names.
+    let bundles_exist: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type='table' AND name='db_identity_bundles'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if bundles_exist == 0 {
+        run_forge_v7_legacy_ddl_and_seed(conn)?;
+    }
+
+    Ok(())
+}
+
+/// Legacy-name DDL + singleton seed + shadow-migrate from v7. Split out
+/// of `run_forge_v7_migrations` so the guard there can skip it once v11
+/// has renamed the bundle tables. See v7's doc comment for what each
+/// statement does and why.
+fn run_forge_v7_legacy_ddl_and_seed(conn: &Connection) -> Result<(), StoreError> {
     // ---- New tables ----
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS db_identities (
@@ -506,28 +567,6 @@ pub fn run_forge_v7_migrations(conn: &Connection) -> Result<(), StoreError> {
         CREATE INDEX IF NOT EXISTS idx_memories_is_blank
             ON db_memories(is_blank);",
     )?;
-
-    // ---- Add identity_id / memory_id columns to db_agent_instances ----
-    let alter_statements = [
-        "ALTER TABLE db_agent_instances ADD COLUMN identity_id TEXT NOT NULL DEFAULT ''",
-        "ALTER TABLE db_agent_instances ADD COLUMN memory_id TEXT NOT NULL DEFAULT ''",
-    ];
-    for stmt in &alter_statements {
-        match conn.execute_batch(stmt) {
-            Ok(_) => {}
-            Err(e) => {
-                let msg = e.to_string();
-                if !msg.contains("duplicate column") {
-                    return Err(StoreError::Sqlite(match e {
-                        rusqlite::Error::SqliteFailure(code, _) => {
-                            rusqlite::Error::SqliteFailure(code, Some(msg))
-                        }
-                        other => other,
-                    }));
-                }
-            }
-        }
-    }
 
     // ---- Seed blank singletons ----
     // The launch UI always renders these as the default option in the
@@ -896,9 +935,90 @@ pub fn run_forge_v10_migrations(conn: &Connection) -> Result<(), StoreError> {
     Ok(())
 }
 
+/// Forge v11 migrations: rename `db_identities` → `db_identity_bundles`
+/// and `db_memories` → `db_memory_bundles`. The "bundle" suffix conveys
+/// that each row carries multiple facets — provider bindings + display
+/// name (for identities) and instructions + context_files + mcp_servers
+/// + skills (for memories) — so the UI's "Identity bundle" / "Memory
+/// bundle" terminology matches the storage layer.
+///
+/// Closes AUDIT_SQLITE_SYSTEMS §8.1.
+///
+/// Idempotent: skips when the new names already exist. SQLite ≥ 3.25
+/// auto-updates the FK reference in `db_identity_bindings` when its
+/// parent table is renamed, so no separate touch of the binding table
+/// is required.
+///
+/// `db_identity_bindings` itself is NOT renamed — its name was already
+/// suffix-consistent with the bundle vocabulary (a binding binds an
+/// identity bundle to a provider account; the surrounding object is the
+/// binding, not the bundle).
+pub fn run_forge_v11_migrations(conn: &Connection) -> Result<(), StoreError> {
+    let identities_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type='table' AND name='db_identities'",
+        [],
+        |row| row.get(0),
+    )?;
+    let identity_bundles_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type='table' AND name='db_identity_bundles'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if identities_exists == 1 && identity_bundles_exists == 0 {
+        conn.execute_batch(
+            "ALTER TABLE db_identities RENAME TO db_identity_bundles;
+             DROP INDEX IF EXISTS idx_identities_is_blank;
+             CREATE INDEX IF NOT EXISTS idx_identity_bundles_is_blank
+                 ON db_identity_bundles(is_blank);",
+        )?;
+    }
+
+    let memories_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type='table' AND name='db_memories'",
+        [],
+        |row| row.get(0),
+    )?;
+    let memory_bundles_exists: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM sqlite_master
+         WHERE type='table' AND name='db_memory_bundles'",
+        [],
+        |row| row.get(0),
+    )?;
+
+    if memories_exists == 1 && memory_bundles_exists == 0 {
+        conn.execute_batch(
+            "ALTER TABLE db_memories RENAME TO db_memory_bundles;
+             DROP INDEX IF EXISTS idx_memories_is_blank;
+             CREATE INDEX IF NOT EXISTS idx_memory_bundles_is_blank
+                 ON db_memory_bundles(is_blank);",
+        )?;
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Run all forge migrations up to and including v7, but NOT v11. Used by
+    /// tests that need to exercise v7's legacy-named DDL/seed/shadow-migrate
+    /// path (which the v11 rename + the guard in `run_forge_v7_migrations`
+    /// skip on post-v11 schemas).
+    fn migrate_through_v7(conn: &Connection) -> Result<(), StoreError> {
+        run_forge_v1_migrations(conn)?;
+        run_forge_v2_migrations(conn)?;
+        run_forge_v3_migrations(conn)?;
+        run_forge_v4_migrations(conn)?;
+        run_forge_v5_migrations(conn)?;
+        run_forge_v6_migrations(conn)?;
+        run_forge_v7_migrations(conn)?;
+        Ok(())
+    }
 
     #[test]
     fn test_wstore_migrations_idempotent() {
@@ -1113,8 +1233,14 @@ mod tests {
 
         run_forge_migrations(&conn).unwrap();
 
-        // Tables exist
-        for table in &["db_identities", "db_identity_bindings", "db_memories"] {
+        // Tables exist under their post-v11 names (v7 creates legacy names,
+        // v11 renames them to `*_bundles`). `db_identity_bindings` is not
+        // renamed.
+        for table in &[
+            "db_identity_bundles",
+            "db_identity_bindings",
+            "db_memory_bundles",
+        ] {
             let count: i64 = conn
                 .query_row(
                     "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
@@ -1125,10 +1251,23 @@ mod tests {
             assert_eq!(count, 1, "table {table} should exist");
         }
 
-        // Blank singletons seeded
+        // Legacy names are gone after v11's rename.
+        for legacy in &["db_identities", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [legacy],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "legacy table {legacy} should be renamed");
+        }
+
+        // Blank singletons seeded (seeded into legacy names by v7, carried
+        // across the v11 rename into the bundle tables).
         let id_blank: i64 = conn
             .query_row(
-                "SELECT count(*) FROM db_identities WHERE id='blank' AND is_blank=1",
+                "SELECT count(*) FROM db_identity_bundles WHERE id='blank' AND is_blank=1",
                 [],
                 |row| row.get(0),
             )
@@ -1137,7 +1276,7 @@ mod tests {
 
         let mem_blank: i64 = conn
             .query_row(
-                "SELECT count(*) FROM db_memories WHERE id='blank' AND is_blank=1",
+                "SELECT count(*) FROM db_memory_bundles WHERE id='blank' AND is_blank=1",
                 [],
                 |row| row.get(0),
             )
@@ -1167,10 +1306,12 @@ mod tests {
         run_forge_migrations(&conn).unwrap();
         run_forge_migrations(&conn).unwrap(); // second pass
 
-        // Singletons remain unique (INSERT OR IGNORE on second pass)
+        // Singletons remain unique. On the second pass v7's guard skips the
+        // legacy-name INSERTs (bundles already exist); the rows live in the
+        // renamed bundle tables.
         let id_count: i64 = conn
             .query_row(
-                "SELECT count(*) FROM db_identities WHERE id='blank'",
+                "SELECT count(*) FROM db_identity_bundles WHERE id='blank'",
                 [],
                 |row| row.get(0),
             )
@@ -1179,12 +1320,28 @@ mod tests {
 
         let mem_count: i64 = conn
             .query_row(
-                "SELECT count(*) FROM db_memories WHERE id='blank'",
+                "SELECT count(*) FROM db_memory_bundles WHERE id='blank'",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
         assert_eq!(mem_count, 1, "blank Memory should remain a singleton");
+
+        // Legacy names must not be re-created by the second pass — v7's
+        // guard must keep the post-v11 schema stable across replays.
+        for legacy in &["db_identities", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [legacy],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(
+                count, 0,
+                "legacy {legacy} must not be resurrected on migration replay"
+            );
+        }
     }
 
     #[test]
@@ -1193,10 +1350,10 @@ mod tests {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .unwrap();
 
-        // Run up through v6 first, insert a forge agent, then run v7.
-        // We fake "before-v7" by re-running migrations after a manual delete
-        // of the v7 rows the first run would have inserted.
-        run_forge_migrations(&conn).unwrap();
+        // Stop the migration chain at v7 so we can verify v7's legacy-named
+        // shadow-migrate path. Once v11 has run, v7's guard skips this block
+        // entirely (the data lives in the renamed bundle tables instead).
+        migrate_through_v7(&conn).unwrap();
         conn.execute_batch(
             "DELETE FROM db_memories;
              INSERT INTO db_forge_agents
@@ -1239,7 +1396,7 @@ mod tests {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .unwrap();
 
-        run_forge_migrations(&conn).unwrap();
+        migrate_through_v7(&conn).unwrap();
         conn.execute_batch(
             "DELETE FROM db_memories;
              INSERT INTO db_forge_agents
@@ -1297,7 +1454,7 @@ mod tests {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .unwrap();
 
-        run_forge_migrations(&conn).unwrap();
+        migrate_through_v7(&conn).unwrap();
         conn.execute_batch(
             "DELETE FROM db_memories;
              INSERT INTO db_memories
@@ -1337,12 +1494,17 @@ mod tests {
         conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
             .unwrap();
 
-        // Bring schema up via the full migration chain. This already creates
-        // the v7 tables and runs the backfill. To prove the backfill works
-        // on data that pre-dates v7, we (a) insert a forge agent + an
-        // instance referencing it, then (b) zero memory_id and (c) re-run
-        // v7 directly. After step (c) memory_id should be populated.
-        run_forge_migrations(&conn).unwrap();
+        // Stage a pre-v7 state: v1..v6 brings the schema to where
+        // db_agent_instances exists without identity_id/memory_id, then we
+        // insert a forge agent + an instance referencing it. v7's ALTER
+        // adds the columns and the backfill copies definition_id into
+        // memory_id.
+        run_forge_v1_migrations(&conn).unwrap();
+        run_forge_v2_migrations(&conn).unwrap();
+        run_forge_v3_migrations(&conn).unwrap();
+        run_forge_v4_migrations(&conn).unwrap();
+        run_forge_v5_migrations(&conn).unwrap();
+        run_forge_v6_migrations(&conn).unwrap();
 
         conn.execute_batch(
             "INSERT INTO db_forge_agents
@@ -1350,8 +1512,8 @@ mod tests {
              VALUES ('forge-1', 'My Coder', '✦', 'claude', 'demo', 1234);
 
              INSERT INTO db_agent_instances
-                (id, definition_id, memory_id, created_at)
-             VALUES ('inst-1', 'forge-1', '', 0);",
+                (id, definition_id, created_at)
+             VALUES ('inst-1', 'forge-1', 0);",
         )
         .unwrap();
 
@@ -1365,6 +1527,192 @@ mod tests {
             )
             .unwrap();
         assert_eq!(backfilled, "forge-1");
+    }
+
+    #[test]
+    fn test_forge_v11_renames_legacy_to_bundle_tables() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Build a pre-v11 schema (v1..v7) so the legacy-named tables are
+        // present with their seeded singletons. v11 then renames them.
+        migrate_through_v7(&conn).unwrap();
+
+        // Sanity check: legacy names exist, bundle names don't.
+        let legacy_id: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='db_identities'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let legacy_mem: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='db_memories'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(legacy_id, 1, "v7 should have created db_identities");
+        assert_eq!(legacy_mem, 1, "v7 should have created db_memories");
+
+        run_forge_v11_migrations(&conn).unwrap();
+
+        // Legacy names gone, bundle names present, data preserved.
+        for legacy in &["db_identities", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [legacy],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "{legacy} should be renamed away");
+        }
+        for bundle in &["db_identity_bundles", "db_memory_bundles"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [bundle],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "{bundle} should exist after rename");
+        }
+
+        let id_blank: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_identity_bundles WHERE id='blank' AND is_blank=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(id_blank, 1, "blank Identity row must survive rename");
+        let mem_blank: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_memory_bundles WHERE id='blank' AND is_blank=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(mem_blank, 1, "blank Memory row must survive rename");
+
+        // Indexes are renamed too.
+        for idx in &[
+            "idx_identity_bundles_is_blank",
+            "idx_memory_bundles_is_blank",
+        ] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                    [idx],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 1, "{idx} should exist post-rename");
+        }
+        for old_idx in &["idx_identities_is_blank", "idx_memories_is_blank"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='index' AND name=?1",
+                    [old_idx],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "legacy index {old_idx} should be dropped");
+        }
+    }
+
+    #[test]
+    fn test_forge_v11_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Full chain twice — must not error and must not leave duplicate
+        // tables behind.
+        run_forge_migrations(&conn).unwrap();
+        run_forge_migrations(&conn).unwrap();
+        // Direct v11 invocation on an already-migrated db must no-op.
+        run_forge_v11_migrations(&conn).unwrap();
+    }
+
+    #[test]
+    fn test_forge_v11_fresh_install_skips_rename() {
+        // On a database that never had the legacy tables (fresh install
+        // built from v1..v10 with a hypothetical future v7 already writing
+        // to bundle names, or — more realistically — a test that creates
+        // the bundle table directly), v11 must be a no-op.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        // Mint just the bundle tables, no legacy.
+        conn.execute_batch(
+            "CREATE TABLE db_identity_bundles (id TEXT PRIMARY KEY, is_blank INTEGER);
+             CREATE TABLE db_memory_bundles  (id TEXT PRIMARY KEY, is_blank INTEGER);",
+        )
+        .unwrap();
+
+        run_forge_v11_migrations(&conn).unwrap();
+
+        // No legacy tables created.
+        for legacy in &["db_identities", "db_memories"] {
+            let count: i64 = conn
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [legacy],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert_eq!(count, 0, "v11 must not resurrect {legacy}");
+        }
+    }
+
+    #[test]
+    fn test_forge_v11_preserves_identity_bindings_fk_cascade() {
+        // SQLite >= 3.25 auto-updates FK references in db_identity_bindings
+        // when its parent (db_identities) is renamed to db_identity_bundles.
+        // Verify the cascade-delete still fires post-rename.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")
+            .unwrap();
+
+        run_forge_migrations(&conn).unwrap();
+
+        // Seed a non-blank identity, an account, and a binding row.
+        conn.execute_batch(
+            "INSERT INTO db_identity_bundles
+                (id, name, description, is_blank, created_at, updated_at)
+             VALUES ('id1', 'Work', '', 0, 0, 0);
+
+             INSERT INTO db_identity_accounts
+                (id, name, provider, kind, secret_ref, created_at, updated_at)
+             VALUES ('acc1', 'gh', 'github', 'pat',
+                     '{\"backend\":\"env\",\"env_var\":\"GITHUB_TOKEN\"}', 0, 0);
+
+             INSERT INTO db_identity_bindings (identity_id, provider, account_id)
+             VALUES ('id1', 'github', 'acc1');",
+        )
+        .unwrap();
+
+        // Delete the parent bundle row — cascade should remove the binding.
+        conn.execute("DELETE FROM db_identity_bundles WHERE id='id1'", [])
+            .unwrap();
+
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM db_identity_bindings WHERE identity_id='id1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            remaining, 0,
+            "FK cascade from db_identity_bundles → db_identity_bindings must \
+             survive the v11 rename"
+        );
     }
 
     #[test]

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -1264,12 +1264,12 @@ pub struct AgentInstance {
     #[serde(default)]
     pub ended_at: i64,
     pub created_at: i64,
-    /// FK to `db_identities.id`. Empty string means "use the blank
+    /// FK to `db_identity_bundles.id`. Empty string means "use the blank
     /// singleton" (= ambient creds, no env-var injection). Set at
     /// instantiation via the launch modal's Identity dropdown.
     #[serde(default)]
     pub identity_id: String,
-    /// FK to `db_memories.id`. Empty string means "use the blank
+    /// FK to `db_memory_bundles.id`. Empty string means "use the blank
     /// singleton" (= vanilla CLI, no instructions). Set at
     /// instantiation via the launch modal's Memory dropdown.
     #[serde(default)]
@@ -1964,7 +1964,7 @@ impl WaveStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, created_at, updated_at
-             FROM db_identities
+             FROM db_identity_bundles
              ORDER BY is_blank ASC, updated_at DESC",
         )?;
         let iter = stmt.query_map([], |row| {
@@ -1988,7 +1988,7 @@ impl WaveStore {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, created_at, updated_at
-             FROM db_identities WHERE id = ?1",
+             FROM db_identity_bundles WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], |row| {
             Ok(Identity {
@@ -2013,7 +2013,7 @@ impl WaveStore {
     pub fn bundle_identity_upsert(&self, identity: &Identity) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO db_identities
+            "INSERT INTO db_identity_bundles
                 (id, name, description, is_blank, created_at, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT(id) DO UPDATE SET
@@ -2041,7 +2041,7 @@ impl WaveStore {
             ));
         }
         let conn = self.conn.lock().unwrap();
-        let rows = conn.execute("DELETE FROM db_identities WHERE id = ?1", params![id])?;
+        let rows = conn.execute("DELETE FROM db_identity_bundles WHERE id = ?1", params![id])?;
         Ok(rows > 0)
     }
 
@@ -2113,7 +2113,7 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, provider, model, instructions,
                     context_files, mcp_servers, skills, created_at, updated_at
-             FROM db_memories
+             FROM db_memory_bundles
              ORDER BY is_blank ASC, updated_at DESC",
         )?;
         let iter = stmt.query_map([], map_memory_row)?;
@@ -2129,7 +2129,7 @@ impl WaveStore {
         let mut stmt = conn.prepare(
             "SELECT id, name, description, is_blank, provider, model, instructions,
                     context_files, mcp_servers, skills, created_at, updated_at
-             FROM db_memories WHERE id = ?1",
+             FROM db_memory_bundles WHERE id = ?1",
         )?;
         let result = stmt.query_row(params![id], map_memory_row);
         match result {
@@ -2142,7 +2142,7 @@ impl WaveStore {
     pub fn bundle_memory_upsert(&self, memory: &Memory) -> Result<(), StoreError> {
         let conn = self.conn.lock().unwrap();
         conn.execute(
-            "INSERT INTO db_memories
+            "INSERT INTO db_memory_bundles
                 (id, name, description, is_blank, provider, model, instructions,
                  context_files, mcp_servers, skills, created_at, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
@@ -2182,7 +2182,7 @@ impl WaveStore {
             ));
         }
         let conn = self.conn.lock().unwrap();
-        let rows = conn.execute("DELETE FROM db_memories WHERE id = ?1", params![id])?;
+        let rows = conn.execute("DELETE FROM db_memory_bundles WHERE id = ?1", params![id])?;
         Ok(rows > 0)
     }
 }

--- a/agentmux-srv/src/registry/schema.rs
+++ b/agentmux-srv/src/registry/schema.rs
@@ -34,9 +34,9 @@ pub struct NamedAgentRecordV1 {
     pub instance_id: String,
     pub instance_name: String,
     pub definition_id: String,
-    /// FK to `db_identities.id`. None = unbound (= ambient creds).
+    /// FK to `db_identity_bundles.id`. None = unbound (= ambient creds).
     pub identity_id: Option<String>,
-    /// FK to `db_memories.id`. None = unbound (= vanilla CLI).
+    /// FK to `db_memory_bundles.id`. None = unbound (= vanilla CLI).
     pub memory_id: Option<String>,
     /// Path **relative to `<shared_home>/agents/`** — never absolute.
     /// Keeps the record portable across machines where the home dir

--- a/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
+++ b/docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md
@@ -41,7 +41,7 @@ This document inventories every SQLite touchpoint: writer, schema, lifecycle, wh
 - PRAGMAs applied per-connection in `WaveStore::configure_and_migrate` (`wstore.rs:56-72`):
   - `journal_mode=WAL`
   - `busy_timeout=5000`
-  - `foreign_keys=ON` (required — `db_agent_instances` cascades on `db_identities` deletion; missed cascades caused issues pre-v6)
+  - `foreign_keys=ON` (required — `db_identity_bindings` cascades on `db_identity_bundles` deletion; missed cascades caused issues pre-v6)
   - `synchronous=NORMAL`
   - `cache_size=-8000`
   - `mmap_size=268435456`
@@ -81,9 +81,9 @@ The `saga` + `saga_step` schema lives in `sagas.db`, owned by `SagaLog` (`sagas/
 | `db_identity_accounts` | Provider OAuth/API-key accounts (one row per attached account) |
 | `db_forge_agent_identities` | Junction: agent ↔ account (legacy v6) |
 | `db_agent_instances` | Per-instance launch rows (block_id, identity_id, memory_id, working_directory, parent_instance_id) |
-| `db_identities` | User-named identity bundles (Work, Personal, …) — Note: type uses `db_identities` in schema but `db_identity_bundles` in some references. **Inconsistency worth fixing.** |
-| `db_identity_bindings` | Junction: identity ↔ account ↔ provider |
-| `db_memories` | User-named memory bundles (notes/instructions) |
+| `db_identity_bundles` (v11; renamed from `db_identities` in v7) | User-named identity bundles (Work, Personal, …) |
+| `db_identity_bindings` | Junction: identity bundle ↔ account ↔ provider |
+| `db_memory_bundles` (v11; renamed from `db_memories` in v7) | User-named memory bundles (notes/instructions) |
 
 #### 2.2.e Workflow / Drone (v9 → v10)
 
@@ -224,7 +224,7 @@ No `sqlx`, no `diesel`, no async DB layer. All SQLite access is synchronous behi
 
 ## 8. Open inconsistencies + clean-up items
 
-1. **Schema naming drift.** v7 creates a table called `db_identities` (`migrations.rs:470`), but the rest of the code and docs call it `db_identity_bundles`. Decide on one; either rename via migration or correct the references. Today readers compose `SELECT … FROM db_identities` so the table name is the canonical one — comments + docs should follow.
+1. ~~**Schema naming drift.** v7 creates a table called `db_identities` (`migrations.rs:470`), but the rest of the code and docs call it `db_identity_bundles`.~~ **Fixed** — v11 (`run_forge_v11_migrations`) renames `db_identities` → `db_identity_bundles` and `db_memories` → `db_memory_bundles` via `ALTER TABLE … RENAME`. SQLite ≥ 3.25 auto-updates the FK reference in `db_identity_bindings`. v7's legacy-name DDL/seed block is guarded so it doesn't re-create empty old tables on subsequent startups. All `wstore.rs` queries and doc comments now use the bundle names.
 
 2. ~~`saga` tables in two files.~~ **Retracted** — the initial audit miscounted; `run_saga_log_migrations` is only invoked from `SagaLog::configure_and_migrate`, so `objects.db` has no saga tables. See §2.2.b.
 
@@ -273,7 +273,7 @@ agentmux-docs internals currently has:
 
 - [`internals/data-layout.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/data-layout.md) — accurate on the per-version tree structure. Missing: registry layout under `shared/`, the planned `shared/store.db`, the `launcher-sagas.db` filename quirk.
 - [`internals/persistence.md`](https://github.com/agentmuxai/agentmux-docs/blob/main/src/content/docs/internals/persistence.md) — accurate on the four-file model. Missing:
-  - The full bundle table catalog (`db_identities`, `db_identity_bindings`, `db_memories`, `db_identity_accounts`)
+  - The full bundle table catalog (`db_identity_bundles`, `db_identity_bindings`, `db_memory_bundles`, `db_identity_accounts`)
   - `db_forge_*` table family
   - `db_drone_*` (workflows → drone rename)
   - The dual-DB `saga` table presence

--- a/frontend/app/view/agent/auth/auth-state.test.ts
+++ b/frontend/app/view/agent/auth/auth-state.test.ts
@@ -656,7 +656,7 @@ describe("auth-state reducer", () => {
                 });
                 const r = update(seeded, {
                     type: "BundleSaveFailed",
-                    error: "UNIQUE constraint failed: db_identities.name",
+                    error: "UNIQUE constraint failed: db_identity_bundles.name",
                 });
                 expect(r.state.kind).toBe("authenticated");
                 expect(r.state.email).toBe("asaf@x.com");

--- a/frontend/app/view/agent/auth/auth-state.ts
+++ b/frontend/app/view/agent/auth/auth-state.ts
@@ -242,7 +242,7 @@ export type AuthEvent =
           intoBundleId: string;
           name: string;
       }
-    /** Save RPC succeeded — bundle id now exists in `db_identities`. */
+    /** Save RPC succeeded — bundle id now exists in `db_identity_bundles`. */
     | { type: "bundle-saved"; bundleId: string }
     /** Save RPC failed — name conflict, DB error, etc. */
     | { type: "bundle-save-failed"; error: string }

--- a/frontend/app/view/memory/memory-model.ts
+++ b/frontend/app/view/memory/memory-model.ts
@@ -41,7 +41,7 @@ export interface MemoryDraft {
 /** Empty draft for the "+ New Memory" flow.
  *
  *  All JSON-array fields default to `"[]"` (not `""`). The backend's
- *  `db_memories.skills` column is JSON-encoded; a literal `""` would
+ *  `db_memory_bundles.skills` column is JSON-encoded; a literal `""` would
  *  trip downstream `JSON.parse(skills)` readers. Reagent P1 on
  *  PR #747 (2026-05-08). */
 export function emptyDraft(): MemoryDraft {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -391,9 +391,9 @@ declare global {
         started_at: number;
         ended_at?: number;
         created_at: number;
-        /** v7 — FK to db_identities. Empty string = blank singleton. */
+        /** v7/v11 — FK to db_identity_bundles. Empty string = blank singleton. */
         identity_id?: string;
-        /** v7 — FK to db_memories. Empty string = blank singleton. */
+        /** v7/v11 — FK to db_memory_bundles. Empty string = blank singleton. */
         memory_id?: string;
         /** v8 — user-chosen instance name (AGENTMUX_AGENT_ID). */
         instance_name?: string;

--- a/specs/settings-cleanup.md
+++ b/specs/settings-cleanup.md
@@ -11,7 +11,7 @@
 
 The first version of this spec only addressed *drift* (keys in code missing from the template). After a re-audit that distinguishes **declared** keys (in `wconfig/types.rs` / `schema/settings.json`) from **read** keys (i.e. something actually accesses them at runtime), the picture is much worse:
 
-- **The `ai:*` namespace is waveterm leftover.** Zero call sites read any `ai:*` setting. AgentMux's agent pane stores its config in `db_agentdefs` / `db_memories`, not these keys.
+- **The `ai:*` namespace is waveterm leftover.** Zero call sites read any `ai:*` setting. AgentMux's agent pane stores its config in `db_forge_agents` / `db_memory_bundles`, not these keys.
 - **`autoupdate:*` is not implemented.** No code path reads any `autoupdate:*` field; there is no updater wired up.
 - **`editor:*` is waveterm leftover** (Monaco code-editor pane, removed). Zero call sites.
 - **`telemetry:enabled` is dead.** `telemetry:interval` and `telemetry:numpoints` *are* used — but only for the sysinfo widget's polling rate, not actual telemetry transmission. The name is misleading and warrants a rename.
@@ -94,7 +94,7 @@ Plus one out-of-template key referenced by code that is **not** in the SettingsT
 
 #### C1. Whole namespace: `ai:*` (waveterm leftover)
 
-The user asked: *"is `ai:` meaning the agent pane, or is that old waveterm?"* — **It is old waveterm.** Zero reads anywhere in the codebase. AgentMux's agent pane uses agent definitions stored in `db_agentdefs` / `db_memories` (see CLAUDE.md), with config flowing through the agent-launch dialog and ACP, not through `SettingsType`.
+The user asked: *"is `ai:` meaning the agent pane, or is that old waveterm?"* — **It is old waveterm.** Zero reads anywhere in the codebase. AgentMux's agent pane uses agent definitions stored in `db_forge_agents` / `db_memory_bundles` (see CLAUDE.md), with config flowing through the agent-launch dialog and ACP, not through `SettingsType`.
 
 Remove these 13 keys from template, schema, and `SettingsType`:
 


### PR DESCRIPTION
## Summary

Closes [AUDIT_SQLITE_SYSTEMS §8.1](docs/specs/AUDIT_SQLITE_SYSTEMS_2026_05_19.md) — the schema-naming drift where v7 created tables under bare `db_identities` / `db_memories` names but the rest of the codebase + UI used "identity bundle" / "memory bundle." User direction (relayed from RFC tracking): _"lets do A .. since that's the clean robust solution .. lets make it clean since its relatively greenfield at the moment."_

- New `run_forge_v11_migrations`: idempotent `ALTER TABLE … RENAME` for `db_identities` → `db_identity_bundles` and `db_memories` → `db_memory_bundles`. SQLite ≥ 3.25 auto-updates the FK reference in `db_identity_bindings`, so the binding cascade-delete still works (covered by a new test).
- `run_forge_v7_migrations` now guards its legacy-name DDL/seed/shadow-migrate block on `db_identity_bundles` not yet existing — prevents re-creating empty old tables alongside the renamed ones on every subsequent startup. The `ALTER COLUMN` on `db_agent_instances` stays outside the guard (idempotent on its own, unrelated to the rename).
- `run_forge_v1_migrations` extracted (the original base `db_forge_agents` CREATE) so tests can stage a pre-v7 schema and exercise the legacy-name path in isolation.
- All `wstore.rs` queries + doc comments updated to bundle names.
- `db_identity_bindings` is **NOT** renamed — its name was already bundle-consistent (a binding binds an identity bundle to a provider account; the surrounding object is the binding, not the bundle).

## Test plan

- [x] `cargo test -p agentmux-srv backend::storage::` — 103 passed (incl. 4 new v11 tests: renames-legacy-to-bundle, idempotent, fresh-install-no-op, preserves identity_bindings FK cascade)
- [x] `npx vitest run frontend/app/view/agent/auth/auth-state.test.ts` — 50 passed
- [ ] Reagent review
- [ ] Codex review
- [ ] Smoke test: launch portable, create an identity + memory, restart, verify they're still listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)