### PR TITLE
feat(agent): OAuth Connect creates a named Identity bundle first

### DIFF
--- a/.changesets/1779443305-feat-agent-oauth-connect-creates-a-named-identity-bundle-fir-pcx7.md
+++ b/.changesets/1779443305-feat-agent-oauth-connect-creates-a-named-identity-bundle-fir-pcx7.md
@@ -1,0 +1,5 @@
+---
+type: patch
+---
+
+feat(agent): OAuth Connect creates a named Identity bundle first

--- a/frontend/app/tab/TabModalLayer.tsx
+++ b/frontend/app/tab/TabModalLayer.tsx
@@ -194,6 +194,7 @@ function renderRequest(
                             }
                         }}
                         initialFormState={req.initialFormState}
+                        autoStartAuth={req.autoStartAuth}
                         onRequestNewIdentity={req.onRequestNewIdentity}
                         onRequestNewMemory={req.onRequestNewMemory}
                     />
@@ -205,6 +206,7 @@ function renderRequest(
                 panel: (
                     <AgentNewIdentityModalPanel
                         initialName={req.initialName}
+                        purpose={req.purpose}
                         // The layer owns the RPC + chaining so its
                         // `submitting()` flag (which gates safeClose)
                         // tracks the in-flight call. Mirrors the

--- a/frontend/app/tab/tab-modal.ts
+++ b/frontend/app/tab/tab-modal.ts
@@ -46,12 +46,32 @@ export interface LaunchAgentRequest {
      *  across the new-bundle round-trip. Codex P2 on PR #910
      *  rounds 6 + 7. */
     initialFormState?: Partial<LaunchFormStateWire>;
-    /** Optional callback fired when the user clicks the "+ New
-     *  identity" button. Caller is expected to call
+    /** When true, the launch modal fires its OAuth `startConnect()`
+     *  exactly once on mount. Set by the OAuth-Connect → New Identity
+     *  → launch round-trip (spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md
+     *  §2): after the user names the bundle and clicks Continue, the
+     *  launch modal re-opens with the new identity preselected and
+     *  this hint set, so OAuth resumes automatically against the
+     *  freshly-named bundle instead of waiting for a second click. */
+    autoStartAuth?: boolean;
+    /** Optional callback fired when the user wants to create a new
+     *  identity bundle. Caller is expected to call
      *  tabModal.replace(newIdentityRequest) — the picker does this.
      *  The `current` snapshot carries the modal's live form state so
-     *  the picker can preserve it across the new-bundle round-trip. */
-    onRequestNewIdentity?: (current: LaunchFormStateWire) => void;
+     *  the picker can preserve it across the new-bundle round-trip.
+     *
+     *  `purpose` distinguishes the two entry points:
+     *   - `"create"` (the plain `+ New identity` button): create a
+     *     named bundle and return to the launch form.
+     *   - `"oauth-continue"` (the OAuth Connect `needs-bundle` click):
+     *     create a named bundle, return to the launch form with the
+     *     new id preselected AND `autoStartAuth` set so OAuth resumes
+     *     automatically against the named bundle.
+     *  Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
+    onRequestNewIdentity?: (
+        current: LaunchFormStateWire,
+        purpose: "create" | "oauth-continue",
+    ) => void;
     /** Same for "+ New memory". */
     onRequestNewMemory?: (current: LaunchFormStateWire) => void;
 }
@@ -144,6 +164,12 @@ export interface NewIdentityBundleRequest {
     originBlockId: string;
     /** Initial value for the name field. Usually empty. */
     initialName?: string;
+    /** Why the modal opened — controls the primary button label only
+     *  ("Create" vs "Continue"). `"create"` (default) is the plain
+     *  `+ New identity` button; `"oauth-continue"` is the OAuth-Connect
+     *  (`needs-bundle`) interposition. Spec
+     *  SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
+    purpose?: "create" | "oauth-continue";
     /** Called after the bundle is persisted on disk. Caller should
      *  `tabModal.replace(launchRequest)` with the new id preselected;
      *  the layer does NOT close after this fires. */

--- a/frontend/app/view/agent/components/AgentLaunchModal.tsx
+++ b/frontend/app/view/agent/components/AgentLaunchModal.tsx
@@ -73,13 +73,25 @@ interface AgentLaunchModalPanelProps {
      *  Codex P2 on PR #910 rounds 6 + 7: rounds 1-6 only restored
      *  identity/memory selection; round 7 added the rest of the form. */
     initialFormState?: Partial<LaunchFormState>;
-    /** Called when the "+" / empty-state New buttons fire. The picker
-     *  is expected to chain `tabModal.replace(newIdentityRequest)` —
-     *  this component doesn't know how to build that request.
+    /** When true, the OAuth Connect panel fires `startConnect()` once
+     *  on mount — set by the OAuth-Connect → New Identity → launch
+     *  round-trip so the user doesn't re-click Connect after naming
+     *  the bundle. Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
+    autoStartAuth?: boolean;
+    /** Called when the "+" / empty-state New buttons fire, OR when the
+     *  OAuth Connect panel needs the New Identity modal interposed
+     *  (`purpose: "oauth-continue"`). The picker is expected to chain
+     *  `tabModal.replace(newIdentityRequest)` — this component doesn't
+     *  know how to build that request.
      *
      *  The current launch form state is passed through so the picker
-     *  can preserve it across the new-bundle round-trip. */
-    onRequestNewIdentity?: (current: LaunchFormState) => void;
+     *  can preserve it across the new-bundle round-trip; `purpose`
+     *  tells the picker whether to set `autoStartAuth` on the return
+     *  launch request. */
+    onRequestNewIdentity?: (
+        current: LaunchFormState,
+        purpose: "create" | "oauth-continue",
+    ) => void;
     onRequestNewMemory?: (current: LaunchFormState) => void;
 }
 
@@ -216,7 +228,12 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
         identityId: identityId(),
         memoryId: memoryId(),
     });
-    const handleNewIdentity = () => props.onRequestNewIdentity?.(snapshot());
+    // The plain `+ New identity` button uses `purpose: "create"`. The
+    // OAuth Connect (`needs-bundle`) interposition routes through the
+    // same callback with `purpose: "oauth-continue"` — see the
+    // PreLaunchAuthPanel `onRequestNewIdentity` wiring below.
+    const handleNewIdentity = () =>
+        props.onRequestNewIdentity?.(snapshot(), "create");
     const handleNewMemory = () => props.onRequestNewMemory?.(snapshot());
 
     // v8 — "Continue agent" dropdown. Filters to instances of the
@@ -818,6 +835,16 @@ export const AgentLaunchModalPanel = (props: AgentLaunchModalPanelProps): JSX.El
                             hasMatchingBinding={bundleHasMatchingBinding}
                             controller={authController}
                             onBundleCreated={onBundleCreated}
+                            autoStartAuth={props.initialFormState != null && props.autoStartAuth === true}
+                            onRequestNewIdentity={
+                                props.onRequestNewIdentity
+                                    ? () =>
+                                          props.onRequestNewIdentity?.(
+                                              snapshot(),
+                                              "oauth-continue",
+                                          )
+                                    : undefined
+                            }
                             disabled={submitting()}
                         />
                     </Show>

--- a/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
+++ b/frontend/app/view/agent/components/AgentNewIdentityModal.tsx
@@ -24,6 +24,17 @@ export interface NewIdentityFormData {
 interface AgentNewIdentityModalPanelProps {
     /** Suggested initial name (often empty). */
     initialName?: string;
+    /** Why this modal was opened — controls only the primary button
+     *  label, nothing else about the form:
+     *   - `"create"` (default): plain `+ New identity` button — the
+     *     primary action reads "Create" (creates a named bundle and
+     *     returns to the launch form).
+     *   - `"oauth-continue"`: the OAuth Connect (`needs-bundle`) click
+     *     interposed this modal first — the primary action reads
+     *     "Continue" because the caller chains into OAuth after the
+     *     bundle is created.
+     *  Spec: SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
+    purpose?: "create" | "oauth-continue";
     onCancel: () => void;
     /** Runs the RPC + downstream chaining. Owned by the layer so its
      *  `submitting()` signal correctly gates ESC / backdrop while the
@@ -43,6 +54,18 @@ export const AgentNewIdentityModalPanel = (
     const [error, setError] = createSignal<string | null>(null);
 
     const canSubmit = () => name().trim().length > 0 && !submitting();
+
+    // Primary-button label. `oauth-continue` callers chain into OAuth
+    // after the bundle is created, so "Continue" reads better than
+    // "Create" — spec §2 decision 4. The progress label tracks the
+    // same split so the in-flight state stays coherent.
+    const purpose = () => props.purpose ?? "create";
+    const primaryLabel = () => {
+        if (submitting()) {
+            return purpose() === "oauth-continue" ? "Continuing…" : "Creating…";
+        }
+        return purpose() === "oauth-continue" ? "Continue" : "Create";
+    };
 
     const submit = async () => {
         if (!canSubmit()) return;
@@ -127,7 +150,7 @@ export const AgentNewIdentityModalPanel = (
                     className="green solid"
                     disabled={!canSubmit()}
                 >
-                    {submitting() ? "Creating…" : "Create"}
+                    {primaryLabel()}
                 </Button>
             </footer>
         </>

--- a/frontend/app/view/agent/components/AgentPicker.tsx
+++ b/frontend/app/view/agent/components/AgentPicker.tsx
@@ -110,10 +110,17 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
     const buildLaunchRequest = (
         agent: AgentDefinition,
         initialFormState?: Partial<LaunchFormStateWire>,
+        // When set, the re-opened launch modal fires its OAuth
+        // `startConnect()` once on mount. Used by the OAuth-Connect →
+        // New Identity → launch round-trip so the user doesn't re-click
+        // Connect after naming the bundle — spec
+        // SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2.
+        autoStartAuth?: boolean,
     ) => ({
         kind: "launch-agent" as const,
         agent,
         originBlockId: props.model.blockId,
+        autoStartAuth,
         onSubmit: async (overrides: LaunchOverrides) => {
             setLaunching(agent.id);
             try {
@@ -130,19 +137,38 @@ export const AgentPicker = (props: AgentPickerProps): JSX.Element => {
             }
         },
         initialFormState,
-        onRequestNewIdentity: (current: LaunchFormStateWire) => {
+        onRequestNewIdentity: (
+            current: LaunchFormStateWire,
+            purpose: "create" | "oauth-continue",
+        ) => {
             // Thread the user's whole live form snapshot through the
             // new-identity round-trip so name/runtime/image/memory
             // survive alongside the freshly-created identity id.
+            //
+            // Two entry points share this chain (spec §2):
+            //  - `"create"`  — the plain `+ New identity` button. On
+            //    Continue/Create, return to the launch form with the
+            //    new id selected; the user clicks Launch when ready.
+            //  - `"oauth-continue"` — the OAuth Connect (`needs-bundle`)
+            //    click. The New Identity modal's primary button reads
+            //    "Continue"; on success the launch form re-opens with
+            //    the new id selected AND `autoStartAuth` set so OAuth
+            //    resumes automatically against the freshly-named
+            //    bundle.
             tabModal.replace({
                 kind: "new-identity" as const,
                 originBlockId: props.model.blockId,
+                purpose,
                 onCreated: (id: string) => {
                     tabModal.replace(
-                        buildLaunchRequest(agent, {
-                            ...current,
-                            identityId: id,
-                        }),
+                        buildLaunchRequest(
+                            agent,
+                            {
+                                ...current,
+                                identityId: id,
+                            },
+                            purpose === "oauth-continue",
+                        ),
                     );
                 },
                 onCancel: () => {

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -69,6 +69,23 @@ export interface PreLaunchAuthPanelProps {
      *  submission — parent should refresh the identity list and
      *  switch the dropdown to this new bundle. */
     onBundleCreated: (bundleId: string) => void;
+    /** Called when the user clicks Connect and the outcome is
+     *  `needs-bundle` (no identity bundle selected — a genuinely
+     *  fresh OAuth). Instead of starting OAuth immediately the panel
+     *  asks the parent to interpose the New Identity modal so the
+     *  user names the bundle first; OAuth then resumes against the
+     *  named bundle. When omitted the panel falls back to starting
+     *  OAuth directly (legacy behaviour). Spec
+     *  SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2. */
+    onRequestNewIdentity?: () => void;
+    /** When true, the panel fires its OAuth `startConnect()` exactly
+     *  once on mount — used by the New Identity → launch round-trip so
+     *  the user doesn't have to click Connect a second time after
+     *  naming the bundle. Spec SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2.
+     *  The auto-start only fires from a connect-able state
+     *  (`unauthenticated` / `expired`); a panel that already shows
+     *  `ready` / `waiting` is left alone. */
+    autoStartAuth?: boolean;
     /** Inline-disabled flag mirroring the modal's submitting state.
      *  Prevents starting a Connect mid-launch. */
     disabled?: boolean;
@@ -145,6 +162,48 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         untrack(() => controller.selected(prov.id, id, outcomeFor(id, prov.id, hasBinding)));
     });
 
+    // Connect / Retry click handler. When the outcome is `needs-bundle`
+    // (no identity bundle selected — a genuinely fresh OAuth) we DON'T
+    // start OAuth immediately: the spec (SPEC_BUNDLE_MANAGEMENT_2026_
+    // 05_22.md §2) interposes the New Identity modal so the user names
+    // the bundle first. The parent's `onRequestNewIdentity` owns the
+    // tabModal.replace chain into that modal. For `needs-account` /
+    // `expired` / openclaw (an existing, named bundle), Connect goes
+    // straight to OAuth — unchanged behaviour. If the parent didn't
+    // supply the callback we fall back to starting OAuth directly.
+    const handleConnect = (): void => {
+        const prov = props.provider;
+        if (!prov) return;
+        const outcome = outcomeFor(
+            props.identityId(),
+            prov.id,
+            props.hasMatchingBinding(),
+        );
+        if (outcome === "needs-bundle" && props.onRequestNewIdentity) {
+            props.onRequestNewIdentity();
+            return;
+        }
+        void startConnect(controller, prov);
+    };
+
+    // Auto-start OAuth once on mount when the parent set `autoStartAuth`
+    // — the New Identity → launch round-trip (spec §2). By this point
+    // the user has named + created the bundle, so the dropdown carries
+    // a non-blank `identityId` and `outcomeFor()` resolves to
+    // `needs-account`; `handleConnect()` therefore routes straight to
+    // OAuth (NOT back into the New Identity modal) with `intoBundleId`
+    // = the new bundle. Guarded so it fires exactly once and only from
+    // a connect-able state — a re-render must not re-trigger it, and a
+    // panel that's already `waiting`/`ready` is left untouched.
+    let autoStartFired = false;
+    createEffect(() => {
+        if (!props.autoStartAuth || autoStartFired) return;
+        const kind = controller.state().kind;
+        if (kind !== "unauthenticated" && kind !== "expired") return;
+        autoStartFired = true;
+        untrack(() => handleConnect());
+    });
+
     // No onCleanup here — controller lifetime is owned by the parent
     // (AgentLaunchModal). Disposing on panel unmount would destroy
     // in-flight auth state any time the parent's `<Show when={authRequired()}>`
@@ -186,7 +245,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                 <Match when={controller.state().kind === "failed"}>
                     <FailedBanner
                         state={controller.state()}
-                        onRetry={() => void startConnect(controller, props.provider)}
+                        onRetry={() => handleConnect()}
                         canRetry={!props.disabled}
                     />
                 </Match>
@@ -199,7 +258,7 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
                     <ConnectCta
                         provider={props.provider}
                         state={controller.state()}
-                        onConnect={() => void startConnect(controller, props.provider)}
+                        onConnect={() => handleConnect()}
                         disabled={props.disabled ?? false}
                     />
                 </Match>

--- a/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
+++ b/frontend/app/view/agent/components/PreLaunchAuthPanel.tsx
@@ -162,24 +162,23 @@ export const PreLaunchAuthPanel = (props: PreLaunchAuthPanelProps): JSX.Element 
         untrack(() => controller.selected(prov.id, id, outcomeFor(id, prov.id, hasBinding)));
     });
 
-    // Connect / Retry click handler. When the outcome is `needs-bundle`
-    // (no identity bundle selected — a genuinely fresh OAuth) we DON'T
-    // start OAuth immediately: the spec (SPEC_BUNDLE_MANAGEMENT_2026_
-    // 05_22.md §2) interposes the New Identity modal so the user names
-    // the bundle first. The parent's `onRequestNewIdentity` owns the
-    // tabModal.replace chain into that modal. For `needs-account` /
-    // `expired` / openclaw (an existing, named bundle), Connect goes
-    // straight to OAuth — unchanged behaviour. If the parent didn't
-    // supply the callback we fall back to starting OAuth directly.
+    // Connect / Retry click handler. When the user has no identity
+    // bundle selected — a genuinely fresh OAuth — we DON'T start OAuth
+    // immediately: the spec (SPEC_BUNDLE_MANAGEMENT_2026_05_22.md §2)
+    // interposes the New Identity modal so the user names the bundle
+    // first; the parent's `onRequestNewIdentity` owns the
+    // tabModal.replace chain into that modal. With a bundle already
+    // selected — `needs-account`, `expired`, or openclaw's force-fresh
+    // — Connect goes straight to OAuth. Without the callback we fall
+    // back to starting OAuth directly.
     const handleConnect = (): void => {
         const prov = props.provider;
         if (!prov) return;
-        const outcome = outcomeFor(
-            props.identityId(),
-            prov.id,
-            props.hasMatchingBinding(),
-        );
-        if (outcome === "needs-bundle" && props.onRequestNewIdentity) {
+        // Gate on a genuinely empty selection, NOT the `needs-bundle`
+        // outcome: `outcomeFor()` returns `needs-bundle` for openclaw
+        // even with a bundle selected, so an outcome-based gate would
+        // trap openclaw in the New Identity step instead of OAuth.
+        if (props.identityId() === "" && props.onRequestNewIdentity) {
             props.onRequestNewIdentity();
             return;
         }


### PR DESCRIPTION
## Bundle PR 1 — Feature 1 of `SPEC_BUNDLE_MANAGEMENT_2026_05_22`

Clicking **Connect** with no identity selected used to OAuth and auto-mint an *unnamed* identity bundle. Now it opens the **New Identity modal first** (name + description), and the credential attaches to that named bundle.

- `AgentNewIdentityModalPanel` gains `purpose: "create" | "oauth-continue"` — button label "Create" vs **"Continue"**.
- Connect with the `needs-bundle` outcome → chains into the New Identity modal via the existing `tabModal.replace` round-trip → on **Continue**: `UpsertIdentityBundleCommand` → returns to the launch modal with the new identity preselected + `autoStartAuth`.
- A one-shot effect in `PreLaunchAuthPanel` fires `startConnect()` once on mount when `autoStartAuth` is set; OAuth runs with `intoBundleId` = the new bundle.
- `needs-account` (existing bundle lacking a binding) → unchanged, straight to OAuth. Plain `+ New identity` → unchanged (`purpose: "create"`).

`tsc` clean. No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)