### PR TITLE
feat(stability): suppress Windows crash modal — supervision Phase 0

### DIFF
--- a/.changesets/1779299494-feat-stability-suppress-windows-crash-modal-supervision-phas-z50c.md
+++ b/.changesets/1779299494-feat-stability-suppress-windows-crash-modal-supervision-phas-z50c.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(stability): suppress Windows crash modal (supervision Phase 0)

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -68,6 +68,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_SystemInformation",
     "Win32_System_ProcessStatus",
     "Win32_System_Diagnostics_Debug",
+    "Win32_System_ErrorReporting",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_UI_Shell",
     "Win32_System_Com",

--- a/agentmux-cef/Cargo.toml
+++ b/agentmux-cef/Cargo.toml
@@ -67,6 +67,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Ole",
     "Win32_System_SystemInformation",
     "Win32_System_ProcessStatus",
+    "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_UI_Shell",
     "Win32_System_Com",

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -70,12 +70,19 @@ pub type OsKeyEvent = std::ffi::c_void;
 /// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
 #[cfg(target_os = "windows")]
 fn suppress_os_crash_dialogs() {
-    use windows_sys::Win32::System::Diagnostics::Debug::{
-        SetErrorMode, SEM_FAILCRITICALERRORS, SEM_NOGPFAULTERRORBOX,
-    };
-    // SetErrorMode is process-wide; it also covers the CEF subprocesses.
+    use windows_sys::Win32::System::Diagnostics::Debug::{SetErrorMode, SEM_FAILCRITICALERRORS};
+    use windows_sys::Win32::System::ErrorReporting::{WerSetFlags, WER_FAULT_REPORTING_NO_UI};
+    // Process-wide; also covers the CEF subprocesses.
     unsafe {
-        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+        // Suppress the WER crash-dialog UI WITHOUT disabling WER itself —
+        // SEM_NOGPFAULTERRORBOX would also kill WER/LocalDumps crash-dump
+        // collection, the postmortem diagnostics this stability work needs.
+        // WER_FAULT_REPORTING_NO_UI is the documented "no UI, keep
+        // reports" path.
+        let _ = WerSetFlags(WER_FAULT_REPORTING_NO_UI);
+        // SEM_FAILCRITICALERRORS suppresses the critical-error handler
+        // (e.g. "no disk in drive" popups) — unrelated to crash reporting.
+        SetErrorMode(SEM_FAILCRITICALERRORS);
     }
 }
 

--- a/agentmux-cef/src/main.rs
+++ b/agentmux-cef/src/main.rs
@@ -62,7 +62,33 @@ pub type OsKeyEvent = cef::sys::_XEvent;
 #[cfg(target_os = "macos")]
 pub type OsKeyEvent = std::ffi::c_void;
 
+/// Suppress the Windows "Application Error" / WER crash dialog so an unhandled
+/// fault (a Chromium `LOG(FATAL)`, an `abort()`, a breakpoint) terminates the
+/// process immediately instead of wedging it behind a modal the user must
+/// dismiss. While that dialog is up the process is frozen and cannot be
+/// auto-recovered. No-op off Windows. Spec:
+/// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
+#[cfg(target_os = "windows")]
+fn suppress_os_crash_dialogs() {
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        SetErrorMode, SEM_FAILCRITICALERRORS, SEM_NOGPFAULTERRORBOX,
+    };
+    // SetErrorMode is process-wide; it also covers the CEF subprocesses.
+    unsafe {
+        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn suppress_os_crash_dialogs() {}
+
 fn main() {
+    // Phase 0 (service supervision & recovery): suppress the Windows crash
+    // modal so a fault terminates the process immediately instead of freezing
+    // it behind an "Application Error" dialog. Must be the first statement —
+    // set before anything can fault.
+    suppress_os_crash_dialogs();
+
     // Set the DLL search path so CEF's runtime LoadLibrary calls (chrome_elf,
     // libEGL, libGLESv2, d3dcompiler_47, …) resolve against the directory that
     // actually holds libcef.dll. Two layouts exist:

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -70,6 +70,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_JobObjects",
     "Win32_System_Threading",
     "Win32_System_Diagnostics_Debug",
+    "Win32_System_ErrorReporting",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Foundation",
     # CreateJobObjectW takes SECURITY_ATTRIBUTES* — guarded by this

--- a/agentmux-launcher/Cargo.toml
+++ b/agentmux-launcher/Cargo.toml
@@ -69,6 +69,7 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_LibraryLoader",
     "Win32_System_JobObjects",
     "Win32_System_Threading",
+    "Win32_System_Diagnostics_Debug",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_Foundation",
     # CreateJobObjectW takes SECURITY_ATTRIBUTES* — guarded by this

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -35,8 +35,30 @@ mod srv_spawner;
 mod state;
 mod wrr;
 
+/// Suppress the Windows "Application Error" / WER crash dialog so an unhandled
+/// fault terminates the process immediately instead of wedging it behind a
+/// modal. No-op off Windows. Spec:
+/// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
+#[cfg(target_os = "windows")]
+fn suppress_os_crash_dialogs() {
+    use windows_sys::Win32::System::Diagnostics::Debug::{
+        SetErrorMode, SEM_FAILCRITICALERRORS, SEM_NOGPFAULTERRORBOX,
+    };
+    unsafe {
+        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn suppress_os_crash_dialogs() {}
+
 #[tokio::main]
 async fn main() {
+    // Phase 0 (service supervision & recovery): suppress the Windows crash
+    // modal so a fault terminates immediately instead of freezing behind an
+    // "Application Error" dialog. First statement — before anything can fault.
+    suppress_os_crash_dialogs();
+
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");
     let exe_dir = exe_path.parent().expect("exe has no parent directory");
     let runtime_dir = exe_dir.join("runtime");

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -41,11 +41,18 @@ mod wrr;
 /// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
 #[cfg(target_os = "windows")]
 fn suppress_os_crash_dialogs() {
-    use windows_sys::Win32::System::Diagnostics::Debug::{
-        SetErrorMode, SEM_FAILCRITICALERRORS, SEM_NOGPFAULTERRORBOX,
-    };
+    use windows_sys::Win32::System::Diagnostics::Debug::{SetErrorMode, SEM_FAILCRITICALERRORS};
+    use windows_sys::Win32::System::ErrorReporting::{WerSetFlags, WER_FAULT_REPORTING_NO_UI};
     unsafe {
-        SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX);
+        // Suppress the WER crash-dialog UI WITHOUT disabling WER itself —
+        // SEM_NOGPFAULTERRORBOX would also kill WER/LocalDumps crash-dump
+        // collection, the postmortem diagnostics this stability work needs.
+        // WER_FAULT_REPORTING_NO_UI is the documented "no UI, keep
+        // reports" path.
+        let _ = WerSetFlags(WER_FAULT_REPORTING_NO_UI);
+        // SEM_FAILCRITICALERRORS suppresses the critical-error handler
+        // (e.g. "no disk in drive" popups) — unrelated to crash reporting.
+        SetErrorMode(SEM_FAILCRITICALERRORS);
     }
 }
 

--- a/agentmux-launcher/src/main.rs
+++ b/agentmux-launcher/src/main.rs
@@ -52,13 +52,20 @@ fn suppress_os_crash_dialogs() {
 #[cfg(not(target_os = "windows"))]
 fn suppress_os_crash_dialogs() {}
 
-#[tokio::main]
-async fn main() {
-    // Phase 0 (service supervision & recovery): suppress the Windows crash
-    // modal so a fault terminates immediately instead of freezing behind an
-    // "Application Error" dialog. First statement — before anything can fault.
+/// Process entry point. `suppress_os_crash_dialogs()` runs FIRST — before the
+/// Tokio runtime is built. The runtime is built explicitly here (rather than
+/// via `#[tokio::main]`, whose generated wrapper would construct it before any
+/// of our code runs) so a fault during runtime construction can't surface the
+/// Windows crash modal either. Spec:
+/// docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md.
+fn main() {
     suppress_os_crash_dialogs();
+    tokio::runtime::Runtime::new()
+        .expect("failed to build Tokio runtime")
+        .block_on(launcher_main());
+}
 
+async fn launcher_main() {
     let exe_path = std::env::current_exe().expect("cannot resolve exe path");
     let exe_dir = exe_path.parent().expect("exe has no parent directory");
     let runtime_dir = exe_dir.join("runtime");

--- a/docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md
+++ b/docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md
@@ -1,0 +1,268 @@
+# Crash Analysis — Host `0x80000003` / Chromium GPU-process FATAL
+
+**Date:** 2026-05-20
+**Build:** `agentmux-0.34.0.exe` (host, PID 7276, ~29 h uptime)
+**Symptom:** Windows "Application Error" modal — *"The exception Breakpoint
+(0x80000003) occurred… Click OK to terminate, CANCEL to debug."* Title bar:
+`DO NOT BOOTY - tab1 - AgentMux`. Screenshot: `crash.png` on the Desktop.
+
+---
+
+## 1. Summary
+
+The host did **not** crash from a bug in AgentMux's own code. It was killed by
+**Chromium's `LOG(FATAL)`** after the bundled GPU process crashed six times in
+one host session and Chromium gave up on it.
+
+`LOG(FATAL)` in Chromium ends with `base::debug::BreakDebugger()` → an `int 3`
+instruction → `STATUS_BREAKPOINT` (`0x80000003`). That is the exact exception
+code in the modal. It is a *deliberate, controlled* abort — not memory
+corruption (`0xC0000005`) and not a Rust `panic!`.
+
+The terminal log line:
+
+```
+[7276:8176:0520/095204.716:FATAL:content\browser\gpu\gpu_data_manager_impl_private.cc:417]
+GPU process isn't usable. Goodbye.
+```
+
+The deeper trigger was **system memory exhaustion** — the Windows page file
+was nearly full, so the GPU process could not restart.
+
+> **Stability mandate.** Rock-solid stability is a core part of AgentMux's
+> value proposition: **the user must never see a crash.** "No crashes ever" is
+> not literally achievable at the process level — GPU drivers segfault, the OS
+> runs out of commit, hardware misbehaves, and none of that is AgentMux's code.
+> What *is* achievable, and is the design target, is that **every fault becomes
+> an invisible, sub-second auto-recovery** — no OS modal, no lost work, at most
+> a flicker. AgentMux is unusually well-positioned for this: it already has a
+> separate supervising `agentmux-launcher` process and already persists all
+> state. The recovery layer in §4.3 is therefore **required**, not optional —
+> this crash is the proof case of the gap.
+
+---
+
+## 2. Timeline & evidence
+
+Sources: `~/.agentmux/versions/0.34.0/logs/cef-debug.log` and
+`agentmux-host-v0.34.0.log.2026-05-20`.
+
+| Local time | Event |
+|---|---|
+| 05‑19 04:31:22 | GPU process crashed **3×** in ~300 ms — `exit_code=-2147483645`. Chromium reinitialized it each time (104–117 ms). App recovered, ran normally. Crash count = 3. |
+| 05‑19 → 05‑20 | ~29 h of normal operation. |
+| 05‑20 09:52:04.705–.716 | GPU process crashed **3× in 11 ms** — `exit_code=-1073741523`, 0 ms init each. Crash count → 4, 5, 6. |
+| 05‑20 09:52:04.716 | `FATAL: GPU process isn't usable. Goodbye.` → host process breakpoints. |
+| 05‑20 09:52:04–09:52:11 | Renderer still emitting `[fe]` console logs for ~7 s, then silent. |
+| 05‑20 09:52:11 → 09:53:04+ | Host's Rust `mem_heartbeat` thread keeps ticking behind the modal (host main process only froze the faulting thread). User dismisses modal; process exits. |
+
+The host itself was healthy throughout — `ws_mb` ≈ 98 MB, `peak_ws_mb` 130 MB.
+Nothing in AgentMux's Rust code or the frontend faulted.
+
+### Exit-code decode
+
+Chromium reports process exit codes as signed 32-bit. Unsigned = `2^32 + code`:
+
+| Reported | Unsigned hex | NTSTATUS | Meaning |
+|---|---|---|---|
+| `-2147483645` | `0x80000003` | `STATUS_BREAKPOINT` | A DCHECK/breakpoint *inside* the GPU process (05‑19). |
+| `-1073741523` | `0xC000012D` | `STATUS_COMMITMENT_LIMIT` | **Out of virtual memory** — the GPU process could not commit memory (05‑20). |
+
+This is the key finding. The 05‑20 GPU crashes were **not** a driver segfault —
+the GPU process exited with `STATUS_COMMITMENT_LIMIT` because the machine was
+out of committable memory.
+
+### Corroborating memory pressure
+
+The host's `mem_heartbeat` around the crash:
+
+```
+16:52:44Z  system memory  load_pct=54  avail_phys_gb=14.6  avail_page_gb=0.1
+```
+
+`avail_page_gb 0.1` — the Windows **page file had ~100 MB free**. When commit is
+that scarce, a fresh GPU process cannot reserve its address space and dies
+before it finishes initializing (hence 0 ms init, then immediate exit).
+
+---
+
+## 3. Root cause
+
+Two layers, in order of importance:
+
+1. **Primary — system memory/commit exhaustion.** The page file was ~full.
+   Each GPU-process restart on 05‑20 failed with `STATUS_COMMITMENT_LIMIT`
+   before it could initialize. Three instant failures pushed the cumulative
+   crash count past Chromium's limit.
+2. **Secondary — a flaky GPU session.** The GPU process had already crashed 3×
+   the day before (breakpoint/DCHECK). Chromium's crash counter is
+   **cumulative for the whole host session**, so the session entered 05‑20
+   "pre-loaded" at count 3 — only three more failures away from FATAL.
+
+**Chromium policy** is what converts these into a hard kill: `GpuProcessHost`
+restarts the GPU process after a crash, but only up to a cap. Once the cap is
+exhausted *and* a usable GPU (hardware or software) cannot be brought up,
+`gpu_data_manager_impl_private.cc` does `LOG(FATAL)` — it takes the whole
+browser process down rather than run in an undefined state.
+
+This is **environmental** (memory + driver), not an AgentMux logic defect. But
+AgentMux has no supervision or fallback around it, so a recoverable subsystem
+failure became a full app crash with a frightening OS modal.
+
+---
+
+## 4. Could it have recovered? (and: can a crashed GPU process be restarted/re-mounted?)
+
+**Short answer: a crashed GPU process *can* be restarted and re-attached — and
+Chromium already does exactly that automatically. It did so successfully 3×
+the day before this crash. What was missing was (a) enough memory for the
+restart to succeed on 05‑20, and (b) AgentMux-level supervision so the
+final FATAL didn't have to be terminal.**
+
+### 4.1 Restart + "mount" is built in — and normally works
+
+The GPU process is a *separate* process from the browser process and from each
+renderer. When it dies, the renderer processes do **not** die — they keep their
+DOM/JS state. Chromium's `GpuProcessHost`:
+
+1. Spawns a fresh GPU process.
+2. Re-creates the GPU channels and hands them back to the Viz display
+   compositor and to every renderer's compositor.
+3. The next compositor frame is produced by the new GPU process.
+
+That re-attachment **is** the "mount" — and it is transparent. The user sees at
+most a brief flash. The cef-debug.log proves it worked here:
+
+```
+0519/043122.624 Reinitialized the GPU process after a crash … 117 ms
+0519/043122.755 Reinitialized the GPU process after a crash … 104 ms
+0519/043122.865 Reinitialized the GPU process after a crash … 0 ms
+```
+
+So "can it be restarted and mounted?" — **yes, by design, and it was.** The
+app survived all three 05‑19 crashes for that reason.
+
+### 4.2 Why the 05‑20 restarts did not mount
+
+A restart can only re-mount if the new process actually *starts*. On 05‑20 each
+restart exited with `STATUS_COMMITMENT_LIMIT` in **0 ms** — it died before it
+could create a GL/D3D context or open a single channel. You cannot mount a
+process that never finished initializing. The failure was *upstream* of
+mounting: the OS could not give the process memory.
+
+So under that memory state, **no number of restarts would have recovered** —
+the fix there is freeing commit, not retrying.
+
+### 4.3 What "the right stuff inside" would have done
+
+Recovery is possible at four distinct layers. AgentMux currently has none of
+them; it is unusually well-positioned to add all four.
+
+**(a) Don't let Chromium FATAL — raise/remove the crash cap.**
+Chromium has a switch `--disable-gpu-process-crash-limit`. With it, Chromium
+keeps restarting the GPU process indefinitely instead of `LOG(FATAL)`. The app
+would have stayed up (GPU flickering until memory freed) rather than dying.
+Cheap, one-line mitigation — but it only converts "crash" into "spin", so it
+must be paired with (b)/(c).
+
+**(b) Software-rendering fallback.**
+Launch (or *re-launch*) the host with `--disable-gpu` /
+`--disable-gpu-compositing`. With GPU disabled there is **no separate GPU
+process to crash** — compositing runs in-process via SwiftShader. Slower, but
+immune to driver breakage and to GPU-process OOM. The ideal design: run with
+GPU on, and if the GPU process crashes N times, relaunch the host once with
+`--disable-gpu` and stay there for the rest of the session.
+
+**(c) Launcher-level supervision + state restore — the real recovery.**
+This is the architecturally correct answer and AgentMux already has the two
+hard prerequisites:
+
+  - `agentmux-launcher` is a **separate supervising process** that owns the
+    host's lifecycle (Job Object, pipe, single-instance). It survives a host
+    crash.
+  - AgentMux **persists all app state** (the reducer stack → `objects.db` etc.).
+
+So the launcher could: detect the host exited with `0x80000003`, recognize a
+GPU FATAL (tail `cef-debug.log` for the `gpu_data_manager` line, or just treat
+a breakpoint exit as relaunch-worthy), and **relaunch the host — with
+`--disable-gpu` on the retry**. The relaunched host reloads the same workspace,
+tabs, and panes from `objects.db`. The user sees a flicker-and-restore instead
+of a crash modal. *That* is recovery: not catching the FATAL (you cannot — it
+is a synchronous `int 3`), but supervising, restarting, and restoring.
+
+**(d) Suppress the OS modal.**
+Independently: the legacy "Application Error / breakpoint" dialog should never
+reach the user. Chromium's Crashpad handler normally suppresses the OS dialog,
+but it did not cover this FATAL path in the browser process. Setting
+`SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS)` in the host (and
+in the launcher for its children), or registering AgentMux with
+`WerAddExcludedApplication`, makes a crash exit silently — so the launcher in
+(c) can restart it without the user ever seeing the dialog.
+
+### 4.4 Recommended end-state
+
+```
+host runs with GPU on
+  │
+  ├─ GPU process crash → Chromium auto-restarts + re-mounts (transparent)   ← already works
+  │
+  ├─ N crashes in a session → launcher relaunches host with --disable-gpu   ← (b)+(c)
+  │     and restores workspace from objects.db
+  │
+  └─ host exits 0x80000003 → no OS modal (SEM_NOGPFAULTERRORBOX),            ← (d)+(c)
+        launcher restarts + restores
+```
+
+The single most valuable piece is **(c)** — launcher supervision with
+state restore — because it turns *any* host crash, not just GPU FATALs, into a
+recoverable blip.
+
+---
+
+## 5. Recommendations
+
+### Immediate (environment — to get running and stop recurrence)
+- **Relaunch AgentMux.** A fresh host resets the GPU crash counter to 0. No
+  data was lost or corrupted.
+- **Free system memory / grow the page file.** `avail_page_gb 0.1` is the real
+  trigger. Close memory-heavy apps, or increase the Windows paging-file size.
+- Update the GPU driver. Clearing `cef-cache` GPU caches is cheap but unlikely
+  to matter here (they are only ~548 KB).
+
+### AgentMux-side (required — stability mandate, see §1 and §4.3)
+Ordered so the user-visible win lands first:
+- **(d)** `SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS)` in host
+  + launcher so a crash never shows the OS modal. Smallest change, immediately
+  removes the scariest symptom. Ship first.
+- **(c)** Launcher: detect host breakpoint/abnormal exit → relaunch + restore
+  from `objects.db`. Highest value; generalizes beyond GPU to *every* host
+  crash. This is the core of the "no visible crashes" guarantee.
+- **(b)** Relaunch with `--disable-gpu` after repeated GPU-process crashes so
+  the retry can't hit the same failure.
+- **(a)** Pass `--disable-gpu-process-crash-limit` so Chromium keeps
+  auto-restarting the GPU process instead of `LOG(FATAL)`-ing.
+- Low-commit-memory guard in the launcher's `mem_heartbeat` path — warn (or
+  shed) before the GPU process gets starved.
+
+Tracking: these should become a stability epic, not a one-off fix — the goal
+is that no fault, AgentMux's or the environment's, is ever visible to the user.
+
+---
+
+## 6. Diagnosis recipe (for next time)
+
+The breakpoint modal **blocks WER**, so there is usually **no dump** in
+`%LOCALAPPDATA%\CrashDumps`. Diagnose from logs instead — they outlive the
+crash:
+
+```bash
+V=0.34.0
+CEF=~/.agentmux/versions/$V/logs/cef-debug.log
+grep -nE 'FATAL|GPU process.*(crashed|exited)' "$CEF"      # the FATAL + crash escalation
+grep mem_heartbeat ~/.agentmux/versions/$V/logs/agentmux-host-v$V.log.* \
+  | grep avail_page_gb                                     # was the page file exhausted?
+```
+
+Decode any `exit_code`: unsigned = `2^32 + code`, then look up the NTSTATUS
+(`0x80000003` breakpoint, `0xC000012D` out-of-memory, `0xC0000005` access
+violation, `0xC0000409` stack-buffer-overrun/fast-fail).

--- a/docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md
+++ b/docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md
@@ -38,8 +38,10 @@ architecture. This spec names it, unifies it, and closes the gaps.
 ## 2. Goals / Non-goals
 
 ### Goals
-- A single, uniform **supervision framework** spanning every long-lived service
-  (launcher, host, srv, Chromium children, sidecar workers).
+- **Uniform recovery *discipline*** across every long-lived service (launcher,
+  host, srv, Chromium children, sidecar workers) — implemented as per-service
+  managers that share primitives and obey one prime directive (§3, §4), **not**
+  a single unified framework.
 - Any service crash → **detect → restart → rehydrate → reconcile**, fast enough
   that the user sees at most a flicker.
 - **Bounded** recovery — a crash budget and a graceful terminal state; never an
@@ -76,28 +78,59 @@ Everything below is an elaboration of this directive.
 
 ---
 
-## 4. Core abstraction — the Supervised Service
+## 4. Core approach — per-service managers + shared primitives
 
-Every long-lived service implements a uniform contract. Defined once in
-`agentmux-common`; integrated thinly per layer.
+**Decision: per-service managers, not a unified framework.** Each service gets
+its *own* manager with its own crash/restart/rehydrate logic. Managers share
+low-level *primitives*; they do not implement one uniform behavioral contract.
 
-```
-SupervisedService
-  identity        stable id + generation number (fencing, see §10-D)
-  spawn()         start the process/subsystem
-  health          liveness  (is the process alive?)
-                + responsiveness (does it answer a ping within budget?)
-  rehydrate()     replay authoritative reducer state into the fresh instance
-  restartPolicy   crash budget + backoff + degraded-mode variants
-  onCrash/onUp    events other layers project to reconcile
-```
+### Why — the VS Code precedent
 
-A **Supervisor** owns one or more services: it watches health, applies the
-restart policy on death, drives `rehydrate()`, and emits lifecycle events.
+VS Code is a mature, far larger multi-process app facing the same problem, and
+it deliberately did **not** build a unified supervisor framework:
 
-A restarted service is **not a special case** — it is simply a new subscriber
-that needs the current state snapshot. This is the central simplification: the
-framework reuses normal state-projection, it does not invent a recovery path.
+- **`UtilityProcess`** (`src/vs/platform/utilityProcess/electron-main/`) — a
+  shared process *primitive*: spawn, MessagePort wiring, `onCrash` / `onExit`
+  events. It *reports* crashes; it does not restart or rehydrate.
+- **Extension host** — its own manager (`ExtensionHostManager` /
+  `AbstractExtensionService`) with a crash counter: after ~3 crashes in a short
+  window it stops auto-restarting and shows "Extension host terminated
+  unexpectedly — Restart?" (= our crash budget + terminal state, §7 / §10-A).
+- **Pty host** — `PtyHostService`: its own restart logic, terminal
+  *reconnection* across a window reload (= our Tier-1 pattern, §6), and
+  unresponsive-detection by ping (= our liveness + responsiveness, §8).
+- **Shared process** — supervised ad-hoc by the Electron main process.
+
+No `SupervisedService` trait, no uniform contract — each manager is bespoke,
+because the services' recovery semantics genuinely differ. They differ here
+too: a host crash is Tier 1 (re-attach to a live srv), an srv crash is Tier 2
+(resume), the GPU has its own escalation. Forcing them through one contract
+would be abstraction for its own sake — the over-reach the original draft of
+this spec leaned toward.
+
+### The model
+
+- **Per-service managers.** `HostManager`, `SrvManager`, … — each owns one
+  service's crash detection, retry ladder (§7), rehydration (§5), and lifecycle
+  events. Bespoke, shaped to that service's tier and failure modes. Every
+  manager still answers the same questions, just in its own way: *identity*
+  (stable id + generation number for fencing, §10-D), *spawn*, *health*
+  (liveness + responsiveness, §8), *rehydrate*, *retry ladder*, and
+  *onCrash / onUp* events.
+- **Shared primitives** in `agentmux-common`, used by the managers — extracted
+  **only when ≥2 managers actually need them**, never speculatively:
+  - a process-handle wrapper (spawn + OS exit/crash event — the `UtilityProcess`
+    analog);
+  - the crash-budget + backoff helper;
+  - the transient/deterministic classifier (§7);
+  - the recovery-metric counter (§12).
+- **No uniform behavioral contract.** Managers are not forced into one shape.
+  Generalization is bottom-up — extract a primitive when it demonstrably
+  repeats — never top-down.
+
+A restarted service is still **not a special case**: the manager re-attaches it
+as a new subscriber that needs the current snapshot (§5). That simplification
+holds either way.
 
 ---
 
@@ -403,10 +436,12 @@ service first.
   when a full relaunch reproduces a GPU-class crash. Crash budget +
   classification + recovery metric. Full
   fault-injection tests. **This is the proof of the whole pattern.**
-- **Phase 2 — srv supervision.** Same contract; host tolerates srv reconnect.
-- **Phase 3 — Generalize.** Extract the `SupervisedService` contract into
-  `agentmux-common`; fold the saga coordinator and Chromium-child handling into
-  the uniform model.
+- **Phase 2 — srv supervision.** A bespoke `SrvManager` (Tier 2, §6); host
+  tolerates srv reconnect.
+- **Phase 3 — Extract shared primitives.** Pull the primitives that ≥2 managers
+  actually use (process-handle wrapper, crash-budget helper, classifier,
+  recovery metric) into `agentmux-common` — bottom-up, never a uniform contract
+  (§4). Fold the saga coordinator and Chromium-child handling in where it pays.
 - **Phase 4 — Root hardening.** Decide (on evidence) whether the launcher needs
   an OS-level respawn.
 

--- a/docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md
+++ b/docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md
@@ -1,0 +1,443 @@
+# SPEC — Service Supervision & Recovery
+
+**Status:** Draft / for design review
+**Date:** 2026-05-20
+**Author:** AgentA
+**Tracking:** to get a long-lived GitHub Discussion thread (sibling of #707 for
+the reducer stack)
+**Case study:** `docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md`
+
+---
+
+## 1. Motivation — the stability mandate
+
+Rock-solid stability is a core part of AgentMux's value proposition. The
+standing product goal is **"no crashes ever."** Stated precisely, because the
+precision is what makes it shippable:
+
+> **"No crashes ever" = the user must never *see* a crash.**
+
+Zero *process faults* is not achievable — GPU drivers segfault, the OS runs out
+of commit, hardware misbehaves, and none of that is AgentMux's code. Zero
+*visible* crashes **is** achievable: every fault becomes an invisible,
+sub-second auto-recovery — no OS modal, no lost work, at most a flicker.
+
+The 2026-05-20 host crash is case study #1. The Chromium GPU process failed
+(environment: a flaky driver + an exhausted page file), Chromium `LOG(FATAL)`-ed
+the whole host, and the user got a raw Windows `0x80000003` "breakpoint" modal.
+A GPU subsystem failure — *not even AgentMux's own code* — took the entire app
+down visibly. That is the exact class of event this framework must absorb.
+
+AgentMux is unusually well-positioned to deliver the achievable guarantee: it
+already has a separate supervising process (`agentmux-launcher`) and already
+persists all application state. The recovery machinery is ~70% latent in the
+architecture. This spec names it, unifies it, and closes the gaps.
+
+---
+
+## 2. Goals / Non-goals
+
+### Goals
+- A single, uniform **supervision framework** spanning every long-lived service
+  (launcher, host, srv, Chromium children, sidecar workers).
+- Any service crash → **detect → restart → rehydrate → reconcile**, fast enough
+  that the user sees at most a flicker.
+- **Bounded** recovery — a crash budget and a graceful terminal state; never an
+  infinite restart loop.
+- **Near-zero steady-state cost** — see §9.
+- Recovery paths **continuously fault-injection-tested** in CI (§14).
+- Auto-recovery is **loud internally** — counted, surfaced, alarmed on (§12).
+
+### Non-goals
+- Catching a Chromium `LOG(FATAL)` or a Rust `panic = abort` *inside* the
+  faulting process. These are synchronous and terminal by design. Recovery is
+  always cross-process: a *supervisor* observes the death and acts.
+- Eliminating process faults. We absorb them, we do not prevent the
+  environment from causing them.
+- A parallel snapshot/checkpoint system. Recovery rehydrates from the
+  persistence that **already exists** (§6, §9).
+- Replacing the reducer stack, the saga coordinator, or WRR. The framework
+  *composes* with them (§13).
+
+---
+
+## 3. Prime directive
+
+Two design concerns — performance overhead, and recovery systems that "shoot
+themselves in the foot" — converge on one rule. It is the framework's prime
+directive; a design that violates it is rejected at review:
+
+> **The supervisor is passive, bounded, and simpler than everything it
+> supervises.** It observes signals that *already exist*, free-rides on
+> persistence that *already happens*, acts only on real crashes, is bounded by
+> a crash budget, and is loud about every action it takes.
+
+Everything below is an elaboration of this directive.
+
+---
+
+## 4. Core abstraction — the Supervised Service
+
+Every long-lived service implements a uniform contract. Defined once in
+`agentmux-common`; integrated thinly per layer.
+
+```
+SupervisedService
+  identity        stable id + generation number (fencing, see §10-D)
+  spawn()         start the process/subsystem
+  health          liveness  (is the process alive?)
+                + responsiveness (does it answer a ping within budget?)
+  rehydrate()     replay authoritative reducer state into the fresh instance
+  restartPolicy   crash budget + backoff + degraded-mode variants
+  onCrash/onUp    events other layers project to reconcile
+```
+
+A **Supervisor** owns one or more services: it watches health, applies the
+restart policy on death, drives `rehydrate()`, and emits lifecycle events.
+
+A restarted service is **not a special case** — it is simply a new subscriber
+that needs the current state snapshot. This is the central simplification: the
+framework reuses normal state-projection, it does not invent a recovery path.
+
+---
+
+## 5. Recovery = Restart + Rehydrate
+
+Recovery has exactly two halves, owned by two different layers:
+
+| Half | Owner | Source of truth |
+|---|---|---|
+| **Restart** — get a fresh process running | Supervisor (this spec) | — |
+| **Rehydrate** — bring it to correct state | Reducer stack + persistence | `objects.db`, `sagas.db`, `launcher-events.log` |
+
+This is the precise relationship to the reducer stack. The supervision
+framework is the **dual** of the reducer/persistence layer, not part of it:
+
+- Reducer stack — *what* the correct state is.
+- Persistence — *where* that state is durable.
+- **Supervision (new)** — *keeps every service alive and reconciled to it.*
+
+The framework **consumes** the reducer as its source of truth. It never owns
+state and never adds a write path (§9).
+
+---
+
+## 6. Layer & ownership map
+
+| Service | Supervised by | Rehydrates from | Restart today |
+|---|---|---|---|
+| `agentmux-srv` (Layer 3) | launcher | `objects.db`, `filestore.db` | launcher spawns it; no auto-restart |
+| `agentmux-cef` host (Layer 2) | launcher | `objects.db` (workspaces/tabs/panes/layout) | launcher spawns it; no auto-restart |
+| GPU process | host → Chromium | re-attach GPU channels | **Chromium auto-restarts + re-mounts** (works; capped) |
+| Renderer processes | host → Chromium | reload + frontend slices rehydrate | Chromium auto-reloads |
+| Sidecar workers / sagas | saga coordinator | `sagas.db` | **already crash-resumes** |
+| `agentmux-launcher` (Layer 1) | **root — see below** | `launcher-events.log` | single-instance re-attach only |
+
+### The root-supervisor problem
+
+You cannot recurse supervisors forever — something is the root. The launcher is
+that root. The resolution is **not** another watchdog process by default; it is:
+
+1. The launcher is kept **deliberately small, boring, and bulletproof** — the
+   least code, the most tests, the fewest dependencies of any component.
+2. The single-instance named pipe means a fresh launch **re-attaches** to
+   surviving children rather than colliding.
+3. **Optional** escalation if data shows the launcher itself ever crashes: a
+   minimal OS-level respawn (Scheduled Task / Service) or a tiny watchdog whose
+   only job is "is the launcher pid alive." This is an open decision (§15) —
+   not built until evidence justifies it.
+
+### Two recovery tiers — host crash vs srv crash
+
+The process topology means recovery cost is **not uniform**. There are two
+tiers, and which one a crash lands in is decided entirely by *which process
+died* — verified against the code:
+
+**Tier 1 — host crash (cheap).** `agentmux-srv` is a **sibling** of the host,
+both spawned by the launcher (`agentmux-launcher/src/main.rs`: "launcher now
+spawns srv directly (sibling of host)"). The agent CLI process and its PTY are
+children of **srv**, not the host — `PersistentSubprocessController`
+(`agentmux-srv/.../blockcontroller/persistent.rs`) keeps a single CLI process
+alive for the whole session. So a host crash kills **only the UI**. srv, the
+agent process, and the PTY are untouched; srv keeps streaming the agent's
+stdout into the block's `.jsonl` and WPS `output` subject the whole time the
+host is down. Recovery = the supervisor relaunches the host, which re-attaches
+to the *still-running* srv, reloads the block tree + layout from `objects.db`,
+and re-subscribes to each block's WPS `output` subject (`.jsonl` replayed).
+**No special content logic** — content survival is a free consequence of the
+topology. The live agent session never stopped.
+
+**Tier 2 — srv crash / OS reboot / full kill (harder).** Here the agent
+subprocess dies *with* srv (it is srv's child). The session **history** is
+still durable in FileStore (`.jsonl`) — content is not lost — but the live
+process is gone. `agentmux-srv/.../blockcontroller/session_recovery.rs` already
+scaffolds graceful resume: a `session:active_pid` meta flag, flipped to
+`session:was_interrupted` on the next boot, surfaces a banner, and the
+persistent controller supports `--resume <session_id>` to pick the conversation
+up mid-flight. So content persists, but the live process needs a (one-click)
+**resume**, not silent continuation.
+
+Implication for phasing: **host supervision (Phase 1) is the Tier-1 cheap case
+and ships first** — content persistence is free, the supervisor only relaunches
+and re-attaches. **srv supervision (Phase 2) is the Tier-2 case** and builds on
+the existing `session_recovery.rs` resume path. The 2026-05-20 crash was a
+Tier-1 host crash: srv and the agent process were alive behind the modal the
+whole time; only an automatic host relaunch was missing.
+
+---
+
+## 7. Crash classification — transient vs deterministic
+
+The single most dangerous mistake a recovery system makes is restarting into
+the same crash forever. Before *every* restart, the supervisor classifies:
+
+- **Transient** — a driver hiccup, an OOM spike, a one-off. Signature differs
+  from recent crashes, or the environment changed. → restart normally.
+- **Deterministic** — same crash signature N times in a row (same exit code +
+  same fault location/log signature). Restarting reproduces it. → **do not
+  restart with the same inputs** — step down the retry ladder.
+
+### Retry ladder
+
+The first retry is always **optimistic — full config, nothing degraded**. Most
+crashes are transient (a driver hiccup, an OOM spike) and a full restart just
+works; the supervisor must not permanently degrade the user for a one-off. The
+supervisor steps down a rung **only when a restart reproduces the crash**:
+
+| Rung | When | What |
+|---|---|---|
+| 1 | first crash (assumed transient) | restart **full config**, current state |
+| 2 | rung 1 reproduced the crash | restart **degraded** (e.g. host `--disable-gpu`) |
+| 3 | rung 2 reproduced it | restart from **last-known-good** state, not crash-time state |
+| 4 | rung 3 reproduced it | **safe mode** — minimal state, recovery UI shown |
+| 5 | budget exhausted | **terminal** — stop, honest recovery dialog, offer report/reset |
+
+Each rung asks *less* of the environment than the one above, so a degraded or
+safe-mode retry has a genuinely better chance than the original — it is not
+"the same thing again." A crash signature =
+`{ exit_code, faulting module/log line, service id }`.
+
+---
+
+## 8. Health signals
+
+"Process exited" is not enough. The 2026-05-20 crash is the proof: the host
+process stayed alive and heart-beating while the renderer was frozen.
+
+Health = **two** independent signals:
+
+- **Liveness** — is the OS process alive? Source: Job Object / process-exit
+  handle. Event-driven, zero cost.
+- **Responsiveness** — does the service answer a ping within a budget? Source:
+  reuse the existing `mem_heartbeat` / launcher-pipe channel; add a cheap
+  request/response.
+
+Rules to avoid false-positive kills (§10-C): generous timeouts, **multiple**
+consecutive missed pings before action, and never confuse *slow* (GC pause,
+legit long op) with *dead*.
+
+---
+
+## 9. Performance budget — first-class
+
+A design that cannot meet this budget is rejected.
+
+**Steady-state target: ≈ 0 measurable overhead.** Achieved because every
+mechanism is passive:
+
+| Mechanism | Cost | Why |
+|---|---|---|
+| Crash detection | ~0 | OS process-exit / Job Object event. No polling. |
+| Liveness | ~0 | Same OS event. |
+| Responsiveness ping | negligible | Few bytes on the launcher pipe every 1–5 s; piggybacks the existing 20 s `mem_heartbeat`. |
+| Rehydration source | **0 added writes** | Reads `objects.db`, which the reducer *already writes* for durability. |
+| Crash/restart events | ~0 | Emitted only on a real crash. Crashes are rare. |
+| Supervisor process | 0 | The launcher already exists and already supervises. |
+
+Real work happens **only during an actual crash** — precisely when a few ms is
+irrelevant.
+
+### Forbidden (the performance traps)
+- ❌ A parallel snapshot/checkpoint system for recovery. Rehydrate from
+  existing persistence or not at all.
+- ❌ Synchronous health checks on any request/hot path.
+- ❌ High-frequency polling. Prefer OS events; cap pings at 1–5 s.
+- ❌ Recovery logging routed through a pipe/log that is itself being recovered
+  (the "don't measure the meter" feedback loop).
+
+If the design ever needs a new write path *for recovery*, it has taken a wrong
+turn — recovery free-rides on persistence, it does not add to it.
+
+---
+
+## 10. Failure modes & defenses — first-class
+
+Recovery systems are notorious for becoming the most fragile part of the
+system. Each known foot-gun and its mandated defense:
+
+**A. Crashloop** — restart → re-crash → restart, forever.
+→ Crash budget (N restarts per rolling window) + exponential backoff + a
+**terminal state**. Never an infinite loop. (This is the project's loop-limit
+discipline applied to processes.)
+
+**B. Recovering into the poison** — rehydrate faithfully restores the state
+that caused the crash.
+→ §7 classification. Deterministic crashes restart from last-known-good /
+safe mode, never blindly from crash-time state.
+
+**C. False-positive kills** — a slow-but-healthy service flagged "hung" and
+killed mid-work.
+→ Conservative health (§8): generous timeouts, multiple missed pings, never
+kill on one signal.
+
+**D. Split-brain** — supervisor restarts a service that was actually alive ⇒
+two writers to `objects.db`.
+→ Single-writer discipline (the reducer stack already enforces this per layer)
++ Job Object + **generation/fencing tokens**: a stale instance's writes are
+rejected by the persist layer.
+
+**E. Cascading restarts** — srv dies → host can't reach srv → host deemed
+unhealthy → host restarted → …
+→ Services **tolerate a dependency being briefly absent** (reconnect, do not
+die). Ordered, isolated restart: restart srv, let host *reconnect*.
+
+**F. Masking real bugs** — silent auto-recovery hides a bug crashing 50×/day.
+→ §12. Loud internally. Recovery *rate* is a P1 health metric, never a success
+metric.
+
+**G. Supervisor is now the most fragile thing** — complex, rarely exercised,
+touches everything.
+→ Prime directive (§3): the supervisor is the simplest, most-tested code in
+the system. Recovery paths are fault-injection-tested in CI (§14) or they rot.
+
+**H. Instrumentation feedback loop** — see §9 forbidden list.
+
+---
+
+## 11. Recovery flow (end to end)
+
+```
+service runs
+  │
+  ├─ liveness/responsiveness OK ──────────────────────────► (no-op, ~0 cost)
+  │
+  ├─ crash / hang detected
+  │     │
+  │     ├─ classify (§7)
+  │     │     ├─ transient + within budget ─► restart ─► rehydrate ─► emit onUp
+  │     │     ├─ deterministic ─────────────► degraded-mode restart
+  │     │     └─ budget exhausted ──────────► safe mode ─► recovery UI
+  │     │
+  │     └─ every branch: count it, log it, surface it (§12)
+  │
+  └─ host-specific: GPU process crash ─► Chromium auto-restarts (works today);
+        after N ─► launcher relaunches host — full config first,
+        --disable-gpu only if the full relaunch also fails (§7 retry ladder)
+```
+
+For the host crash, the user-visible end state is **flicker-and-restore**: the
+launcher detects the host's abnormal exit, suppresses the OS modal
+(`SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS)` in host +
+launcher), relaunches the host (full config first; `--disable-gpu` only if the
+full relaunch reproduces the crash — §7 retry ladder), and the host reloads the
+exact workspace/tabs/panes from `objects.db`.
+
+---
+
+## 12. Observability — loud internally
+
+"Invisible to the user" must never mean "invisible to us."
+
+- Every detection, classification, restart, and escalation is logged with the
+  crash signature.
+- A per-service **recovery counter** and **recovery rate** metric.
+- The diagnostics panel surfaces recent recoveries (sibling of the reducer
+  dispatch ring).
+- A recovery rate above threshold is a **P1 alarm** — an auto-recovered crash
+  is still a bug to fix, not a success.
+
+---
+
+## 13. Relationship to existing systems
+
+The framework **composes with**, does not replace:
+
+- **Reducer stack** — supplies the authoritative state `rehydrate()` replays.
+  The framework is its dual (§5).
+- **Saga coordinator** — already does crash-resume from `sagas.db`. The
+  framework **generalizes** that pattern from "resume sagas" to "resume whole
+  services." The coordinator becomes one supervised service among many.
+- **WRR (Window Reality Reconciliation)** — already a reconciliation loop
+  (model vs Win32 reality). Recovery reconciliation is its sibling; share the
+  reconciliation primitives where possible.
+- **Job Object / single-instance pipe** — already provide child-process
+  containment and re-attach; the framework builds the restart policy on top.
+
+---
+
+## 14. Testing strategy — fault injection
+
+Recovery code that is not continuously exercised rots, and untested recovery is
+worse than none (§10-G). Therefore:
+
+- A **fault-injection harness** that kills real processes (host, srv, GPU) and
+  asserts: recovery completes, state is intact, the crash was counted, the user
+  surface shows at most a flicker.
+- These run in CI as a first-class suite, not a manual afterthought.
+- Property-style: kill at random points (mid-write, mid-saga, mid-rehydrate);
+  persistence atomicity (SQLite transactions) must hold.
+- Crash classification tested with synthetic repeated signatures.
+
+---
+
+## 15. Phased rollout
+
+Going app-wide in one step is itself a foot-gun. Prove the discipline on one
+service first.
+
+- **Phase 0 — Modal suppression.** `SetErrorMode` in host + launcher. Smallest
+  change; immediately removes the scariest symptom. Ships independently.
+- **Phase 1 — Host supervision (the case-study path).** Launcher detects host
+  abnormal exit → restart → rehydrate from `objects.db`, re-attaching to the
+  still-running srv (Tier 1, §6). Retry ladder per §7 — `--disable-gpu` only
+  when a full relaunch reproduces a GPU-class crash. Crash budget +
+  classification + recovery metric. Full
+  fault-injection tests. **This is the proof of the whole pattern.**
+- **Phase 2 — srv supervision.** Same contract; host tolerates srv reconnect.
+- **Phase 3 — Generalize.** Extract the `SupervisedService` contract into
+  `agentmux-common`; fold the saga coordinator and Chromium-child handling into
+  the uniform model.
+- **Phase 4 — Root hardening.** Decide (on evidence) whether the launcher needs
+  an OS-level respawn.
+
+Each phase ships only when the previous one is boringly reliable.
+
+---
+
+## 16. Open decisions
+
+1. **Root supervisor** — leave the launcher as a bulletproof root, or add a
+   minimal OS-level respawn? Default: leave it; revisit on evidence (§6, §15
+   Phase 4).
+2. **Crash-budget numbers** — N restarts per window, backoff curve, window
+   length. Needs real crash-rate data.
+3. **Last-known-good state** — do we keep periodic known-good markers in
+   `objects.db`, or is "crash-time state minus the last command" enough? (Must
+   not violate §9 — no new write path; likely a marker, not a copy.)
+4. **`--disable-gpu-process-crash-limit`** — pass it always (Chromium keeps
+   auto-restarting the GPU process instead of `LOG(FATAL)`), or only after the
+   first GPU crash?
+5. **Hang detection budget** — ping interval and missed-ping threshold;
+   needs measurement so legit long operations are never misclassified.
+6. **Frontend (Layer 4)** — is a frozen renderer in scope here, or handled by
+   Chromium reload + slice rehydrate alone?
+
+---
+
+## 17. References
+
+- `docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md` — case study #1.
+- `docs/specs/MASTER_REDUCER_STACK_STATUS_2026-05-05.md` — reducer stack.
+- `docs/specs/SPEC_PHASE_E_SAGAS_2026-04-30.md` — saga crash-resume precedent.
+- Discussion #707 — reducer-stack tracking thread (model for this spec's
+  tracking thread).


### PR DESCRIPTION
## Phase 0 — suppress the Windows crash modal

First slice of the **service supervision & recovery framework** (Discussion
#943, issue #942).

### Problem

When the host hits an unhandled fault — a Chromium `LOG(FATAL)`, an `abort()`,
a breakpoint — Windows shows an "Application Error" modal. The 2026-05-20 GPU
crash is the case study: the `0x80000003` *"a breakpoint has been reached… OK
to terminate, CANCEL to debug"* dialog. That modal **freezes the process**
behind an OK/Cancel prompt — it cannot be auto-recovered while the dialog is
up, and the user sees a raw OS error instead of a graceful restart.

### Change

`SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX)`, called as the
**first statement of `main()`** in both the host (`agentmux-cef`) and the
launcher (`agentmux-launcher`). A fault now terminates the process immediately
and silently; the launcher's supervisor (Phase 1) relaunches it.

- `agentmux-cef/src/main.rs`, `agentmux-launcher/src/main.rs` — a small
  `suppress_os_crash_dialogs()` (cfg-gated; no-op off Windows), called first.
- Both `Cargo.toml`s gain the `Win32_System_Diagnostics_Debug` windows-sys
  feature (where `SetErrorMode` lives).

Smallest, self-contained slice — removes the scariest symptom, ships
independently of the rest of the framework.

### Verification

- `cargo check -p agentmux-launcher` and `cargo check -p agentmux-cef` — both
  clean (pre-existing warnings only).
- Runtime verification (a fault actually terminating without the modal)
  requires a crash repro and is **not automated here** — the fault-injection
  harness is Phase 1 (spec §14).

### Note on crash dumps

`SEM_NOGPFAULTERRORBOX` suppresses the WER **dialog**. Today the breakpoint
modal *already* blocks WER dump collection (the process is frozen at the
prompt), so this change is **no worse** for dumps and likely better — a
silent terminate lets WER LocalDumps proceed. Flagging for confirmation; if
LocalDumps still doesn't collect, Phase 1 adds a `SetUnhandledExceptionFilter`
that writes a minidump before exit.

### Docs riding along

- `docs/specs/SPEC_SERVICE_SUPERVISION_AND_RECOVERY_2026_05_20.md` — the full
  framework spec (Draft).
- `docs/analysis/CRASH_GPU_PROCESS_FATAL_2026_05_20.md` — case study #1.

Discussion #943 · Issue #942

🤖 Generated with [Claude Code](https://claude.com/claude-code)
