### PR TITLE
feat(menu): hamburger order — Settings, Command Palette, DevTools, Online Docs

### DIFF
--- a/.changesets/1779276792-feat-menu-hamburger-order-settings-command-palette-devtools--y6z0.md
+++ b/.changesets/1779276792-feat-menu-hamburger-order-settings-command-palette-devtools--y6z0.md
@@ -1,0 +1,12 @@
+---
+type: patch
+---
+
+feat(menu): hamburger order — Settings, Command Palette, DevTools, Online Docs
+
+Follow-up tweak to PR #936's hamburger menu. The bottom group is reordered
+to **Settings · Command Palette · DevTools · Online Docs**, and the
+"Documentation" item is renamed to **"Online Docs"** (its action — open
+`https://docs.agentmux.ai` in the browser — is unchanged).
+
+Frontend-only; one block in `tabbar.tsx`.

--- a/frontend/app/tab/tabbar.tsx
+++ b/frontend/app/tab/tabbar.tsx
@@ -670,11 +670,6 @@ function TabBar(props: TabBarProps): JSX.Element {
             },
             { label: "", divider: true },
             {
-                label: "Documentation",
-                icon: "book",
-                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
-            },
-            {
                 label: "Settings",
                 icon: "cog",
                 onClick: () =>
@@ -684,15 +679,20 @@ function TabBar(props: TabBarProps): JSX.Element {
                     }),
             },
             {
+                label: "Command Palette",
+                icon: "magnifying-glass",
+                shortcut: kbd("⌘P", "Ctrl+P"),
+                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
+            },
+            {
                 label: "DevTools",
                 icon: "code",
                 onClick: () => getApi().toggleDevtools(),
             },
             {
-                label: "Command Palette",
-                icon: "magnifying-glass",
-                shortcut: kbd("⌘P", "Ctrl+P"),
-                onClick: () => modalsModel.pushModal("CommandPaletteModal"),
+                label: "Online Docs",
+                icon: "book",
+                onClick: () => getApi().openExternal("https://docs.agentmux.ai"),
             },
             { label: "", divider: true },
             {


### PR DESCRIPTION
## Summary

Follow-up tweak to PR #936's hamburger (≡) menu. The bottom group is reordered to **Settings · Command Palette · DevTools · Online Docs**, and the **"Documentation"** item is renamed to **"Online Docs"** (action unchanged — opens `https://docs.agentmux.ai` in the external browser).

Before (#936): Documentation · Settings · DevTools · Command Palette
After: Settings · Command Palette · DevTools · Online Docs

Frontend-only — one block in `tabbar.tsx`.

> Note: this change briefly rode along in PR #939 by accident (an uncommitted live-preview edit that carried across a branch switch). Reagent flagged it; it was reverted there and split into this dedicated PR.

## Test plan

- [x] `task build:frontend` — clean
- [ ] Reagent + Codex review
- [ ] Smoke: open the ≡ menu — confirm the new bottom-group order; "Online Docs" opens the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)