### PR TITLE
feat(agent): recency-sorted launch picker + updated_at on agent definitions

### DIFF
--- a/.changesets/1779276359-feat-agent-recency-sorted-launch-picker-updated-at-on-agent--ds88.md
+++ b/.changesets/1779276359-feat-agent-recency-sorted-launch-picker-updated-at-on-agent--ds88.md
@@ -1,0 +1,23 @@
+---
+type: patch
+---
+
+feat(agent): recency-sorted launch picker + updated_at on agent definitions
+
+**Recency-sorted picker.** `agent_def_list` previously ordered by
+`created_at ASC` (oldest first). It now orders **most-recently-used first**:
+a `LEFT JOIN` on `MAX(db_agent_instances.started_at)` per definition. Never-
+launched agents (no instance rows → NULL `last_used`) sort after the launched
+ones under `DESC`, ordered among themselves by `created_at ASC`. The
+AgentPicker reflects this order directly.
+
+**Default selection.** The AgentPicker now focuses the first card (the
+most-recently-used agent) on mount via a new `AgentCard.defaultFocus` prop —
+so the focus ring marks the default and Enter launches it immediately.
+
+**`updated_at` on agent definitions.** `db_agent_definitions` gains an
+`updated_at` column (schema v2 — `OBJECT_SCHEMA_VERSION` bumped, with an
+idempotent `ALTER TABLE ADD COLUMN` for existing dev databases). It is set to
+`created_at` on insert and stamped fresh on every `agent_def_update`. Surfaced
+on the `AgentDefinition` struct + `gotypes.d.ts` type. (`db_memory_bundles` /
+`db_identity_bundles` already had `updated_at`; agent definitions did not.)

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -354,7 +354,7 @@ fn reseed_if_needed(
             agent.restart_on_crash = existing_agent.restart_on_crash;
             agent.created_at = existing_agent.created_at;
             agent.accounts = existing_agent.accounts.clone();
-            wstore.agent_def_update(&agent)?;
+            wstore.agent_def_update(&mut agent)?;
             updated += 1;
         } else {
             wstore.agent_def_insert(&mut agent)?;

--- a/agentmux-srv/src/backend/agent_seed.rs
+++ b/agentmux-srv/src/backend/agent_seed.rs
@@ -163,6 +163,7 @@ pub fn seed_agents(wstore: &Arc<WaveStore>) -> Result<SeedReport, StoreError> {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: now,
         };
         wstore.agent_def_insert(&mut agent)?;
 
@@ -334,6 +335,7 @@ fn reseed_if_needed(
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: now,
         };
 
         if let Some(existing_agent) = existing_map.get(agent_def.id.as_str()) {

--- a/agentmux-srv/src/backend/storage/migrations.rs
+++ b/agentmux-srv/src/backend/storage/migrations.rs
@@ -22,9 +22,11 @@ use tracing::warn;
 use super::error::StoreError;
 
 /// `user_version` value stamped into `objects.db` after `run_object_schema`.
-/// The flat schema resets the version counter to 1 — the pre-flatten
-/// migration chain never set `user_version`, so legacy files read 0.
-pub const OBJECT_SCHEMA_VERSION: i64 = 1;
+/// The flat schema reset the counter to 1 (the pre-flatten chain never set
+/// `user_version`, so legacy files read 0). Bumped per additive migration:
+///   v1 — flat schema baseline
+///   v2 — db_agent_definitions.updated_at
+pub const OBJECT_SCHEMA_VERSION: i64 = 2;
 /// `user_version` value stamped into `filestore.db`.
 pub const FILESTORE_SCHEMA_VERSION: i64 = 1;
 /// `user_version` value stamped into `sagas.db`.
@@ -130,7 +132,8 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
             accounts             TEXT NOT NULL DEFAULT '',
             parent_id            TEXT NOT NULL DEFAULT '',
             branch_label         TEXT NOT NULL DEFAULT '',
-            created_at           INTEGER NOT NULL DEFAULT 0
+            created_at           INTEGER NOT NULL DEFAULT 0,
+            updated_at           INTEGER NOT NULL DEFAULT 0
         );
         CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_definitions_slug
             ON db_agent_definitions(slug);
@@ -290,6 +293,25 @@ pub fn run_object_schema(conn: &Connection) -> Result<(), StoreError> {
         CREATE INDEX IF NOT EXISTS idx_drone_runs_status
             ON db_drone_runs(status);",
     )?;
+
+    // ---- Additive column migrations (schema v2+) ----
+    // The flat CREATE batch above covers fresh databases. These ALTERs
+    // carry an existing database (e.g. a developer's dev DB that persists
+    // across builds) forward. Idempotent: the "duplicate column" error is
+    // swallowed. New additive columns append here + bump OBJECT_SCHEMA_VERSION.
+    //
+    // v2: db_agent_definitions.updated_at — last-modified timestamp
+    //     (created_at already existed; updates now stamp updated_at).
+    for stmt in &[
+        "ALTER TABLE db_agent_definitions ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0",
+    ] {
+        if let Err(e) = conn.execute_batch(stmt) {
+            let msg = e.to_string();
+            if !msg.contains("duplicate column") {
+                return Err(e.into());
+            }
+        }
+    }
 
     // ---- Seed blank Identity / Memory singletons ----
     // The launch UI renders these as the default option in its Identity /

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -719,7 +719,11 @@ impl WaveStore {
     /// `parent_id` and `branch_label` are NOT updatable post-insert — they
     /// describe the agent's provenance; renaming or re-branching is done by
     /// creating a new fork, not mutating the original.
-    pub fn agent_def_update(&self, agent: &AgentDefinition) -> Result<bool, StoreError> {
+    ///
+    /// Self-stamps `updated_at` with the current time and writes it back into
+    /// `agent.updated_at`, so the caller's struct (e.g. an RPC response body)
+    /// reflects exactly what landed in the database.
+    pub fn agent_def_update(&self, agent: &mut AgentDefinition) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -750,6 +754,9 @@ impl WaveStore {
                 agent.id
             ],
         )?;
+        // Reflect the persisted timestamp back to the caller's struct so an
+        // RPC response carries the fresh value, not the pre-update one.
+        agent.updated_at = now;
         Ok(rows > 0)
     }
 

--- a/agentmux-srv/src/backend/storage/wstore.rs
+++ b/agentmux-srv/src/backend/storage/wstore.rs
@@ -499,6 +499,11 @@ pub struct AgentDefinition {
     /// branches that didn't set a label. Added in v6.
     #[serde(default)]
     pub branch_label: String,
+    /// Last-modified timestamp (epoch ms). Set to `created_at` on insert
+    /// and refreshed on every `agent_def_update`. Schema v2. `0` for
+    /// rows written before v2 (until next update).
+    #[serde(default)]
+    pub updated_at: i64,
 }
 
 /// Derive a filesystem-safe slug from a display name. Lowercase,
@@ -567,15 +572,30 @@ pub struct AgentHistory {
 }
 
 impl WaveStore {
-    /// List all agent definitions, ordered by created_at ascending.
+    /// List all agent definitions, **most-recently-used first**.
+    ///
+    /// "Used" = the latest `started_at` of any `db_agent_instances` row for
+    /// the definition. Agents that have never been launched have no instance
+    /// row, so their `last_used` is NULL — SQLite sorts NULLs last under
+    /// `DESC`, placing never-launched agents after the launched ones,
+    /// ordered among themselves by `created_at ASC` (stable, oldest-first).
+    /// The launch picker relies on this order to default-select the
+    /// most-recent agent.
     pub fn agent_def_list(&self) -> Result<Vec<AgentDefinition>, StoreError> {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn.prepare(
-            "SELECT id, slug, name, icon, provider, description, working_directory, shell,
-                    provider_flags, auto_start, restart_on_crash, idle_timeout_minutes, created_at,
-                    agent_type, environment, agent_bus_id, is_seeded, accounts,
-                    parent_id, branch_label
-             FROM db_agent_definitions ORDER BY created_at ASC",
+            "SELECT d.id, d.slug, d.name, d.icon, d.provider, d.description,
+                    d.working_directory, d.shell, d.provider_flags, d.auto_start,
+                    d.restart_on_crash, d.idle_timeout_minutes, d.created_at,
+                    d.agent_type, d.environment, d.agent_bus_id, d.is_seeded,
+                    d.accounts, d.parent_id, d.branch_label, d.updated_at
+             FROM db_agent_definitions d
+             LEFT JOIN (
+                 SELECT definition_id, MAX(started_at) AS last_used
+                 FROM db_agent_instances
+                 GROUP BY definition_id
+             ) i ON i.definition_id = d.id
+             ORDER BY i.last_used DESC, d.created_at ASC",
         )?;
         let rows = stmt.query_map([], |row| {
             Ok(AgentDefinition {
@@ -599,6 +619,7 @@ impl WaveStore {
                 accounts: row.get(17)?,
                 parent_id: row.get(18)?,
                 branch_label: row.get(19)?,
+                updated_at: row.get(20)?,
             })
         })?;
         let mut agents = Vec::new();
@@ -663,9 +684,9 @@ impl WaveStore {
             "INSERT INTO db_agent_definitions (id, slug, name, icon, provider, description,
              working_directory, shell, provider_flags, auto_start, restart_on_crash,
              idle_timeout_minutes, created_at, agent_type, environment, agent_bus_id,
-             is_seeded, accounts, parent_id, branch_label)
+             is_seeded, accounts, parent_id, branch_label, updated_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16,
-                     ?17, ?18, ?19, ?20)",
+                     ?17, ?18, ?19, ?20, ?21)",
             params![
                 agent.id,
                 agent.slug,
@@ -687,6 +708,8 @@ impl WaveStore {
                 agent.accounts,
                 agent.parent_id,
                 agent.branch_label,
+                // New definitions: updated_at == created_at.
+                agent.created_at,
             ],
         )?;
         Ok(())
@@ -698,12 +721,16 @@ impl WaveStore {
     /// creating a new fork, not mutating the original.
     pub fn agent_def_update(&self, agent: &AgentDefinition) -> Result<bool, StoreError> {
         let conn = self.conn.lock().unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
         let rows = conn.execute(
             "UPDATE db_agent_definitions SET name=?1, icon=?2, provider=?3, description=?4,
              working_directory=?5, shell=?6, provider_flags=?7, auto_start=?8,
              restart_on_crash=?9, idle_timeout_minutes=?10,
-             agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14
-             WHERE id=?15",
+             agent_type=?11, environment=?12, agent_bus_id=?13, accounts=?14, updated_at=?15
+             WHERE id=?16",
             params![
                 agent.name,
                 agent.icon,
@@ -719,6 +746,7 @@ impl WaveStore {
                 agent.environment,
                 agent.agent_bus_id,
                 agent.accounts,
+                now,
                 agent.id
             ],
         )?;
@@ -2547,6 +2575,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         // "Agent X" → "agent-x"
@@ -2608,6 +2637,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut a1).unwrap();
         assert_eq!(a1.slug, "explicit");
@@ -2664,6 +2694,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         }
     }
 
@@ -2784,6 +2815,49 @@ mod tests {
         assert_eq!(running.len(), 0);
         let stopped = store.instance_list(None, Some("stopped")).unwrap();
         assert_eq!(stopped.len(), 1);
+    }
+
+    #[test]
+    fn test_agent_def_list_orders_by_last_used() {
+        let store = v6_test_store();
+        // Three definitions; none launched yet.
+        let mut a = sample_agent("def-a", "agent-a");
+        let mut b = sample_agent("def-b", "agent-b");
+        let mut c = sample_agent("def-c", "agent-c");
+        store.agent_def_insert(&mut a).unwrap();
+        store.agent_def_insert(&mut b).unwrap();
+        store.agent_def_insert(&mut c).unwrap();
+
+        let mk = |id: &str, def: &str, started: i64| AgentInstance {
+            id: id.to_string(),
+            definition_id: def.to_string(),
+            parent_instance_id: String::new(),
+            block_id: String::new(),
+            session_id: String::new(),
+            status: InstanceStatus::Running.as_str().to_string(),
+            github_context: String::new(),
+            started_at: started,
+            ended_at: 0,
+            created_at: started,
+            identity_id: String::new(),
+            memory_id: String::new(),
+            instance_name: String::new(),
+            working_directory: String::new(),
+            display_hidden: false,
+        };
+        // Launch def-a, then def-b later. def-c is never launched.
+        store.instance_create(&mk("i-a", "def-a", 500)).unwrap();
+        store.instance_create(&mk("i-b", "def-b", 600)).unwrap();
+
+        let ids = |s: &WaveStore| -> Vec<String> {
+            s.agent_def_list().unwrap().into_iter().map(|d| d.id).collect()
+        };
+        // Most-recently-launched first; never-launched (def-c) last.
+        assert_eq!(ids(&store), vec!["def-b", "def-a", "def-c"]);
+
+        // A newer launch of def-a flips it above def-b (MAX(started_at)).
+        store.instance_create(&mk("i-a2", "def-a", 700)).unwrap();
+        assert_eq!(ids(&store), vec!["def-a", "def-b", "def-c"]);
     }
 
     #[test]

--- a/agentmux-srv/src/identity/resolver.rs
+++ b/agentmux-srv/src/identity/resolver.rs
@@ -358,6 +358,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -397,6 +398,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -480,6 +482,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 
@@ -558,6 +561,7 @@ mod tests {
             accounts: String::new(),
             parent_id: String::new(),
             branch_label: String::new(),
+            updated_at: 0,
         };
         store.agent_def_insert(&mut def).unwrap();
 

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -115,6 +115,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     accounts: String::new(),
                     parent_id: String::new(),
                     branch_label: String::new(),
+                    updated_at: now,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("createagent: {e}"))?;
                 broker.publish(crate::backend::wps::WaveEvent {
@@ -176,6 +177,10 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // not in-place edits).
                     parent_id: old.parent_id.clone(),
                     branch_label: old.branch_label.clone(),
+                    // agent_def_update stamps a fresh updated_at in the DB;
+                    // the returned struct carries the prior value (the
+                    // agents:changed re-fetch corrects it client-side).
+                    updated_at: old.updated_at,
                 };
                 let found = wstore.agent_def_update(&agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
@@ -527,6 +532,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     accounts: String::new(),
                     parent_id: String::new(),
                     branch_label: String::new(),
+                    updated_at: now,
                 };
                 wstore.agent_def_insert(&mut agent).map_err(|e| format!("importagentfromclaw: {e}"))?;
 
@@ -657,6 +663,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                         accounts: String::new(),
                         parent_id: String::new(),
                         branch_label: String::new(),
+                        updated_at: now,
                     };
 
                     if let Err(e) = wstore.agent_def_insert(&mut agent) {
@@ -1415,6 +1422,7 @@ fn register_v6_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     accounts: String::new(),
                     parent_id: source.id.clone(),
                     branch_label: cmd.branch_label.clone(),
+                    updated_at: now,
                 };
                 wstore
                     .agent_def_insert(&mut fork)

--- a/agentmux-srv/src/server/agent_handlers.rs
+++ b/agentmux-srv/src/server/agent_handlers.rs
@@ -148,7 +148,7 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                 // slug is preserved from the existing row — it's
                 // immutable after creation. The update path never
                 // accepts a new slug from the client.
-                let agent = AgentDefinition {
+                let mut agent = AgentDefinition {
                     id: cmd.id,
                     slug: old.slug.clone(),
                     name: cmd.name,
@@ -177,12 +177,12 @@ pub fn register_agent_handlers(engine: &Arc<WshRpcEngine>, state: &AppState) {
                     // not in-place edits).
                     parent_id: old.parent_id.clone(),
                     branch_label: old.branch_label.clone(),
-                    // agent_def_update stamps a fresh updated_at in the DB;
-                    // the returned struct carries the prior value (the
-                    // agents:changed re-fetch corrects it client-side).
+                    // Placeholder — agent_def_update self-stamps the real
+                    // timestamp and writes it back into `agent` below, so
+                    // the response body carries the fresh value.
                     updated_at: old.updated_at,
                 };
-                let found = wstore.agent_def_update(&agent).map_err(|e| format!("updateagent: {e}"))?;
+                let found = wstore.agent_def_update(&mut agent).map_err(|e| format!("updateagent: {e}"))?;
                 if !found {
                     return Err(format!("updateagent: agent {} not found", agent.id));
                 }

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -670,6 +670,11 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
             { label: "", divider: true },
             {
+                label: "Documentation",
+                icon: "book",
+                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
+            },
+            {
                 label: "Settings",
                 icon: "cog",
                 onClick: () =>
@@ -679,20 +684,15 @@ function TabBar(props: TabBarProps): JSX.Element {
                     }),
             },
             {
-                label: "Command Palette",
-                icon: "magnifying-glass",
-                shortcut: kbd("⌘P", "Ctrl+P"),
-                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
-            },
-            {
                 label: "DevTools",
                 icon: "code",
                 onClick: () => getApi().toggleDevtools(),
             },
             {
-                label: "Online Docs",
-                icon: "book",
-                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
+                label: "Command Palette",
+                icon: "magnifying-glass",
+                shortcut: kbd("⌘P", "Ctrl+P"),
+                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
             },
             { label: "", divider: true },
             {

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -670,11 +670,6 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
             { label: "", divider: true },
             {
-                label: "Documentation",
-                icon: "book",
-                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
-            },
-            {
                 label: "Settings",
                 icon: "cog",
                 onClick: () =>
@@ -684,15 +679,20 @@ function TabBar(props: TabBarProps): JSX.Element {
                     }),
             },
             {
+                label: "Command Palette",
+                icon: "magnifying-glass",
+                shortcut: kbd("⌘P", "Ctrl+P"),
+                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
+            },
+            {
                 label: "DevTools",
                 icon: "code",
                 onClick: () => getApi().toggleDevtools(),
             },
             {
-                label: "Command Palette",
-                icon: "magnifying-glass",
-                shortcut: kbd("⌘P", "Ctrl+P"),
-                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
+                label: "Online Docs",
+                icon: "book",
+                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
             },
             { label: "", divider: true },
             {

--- a/frontend/app/view/agent/components/AgentCard.tsx
+++ b/frontend/app/view/agent/components/AgentCard.tsx
@@ -19,7 +19,7 @@
  * closes).
  */
 
-import { createMemo, Show, type JSX } from "solid-js";
+import { createMemo, onMount, Show, type JSX } from "solid-js";
 import { ProviderLogo } from "@/element/ProviderLogo";
 import { getCliCatalogEntry } from "../defaults/cli-catalog";
 
@@ -33,12 +33,21 @@ interface AgentCardProps {
     installed: boolean | undefined;
     /** Opens the AgentLaunchModal (or Install modal) for this definition. */
     onLaunch: (agent: AgentDefinition) => void;
+    /** When true this card is the picker's default choice (the
+     *  most-recently-used agent) — focus it on mount so Enter launches
+     *  it and the focus ring marks it as the default. */
+    defaultFocus?: boolean;
 }
 
 export const AgentCard = (props: AgentCardProps): JSX.Element => {
     const catalog = createMemo(() => getCliCatalogEntry(props.agent.provider));
     const title = () => catalog()?.blurb || props.agent.description || props.agent.name;
     const caption = () => catalog()?.displayName || props.agent.name;
+
+    let cardEl: HTMLDivElement | undefined;
+    onMount(() => {
+        if (props.defaultFocus && !props.disabled) cardEl?.focus();
+    });
 
     const handleCardClick = () => {
         if (!props.disabled) props.onLaunch(props.agent);
@@ -54,6 +63,7 @@ export const AgentCard = (props: AgentCardProps): JSX.Element => {
 
     return (
         <div
+            ref={cardEl}
             class={`agent-card${props.launching ? " agent-card--launching" : ""}`}
             classList={{
                 "agent-card--disabled": props.disabled,

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -418,13 +418,16 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
                     <div class="agent-picker">
                         <div class="agent-picker-list">
                             <For each={agents()}>
-                                {(agent) => (
+                                {(agent, index) => (
                                     <AgentCard
                                         agent={agent}
                                         launching={launching() === agent.id}
                                         disabled={busy()}
                                         installed={installState()[agent.id]}
                                         onLaunch={handleSelect}
+                                        // agent_def_list returns most-recently-used
+                                        // first, so index 0 is the default choice.
+                                        defaultFocus={index() === 0}
                                     />
                                 )}
                             </For>

--- a/frontend/types/gotypes.d.ts
+++ b/frontend/types/gotypes.d.ts
@@ -245,6 +245,12 @@ declare global {
          * Empty for root definitions. Added in v6.
          */
         branch_label?: string;
+        /**
+         * Last-modified timestamp (epoch ms). Set to created_at on insert,
+         * refreshed on every update. Schema v2. `0` for rows last written
+         * before v2.
+         */
+        updated_at?: number;
     };
 
     // ── v6: identity, instance, junction ────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Recency-sorted picker.** `agent_def_list` ordered by `created_at ASC` (oldest first); now orders **most-recently-used first** via a `LEFT JOIN` on `MAX(db_agent_instances.started_at)` per definition. Never-launched agents (NULL `last_used`) sort after the launched ones under `DESC`, ordered among themselves by `created_at ASC`. The AgentPicker reflects this directly.
- **Default selection.** The AgentPicker focuses the first card (the most-recently-used agent) on mount — new `AgentCard.defaultFocus` prop. The focus ring marks it as the default; Enter/Space launches it.
- **`updated_at` on agent definitions.** `db_agent_definitions` previously had only `created_at` (memory/identity bundles already had both). Added `updated_at` — schema **v2** (`OBJECT_SCHEMA_VERSION` 1→2, with an idempotent `ALTER TABLE ADD COLUMN` for existing dev DBs that persist across builds). Set to `created_at` on insert; stamped fresh on every `agent_def_update`. Surfaced on the `AgentDefinition` struct + `gotypes.d.ts`.

## Reviewer notes

- SQLite sorts NULLs **last** under `DESC`, so the `ORDER BY i.last_used DESC, d.created_at ASC` cleanly places launched-by-recency first, then never-launched by creation order — no `NULLS LAST` needed.
- The `ALTER TABLE ADD COLUMN` is the flat schema's documented additive-migration pattern (idempotent, duplicate-column error swallowed) — fresh DBs get the column from the `CREATE TABLE`; only persistent dev DBs hit the ALTER.
- `agent_def_insert`/`agent_def_update` own the `updated_at` column value (insert→`created_at`, update→`now`); the struct field on returned objects is informational and self-corrects via the `agents:changed` re-fetch.

## Test plan

- [x] `cargo test -p agentmux-srv backend::storage` — 95 pass incl. new `test_agent_def_list_orders_by_last_used`
- [x] `task build:frontend` — clean
- [ ] Reagent + Codex review
- [ ] Smoke: launch agent A then B; reopen a picker → B is first and focused; relaunch A → A moves to first

🤖 Generated with [Claude Code](https://claude.com/claude-code)