### PR TITLE
feat(menu): menu positioning framework — paintable-area guard (spec + Phases 1-4)

### DIFF
--- a/.changesets/1779354885-docs-menu-spec-for-menu-positioning-framework-paintable-area-r74k.md
+++ b/.changesets/1779354885-docs-menu-spec-for-menu-positioning-framework-paintable-area-r74k.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+docs(menu): spec for menu positioning framework + paintable-area guard

--- a/.changesets/1779355389-feat-menu-usemenuposition-framework-primitive-phase-1-ng7w.md
+++ b/.changesets/1779355389-feat-menu-usemenuposition-framework-primitive-phase-1-ng7w.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(menu): useMenuPosition framework primitive (Phase 1)

--- a/.changesets/1779355644-feat-menu-route-flyoutmenu-popover-through-usemenuposition-p-tjr7.md
+++ b/.changesets/1779355644-feat-menu-route-flyoutmenu-popover-through-usemenuposition-p-tjr7.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(menu): route FlyoutMenu + Popover through useMenuPosition (Phase 2)

--- a/.changesets/1779358906-feat-menu-migrate-more-dropdown-tokenbreakdownpopover-to-use-f1c0.md
+++ b/.changesets/1779358906-feat-menu-migrate-more-dropdown-tokenbreakdownpopover-to-use-f1c0.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(menu): migrate More dropdown + TokenBreakdownPopover to useMenuPosition (Phase 3)

--- a/.changesets/1779359149-feat-menu-paintable-area-guard-dev-assertion-ci-grep-gate-ph-jlgv.md
+++ b/.changesets/1779359149-feat-menu-paintable-area-guard-dev-assertion-ci-grep-gate-ph-jlgv.md
@@ -1,0 +1,5 @@
+---
+type: minor
+---
+
+feat(menu): paintable-area guard — dev assertion + CI grep gate (Phase 4)

--- a/.changesets/1779404543-fix-menu-preserve-crossaxis-alignmentaxis-offset-semantics-i-ssb3.md
+++ b/.changesets/1779404543-fix-menu-preserve-crossaxis-alignmentaxis-offset-semantics-i-ssb3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(menu): preserve crossAxis/alignmentAxis offset semantics in Popover

--- a/.changesets/1779462096-fix-menu-route-the-right-click-context-menu-through-computem-ftu3.md
+++ b/.changesets/1779462096-fix-menu-route-the-right-click-context-menu-through-computem-ftu3.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(menu): route the right-click context menu through computeMenuPosition

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -140,11 +140,19 @@ tasks:
             - task: bundle
             - bash scripts/build-appimage-linux.sh
 
+    check:menu-positioning:
+        desc: >-
+            Grep gate — fails if computePosition() is called outside the
+            sanctioned menu positioning files (SPEC_MENU_PAINTABLE_AREA_GUARD
+            §6.2). Forces new menus through useMenuPosition.
+        cmd: bash scripts/check-menu-positioning.sh
+
     build:frontend:
         desc: Build the frontend (production mode).
         cmd: bash scripts/vite-build.sh --mode production --config vite.config.ts
         deps:
             - npm:install
+            - check:menu-positioning
         env:
             VITE_PLATFORM: "{{OS}}"
 

--- a/docs/specs/SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20.md
+++ b/docs/specs/SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20.md
@@ -1,0 +1,246 @@
+# SPEC: Menu positioning framework — offset every menu into the paintable area
+
+**Date:** 2026-05-20 (revised 2026-05-21)
+**Author:** AgentX
+**Status:** Draft
+
+---
+
+## TL;DR
+
+A menu **cannot** render outside the window — the OS clips at the window frame, that state does not exist. The real failure is subtler: a menu gets *positioned* such that part of its body falls **outside the paintable area** — past a window edge, or behind a native browser-pane window — where it is clipped and unreachable.
+
+The fix is always the same single operation: **offset the menu** so its entire body lands inside the paintable area. Today that offset is computed inconsistently — one menu does it correctly, most don't, across three unrelated code paths.
+
+This spec defines **one positioning framework** (`useMenuPosition`) that every DOM menu routes through, and a guard that keeps it that way.
+
+---
+
+## 1. The behavior we want
+
+A menu has:
+- an **anchor** — an element rect, or a raw click point
+- a **natural size** — measured once it renders
+
+The framework's only job:
+
+> If placing the menu at its anchor would push any part of it outside the **paintable area**, choose an **offset** (shift along an axis, and/or flip to the opposite side of the anchor) so the *entire* menu body lands inside the paintable area.
+
+That's it. Nothing renders outside the window — impossible by construction. The framework picks the offset that makes the menu paint fully, correctly, inside the visible region.
+
+---
+
+## 2. The paintable area
+
+> **Paintable area** — the window client region where a DOM-rendered menu is actually visible. It is the window viewport **minus** the rectangles occupied by **native child windows** that paint above the DOM.
+
+Two kinds of boundary, treated identically:
+
+1. **Window edge** — the menu must stay within `[0, innerWidth] × [0, innerHeight]`.
+2. **Native-pane edge** — AgentMux browser panes are `CefBrowserView` instances: native OS child windows, **not** iframes ([`SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md`](SPEC_BROWSER_AND_EDITOR_PANES_2026_04_16.md)). Native child windows paint **above** the host webview's DOM. A DOM menu whose body overlaps a browser pane is drawn *behind* that pane — invisible, even though its x/y is "inside the window."
+
+A correct offset respects **both** boundaries. A framework that only checks `window.innerWidth/innerHeight` handles the first and silently fails the second.
+
+> The window edge is the common case. The native-pane edge is the AgentMux-specific case that nothing in the codebase handles today.
+
+---
+
+## 3. Current state — how each menu offsets (or doesn't)
+
+The Explore pass over the codebase (verified against HEAD `7e3d5722`) found **7+ menu surfaces** and **three unrelated positioning strategies**:
+
+| # | Surface | File | Render layer | Offset logic | Correct? |
+|---|---|---|---|---|---|
+| 1 | **FlyoutMenu** (hamburger, dropdowns) | `frontend/app/element/flyoutmenu.tsx:51` | DOM | floating-ui `computePosition`, **placement only — no middleware** | ❌ never offsets |
+| 2 | **MenuButton** | `frontend/app/element/menubutton.tsx` | DOM | wraps FlyoutMenu | ❌ inherits |
+| 3 | **FlyoutMenu submenu** | `flyoutmenu.tsx:262-289` | DOM | ad-hoc manual `getBoundingClientRect` vs `innerWidth/Height`, one-shot `flipped` flag | ⚠️ offsets, but window-edge only + buggy (see §3.1) |
+| 4 | **Popover** (status bar, notifications) | `frontend/app/element/popover.tsx:59` | DOM | floating-ui, `offset` only — `shift`/`flip` only if the *caller* passes them | ❌ no offset by default |
+| 5 | **Tooltip** | `frontend/app/element/tooltip.tsx:49` | DOM | floating-ui `offset(10)` + `flip()` + `shift({padding:12})` | ✅ offsets correctly (window edge only) |
+| 6 | **More dropdown** (widget bar) | `frontend/app/window/action-widgets.tsx:229` | DOM `position:fixed` | manual `window.innerWidth - rect.right` | ⚠️ horizontal offset only |
+| 7 | **TokenBreakdownPopover** | `frontend/app/statusbar/TokenBreakdownPopover.tsx:76-84` | DOM `position:fixed` | manual clamp, bespoke 8px gutter | ⚠️ correct but hand-rolled |
+| 8 | **Native context menus** (all right-click) | `frontend/app/store/contextmenu.ts:52-58` | **native CEF/OS** | raw `clientX/clientY` → `getApi().showContextMenu` | ✅ OS offsets natively, paints above panes |
+| 9 | **Command palette** | `frontend/app/modals/command-palette.tsx` | DOM modal | modal-v2 centering | ✅ centered, never near an edge |
+
+Of the six **DOM menus**, exactly **one** (Tooltip) offsets correctly — and even that one only knows about the window edge, not native panes.
+
+### 3.1 Confirmed code facts
+
+- `flyoutmenu.tsx:51-54` — `computePosition(referenceEl, floatingEl, { placement: props.placement ?? "bottom-start" })`. No middleware array at all. The most-used DOM menu computes a raw placement and never offsets.
+- `popover.tsx:59` — `middleware = [...(props.middleware ?? []), offsetMiddleware(offsetVal)]`. `shift`/`flip` exist only if a caller threads them in. `NotificationPopover` does not.
+- `flyoutmenu.tsx:262-289` — the `SubMenu` component *does* offset (`overflowRight = rect.right - window.innerWidth`, flip-left / clamp-top), proving menus genuinely need offsetting — but: it's window-edge-only, and gated by a one-shot `flipped` flag that never re-evaluates after a resize or scroll.
+- `contextmenu.ts:56` — `{ x: clientX, y: clientY }` handed to native `showContextMenu`. No DOM-side offset, and none needed: the OS positions native menus and paints them above everything, native panes included.
+
+The submenu code at §3.1 line 3 is the proof point: a developer hit a menu landing past the window edge and hand-patched an offset for that *one* surface. The framework generalizes that patch and extends it to the native-pane boundary.
+
+---
+
+## 4. Why it's inconsistent
+
+| Strategy | Surfaces | Mechanism |
+|---|---|---|
+| **floating-ui** | FlyoutMenu, MenuButton, Popover, Tooltip, NotificationPopover | `@floating-ui/dom` `computePosition` |
+| **Manual viewport math** | More dropdown, TokenBreakdownPopover, FlyoutMenu submenu | hand-rolled `getBoundingClientRect` + `innerWidth/Height` |
+| **Native OS** | all right-click context menus | CEF `showContextMenu` → OS menu |
+
+Nothing *enforces* a single path. `@floating-ui/dom` is already a dependency and already has the exact middleware needed (`shift`, `flip`, `size`) — but four of the five floating-ui consumers don't apply it. Each new menu re-decides positioning from scratch.
+
+**Unification today: 2/5.** Target: **4/5** — every DOM menu through one offsetter; native context menus stay native (that's correct, not a gap).
+
+---
+
+## 5. The framework — `useMenuPosition`
+
+One hook. Every **DOM** menu routes through it. Native context menus are out of scope (§7).
+
+```typescript
+interface MenuPositionRequest {
+    anchor: HTMLElement | DOMRect | { x: number; y: number };
+    placement?: Placement;        // preferred side; flips if it doesn't fit
+    gutter?: number;              // min gap from any paintable edge (default 8)
+    avoidNativePanes?: boolean;   // default true — treat browser-pane rects as boundaries
+}
+
+interface MenuPositionResult {
+    style: JSX.CSSProperties;     // position:fixed; left/top — the offset, applied
+    placement: Placement;         // side chosen after any flip
+    maxHeight: number;            // when the menu is taller than the free space
+    maxWidth: number;
+}
+
+function useMenuPosition(req: () => MenuPositionRequest): () => MenuPositionResult;
+```
+
+### 5.1 How it computes the offset
+
+1. **Resolve anchor** to a `DOMRect` (element → `getBoundingClientRect`; point → zero-size rect).
+2. **Measure** the menu's natural size.
+3. **Compute the paintable area** — viewport rect minus native-pane rects (when `avoidNativePanes`). See §5.3.
+4. **Offset** via floating-ui with a *fixed, non-optional* middleware stack:
+   - `offset(gutter)` — the gap from the anchor
+   - `flip()` — if the preferred side doesn't fit, use the opposite side of the anchor
+   - `shift({ padding: gutter })` — slide the menu along the cross-axis to pull it back inside
+   - `size()` — when the menu is taller/wider than the free space, emit `maxHeight`/`maxWidth` so it scrolls internally instead of being placed partly outside
+   - **custom `boundary`** — floating-ui's `detectOverflow` boundary is set to the **paintable area**, not the default viewport. This is the line that makes `flip`/`shift` offset away from native panes, not just window edges.
+5. **Residual check** — if the resolved rect still intersects a native-pane rect (floating-ui can't always satisfy a punched-out region), apply §5.2.
+6. Return the offset as `style`, plus the resolved `placement` and size caps.
+
+### 5.2 When the menu can't fully fit
+
+A menu anchored dead-center over a maximized browser pane may have no fully-paintable spot. Degrade in this order:
+
+1. **Shrink** — apply `maxHeight`/`maxWidth` + internal scroll so the menu fits a non-occluded strip. Covers the overwhelming majority.
+2. **Re-anchor** — move the menu to the nearest fully-paintable region, draw a connector back to the anchor.
+3. **Promote to native** — render as a native OS menu via the `contextmenu.ts` path, which paints above browser panes. Only possible for menus expressible as `ContextMenuItem[]` (no custom JSX rows).
+
+**v1 ships shrink-only (step 1).** Steps 2-3 are follow-ups — see Q2.
+
+### 5.3 Sourcing native-pane rectangles
+
+The layout reducer already knows every browser pane's `blockId` and on-screen rect — `browser_pane_resize` propagates layout changes to the HWND. A `getNativePaneRects(): DOMRect[]` selector walks the current tab's layout tree for blocks with `view: "browser"` (+ any future native-HWND view) and returns their client rects. Measured once per menu-open, same frame.
+
+---
+
+## 6. The guard
+
+`useMenuPosition` is the carrot. The guard makes a wrongly-offset menu a **caught error**, not a silent visual bug.
+
+### 6.1 Dev-mode runtime assertion
+
+`assertMenuInPaintableArea(el: HTMLElement)`, called from each DOM menu's mount effect under `AGENTMUX_DEV=1`:
+
+- One RAF after the menu opens, measure its rect.
+- Intersect with the paintable area.
+- Any part outside, or behind a native pane → `console.error` tagged `[menu-guard]` with the anchor and the offending boundary. Surfaces via `muxlog host '[menu-guard]'`.
+- Dev-only — stripped from release builds, zero runtime cost.
+
+### 6.2 CI grep gate
+
+- Flag any `computePosition(` in `frontend/app/**` outside `useMenuPosition` / the three sanctioned components.
+- Flag new `position: fixed` + `getBoundingClientRect` offset arithmetic outside the framework.
+- Forces new menus through the hook instead of re-rolling manual math — the thing that produced today's 2/5.
+
+### 6.3 Out of scope for the guard
+
+Native context menus. The OS offsets and paints those; they are correctly exempt. The guard governs **DOM menus only**.
+
+---
+
+## 7. What converges, what stays native
+
+| Surface | Action |
+|---|---|
+| Native context menus (all right-click) | **Keep native.** Correct as-is — OS offsets them, they paint above browser panes. |
+| FlyoutMenu | Route through `useMenuPosition`; delete the ad-hoc submenu offset (§3.1). |
+| MenuButton | No change — inherits the FlyoutMenu fix. |
+| Popover | Route through `useMenuPosition`; make `flip`/`shift`/`size` non-optional. |
+| Tooltip | Migrate for consistency — already correct, low priority (Q3). |
+| More dropdown | Replace manual `innerWidth - rect.right` with `useMenuPosition`. |
+| TokenBreakdownPopover | Replace bespoke clamp with `useMenuPosition`. |
+| Command palette | No change — modal-centered, never near a boundary. |
+
+Result: **one offsetter for every DOM menu; native menus stay native.** A literal 5/5 ("one component for menus, tooltips, modals, and OS context menus") isn't worth collapsing genuinely different surfaces — 4/5 is the right target.
+
+---
+
+## 8. Implementation phases
+
+### Phase 0 — confirm unknowns (½ day)
+Q1 (editor pane DOM-vs-native), Q2 (fallback scope), verify `getNativePaneRects` sources cleanly from the layout reducer.
+
+### Phase 1 — `useMenuPosition` + paintable-area selector (1.5 days)
+`frontend/app/util/menu-position.ts` — the hook, `getPaintableArea()`, `getNativePaneRects()`. Fixed middleware stack with custom `boundary`. Unit tests: anchor at each edge, anchor over a synthetic native-pane rect, tall-menu shrink.
+
+### Phase 2 — migrate FlyoutMenu + Popover (1 day)
+Covers the majority of DOM menus (MenuButton, NotificationPopover inherit). Delete the one-shot `flipped` submenu logic — submenus offset through the hook.
+
+### Phase 3 — migrate manual-math surfaces (½ day)
+More dropdown, TokenBreakdownPopover → `useMenuPosition`. Optional: Tooltip.
+
+### Phase 4 — the guard (½ day)
+`assertMenuInPaintableArea` dev assertion + CI grep gate.
+
+### Phase 5 — edge-case pass (½ day)
+Manual matrix per §9.
+
+**Total: ~5 days.**
+
+---
+
+## 9. Validation
+
+- [ ] `npm run build` green
+- [ ] Unit tests: `useMenuPosition` offsets correctly at all 4 window edges; offsets away from a synthetic native-pane rect; shrinks a too-tall menu
+- [ ] `task dev` manual matrix:
+  - [ ] Hamburger menu with the window dragged so ≡ is near the right edge → menu flips/shifts fully in-bounds
+  - [ ] `FlyoutMenu` submenu near the bottom edge → offsets up, stays whole
+  - [ ] A DOM menu (More dropdown) anchored where it would overlap a maximized browser pane → menu is offset/shrunk, never drawn behind the pane
+  - [ ] Window resized very small → no menu placed partly past a window edge
+  - [ ] Right-click bottom-right pane → native context menu fully visible (sanity — native path, unchanged)
+- [ ] `muxlog host '[menu-guard]'` shows zero violations across the matrix
+- [ ] CI grep gate fails a deliberately-added stray `computePosition` call
+
+---
+
+## 10. Risk register
+
+| Risk | Mitigation |
+|---|---|
+| Paintable area minus N panes is not a single rect; floating-ui `boundary` wants a rect | Pass the largest inscribed free rect as `boundary`, then run the §5.1-step-5 residual check for leftover overlap |
+| `getNativePaneRects` reads stale geometry | Source from the layout reducer's current state, measured the same frame the menu opens; `autoUpdate` re-measures on RAF |
+| Migration regresses a working menu | Phase-by-phase, each phase independently shippable; Tooltip migration is optional precisely because it already works |
+| Dev assertion log noise | `[menu-guard]` tag, dev-only, debounced to one log per violation per open |
+| Perf — measuring the paintable area on every open | N panes per tab rarely exceeds ~6; compute once per open, not per RAF |
+
+---
+
+## 11. Open questions
+
+1. **Q1** — Editor panes: DOM (Monaco/CodeMirror in-webview) or native HWND? Determines whether they're boundaries. The 2026 monaco-removal work suggests DOM — confirm.
+2. **Q2** — Fallback ladder (§5.2): ship shrink-only for v1, or build re-anchor + native-promote now? Recommend shrink-only; file the rest.
+3. **Q3** — Migrate Tooltip in Phase 3 or leave it independent? It works; migration is purely for one-offsetter consistency.
+4. **Q4** — Window straddling two monitors at different DPI: is `window.innerWidth/innerHeight` still the right paintable bound? Likely yes (window-relative, not screen-relative) — verify on the Phase 5 matrix.
+5. **Q5** — Does any menu *intentionally* sit flush to a boundary today? Audit before enforcing the guard so a deliberate design isn't "corrected."
+
+---
+
+*End of spec.*

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -9,7 +9,11 @@ import clsx from "clsx";
 import { createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
-import { computeMenuPosition, type MenuPositionResult } from "@/app/util/menu-position";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+    type MenuPositionResult,
+} from "@/app/util/menu-position";
 
 import "./flyoutmenu.scss";
 
@@ -65,6 +69,9 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
             if (!(referenceEl instanceof Element) || !(floatingEl instanceof Element)) return;
             cleanupAutoUpdate?.();
             cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
+            // Dev-only paintable-area guard (spec §6.1); gated so it is
+            // zero-cost in release builds.
+            assertMenuInPaintableArea(el, "flyout-menu");
         });
     };
 
@@ -294,6 +301,8 @@ const SubMenu = (props: SubMenuProps): JSX.Element => {
                 el,
                 update,
             );
+            // Dev-only paintable-area guard (spec §6.1).
+            assertMenuInPaintableArea(el, "submenu");
         });
     };
 

--- a/frontend/app/element/flyoutmenu.tsx
+++ b/frontend/app/element/flyoutmenu.tsx
@@ -3,14 +3,20 @@
 
 import {
     autoUpdate,
-    computePosition,
     type Placement,
 } from "@floating-ui/dom";
 import clsx from "clsx";
-import { createEffect, createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
+import { createSignal, For, JSX, onCleanup, onMount, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
+import { computeMenuPosition, type MenuPositionResult } from "@/app/util/menu-position";
+
 import "./flyoutmenu.scss";
+
+/** Serialize a MenuPositionResult.style (position:fixed + left/top) to a CSS string. */
+function styleToString(s: MenuPositionResult["style"]): string {
+    return `position:${s.position};left:${s.left};top:${s.top}`;
+}
 
 type MenuProps = {
     items: MenuItem[];
@@ -25,9 +31,7 @@ type MenuProps = {
 const FlyoutMenu = (props: MenuProps): JSX.Element => {
     const [visibleSubMenus, setVisibleSubMenus] = createSignal<{ [key: string]: any }>({});
     const [hoveredItems, setHoveredItems] = createSignal<string[]>([]);
-    const [subMenuPosition, setSubMenuPosition] = createSignal<{
-        [key: string]: { top: number; left: number; parentLeft: number; label: string };
-    }>({});
+    const [subMenuPosition, setSubMenuPosition] = createSignal<SubMenuPositionMap>({});
 
     const [isOpen, setIsOpen] = createSignal(false);
     const [floatingStyle, setFloatingStyle] = createSignal("position:absolute;left:0px;top:0px");
@@ -48,10 +52,11 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 
     const updatePosition = async () => {
         if (!referenceEl || !floatingEl) return;
-        const pos = await computePosition(referenceEl, floatingEl, {
-            placement: props.placement ?? "bottom-start",
-        });
-        setFloatingStyle(`position:absolute;left:${pos.x}px;top:${pos.y}px`);
+        const pos = await computeMenuPosition(
+            { anchor: referenceEl, placement: props.placement ?? "bottom-start" },
+            floatingEl,
+        );
+        setFloatingStyle(styleToString(pos.style));
     };
 
     const registerFloating = (el: HTMLElement) => {
@@ -82,12 +87,10 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
     });
 
     const handleSubMenuPosition = (key: string, itemRect: DOMRect, label: string) => {
-        const scrollTop = window.scrollY || document.documentElement.scrollTop;
-        const scrollLeft = window.scrollX || document.documentElement.scrollLeft;
-        const top = itemRect.top - 2 + scrollTop;
-        const left = itemRect.right + scrollLeft - 2;
-        const parentLeft = itemRect.left + scrollLeft;
-        setSubMenuPosition((prev) => ({ ...prev, [key]: { top, left, parentLeft, label } }));
+        // Store the parent menu item's rect; the SubMenu component routes it
+        // through useMenuPosition (right-start, flips to left-start near the
+        // right edge) — no hand-rolled window-edge math here.
+        setSubMenuPosition((prev) => ({ ...prev, [key]: { anchorRect: itemRect, label } }));
     };
 
     const handleMouseEnterItem = (
@@ -236,7 +239,7 @@ const FlyoutMenu = (props: MenuProps): JSX.Element => {
 };
 
 type SubMenuPositionMap = {
-    [key: string]: { top: number; left: number; parentLeft: number; label: string };
+    [key: string]: { anchorRect: DOMRect; label: string };
 };
 
 type SubMenuProps = {
@@ -260,43 +263,47 @@ type SubMenuProps = {
 };
 
 const SubMenu = (props: SubMenuProps): JSX.Element => {
-    let subMenuEl: HTMLDivElement | undefined;
-    let flipped = false;
     const position = () => props.subMenuPosition[props.parentKey];
 
-    createEffect(() => {
-        const pos = position();
-        if (!pos || flipped || !subMenuEl) return;
-        const rect = subMenuEl.getBoundingClientRect();
-        const overflowRight = rect.right - window.innerWidth;
-        const overflowBottom = rect.bottom - window.innerHeight;
-        if (overflowRight <= 0 && overflowBottom <= 0) {
-            flipped = true;
-            return;
-        }
-        flipped = true;
-        props.setSubMenuPosition((prev) => ({
-            ...prev,
-            [props.parentKey]: {
-                label: pos.label,
-                parentLeft: pos.parentLeft,
-                left: overflowRight > 0 ? pos.parentLeft - rect.width + 2 : pos.left,
-                top: overflowBottom > 0
-                    ? window.innerHeight - rect.height - 10 + window.scrollY
-                    : pos.top,
-            },
-        }));
-    });
+    // Submenu positioning routes through the Phase 1 primitive: anchored to the
+    // parent menu item's rect, preferred placement right-start — flip() turns
+    // that into left-start near the right edge, shift() pulls it back inside
+    // near the bottom edge, all paintable-area aware. autoUpdate keeps it live
+    // on scroll/resize (the old one-shot `flipped` flag never re-evaluated).
+    const [subStyle, setSubStyle] = createSignal("position:fixed;left:0px;top:0px");
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerSubMenu = (el: HTMLDivElement) => {
+        requestAnimationFrame(() => {
+            const pos = position();
+            if (!pos || !(el instanceof Element)) return;
+            const update = async () => {
+                const cur = position();
+                if (!cur) return;
+                const computed = await computeMenuPosition(
+                    { anchor: cur.anchorRect, placement: "right-start" },
+                    el,
+                );
+                setSubStyle(styleToString(computed.style));
+            };
+            cleanupAutoUpdate?.();
+            // anchorRect is a static DOMRect, so autoUpdate's reference is a
+            // virtual element; it still re-runs on scroll/resize.
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => position()?.anchorRect ?? pos.anchorRect },
+                el,
+                update,
+            );
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
 
     const subMenu = (
         <div
-            ref={(el) => { subMenuEl = el; }}
+            ref={registerSubMenu}
             class="menu sub-menu"
-            style={{
-                top: `${position()?.top ?? 0}px`,
-                left: `${position()?.left ?? 0}px`,
-                position: "absolute",
-            }}
+            style={subStyle()}
             data-pane-overlay
         >
             <For each={props.subItems}>

--- a/frontend/app/element/popover.tsx
+++ b/frontend/app/element/popover.tsx
@@ -62,14 +62,30 @@ const Popover = (props: PopoverProps): JSX.Element => {
     // props.middleware is still accepted for backward-compat (no caller passes
     // it today), but flip + shift + size + the paintable-area boundary are now
     // applied unconditionally via computeMenuPosition — they are no longer
-    // caller-optional. The gutter (gap from the anchor) maps from props.offset:
-    // a bare number is the gutter; an object form contributes its mainAxis.
-    const gutter = (): number => {
-        if (typeof offsetVal === "number") return offsetVal;
-        if (offsetVal && typeof offsetVal === "object" && "mainAxis" in offsetVal) {
-            return typeof offsetVal.mainAxis === "number" ? offsetVal.mainAxis : 3;
+    // caller-optional. props.offset keeps full Floating UI `offset()` object
+    // semantics: a bare number is the gutter; an object form maps mainAxis →
+    // gutter and preserves crossAxis/alignmentAxis (NotificationPopover relies
+    // on crossAxis to nudge its caret-aligned popover).
+    const resolveOffset = (): {
+        gutter: number;
+        crossAxis: number;
+        alignmentAxis: number | undefined;
+    } => {
+        if (typeof offsetVal === "number") {
+            return { gutter: offsetVal, crossAxis: 0, alignmentAxis: undefined };
         }
-        return 3;
+        if (offsetVal && typeof offsetVal === "object") {
+            const num = (v: unknown): number | undefined =>
+                typeof v === "number" ? v : undefined;
+            return {
+                gutter: num((offsetVal as { mainAxis?: unknown }).mainAxis) ?? 3,
+                crossAxis: num((offsetVal as { crossAxis?: unknown }).crossAxis) ?? 0,
+                alignmentAxis: num(
+                    (offsetVal as { alignmentAxis?: unknown }).alignmentAxis,
+                ),
+            };
+        }
+        return { gutter: 3, crossAxis: 0, alignmentAxis: undefined };
     };
 
     const styleToString = (s: MenuPositionResult["style"]): string =>
@@ -77,8 +93,15 @@ const Popover = (props: PopoverProps): JSX.Element => {
 
     const updatePosition = async () => {
         if (!referenceEl || !floatingEl) return;
+        const off = resolveOffset();
         const pos = await computeMenuPosition(
-            { anchor: referenceEl, placement, gutter: gutter() },
+            {
+                anchor: referenceEl,
+                placement,
+                gutter: off.gutter,
+                offsetCrossAxis: off.crossAxis,
+                offsetAlignmentAxis: off.alignmentAxis,
+            },
             floatingEl,
         );
         setFloatingStyle(styleToString(pos.style));

--- a/frontend/app/element/popover.tsx
+++ b/frontend/app/element/popover.tsx
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from "@/element/button";
+import { computeMenuPosition, type MenuPositionResult } from "@/app/util/menu-position";
 import {
     autoUpdate,
-    computePosition,
-    offset as offsetMiddleware,
     type Middleware,
     type OffsetOptions,
     type Placement,
@@ -56,12 +55,29 @@ const Popover = (props: PopoverProps): JSX.Element => {
     let floatingEl: HTMLElement | null = null;
     let cleanupAutoUpdate: (() => void) | null = null;
 
-    const middleware: Middleware[] = [...(props.middleware ?? []), offsetMiddleware(offsetVal as any)];
+    // props.middleware is still accepted for backward-compat (no caller passes
+    // it today), but flip + shift + size + the paintable-area boundary are now
+    // applied unconditionally via computeMenuPosition — they are no longer
+    // caller-optional. The gutter (gap from the anchor) maps from props.offset:
+    // a bare number is the gutter; an object form contributes its mainAxis.
+    const gutter = (): number => {
+        if (typeof offsetVal === "number") return offsetVal;
+        if (offsetVal && typeof offsetVal === "object" && "mainAxis" in offsetVal) {
+            return typeof offsetVal.mainAxis === "number" ? offsetVal.mainAxis : 3;
+        }
+        return 3;
+    };
+
+    const styleToString = (s: MenuPositionResult["style"]): string =>
+        `position:${s.position};left:${s.left};top:${s.top}`;
 
     const updatePosition = async () => {
         if (!referenceEl || !floatingEl) return;
-        const pos = await computePosition(referenceEl, floatingEl, { placement, middleware });
-        setFloatingStyle(`position:absolute;left:${pos.x}px;top:${pos.y}px`);
+        const pos = await computeMenuPosition(
+            { anchor: referenceEl, placement, gutter: gutter() },
+            floatingEl,
+        );
+        setFloatingStyle(styleToString(pos.style));
     };
 
     const openPopover = () => {

--- a/frontend/app/element/popover.tsx
+++ b/frontend/app/element/popover.tsx
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from "@/element/button";
-import { computeMenuPosition, type MenuPositionResult } from "@/app/util/menu-position";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+    type MenuPositionResult,
+} from "@/app/util/menu-position";
 import {
     autoUpdate,
     type Middleware,
@@ -104,6 +108,9 @@ const Popover = (props: PopoverProps): JSX.Element => {
             if (referenceEl instanceof Element && floatingEl instanceof Element) {
                 cleanupAutoUpdate?.();
                 cleanupAutoUpdate = autoUpdate(referenceEl, floatingEl, updatePosition);
+                // Dev-only paintable-area guard (spec §6.1); gated so it is
+                // zero-cost in release builds.
+                assertMenuInPaintableArea(el, "popover");
             }
         });
     };

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -11,8 +11,10 @@
  * canonical `<Modal>`). Spec: SPEC_STATUSBAR_TOKEN_USAGE_2026_04_24.md §4.2.
  */
 
-import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
+import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
+import { autoUpdate } from "@floating-ui/dom";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
 import { ConfirmModal } from "@/element/modal";
 import { getCliCatalogEntry } from "@/app/view/agent/defaults/cli-catalog";
 import {
@@ -69,19 +71,45 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
         return getTotal();
     });
 
-    // Anchor positioning — popover bottom-edge pins to the status bar's
-    // top, horizontally aligned to the right edge of the indicator so
-    // it extends leftward into the main pane area. Clamped so it never
-    // runs off the viewport.
+    // Positioning routes through the shared primitive (Phase 3): anchored to
+    // the TokenUsageIndicator rect, preferred placement top-end so the popover
+    // opens upward and right-aligns to the indicator (it lives in the status
+    // bar at the bottom of the window). flip/shift/size + the paintable-area
+    // boundary replace the old bespoke 8px-GUTTER viewport clamp.
     const POPOVER_WIDTH = 320;
-    const GUTTER = 8;
-    const positioning = createMemo(() => {
-        const r = props.anchorRect;
-        if (!r) return { bottom: GUTTER, right: GUTTER };
-        const rightFromViewport = Math.max(GUTTER, window.innerWidth - r.right);
-        const bottomFromViewport = Math.max(GUTTER, window.innerHeight - r.top);
-        return { bottom: bottomFromViewport, right: rightFromViewport };
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
     });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        rootRef = el;
+        props.ref?.(el);
+        requestAnimationFrame(() => {
+            const r = props.anchorRect;
+            if (!r || !(el instanceof Element)) return;
+            const update = async () => {
+                const cur = props.anchorRect;
+                if (!cur) return;
+                const pos = await computeMenuPosition(
+                    { anchor: cur, placement: "top-end" },
+                    el,
+                );
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            // anchorRect is a static DOMRect → virtual reference element.
+            cleanupAutoUpdate = autoUpdate(
+                { getBoundingClientRect: () => props.anchorRect ?? r },
+                el,
+                update,
+            );
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
 
     const handleResetClick = () => setConfirmingReset(true);
 
@@ -94,19 +122,12 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
     return (
         <>
             <div
-                ref={(el) => {
-                    rootRef = el;
-                    props.ref?.(el);
-                }}
+                ref={registerFloating}
                 class="token-usage-breakdown"
                 role="dialog"
                 aria-label="Token usage breakdown"
-                style={{
-                    position: "fixed",
-                    bottom: `${positioning().bottom}px`,
-                    right: `${positioning().right}px`,
-                    width: `${POPOVER_WIDTH}px`,
-                }}
+                data-pane-overlay
+                style={{ ...floatingStyle(), width: `${POPOVER_WIDTH}px` }}
             >
                 <div class="token-usage-breakdown-header">
                     <span class="token-usage-breakdown-title">Token Usage</span>

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -14,7 +14,10 @@
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import { autoUpdate } from "@floating-ui/dom";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
-import { computeMenuPosition } from "@/app/util/menu-position";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+} from "@/app/util/menu-position";
 import { ConfirmModal } from "@/element/modal";
 import { getCliCatalogEntry } from "@/app/view/agent/defaults/cli-catalog";
 import {
@@ -106,6 +109,8 @@ export const TokenBreakdownPopover = (props: TokenBreakdownPopoverProps): JSX.El
                 el,
                 update,
             );
+            // Dev-only paintable-area guard (spec §6.1).
+            assertMenuInPaintableArea(el, "token-breakdown-popover");
         });
     };
 

--- a/frontend/app/util/menu-position.test.ts
+++ b/frontend/app/util/menu-position.test.ts
@@ -244,3 +244,46 @@ describe("computeMenuPosition — too-tall menu shrink (§5.2 step 1)", () => {
         expect(res.maxHeight).toBeLessThanOrEqual(400);
     });
 });
+
+describe("computeMenuPosition — cross-axis offset (Floating UI offset() parity)", () => {
+    const menuRect = makeRect(0, 0, 200, 300);
+
+    it("shifts the menu along the cross axis by offsetCrossAxis", async () => {
+        // bottom-start placement → cross axis is horizontal. The same anchor
+        // with a +40 crossAxis must land 40px further right than with none.
+        const base = await computeMenuPosition(
+            { anchor: { x: 100, y: 100 }, placement: "bottom-start", avoidNativePanes: false },
+            elementWithRect(menuRect),
+        );
+        const nudged = await computeMenuPosition(
+            {
+                anchor: { x: 100, y: 100 },
+                placement: "bottom-start",
+                offsetCrossAxis: 40,
+                avoidNativePanes: false,
+            },
+            elementWithRect(menuRect),
+        );
+        const baseLeft = parseInt(base.style.left as string, 10);
+        const nudgedLeft = parseInt(nudged.style.left as string, 10);
+        expect(nudgedLeft - baseLeft).toBe(40);
+    });
+
+    it("leaves placement unchanged when no cross-axis offset is given", async () => {
+        const a = await computeMenuPosition(
+            { anchor: { x: 100, y: 100 }, placement: "bottom-start", avoidNativePanes: false },
+            elementWithRect(menuRect),
+        );
+        const b = await computeMenuPosition(
+            {
+                anchor: { x: 100, y: 100 },
+                placement: "bottom-start",
+                offsetCrossAxis: 0,
+                avoidNativePanes: false,
+            },
+            elementWithRect(menuRect),
+        );
+        expect(a.style.left).toBe(b.style.left);
+        expect(a.style.top).toBe(b.style.top);
+    });
+});

--- a/frontend/app/util/menu-position.test.ts
+++ b/frontend/app/util/menu-position.test.ts
@@ -1,0 +1,246 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the Phase 1 menu positioning primitive
+// (SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20 §9).
+//
+// jsdom returns all-zero rects from getBoundingClientRect, so every test
+// stubs the geometry it needs explicitly: window.innerWidth/Height for the
+// viewport, the floating menu's rect for its natural size, and per-element
+// rects for synthetic native panes.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    computeMenuPosition,
+    getNativePaneRects,
+    getPaintableArea,
+} from "./menu-position";
+
+const VIEWPORT_W = 1200;
+const VIEWPORT_H = 800;
+
+function makeRect(x: number, y: number, w: number, h: number): DOMRect {
+    return {
+        x,
+        y,
+        width: w,
+        height: h,
+        top: y,
+        left: x,
+        right: x + w,
+        bottom: y + h,
+        toJSON: () => ({ x, y, width: w, height: h }),
+    } as DOMRect;
+}
+
+/**
+ * A detached element with a fixed size.
+ *
+ * floating-ui sizes the floating element via `offsetWidth`/`offsetHeight`
+ * (its `getCssDimensions`), not `getBoundingClientRect` — jsdom reports 0 for
+ * both unless we define them. Stub all three so floating-ui sees a real menu.
+ */
+function elementWithRect(rect: DOMRect): HTMLElement {
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () => rect;
+    Object.defineProperty(el, "offsetWidth", { value: rect.width, configurable: true });
+    Object.defineProperty(el, "offsetHeight", { value: rect.height, configurable: true });
+    return el;
+}
+
+/** A `.browser-placeholder` mounted in the document with a stubbed rect. */
+function mountNativePane(rect: DOMRect): HTMLElement {
+    const el = document.createElement("div");
+    el.className = "browser-placeholder";
+    el.getBoundingClientRect = () => rect;
+    document.body.appendChild(el);
+    return el;
+}
+
+beforeEach(() => {
+    window.innerWidth = VIEWPORT_W;
+    window.innerHeight = VIEWPORT_H;
+    // floating-ui's overflow detection intersects the boundary with the
+    // 'viewport' rootBoundary, which it derives from
+    // documentElement.clientWidth/Height (and visualViewport). jsdom reports
+    // 0 for those, collapsing the effective clip rect to 0x0. Stub them so
+    // floating-ui sees a real viewport — this mirrors a real browser.
+    Object.defineProperty(document.documentElement, "clientWidth", {
+        value: VIEWPORT_W,
+        configurable: true,
+    });
+    Object.defineProperty(document.documentElement, "clientHeight", {
+        value: VIEWPORT_H,
+        configurable: true,
+    });
+});
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("getNativePaneRects", () => {
+    it("returns no rects when there are no browser panes", () => {
+        expect(getNativePaneRects()).toEqual([]);
+    });
+
+    it("returns the rect of each mounted browser-placeholder", () => {
+        mountNativePane(makeRect(100, 100, 400, 300));
+        mountNativePane(makeRect(600, 100, 400, 300));
+        const rects = getNativePaneRects();
+        expect(rects).toHaveLength(2);
+        expect(rects[0].width).toBe(400);
+    });
+
+    it("skips zero-area placeholders (pane not yet created)", () => {
+        mountNativePane(makeRect(0, 0, 0, 0));
+        mountNativePane(makeRect(10, 10, 200, 200));
+        expect(getNativePaneRects()).toHaveLength(1);
+    });
+});
+
+describe("getPaintableArea", () => {
+    it("is the whole viewport when there are no native panes", () => {
+        const { largestFreeRect, rects } = getPaintableArea();
+        expect(rects).toEqual([]);
+        expect(largestFreeRect.width).toBe(VIEWPORT_W);
+        expect(largestFreeRect.height).toBe(VIEWPORT_H);
+    });
+
+    it("excludes a pane docked against the right edge", () => {
+        // Pane covers the right 400px; largest free rect is the left strip.
+        mountNativePane(makeRect(800, 0, 400, VIEWPORT_H));
+        const { largestFreeRect } = getPaintableArea();
+        expect(largestFreeRect.left).toBe(0);
+        expect(largestFreeRect.right).toBe(800);
+        expect(largestFreeRect.height).toBe(VIEWPORT_H);
+    });
+
+    it("picks the larger free strip when a pane splits the viewport", () => {
+        // Pane occupies the bottom 200px → top strip (1200x600) is largest.
+        mountNativePane(makeRect(0, 600, VIEWPORT_W, 200));
+        const { largestFreeRect } = getPaintableArea();
+        expect(largestFreeRect.top).toBe(0);
+        expect(largestFreeRect.bottom).toBe(600);
+    });
+});
+
+describe("computeMenuPosition — window edges (§9)", () => {
+    // 200x300 menu; floating-ui reads its natural size off the element rect.
+    const menuRect = makeRect(0, 0, 200, 300);
+
+    function menuEl(): HTMLElement {
+        return elementWithRect(menuRect);
+    }
+
+    it("keeps the menu in-bounds when anchored near the top-left corner", async () => {
+        const res = await computeMenuPosition(
+            { anchor: { x: 5, y: 5 }, avoidNativePanes: false },
+            menuEl(),
+        );
+        const left = parseInt(res.style.left as string, 10);
+        const top = parseInt(res.style.top as string, 10);
+        expect(left).toBeGreaterThanOrEqual(0);
+        expect(top).toBeGreaterThanOrEqual(0);
+    });
+
+    it("shifts the menu back inside when anchored near the right edge", async () => {
+        const res = await computeMenuPosition(
+            { anchor: { x: VIEWPORT_W - 10, y: 100 }, avoidNativePanes: false },
+            menuEl(),
+        );
+        const left = parseInt(res.style.left as string, 10);
+        // Right edge of the 200px-wide menu must not pass the viewport.
+        expect(left + 200).toBeLessThanOrEqual(VIEWPORT_W);
+    });
+
+    it("flips/shifts the menu up when anchored near the bottom edge", async () => {
+        const res = await computeMenuPosition(
+            { anchor: { x: 100, y: VIEWPORT_H - 10 }, avoidNativePanes: false },
+            menuEl(),
+        );
+        const top = parseInt(res.style.top as string, 10);
+        expect(top + 300).toBeLessThanOrEqual(VIEWPORT_H);
+    });
+
+    it("keeps the menu in-bounds anchored near the bottom-right corner", async () => {
+        const res = await computeMenuPosition(
+            {
+                anchor: { x: VIEWPORT_W - 10, y: VIEWPORT_H - 10 },
+                avoidNativePanes: false,
+            },
+            menuEl(),
+        );
+        const left = parseInt(res.style.left as string, 10);
+        const top = parseInt(res.style.top as string, 10);
+        expect(left + 200).toBeLessThanOrEqual(VIEWPORT_W);
+        expect(top + 300).toBeLessThanOrEqual(VIEWPORT_H);
+    });
+
+    it("emits a position:fixed style", async () => {
+        const res = await computeMenuPosition(
+            { anchor: { x: 100, y: 100 }, avoidNativePanes: false },
+            menuEl(),
+        );
+        expect(res.style.position).toBe("fixed");
+    });
+});
+
+describe("computeMenuPosition — native pane avoidance (§9)", () => {
+    it("offsets the menu away from a synthetic native-pane rect", async () => {
+        // Pane covers the right half of the viewport. A menu anchored just
+        // left of the pane edge must land entirely inside the left free
+        // strip (right edge <= 600), not behind the pane.
+        mountNativePane(makeRect(600, 0, 600, VIEWPORT_H));
+        const menu = elementWithRect(makeRect(0, 0, 200, 300));
+
+        const res = await computeMenuPosition(
+            { anchor: { x: 580, y: 100 }, avoidNativePanes: true },
+            menu,
+        );
+        const left = parseInt(res.style.left as string, 10);
+        expect(left + 200).toBeLessThanOrEqual(600);
+    });
+
+    it("ignores native panes when avoidNativePanes is false", async () => {
+        // Same pane, but avoidance off — the menu may extend past x=600 since
+        // only the viewport clamps it. It must still stay within the viewport.
+        mountNativePane(makeRect(600, 0, 600, VIEWPORT_H));
+        const menu = elementWithRect(makeRect(0, 0, 200, 300));
+
+        const res = await computeMenuPosition(
+            { anchor: { x: 580, y: 100 }, avoidNativePanes: false },
+            menu,
+        );
+        const left = parseInt(res.style.left as string, 10);
+        // Allowed to overlap the pane region; only the viewport bounds it.
+        expect(left + 200).toBeLessThanOrEqual(VIEWPORT_W);
+        expect(left + 200).toBeGreaterThan(600);
+    });
+});
+
+describe("computeMenuPosition — too-tall menu shrink (§5.2 step 1)", () => {
+    it("clamps maxHeight below the menu's natural height", async () => {
+        // A 200x2000 menu cannot fit in an 800px viewport — size() must emit
+        // a maxHeight well under 2000 so the menu scrolls internally.
+        const tallMenu = elementWithRect(makeRect(0, 0, 200, 2000));
+        const res = await computeMenuPosition(
+            { anchor: { x: 100, y: 400 }, avoidNativePanes: false },
+            tallMenu,
+        );
+        expect(res.maxHeight).toBeLessThan(2000);
+        expect(res.maxHeight).toBeLessThanOrEqual(VIEWPORT_H);
+        expect(res.maxHeight).toBeGreaterThan(0);
+    });
+
+    it("clamps maxHeight further when a native pane shrinks the free area", async () => {
+        // Pane covers the bottom half → free strip is only 400px tall.
+        mountNativePane(makeRect(0, 400, VIEWPORT_W, 400));
+        const tallMenu = elementWithRect(makeRect(0, 0, 200, 2000));
+        const res = await computeMenuPosition(
+            { anchor: { x: 100, y: 50 }, avoidNativePanes: true },
+            tallMenu,
+        );
+        expect(res.maxHeight).toBeLessThanOrEqual(400);
+    });
+});

--- a/frontend/app/util/menu-position.ts
+++ b/frontend/app/util/menu-position.ts
@@ -31,6 +31,17 @@ export interface MenuPositionRequest {
     placement?: Placement;
     /** Minimum gap from the anchor and from any paintable edge. Default 8. */
     gutter?: number;
+    /**
+     * Cross-axis nudge (px) — shifts the menu perpendicular to its placement
+     * side, exactly like Floating UI's `offset({ crossAxis })`. Default 0.
+     */
+    offsetCrossAxis?: number;
+    /**
+     * Alignment-axis nudge (px) — overrides {@link offsetCrossAxis} for aligned
+     * (`*-start` / `*-end`) placements, like Floating UI's
+     * `offset({ alignmentAxis })`. Default: unset (crossAxis applies).
+     */
+    offsetAlignmentAxis?: number;
     /** Treat native browser-pane rects as boundaries. Default true. */
     avoidNativePanes?: boolean;
 }
@@ -268,7 +279,8 @@ function virtualReference(rect: DOMRect): { getBoundingClientRect: () => DOMRect
 
 /**
  * Run the fixed floating-ui middleware stack (spec §5.1 step 2):
- * offset(gutter) → flip() → shift({padding:gutter}) → size().
+ * offset({mainAxis:gutter, crossAxis, alignmentAxis}) → flip() →
+ * shift({padding:gutter}) → size().
  *
  * When `avoidNativePanes` is true, every overflow-detecting middleware uses the
  * paintable area's largest free rect as `boundary` — this is the line that
@@ -314,7 +326,11 @@ export async function computeMenuPosition(
         strategy: "fixed",
         placement,
         middleware: [
-            offset(gutter),
+            offset({
+                mainAxis: gutter,
+                crossAxis: request.offsetCrossAxis ?? 0,
+                alignmentAxis: request.offsetAlignmentAxis,
+            }),
             flip({ ...overflowOpts }),
             shift({ ...overflowOpts }),
             size({

--- a/frontend/app/util/menu-position.ts
+++ b/frontend/app/util/menu-position.ts
@@ -1,0 +1,343 @@
+// Copyright 2026, AgentMux Corp.
+// SPDX-License-Identifier: Apache-2.0
+
+// Menu positioning framework — Phase 1 primitive.
+//
+// Implements SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20 §5: one hook every
+// DOM menu routes through so menus offset away from BOTH window edges and
+// native browser-pane child windows (which paint above the host webview's
+// DOM and would otherwise clip/occlude a menu placed "inside the window").
+//
+// Phase 1 ships the primitive only — nothing calls it yet except the unit
+// tests. Migration of FlyoutMenu/Popover/etc. is Phase 2-3.
+
+import {
+    autoUpdate,
+    computePosition,
+    flip,
+    offset,
+    shift,
+    size,
+    type Placement,
+} from "@floating-ui/dom";
+import { createSignal, type JSX } from "solid-js";
+
+// ── Public types (spec §5) ──────────────────────────────────────────────────
+
+export interface MenuPositionRequest {
+    /** Element rect, a raw DOMRect, or a click point. */
+    anchor: HTMLElement | DOMRect | { x: number; y: number };
+    /** Preferred side; flips to the opposite side of the anchor if it doesn't fit. */
+    placement?: Placement;
+    /** Minimum gap from the anchor and from any paintable edge. Default 8. */
+    gutter?: number;
+    /** Treat native browser-pane rects as boundaries. Default true. */
+    avoidNativePanes?: boolean;
+}
+
+export interface MenuPositionResult {
+    /** position:fixed + left/top — the computed offset, applied. */
+    style: JSX.CSSProperties;
+    /** Side chosen after any flip. */
+    placement: Placement;
+    /** Cap when the menu is taller than the free space (internal scroll). */
+    maxHeight: number;
+    /** Cap when the menu is wider than the free space. */
+    maxWidth: number;
+}
+
+const DEFAULT_GUTTER = 8;
+
+// ── Native-pane rectangles (spec §5.3) ───────────────────────────────────────
+
+/**
+ * Rectangles of native child windows that paint ABOVE the host webview's DOM.
+ *
+ * Browser panes are `CefBrowserView` instances — native OS child windows, not
+ * iframes — so a DOM menu overlapping one is drawn behind it. Editor panes are
+ * CodeMirror rendered into a DOM `<div>` inside the webview (verified against
+ * `frontend/app/view/editor/editor-view.tsx`: `new EditorView({...})` with
+ * `@codemirror/*` extensions), so they do NOT occlude DOM menus and are NOT
+ * included here.
+ *
+ * Geometry source: the layout reducer tracks per-block node *sizes*, but not
+ * directly the on-screen client rects in DOM-pixel space. The browser pane's
+ * own resize path (`browser-view.tsx`) derives its rect from a stable
+ * `.browser-placeholder` element via `getBoundingClientRect()`. We mirror that:
+ * query every `.browser-placeholder` in the document and measure it. This is
+ * the exact rect the host already syncs to the native HWND, so it is the
+ * authoritative on-screen geometry. Measured once per menu-open (cheap — a
+ * tab rarely has more than ~6 panes; spec §10 risk row 5).
+ */
+export function getNativePaneRects(): DOMRect[] {
+    if (typeof document === "undefined") return [];
+    const rects: DOMRect[] = [];
+    // `.browser-placeholder` is the wrapper div whose getBoundingClientRect()
+    // browser-view.tsx feeds to `browser_pane_resize` — i.e. the live pane rect.
+    const panes = document.querySelectorAll<HTMLElement>(".browser-placeholder");
+    panes.forEach((el) => {
+        const r = el.getBoundingClientRect();
+        // Skip zero-area placeholders (pane not yet created / detached tab).
+        if (r.width > 0 && r.height > 0) rects.push(r);
+    });
+    return rects;
+}
+
+// ── Paintable area (spec §5.1 step 3, §10 risk row 1) ────────────────────────
+
+function makeRect(x: number, y: number, width: number, height: number): DOMRect {
+    // DOMRect.fromRect isn't in every jsdom build — construct a plain rect.
+    return {
+        x,
+        y,
+        width,
+        height,
+        top: y,
+        left: x,
+        right: x + width,
+        bottom: y + height,
+        toJSON() {
+            return { x, y, width, height };
+        },
+    } as DOMRect;
+}
+
+function intersects(a: DOMRect, b: DOMRect): boolean {
+    return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+}
+
+function area(r: DOMRect): number {
+    return Math.max(0, r.width) * Math.max(0, r.height);
+}
+
+/**
+ * The window viewport minus native-pane rects, plus the largest inscribed
+ * axis-aligned free rectangle.
+ *
+ * floating-ui's `boundary` accepts a single rect, but "viewport minus N panes"
+ * is generally not one rect (spec §10 risk row 1). Heuristic for v1: take the
+ * bounding union of all panes, then test the four viewport sub-regions around
+ * that union (the strips above / below / left / right of the union) plus the
+ * full viewport when no pane intersects it; pick the largest free one. This is
+ * an approximation — it does not find the true maximal empty rectangle — but it
+ * is correct for the common AgentMux layouts (panes tiled against an edge) and
+ * cheap. The §5.1-step-5 residual check (Phase 2+) catches leftover overlap.
+ */
+export function getPaintableArea(): { rects: DOMRect[]; largestFreeRect: DOMRect } {
+    const vw = typeof window !== "undefined" ? window.innerWidth : 0;
+    const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+    const viewport = makeRect(0, 0, vw, vh);
+    const rects = getNativePaneRects();
+
+    // No panes — the whole viewport is paintable.
+    if (rects.length === 0) {
+        return { rects, largestFreeRect: viewport };
+    }
+
+    // Bounding union of every pane rect, clamped to the viewport.
+    let uL = Infinity, uT = Infinity, uR = -Infinity, uB = -Infinity;
+    for (const r of rects) {
+        uL = Math.min(uL, r.left);
+        uT = Math.min(uT, r.top);
+        uR = Math.max(uR, r.right);
+        uB = Math.max(uB, r.bottom);
+    }
+    uL = Math.max(0, uL);
+    uT = Math.max(0, uT);
+    uR = Math.min(vw, uR);
+    uB = Math.min(vh, uB);
+
+    // Candidate free strips around the pane union.
+    const candidates: DOMRect[] = [
+        makeRect(0, 0, vw, uT), // strip above the union
+        makeRect(0, uB, vw, vh - uB), // strip below the union
+        makeRect(0, 0, uL, vh), // strip left of the union
+        makeRect(uR, 0, vw - uR, vh), // strip right of the union
+    ];
+
+    // Keep candidates that are non-degenerate and don't intersect any pane.
+    let best = candidates[0];
+    let bestArea = -1;
+    for (const c of candidates) {
+        if (c.width <= 0 || c.height <= 0) continue;
+        if (rects.some((p) => intersects(c, p))) continue;
+        const a = area(c);
+        if (a > bestArea) {
+            bestArea = a;
+            best = c;
+        }
+    }
+
+    // Fallback: panes cover every strip (e.g. a centered pane). Use the
+    // viewport itself — Phase 2's residual check / shrink handles the rest.
+    if (bestArea < 0) {
+        return { rects, largestFreeRect: viewport };
+    }
+    return { rects, largestFreeRect: best };
+}
+
+// ── Anchor resolution (spec §5.1 step 1) ─────────────────────────────────────
+
+function isPoint(a: MenuPositionRequest["anchor"]): a is { x: number; y: number } {
+    return (
+        typeof (a as { x?: unknown }).x === "number" &&
+        typeof (a as { y?: unknown }).y === "number" &&
+        typeof (a as { width?: unknown }).width !== "number"
+    );
+}
+
+/** Resolve any anchor form to a DOMRect. Point → zero-size rect at x/y. */
+function resolveAnchorRect(anchor: MenuPositionRequest["anchor"]): DOMRect {
+    if (anchor instanceof HTMLElement) {
+        return anchor.getBoundingClientRect();
+    }
+    if (isPoint(anchor)) {
+        return makeRect(anchor.x, anchor.y, 0, 0);
+    }
+    return anchor as DOMRect;
+}
+
+// ── The hook (spec §5, §5.1) ─────────────────────────────────────────────────
+
+/**
+ * SolidJS hook — accessor in, accessor out (matches the `() => T` signal
+ * convention in flyoutmenu.tsx / popover.tsx).
+ *
+ * The returned accessor yields the latest {@link MenuPositionResult}. To get
+ * live updates (flip/shift on scroll/resize), call `register(floatingEl)` with
+ * the menu's DOM node once it mounts — mirrors the `registerFloating` +
+ * `autoUpdate` pattern in flyoutmenu.tsx:57-64. `register` returns a cleanup
+ * fn; the caller should also invoke it (or rely on the menu unmounting) to
+ * stop the autoUpdate loop.
+ *
+ * Usage:
+ *   const pos = useMenuPosition(() => ({ anchor: btn }));
+ *   <div ref={pos().register} style={pos().style}>...</div>
+ */
+export interface UseMenuPositionResult extends MenuPositionResult {
+    /** Attach the floating menu element; starts an autoUpdate loop. Returns cleanup. */
+    register: (floatingEl: HTMLElement) => () => void;
+}
+
+export function useMenuPosition(
+    req: () => MenuPositionRequest,
+): () => UseMenuPositionResult {
+    const [result, setResult] = createSignal<MenuPositionResult>({
+        style: { position: "fixed", left: "0px", top: "0px" },
+        placement: req().placement ?? "bottom-start",
+        maxHeight: typeof window !== "undefined" ? window.innerHeight : 0,
+        maxWidth: typeof window !== "undefined" ? window.innerWidth : 0,
+    });
+
+    let floatingEl: HTMLElement | null = null;
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const compute = async (): Promise<void> => {
+        if (!floatingEl) return;
+        const computed = await computeMenuPosition(req(), floatingEl);
+        setResult(computed);
+    };
+
+    const register = (el: HTMLElement): (() => void) => {
+        floatingEl = el;
+        const anchor = req().anchor;
+        const referenceEl =
+            anchor instanceof HTMLElement
+                ? anchor
+                : virtualReference(resolveAnchorRect(anchor));
+        cleanupAutoUpdate?.();
+        cleanupAutoUpdate = autoUpdate(referenceEl, el, () => {
+            void compute();
+        });
+        return () => {
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = null;
+            floatingEl = null;
+        };
+    };
+
+    return () => ({ ...result(), register });
+}
+
+// ── Core computation — exported for direct/test use ─────────────────────────
+
+/** floating-ui accepts a virtual element exposing getBoundingClientRect. */
+function virtualReference(rect: DOMRect): { getBoundingClientRect: () => DOMRect } {
+    return { getBoundingClientRect: () => rect };
+}
+
+/**
+ * Run the fixed floating-ui middleware stack (spec §5.1 step 2):
+ * offset(gutter) → flip() → shift({padding:gutter}) → size().
+ *
+ * When `avoidNativePanes` is true, every overflow-detecting middleware uses the
+ * paintable area's largest free rect as `boundary` — this is the line that
+ * makes flip/shift offset away from native panes, not just window edges.
+ *
+ * Async because computePosition is async; callers (and tests) await it.
+ */
+export async function computeMenuPosition(
+    request: MenuPositionRequest,
+    floatingEl: HTMLElement,
+): Promise<MenuPositionResult> {
+    const gutter = request.gutter ?? DEFAULT_GUTTER;
+    const avoidNativePanes = request.avoidNativePanes ?? true;
+    const placement = request.placement ?? "bottom-start";
+
+    const anchorRect = resolveAnchorRect(request.anchor);
+    const reference =
+        request.anchor instanceof HTMLElement
+            ? request.anchor
+            : virtualReference(anchorRect);
+
+    // boundary: the paintable area's largest free rect when avoiding panes;
+    // otherwise the raw window viewport. We pass an explicit Rect in both
+    // cases (rather than leaning on floating-ui's default "clippingAncestors")
+    // so overflow detection is deterministic — clippingAncestors walks the DOM
+    // and is unreliable for a portal'd, not-yet-laid-out menu. A plain Rect is
+    // a valid floating-ui Boundary.
+    const viewportRect = makeRect(
+        0,
+        0,
+        typeof window !== "undefined" ? window.innerWidth : 0,
+        typeof window !== "undefined" ? window.innerHeight : 0,
+    );
+    const boundary = avoidNativePanes
+        ? getPaintableArea().largestFreeRect
+        : viewportRect;
+    const overflowOpts = { boundary: { ...boundary } as DOMRect, padding: gutter };
+
+    let maxHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+    let maxWidth = typeof window !== "undefined" ? window.innerWidth : 0;
+
+    const computed = await computePosition(reference as Element, floatingEl, {
+        strategy: "fixed",
+        placement,
+        middleware: [
+            offset(gutter),
+            flip({ ...overflowOpts }),
+            shift({ ...overflowOpts }),
+            size({
+                ...overflowOpts,
+                apply({ availableWidth, availableHeight }) {
+                    // Capture the free space so a too-tall/wide menu can scroll
+                    // internally instead of being placed partly outside (§5.2
+                    // step 1 — shrink).
+                    maxHeight = Math.max(0, Math.floor(availableHeight));
+                    maxWidth = Math.max(0, Math.floor(availableWidth));
+                },
+            }),
+        ],
+    });
+
+    return {
+        style: {
+            position: "fixed",
+            left: `${Math.round(computed.x)}px`,
+            top: `${Math.round(computed.y)}px`,
+        },
+        placement: computed.placement,
+        maxHeight,
+        maxWidth,
+    };
+}

--- a/frontend/app/util/menu-position.ts
+++ b/frontend/app/util/menu-position.ts
@@ -341,3 +341,84 @@ export async function computeMenuPosition(
         maxWidth,
     };
 }
+
+// ── Dev-mode guard (spec §6.1) ───────────────────────────────────────────────
+
+/** True only in dev builds. Vite static-replaces `import.meta.env.DEV`, so the
+ *  whole guard body is dead-code-eliminated from release bundles. */
+function isDevBuild(): boolean {
+    try {
+        return import.meta.env.DEV === true;
+    } catch {
+        return false;
+    }
+}
+
+/** Elements that have already logged a violation this open — debounce so the
+ *  guard logs at most once per element per open (spec §10 risk row 4). A
+ *  WeakSet keeps no element alive past unmount. */
+const guardedElements = new WeakSet<HTMLElement>();
+
+/**
+ * Dev-only runtime assertion (spec §6.1): one RAF after a menu opens, measure
+ * its rect and confirm the whole body lands inside the paintable area — i.e.
+ * within the window and not behind a native browser-pane child window. Any
+ * violation is a `console.error` tagged `[menu-guard]` (surfaces via
+ * `muxlog host '[menu-guard]'`).
+ *
+ * Zero-cost in release builds: the `isDevBuild()` gate is static-replaced to
+ * `false` by Vite and the whole body is dropped. Callers still gate the call
+ * site too so the RAF schedule itself is elided.
+ *
+ * @param el    the menu's floating DOM node
+ * @param label short identifier for the menu surface, e.g. "flyout-menu"
+ */
+export function assertMenuInPaintableArea(el: HTMLElement, label: string): void {
+    if (!isDevBuild()) return;
+    if (typeof requestAnimationFrame === "undefined") return;
+    requestAnimationFrame(() => {
+        if (!el.isConnected) return;
+        if (guardedElements.has(el)) return;
+
+        const rect = el.getBoundingClientRect();
+        // A not-yet-laid-out menu reports a zero rect — skip, RAF was too early.
+        if (rect.width <= 0 || rect.height <= 0) return;
+
+        const vw = typeof window !== "undefined" ? window.innerWidth : 0;
+        const vh = typeof window !== "undefined" ? window.innerHeight : 0;
+
+        const violations: string[] = [];
+
+        // 1. Window edges.
+        if (rect.left < 0) violations.push(`left edge (left=${Math.round(rect.left)})`);
+        if (rect.top < 0) violations.push(`top edge (top=${Math.round(rect.top)})`);
+        if (rect.right > vw) {
+            violations.push(`right edge (right=${Math.round(rect.right)} > ${vw})`);
+        }
+        if (rect.bottom > vh) {
+            violations.push(`bottom edge (bottom=${Math.round(rect.bottom)} > ${vh})`);
+        }
+
+        // 2. Native-pane rects — a menu overlapping one is drawn behind it.
+        for (const pane of getNativePaneRects()) {
+            if (intersects(rect, pane)) {
+                violations.push(
+                    `behind native pane (pane ${Math.round(pane.left)},` +
+                        `${Math.round(pane.top)} ${Math.round(pane.width)}x` +
+                        `${Math.round(pane.height)})`,
+                );
+            }
+        }
+
+        if (violations.length > 0) {
+            guardedElements.add(el);
+            // eslint-disable-next-line no-console
+            console.error(
+                `[menu-guard] "${label}" rendered outside the paintable area: ` +
+                    violations.join("; ") +
+                    ` — menu rect ${Math.round(rect.left)},${Math.round(rect.top)} ` +
+                    `${Math.round(rect.width)}x${Math.round(rect.height)}`,
+            );
+        }
+    });
+}

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -20,6 +20,8 @@ import { atoms, createBlock, getApi } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { invokeCommand } from "@/app/platform/ipc";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
+import { computeMenuPosition } from "@/app/util/menu-position";
+import { autoUpdate } from "@floating-ui/dom";
 import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
 import "./action-widgets.scss";
@@ -133,14 +135,14 @@ ActionWidget.displayName = "ActionWidget";
 const MoreDropdown = ({
     widgets,
     onClose,
-    pos,
+    anchor,
     settings,
     wmap,
     ref,
 }: {
     widgets: () => { key: string; widget: WidgetConfigType }[];
     onClose: () => void;
-    pos: () => { top: number; right: number };
+    anchor: () => HTMLElement | null;
     settings: () => Record<string, any>;
     wmap: () => Record<string, WidgetConfigType>;
     ref?: (el: HTMLDivElement) => void;
@@ -150,6 +152,39 @@ const MoreDropdown = ({
     // dropdown so DOM renders above the pane in this rect.
     // See `frontend/app/platform/pane-overlay.ts`.
     usePaneOverlay(() => overlayEl);
+
+    // Positioning routes through the shared primitive (Phase 3): anchored to
+    // the More button, preferred placement bottom-end (right-aligned, as
+    // before). flip/shift/size + the paintable-area boundary replace the old
+    // hand-rolled `window.innerWidth - rect.right` clamp.
+    const [floatingStyle, setFloatingStyle] = createSignal<JSX.CSSProperties>({
+        position: "fixed",
+        left: "0px",
+        top: "0px",
+    });
+    let cleanupAutoUpdate: (() => void) | null = null;
+
+    const registerFloating = (el: HTMLDivElement) => {
+        overlayEl = el;
+        ref?.(el);
+        requestAnimationFrame(() => {
+            const anchorEl = anchor();
+            if (!(anchorEl instanceof Element) || !(el instanceof Element)) return;
+            const update = async () => {
+                const a = anchor();
+                if (!a) return;
+                const pos = await computeMenuPosition(
+                    { anchor: a, placement: "bottom-end", gutter: 4 },
+                    el,
+                );
+                setFloatingStyle(pos.style);
+            };
+            cleanupAutoUpdate?.();
+            cleanupAutoUpdate = autoUpdate(anchorEl, el, update);
+        });
+    };
+
+    onCleanup(() => cleanupAutoUpdate?.());
 
     const handleItemClick = (widget: WidgetConfigType) => {
         handleWidgetSelect(widget);
@@ -177,12 +212,10 @@ const MoreDropdown = ({
 
     return (
         <div
-            ref={(el) => {
-                overlayEl = el;
-                ref?.(el);
-            }}
+            ref={registerFloating}
             class="action-widget-more-dropdown"
-            style={{ position: "fixed", top: `${pos().top}px`, right: `${pos().right}px` }}
+            style={floatingStyle()}
+            data-pane-overlay
         >
             <For each={widgets()}>
                 {({ key, widget }) => (
@@ -233,18 +266,11 @@ const ActionWidgets = (): JSX.Element => {
 
     // More dropdown state
     const [moreOpen, setMoreOpen] = createSignal(false);
-    const [morePos, setMorePos] = createSignal<{ top: number; right: number }>({ top: 0, right: 0 });
     let moreButtonRef!: HTMLDivElement;
     let moreDropdownRef: HTMLDivElement | undefined;
 
-    const openMore = (e: MouseEvent) => {
-        if (moreOpen()) {
-            setMoreOpen(false);
-            return;
-        }
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-        setMorePos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-        setMoreOpen(true);
+    const openMore = (_e: MouseEvent) => {
+        setMoreOpen(!moreOpen());
     };
 
     const closeMore = () => setMoreOpen(false);
@@ -499,7 +525,7 @@ const ActionWidgets = (): JSX.Element => {
                     <MoreDropdown
                         widgets={moreWidgets}
                         onClose={closeMore}
-                        pos={morePos}
+                        anchor={() => moreButtonRef ?? null}
                         settings={settings}
                         wmap={wmap}
                         ref={(el) => (moreDropdownRef = el)}

--- a/frontend/app/window/action-widgets.tsx
+++ b/frontend/app/window/action-widgets.tsx
@@ -20,7 +20,10 @@ import { atoms, createBlock, getApi } from "@/store/global";
 import { fireAndForget, isBlank, makeIconClass } from "@/util/util";
 import { invokeCommand } from "@/app/platform/ipc";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
-import { computeMenuPosition } from "@/app/util/menu-position";
+import {
+    assertMenuInPaintableArea,
+    computeMenuPosition,
+} from "@/app/util/menu-position";
 import { autoUpdate } from "@floating-ui/dom";
 import { createEffect, createSignal, For, onCleanup, onMount, Show, type JSX } from "solid-js";
 import { Portal } from "solid-js/web";
@@ -181,6 +184,8 @@ const MoreDropdown = ({
             };
             cleanupAutoUpdate?.();
             cleanupAutoUpdate = autoUpdate(anchorEl, el, update);
+            // Dev-only paintable-area guard (spec §6.1).
+            assertMenuInPaintableArea(el, "more-dropdown");
         });
     };
 

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -8,6 +8,7 @@
 // the React app bootstraps.
 
 import { invokeCommand, listenEvent } from "@/app/platform/ipc";
+import { computeMenuPosition } from "@/app/util/menu-position";
 import { benchMark } from "@/util/startup-bench";
 
 // Cache for "synchronous" values that are fetched once at startup.
@@ -144,6 +145,10 @@ function showJsContextMenu(
     menuEl.setAttribute("data-pane-overlay", "");
     menuEl.style.left = `${position.x}px`;
     menuEl.style.top = `${position.y}px`;
+    // Hidden until computeMenuPosition places it — avoids a one-frame flash
+    // at the cursor and stops the pane-overlay clip from firing for a
+    // not-yet-positioned menu (visibility:hidden de-registers the rect).
+    menuEl.style.visibility = "hidden";
 
     function renderItems(container: HTMLElement, itemList: NativeContextMenuItem[]) {
         for (const item of itemList) {
@@ -216,16 +221,27 @@ function showJsContextMenu(
 
     renderItems(menuEl, items);
 
-    // Clamp to viewport
     overlay.appendChild(menuEl);
     document.body.appendChild(overlay);
-    const rect = menuEl.getBoundingClientRect();
-    if (rect.right > window.innerWidth) {
-        menuEl.style.left = `${Math.max(0, window.innerWidth - rect.width - 4)}px`;
-    }
-    if (rect.bottom > window.innerHeight) {
-        menuEl.style.top = `${Math.max(0, window.innerHeight - rect.height - 4)}px`;
-    }
+
+    // Position through the shared paintable-area framework. A native browser
+    // pane is an OS child window that paints above the DOM, so a context menu
+    // drawn over one is occluded (the airspace clip is a fragile fallback).
+    // computeMenuPosition flips/shifts/sizes the menu into the free area
+    // around any browser pane, so it lands clear of the pane entirely.
+    void computeMenuPosition(
+        { anchor: { x: position.x, y: position.y }, placement: "bottom-start" },
+        menuEl,
+    ).then((pos) => {
+        if (!menuEl.isConnected) return;
+        if (pos.style.left != null) menuEl.style.left = String(pos.style.left);
+        if (pos.style.top != null) menuEl.style.top = String(pos.style.top);
+        menuEl.style.visibility = "";
+    }).catch(() => {
+        // computeMenuPosition should not throw; if it does, fall back to the
+        // raw cursor position rather than leaving the menu invisible.
+        if (menuEl.isConnected) menuEl.style.visibility = "";
+    });
 }
 
 /**

--- a/frontend/util/cef-api.ts
+++ b/frontend/util/cef-api.ts
@@ -224,13 +224,19 @@ function showJsContextMenu(
     overlay.appendChild(menuEl);
     document.body.appendChild(overlay);
 
-    // Position through the shared paintable-area framework. A native browser
-    // pane is an OS child window that paints above the DOM, so a context menu
-    // drawn over one is occluded (the airspace clip is a fragile fallback).
-    // computeMenuPosition flips/shifts/sizes the menu into the free area
-    // around any browser pane, so it lands clear of the pane entirely.
+    // Position at the cursor via the shared framework — flip/shift/size keep
+    // the menu on-screen near window edges. Unlike FlyoutMenu/Popover, a
+    // right-click context menu MUST appear where the user clicked, so
+    // `avoidNativePanes` is OFF: it is *expected* to land over a browser
+    // pane. The `data-pane-overlay` clip reveals it through the native pane;
+    // holding it visibility:hidden until placed means the clip rect registers
+    // once, at the final position — no flapping, no stale-rect black artifact.
     void computeMenuPosition(
-        { anchor: { x: position.x, y: position.y }, placement: "bottom-start" },
+        {
+            anchor: { x: position.x, y: position.y },
+            placement: "bottom-start",
+            avoidNativePanes: false,
+        },
         menuEl,
     ).then((pos) => {
         if (!menuEl.isConnected) return;

--- a/scripts/check-menu-positioning.sh
+++ b/scripts/check-menu-positioning.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# check-menu-positioning.sh — CI grep gate for the menu positioning framework.
+#
+# SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20 §6.2.
+#
+# Every DOM menu must route its positioning through `useMenuPosition` /
+# `computeMenuPosition` (frontend/app/util/menu-position.ts) so it offsets away
+# from BOTH window edges and native browser-pane child windows. This gate
+# FAILS the build if a raw floating-ui `computePosition(` call appears in
+# `frontend/app/**` outside the sanctioned positioning files — forcing any new
+# menu through the shared primitive instead of re-rolling viewport math (the
+# inconsistency the spec exists to kill).
+#
+# Sanctioned files:
+#   - util/menu-position.ts       the primitive itself
+#   - element/flyoutmenu.tsx      migrated (Phase 2)
+#   - element/popover.tsx         migrated (Phase 2)
+#   - element/tooltip.tsx         spec Q3 — already correct, migration optional
+#
+# Grandfathered (NOT menus — pre-date the spec, out of the menu framework's
+# scope per spec §3's surface inventory; they are autocomplete/search-result
+# dropdowns bound to a text input, not anchored pop-up menus):
+#   - suggestion/suggestion.tsx
+#   - element/search.tsx
+#
+# Usage:
+#   bash scripts/check-menu-positioning.sh
+# Exit 0 = clean, exit 1 = a stray computePosition call was found.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+SEARCH_DIR="frontend/app"
+
+# Files allowed to call computePosition directly. Paths are repo-relative.
+ALLOWLIST=(
+    "frontend/app/util/menu-position.ts"
+    "frontend/app/element/flyoutmenu.tsx"
+    "frontend/app/element/popover.tsx"
+    "frontend/app/element/tooltip.tsx"
+    "frontend/app/suggestion/suggestion.tsx"
+    "frontend/app/element/search.tsx"
+)
+
+is_allowed() {
+    local f="$1"
+    for allowed in "${ALLOWLIST[@]}"; do
+        [[ "$f" == "$allowed" ]] && return 0
+    done
+    return 1
+}
+
+# Collect every file under frontend/app/** containing a `computePosition(` call.
+# grep is the right tool here — this script IS the grep gate.
+matches="$(grep -rln --include='*.ts' --include='*.tsx' 'computePosition(' "$SEARCH_DIR" 2>/dev/null || true)"
+
+violations=()
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    # Normalize ./ prefix and backslashes (Windows git-bash).
+    f="${f#./}"
+    f="${f//\\//}"
+    if ! is_allowed "$f"; then
+        violations+=("$f")
+    fi
+done <<< "$matches"
+
+if [[ ${#violations[@]} -gt 0 ]]; then
+    echo "ERROR: stray computePosition() call(s) outside the sanctioned menu" >&2
+    echo "       positioning files. New menus must route through" >&2
+    echo "       useMenuPosition / computeMenuPosition (frontend/app/util/menu-position.ts)." >&2
+    echo "" >&2
+    for v in "${violations[@]}"; do
+        echo "  - $v" >&2
+        grep -n 'computePosition(' "$v" 2>/dev/null | sed 's/^/      /' >&2 || true
+    done
+    echo "" >&2
+    echo "If this is a genuinely new menu surface: migrate it to useMenuPosition." >&2
+    echo "If it is intentionally exempt: add it to ALLOWLIST in this script with a" >&2
+    echo "comment explaining why (see SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20 §6.2)." >&2
+    exit 1
+fi
+
+echo "OK: no stray computePosition() calls — all menu positioning routes through the framework."
+exit 0


### PR DESCRIPTION
## Summary

Unifies AgentMux's menu positioning. Spec + full implementation (Phases 1-4). Every DOM menu now offsets through one paintable-area-aware primitive.

## Commits

| Commit | Phase |
|---|---|
| spec | Analysis + design — `SPEC_MENU_PAINTABLE_AREA_GUARD_2026_05_20.md` |
| Phase 1 | `useMenuPosition` primitive — `frontend/app/util/menu-position.ts` + 15 tests |
| Phase 2 | FlyoutMenu + Popover migrated; ad-hoc submenu offset deleted |
| Phase 3 | More dropdown + TokenBreakdownPopover migrated |
| Phase 4 | `assertMenuInPaintableArea` dev guard + `check-menu-positioning.sh` CI gate |

## What changed

- **The paintable area** = window viewport **minus** native browser-pane HWND rects. Browser panes are `CefBrowserView` native child windows that paint *above* the DOM — a DOM menu over one is invisible regardless of viewport math. The primitive uses the paintable area (not the viewport) as floating-ui's overflow boundary.
- **One positioner** — `useMenuPosition` / `computeMenuPosition`: fixed `offset`+`flip`+`shift`+`size` middleware. FlyoutMenu, MenuButton, Popover, NotificationPopover, More dropdown, TokenBreakdownPopover all route through it.
- **Deleted** the hand-rolled offset code: FlyoutMenu's one-shot `flipped` submenu flag, the More dropdown's manual `innerWidth - rect.right`, TokenBreakdownPopover's bespoke gutter.
- **Guard** — dev-only `[menu-guard]` runtime assertion + a CI gate (`check:menu-positioning` task) that fails on stray `computePosition` outside sanctioned files.
- Native context menus stay native (correctly exempt).
- Tooltip left as-is (spec Q3 — already correct).

## Status

- [x] `npm run build` green
- [x] `npm test -- menu-position` — 15/15
- [x] `check-menu-positioning.sh` gate passes
- [ ] **Runtime regression testing pending** — the FlyoutMenu/Popover migration changes how every DOM menu positions; needs a `task dev` pass over the spec §9 matrix (menus near window edges, submenus, menu over a browser pane, tiny window). Not yet done.

## Note

The CI gate found two additional `computePosition` callers beyond the spec's inventory — `suggestion.tsx` and `search.tsx` (autocomplete/search popovers). They're currently allowlisted; migrating them is a sensible follow-up (the spec's §3 inventory missed them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)