### PR TITLE
fix(term): route keyboard input through the blockinput wscommand

### DIFF
--- a/.changesets/1779383684-fix-term-route-keyboard-input-through-the-blockinput-wscomma-stgh.md
+++ b/.changesets/1779383684-fix-term-route-keyboard-input-through-the-blockinput-wscomma-stgh.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(term): route keyboard input through the blockinput wscommand so fast typing stays in order

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentmux-bashwrap"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-cef"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "agentmux-common",
  "axum 0.8.9",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-common"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "dirs",
  "serde",
@@ -71,7 +71,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-launcher"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "agentmux-common",
  "chrono",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "agentmux-srv"
-version = "0.37.1"
+version = "0.37.2"
 dependencies = [
  "agentmux-common",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = ["agentmux-srv", "agentmux-cef", "agentmux-launcher", "agentmux-common
 # `version.workspace = true` so a single bump touches one Cargo.toml.
 # RFC #857 Phase 1.
 [workspace.package]
-version = "0.37.1"
+version = "0.37.2"
 
 [profile.release]
 strip = true

--- a/agentmux-srv/src/backend/blockcontroller/shell.rs
+++ b/agentmux-srv/src/backend/blockcontroller/shell.rs
@@ -979,13 +979,12 @@ impl Controller for ShellController {
         match seq {
             None => tx.try_send(input).map_err(|e| format!("send_input: {e}")),
             Some(s) => {
-                // Detect session reset: seq==0 means the TermViewModel restarted,
-                // or the arriving seq is far below expected (e.g. benchmark advanced
-                // next to 1357, user's new TermViewModel is at seq 6).
-                const SESSION_RESET_THRESHOLD: u64 = 64;
-                let large_gap = s < inner.input_seq_next
-                    && inner.input_seq_next - s > SESSION_RESET_THRESHOLD;
-                if (s == 0 && inner.input_seq_next > 0) || large_gap {
+                // Detect session reset: seq==0 means the TermViewModel
+                // restarted and its per-block counter is back at zero.
+                // (A gap-threshold heuristic was tried and removed — a
+                // stale/duplicate packet far behind could falsely trigger
+                // a reset and replay old input.)
+                if s == 0 && inner.input_seq_next > 0 {
                     tracing::info!(
                         block_id = %self.block_id,
                         prev_next = inner.input_seq_next,

--- a/frontend/app/view/term/termViewModel.ts
+++ b/frontend/app/view/term/termViewModel.ts
@@ -7,6 +7,7 @@ import type { PaneVoiceHandle } from "@/app/hook/useVoiceInput";
 import { appHandleKeyDown } from "@/app/store/keymodel";
 import { waveEventSubscribe } from "@/app/store/wps";
 import { RpcApi } from "@/app/store/rpc-api";
+import { sendWSCommand } from "@/app/store/ws";
 import { makeFeBlockRouteId } from "@/app/store/rpc-router";
 import { DefaultRouter, TabRpcClient } from "@/app/store/rpc-util";
 import { TermRpcClient } from "@/app/view/term/term-rpc";
@@ -291,18 +292,18 @@ class TermViewModel implements ViewModel {
         });
 
         // Voice input handle — streams transcript characters into the
-        // PTY via the same controllerinput RPC that keystrokes use, so
+        // PTY via the same blockinput path that keystrokes use, so
         // xterm input modes (echo, line-buffered, etc.) are honored.
         // No interim preview: the terminal has no affordance for it.
         this.voiceHandle = () => ({
             appendFinal: (text: string) => {
                 const inputdata64 = stringToBase64(text);
-                RpcApi.ControllerInputCommand(TabRpcClient, {
+                const cmd: BlockInputWSCommand = {
+                    wscommand: "blockinput",
                     blockid: this.blockId,
                     inputdata64,
-                    signame: "",
-                    termsize: undefined,
-                });
+                };
+                sendWSCommand(cmd);
             },
             setInterim: () => { /* terminal has no preview affordance */ },
         });
@@ -340,8 +341,13 @@ class TermViewModel implements ViewModel {
     }
 
     sendDataToController(data: string) {
-        const b64data = stringToBase64(data);
-        RpcApi.ControllerInputCommand(TabRpcClient, { blockid: this.blockId, inputdata64: b64data });
+        const inputdata64 = stringToBase64(data);
+        // Use the blockinput wscommand, not the controllerinput RPC: blockinput
+        // is processed inline & synchronously in the WS receive loop, so
+        // consecutive keystrokes reach the PTY in TCP order. The RPC path is
+        // dispatched concurrently by the engine and can reorder fast typing.
+        const cmd: BlockInputWSCommand = { wscommand: "blockinput", blockid: this.blockId, inputdata64 };
+        sendWSCommand(cmd);
     }
 
     triggerRestartAtom() {

--- a/frontend/app/view/term/termsticker.tsx
+++ b/frontend/app/view/term/termsticker.tsx
@@ -1,8 +1,7 @@
 // Copyright 2025-2026, AgentMux Corp.
 // SPDX-License-Identifier: Apache-2.0
 
-import { RpcApi } from "@/app/store/rpc-api";
-import { TabRpcClient } from "@/app/store/rpc-util";
+import { sendWSCommand } from "@/app/store/ws";
 import { createBlock } from "@/store/global";
 import { getWebServerEndpoint } from "@/util/endpoints";
 import { stringToBase64 } from "@/util/util";
@@ -82,8 +81,13 @@ function TermSticker(props: { sticker: StickerType; config: StickerTermConfig })
         clickHandler = () => {
             console.log("clickHandler", sticker.clickcmd, sticker.clickblockdef);
             if (sticker.clickcmd) {
-                const b64data = stringToBase64(sticker.clickcmd);
-                RpcApi.ControllerInputCommand(TabRpcClient, { blockid: config.blockId, inputdata64: b64data });
+                const inputdata64 = stringToBase64(sticker.clickcmd);
+                const cmd: BlockInputWSCommand = {
+                    wscommand: "blockinput",
+                    blockid: config.blockId,
+                    inputdata64,
+                };
+                sendWSCommand(cmd);
             }
             if (sticker.clickblockdef) {
                 createBlock(sticker.clickblockdef);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentmux",
-  "version": "0.37.3",
+  "version": "0.37.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentmux",
-      "version": "0.37.3",
+      "version": "0.37.2",
       "license": "Apache-2.0",
       "workspaces": [
         "docs"
@@ -4480,7 +4480,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11828,8 +11827,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "productName": "AgentMux",
   "description": "Open-Source AI-Native Terminal Built for Seamless Workflows",
   "license": "Apache-2.0",
-  "version": "0.37.1",
+  "version": "0.37.2",
   "homepage": "https://github.com/agentmuxai/agentmux",
   "build": {
     "appId": "ai.agentmux.app"


### PR DESCRIPTION
## Problem

Fast typing into a terminal pane produced **out-of-order characters** — keystrokes appeared with variable latency, so the user was already on the next key before the prior one rendered. Slow typing was unaffected. Reproduced across multiple sessions and versions, including v0.37.6 after PR #951.

## Root cause

Keystrokes were sent via the `controllerinput` **RPC**. RPC messages are dispatched through the RPC engine, which runs handlers **concurrently** — two adjacent keystroke RPCs race and can call `send_input` in reversed order.

PR #951 added a seq reorder buffer to compensate, but **the frontend never sent a `seq`** (Codex P1), so the buffer never activated for real typing. It was dead code on the hot path.

## Fix

Switch all keyboard/text input to the `blockinput` **wscommand**:

- `blockinput` is handled **inline and synchronously** in the WS receive loop — `handle_incoming_text` is awaited, so one message is fully processed before the next is read. TCP order is preserved end-to-end. No race, no buffer, no seq.
- Switched: `termViewModel.sendDataToController`, the voice input handle, and term-sticker click-commands.
- `controllerinput` RPC is kept for the SIGINT signal path (`useAgentCommands.ts`) and a future `term.type` agent API.

Also **drops the `gap > 64` session-reset heuristic** in `shell.rs` (Codex P2 on #951): a stale/duplicate packet far behind the expected seq could falsely trigger a reset and replay old input. The explicit `seq == 0` reset is kept.

The reorder buffer itself is left intact for the future `term.type` agent API, which will send many chars at once and genuinely needs ordering.

## Builds on

PR #951 — addresses its Codex P1 (frontend never sends seq) and P2 (gap heuristic misfire) findings.

## Test plan

- [ ] Slow typing: characters in order, no latency
- [ ] Fast typing (hold a key / type a sentence quickly): correct order, no latency spikes
- [ ] Open a new terminal while another is active: both accept input
- [ ] Close and reopen a terminal pane: input still works
- [ ] Voice input into a terminal still reaches the PTY
- [ ] Sticker click-commands still send input

🤖 Generated with [Claude Code](https://claude.com/claude-code)