### PR TITLE
feat(statusbar): DEV badge on the version chip

### DIFF
--- a/.changesets/1779380831-feat-statusbar-dev-badge-on-the-version-chip-k4sm.md
+++ b/.changesets/1779380831-feat-statusbar-dev-badge-on-the-version-chip-k4sm.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): DEV badge on the version chip

--- a/docs/specs/SPEC_DEV_VERSION_BADGE_2026_05_21.md
+++ b/docs/specs/SPEC_DEV_VERSION_BADGE_2026_05_21.md
@@ -1,0 +1,144 @@
+# SPEC — Build identification in the status bar
+
+**Status:** Draft / for implementation
+**Date:** 2026-05-21
+**Author:** AgentA
+**Area:** `frontend/app/statusbar/StatusBar.tsx` + `.scss`,
+`frontend/app/statusbar/InstancePanel.tsx`, `frontend/types/custom.d.ts`,
+`agentmux-cef/src/commands/platform.rs`, `agentmux-cef/build.rs`
+
+Three small, related features. All make it possible to tell *which build* a
+running window is — a recurring pain when several dev/portable builds run side
+by side.
+
+---
+
+## Current state — there is no real build metadata
+
+`get_about_modal_details` (`platform.rs:123-129`) returns:
+
+```jsonc
+{ "version": version, "buildTime": version, "platform": …, "arch": … }
+```
+
+`buildTime` is **hard-coded to the version string** — it is not a time. So the
+Instance panel's "Build" row (`InstancePanel.tsx:294-298`, renders
+`about().buildTime`) just re-displays the version already shown in the
+"Version" row above it. There is **no commit hash and no build timestamp**
+anywhere in the product. Features B and C add both.
+
+Instance-panel rows today: **Version** → **Build** → **Runtime** (platform ·
+arch).
+
+---
+
+## Feature A — DEV badge on the version chip  ✅ implemented
+
+### Problem
+
+A `task dev` build and a packaged portable show an identical version chip
+(`vX.Y.Z`). With several builds running, there is no way to tell them apart —
+this cost real time when a dev build and a portable were both `v0.37.6`.
+
+### Behavior
+
+When the running build is a dev build, the version chip shows a `DEV` badge to
+the right of the version: `v0.37.6 DEV`. Portables are unchanged. The badge is
+a non-interactive label.
+
+### Implementation (done)
+
+`StatusBar.tsx` — `<Show when={isDev()}><span class="status-version-dev">DEV
+</span></Show>` inside the version button (and the offline-fallback span),
+after `v{version}`. `isDev()` from `@/store/global`. `StatusBar.scss` —
+`.status-version-dev` outlined accent tag.
+
+---
+
+## Feature B — "Build" row shows the commit hash
+
+### Desired
+
+The "Build" row shows the **truncated git commit hash** (`git rev-parse
+--short HEAD`, ~7 chars) of the commit the build was made from — a precise,
+non-redundant build identifier:
+
+```
+ Version   v0.37.6
+ Build     a1b9f3c
+```
+
+### Implementation
+
+1. **`agentmux-cef/build.rs`** — at compile time, run `git rev-parse --short
+   HEAD`; emit `cargo:rustc-env=AGENTMUX_GIT_HASH=<hash>`. Fall back to
+   `"unknown"` if git is unavailable / not a repo (source-tarball builds) —
+   never fail the build. Emit `cargo:rerun-if-changed=.git/HEAD` (+ the active
+   ref) so the hash refreshes when `HEAD` moves. *Optional:* suffix `-dirty`
+   when `git status --porcelain` is non-empty.
+2. **`platform.rs`** — add a `gitHash` field to `get_about_modal_details`,
+   from `env!("AGENTMUX_GIT_HASH")`.
+3. **`AboutModalDetails`** (`custom.d.ts`) — add `gitHash: string`.
+4. **`InstancePanel.tsx`** — the "Build" row renders `about().gitHash`, mono.
+   Keep/add a copy button (the "Version" row already has one).
+
+---
+
+## Feature C — new "Time" row with the build timestamp
+
+### Desired
+
+A new **"Time"** row, positioned **between "Build" and "Runtime"**, showing
+when the build was produced:
+
+```
+ Version   v0.37.6
+ Build     a1b9f3c
+ Time      Jan 3, 2019 8:12AM
+ Runtime   windows · x64
+```
+
+Format: `Jan 3, 2019 8:12AM` — abbreviated month, day with no leading zero,
+full year, 12-hour clock with no leading zero, 2-digit minute, `AM`/`PM` with
+**no space** before it.
+
+### Implementation
+
+1. **`agentmux-cef/build.rs`** — alongside the hash, emit the build time:
+   `cargo:rustc-env=AGENTMUX_BUILD_TIME=<epoch-ms or RFC3339>`.
+2. **`platform.rs`** — make `buildTime` a **real timestamp** at last (from
+   `env!("AGENTMUX_BUILD_TIME")`), not the version string.
+3. **`AboutModalDetails`** — `buildTime` stays, now genuinely a time
+   (epoch-ms `number`, or an ISO `string` — pick one; epoch-ms is simplest to
+   format).
+4. **`InstancePanel.tsx`** — add the "Time" row between "Build" and "Runtime",
+   rendering `about().buildTime` formatted as above.
+
+### Formatting note
+
+No date formatter exists in `frontend/util` today. `Intl.DateTimeFormat`
+(`{month:"short", day:"numeric", year:"numeric", hour:"numeric",
+minute:"2-digit", hour12:true}`) yields `Jan 3, 2019, 8:12 AM` — close, but
+has a comma after the year and a space before `AM`. Strip both to match the
+exact `Jan 3, 2019 8:12AM` target (small helper, co-located with InstancePanel
+or a new `frontend/util` date helper).
+
+---
+
+## Open decisions
+
+1. **`-dirty` suffix** on the hash — include now (recommended; a few lines in
+   `build.rs`, most useful on the dev builds Feature A flags) or defer.
+2. **`buildTime` type** — epoch-ms `number` vs ISO `string`. Spec recommends
+   epoch-ms.
+3. **Hash/time source for `agentmux-srv` / launcher** — out of scope; this spec
+   embeds metadata in the CEF host only (`get_about_modal_details` runs there).
+
+---
+
+## Rollout
+
+- **Feature A** — DEV badge. Trivial, frontend-only. **Implemented.**
+- **Features B + C** — one PR: they share all the plumbing (`build.rs`
+  embedding, `get_about_modal_details`, `AboutModalDetails`, the InstancePanel
+  rows). Build-script + host + shared types.

--- a/frontend/app/statusbar/StatusBar.scss
+++ b/frontend/app/statusbar/StatusBar.scss
@@ -247,6 +247,19 @@
             opacity: 0.6;
             font-size: 0.9em;
         }
+
+        // DEV build marker — distinguishes a `task dev` instance from a
+        // packaged portable at a glance. Gated on isDev() in StatusBar.tsx.
+        .status-version-dev {
+            margin-left: 4px;
+            padding: 0 3px;
+            border: 1px solid var(--accent-color);
+            border-radius: 3px;
+            font-size: 0.85em;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            color: var(--accent-color);
+        }
     }
 }
 

--- a/frontend/app/statusbar/StatusBar.tsx
+++ b/frontend/app/statusbar/StatusBar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { getApi, windowCountAtom, backendStatusAtom } from "@/store/global";
+import { getApi, windowCountAtom, backendStatusAtom, isDev } from "@/store/global";
 import { createEffect, createSignal, onCleanup, Show, type JSX } from "solid-js";
 import { BackendStatus } from "./BackendStatus";
 import { ConfigStatus } from "./ConfigStatus";
@@ -73,6 +73,9 @@ const StatusBar = (): JSX.Element => {
                                 aria-label="Backend offline"
                             >
                                 v{version}
+                                <Show when={isDev()}>
+                                    <span class="status-version-dev">DEV</span>
+                                </Show>
                             </span>
                         }
                     >
@@ -87,6 +90,9 @@ const StatusBar = (): JSX.Element => {
                             aria-expanded={panelOpen()}
                         >
                             v{version}
+                            <Show when={isDev()}>
+                                <span class="status-version-dev">DEV</span>
+                            </Show>
                             <Show when={windowCount() > 1}>
                                 <span class="instance-num"> ({windowCount()})</span>
                             </Show>


### PR DESCRIPTION
## What

The status-bar version chip now shows a **`DEV`** badge to the right of the
version when the build is a dev build:

```
 v0.37.6 DEV      ← task dev
 v0.37.6          ← packaged portable (unchanged)
```

## Why

A `task dev` build and a packaged portable showed an identical chip
(`vX.Y.Z`). With several builds running side by side — routine during
testing — there was no way to tell them apart. This caused real confusion in
the recent opacity investigation (a dev build and a portable were both
`v0.37.6`).

## How

Frontend-only:
- `StatusBar.tsx` — `<Show when={isDev()}>` rendering a `DEV` span inside the
  version button and the offline-fallback span, after `v{version}`. `isDev()`
  is the existing dev-mode flag (`@/store/global`).
- `StatusBar.scss` — `.status-version-dev`, a small outlined accent tag.

Portables are unaffected (`isDev()` is false).

## Spec

Adds `docs/specs/SPEC_DEV_VERSION_BADGE_2026_05_21.md` — this PR is Feature A;
the spec also defines Feature B (Build row → commit hash) and Feature C (a
"Time" row with the real build timestamp), tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)