### PR TITLE
fix(statusbar): opacity slider updates live while dragging

### DIFF
--- a/.changesets/1779334638-fix-statusbar-opacity-slider-value-updates-live-while-draggi-pb26.md
+++ b/.changesets/1779334638-fix-statusbar-opacity-slider-value-updates-live-while-draggi-pb26.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(statusbar): opacity slider value updates live while dragging

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -321,6 +321,12 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                             const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
                             return (win?.meta?.["window:opacity"] as number | undefined) ?? 1.0;
                         };
+                        // While the slider is being dragged, `dragOpacity` holds the
+                        // live value so the thumb + % label track the drag. It's
+                        // cleared on release, after which `currentOpacity()` (the
+                        // persisted meta, written by onChange) is the source again.
+                        const [dragOpacity, setDragOpacity] = createSignal<number | null>(null);
+                        const displayOpacity = () => dragOpacity() ?? currentOpacity();
                         return (
                             <>
                             <div
@@ -423,9 +429,10 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         min={0.35}
                                         max={1.0}
                                         step={0.05}
-                                        value={currentOpacity()}
+                                        value={displayOpacity()}
                                         onInput={(e) => {
                                             const val = parseFloat(e.currentTarget.value);
+                                            setDragOpacity(val);
                                             dispatchWindowOpacity({
                                                 type: "SetWindowOpacity",
                                                 windowId: entry.windowId!,
@@ -435,6 +442,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                             });
                                         }}
                                         onChange={(e) => {
+                                            setDragOpacity(null);
                                             const raw = parseFloat(e.currentTarget.value);
                                             const val = Math.round(raw * 100) / 100;
                                             if (!entry.windowId) return;
@@ -453,7 +461,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         }}
                                     />
                                     <span class="instance-panel-opacity-value">
-                                        {Math.round(currentOpacity() * 100)}%
+                                        {Math.round(displayOpacity() * 100)}%
                                     </span>
                                 </div>
                             </Show>


### PR DESCRIPTION
## Problem

In the status-bar Instance panel, the per-window **Opacity** slider's thumb
and `%` label only updated when the user *released* the slider — not while
dragging.

Root cause: both were bound to `currentOpacity()`, which reads the persisted
`window:opacity` window meta. That meta is written **only** by the `onChange`
(release) handler. The `onInput` (drag) handler dispatches to the live
window-opacity store — so the *window* dimmed live, but the slider value
didn't.

## Fix — `frontend/app/statusbar/InstancePanel.tsx`

A per-row `dragOpacity` signal:
- `onInput` (drag) → `setDragOpacity(val)`
- `onChange` (release) → `setDragOpacity(null)`
- `displayOpacity() = dragOpacity() ?? currentOpacity()` drives the slider
  `value` and the `%` label.

So during a drag the thumb + label track continuously; on release it falls
back to the persisted value (canonical once it settles, ~one frame later).

## Verification

`npx tsc --noEmit` — clean for `InstancePanel.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)