### PR TITLE
fix(shell,term): surface PTY errors + guarantee keystroke ordering

### DIFF
--- a/.changesets/1779243492-fix-bench-term-echo-fix-ws-message-parsing-use-resid-for-rpc-9xfx.md
+++ b/.changesets/1779243492-fix-bench-term-echo-fix-ws-message-parsing-use-resid-for-rpc-9xfx.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(bench-term-echo): fix WS message parsing — use resid for RPC correlation, rpcMsg.command for event routing, add 10s timeout

--- a/.changesets/1779273148-fix-shell-write-error-message-to-terminal-when-pty-open-or-s-b97b.md
+++ b/.changesets/1779273148-fix-shell-write-error-message-to-terminal-when-pty-open-or-s-b97b.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(shell): write error message to terminal when PTY open or shell spawn fails

--- a/.changesets/1779299671-feat-authfile-write-authkey-dev-for-all-runtime-modes-so-por-fxvc.md
+++ b/.changesets/1779299671-feat-authfile-write-authkey-dev-for-all-runtime-modes-so-por-fxvc.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(authfile): write authkey.dev for all runtime modes so portable builds are discoverable by the benchmark

--- a/.changesets/1779302543-fix-term-guarantee-keystroke-ordering-via-per-block-sequence-gcxd.md
+++ b/.changesets/1779302543-fix-term-guarantee-keystroke-ordering-via-per-block-sequence-gcxd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): guarantee keystroke ordering via per-block sequence numbers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.37.0"
+version = "0.37.1"
 
 [profile.release]
 strip = true

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -412,19 +412,13 @@ fn main() {
 
     // Dev-only: write authkey.dev so external test harnesses can call
     // the service API without polling logs or driving the UI. Gate is
-    // runtime, not cfg(debug_assertions), because `task dev` builds
-    // --release (Taskfile.yml `build:host:windows`) — a compile-time
-    // gate would silently no-op the file write in dev mode, defeating
-    // the purpose. Taskfile sets AGENTMUX_DEV=1 on the dev task; the
-    // user's installed/portable builds do not, so the file is only
-    // written when the operator has opted into dev mode for THIS run.
-    // See docs/specs/SPEC_TEST_API_ACCESS.md §3 (threat model) — the
-    // attacker class affected is "same-user local process", which we
-    // do not defend against.
-    // Dev mode is signalled by AGENTMUX_RUNTIME_MODE=dev:<branch>
-    // injected by the launcher (see agentmux_common::RuntimeMode).
-    // We use the same boolean we computed at startup.
-    if is_dev {
+    // Write authkey.dev for ALL runtime modes (dev, portable, installed).
+    // The file lets bench-term-echo.mjs and the PowerShell test harnesses
+    // discover the running instance without manual --ws-url / --auth-key flags.
+    // Security: the WS server is loopback-only; any same-user process already
+    // has equivalent TCP access. See SPEC_TEST_API_ACCESS.md §3 and
+    // SPEC_BENCHMARK_PORTABLE_DISCOVERY_2026_05_20.md for rationale.
+    {
         let endpoints = app_state.backend_endpoints.lock().clone();
         let auth_key = app_state.auth_key.lock().clone();
         let ipc_token = app_state.ipc_token.clone();
@@ -447,8 +441,8 @@ fn main() {
             &instance,
             host_pid,
         ) {
-            Ok(p) => tracing::info!("Wrote dev authkey file: {}", p.display()),
-            Err(e) => tracing::warn!("Failed to write dev authkey file: {}", e),
+            Ok(p) => tracing::info!("Wrote authkey file: {}", p.display()),
+            Err(e) => tracing::warn!("Failed to write authkey file: {}", e),
         }
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/acp.rs
+++ b/agentmux-srv/src/backend/blockcontroller/acp.rs
@@ -562,7 +562,7 @@ impl Controller for AcpController {
         self.get_status_snapshot()
     }
 
-    fn send_input(&self, input: BlockInputUnion) -> Result<(), String> {
+    fn send_input(&self, input: BlockInputUnion, _seq: Option<u64>) -> Result<(), String> {
         if let Some(data) = input.input_data {
             // Raw input from the frontend — treat as a user message.
             // The frontend sends the user prompt as UTF-8 bytes.

--- a/agentmux-srv/src/backend/blockcontroller/mod.rs
+++ b/agentmux-srv/src/backend/blockcontroller/mod.rs
@@ -180,7 +180,7 @@ pub trait Controller: Send + Sync {
     fn get_runtime_status(&self) -> BlockControllerRuntimeStatus;
 
     /// Send input (terminal data, signal, or resize) to the controller.
-    fn send_input(&self, input: BlockInputUnion) -> Result<(), String>;
+    fn send_input(&self, input: BlockInputUnion, seq: Option<u64>) -> Result<(), String>;
 
     /// Get the controller type (e.g., "shell", "cmd").
     fn controller_type(&self) -> &str;
@@ -267,9 +267,9 @@ pub fn stop_block_controller(block_id: &str) -> Result<(), String> {
 }
 
 /// Send input to a block's controller.
-pub fn send_input(block_id: &str, input: BlockInputUnion) -> Result<(), String> {
+pub fn send_input(block_id: &str, input: BlockInputUnion, seq: Option<u64>) -> Result<(), String> {
     match get_controller(block_id) {
-        Some(ctrl) => ctrl.send_input(input),
+        Some(ctrl) => ctrl.send_input(input, seq),
         None => Err(format!("no controller for block {block_id}")),
     }
 }
@@ -523,7 +523,7 @@ mod tests {
 
     #[test]
     fn test_send_input_no_controller() {
-        let result = send_input("nonexistent", BlockInputUnion::data(b"test".to_vec()));
+        let result = send_input("nonexistent", BlockInputUnion::data(b"test".to_vec()), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("no controller"));
     }

--- a/agentmux-srv/src/backend/blockcontroller/persistent.rs
+++ b/agentmux-srv/src/backend/blockcontroller/persistent.rs
@@ -592,7 +592,7 @@ impl Controller for PersistentSubprocessController {
         self.get_status_snapshot()
     }
 
-    fn send_input(&self, _input: BlockInputUnion) -> Result<(), String> {
+    fn send_input(&self, _input: BlockInputUnion, _seq: Option<u64>) -> Result<(), String> {
         Err("persistent controller does not accept raw input; use send_message()".to_string())
     }
 

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -14,6 +14,7 @@
 //! 3. Wait loop: monitor process exit, update status
 
 
+use std::collections::BTreeMap;
 use std::io::Read as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -113,6 +114,10 @@ struct ShellControllerInner {
     last_pty_output: Option<Instant>,
     /// True if this pane is running an agent CLI (e.g. claude).
     is_agent_pane: bool,
+    /// Next expected input sequence number (0 = fresh block).
+    input_seq_next: u64,
+    /// Reorder buffer: early-arriving inputs keyed by their seq.
+    input_seq_buf: BTreeMap<u64, BlockInputUnion>,
 }
 
 /// Factory function type for creating ConnInterface instances.
@@ -169,6 +174,8 @@ impl ShellController {
                 spawn_ts_ms: None,
                 last_pty_output: None,
                 is_agent_pane: false,
+                input_seq_next: 0,
+                input_seq_buf: BTreeMap::new(),
             })),
             conn_factory: Mutex::new(None),
             broker,
@@ -976,13 +983,43 @@ impl Controller for ShellController {
         self.get_status_snapshot()
     }
 
-    fn send_input(&self, input: BlockInputUnion) -> Result<(), String> {
-        let inner = self.inner.lock().unwrap();
-        match &inner.input_tx {
-            Some(tx) => tx
-                .try_send(input)
-                .map_err(|e| format!("failed to send input: {e}")),
-            None => Err("controller is not running".to_string()),
+    fn send_input(&self, input: BlockInputUnion, seq: Option<u64>) -> Result<(), String> {
+        let mut inner = self.inner.lock().unwrap();
+        let tx = match &inner.input_tx {
+            Some(tx) => tx.clone(),
+            None => return Err("controller is not running".to_string()),
+        };
+        match seq {
+            None => tx.try_send(input).map_err(|e| format!("send_input: {e}")),
+            Some(s) => {
+                let next = inner.input_seq_next;
+                if s == next {
+                    tx.try_send(input).map_err(|e| format!("send_input: {e}"))?;
+                    inner.input_seq_next += 1;
+                    loop {
+                        let expected = inner.input_seq_next;
+                        match inner.input_seq_buf.remove(&expected) {
+                            Some(buffered) => {
+                                tx.try_send(buffered)
+                                    .map_err(|e| format!("send_input drain: {e}"))?;
+                                inner.input_seq_next += 1;
+                            }
+                            None => break,
+                        }
+                    }
+                    Ok(())
+                } else if s > next {
+                    if inner.input_seq_buf.len() < SHELL_INPUT_CH_SIZE {
+                        inner.input_seq_buf.insert(s, input);
+                    } else {
+                        tracing::warn!(block_id = %self.block_id, seq = s, "input reorder buffer full, dropping");
+                    }
+                    Ok(())
+                } else {
+                    tracing::warn!(block_id = %self.block_id, seq = s, next, "duplicate input seq, discarding");
+                    Ok(())
+                }
+            }
         }
     }
 
@@ -1378,7 +1415,7 @@ mod tests {
             None,
         );
 
-        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()));
+        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not running"));
     }

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -403,6 +403,13 @@ impl Controller for ShellController {
 
         let pair = pty_system.openpty(pty_size).map_err(|e| {
             tracing::error!(block_id = %self.block_id, error = %e, "failed to open PTY");
+            if let Some(ref broker) = self.broker {
+                let msg = format!(
+                    "\r\n\x1b[31mTerminal failed to open: {e}\x1b[0m\r\n\
+                     \x1b[33mThis is often caused by low system memory.\x1b[0m\r\n"
+                );
+                handle_append_block_file(broker, &self.block_id, "term", msg.as_bytes(), None);
+            }
             let mut inner = self.inner.lock().unwrap();
             Self::set_status(&mut inner, STATUS_DONE);
             inner.proc_exit_code = -1;
@@ -603,6 +610,13 @@ impl Controller for ShellController {
 
         let mut child = pair.slave.spawn_command(cmd).map_err(|e| {
             tracing::error!(block_id = %self.block_id, error = %e, cmd = %cmd_str, "spawn failed");
+            if let Some(ref broker) = self.broker {
+                let msg = format!(
+                    "\r\n\x1b[31mShell failed to start: {e}\x1b[0m\r\n\
+                     \x1b[33mThis is often caused by low system memory.\x1b[0m\r\n"
+                );
+                handle_append_block_file(broker, &self.block_id, "term", msg.as_bytes(), None);
+            }
             let mut inner = self.inner.lock().unwrap();
             Self::set_status(&mut inner, STATUS_DONE);
             inner.proc_exit_code = -1;

--- a/agentmux-srv/src/backend/blockcontroller/subprocess.rs
+++ b/agentmux-srv/src/backend/blockcontroller/subprocess.rs
@@ -778,7 +778,7 @@ impl Controller for SubprocessController {
         self.get_status_snapshot()
     }
 
-    fn send_input(&self, input: BlockInputUnion) -> Result<(), String> {
+    fn send_input(&self, input: BlockInputUnion, _seq: Option<u64>) -> Result<(), String> {
         // SubprocessController doesn't accept raw PTY input — user messages
         // go through spawn_turn() (via AgentInputCommand RPC).
         //
@@ -853,7 +853,7 @@ mod tests {
             None,
             None,
         );
-        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()));
+        let result = ctrl.send_input(BlockInputUnion::data(b"hello".to_vec()), None);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("AgentInputCommand"));
     }

--- a/agentmux-srv/src/backend/rpc_types.rs
+++ b/agentmux-srv/src/backend/rpc_types.rs
@@ -510,6 +510,12 @@ pub struct CommandBlockInputData {
     pub signame: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub termsize: Option<serde_json::Value>,
+    /// Monotonically increasing per-block counter attached by the frontend.
+    /// None = legacy client; inputs are forwarded unconditionally.
+    /// When present, the backend uses a reorder buffer to guarantee PTY
+    /// insertion order even if tokio::spawn tasks execute out of sequence.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
 }
 
 /// Data for `tooldecision` — frontend's reply to a per-tool-call

--- a/agentmux-srv/src/main.rs
+++ b/agentmux-srv/src/main.rs
@@ -506,6 +506,7 @@ async fn main() {
         backend::blockcontroller::send_input(
             block_id,
             backend::blockcontroller::BlockInputUnion::data(data.to_vec()),
+            None,
         )
     }));
     let poller = Arc::new(Poller::new(

--- a/agentmux-srv/src/server/websocket.rs
+++ b/agentmux-srv/src/server/websocket.rs
@@ -391,7 +391,7 @@ async fn handle_incoming_text(
                             match base64::engine::general_purpose::STANDARD.decode(data64) {
                                 Ok(data) => {
                                     let input = blockcontroller::BlockInputUnion::data(data);
-                                    if let Err(e) = blockcontroller::send_input(block_id, input) {
+                                    if let Err(e) = blockcontroller::send_input(block_id, input, None) {
                                         tracing::debug!("ws: blockinput error: {}", e);
                                     }
                                 }
@@ -409,7 +409,7 @@ async fn handle_incoming_text(
                         match serde_json::from_value::<TermSize>(ts_val.clone()) {
                             Ok(ts) => {
                                 let input = blockcontroller::BlockInputUnion::resize(ts);
-                                if let Err(e) = blockcontroller::send_input(block_id, input) {
+                                if let Err(e) = blockcontroller::send_input(block_id, input, None) {
                                     tracing::debug!("ws: setblocktermsize error: {}", e);
                                 }
                             }
@@ -649,8 +649,9 @@ fn register_handlers(engine: &Arc<WshRpcEngine>, state: AppState) {
             Box::pin(async move {
                 let cmd: CommandBlockInputData = serde_json::from_value(data)
                     .map_err(|e| format!("controllerinput: {e}"))?;
+                let seq = cmd.seq;
                 let input = parse_block_input(&cmd)?;
-                blockcontroller::send_input(&cmd.blockid, input)?;
+                blockcontroller::send_input(&cmd.blockid, input, seq)?;
                 Ok(None)
             })
         }),

--- a/docs/specs/SPEC_BENCHMARK_PORTABLE_DISCOVERY_2026_05_20.md
+++ b/docs/specs/SPEC_BENCHMARK_PORTABLE_DISCOVERY_2026_05_20.md
@@ -1,0 +1,152 @@
+# SPEC: Benchmark Auth-File Discovery — Dev and Portable Instances
+
+**Date:** 2026-05-20  
+**Status:** Implemented (same PR as SPEC_DEAD_TERMINAL_PANE_2026_05_20.md)  
+**Affected tooling:** `tools/tests/bench-term-echo.mjs`, `tools/tests/authfile.ps1`  
+**Affected host:** `agentmux-cef/src/main.rs`, `agentmux-cef/src/dev_authfile.rs`
+
+---
+
+## Motivation
+
+`bench-term-echo.mjs` measures terminal echo latency end-to-end through the WS
+App API. Its primary use case is long-running session diagnostics: run the
+benchmark before and after a suspected regression (e.g. memory pressure
+accumulating over hours) to catch latency degradation.
+
+Currently the benchmark is **dev-only**: it discovers the running instance by
+reading `authkey.dev`, which the host writes only when `RuntimeMode == Dev`.
+Portable and installed builds never write this file, so the benchmark cannot
+target them without manually passing `--ws-url` and `--auth-key` — which
+requires knowing the ephemeral WS port the sidecar bound to.
+
+For long-session regression testing the portable build is the correct target:
+it reflects the exact shipped binary, it runs without `task dev` overhead, and
+it accumulates memory state identically to a production deployment.
+
+---
+
+## Current Architecture
+
+```
+RuntimeMode::Dev    →  data dir: ~/.agentmux/dev/<branch>/data/
+RuntimeMode::Installed/Portable  →  data dir: ~/.agentmux/versions/<version>/data/
+```
+
+`agentmux-cef/src/main.rs` (lines ~427-453):
+```rust
+if is_dev {
+    dev_authfile::write_dev_auth_file(
+        &data_dir_path, &auth_key, &ws_endpoint, ... host_pid
+    ).ok();
+}
+```
+
+`is_dev` is `true` only when `RuntimeMode` matches `Dev { .. }` — i.e., when the
+exe is under `dist/cef-dev/`. Portable and installed builds leave `is_dev = false`
+and the file is never written.
+
+`bench-term-echo.mjs` `findAuthFile()` already searches both:
+```js
+const searchRoots = [
+    join(home, ".agentmux", "dev"),
+    join(home, ".agentmux", "versions"),
+];
+```
+
+So if portables write `authkey.dev` to their data dir, the benchmark finds it
+with no changes to its discovery logic.
+
+---
+
+## Change
+
+### 1. Write `authkey.dev` unconditionally (`agentmux-cef/src/main.rs`)
+
+Remove the `if is_dev {` gate. The auth file is written for **all** runtime modes:
+dev, portable, and installed.
+
+The file path remains `data_dir/authkey.dev` in all cases. For a portable running
+version `v0.37.1` the file is at:
+
+```
+~/.agentmux/versions/0.37.1/data/authkey.dev
+```
+
+### 2. No changes needed to `bench-term-echo.mjs` discovery
+
+`findAuthFile()` already searches `~/.agentmux/versions/*/data/authkey.dev`. The
+benchmark gains portable support for free.
+
+### 3. Minor benchmark UX — label instance type in output
+
+Add `(portable)` / `(dev)` label to the "Using authkey.dev" line so the operator
+knows which instance type they are targeting:
+
+```
+Using authkey.dev: ~/.agentmux/versions/0.37.1/data/authkey.dev
+  (instance=v0.37.1, pid=12345, mode=portable)
+```
+
+---
+
+## Security Considerations
+
+`authkey.dev` already exists for dev builds and is considered acceptable:
+
+- The WS server binds to `127.0.0.1` (loopback-only). No remote machine can use
+  the auth key.
+- The file is in the user's own home directory; any process running as the same
+  user already has equivalent access to the WS port via raw TCP.
+- The `host_pid` liveness check means stale auth files from crashed instances
+  are skipped automatically.
+
+Extending to portable builds does not change the threat surface.
+
+---
+
+## Long-Session Benchmark Workflow
+
+```bash
+# 1. Launch portable (extracts to any dir)
+#    AgentMux writes ~/.agentmux/versions/<v>/data/authkey.dev at startup.
+
+# 2. Let it run for a long session (hours). Open tabs, use terminals.
+
+# 3. When latency is suspected, run the benchmark — no manual auth flags needed:
+node tools/tests/bench-term-echo.mjs --busy --output-file before.json
+
+# 4. Compare against a fresh-start baseline:
+node tools/tests/bench-term-echo.mjs --busy --output-file after.json
+
+node -e "
+const b = JSON.parse(require('fs').readFileSync('before.json'));
+const a = JSON.parse(require('fs').readFileSync('after.json'));
+const fmt = (x) => x.toFixed(1) + ' ms';
+console.log('           before  after');
+console.log('quiet p95:', fmt(b.quiet.p95), '->', fmt(a.quiet.p95));
+console.log('busy  p95:', fmt(b.busy.p95),  '->', fmt(a.busy.p95));
+"
+```
+
+---
+
+## Relationship to Dead-Terminal Spec
+
+`SPEC_DEAD_TERMINAL_PANE_2026_05_20.md` documents that dead terminals appear
+under memory pressure (≥93% RAM). The benchmark is the instrument for catching
+**latency degradation** that precedes or accompanies that condition. Running
+`bench-term-echo.mjs --busy` when the system is under moderate pressure (70–85%)
+should show rising p95/p99 before terminal failures begin.
+
+A future CI step could fail if p95 exceeds a threshold, giving early warning.
+
+---
+
+## Related
+
+- `docs/specs/SPEC_TEST_API_ACCESS.md` §5–§6 — auth file format and security model
+- `docs/specs/SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19.md` — benchmark design
+- `docs/specs/SPEC_DEAD_TERMINAL_PANE_2026_05_20.md` — failure modes this workflow targets
+- `agentmux-cef/src/dev_authfile.rs` — auth file writer
+- `agentmux-cef/src/main.rs` — write gate (the `if is_dev {` block)

--- a/docs/specs/SPEC_DEAD_TERMINAL_PANE_2026_05_20.md
+++ b/docs/specs/SPEC_DEAD_TERMINAL_PANE_2026_05_20.md
@@ -1,0 +1,199 @@
+# SPEC: Dead Terminal Pane — Silent PTY Failure & RT Info Race
+
+**Date:** 2026-05-20  
+**Status:** Open — pending fix  
+**Observed on:** v0.34.0 (Windows 11)  
+**Log evidence:** `~/.agentmux/versions/0.34.0/logs/agentmux-host-v0.34.0.log.2026-05-20`
+
+---
+
+## Summary
+
+Opening a new terminal pane sometimes produces a "dead" pane: xterm.js renders a
+blinking cursor, but no shell prompt appears and keystrokes do nothing. Two distinct
+root causes were identified from logs. Both produce identical user-facing symptoms.
+
+---
+
+## Observed Symptoms
+
+- Terminal pane opens with a blinking cursor, black background.
+- Pressing any key has no effect.
+- Host log floods with `[fe] lastHandledEvent return false` (~6 Hz, one per keypress).
+- No error message shown inside the pane or in any UI surface.
+
+---
+
+## Root Cause 1 — Silent PTY Spawn Failure Under Memory Pressure
+
+### Evidence
+
+When `load_pct ≥ 93` (observed: `avail_phys_gb: 4.2 / 61.6 GB`):
+
+- `object.CreateBlock` succeeds in the backend.
+- **No** `resync_controller`, `PTY opened`, or `process spawned` entries appear in the
+  sidecar log for the new block.
+- xterm.js still mounts (it needs no process), showing the blinking cursor.
+- The block sits in the layout with xterm running but no PTY behind it.
+
+### What Happens
+
+`portable-pty` / the OS shell spawn fails because there is insufficient memory to
+fork a new process. The failure is either swallowed silently in the block controller
+or the controller is never invoked. No error propagates to the frontend.
+
+### Missing Signals
+
+1. No `ERROR`-level log entry in sidecar when shell spawn fails.
+2. No error event pushed to the block's `blockfile` stream.
+3. No memory-pressure warning in any UI surface before or after the failure.
+
+---
+
+## Root Cause 2 — RT Info Race on Pane Open
+
+### Evidence
+
+Even with sufficient memory (`load_pct: 52`, `avail_phys_gb: 29.4 GB`), block
+`c88fc5f9` was opened and:
+
+```
+[srv]  PTY opened  rows=25 cols=80
+[srv]  process spawned successfully
+[fe]   New BlockAtom c88fc5f9 changeConn
+[fe]   object.GetObject block:c88fc5f9 | 64ms          ← slow fetch
+[fe]   long-task 51ms
+[fe]   long-task 50ms
+[fe]   [reactive] registered agent Terminal -> c88fc5f9
+[fe]   error setting RT info {}                         ← RT info call failed
+[fe]   setFocusedChild c88fc5f9 ... textarea.xterm-helper-textarea
+[fe]   lastHandledEvent return false  (repeated every ~170ms)
+```
+
+The PTY is alive at the default 25×80 but the frontend's `setRTInfo` call returned
+`{}` (empty / error response). Without RT info the shell may not emit a prompt and
+the `blockinput` path appears unresponsive to the frontend.
+
+### What Happens
+
+There is a race between:
+1. The renderer performing two 50 ms long-tasks (layout + WaveObj resolution) that
+   block the JS thread.
+2. The reactive `Terminal` agent registering and immediately calling `setRTInfo`.
+
+By the time `setRTInfo` fires, some required state (the WS subscription, the block
+controller's reactive channel, or the block's runtime-info slot) is not yet ready.
+The service returns `{}` instead of a success response. The frontend swallows this
+as a non-fatal path and proceeds, leaving the PTY at the wrong size and the
+frontend's WS message pump in an undetermined state.
+
+---
+
+## Memory Pressure Timeline (from `mem_heartbeat`)
+
+| Time     | `load_pct` | `avail_phys_gb` | Effect                            |
+|----------|-----------|-----------------|-----------------------------------|
+| 10:15:xx | 93%       | 4.2             | First dead pane — PTY never spawned |
+| 10:16:32 | 72%       | 17.2            | User freed memory                 |
+| 10:16:52 | 56%       | 27.1            | Stabilising                       |
+| 10:21:xx | 52%       | 29.4            | Second dead pane — RT info race   |
+
+The memory threshold at which shell spawn fails is not precisely known. It likely
+depends on commit charge, not just physical pages.
+
+---
+
+## Proposed Fixes
+
+### Fix A — Backend PTY Spawn Error Propagation (Root Cause 1)
+
+In `agentmuxsrv-rs/src/backend/blockcontroller/shell.rs`, when the shell process
+spawn fails:
+
+1. Log at `ERROR` level with the OS error code.
+2. Push an error record onto the block's `blockfile` output stream immediately, so
+   the frontend receives it via its existing `blockfile` event subscription.
+3. Set a `pty_failed: true` flag on the block metadata so any reconnecting frontend
+   can detect the failure without waiting for another event.
+
+The error record written to `blockfile` uses a distinguished prefix so the frontend
+can detect it without ambiguity (e.g. `\x1b[31mShell failed to start: <os error>\x1b[0m\r\n`
+rendered directly by xterm.js, plus a structured metadata flag).
+
+### Fix B — Frontend Error Overlay (reacts to Fix A, Root Cause 1)
+
+When the frontend's `blockfile` event handler receives the structured error record,
+it renders an error overlay in place of the cursor:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Shell did not start                                │
+│                                                     │
+│  The terminal process failed to launch.             │
+│  This is often caused by low system memory.         │
+│                                                     │
+│  [Retry]   [Close]                                  │
+└─────────────────────────────────────────────────────┘
+```
+
+No timeout or polling needed — the overlay appears as soon as the backend error
+event arrives. **Retry** calls `block.restart`; **Close** calls `object.DeleteBlock`.
+
+Touch-points:
+- `frontend/app/view/term/termwrap.ts` — handle the `pty_failed` metadata flag in
+  the `blockfile` event; expose a `ptyFailed` signal to the view.
+- `frontend/app/view/term/term.tsx` (or equivalent) — render the overlay when
+  `ptyFailed === true`.
+
+### Fix C — RT Info Retry / Defer (Root Cause 2)
+
+In the frontend terminal init path, `setRTInfo` should not be fire-and-forget. If
+it returns `{}` or an error:
+
+1. Retry with exponential backoff (3 retries: 100 / 300 / 1000 ms).
+2. If all retries fail, surface the same error overlay as Fix B.
+
+The long-tasks (51 ms + 50 ms) that precede the race should also be investigated.
+They occur during `WaveObj` resolution and layout update on the new block — if they
+can be split or deferred, the RT info call arrives at a more settled state.
+
+### Fix D — Memory Pressure Warning (pre-emptive UX)
+
+The `mem_heartbeat` target already fires every 20 s. Expose this to the frontend:
+
+| `load_pct` | Action |
+|-----------|--------|
+| ≥ 85%    | Show amber warning badge in the title bar / status strip |
+| ≥ 95%    | Show red badge + toast: "System memory critical — terminal panes may fail to open" |
+
+Implementation: the host already logs `mem_heartbeat` — add a CEF → frontend IPC
+message (or include the latest heartbeat in the `GetSysInfo` poll response) so the
+renderer can display the badge without an additional RPC.
+
+---
+
+## Investigation Notes
+
+- **`[fe] lastHandledEvent return false`**: Logged when `xterm.js` receives a key
+  event but the upstream handler (the `blockinput` WS sender) declines to process
+  it. This is a symptom, not a cause; the cause is either missing PTY (Root Cause 1)
+  or the broken RT info path (Root Cause 2).
+
+- **Block `67c5580d`** (original dead pane from the 93% session): still in the
+  layout tree as of the log snapshot. Its controller was never started so the block
+  is permanently inert. It should be garbage-collected or the user should be able
+  to retry it.
+
+- **`failed to watch directory for subagents: ~/.config/claude-terminal`** (logged
+  on every terminal open): non-fatal but noisy. The path `~/.config/claude-terminal`
+  does not exist. Either create it on first use or make the watcher optional.
+
+---
+
+## Related
+
+- `docs/specs/SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19.md` — PTY echo-latency
+  benchmark; the "shell never started" case produces ∞ latency.
+- `frontend/app/view/term/termwrap.ts` — xterm.js wrapper; the `writeInFlight`
+  fast-path fix (PR #926) is in this file.
+- `agentmuxsrv-rs/src/backend/blockcontroller/shell.rs` — PTY spawn site.

--- a/docs/specs/SPEC_KEYSTROKE_ORDER_GUARANTEE_2026_05_20.md
+++ b/docs/specs/SPEC_KEYSTROKE_ORDER_GUARANTEE_2026_05_20.md
@@ -1,0 +1,278 @@
+# SPEC: Keystroke Ordering Guarantee
+
+**Date:** 2026-05-20  
+**Status:** Open — pending fix  
+**Observed on:** v0.34.0+ (all platforms)  
+**Symptom:** Characters typed in order appear in the terminal out of order  
+**Severity:** High — data-corrupting under sustained fast typing
+
+---
+
+## Summary
+
+A structural race in the RPC dispatch layer allows consecutive `controllerinput`
+messages to reach the per-block input channel in a different order than the user
+typed them. The result is transposed, dropped, or duplicated characters in the
+terminal — not a rendering glitch, but actual PTY input corruption.
+
+The fix does not require any performance improvement. A sequence-number guard on
+`CommandBlockInputData` and a per-block reorder buffer eliminates the race with
+microsecond-level overhead.
+
+---
+
+## Keystroke Path (current)
+
+```
+keypress
+  │
+  ▼ (xterm.js onData — synchronous, one event per key)
+handleTermData()  [termwrap.ts]
+  │
+  ▼ (synchronous)
+sendDataToController()  [termViewModel.ts]
+  │
+  ▼ (synchronous, direct WS.send())
+WS frame: { wscommand:"rpc", message:{ command:"controllerinput", ... } }
+  │
+  ▼ (TCP — guaranteed in-order delivery)
+WS receive loop  [websocket.rs — single Tokio task]
+  │
+  ▼ engine.handle_message(rpc_msg)
+tokio::spawn(async { engine.handle_request(msg).await })  ← ORDER LOST HERE
+  │
+  ▼ (Tokio thread pool — tasks may execute in any order)
+handle_request → send_input → inner.lock() → try_send(input_tx)
+  │
+  ▼ (mpsc channel — FIFO *within* the order items were inserted)
+input loop: input_rx.recv() → writer.write_all()  [PTY stdin — FIFO, correct]
+```
+
+---
+
+## Root Cause
+
+`engine.handle_message()` (engine.rs ~line 269) spawns a new Tokio task for every
+incoming RPC command:
+
+```rust
+pub fn handle_message(self: &Arc<Self>, msg: RpcMessage) {
+    let engine = self.clone();
+    tokio::spawn(async move {
+        engine.handle_request(msg).await;   // ← independent task per message
+    });
+}
+```
+
+The WS receive loop dispatches messages in TCP arrival order. But once spawned,
+each task is scheduled independently by Tokio's work-stealing executor. On a
+multi-core machine, five tasks spawned in order 1→2→3→4→5 may acquire the
+`ShellController.inner` lock and call `try_send()` in order 1→3→2→5→4.
+
+The per-block MPSC channel then delivers 1→3→2→5→4 to PTY stdin.
+
+**No sequence numbers exist** in `RpcMessage`, `CommandBlockInputData`, or any
+WS framing struct to detect or correct this reordering.
+
+---
+
+## Why It Appears During Long Sessions
+
+Tokio's work-stealing becomes more aggressive under load (more tasks in flight,
+more CPU contention). A fresh session with low memory and few background tasks
+rarely triggers the race. A long session with many open panes, background agents,
+and increased GC/scheduling pressure causes frequent out-of-order execution.
+
+---
+
+## Ordering Guarantees at Each Layer
+
+| Layer | Ordered? | Why |
+|-------|----------|-----|
+| xterm.js `onData` | ✅ Yes | Synchronous JS event dispatch |
+| Frontend `WS.send()` | ✅ Yes | Direct call, no queue |
+| TCP delivery | ✅ Yes | TCP stream guarantee |
+| WS receive loop | ✅ Yes | Single-task loop, messages processed one at a time |
+| `tokio::spawn` dispatch | ❌ **No** | Independent tasks, work-stealing scheduler |
+| `inner.lock()` + `try_send()` | ❌ **No** | Race between concurrent async tasks |
+| MPSC channel → PTY stdin | ✅ Yes | Single consumer, FIFO within insertion order |
+
+The ordering is lost between WS receive and the MPSC channel insertion.
+
+---
+
+## Proposed Fix — Sequence Numbers + Per-Block Reorder Buffer
+
+### Why not just handle `controllerinput` synchronously?
+
+Handling it inline in the WS receive loop (instead of spawning a task) would
+preserve order, but the receive loop is shared by all RPC commands. A slow
+`controllerinput` (e.g. waiting on a full MPSC channel) would stall all WS
+processing for all blocks. The sequence-number approach is safer and gives
+additional diagnostic value.
+
+### Changes
+
+#### 1. Add `seq` to `CommandBlockInputData` (`rpc_types.rs`)
+
+```rust
+pub struct CommandBlockInputData {
+    pub blockid: String,
+    pub inputdata64: String,
+    pub signame: String,
+    pub termsize: Option<serde_json::Value>,
+    pub seq: Option<u64>,   // ← NEW: monotonically increasing per-block counter
+}
+```
+
+Default `None` preserves backward compatibility — inputs with no seq are
+accepted unconditionally (existing clients continue to work).
+
+#### 2. Per-block sequence state in `ShellControllerInner`
+
+```rust
+pub struct ShellControllerInner {
+    // ...existing fields...
+    pub input_seq_next: u64,          // next expected sequence number
+    pub input_seq_buf: BTreeMap<u64, BlockInputUnion>,  // reorder buffer
+}
+```
+
+#### 3. Sequence enforcement in `send_input()` (`shell.rs`)
+
+```rust
+fn send_input(&self, input: BlockInputUnion, seq: Option<u64>) -> Result<(), String> {
+    let mut inner = self.inner.lock().unwrap();
+    let tx = inner.input_tx.as_ref()
+        .ok_or_else(|| "controller is not running".to_string())?;
+
+    match seq {
+        None => {
+            // No seq — legacy client, send immediately
+            tx.try_send(input).map_err(|e| format!("send_input: {e}"))
+        }
+        Some(s) => {
+            let next = inner.input_seq_next;
+            if s == next {
+                // In-order: send now, then drain any buffered successors
+                tx.try_send(input).map_err(|e| format!("send_input: {e}"))?;
+                inner.input_seq_next = next + 1;
+                while let Some(buffered) = inner.input_seq_buf.remove(&inner.input_seq_next) {
+                    tx.try_send(buffered).map_err(|e| format!("send_input drain: {e}"))?;
+                    inner.input_seq_next += 1;
+                }
+                Ok(())
+            } else if s > next {
+                // Early arrival: buffer it
+                inner.input_seq_buf.insert(s, input);
+                Ok(())
+            } else {
+                // Duplicate (seq < next): discard
+                tracing::warn!(block_id = %self.block_id, seq, next, "duplicate input seq, discarding");
+                Ok(())
+            }
+        }
+    }
+}
+```
+
+#### 4. Frontend: increment and attach `seq` in `sendDataToController()`
+
+```typescript
+// termViewModel.ts
+private inputSeq = 0;
+
+sendDataToController(data: string) {
+    const b64data = stringToBase64(data);
+    RpcApi.ControllerInputCommand(TabRpcClient, {
+        blockid: this.blockId,
+        inputdata64: b64data,
+        seq: this.inputSeq++,
+    });
+}
+```
+
+The counter is per-`TermViewModel` instance (= per terminal pane). It resets
+when the pane is closed and a new one opened.
+
+---
+
+## Reorder Buffer Sizing & Safety
+
+The buffer holds at most `N - 1` entries where `N` is the window of concurrent
+Tokio tasks in flight for a single block. In practice this is 2–5 during fast
+typing. A hard cap of **32 entries** is reasonable (matching `SHELL_INPUT_CH_SIZE`);
+entries beyond the cap are dropped with a warning.
+
+The buffer is bounded in memory: each entry is at most a few hundred bytes
+(keystrokes are short). 32 entries × 512 bytes = 16 KB worst case per block.
+
+---
+
+## Diagnostic Additions
+
+### 1. Log out-of-order arrival (INFO level)
+
+```rust
+tracing::info!(block_id = %self.block_id, arrived = s, expected = next,
+    "out-of-order input: buffering");
+```
+
+This makes the bug visible in production logs without user impact.
+
+### 2. Expose `input_reorder_count` in `BlockControllerRuntimeStatus`
+
+```rust
+pub input_reorder_count: u64,  // total out-of-order arrivals since start
+```
+
+Agents and the benchmark can query this to measure how often reordering occurs
+under load — turning a silent corruption into a measurable metric.
+
+### 3. Benchmark extension: `--seq-test` mode
+
+Add a mode to `bench-term-echo.mjs` that sends a known character sequence
+(`abcde...z` × N) and checks if the echo comes back in the same order. Any
+transposition is reported as a reorder event. This gives a reproducible test
+for the fix and a regression guard for CI.
+
+---
+
+## Before/After Verification
+
+```bash
+# Before fix: run seq-test under load
+node tools/tests/bench-term-echo.mjs --seq-test --busy
+
+# After fix: same command — reorder_count should be 0
+node tools/tests/bench-term-echo.mjs --seq-test --busy
+```
+
+Expected output (post-fix):
+```
+=== Sequence integrity test (100 rounds, busy terminal) ===
+  Reorder events: 0 / 100
+  PASS
+```
+
+---
+
+## Non-Goals
+
+- **Not** changing the `tokio::spawn` model for all RPC commands — only
+  `controllerinput` ordering matters for correctness; other commands are
+  idempotent or order-insensitive.
+- **Not** switching to a synchronous input path — sequence numbers give the
+  same correctness guarantee without stalling the WS receive loop.
+- **Not** fixing the RT info race (Root Cause 2 in SPEC_DEAD_TERMINAL_PANE) —
+  that is a separate issue.
+
+---
+
+## Related
+
+- `SPEC_DEAD_TERMINAL_PANE_2026_05_20.md` — PTY spawn failure (different issue)
+- `SPEC_TERMINAL_LATENCY_BENCHMARK_2026_05_19.md` — benchmark infrastructure
+- `agentmux-srv/src/backend/rpc/engine.rs` — `handle_message()` spawn site
+- `agentmux-srv/src/backend/blockcontroller/shell.rs` — `send_input()`, input loop
+- `frontend/app/view/term/termViewModel.ts` — `sendDataToController()`

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -72,6 +72,7 @@ class TermViewModel implements ViewModel {
     agentRuntimeLabel: () => string | null;
     searchAtoms?: SearchAtoms;
     voiceHandle: () => PaneVoiceHandle;
+    private inputSeq: number = 0;
 
     constructor(blockId: string, nodeModel: BlockNodeModel) {
         this.viewType = "term";
@@ -341,7 +342,7 @@ class TermViewModel implements ViewModel {
 
     sendDataToController(data: string) {
         const b64data = stringToBase64(data);
-        RpcApi.ControllerInputCommand(TabRpcClient, { blockid: this.blockId, inputdata64: b64data });
+        RpcApi.ControllerInputCommand(TabRpcClient, { blockid: this.blockId, inputdata64: b64data, seq: this.inputSeq++ });
     }
 
     triggerRestartAtom() {

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -150,6 +150,7 @@ declare global {
         inputdata64?: string;
         signame?: string;
         termsize?: TermSize;
+        seq?: number;
     };
 
     // wshrpc.CommandToolDecisionData — per-tool-call permission reply.

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
@@ -269,6 +269,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -896,6 +897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -944,6 +946,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1041,7 +1044,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1058,7 +1060,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1075,7 +1076,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,7 +1092,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,7 +1108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,7 +1124,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,7 +1140,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,7 +1156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,7 +1172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,7 +1188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,7 +1204,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,7 +1220,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,7 +1236,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,7 +1252,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,7 +1268,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,7 +1284,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1313,7 +1300,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1330,7 +1316,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1347,7 +1332,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1364,7 +1348,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1381,7 +1364,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1398,7 +1380,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1415,7 +1396,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1432,7 +1412,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1449,7 +1428,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1466,7 +1444,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1694,6 +1671,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -1911,7 +1899,6 @@
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
       "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1951,7 +1938,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1972,7 +1958,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1993,7 +1978,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,7 +1998,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2035,7 +2018,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2056,7 +2038,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2077,7 +2058,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,7 +2078,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,7 +2098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2140,7 +2118,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2161,7 +2138,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2182,7 +2158,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2203,7 +2178,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2283,7 +2257,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2297,7 +2270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2311,7 +2283,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2325,7 +2296,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,7 +2309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,7 +2322,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2367,7 +2335,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,7 +2348,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,7 +2361,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,7 +2374,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,7 +2387,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2437,7 +2400,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2451,7 +2413,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2465,7 +2426,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,7 +2439,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2493,7 +2452,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2507,7 +2465,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,7 +2478,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2535,7 +2491,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2549,7 +2504,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2563,7 +2517,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2530,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2591,7 +2543,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,7 +2556,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2619,7 +2569,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3005,6 +2954,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -3442,6 +3392,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3460,8 +3411,9 @@
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -3480,7 +3432,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@testing-library/user-event": {
@@ -3942,8 +3894,9 @@
       "version": "22.19.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
       "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4037,6 +3990,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4489,6 +4443,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4580,7 +4535,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
@@ -4785,6 +4740,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4798,6 +4754,13 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -4965,6 +4928,7 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
       "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.2",
         "@chevrotain/gast": "11.1.2",
@@ -4990,7 +4954,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -5203,7 +5167,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cssesc": {
@@ -5230,6 +5194,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5639,6 +5604,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5849,7 +5815,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5975,7 +5941,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6042,6 +6008,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6340,7 +6307,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6457,7 +6423,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6503,7 +6468,7 @@
       "version": "4.13.6",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
       "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -7186,7 +7151,7 @@
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.4.tgz",
       "integrity": "sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -7231,7 +7196,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7348,7 +7313,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7368,7 +7333,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7559,7 +7524,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7728,6 +7693,7 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -7795,7 +7761,7 @@
       "version": "1.31.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
       "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7828,7 +7794,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7849,7 +7814,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7870,7 +7834,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7891,7 +7854,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7912,7 +7874,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7933,7 +7894,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7954,7 +7914,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7975,7 +7934,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7996,7 +7954,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8017,7 +7974,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8038,7 +7994,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8103,6 +8058,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -8644,6 +8611,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -9280,7 +9248,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9313,7 +9282,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9370,7 +9339,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9420,7 +9388,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9722,7 +9689,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9768,7 +9734,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9784,6 +9749,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9867,6 +9833,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9898,6 +9865,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10038,6 +10006,19 @@
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -10049,7 +10030,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -10063,7 +10044,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -10378,7 +10359,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -10444,8 +10425,8 @@
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10546,8 +10527,9 @@
       "version": "1.97.2",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.2.tgz",
       "integrity": "sha512-y5LWb0IlbO4e97Zr7c3mlpabcbBtS+ieiZ9iwDooShpFKWXf62zz5pEPdwrLYm+Bxn1fnbwFGzHuCLSA9tBmrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -10593,6 +10575,7 @@
       "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
       "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -10730,6 +10713,7 @@
       "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
       "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.1.0",
         "seroval": "~1.5.0",
@@ -10755,6 +10739,27 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10938,7 +10943,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -11020,6 +11025,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-calc": "^3.2.0",
         "@csstools/css-parser-algorithms": "^4.0.0",
@@ -11456,7 +11462,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
       "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -11481,6 +11488,32 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/terser": {
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",
@@ -11572,7 +11605,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11801,7 +11833,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -11821,7 +11853,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11851,6 +11882,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11903,7 +11935,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11924,6 +11956,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -12134,8 +12167,8 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
-      "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -12301,7 +12334,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12318,7 +12350,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12335,7 +12366,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12352,7 +12382,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12369,7 +12398,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12386,7 +12414,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12403,7 +12430,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12420,7 +12446,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12437,7 +12462,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12454,7 +12478,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12471,7 +12494,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12488,7 +12510,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12505,7 +12526,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12522,7 +12542,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12539,7 +12558,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12556,7 +12574,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12573,7 +12590,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12590,7 +12606,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12607,7 +12622,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12624,7 +12638,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12641,7 +12654,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12658,7 +12670,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12675,7 +12686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12692,7 +12702,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12709,7 +12718,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12726,7 +12734,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12740,7 +12747,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12782,7 +12788,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12818,6 +12823,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"

--- a/tools/tests/bench-term-echo.mjs
+++ b/tools/tests/bench-term-echo.mjs
@@ -93,7 +93,7 @@ function findAuthFile(overrideWsUrl, overrideAuthKey) {
     if (candidates.length === 0) {
         throw new Error(
             `No authkey.dev found under ~/.agentmux/dev/*/data/ or ~/.agentmux/versions/*/data/.\n` +
-            `Start a dev instance first: task dev\n` +
+            `Start an instance: task dev  (dev)  or launch the portable build.\n` +
             `See docs/specs/SPEC_TEST_API_ACCESS.md §5`
         );
     }
@@ -107,7 +107,8 @@ function findAuthFile(overrideWsUrl, overrideAuthKey) {
             process.stderr.write(`Stale authkey.dev (pid ${auth.host_pid} dead): ${path}\n`);
             continue;
         }
-        process.stderr.write(`Using authkey.dev: ${path} (instance=${auth.instance}, pid=${auth.host_pid})\n`);
+        const mode = path.includes(`${join("", ".agentmux", "dev")}`) ? "dev" : "portable";
+        process.stderr.write(`Using authkey.dev: ${path} (instance=${auth.instance}, pid=${auth.host_pid}, mode=${mode})\n`);
         return auth;
     }
 

--- a/tools/tests/bench-term-echo.mjs
+++ b/tools/tests/bench-term-echo.mjs
@@ -136,22 +136,36 @@ function openWs(wsEndpoint, authKey) {
     const eventHandlers = [];       // (msg) => void
 
     ws.on("message", (raw) => {
-        const msg = JSON.parse(raw.toString("utf8"));
-        if (msg.wscommand === "eventrecv") {
-            for (const h of eventHandlers) h(msg);
+        // Envelope: { eventtype: "rpc", data: <RpcMessage> }
+        // RpcMessage response: { resid: <original reqid>, data: {...} }
+        // RpcMessage event:    { command: "eventrecv", data: { event, scopes, data } }
+        const envelope = JSON.parse(raw.toString("utf8"));
+        if (envelope.eventtype !== "rpc") return;
+        const rpcMsg = envelope.data;
+        if (!rpcMsg) return;
+
+        if (rpcMsg.command === "eventrecv") {
+            for (const h of eventHandlers) h(rpcMsg.data);
             return;
         }
-        if (msg.reqid && pending.has(msg.reqid)) {
-            const { resolve } = pending.get(msg.reqid);
-            pending.delete(msg.reqid);
-            resolve(msg);
+        if (rpcMsg.resid && pending.has(rpcMsg.resid)) {
+            const { resolve } = pending.get(rpcMsg.resid);
+            pending.delete(rpcMsg.resid);
+            resolve(rpcMsg);
         }
     });
 
-    function rpc(command, data) {
+    function rpc(command, data, timeoutMs = 10000) {
         return new Promise((resolve, reject) => {
             const reqid = randomUUID();
-            pending.set(reqid, { resolve, reject });
+            const timer = setTimeout(() => {
+                pending.delete(reqid);
+                reject(new Error(`RPC timeout: ${command} (${timeoutMs}ms)`));
+            }, timeoutMs);
+            pending.set(reqid, {
+                resolve: (msg) => { clearTimeout(timer); resolve(msg); },
+                reject,
+            });
             ws.send(JSON.stringify({ wscommand: "rpc", message: { command, reqid, data } }));
         });
     }


### PR DESCRIPTION
## Summary

Three fixes for terminal reliability under load and long sessions:

**1. PTY/spawn error propagation** (original fix)
- When PTY open or shell spawn fails (e.g. under memory pressure), writes an ANSI-colored error message directly to the \`blockfile\` stream so xterm.js renders it immediately
- Previously: silent black pane with blinking cursor; user had no indication of failure

**2. Portable benchmark discovery**
- Removes \`if is_dev {\` gate on \`authkey.dev\` write in \`agentmux-cef/src/main.rs\`
- \`bench-term-echo.mjs\` can now target portable builds for long-session regression testing without manual \`--ws-url\`/\`--auth-key\` flags
- Spec: \`docs/specs/SPEC_BENCHMARK_PORTABLE_DISCOVERY_2026_05_20.md\`

**3. Keystroke ordering guarantee** (new)
- Root cause: \`engine.handle_message()\` calls \`tokio::spawn()\` per RPC message; Tokio work-stealing scheduler executes tasks out of order, so characters typed fast arrive at PTY stdin transposed
- Fix: \`CommandBlockInputData.seq: Option<u64>\` + per-block \`BTreeMap\` reorder buffer in \`ShellControllerInner\`; frontend attaches a monotonically increasing counter per \`TermViewModel\` on every \`sendDataToController()\` call
- Backward compatible: \`seq = None\` (legacy clients) forwards unconditionally
- Buffer capped at \`SHELL_INPUT_CH_SIZE\` (32) entries; duplicates discarded with a warn log
- Spec: \`docs/specs/SPEC_KEYSTROKE_ORDER_GUARANTEE_2026_05_20.md\`

## Remaining work

- [ ] Frontend: retry \`setRTInfo\` with backoff when it returns \`{}\` (RT info race)
- [ ] Memory pressure warning badge at ≥85%/≥95% load
- [ ] Benchmark \`--seq-test\` mode for CI regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)