### PR TITLE
fix(build): stamp srv binary with the live post-bump version

### DIFF
--- a/.changesets/1779360895-fix-build-stamp-srv-binary-with-the-live-post-bump-version-30eo.md
+++ b/.changesets/1779360895-fix-build-stamp-srv-binary-with-the-live-post-bump-version-30eo.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(build): stamp srv binary with the live post-bump version

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,8 +180,16 @@ tasks:
         platforms: [windows]
         cmds:
             - cargo build --release -p agentmux-srv
-            - cmd: pwsh -Command "New-Item -ItemType Directory -Force -Path dist/bin | Out-Null; Copy-Item target/release/agentmux-srv.exe dist/bin/agentmux-srv-{{.VERSION}}-windows.x64.exe -Force"
-            - echo "✓ Built agentmux-srv for Windows (dist/bin/agentmux-srv-{{.VERSION}}-windows.x64.exe)"
+            # Read the version LIVE from package.json — `{{.VERSION}}` is frozen
+            # at `task` invocation start, BEFORE `task package`'s auto-bump
+            # runs, so it would stamp the binary with the stale (pre-bump)
+            # version while package-portable.sh resolves the version live.
+            #
+            # The pwsh command is SINGLE-quoted: Task runs cmds through a POSIX
+            # shell, which would otherwise expand `$v` to empty before pwsh
+            # sees it (naming the binary `agentmux-srv--windows.x64.exe`).
+            # Single quotes pass `$v` through literally for pwsh to evaluate.
+            - cmd: pwsh -Command '$v = (Get-Content -Raw package.json | ConvertFrom-Json).version; New-Item -ItemType Directory -Force -Path dist/bin | Out-Null; Copy-Item target/release/agentmux-srv.exe dist/bin/agentmux-srv-$v-windows.x64.exe -Force'
 
     # agentmux-wsh build tasks removed — wsh has been retired.
     # See specs/SPEC_RETIRE_WSH_2026_04_12.md.


### PR DESCRIPTION
## Regression from #949

#949 made `task package` auto-bump the version as its **first** command. But
Task resolves the `{{.VERSION}}` template variable **once at invocation start**
— before that bump runs.

`build:backend:rust:windows` named the srv binary with `{{.VERSION}}` (the
stale, pre-bump version), while `package-portable.sh` resolves the version
*live* (post-bump). The names mismatched and packaging failed:

```
ERROR: dist/bin/agentmux-srv-0.37.4-windows.x64.exe not found — build first
```

## Fix

`build:backend:rust:windows` now reads the version **live from `package.json`**
in the copy step — the same source `package-portable.sh` uses — so both agree
on the post-bump version.

The `dist/bin` path has no spaces, so it needs no quoting. (An earlier in-flight
attempt used `\"` to quote it — invalid PowerShell, which escapes with a
backtick, not a backslash; that broke the `Copy-Item` outright.)

`task dev` is unaffected — it doesn't bump, so live-read and `{{.VERSION}}`
resolve to the same value there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)