### PR TITLE
docs(readme): fix Widgets table — DevTools removed, Drone added

### DIFF
--- a/.changesets/1779279479-docs-readme-fix-widgets-table-devtools-removed-drone-added-a08a.md
+++ b/.changesets/1779279479-docs-readme-fix-widgets-table-devtools-removed-drone-added-a08a.md
@@ -1,0 +1,13 @@
+---
+type: patch
+---
+
+docs(readme): fix Widgets table — DevTools removed, Drone added
+
+The README's Widgets table drifted from `widgets.json`:
+
+- Removed the **DevTools** widget row — DevTools stopped being a widget in
+  PR #936; it's now a hamburger-menu item. Added a corresponding row to the
+  "Not widgets — opened from elsewhere" table (Hamburger ≡ → DevTools).
+- Added the **Drone** widget row (`diagram-project` icon, More tier) — it
+  was present in `widgets.json` but missing from the README table.

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ The widget bar shows pinned widgets directly; the rest live in a **More** dropdo
 | **Browser** | globe | `browser` | Embedded native `CefBrowserView` | Pinned |
 | **Terminal** | square-terminal | `term` | Terminal with xterm.js and real PTY | Pinned |
 | **Sysinfo** | chart-line | `sysinfo` | Live system metrics (CPU, memory, network, disk) | Pinned |
-| **DevTools** | code | `devtools` | Toggle Chromium DevTools (does not open a pane) | Pinned |
 | **Editor** | file-code | `editor` | Code editor with syntax highlighting | More |
 | **Swarm** | bee | `swarm` | Multi-agent orchestration overview | More |
+| **Drone** | diagram-project | `drone` | Visual DAG-of-blocks drone engine | More |
 | **Help** | circle-question | `help` | Built-in documentation and help | More |
 
 ### Not widgets — opened from elsewhere
@@ -94,6 +94,7 @@ The widget bar shows pinned widgets directly; the rest live in a **More** dropdo
 | **Identity** | Tab inside an Agent pane (cog → settings → Identity). Manage the credential bundle assigned to this instance. |
 | **Memory** | Tab inside an Agent pane (cog → settings → Memory). Manage the personality / capability bundle (provider, model, instructions, MCP, skills). Replaces the old Forge concept. |
 | **Settings** | Hamburger menu (≡) in the top tab bar → Settings. Opens `settings.json` in your default editor. |
+| **DevTools** | Hamburger menu (≡) in the top tab bar → DevTools. Toggles Chromium DevTools (no longer a widget). |
 
 ## Agents
 


### PR DESCRIPTION
## Summary

The README's Widgets table had drifted from `agentmux-srv/src/config/widgets.json`:

- **Removed the DevTools widget row** — DevTools stopped being a widget in PR #936 (`defwidget@devtools` dropped from `widgets.json`); it's now a hamburger-menu item. Added a row to the "Not widgets — opened from elsewhere" table (Hamburger ≡ → DevTools).
- **Added the Drone widget row** (`diagram-project` icon, More tier) — present in `widgets.json` but missing from the README.

Companion to agentmux-docs PR #41 (the broader docs refresh for the schema flatten + de-forge).

## Test plan

- [x] Table cross-checked against `widgets.json`
- [ ] Reagent + Codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)