### PR TITLE
fix(agent): gear/cog opens the settings panel reliably

### DIFF
--- a/.changesets/1779271911-fix-agent-gear-cog-opens-the-settings-panel-reliably-4o46.md
+++ b/.changesets/1779271911-fix-agent-gear-cog-opens-the-settings-panel-reliably-4o46.md
@@ -1,0 +1,24 @@
+---
+type: patch
+---
+
+fix(agent): gear/cog opens the settings panel reliably
+
+Clicking the ⚙ gear in an agent pane header did nothing. The gear flips an
+overlay-tab signal, but the panel was rendered behind
+`<Show when={showOverlayTab() != null && currentAgent() != null}>`.
+
+`currentAgent()` resolves the pane's `agentId` block-meta against the
+`db_agent_definitions` list. That only matches for panes launched via
+`launchAgentDefinition` (the AgentPicker → launch-modal path). It is `null`
+for provider quick-launch panes (`launchAgent` writes a *provider* id), for
+a pane whose definition was deleted, and during the async window before /
+if `ListAgentDefinitionsCommand` resolves. In every one of those cases the
+gear silently no-op'd — click, nothing.
+
+Fix: gate the overlay only on `showOverlayTab() != null` and pass
+`currentAgent()` (possibly `undefined`) straight through. The panel chain
+already handles a missing definition — `AgentCardSettingsPanel.agent` is
+typed `AgentDefinition | undefined` (create-mode), and the Identity tab has
+a "save the agent first" fallback. `AgentFocusedPanel`'s `agent` prop is
+widened to `AgentDefinition | undefined` to match what it forwards.

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -622,12 +622,20 @@ const AgentPresentationView = ({ model, agentId }: { model: AgentViewModel; agen
                 />
             </Show>
 
-            {/* Title-bar action overlay: ⚙ Agent / 👤 Identity */}
-            <Show when={showOverlayTab() != null && currentAgent() != null}>
+            {/* Title-bar action overlay: ⚙ Agent / 👤 Identity.
+                Gated only on the tab being open — NOT on currentAgent()
+                resolving. The pane's `agentId` is a db_agent_definitions
+                id only for definition-launched panes; provider quick-launch
+                writes a provider id, and the definition list may also be
+                mid-load or have failed to fetch. Requiring currentAgent()
+                here made the gear silently no-op in all those cases. The
+                panel handles an undefined agent (create-mode + the Identity
+                tab's "save first" fallback). */}
+            <Show when={showOverlayTab() != null}>
                 <AgentFocusedPanel
                     blockId={model.blockId}
                     nodeModel={model.nodeModel}
-                    agent={currentAgent()!}
+                    agent={currentAgent()}
                     initialTab={showOverlayTab()!}
                     onClose={() => setShowOverlayTab(null)}
                     onTabChange={(tab) => { model._lastOverlayTab = tab; }}

--- a/frontend/app/view/agent/components/AgentFocusedPanel.tsx
+++ b/frontend/app/view/agent/components/AgentFocusedPanel.tsx
@@ -17,7 +17,11 @@ import type { OverlayTab } from "../agent-model";
 interface AgentFocusedPanelProps {
     blockId: string;
     nodeModel: BlockNodeModel;
-    agent: AgentDefinition;
+    /** The agent definition, or undefined when the pane can't be resolved
+     *  to a `db_agent_definitions` row (provider quick-launch, deleted
+     *  definition, list not yet loaded). Forwarded straight to
+     *  `AgentCardSettingsPanel`, which treats undefined as create-mode. */
+    agent: AgentDefinition | undefined;
     initialTab: OverlayTab;
     onClose: () => void;
     onTabChange?: (tab: SettingsTab) => void;


### PR DESCRIPTION
## Summary

Clicking the ⚙ gear in an agent pane header did nothing.

The gear's click flips an overlay-tab signal (`_setOverlayTab`), but the panel was rendered behind:

```tsx
<Show when={showOverlayTab() != null && currentAgent() != null}>
```

`currentAgent()` resolves the pane's `agentId` block-meta against the `db_agent_definitions` list. That only matches for panes launched via `launchAgentDefinition` (the AgentPicker → launch-modal path). It is `null` for:
- **provider quick-launch panes** — `launchAgent` writes a *provider* id (`claude`/`codex`/…), not a definition id
- a pane whose definition was **deleted**
- the **async window** before / if `ListAgentDefinitionsCommand` resolves (its fetch error is silently swallowed)

In every one of those cases the gear silently no-op'd — click, nothing.

## Fix

Gate the overlay only on `showOverlayTab() != null`; pass `currentAgent()` (possibly `undefined`) straight through. The panel chain already handles a missing definition:
- `AgentCardSettingsPanel.agent` is typed `AgentDefinition | undefined` — undefined = create-mode
- the Identity tab has a "save the agent first" fallback

`AgentFocusedPanel`'s `agent` prop is widened from `AgentDefinition` to `AgentDefinition | undefined` to match what it forwards.

When `currentAgent()` *does* resolve (the common picker-launched case) behavior is unchanged — the panel opens to the definition detail view.

## Test plan

- [x] `tsc` clean for the touched files; `task build:frontend` clean
- [ ] Reagent + Codex review
- [ ] Smoke: launch an agent (both via the picker and via quick-launch if available), click the ⚙ gear → the settings overlay opens; Agent + Identity tabs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)