### PR TITLE
revert: opacity slider live-drag (#947) — it broke window transparency

### DIFF
--- a/.changesets/1779334638-fix-statusbar-opacity-slider-value-updates-live-while-draggi-pb26.md
+++ b/.changesets/1779334638-fix-statusbar-opacity-slider-value-updates-live-while-draggi-pb26.md
@@ -1,5 +1,0 @@
----
-type: patch
----
-
-fix(statusbar): opacity slider value updates live while dragging

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -321,12 +321,6 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                             const win = getObjectValue<WaveWindow>(makeORef("window", entry.windowId));
                             return (win?.meta?.["window:opacity"] as number | undefined) ?? 1.0;
                         };
-                        // While the slider is being dragged, `dragOpacity` holds the
-                        // live value so the thumb + % label track the drag. It's
-                        // cleared on release, after which `currentOpacity()` (the
-                        // persisted meta, written by onChange) is the source again.
-                        const [dragOpacity, setDragOpacity] = createSignal<number | null>(null);
-                        const displayOpacity = () => dragOpacity() ?? currentOpacity();
                         return (
                             <>
                             <div
@@ -429,10 +423,9 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         min={0.35}
                                         max={1.0}
                                         step={0.05}
-                                        value={displayOpacity()}
+                                        value={currentOpacity()}
                                         onInput={(e) => {
                                             const val = parseFloat(e.currentTarget.value);
-                                            setDragOpacity(val);
                                             dispatchWindowOpacity({
                                                 type: "SetWindowOpacity",
                                                 windowId: entry.windowId!,
@@ -442,7 +435,6 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                             });
                                         }}
                                         onChange={(e) => {
-                                            setDragOpacity(null);
                                             const raw = parseFloat(e.currentTarget.value);
                                             const val = Math.round(raw * 100) / 100;
                                             if (!entry.windowId) return;
@@ -461,7 +453,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         }}
                                     />
                                     <span class="instance-panel-opacity-value">
-                                        {Math.round(displayOpacity() * 100)}%
+                                        {Math.round(currentOpacity() * 100)}%
                                     </span>
                                 </div>
                             </Show>


### PR DESCRIPTION
Reverts #947.

## Why

#947 added live value-tracking to the opacity slider (the `%` updating during
drag instead of only on release). It was verified by `tsc` and approved by the
review bots — but **never smoke-tested against the actual feature**, and it
**broke window transparency** entirely.

Confirmed empirically: **v0.37.1 (pre-#947) has working transparency**; builds
carrying #947 do not. The bots can't catch a broken runtime feature — only
dragging the slider and watching the window can.

The live-value display was a cosmetic optimization on top of a working
feature. It is not worth losing transparency, so #947 is reverted to restore
the feature. A future attempt at the value-display tweak must be smoke-tested
end-to-end against transparency before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)