### PR TITLE
feat(menu): hamburger menu tweaks — reorder, DevTools item, Documentation link

### DIFF
--- a/.changesets/1779270665-feat-menu-hamburger-menu-tweaks-reorder-devtools-item-docume-b3wy.md
+++ b/.changesets/1779270665-feat-menu-hamburger-menu-tweaks-reorder-devtools-item-docume-b3wy.md
@@ -1,0 +1,23 @@
+---
+type: patch
+---
+
+feat(menu): hamburger menu tweaks — reorder, DevTools item, Documentation link
+
+Three tab-bar hamburger (≡) menu changes:
+
+- **Reorder.** "New Tab" is now the topmost item. "Command Palette" moves
+  from the top down to just below Settings.
+- **DevTools is no longer a widget.** Removed `defwidget@devtools` from
+  `widgets.json` (and the now-dead devtools special-case in
+  `handleWidgetSelect`). DevTools toggling moves into the hamburger menu as
+  a "DevTools" item between Settings and Command Palette — same
+  `toggleDevtools()` action. (The Command Palette's "Toggle DevTools"
+  command is unaffected.)
+- **"Help" → "Documentation".** The menu item is renamed and now opens
+  `https://docs.agentmux.ai` in the external browser via
+  `getApi().openExternal(...)`, instead of opening the in-app help pane.
+  The `help` widget / `view: "help"` pane are unchanged.
+
+New bottom-of-menu order: Documentation · Settings · DevTools · Command
+Palette · — · Exit.

--- a/agentmux-srv/src/config/widgets.json
+++ b/agentmux-srv/src/config/widgets.json
@@ -100,17 +100,5 @@
                 "view": "help"
             }
         }
-    },
-    "defwidget@devtools": {
-        "display:order": 8,
-        "display:pinned": true,
-        "icon": "code",
-        "label": "devtools",
-        "description": "Toggle Developer Tools",
-        "blockdef": {
-            "meta": {
-                "view": "devtools"
-            }
-        }
     }
 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { atoms, createBlock, createTab, getApi, setActiveTab, settingsAtom } from "@/store/global";
+import { atoms, createTab, getApi, setActiveTab, settingsAtom } from "@/store/global";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { THEME_OPTIONS } from "@/app/menu/base-menus";
@@ -645,13 +645,6 @@ function TabBar(props: TabBarProps): JSX.Element {
 
         return [
             {
-                label: "Command Palette",
-                icon: "magnifying-glass",
-                shortcut: kbd("⌘P", "Ctrl+P"),
-                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
-            },
-            { label: "", divider: true },
-            {
                 label: "New Tab",
                 icon: "plus",
                 shortcut: kbd("⌘T", "Ctrl+T"),
@@ -677,9 +670,9 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
             { label: "", divider: true },
             {
-                label: "Help",
-                icon: "circle-question",
-                onClick: () => fireAndForget(() => createBlock({ meta: { view: "help" } })),
+                label: "Documentation",
+                icon: "book",
+                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
             },
             {
                 label: "Settings",
@@ -689,6 +682,17 @@ function TabBar(props: TabBarProps): JSX.Element {
                         const path = await invokeCommand<string>("ensure_settings_file");
                         await invokeCommand("open_in_editor", { path });
                     }),
+            },
+            {
+                label: "DevTools",
+                icon: "code",
+                onClick: () => getApi().toggleDevtools(),
+            },
+            {
+                label: "Command Palette",
+                icon: "magnifying-glass",
+                shortcut: kbd("⌘P", "Ctrl+P"),
+                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
             },
             { label: "", divider: true },
             {

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -75,10 +75,6 @@ function getMoreWidgets(
 // ── Widget actions ────────────────────────────────────────────────────────────
 
 async function handleWidgetSelect(widget: WidgetConfigType) {
-    if (widget.blockdef?.meta?.view === "devtools") {
-        getApi().toggleDevtools();
-        return;
-    }
     createBlock(widget.blockdef, widget.magnified);
 }
 


### PR DESCRIPTION
## Summary

Three tab-bar hamburger (≡) menu changes:

1. **Reorder** — "New Tab" is now the topmost item. "Command Palette" moves from the top down to just below Settings.
2. **DevTools is no longer a widget** — removed `defwidget@devtools` from `widgets.json` (and the now-dead devtools special-case in `handleWidgetSelect`). DevTools toggling becomes a hamburger menu **"DevTools"** item, placed between Settings and Command Palette — same `getApi().toggleDevtools()` action. The Command Palette's separate "Toggle DevTools" command is unaffected.
3. **"Help" → "Documentation"** — the item is renamed and now opens `https://docs.agentmux.ai` in the external browser (`getApi().openExternal`), instead of opening the in-app help pane. The `help` widget / `view: "help"` pane are left unchanged.

New bottom-of-menu order: **Documentation · Settings · DevTools · Command Palette · — · Exit**.

## Test plan

- [x] `cargo build -p agentmux-srv` — clean; `widgets.json` validated as JSON
- [x] `task build:frontend` (vite) — clean
- [ ] Reagent + Codex review
- [ ] Smoke: open the ≡ menu — confirm New Tab on top, Documentation opens the docs site in a browser, DevTools toggles Chromium DevTools, Command Palette still works; confirm the DevTools widget no longer appears in the widget bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)