### PR TITLE
feat(statusbar): Build row shows commit hash + Time row

### DIFF
--- a/.changesets/1779404968-feat-statusbar-build-row-shows-commit-hash-new-time-row-show-np9s.md
+++ b/.changesets/1779404968-feat-statusbar-build-row-shows-commit-hash-new-time-row-show-np9s.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(statusbar): Build row shows commit hash, new Time row shows build timestamp

--- a/agentmux-cef/build.rs
+++ b/agentmux-cef/build.rs
@@ -1,4 +1,19 @@
 fn main() {
+    // Emitting any rerun-if-changed directive disables Cargo's default
+    // "rerun build.rs if any package file changed", so every input is listed
+    // explicitly. The git-ref entries make the embedded commit hash / build
+    // timestamp refresh whenever HEAD moves, even if no package file changed.
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
+    println!("cargo:rerun-if-env-changed=TARGET");
+    for git_path in ["../.git/HEAD", "../.git/refs", "../.git/packed-refs"] {
+        if std::path::Path::new(git_path).exists() {
+            println!("cargo:rerun-if-changed={git_path}");
+        }
+    }
+    #[cfg(target_os = "windows")]
+    println!("cargo:rerun-if-changed=resources/win/agentmux.ico");
+
     // Emit the target triple so we can locate sidecar binaries at runtime.
     println!(
         "cargo:rustc-env=AGENTMUX_TARGET_TRIPLE={}",

--- a/agentmux-cef/build.rs
+++ b/agentmux-cef/build.rs
@@ -5,6 +5,25 @@ fn main() {
         std::env::var("TARGET").unwrap()
     );
 
+    // Embed the git short hash + build timestamp for the Instance panel's
+    // Build / Time rows. Falls back to "unknown" / 0 when git is unavailable
+    // (e.g. building from a source tarball) — never fails the build.
+    let git_hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=AGENTMUX_GIT_HASH={git_hash}");
+
+    let build_time_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(0);
+    println!("cargo:rustc-env=AGENTMUX_BUILD_TIME={build_time_ms}");
+
     // Windows: embed application icon + version info into PE VERSIONINFO resource.
     // FileDescription controls the "Name" column in Task Manager's Processes tab.
     // The actual exe filename controls WER crash dump names and Event Viewer entries.

--- a/agentmux-cef/build.rs
+++ b/agentmux-cef/build.rs
@@ -1,18 +1,13 @@
 fn main() {
-    // Emitting any rerun-if-changed directive disables Cargo's default
-    // "rerun build.rs if any package file changed", so every input is listed
-    // explicitly. The git-ref entries make the embedded commit hash / build
-    // timestamp refresh whenever HEAD moves, even if no package file changed.
-    println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
-    println!("cargo:rerun-if-env-changed=TARGET");
-    for git_path in ["../.git/HEAD", "../.git/refs", "../.git/packed-refs"] {
-        if std::path::Path::new(git_path).exists() {
-            println!("cargo:rerun-if-changed={git_path}");
-        }
-    }
-    #[cfg(target_os = "windows")]
-    println!("cargo:rerun-if-changed=resources/win/agentmux.ico");
+    // No `cargo:rerun-if-changed` directives by design: emitting any of them
+    // disables Cargo's default "rerun build.rs when any package file changes".
+    // That default is exactly what keeps AGENTMUX_GIT_HASH / AGENTMUX_BUILD_TIME
+    // honest — build.rs re-runs whenever agentmux-cef is rebuilt, so the
+    // embedded metadata always describes the binary just produced. A commit
+    // that touches no agentmux-cef file yields no new binary; the prior binary
+    // (carrying its own correct metadata) is what continues to run. An explicit
+    // rerun-if-changed list would instead disable source-tree watching and go
+    // stale on ordinary source edits.
 
     // Emit the target triple so we can locate sidecar binaries at runtime.
     println!(

--- a/agentmux-cef/src/commands/platform.rs
+++ b/agentmux-cef/src/commands/platform.rs
@@ -126,7 +126,8 @@ pub fn get_about_modal_details(state: &Arc<AppState>) -> serde_json::Value {
 
     serde_json::json!({
         "version": version,
-        "buildTime": version,
+        "gitHash": env!("AGENTMUX_GIT_HASH"),
+        "buildTime": env!("AGENTMUX_BUILD_TIME").parse::<i64>().unwrap_or(0),
         "platform": match std::env::consts::OS {
             "macos" => "darwin",
             "windows" => "win32",

--- a/frontend/app/modals/about.tsx
+++ b/frontend/app/modals/about.tsx
@@ -36,7 +36,7 @@ const AboutModal = ({}: AboutModalProps) => {
                     </div>
                     <div class="items-center gap-4 self-stretch w-full text-center">
                         Client Version {details.version} ({isDev() ? "dev-" : ""}
-                        {details.buildTime})
+                        {details.gitHash})
                         <br />
                         Update Channel: {updaterChannel}
                     </div>

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -50,11 +50,26 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         const d = getApi().getAboutModalDetails();
         return {
             version: d?.version ?? "unknown",
-            buildTime: d?.buildTime ? String(d.buildTime) : null,
+            gitHash: (d as any)?.gitHash ?? null,
+            buildTime: typeof d?.buildTime === "number" && d.buildTime > 0 ? d.buildTime : null,
             platform: (d as any)?.platform ?? null,
             arch: (d as any)?.arch ?? null,
         };
     });
+
+    // Build timestamp -> "Jan 3, 2019 8:12AM": abbreviated month, no
+    // leading-zero day/hour, 2-digit minute, AM/PM with no separating space.
+    const formatBuildTime = (ms: number): string => {
+        const s = new Date(ms).toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            hour12: true,
+        });
+        return s.replace(/, (\d{1,2}:\d{2})/, " $1").replace(/\s(AM|PM)$/, "$1");
+    };
 
     const entries = openWindowEntriesAtom;
     const [myLabel, setMyLabel] = createSignal<string | null>(null);
@@ -291,10 +306,18 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
                         ⧉
                     </button>
                 </div>
-                <Show when={about().buildTime}>
+                <Show when={about().gitHash}>
                     <div class="instance-panel-row instance-panel-row-meta">
                         <span class="instance-panel-label">Build</span>
-                        <span class="instance-panel-value instance-panel-mono">{about().buildTime}</span>
+                        <span class="instance-panel-value instance-panel-mono">{about().gitHash}</span>
+                    </div>
+                </Show>
+                <Show when={about().buildTime}>
+                    <div class="instance-panel-row instance-panel-row-meta">
+                        <span class="instance-panel-label">Time</span>
+                        <span class="instance-panel-value instance-panel-mono">
+                            {formatBuildTime(about().buildTime!)}
+                        </span>
                     </div>
                 </Show>
                 <Show when={about().platform || about().arch}>

--- a/frontend/app/statusbar/InstancePanel.tsx
+++ b/frontend/app/statusbar/InstancePanel.tsx
@@ -50,7 +50,7 @@ export const InstancePanel = (props: InstancePanelProps): JSX.Element => {
         const d = getApi().getAboutModalDetails();
         return {
             version: d?.version ?? "unknown",
-            gitHash: (d as any)?.gitHash ?? null,
+            gitHash: d?.gitHash ?? null,
             buildTime: typeof d?.buildTime === "number" && d.buildTime > 0 ? d.buildTime : null,
             platform: (d as any)?.platform ?? null,
             arch: (d as any)?.arch ?? null,

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -475,7 +475,7 @@ declare global {
 
     interface AboutModalDetails {
         version: string;
-        gitHash: string;
+        gitHash?: string;
         buildTime: number;
     }
 

--- a/frontend/types/custom.d.ts
+++ b/frontend/types/custom.d.ts
@@ -475,6 +475,7 @@ declare global {
 
     interface AboutModalDetails {
         version: string;
+        gitHash: string;
         buildTime: number;
     }
 


### PR DESCRIPTION
## What

Implements **Features B + C** of `SPEC_DEV_VERSION_BADGE_2026_05_21.md` (Feature A — the DEV badge — shipped in #955).

The Instance panel's **"Build"** row rendered `buildTime`, and `get_about_modal_details` hard-coded `buildTime` to the **version string** — so "Build" just duplicated the "Version" row above it.

Now:

```
 Version   v0.37.8
 Build     a1b9f3c              ← the commit it was built from
 Time      May 21, 2026 3:45PM  ← when it was built
 Runtime   win32 · x64
```

## How

- **`agentmux-cef/build.rs`** — embeds the git short hash (`AGENTMUX_GIT_HASH`) and a build timestamp (`AGENTMUX_BUILD_TIME`) at compile time. Both fall back gracefully (`unknown` / `0`) if git is unavailable (e.g. a source-tarball build) — never fails the build.
- **`get_about_modal_details`** — returns a real `gitHash` and a real `buildTime` (epoch ms). `buildTime` was previously the version string.
- **`AboutModalDetails`** — adds `gitHash: string`.
- **`InstancePanel.tsx`** — "Build" row → commit hash; new "Time" row between Build and Runtime → build timestamp formatted `Jan 3, 2019 8:12AM` (a small `Intl.DateTimeFormat`-based helper). The row hides if there's no real timestamp.
- **About modal** — shows the commit hash instead of the duplicate version.

## Verify

`tsc` clean. On a real build the rows show the actual commit + build time; on a source build with no git they degrade to `unknown` / hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)