### PR TITLE
refactor(modal): migrate window-scope callers to unified modal (stage 2)

### DIFF
--- a/.changesets/1779431857-refactor-modal-migrate-window-scope-callers-to-unified-modal-zef5.md
+++ b/.changesets/1779431857-refactor-modal-migrate-window-scope-callers-to-unified-modal-zef5.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+refactor(modal): migrate window-scope callers to unified modal (stage 2)

--- a/frontend/app/modals/about.tsx
+++ b/frontend/app/modals/about.tsx
@@ -3,7 +3,7 @@
 
 import logoUrl from "@/app/asset/logo.svg?url";
 import { modalsModel } from "@/app/store/modalmodel";
-import { Modal, ModalBody } from "@/element/modal-v2";
+import { Modal, ModalBody } from "@/element/modal";
 
 import { isDev } from "@/util/isdev";
 import { getApi } from "../store/global";

--- a/frontend/app/modals/command-palette.tsx
+++ b/frontend/app/modals/command-palette.tsx
@@ -8,7 +8,7 @@
 import { commandRegistry, type CommandEntry } from "@/app/store/command-registry";
 import { modalsModel } from "@/app/store/modalmodel";
 import { disableGlobalKeybindings, enableGlobalKeybindings } from "@/app/store/keymodel";
-import { Modal } from "@/element/modal-v2";
+import { Modal } from "@/element/modal";
 import { createMemo, createSignal, For, onCleanup, onMount, type JSX } from "solid-js";
 import "./command-palette.scss";
 

--- a/frontend/app/modals/messagemodal.tsx
+++ b/frontend/app/modals/messagemodal.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Button } from "@/element/button";
-import { Modal, ModalBody, ModalFooter } from "@/element/modal-v2";
+import { Modal, ModalBody, ModalFooter } from "@/element/modal";
 import { modalsModel } from "@/app/store/modalmodel";
 
 import type { JSX } from "solid-js";

--- a/frontend/app/modals/userinputmodal.tsx
+++ b/frontend/app/modals/userinputmodal.tsx
@@ -3,7 +3,7 @@
 
 import { Button } from "@/element/button";
 import { Markdown } from "@/element/markdown";
-import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal";
 import { modalsModel } from "@/store/modalmodel";
 import * as keyutil from "@/util/keyutil";
 import { fireAndForget } from "@/util/util";

--- a/frontend/app/statusbar/TokenBreakdownPopover.tsx
+++ b/frontend/app/statusbar/TokenBreakdownPopover.tsx
@@ -13,7 +13,7 @@
 
 import { createMemo, createSignal, For, Show, type JSX } from "solid-js";
 import { usePaneOverlay } from "@/app/platform/pane-overlay";
-import { ConfirmModal } from "@/element/modal-v2";
+import { ConfirmModal } from "@/element/modal";
 import { getCliCatalogEntry } from "@/app/view/agent/defaults/cli-catalog";
 import {
     getBreakdown,

--- a/frontend/app/view/agent/agent-view.tsx
+++ b/frontend/app/view/agent/agent-view.tsx
@@ -48,7 +48,7 @@ import { SessionDigestBanner } from "./components/SessionDigestBanner";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { createBlock, getApi, WOS } from "@/app/store/global";
-import { ConfirmModal } from "@/element/modal-v2";
+import { ConfirmModal } from "@/element/modal";
 import { ContextMenuModel } from "@/app/store/contextmenu";
 import { parseAgentAccounts, loadAccounts } from "@/app/view/identity/identity-model";
 import { buildStartupPayload, resolveAccounts } from "./startup/buildStartupPayload";

--- a/frontend/app/view/agent/components/AgentActionBar.tsx
+++ b/frontend/app/view/agent/components/AgentActionBar.tsx
@@ -5,7 +5,7 @@ import { createSignal, Show, type JSX } from "solid-js";
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { Button } from "@/element/button";
-import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal";
 import { ImportPreviewModal } from "./ImportPreviewModal";
 
 export const AgentActionBar = (): JSX.Element => {

--- a/frontend/app/view/agent/components/ImportPreviewModal.tsx
+++ b/frontend/app/view/agent/components/ImportPreviewModal.tsx
@@ -5,7 +5,7 @@ import { createEffect, createMemo, createSignal, For, Show, type JSX } from "sol
 import { RpcApi } from "@/app/store/rpc-api";
 import { TabRpcClient } from "@/app/store/rpc-util";
 import { Button } from "@/element/button";
-import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal-v2";
+import { Modal, ModalBody, ModalFooter, ModalHeader } from "@/element/modal";
 
 interface ImportPreviewModalProps {
     payload: ExportAgentDefinitionsResult | null;


### PR DESCRIPTION
## Stage 2 of 5 — `SPEC_UNIFIED_MODAL_SYSTEM_2026_05_21`

Migrates the **8 `@/element/modal-v2` importers** to the unified `@/element/modal` primitive (added in #959).

A **pure import-path swap** — `window` is the unified primitive's default `scope` and the API (`Modal`, `ConfirmModal`, `ModalHeader/Body/Footer`) is identical, so behaviour is unchanged for every dialog:

- `modals/about.tsx`, `modals/command-palette.tsx`, `modals/messagemodal.tsx`, `modals/userinputmodal.tsx`
- `statusbar/TokenBreakdownPopover.tsx`
- `view/agent/agent-view.tsx`, `view/agent/components/AgentActionBar.tsx`, `view/agent/components/ImportPreviewModal.tsx`

`modal-v2.*` stays in place — stage 3 migrates the tab-scope agent modals, stage 4 retires the v1 registry, stage 5 deletes `modal-v2`.

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)