### PR TITLE
fix(magnify): single-instance pane render + nothing visible behind a magnified pane

### DIFF
--- a/.changesets/1779410797-fix-magnify-single-instance-pane-render-fixes-zoom-browser-p-4rem.md
+++ b/.changesets/1779410797-fix-magnify-single-instance-pane-render-fixes-zoom-browser-p-4rem.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(magnify): single-instance pane render — fixes zoom + browser-pane black on restore

--- a/docs/specs/SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md
+++ b/docs/specs/SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md
@@ -1,0 +1,363 @@
+# SPEC: Magnify & Zoom — Implementation Plan
+
+**Date:** 2026-05-21
+**Author:** AgentX
+**Status:** Draft — implementation plan, ready for review
+**Companions:**
+- `SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md` — the defects + default changes (the *what*).
+- `SPEC_MAXIMIZE_ZOOM_ARCHITECTURE_2026-05-21.md` — architecture analysis (the *why*).
+
+This document is the *how*: a phased, file-level implementation plan.
+
+---
+
+## 1. Overview
+
+Four phases, ordered so each lands independently and de-risks the next.
+Phase 0 ships the user-visible default changes immediately; Phases 1–2 are
+mechanical de-duplication that shrink the surface; Phase 3 is the real fix
+for the magnify zoom regression and the browser-pane black/stuck failure;
+Phase 4 is optional cleanup.
+
+| Phase | Goal | Risk | Blocks |
+|-------|------|------|--------|
+| 0 | Magnified-pane defaults (full-window, 100% opacity) | Low | — |
+| 1 | Collapse the `zoom.*` platform split | Low | — |
+| 2 | Extract a shared `TileLayout` core | Medium | 1 |
+| 3 | Single-instance magnified render + browser-pane robustness | High | 2 |
+| 4 | Consolidate the zoom module | Low | 1 |
+
+Each phase = one PR = one changeset. Phases 0/1/4 can land in parallel;
+3 should land on top of 2 so the fix is written once, not pasted ×3.
+
+---
+
+## 2. Guiding principles
+
+1. **One render per pane.** A pane is one `Block` component instance.
+   "Magnified" is a position/size *state* of that instance, never a second
+   instance.
+2. **Native panes are reducer-owned.** Browser-pane create/resize/close flow
+   through the host reducer (`HostState.browser_panes`). The DOM never races
+   the reducer for geometry or lifecycle.
+3. **No behavioural change without a test.** Every phase ships regression
+   tests; Phase 3 ships the magnify→restore tests in the companion spec §2.6.
+4. **De-duplicate before fixing.** The magnify fix is written once, in shared
+   code — never pasted into three `TileLayout.*.tsx` files.
+
+---
+
+## 3. Phase 0 — Magnified-pane defaults
+
+**Goal:** magnified pane covers the whole window and is fully opaque.
+Independent of the refactor; ship first.
+
+### 3.1 Changes
+
+| File | Change |
+|------|--------|
+| `frontend/layout/lib/TileLayout.win32.tsx:263` | `magnifiedBlockSizeAtom() ?? 0.9` → `?? 1.0` |
+| `frontend/layout/lib/TileLayout.linux.tsx:234` | same |
+| `frontend/layout/lib/TileLayout.darwin.tsx:232` | same |
+| `frontend/app/block/block.scss:308` | `--magnified-block-opacity: 0.95` → `1` |
+
+`window:magnifiedblocksize` / `window:magnifiedblockopacity` stay
+`Option<f64>` (default `None`) in `agentmux-srv/.../wconfig/types.rs` — the
+frontend fallbacks *are* the defaults, so no backend change.
+
+> Note: the three `?? 0.9` edits collapse to **one** site after Phase 2. If
+> Phase 2 lands first, Phase 0's size change is a single-file edit. Ordering
+> 0-before-2 is fine too — just three identical edits.
+
+### 3.2 Acceptance
+
+- Magnify any pane → it fills the window edge-to-edge, no margin gap.
+- Magnified pane background is fully opaque.
+- `window:magnifiedblocksize` / `window:magnifiedblockopacity` still
+  override when a user sets them.
+
+### 3.3 Tests
+
+- Unit: `containerStyle` at size `1.0` yields `margin = 0`,
+  `width/height = 100%`.
+
+---
+
+## 4. Phase 1 — Collapse the `zoom.*` platform split
+
+**Goal:** delete ~370 lines of byte-identical duplication. The three
+`zoom.{win32,linux,darwin}.ts` files differ only in header comments
+(verified by `diff`); all executable code is identical. Platform behaviour
+lives entirely in `window-header.{scss,darwin.scss}`.
+
+### 4.1 Changes
+
+- Rename `frontend/app/store/zoom.win32.ts` → `zoom.ts` (canonical content).
+- Delete `zoom.linux.ts`, `zoom.darwin.ts`, `zoom.platform.ts`.
+- Update importers of `@/store/zoom.platform` (`app.tsx`, `keymodel.ts`,
+  any others) to import `@/store/zoom`.
+- Fold the platform-specific *comments* that were in each variant into one
+  block comment in `zoom.ts` so the WebKitGTK / macOS notes are not lost.
+
+### 4.2 Pre-check (do this first)
+
+Confirm Vite's `platformResolve` plugin tolerates a plain, non-suffixed
+module — i.e. a `zoom.ts` with no `.platform`/`.win32` sibling resolves
+normally. If the plugin *requires* the suffix pattern for any path it has
+seen before, either (a) keep a one-line `zoom.platform.ts` re-exporting
+`./zoom`, or (b) patch the plugin. Decide before writing the deletion.
+
+### 4.3 Acceptance
+
+- `task build:frontend` succeeds on all three platforms.
+- Zoom (keyboard + wheel, pane + chrome) behaves identically to before on
+  Windows; smoke-check Linux/macOS if available.
+
+### 4.4 Tests
+
+- Existing zoom tests pass against the single module.
+
+---
+
+## 5. Phase 2 — Extract a shared `TileLayout` core
+
+**Goal:** stop the magnify fix from being a three-file paste.
+`TileLayout.{win32,linux,darwin}.tsx` are ~730–840 lines, ~75–90 % shared.
+The magnify-relevant pieces — `MagnifiedPaneOverlay`, `DisplayNode`'s
+magnify logic, `DisplayNodesWrapper` — are copy-pasted verbatim ×3.
+
+### 5.1 Changes
+
+- New `frontend/layout/lib/TileLayout.shared.tsx` containing the
+  platform-identical components/helpers. Start with the magnify surface
+  (`MagnifiedPaneOverlay`, `DisplayNodesWrapper`, and the magnify branch of
+  `DisplayNode`); migrate more later as a follow-up.
+- `TileLayout.{win32,linux,darwin}.tsx` import from `TileLayout.shared.tsx`
+  and keep **only** genuine platform deltas: Win32 launcher wiring, Win32
+  drag-preview image generation, the double-click-maximize target wiring,
+  and any confirmed platform-specific markup.
+
+### 5.2 Method (avoid silent platform regressions)
+
+1. `diff` win32↔linux and linux↔darwin. Classify every differing line as
+   *intentional* (launcher, drag-preview, dblclick) or *drift* (comments,
+   formatting, stale copies).
+2. Move only lines that are byte-identical across all three into
+   `TileLayout.shared.tsx`.
+3. For intentionally-divergent pieces, expose a prop / injection point on
+   the shared component rather than forking it.
+4. Land Phase 2 as a **pure refactor** — no behavioural change, existing
+   layout tests must pass untouched.
+
+### 5.3 Acceptance
+
+- All three `TileLayout.*.tsx` build; layout/tile tests pass unchanged.
+- No visual or behavioural diff in tiling, dragging, splitting, magnify.
+
+### 5.4 Tests
+
+- Existing `frontend/layout/tests/layoutModel.test.ts` and drag/tile tests
+  pass with zero edits.
+
+---
+
+## 6. Phase 3 — Single-instance magnified render + browser-pane robustness
+
+**Goal:** fix the magnify zoom regression *and* the browser-pane
+black/stuck failure, at the root, in shared code. This is the core phase.
+
+### 6.1 Root cause recap
+
+Today the magnified pane is rendered **twice**: `DisplayNode` keeps the
+tile `<Block>` mounted (`tile-hidden` = `visibility:hidden`) and
+`MagnifiedPaneOverlay` calls `renderContent` to mount a **second** `<Block>`
+for the same `blockId`. Two `Block`s share one `blockId`-keyed registry
+slot and (for browser panes) one native window. The overlay copy's
+`onCleanup` on restore deletes the registry slot / disposes the view model
+/ fires `browser_pane_close`. See companion spec §2.
+
+### 6.2 Design — reparent one instance, do not re-render
+
+Render the pane's `<Block>` **once** and *move its DOM node* between the
+tile slot and the magnify overlay slot. Moving a DOM subtree with
+`appendChild` does **not** dispose a SolidJS component (its lifecycle is
+tied to the reactive owner, not DOM position) — so the `Block`, its
+`ViewModel`, its registry entry, and (critically) the single
+`.browser-placeholder` and the native browser window all survive the
+magnify/restore transition untouched.
+
+Concretely:
+
+1. **`MagnifiedPaneOverlay` stops rendering content.** It becomes a
+   positioned, styled container only (backdrop + `.magnify-container` with
+   `containerStyle`). On mount it publishes its inner mount element to the
+   layout model, e.g. `layoutModel.setMagnifyMount(el)` /
+   `layoutModel.magnifyMountAtom()`. Remove the `renderContent(nodeModel)`
+   call (`TileLayout.win32.tsx:300` and platform twins / shared).
+
+2. **`DisplayNode` owns a stable content wrapper.** `leafContent()` renders
+   into a wrapper `<div class="tile-leaf">` that is created once. The
+   `<Block>` lives inside it, unconditionally, for the node's whole life.
+
+3. **Reparent on magnify state change.** An effect in `DisplayNode`:
+   ```
+   createEffect(() => {
+     const mount = layoutModel.magnifyMountAtom();
+     if (isMagnified() && mount) mount.appendChild(wrapperEl);
+     else tileNodeRef.appendChild(wrapperEl);   // back to the tile
+   });
+   ```
+   On restore the wrapper is reparented to the tile *before* the overlay
+   `<Show>` tears down (the effect runs on the `isMagnified()` flip, which
+   precedes the overlay unmount), so the wrapper is never destroyed with
+   the overlay.
+
+4. **Drop the `tile-hidden` twin.** With a single instance there is no
+   hidden duplicate; `tile-hidden` / the `.magnify-pane` content slot are
+   removed. The empty tile node may keep a placeholder box for layout
+   stability while magnified — confirm during implementation.
+
+### 6.3 Browser-pane specifics (companion arch spec §4.A′)
+
+Single-instance render already gives browser panes **one**
+`.browser-placeholder`, **one** `browser_pane_create`, **one**
+`browser_pane_close`, and **one** geometry authority — the reparent moves
+that single placeholder, and its `ResizeObserver` + 200 ms interval then
+report the magnified rect (and the tile rect again on restore). The
+HWND-flicker and the destroy-on-restore both disappear.
+
+Two added guarantees:
+
+- **No close on a magnify transition.** Verify the reparent keeps the
+  `BrowserViewComponent` subtree mounted (no unmount → no `onCleanup` →
+  no `browser_pane_close`). Add an explicit test asserting the host
+  `browser_panes` entry stays `Live` across magnify→restore.
+- **Defensive recovery.** In `browser-view.tsx`, if the component is
+  mounted with `paneCreated() === true` but a host query reports the
+  `block_id` is `Closed`/absent, call `createPane` again. This uses the
+  host reducer's existing three-way `TryRegisterBrowserPaneLive`
+  (`Fresh`/`AlreadyLive`/`Closing`) signal and guarantees a pane can never
+  be permanently black even if a future change reintroduces a race.
+
+### 6.4 Files
+
+| File | Change |
+|------|--------|
+| `frontend/layout/lib/TileLayout.shared.tsx` | `MagnifiedPaneOverlay` → container-only; publishes mount node. `DisplayNode` → stable wrapper + reparent effect; remove `tile-hidden` twin |
+| `frontend/layout/lib/layoutModel.ts` | Add `magnifyMount` atom + `setMagnifyMount` (mount-node handoff) |
+| `frontend/layout/lib/tilelayout.scss` | Remove `.tile-node.tile-hidden` / `.magnify-pane`; keep `.magnify-container` |
+| `frontend/app/view/browser/browser-view.tsx` | Defensive recreate-if-`Closed`; confirm no close on reparent |
+| `frontend/layout/lib/TileLayout.{win32,linux,darwin}.tsx` | Drop now-shared magnify code (consumed from shared) |
+
+No host Rust change is expected — the reducer already de-dupes create and
+the single-instance render removes the spurious close. *If* validation shows
+the reparent cannot keep the subtree mounted on some platform, escalate to
+the arch-spec §6 fallback (a reducer-tracked `relocate` that keeps the entry
+`Live`); that *would* add a host reducer command.
+
+### 6.5 Acceptance (companion spec §2.6)
+
+- **Terminal/agent/swarm pane:** magnify → restore → `Ctrl +`, `Ctrl -`,
+  `Ctrl+scroll` all zoom that pane. Repeat ×5. View model never disposed
+  while on screen.
+- **Browser pane:** magnify → restore → pane stays live (not black), keeps
+  URL/scroll, tracks the tile rect again. Repeat ×5.
+- While magnified, exactly one rect drives `browser_pane_resize` (no
+  flicker).
+- Magnify still renders above other panes (z-order correct).
+
+### 6.6 Tests
+
+- `getBlockComponentModel(blockId)` returns a live model after a simulated
+  magnify→restore cycle.
+- Host `browser_panes[block_id]` stays `Live` across magnify→restore (Rust
+  reducer test, alongside the existing lifecycle tests in `browser_panes.rs`).
+- `browser-view.tsx`: recreate path fires when host reports `Closed`.
+
+### 6.7 Risks
+
+- **Subtree-preserving reparent.** The whole fix depends on `appendChild`
+  moving the `<Block>` DOM without SolidJS disposing it. Prototype this in
+  isolation first; if it disposes, use the §6 fallback.
+- **Non-magnified browser panes during magnify.** Native browser HWNDs
+  paint above DOM, so a browser pane in another tile could show above a
+  magnified DOM pane. Verify the host hides/occludes non-magnified browser
+  panes while something is magnified — this may be pre-existing behaviour;
+  confirm, file a follow-up if not.
+- **Effect ordering.** The reparent effect must see `magnifyMountAtom()`
+  populated before it runs on magnify-on. Guard for `mount == null`.
+
+---
+
+## 7. Phase 4 — Consolidate the zoom module (optional follow-up)
+
+**Goal:** one zoom module, one dispatch path. Currently zoom has four
+entrypoints (keyboard via `keymodel`, wheel via an ad-hoc `window` listener
+in `app.tsx`) and two domains (pane vs chrome) interleaved.
+
+### 7.1 Changes
+
+- `zoom.ts` exposes a small, explicit surface: `paneZoom.{in,out,reset}`,
+  `chromeZoom.{in,out,reset}`, and one pane-resolution helper.
+- Route the wheel path (`AppZoomHandler`) and the keyboard path
+  (`keymodel.ts`) through that surface so clamps, steps, and the zoom
+  indicator live in one place.
+
+Lower priority; do after Phase 3 stabilises. Not required for the bug fix.
+
+---
+
+## 8. Testing strategy (cross-cutting)
+
+- **Unit** — `containerStyle` (Phase 0); zoom module (Phase 1/4); reparent
+  registry survival (Phase 3).
+- **Rust reducer** — `browser_panes` stays `Live` across magnify→restore
+  (Phase 3), beside the existing Live→Closing lifecycle tests.
+- **Manual matrix** — for Phase 3, the magnify→restore cycle ×5 on each pane
+  type: terminal, agent, swarm, browser, editor. Browser is the critical
+  case; editor is DOM-rendered (CodeMirror) so behaves like terminal.
+- **Platform** — Phase 1/2 need a build check on all three platforms;
+  Phase 3 behaviour is platform-shared after Phase 2 but still smoke-test
+  Win32 (native HWND path) primarily.
+
+---
+
+## 9. PR & changeset plan
+
+Per `CLAUDE.md`: feature PRs use the changesets workflow
+(`task changeset -- patch "..."`); do **not** bump `package.json` /
+`Cargo.toml`.
+
+| PR | Phase | Changeset summary |
+|----|-------|-------------------|
+| 1 | 0 | `fix(magnify): magnified pane fills the window and is fully opaque` |
+| 2 | 1 | `refactor(zoom): collapse the identical zoom platform split into one module` |
+| 3 | 2 | `refactor(layout): extract shared TileLayout core` |
+| 4 | 3 | `fix(magnify): single-instance magnified render — fixes zoom + browser-pane black/stuck` |
+| 5 | 4 | `refactor(zoom): consolidate zoom entrypoints` (optional) |
+
+PRs 1, 2, 5 are independent and can land in any order. PR 3 precedes PR 4.
+Each goes through the normal review path (reagent + codex).
+
+---
+
+## 10. Rollback & sequencing notes
+
+- Phases 0/1/2/4 are low-risk and individually revertable.
+- Phase 3 is the behavioural change; if a regression surfaces, reverting
+  PR 4 restores the (buggy but known) duplicate-render behaviour without
+  touching Phases 0–2.
+- If Phase 2 slips, Phase 3 can still ship by pasting the fix into the three
+  `TileLayout.*.tsx` files — explicitly discouraged, but unblocks the fix.
+
+---
+
+## 11. Out of scope
+
+- Window-maximize focus loss after `SW_RESTORE` (arch spec P5) — separate
+  follow-up; add a `window-state-change` event then.
+- The `useWindowDrag.*` platform split — fold into Phase 2 only if cheap;
+  otherwise a later cleanup.
+- Magnified-pane blur (`window:magnifiedblockblur*px`) — unchanged.
+- Renaming "magnify" vs "maximize" terminology (arch spec §4.E) — user-facing
+  string change; needs product sign-off, tracked separately.

--- a/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
+++ b/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
@@ -234,24 +234,27 @@ panes. There is no `.magnified` opacity rule anywhere in `block.scss`.
 
 ### 4.2 Change
 
-Two parts:
+A magnified pane is made **fully opaque, unconditionally** — two solid
+layers, neither depending on a CSS variable resolving:
 
-1. **Add the missing rule.** In `block.scss`, give a magnified pane an
-   opaque inner background:
-   ```scss
-   &.magnified .block-frame-default-inner {
-       background-color: rgb(from var(--block-bg-color) r g b / var(--magnified-block-opacity));
-   }
-   ```
-   This is what actually makes a magnified pane honor an opacity at all.
-2. **Default the var to fully opaque.** `--magnified-block-opacity`
-   `0.95` → `1` (`block.scss:308`). It stays shared with the existing
-   `&.ephemeral` rule — a 0.95→1 shift for ephemeral panes is imperceptible
-   and not worth a separate variable.
+1. **Magnify overlay base.** `tilelayout.scss` `.magnify-pane` gets
+   `background-color: rgb(from var(--block-bg-color) r g b)` — the theme
+   colour with no alpha (fully opaque). This is the slot the single pane
+   instance is reparented into, so it backs the whole magnified area.
+2. **Block inner.** `block.scss` `&.magnified .block-frame-default-inner`
+   gets the same opaque `rgb(from var(--block-bg-color) r g b)`, so the
+   pane's own frame is opaque too (headers, rounded corners, browser-pane
+   edges).
 
-`window:magnifiedblockopacity` stays `Option<f64>` (`types.rs:164`,
-default `None`), so the CSS var fallback is the effective default and the
-setting still overrides — no backend change required.
+`rgb(from <color> r g b)` with the alpha omitted yields a fully opaque
+colour — so the result does not depend on `--magnified-block-opacity`
+resolving (an earlier var-based attempt failed when the var was out of
+scope, leaving the declaration invalid and dropped).
+
+The `--magnified-block-opacity` variable / `window:magnifiedblockopacity`
+setting were never actually wired to magnified panes (only `.ephemeral`),
+and remain so — left untouched. A configurable magnified-pane opacity, if
+ever wanted, is a separate feature; the requirement here is simply 100%.
 
 The blur (`--magnified-block-blur: 10px`,
 `window:magnifiedblockblur*px`) is **out of scope** — left unchanged unless

--- a/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
+++ b/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
@@ -1,0 +1,270 @@
+# SPEC: Magnify zoom regression + magnified-pane defaults
+
+**Date:** 2026-05-21
+**Author:** AgentX
+**Status:** Draft — investigation complete, implementation pending
+
+---
+
+## 1. Summary
+
+Three related changes to the pane *magnify* feature (the maximize button in
+the pane header, top-right):
+
+1. **Bug fix** — after a pane is magnified then restored, that pane is left
+   in a broken state. Two failure modes, one root cause:
+   - **Terminal / agent / swarm panes** — per-pane zoom (`Ctrl +/-` and
+     `Ctrl+scroll`) stops working *for that pane*; the pane otherwise works.
+   - **Browser panes** — far worse: the pane goes **black and stuck** (the
+     native browser window is destroyed and never recreated).
+   Panes that were never magnified are unaffected.
+2. **Default change** — a magnified pane currently leaves a margin gap; it
+   should cover the entire window.
+3. **Default change** — a magnified pane is currently slightly translucent;
+   it should be fully opaque (100%).
+
+Items 2 and 3 are setting-default changes only. Item 1 is a real defect.
+The architectural backdrop — including the reducer system and why browser
+panes need special treatment — is in the companion
+`SPEC_MAXIMIZE_ZOOM_ARCHITECTURE_2026-05-21.md`.
+
+---
+
+## 2. Bug: zoom dies on a magnified-then-restored pane
+
+### 2.1 Symptom
+
+Magnify any pane via its header button, then restore it. After restore,
+`Ctrl +`, `Ctrl -`, and `Ctrl+scroll` no longer zoom that pane. Reproduces
+100% of the time, with any pane. Other panes still zoom normally.
+
+### 2.2 Root cause — duplicate `Block` render sharing one registry entry
+
+The magnify feature renders the magnified pane **twice**:
+
+- `frontend/layout/lib/TileLayout.win32.tsx:502` — the original tile node
+  stays mounted and merely gets the `tile-hidden` CSS class while magnified
+  (`class={clsx("tile-node", { "tile-hidden": isMagnified() })}`).
+- `frontend/layout/lib/TileLayout.win32.tsx:260` `MagnifiedPaneOverlay` —
+  renders the *same node* a second time via
+  `props.layoutModel.renderContent(nodeModel)` (line 300), into a separate
+  overlay container "outside display-container to avoid stacking context
+  issues".
+
+So while magnified there are **two live `Block` components for the same
+`blockId`**.
+
+`Block` (`frontend/app/block/block.tsx:290`) registers itself in a
+**`blockId`-keyed map**:
+
+- `createEffect` (line 302) → `registerBlockComponentModel(blockId, { viewModel })`
+- `onCleanup` (line 314) → `unregisterBlockComponentModel(blockId)` **and**
+  `viewModel()?.dispose()`
+
+`blockComponentModelMap` is keyed by `blockId` alone
+(`frontend/app/store/global.ts:680-687`), so the two `Block` instances share
+**one** map entry.
+
+Lifecycle of the shared entry:
+
+| Step | Event | `blockComponentModelMap[blockId]` |
+|------|-------|-----------------------------------|
+| 1 | Tile `Block` mounts | `{ viewModel: vm1 }` |
+| 2 | Magnify → overlay `Block` mounts; its effect finds `vm1`, reuses it (no re-register) | `{ viewModel: vm1 }` |
+| 3 | Restore → overlay `Block` unmounts → `onCleanup`: `unregisterBlockComponentModel(blockId)` **deletes the entry** and `viewModel().dispose()` **disposes `vm1`** | *(deleted)* |
+| 4 | Tile `Block` is still mounted but never re-runs its effect (view type unchanged) → never re-registers | *(still deleted)* |
+
+After restore the registry has **no entry** for that `blockId`, and the
+shared view model `vm1` has been disposed. The tile `Block` keeps rendering
+visually (it still holds `vm1` in its local signal), which is why the pane
+*looks* fine — but anything that resolves the pane *through the registry* is
+now broken.
+
+### 2.3 Why this kills zoom specifically
+
+Both zoom paths resolve the pane through `getBlockComponentModel`:
+
+- Keyboard: `keymodel.ts:655` `Ctrl:=` → `zoomIn()` →
+  `zoom.win32.ts:109` → `getBlockZoom()` →
+  `getBlockComponentModel(blockId)` → `zoom.win32.ts:59`.
+- Wheel: `app.tsx:268` `Ctrl+scroll` → `zoomBlockIn(blockId)` →
+  `getBlockZoom()` → same lookup.
+
+`getBlockZoom` (`zoom.win32.ts:58`):
+
+```ts
+const bcm = getBlockComponentModel(blockId);
+if (!bcm?.viewModel) return null;        // ← registry entry gone → null
+```
+
+`zoomIn` / `zoomBlockIn` early-return when `getBlockZoom` returns `null`, so
+both zoom gestures become silent no-ops. The pane keeps working otherwise
+because it renders off the still-held (though disposed) `vm1`, not the
+registry.
+
+This also explains why only the magnified-then-restored pane is affected:
+its registry entry is the only one that got deleted.
+
+### 2.4 Browser panes — the same defect, but destructive
+
+A browser pane is a native `CefBrowserView` child window, not DOM. Its DOM
+side (`browser-view.tsx`) renders only a `.browser-placeholder`; the native
+pane is created on mount (`browser_pane_create`), tracked to the placeholder
+rect via `browser_pane_resize` (a `ResizeObserver` + a 200 ms interval), and
+**closed on unmount (`browser_pane_close`)**. Lifecycle is coupled 1:1 to the
+`BrowserViewComponent` mount/unmount cycle.
+
+Apply the §2.2 duplicate render to that:
+
+1. **Magnify** → the overlay mounts a *second* `BrowserViewComponent` for the
+   same `block_id`. The host reducer's `TryRegisterBrowserPaneLive` returns
+   `AlreadyLive`, so no second native window is created — but now **two
+   `.browser-placeholder` nodes drive geometry**: `tile-hidden` is
+   `visibility: hidden` (the node keeps its layout box), so the still-mounted
+   tile placeholder reports the *tile* rect while the overlay placeholder
+   reports the *magnified* rect. Their two 200 ms intervals fire
+   `browser_pane_resize` alternately → the native HWND is yanked between the
+   tile rect and the magnified rect.
+2. **Restore** → the overlay `BrowserViewComponent` unmounts → its
+   `onCleanup` fires `browser_pane_close` → the host reducer flips the
+   *shared* `block_id` entry `Live → Closing` and **destroys the native
+   window**.
+3. The tile `BrowserViewComponent` is still mounted, still believes
+   `paneCreated === true`. `createPane` runs only once (in `onMount`) so the
+   pane is **never recreated**. Its resize calls hit a `Closing`/destroyed
+   pane and are no-op'd by the reducer.
+
+→ The browser pane is **black** (native window destroyed, no compositor) and
+**stuck** (no recreate path). Same root cause as the zoom bug — the
+duplicate `Block` render — but for browser panes it destroys the pane
+because the native-window lifecycle is mount-coupled.
+
+### 2.5 Fix options
+
+**Option A (recommended) — render the magnified pane as a single instance.**
+Do not mount a second `Block`. Instead, render the magnified node exactly
+once and *reposition* it into the overlay (e.g. SolidJS `<Portal>` the
+existing tile `DisplayNode`'s content into the overlay container, or move the
+DOM node). One `Block` → one registry entry → no unregister-on-restore.
+`tile-hidden` becomes unnecessary for the magnified node. This removes the
+whole class of duplicate-render bugs but touches the magnify render path in
+all three `TileLayout.*.tsx` files.
+
+**Option B (terminal-only mitigation) — make registration duplicate-safe.**
+Give each `Block` mount an identity token. `unregisterBlockComponentModel`
+deletes the entry only if the caller is the current owner; the surviving
+duplicate re-registers itself when it becomes the sole instance; `dispose()`
+runs only when the last instance unmounts. This fixes the *zoom* symptom for
+terminal/agent/swarm panes — but it does **not** fix browser panes (§2.4):
+the two `.browser-placeholder` nodes still fight over `browser_pane_resize`
+while magnified, and the mount-coupled `browser_pane_close` can still destroy
+the native window. Option B is insufficient.
+
+**Recommendation: Option A — and it is mandatory, not preferred.** The
+duplicate render is the underlying defect. Only a single render instance
+gives one registry entry, one `.browser-placeholder`, one
+`browser_pane_create`/`close`. Option B papers over the zoom symptom and
+leaves browser panes broken. See the companion architecture spec §4.A / §4.A′
+for the single-instance design and the browser-pane reducer guarantees.
+
+### 2.6 Acceptance criteria
+
+- **Terminal/agent/swarm pane:** magnify, restore, then `Ctrl +`, `Ctrl -`,
+  `Ctrl+scroll` all zoom that pane. Repeat several times — zoom keeps
+  working. The shared view model is not disposed while the pane is on screen.
+- **Browser pane:** magnify, restore — the pane stays live (not black), keeps
+  its URL/scroll, and tracks the tile rect again. Repeat several times.
+- While a browser pane is magnified, only one rect drives
+  `browser_pane_resize` (no 0×0 / magnified-rect flicker).
+- Regression tests: after a simulated magnify→restore cycle,
+  `getBlockComponentModel(blockId)` still returns a live model; the host
+  `browser_panes` entry for that `block_id` is still `Live` (never
+  transitioned to `Closing`).
+
+---
+
+## 3. Default change: magnified pane covers the whole window
+
+### 3.1 Current behaviour
+
+`MagnifiedPaneOverlay` sizes the magnified pane from the
+`window:magnifiedblocksize` setting, **defaulting to `0.9`**:
+
+- `TileLayout.win32.tsx:263` — `magnifiedBlockSizeAtom() ?? 0.9`
+- `TileLayout.linux.tsx:234`, `TileLayout.darwin.tsx:232` — same.
+
+`containerStyle` (`TileLayout.win32.tsx:282`) then centres it:
+
+```ts
+const size = magnifiedNodeSize();          // 0.9
+const margin = ((1 - size) / 2) * 100;     // 5
+// top/left = 5%, width/height = 90%
+```
+
+→ a 5% margin on every side. That is the gap the user sees.
+
+### 3.2 Change
+
+Change the effective default of `window:magnifiedblocksize` from `0.9` to
+`1.0` in all three `TileLayout.*.tsx` files (`?? 0.9` → `?? 1.0`). At `1.0`,
+`margin` computes to `0` and the pane fills the overlay container.
+
+The setting itself is retained — a user can still set a smaller value. Only
+the default changes. `window:magnifiedblocksize` is `Option<f64>` in the
+backend (`agentmux-srv/src/backend/wconfig/types.rs:167`, default `None`), so
+the frontend fallback *is* the default; no backend change is required.
+
+---
+
+## 4. Default change: magnified pane opacity 100%
+
+### 4.1 Current behaviour
+
+The magnified block's background opacity comes from
+`--magnified-block-opacity`, declared in
+`frontend/app/block/block.scss:308` as **`0.95`**, consumed at
+`block.scss:312` (`background-color: rgb(... / var(--magnified-block-opacity))`).
+`blockframe.tsx:754` overrides it inline from the
+`window:magnifiedblockopacity` setting when that setting is present;
+when unset, the `0.95` fallback applies.
+
+### 4.2 Change
+
+Change the `--magnified-block-opacity` default in `block.scss:308` from
+`0.95` to `1` (fully opaque). `window:magnifiedblockopacity` is likewise
+`Option<f64>` in the backend (`types.rs:164`, default `None`), so this CSS
+fallback is the effective default; no backend change required.
+
+The blur (`--magnified-block-blur: 10px`,
+`window:magnifiedblockblur*px`) is **out of scope** — left unchanged unless
+the user asks.
+
+---
+
+## 5. Files touched (implementation checklist)
+
+| Concern | File | Change |
+|--------|------|--------|
+| Magnify bug (Option A) | `frontend/layout/lib/TileLayout.{win32,linux,darwin}.tsx` | Single-instance magnified render — no duplicate `Block` mount (see arch spec §4.A) |
+| Browser-pane robustness | `frontend/app/view/browser/browser-view.tsx`; verify host `browser_panes` reducer | One `.browser-placeholder` drives geometry; no `browser_pane_close` on a magnify transition; optional recreate-if-`Closed` recovery (arch spec §4.A′) |
+| Regression tests | `frontend/layout/tests/`, browser-pane tests | Registry survives magnify→restore; host `browser_panes` entry stays `Live` |
+| Cover whole window | `frontend/layout/lib/TileLayout.win32.tsx:263`, `TileLayout.linux.tsx:234`, `TileLayout.darwin.tsx:232` | `?? 0.9` → `?? 1.0` |
+| Opacity 100% | `frontend/app/block/block.scss:308` | `--magnified-block-opacity: 0.95` → `1` |
+
+The defaults (size, opacity) are frontend-only. The magnify/browser-pane fix
+is frontend-led but may need a host reducer change if magnify becomes a
+reducer-tracked relocate (arch spec §6). Per `CLAUDE.md`, feature PRs use the
+changesets workflow — add a `task changeset -- patch "..."` entry; do **not**
+bump `package.json`/`Cargo.toml`.
+
+---
+
+## 6. Open questions
+
+- Option A is mandatory (browser panes rule out Option B) — confirm the
+  single-instance render approach (Portal/reparent vs reducer-tracked
+  relocate) per arch spec §6 before implementation.
+- Should `window:magnifiedblocksize` continue to support sub-1.0 values now
+  that the default is full-window, or is the setting effectively retired?
+- Blur on the magnified pane — keep the 10px default, or revisit alongside
+  the opacity change?

--- a/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
+++ b/docs/specs/SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md
@@ -220,20 +220,38 @@ the frontend fallback *is* the default; no backend change is required.
 
 ### 4.1 Current behaviour
 
-The magnified block's background opacity comes from
-`--magnified-block-opacity`, declared in
-`frontend/app/block/block.scss:308` as **`0.95`**, consumed at
-`block.scss:312` (`background-color: rgb(... / var(--magnified-block-opacity))`).
-`blockframe.tsx:754` overrides it inline from the
-`window:magnifiedblockopacity` setting when that setting is present;
-when unset, the `0.95` fallback applies.
+A magnified pane renders translucent: `--block-bg-color` is translucent in
+every theme (`theme.scss` default `rgba(0,0,0,0.5)` — 50%; named themes
+~70%), and a magnified pane has **no opacity override** — so the blurred
+magnify backdrop bleeds through it.
+
+The `--magnified-block-opacity` CSS var *looks* like the control for this,
+but it is misapplied: declared in `block.scss:308` and consumed only by the
+`&.ephemeral` selector (`block.scss:312`) — never by `.magnified`. So
+neither the var's default nor the `window:magnifiedblockopacity` setting
+(`blockframe.tsx:754` feeds the var inline) has ever affected magnified
+panes. There is no `.magnified` opacity rule anywhere in `block.scss`.
 
 ### 4.2 Change
 
-Change the `--magnified-block-opacity` default in `block.scss:308` from
-`0.95` to `1` (fully opaque). `window:magnifiedblockopacity` is likewise
-`Option<f64>` in the backend (`types.rs:164`, default `None`), so this CSS
-fallback is the effective default; no backend change required.
+Two parts:
+
+1. **Add the missing rule.** In `block.scss`, give a magnified pane an
+   opaque inner background:
+   ```scss
+   &.magnified .block-frame-default-inner {
+       background-color: rgb(from var(--block-bg-color) r g b / var(--magnified-block-opacity));
+   }
+   ```
+   This is what actually makes a magnified pane honor an opacity at all.
+2. **Default the var to fully opaque.** `--magnified-block-opacity`
+   `0.95` → `1` (`block.scss:308`). It stays shared with the existing
+   `&.ephemeral` rule — a 0.95→1 shift for ephemeral panes is imperceptible
+   and not worth a separate variable.
+
+`window:magnifiedblockopacity` stays `Option<f64>` (`types.rs:164`,
+default `None`), so the CSS var fallback is the effective default and the
+setting still overrides — no backend change required.
 
 The blur (`--magnified-block-blur: 10px`,
 `window:magnifiedblockblur*px`) is **out of scope** — left unchanged unless

--- a/docs/specs/SPEC_MAXIMIZE_ZOOM_ARCHITECTURE_2026-05-21.md
+++ b/docs/specs/SPEC_MAXIMIZE_ZOOM_ARCHITECTURE_2026-05-21.md
@@ -1,0 +1,339 @@
+# SPEC: Maximize & Zoom — Architecture Analysis
+
+**Date:** 2026-05-21
+**Author:** AgentX
+**Status:** Draft — analysis for discussion
+**Companion:** `SPEC_MAGNIFY_ZOOM_REGRESSION_AND_DEFAULTS_2026-05-21.md`
+(the immediate bug fix + default changes; this doc is the architectural
+backdrop that explains *why* that bug was possible).
+
+---
+
+## 1. Scope
+
+Two feature clusters that overlap in user language and in code:
+
+- **"Maximize"** — actually two unrelated mechanisms sharing one word.
+- **"Zoom"** — one core behaviour reached through four entrypoints.
+
+This document maps the current architecture, names the structural problems
+(duplication, fragmentation, a registry that cannot represent the magnified
+pane), and proposes a target architecture and sequencing.
+
+---
+
+## 2. Current architecture
+
+### 2.1 "Maximize" is two different things
+
+| | Window maximize | Pane magnify |
+|---|---|---|
+| Scope | OS top-level window | One pane inside the tab layout |
+| Trigger | Title-bar button (`system-status.tsx`), double-click title bar (`useWindowDrag.*`), Command Palette (`command-registry.ts` `window:maximize`) | Pane-header button (`blockframe.tsx` `OptMagnifyButton`), `Escape`, backdrop click |
+| Implementation | `agentmux-cef/src/commands/window.rs::maximize_window` → Win32 `ShowWindow(SW_MAXIMIZE/SW_RESTORE)` | `layoutModel.ts` + `layoutMagnify.ts` + `MagnifiedPaneOverlay` in `TileLayout.*.tsx` |
+| State | OS-owned (`WINDOWPLACEMENT`) | `treeState.magnifiedNodeId` |
+| Settings | — | `window:magnifiedblock{size,opacity,blurprimarypx,blursecondarypx}` |
+
+**Naming collision.** The pane-header control is an `OptMagnifyButton`
+(`title: "Magnify"`), but users — reasonably — call it "maximize", and the
+icon set includes `window-maximize`. The reported "maximize breaks zoom" bug
+was *pane magnify*, not window maximize. The codebase should pick one term
+per mechanism and use it everywhere (UI, icons, code).
+
+### 2.2 Zoom — four entrypoints, one core
+
+```
+keyboard  Ctrl +/-/0   keymodel.ts globalKeyMap ─┐
+wheel     Ctrl+scroll  app.tsx AppZoomHandler ────┼─→ zoom.{os}.ts
+                                                  │     ├─ per-pane zoom  (term:zoom block meta)
+                                                  │     └─ chrome zoom    (--zoomfactor CSS var)
+pane resolution ─────────────────────────────────┘
+   getBlockComponentModel(blockId)  ← global.ts blockComponentModelMap
+```
+
+- **Per-pane zoom** scales a terminal/agent/swarm pane's font via the
+  `term:zoom` block-meta value.
+- **Chrome zoom** scales the title bar + status bar via a `--zoomfactor`
+  CSS variable.
+- Both keyboard and wheel paths resolve the target pane through
+  `getBlockComponentModel(blockId)` — a `Map<blockId, model>` in
+  `global.ts`.
+
+### 2.3 Platform split
+
+`zoom`, `TileLayout`, and `useWindowDrag` are each split into
+`.win32` / `.linux` / `.darwin` files plus a `.platform` stub that Vite's
+`platformResolve` plugin rewrites at build time.
+
+### 2.4 Browser panes — a native window, not DOM
+
+A browser pane is **not** rendered DOM. It is a `CefBrowserView` — a native
+OS child window (HWND on Windows) that paints *above* the host webview. The
+DOM side (`browser-view.tsx`) renders only a `.browser-placeholder` div; the
+native pane is positioned to track that div:
+
+- `onMount` → `browser_pane_create` (creates the native HWND, once).
+- A `ResizeObserver` + a 200 ms `setInterval` call `syncPosition`, which
+  reads `placeholderRef.getBoundingClientRect()` and fires
+  `browser_pane_resize` to move/size the native HWND to match.
+- `onCleanup` → `browser_pane_close` (flips the backend pane to `Closing`,
+  destroys the HWND).
+
+So a browser pane's **entire lifecycle is coupled to the
+`BrowserViewComponent` mount/unmount cycle**, and its geometry is driven by a
+single `.browser-placeholder` DOM node.
+
+### 2.5 The reducer system
+
+Browser-pane state is reducer-managed on **both** sides:
+
+- **Host reducer** (`agentmux-cef/src/reducer/mod.rs`) — `HostState.browser_panes:
+  HashMap<block_id, BrowserPaneEntry>` with an explicit `BrowserPaneLifecycle`
+  (`Created/Live → Closing → Closed`). Commands: `TryRegisterBrowserPaneLive`
+  (three-way `Fresh` / `AlreadyLive` / `Closing`), `CompleteBrowserPaneCreate`,
+  `EnqueueBrowserPaneClose`. The reducer is the authority; `browser_panes.rs`
+  is a thin executor. Late IPCs against a `Closing` pane are deliberately
+  no-op'd.
+- **Frontend reducer** (`frontend/app/store/browser-pane-state/`) — slice #9;
+  a pane must be `registerPane`'d synchronously in the `BrowserViewModel`
+  constructor.
+
+The reducer keys panes by `block_id`. It correctly *protects against double
+create* (a second `browser_pane_create` for a live `block_id` returns
+`AlreadyLive`) — but it has **no concept of a pane being presented in two
+surfaces at once**, and a `browser_pane_close` from *either* surface flips the
+single shared entry to `Closing`. Any robustness fix must go *through* the
+reducer, not around it.
+
+---
+
+## 3. Structural problems
+
+### P1 — The pane registry cannot represent a pane rendered twice
+
+`blockComponentModelMap` is keyed by `blockId` alone. The magnify feature
+renders the magnified pane **twice at once** (see P2), so two live `Block`
+components contend for **one** map slot. When the second copy unmounts on
+restore it deletes the shared slot — and the surviving copy never
+re-registers. Result: zoom (and anything else resolving via the registry)
+silently dies for that pane. Full mechanism in the companion bug spec §2.
+
+This is architectural, not incidental: *any* future feature that renders a
+pane in a second surface (picture-in-picture, drag preview, tear-off
+ghost) hits the same wall.
+
+### P2 — Magnify is a second render, not a relocation
+
+`MagnifiedPaneOverlay` (`TileLayout.win32.tsx:260`) calls
+`layoutModel.renderContent(nodeModel)` to draw the magnified pane a second
+time, into an overlay container, while the original tile node stays mounted
+under a `tile-hidden` CSS class. So the magnified pane has **two component
+trees, two `ViewModel` mount cycles, two registry mounts** for one logical
+pane. On restore the overlay copy's cleanup disposes the *shared* view model
+and clears the registry slot.
+
+The magnified pane is the *same pane* — it should be the *same component
+instance*, merely repositioned. The current design was chosen "to avoid
+stacking-context issues that prevent z-index working on tile-nodes" — a real
+constraint (see Risks §6), but it traded a CSS problem for a lifecycle bug.
+
+### P3 — Large platform-split duplication
+
+| Module | Files | Total LOC | Actual divergence |
+|--------|-------|-----------|-------------------|
+| `zoom.{win32,linux,darwin}.ts` | 3 + stub | ~552 | **0 lines of code** — only header comments differ; all three are byte-identical executable code |
+| `TileLayout.{win32,linux,darwin}.tsx` | 3 + stub | ~2340 | ~206 lines win32↔linux, ~86 linux↔darwin — real deltas exist (launcher wiring, drag-preview) but `MagnifiedPaneOverlay`, `DisplayNode`, `DisplayNodesWrapper` are copy-pasted 3× |
+| `useWindowDrag.{win32,linux,darwin}.ts` | 3 + stub | ~314 | win32/linux diverge; darwin is an 11-line stub |
+
+Consequences:
+
+- **The magnify fix must be pasted into three files.** Three chances to
+  drift; the files have *already* drifted (comment rot, 206-line gap).
+- `zoom.platform.ts` indirection exists for **zero** code divergence — the
+  platform behaviour is entirely in `window-header.{scss,darwin.scss}`.
+- A reviewer cannot tell, without diffing, which lines are intentionally
+  platform-specific and which are accidental drift.
+
+### P4 — Zoom is fragmented
+
+One behaviour, but: two domains (pane vs chrome) interleaved in one file;
+two dispatch mechanisms (the `keymodel` global key map vs an ad-hoc
+`window` `wheel` listener mounted by `AppZoomHandler` in `app.tsx`); two
+pane-resolution strategies (`getFocusedBlockId()` for keyboard,
+`target.closest("[data-blockid]")` for wheel). There is no single "zoom
+service" — behaviour and policy are scattered across `zoom.*.ts`,
+`keymodel.ts`, and `app.tsx`.
+
+### P6 — Browser panes: the duplicate render is *destructive*, not cosmetic
+
+For a terminal/agent pane the duplicate render (P2) "only" corrupts the
+registry → zoom dies, but the pane keeps working. For a **browser pane** the
+same duplicate render destroys the pane:
+
+1. Magnify → the overlay mounts a *second* `BrowserViewComponent` for the
+   same `block_id`. Its `onMount` fires `browser_pane_create` again — the
+   reducer returns `AlreadyLive` (no second HWND, good) — but now **two
+   placeholders drive geometry**: `tile-hidden` is `visibility: hidden`, so
+   the still-mounted tile placeholder keeps its layout box and reports the
+   tile rect, while the overlay placeholder reports the magnified rect. Their
+   two 200 ms intervals fire `browser_pane_resize` alternately → the native
+   HWND is yanked between the tile rect and the magnified rect every tick.
+2. Restore → the overlay `BrowserViewComponent` unmounts → its `onCleanup`
+   fires **`browser_pane_close`** → the host reducer flips the *shared*
+   `block_id` entry `Live → Closing` and **destroys the native HWND**.
+3. The tile `BrowserViewComponent` is still mounted and still believes
+   `paneCreated === true`. `createPane` only ever runs once (in `onMount`),
+   so it **never recreates** the pane. Its `syncPosition` keeps firing
+   `browser_pane_resize` against a `Closing`/destroyed pane — all no-op'd by
+   the reducer.
+
+Net result: **the browser pane goes black (HWND destroyed, no compositor)
+and is stuck (no recreate path)** — exactly the reported symptom. This is the
+direct consequence of (a) the duplicate render and (b) browser-pane lifecycle
+being coupled 1:1 to component mount/unmount (§2.4). It is the strongest
+argument that the magnified pane *must* be a single component instance.
+
+### P5 — Window maximize emits no state-change event
+
+`maximize_window` toggles via raw `ShowWindow` and returns; the frontend is
+never told the new window state, and on `SW_RESTORE` the CEF webview can
+lose keyboard focus. Lower priority (the reported bug was pane magnify), but
+worth a follow-up: a `window-state-change` event would let the frontend
+re-assert focus and update chrome.
+
+---
+
+## 4. Target architecture
+
+### A. One render per pane (fixes P1 + P2 + P6) — mandatory
+
+A pane is rendered by exactly one `Block` component instance. "Magnified" is
+a *position/size state* of that instance, not a second instance. Implement
+the overlay as a **positioned mount target** and relocate the existing
+`DisplayNode` content into it (SolidJS `<Portal>` / DOM reparent), or move
+the tile node itself. `tile-hidden` twin and `renderContent`-again go away.
+The `ViewModel` lifecycle, the registry slot, and the browser-pane
+create/close lifecycle are then all untouched by magnify.
+
+**This is no longer optional.** The reference-count fallback (Option B in the
+bug spec) is sufficient for terminal panes but **not** for browser panes:
+even with the registry slot ref-counted, the two `.browser-placeholder`
+nodes still fight over `browser_pane_resize` while magnified (P6 step 1), and
+mount-coupling still means a stray unmount can close the pane. Only a single
+render instance — hence a single placeholder, a single create, a single
+close — makes browser panes robust. Single-instance is the target for *all*
+pane types.
+
+### A′. Browser panes through the reducer (fixes P6)
+
+Single-instance render removes the duplicate `create`/`close`/`resize`, but
+two further guarantees should be made explicit so the native pane can never
+again be orphaned:
+
+- **Geometry has one authority.** Exactly one `.browser-placeholder` drives
+  `browser_pane_resize`. While magnified, that one placeholder reports the
+  magnified rect; on restore it reports the tile rect. No hidden/zero-area
+  placeholder ever emits geometry.
+- **Lifecycle decoupled from transient unmounts.** A browser pane's
+  `browser_pane_close` should fire on *logical* pane destruction (the block
+  is closed/removed), not on any `BrowserViewComponent` unmount. If a future
+  change ever does reparent across a real unmount, route close through a
+  reducer command that distinguishes "pane removed" from "pane relocated"
+  (e.g. the host reducer already has `Live → Closing`; add a relocate path
+  that keeps the entry `Live`).
+- **Recovery path.** As defensive depth, `BrowserViewComponent` should
+  recreate the native pane if it finds itself mounted with
+  `paneCreated === true` but the host reports the `block_id` is `Closed` —
+  so a pane can never be permanently black/stuck even if a lifecycle race
+  slips through. The host reducer's three-way `TryRegisterBrowserPaneLive`
+  (`Fresh`/`AlreadyLive`/`Closing`) already gives the frontend enough signal
+  to drive this.
+
+### B. Collapse the zoom platform split (fixes P3, zoom half)
+
+Delete `zoom.linux.ts`, `zoom.darwin.ts`, `zoom.platform.ts`; keep a single
+`zoom.ts`. Platform differences already live in
+`window-header.{scss,darwin.scss}` and stay there. Net: ~−370 LOC, one file
+to maintain. (Confirm `platformResolve` tolerates a non-suffixed module —
+Risks §6.)
+
+### C. Extract a shared TileLayout core (fixes P3, layout half)
+
+Move the platform-identical pieces — `MagnifiedPaneOverlay`, `DisplayNode`'s
+magnify logic, `DisplayNodesWrapper` — into a `TileLayout.shared.tsx`. The
+`TileLayout.{os}.tsx` files keep only genuine platform deltas (launcher
+wiring, Win32 drag-preview generation, the dblclick-maximize target). The
+magnify fix from §A then lives in **one** place.
+
+### D. A single zoom module (fixes P4)
+
+Consolidate into one `zoom.ts` exposing a small surface:
+`paneZoom.{in,out,reset}`, `chromeZoom.{in,out,reset}`, and one
+pane-resolution helper. Route the wheel path and the keyboard path through
+that same module so policy (clamps, steps, indicator) lives in one place.
+Full rewrite is optional; the firm requirement is: **the bug fix must not be
+duplicated**, and pane vs chrome zoom must stop being two half-documented
+halves of one file.
+
+### E. Disambiguate "maximize" vs "magnify"
+
+Pick one term per mechanism and apply it across UI strings, icon names, and
+code identifiers. Recommendation: keep **"magnify"** for the pane action
+(matches `magnifiedNodeId`, `layoutMagnify`) and reserve **"maximize"** for
+the OS window. Update the pane-header tooltip/icon accordingly.
+
+---
+
+## 5. Recommended sequencing
+
+1. **Zoom platform collapse (B)** — mechanical, low-risk, shrinks the
+   surface before any behavioural change.
+2. **TileLayout shared-core extraction (C)** — so the magnify fix lands once.
+3. **Magnify-as-relocation (A + A′)** — the real fix for the zoom regression
+   *and* the browser-pane black/stuck failure. Land the companion spec's
+   defaults (full-window size, 100% opacity) in the same pass since they
+   touch the same code. Validate explicitly with a browser pane, a terminal
+   pane, and an agent pane, magnified and restored repeatedly.
+4. **Zoom module consolidation (D)** — opportunistic, after the structure
+   is deduplicated.
+5. **Window-state event (P5)** — separate follow-up.
+
+> If the team needs the regression fixed *before* C lands, apply the bug
+> spec's fix — but accept it will be a 3-file paste and schedule C to
+> reclaim it.
+
+---
+
+## 6. Risks & open questions
+
+- **Native child windows (chief risk).** Browser panes are `CefBrowserView`
+  native child HWNDs, not DOM. The current separate-overlay render exists
+  specifically to dodge "stacking-context issues". A single-instance
+  Portal/DOM-reparent must be verified to:
+  - keep the *same* `.browser-placeholder` node alive across the magnify
+    transition (a reparent that unmounts/remounts the subtree would still
+    fire `browser_pane_close`/`create` — the very thing §A′ forbids); and
+  - keep the native pane correctly positioned and z-ordered above the
+    overlay when magnified.
+  If a clean reparent that preserves the subtree proves impossible, the
+  fallback is **not** Option B — it is to make magnify a reducer-tracked
+  *relocate* of the browser pane (host keeps the entry `Live`, just resizes
+  the HWND to the magnified rect) while the DOM still single-renders. The
+  reducer must be the source of truth; DOM-driven geometry races must end.
+- **`platformResolve` plugin.** Confirm it resolves a plain `zoom.ts`
+  (no `.win32`/`.platform` suffix) without complaint before deleting the
+  split.
+- **TileLayout real deltas.** Audit exactly which of the ~206 win32↔linux
+  differing lines are intentional (launcher, drag-preview) vs drift, so the
+  shared core does not accidentally erase platform behaviour.
+- **Terminology change (E)** is user-visible (tooltip text) — confirm before
+  shipping.
+
+---
+
+## 7. Out of scope
+
+- Rewriting the OS window-maximize path beyond adding a state event.
+- Changing the magnify blur defaults (`window:magnifiedblockblur*px`).
+- The `useWindowDrag` platform split — flagged under P3 but not addressed
+  here; fold into C if convenient.

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -313,6 +313,15 @@
             backdrop-filter: blur(var(--magnified-block-blur));
         }
 
+        // A magnified pane floats over the blurred magnify backdrop. The
+        // default --block-bg-color is translucent in every theme (e.g. 50%),
+        // so without this the backdrop bleeds through the magnified pane.
+        // Force the configured opacity — default 1 (fully opaque), still
+        // overridable via the window:magnifiedblockopacity setting.
+        &.magnified .block-frame-default-inner {
+            background-color: rgb(from var(--block-bg-color) r g b / var(--magnified-block-opacity));
+        }
+
         .connstatus-overlay {
             position: absolute;
             top: calc(var(--header-height) + 6px);

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -315,11 +315,10 @@
 
         // A magnified pane floats over the blurred magnify backdrop. The
         // default --block-bg-color is translucent in every theme (e.g. 50%),
-        // so without this the backdrop bleeds through the magnified pane.
-        // Force the configured opacity — default 1 (fully opaque), still
-        // overridable via the window:magnifiedblockopacity setting.
+        // so without this the backdrop bleeds through. Force the opaque form
+        // of the theme colour (r g b with no alpha = fully opaque).
         &.magnified .block-frame-default-inner {
-            background-color: rgb(from var(--block-bg-color) r g b / var(--magnified-block-opacity));
+            background-color: rgb(from var(--block-bg-color) r g b);
         }
 
         .connstatus-overlay {

--- a/frontend/app/block/block.scss
+++ b/frontend/app/block/block.scss
@@ -305,7 +305,7 @@
             }
         }
 
-        --magnified-block-opacity: 0.95;
+        --magnified-block-opacity: 1;
         --magnified-block-blur: 10px;
 
         &.ephemeral {

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -311,6 +311,11 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
+    // True when any pane is magnified. Every tile node is then hidden
+    // (display:none) so nothing inside AgentMux — DOM panes or native browser
+    // panes — shows behind the magnified pane. The magnified pane itself is
+    // reparented into the magnify overlay, outside the tile nodes.
+    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
     const [isDragging, setIsDragging] = createSignal(false);
 
 
@@ -466,7 +471,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
     return (
         <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": isMagnified() })}
+            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
             ref={tileNodeRef}
             id={props.node.id}
             style={tileTransform() as JSX.CSSProperties}

--- a/frontend/layout/lib/TileLayout.darwin.tsx
+++ b/frontend/layout/lib/TileLayout.darwin.tsx
@@ -16,7 +16,6 @@ import { Key } from "@solid-primitives/keyed";
 import { debounce, throttle } from "throttle-debounce";
 import { LayoutModel } from "./layoutModel";
 import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import { getNodeModel } from "./layoutNodeModels";
 import "./tilelayout.scss";
 import {
     LayoutNode,
@@ -230,7 +229,7 @@ function NodeBackdrops(props: { layoutModel: LayoutModel }) {
 const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
     const magnifiedNodeId = () => props.layoutModel.magnifiedNodeIdAtom();
     const magnifiedBlockSizeAtom = getSettingsKeyAtom("window:magnifiedblocksize");
-    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 0.9;
+    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 1.0;
 
     // Find the leaf node matching the magnified node ID
     const magnifiedNode = createMemo(() => {
@@ -260,18 +259,24 @@ const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
         } as JSX.CSSProperties;
     });
 
+    // The magnified pane is NOT rendered here. `DisplayNode` keeps the single
+    // `.tile-leaf` instance and reparents it into `.magnify-pane` below while
+    // magnified — one Block, one ViewModel, one browser-pane HWND across the
+    // magnify/restore cycle. Rendering a second copy here left the restored
+    // pane without zoom (terminal) or black (browser-pane native window
+    // destroyed on the duplicate's unmount). See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
     return (
         <Show when={magnifiedNode()}>
-            {(node) => {
-                const nodeModel = getNodeModel(props.layoutModel, node());
-                return (
-                    <div class="magnify-container" style={containerStyle()}>
-                        <div class="magnify-pane">
-                            {props.layoutModel.renderContent(nodeModel)}
-                        </div>
-                    </div>
-                );
-            }}
+            <div class="magnify-container" style={containerStyle()}>
+                <div
+                    class="magnify-pane"
+                    ref={(el) => {
+                        props.layoutModel.magnifyMount._set(el);
+                        onCleanup(() => props.layoutModel.magnifyMount._set(null));
+                    }}
+                />
+            </div>
         </Show>
     );
 };
@@ -302,6 +307,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const nodeModel = useNodeModel(props.layoutModel, props.node);
     let tileNodeRef: HTMLDivElement | undefined;
     let previewRef: HTMLDivElement | undefined;
+    let leafRef: HTMLDivElement | undefined;
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
@@ -414,10 +420,28 @@ const DisplayNode = (props: DisplayNodeProps) => {
     });
 
     const leafContent = () => (
-        <div class="tile-leaf">
+        <div class="tile-leaf" ref={leafRef}>
             {props.layoutModel.renderContent(nodeModel)}
         </div>
     );
+
+    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
+    // once (below, in the tile node). While this node is magnified, move that
+    // same DOM node into the magnify overlay's mount slot rather than letting
+    // the overlay render a second copy. Moving a DOM subtree does not dispose
+    // its SolidJS component, so the Block, its ViewModel, the block-component
+    // registry entry, and any browser-pane native window all survive the
+    // magnify/restore cycle intact. See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
+    createEffect(() => {
+        const mount = props.layoutModel.magnifyMount();
+        if (!leafRef) return;
+        if (isMagnified() && mount) {
+            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
+        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
+            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
+        }
+    });
 
     const previewElement = () => {
         const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -313,6 +313,11 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
+    // True when any pane is magnified. Every tile node is then hidden
+    // (display:none) so nothing inside AgentMux — DOM panes or native browser
+    // panes — shows behind the magnified pane. The magnified pane itself is
+    // reparented into the magnify overlay, outside the tile nodes.
+    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
     const [isDragging, setIsDragging] = createSignal(false);
 
 
@@ -447,7 +452,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
     return (
         <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": isMagnified() })}
+            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
             ref={tileNodeRef}
             id={props.node.id}
             style={tileTransform() as JSX.CSSProperties}

--- a/frontend/layout/lib/TileLayout.linux.tsx
+++ b/frontend/layout/lib/TileLayout.linux.tsx
@@ -15,7 +15,6 @@ import { Key } from "@solid-primitives/keyed";
 import { debounce, throttle } from "throttle-debounce";
 import { LayoutModel } from "./layoutModel";
 import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import { getNodeModel } from "./layoutNodeModels";
 import "./tilelayout.scss";
 import {
     LayoutNode,
@@ -232,7 +231,7 @@ function NodeBackdrops(props: { layoutModel: LayoutModel }) {
 const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
     const magnifiedNodeId = () => props.layoutModel.magnifiedNodeIdAtom();
     const magnifiedBlockSizeAtom = getSettingsKeyAtom("window:magnifiedblocksize");
-    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 0.9;
+    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 1.0;
 
     // Find the leaf node matching the magnified node ID
     const magnifiedNode = createMemo(() => {
@@ -262,18 +261,24 @@ const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
         } as JSX.CSSProperties;
     });
 
+    // The magnified pane is NOT rendered here. `DisplayNode` keeps the single
+    // `.tile-leaf` instance and reparents it into `.magnify-pane` below while
+    // magnified — one Block, one ViewModel, one browser-pane HWND across the
+    // magnify/restore cycle. Rendering a second copy here left the restored
+    // pane without zoom (terminal) or black (browser-pane native window
+    // destroyed on the duplicate's unmount). See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
     return (
         <Show when={magnifiedNode()}>
-            {(node) => {
-                const nodeModel = getNodeModel(props.layoutModel, node());
-                return (
-                    <div class="magnify-container" style={containerStyle()}>
-                        <div class="magnify-pane">
-                            {props.layoutModel.renderContent(nodeModel)}
-                        </div>
-                    </div>
-                );
-            }}
+            <div class="magnify-container" style={containerStyle()}>
+                <div
+                    class="magnify-pane"
+                    ref={(el) => {
+                        props.layoutModel.magnifyMount._set(el);
+                        onCleanup(() => props.layoutModel.magnifyMount._set(null));
+                    }}
+                />
+            </div>
         </Show>
     );
 };
@@ -304,6 +309,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const nodeModel = useNodeModel(props.layoutModel, props.node);
     let tileNodeRef: HTMLDivElement | undefined;
     let previewRef: HTMLDivElement | undefined;
+    let leafRef: HTMLDivElement | undefined;
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
@@ -395,10 +401,28 @@ const DisplayNode = (props: DisplayNodeProps) => {
     });
 
     const leafContent = () => (
-        <div class="tile-leaf">
+        <div class="tile-leaf" ref={leafRef}>
             {props.layoutModel.renderContent(nodeModel)}
         </div>
     );
+
+    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
+    // once (below, in the tile node). While this node is magnified, move that
+    // same DOM node into the magnify overlay's mount slot rather than letting
+    // the overlay render a second copy. Moving a DOM subtree does not dispose
+    // its SolidJS component, so the Block, its ViewModel, the block-component
+    // registry entry, and any browser-pane native window all survive the
+    // magnify/restore cycle intact. See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
+    createEffect(() => {
+        const mount = props.layoutModel.magnifyMount();
+        if (!leafRef) return;
+        if (isMagnified() && mount) {
+            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
+        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
+            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
+        }
+    });
 
     const previewElement = () => {
         const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -14,7 +14,6 @@ import { Key } from "@solid-primitives/keyed";
 import { debounce, throttle } from "throttle-debounce";
 import { LayoutModel } from "./layoutModel";
 import { useNodeModel, useTileLayout } from "./layoutModelHooks";
-import { getNodeModel } from "./layoutNodeModels";
 import "./tilelayout.scss";
 import {
     LayoutNode,
@@ -260,7 +259,7 @@ function NodeBackdrops(props: { layoutModel: LayoutModel }) {
 const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
     const magnifiedNodeId = () => props.layoutModel.magnifiedNodeIdAtom();
     const magnifiedBlockSizeAtom = getSettingsKeyAtom("window:magnifiedblocksize");
-    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 0.9;
+    const magnifiedNodeSize = () => magnifiedBlockSizeAtom() ?? 1.0;
 
     // Find the leaf node matching the magnified node ID
     const magnifiedNode = createMemo(() => {
@@ -290,18 +289,24 @@ const MagnifiedPaneOverlay = (props: { layoutModel: LayoutModel }) => {
         } as JSX.CSSProperties;
     });
 
+    // The magnified pane is NOT rendered here. `DisplayNode` keeps the single
+    // `.tile-leaf` instance and reparents it into `.magnify-pane` below while
+    // magnified — one Block, one ViewModel, one browser-pane HWND across the
+    // magnify/restore cycle. Rendering a second copy here left the restored
+    // pane without zoom (terminal) or black (browser-pane native window
+    // destroyed on the duplicate's unmount). See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
     return (
         <Show when={magnifiedNode()}>
-            {(node) => {
-                const nodeModel = getNodeModel(props.layoutModel, node());
-                return (
-                    <div class="magnify-container" style={containerStyle()}>
-                        <div class="magnify-pane">
-                            {props.layoutModel.renderContent(nodeModel)}
-                        </div>
-                    </div>
-                );
-            }}
+            <div class="magnify-container" style={containerStyle()}>
+                <div
+                    class="magnify-pane"
+                    ref={(el) => {
+                        props.layoutModel.magnifyMount._set(el);
+                        onCleanup(() => props.layoutModel.magnifyMount._set(null));
+                    }}
+                />
+            </div>
         </Show>
     );
 };
@@ -332,6 +337,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const nodeModel = useNodeModel(props.layoutModel, props.node);
     let tileNodeRef: HTMLDivElement | undefined;
     let previewRef: HTMLDivElement | undefined;
+    let leafRef: HTMLDivElement | undefined;
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
@@ -471,10 +477,28 @@ const DisplayNode = (props: DisplayNodeProps) => {
     });
 
     const leafContent = () => (
-        <div class="tile-leaf">
+        <div class="tile-leaf" ref={leafRef}>
             {props.layoutModel.renderContent(nodeModel)}
         </div>
     );
+
+    // Single-instance magnify: the pane's `.tile-leaf` is rendered exactly
+    // once (below, in the tile node). While this node is magnified, move that
+    // same DOM node into the magnify overlay's mount slot rather than letting
+    // the overlay render a second copy. Moving a DOM subtree does not dispose
+    // its SolidJS component, so the Block, its ViewModel, the block-component
+    // registry entry, and any browser-pane native window all survive the
+    // magnify/restore cycle intact. See
+    // SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
+    createEffect(() => {
+        const mount = props.layoutModel.magnifyMount();
+        if (!leafRef) return;
+        if (isMagnified() && mount) {
+            if (leafRef.parentElement !== mount) mount.appendChild(leafRef);
+        } else if (tileNodeRef && leafRef.parentElement !== tileNodeRef) {
+            tileNodeRef.insertBefore(leafRef, tileNodeRef.firstChild);
+        }
+    });
 
     const previewElement = () => {
         const dpr = typeof devicePixelRatio === "function" ? (devicePixelRatio as () => number)() : devicePixelRatio;

--- a/frontend/layout/lib/TileLayout.win32.tsx
+++ b/frontend/layout/lib/TileLayout.win32.tsx
@@ -341,6 +341,11 @@ const DisplayNode = (props: DisplayNodeProps) => {
     const addlProps = () => nodeModel.additionalProps();
     const isEphemeral = () => nodeModel.isEphemeral();
     const isMagnified = () => nodeModel.isMagnified();
+    // True when any pane is magnified. Every tile node is then hidden
+    // (display:none) so nothing inside AgentMux — DOM panes or native browser
+    // panes — shows behind the magnified pane. The magnified pane itself is
+    // reparented into the magnify overlay, outside the tile nodes.
+    const magnifyActive = () => !!props.layoutModel.magnifiedNodeIdAtom();
     const [isDragging, setIsDragging] = createSignal(false);
 
     // Clear isDragging when activeDrag goes false (handles the Win11 safety-net
@@ -523,7 +528,7 @@ const DisplayNode = (props: DisplayNodeProps) => {
 
     return (
         <div
-            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": isMagnified() })}
+            class={clsx("tile-node", { dragging: isDragging(), "tile-hidden": magnifyActive() })}
             ref={tileNodeRef}
             id={props.node.id}
             style={tileTransform() as JSX.CSSProperties}

--- a/frontend/layout/lib/layoutModel.ts
+++ b/frontend/layout/lib/layoutModel.ts
@@ -272,6 +272,13 @@ export class LayoutModel {
      */
     lastEphemeralNodeId: string;
     magnifiedNodeSizeAtom: () => number;
+    /**
+     * Mount element of the magnify overlay's pane slot. `MagnifiedPaneOverlay`
+     * publishes it while a node is magnified; `DisplayNode` reparents its
+     * single `.tile-leaf` into it instead of the overlay rendering a second
+     * copy of the pane. See SPEC_MAGNIFY_ZOOM_IMPLEMENTATION_2026-05-21.md.
+     */
+    magnifyMount: SignalAtom<HTMLElement | null>;
 
     /**
      * The size of the resize handles, in CSS pixels.
@@ -425,6 +432,7 @@ export class LayoutModel {
 
             this.ephemeralNode = createSignalAtom<LayoutNode>(undefined);
             this.magnifiedNodeSizeAtom = getSettingsKeyAtom("window:magnifiedblocksize");
+            this.magnifyMount = createSignalAtom<HTMLElement | null>(null);
 
             this.magnifiedNodeIdAtom = createMemo(() => {
                 const treeState = this.localTreeStateAtom();

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -145,6 +145,11 @@
     .magnify-pane {
         width: 100%;
         height: 100%;
+        // Opaque base behind the magnified pane. The pane content
+        // (--block-bg-color) is translucent in every theme; without a solid
+        // backing the blurred magnify backdrop bleeds through. `r g b` with
+        // no alpha = the theme colour at full opacity.
+        background-color: rgb(from var(--block-bg-color) r g b);
     }
 
     .tile-node.tile-hidden {

--- a/frontend/layout/lib/tilelayout.scss
+++ b/frontend/layout/lib/tilelayout.scss
@@ -152,8 +152,13 @@
         background-color: rgb(from var(--block-bg-color) r g b);
     }
 
+    // While a pane is magnified, every tile node is hidden with display:none
+    // (not visibility:hidden — that keeps layout box, so a browser pane inside
+    // would still report a non-zero rect and its native window would bleed
+    // through the magnified pane). display:none collapses the node to 0×0, and
+    // the host's airspace logic hides any browser pane reporting a 0×0 rect.
     .tile-node.tile-hidden {
-        visibility: hidden;
+        display: none;
     }
 
     &.animate {


### PR DESCRIPTION
## Summary

Fixes magnified ("maximized") panes: a magnified-then-restored pane was left broken, and a magnified pane let other AgentMux content bleed through. Four related fixes.

### 1. Single-instance render — fixes the magnify→restore regression

The magnified pane was rendered **twice** (a hidden tile copy + an overlay copy) sharing one `blockId`-keyed registry entry and, for browser panes, one native `CefBrowserView`. On restore the overlay copy's unmount cleared the shared registry / disposed the shared `ViewModel` / fired `browser_pane_close` — leaving the surviving copy with:
- **terminal/agent panes** — dead zoom (`Ctrl +/-`, `Ctrl+scroll`)
- **browser panes** — a destroyed native window (pane goes **black and stuck**)

Fix: render the pane's `.tile-leaf` once and **reparent** that single DOM node into the magnify overlay while magnified. Moving a DOM subtree doesn't dispose its SolidJS component, so the `Block`, `ViewModel`, registry entry, and browser-pane HWND all survive. `MagnifiedPaneOverlay` exposes a mount slot via the new `layoutModel.magnifyMount` signal.

### 2. Nothing inside AgentMux shows behind a magnified pane

While any pane is magnified, every tile node is hidden with `display:none` (was `visibility:hidden` on just the magnified node). `display:none` collapses each node to 0×0, so a browser pane inside reports a 0×0 rect and the host's **existing** airspace logic hides its native window — native browser panes paint above DOM, so an opaque background alone could not occlude them. No new host code.

OS-level window transparency (`WS_EX_LAYERED`, e.g. 80%) is untouched — the global "desktop at N%" still applies; only *AgentMux* content is hidden behind the magnified pane.

### 3. Magnified pane is fully opaque

A magnified pane used the bare `--block-bg-color`, translucent in every theme (default 50%), so the blurred backdrop bled through. `.magnify-pane` and `.magnified .block-frame-default-inner` now use `rgb(from var(--block-bg-color) r g b)` — the theme colour with alpha omitted = fully opaque.

### 4. Magnified pane fills the window

`window:magnifiedblocksize` default `0.9` → `1.0` (was leaving a 5% margin gap). Still a user-overridable setting.

## Design docs

`docs/specs/SPEC_MAGNIFY_ZOOM_{REGRESSION_AND_DEFAULTS,IMPLEMENTATION}_2026-05-21.md` and `SPEC_MAXIMIZE_ZOOM_ARCHITECTURE_2026-05-21.md` — root-cause analysis, reducer/browser-pane considerations, phased plan.

## Test plan

- [x] `task build:frontend` — clean
- [x] `npx vitest run frontend/layout` — 51/51 pass
- [x] Verified live in `task dev` (Windows)
- [ ] Manual:
  - [ ] Terminal pane: magnify → restore → `Ctrl +/-` and `Ctrl+scroll` still zoom; repeat ×5
  - [ ] Browser pane: magnify → restore → stays live (not black), keeps URL/scroll; repeat ×5
  - [ ] Magnify a pane while another tile holds a browser pane — nothing bleeds through
  - [ ] Magnified pane fills the window, fully opaque
  - [ ] `Escape` / backdrop-click still unmagnify

🤖 Generated with [Claude Code](https://claude.com/claude-code)