### PR TITLE
feat(statusbar): opacity slider % tracks the drag

### DIFF
--- a/.changesets/1779379302-feat-statusbar-opacity-slider-tracks-the-drag-reactive-store-vqdd.md
+++ b/.changesets/1779379302-feat-statusbar-opacity-slider-tracks-the-drag-reactive-store-vqdd.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): opacity slider % tracks the drag (reactive store)

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -22,7 +22,7 @@ import { usePaneOverlay } from "@/app/platform/pane-overlay";
 import { writeText as clipboardWriteText } from "@/util/clipboard";
 import { ObjectService } from "@/store/services";
 import { getObjectValue, makeORef } from "@/store/wos";
-import { dispatchWindowOpacity } from "@/app/store/window-opacity-store";
+import { dispatchWindowOpacity, liveWindowOpacity } from "@/app/store/window-opacity-store";
 import { createMemo, createSignal, For, onCleanup, Show, type JSX } from "solid-js";
 import {
     DISPLAY_NAME_MAX_LEN,
@@ -453,7 +453,14 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                                         }}
                                     />
                                     <span class="instance-panel-opacity-value">
-                                        {Math.round(currentOpacity() * 100)}%
+                                        {/* Live store value tracks the drag tick-by-tick;
+                                            falls back to the persisted meta when the store
+                                            has no entry yet. The slider <input> and its
+                                            onInput/onChange handlers are deliberately
+                                            untouched — only this label is reactive. */}
+                                        {Math.round(
+                                            (liveWindowOpacity(entry.windowId) ?? currentOpacity()) * 100,
+                                        )}%
                                     </span>
                                 </div>
                             </Show>

--- a/frontend/app/store/window-opacity-store.ts
+++ b/frontend/app/store/window-opacity-store.ts
@@ -6,21 +6,27 @@
  * See SPEC_PER_WINDOW_OPACITY_2026-05-14.md §7.2.
  *
  * Responsibilities:
- *   - Hold the reducer's current state.
+ *   - Hold the reducer's current state (a Solid signal, so UI can react to it).
  *   - Route WindowOpacityCommand through `update()`.
  *   - Apply IPC side-effects (setWindowOpacity) for emitted events.
  *     The reducer itself performs no I/O.
  */
 
+import { createSignal } from "solid-js";
+
 import { getApi } from "@/store/global";
 import { update } from "./window-opacity/reducer";
 import { initialState, type WindowOpacityCommand, type WindowOpacityState } from "./window-opacity/types";
 
-let currentState: WindowOpacityState = initialState();
+// Module-level reactive state. A signal (not a plain `let`) so a UI reader —
+// e.g. the status-bar opacity slider's % label — re-runs whenever opacity is
+// dispatched, including on every tick of a slider drag. `dispatchWindowOpacity`
+// is the only writer.
+const [state, setState] = createSignal<WindowOpacityState>(initialState());
 
 export function dispatchWindowOpacity(command: WindowOpacityCommand): void {
-    const { state: nextState, events } = update(currentState, command);
-    currentState = nextState;
+    const { state: nextState, events } = update(state(), command);
+    setState(nextState);
 
     for (const event of events) {
         switch (event.type) {
@@ -45,7 +51,13 @@ export function dispatchWindowOpacity(command: WindowOpacityCommand): void {
     }
 }
 
-/** Read-only snapshot of the current opacity for a window. */
-export function getWindowOpacityState(windowId: string): number {
-    return currentState.opacities[windowId] ?? 1.0;
+/**
+ * Reactive read of the live opacity the store currently holds for a window,
+ * or `undefined` when the store has no entry yet (nothing dispatched for it
+ * this session). Read inside a reactive context (e.g. JSX), it re-runs on
+ * every `dispatchWindowOpacity` — so a slider's % label tracks the drag.
+ */
+export function liveWindowOpacity(windowId: string | undefined): number | undefined {
+    if (!windowId) return undefined;
+    return state().opacities[windowId];
 }


### PR DESCRIPTION
## What

The Instance-panel opacity slider's `%` label updated only on *release*. It now
tracks the drag tick-by-tick.

## How — store-reactive, slider input untouched

The `%` label read `currentOpacity()` — the persisted `window:opacity` meta,
written only by `onChange`. So it lagged the drag.

- **`window-opacity-store.ts`** — the store's state is now a Solid signal (was
  a plain `let`); new reactive `liveWindowOpacity()` accessor.
- **`InstancePanel.tsx`** — the `%` label reads
  `liveWindowOpacity() ?? currentOpacity()`. The store is updated by
  `dispatchWindowOpacity` on every `onInput`, so the label tracks the drag;
  it falls back to the persisted value before any drag.

The slider `<input>`, `onInput`, and `onChange` are **byte-for-byte
unchanged** — the transparency IPC path is not touched.

## Background

This replaces the reverted #947, which implemented the same feature by routing
the slider's `value` through a drag-updating signal. This version changes
**only the label**, never the controlled `<input>`.

## Verification

`tsc` clean. Confirmed in a `task dev` build — transparency and the live `%`
both work.

> Before merge: a portable will be built and launched several times to confirm
> transparency holds across launches (it had an intermittent failure earlier in
> testing — being thorough per the smoke-test-before-merge rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)