### PR TITLE
fix(security): correct shell integration component name in SECURITY.md

### DIFF
--- a/.changesets/1779442913-fix-security-md-shell-integration-name.md
+++ b/.changesets/1779442913-fix-security-md-shell-integration-name.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+fix(security): correct shell integration component name in SECURITY.md scope

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ In scope:
 
 - The AgentMux desktop application (`agentmux-cef`, `agentmux-launcher`)
 - The bundled backend (`agentmux-srv`)
-- The shell integration binary (`wsh`)
+- Shell integration (`agentmux-bashwrap` crate and the `shell-integration/` scripts)
 - Build and release tooling that produces shipped binaries
 
 Out of scope:


### PR DESCRIPTION
## Summary

Follow-up to #967. The SECURITY.md added there listed `wsh` as the shell-integration binary, but `wsh` is an upstream Wave Terminal name — AgentMux's shell integration is the `agentmux-bashwrap` crate plus the `shell-integration/` scripts.

```diff
- - The shell integration binary (`wsh`)
+ - Shell integration (`agentmux-bashwrap` crate and the `shell-integration/` scripts)
```

## Why

Caught during post-merge review of #967. `wsh` does not exist anywhere in the AgentMux tree:

```
$ find . -maxdepth 2 -type d \( -name "*wsh*" -o -name "*shell*" -o -name "*bashwrap*" \)
./agentmux-bashwrap
./shell-integration
```

Reporting against a non-existent component would have confused vulnerability reporters.

## Test plan

- [x] `agentmux-bashwrap/` directory exists in repo
- [x] `shell-integration/` directory exists in repo
- [x] `wsh` does not exist in repo
- [x] Changeset file added (`patch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)